### PR TITLE
ci(ghaction): add ci run on main pushes to trigger cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
   workflow_call:
 
 env:


### PR DESCRIPTION
### Description
In order for PRs (childrens of main branch) to reuse build (dependencies) cache, we need to cache a parent branch. 