### PR TITLE
feat: Add utility methods to simplify InMemoryVectorStore creation

### DIFF
--- a/rig-core/examples/vector_search.rs
+++ b/rig-core/examples/vector_search.rs
@@ -3,7 +3,7 @@ use std::env;
 use rig::{
     embeddings::EmbeddingsBuilder,
     providers::openai::Client,
-    vector_store::{in_memory_store::InMemoryVectorStore, VectorStore, VectorStoreIndex},
+    vector_store::{in_memory_store::InMemoryVectorIndex, VectorStoreIndex},
 };
 
 #[tokio::main]
@@ -14,8 +14,6 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let model = openai_client.embedding_model("text-embedding-ada-002");
 
-    let mut vector_store = InMemoryVectorStore::default();
-
     let embeddings = EmbeddingsBuilder::new(model.clone())
         .simple_document("doc0", "Definition of a *flurbo*: A flurbo is a green alien that lives on cold planets")
         .simple_document("doc1", "Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.")
@@ -23,9 +21,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .build()
         .await?;
 
-    vector_store.add_documents(embeddings).await?;
-
-    let index = vector_store.index(model);
+    let index = InMemoryVectorIndex::from_embeddings(model, embeddings).await?;
 
     let results = index
         .top_n_from_query("What is a linglingdong?", 1)

--- a/rig-core/src/vector_store/in_memory_store.rs
+++ b/rig-core/src/vector_store/in_memory_store.rs
@@ -97,6 +97,15 @@ impl InMemoryVectorStore {
     pub fn is_empty(&self) -> bool {
         self.embeddings.is_empty()
     }
+
+    /// Uitilty method to create an InMemoryVectorStore from a list of embeddings.
+    pub async fn from_embeddings(
+        embeddings: Vec<DocumentEmbeddings>,
+    ) -> Result<Self, VectorStoreError> {
+        let mut store = InMemoryVectorStore::default();
+        store.add_documents(embeddings).await?;
+        Ok(store)
+    }
 }
 
 pub struct InMemoryVectorIndex<M: EmbeddingModel> {
@@ -151,12 +160,13 @@ impl<M: EmbeddingModel> InMemoryVectorIndex<M> {
         Ok(store.index(query_model))
     }
 
+    /// Utility method to create an InMemoryVectorIndex from a list of embeddings
+    /// and an embedding model.
     pub async fn from_embeddings(
         query_model: M,
         embeddings: Vec<DocumentEmbeddings>,
     ) -> Result<Self, VectorStoreError> {
-        let mut store = InMemoryVectorStore::default();
-        store.add_documents(embeddings).await?;
+        let store = InMemoryVectorStore::from_embeddings(embeddings).await?;
         Ok(store.index(query_model))
     }
 }


### PR DESCRIPTION
- Add `InMemoryVectorStore::from_documents` utility method
- Add `InMemoryVectorStore::from_embeddings` utility method
- Add docstrings
- Update example

Previously:
```rust
let model = openai_client.embedding_model("text-embedding-ada-002");

let mut vector_store = InMemoryVectorStore::default();

let embeddings = EmbeddingsBuilder::new(model.clone())
    .simple_document("doc0", "Definition of a *flurbo*: A flurbo is a green alien that lives on cold planets")
    .simple_document("doc1", "Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.")
    .simple_document("doc2", "Definition of a *linglingdong*: A term used by inhabitants of the far side of the moon to describe humans.")
    .build()
    .await?;

vector_store.add_documents(embeddings).await?;

let index = vector_store.index(model);
```

Can now be written as:
```rust
let model = openai_client.embedding_model("text-embedding-ada-002");

let embeddings = EmbeddingsBuilder::new(model.clone())
    .simple_document("doc0", "Definition of a *flurbo*: A flurbo is a green alien that lives on cold planets")
    .simple_document("doc1", "Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.")
    .simple_document("doc2", "Definition of a *linglingdong*: A term used by inhabitants of the far side of the moon to describe humans.")
    .build()
    .await?;

let index = InMemoryVectorIndex::from_embeddings(model, embeddings).await?;
```

Or even shorter if using `InMemoryVectorIndex::from_documents`!