### PR TITLE
fix: move context documents to user prompt message

### DIFF
--- a/rig-core/src/completion.rs
+++ b/rig-core/src/completion.rs
@@ -120,6 +120,28 @@ pub struct Document {
     pub additional_props: HashMap<String, String>,
 }
 
+impl std::fmt::Display for Document {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let metadata = self
+            .additional_props
+            .iter()
+            .map(|(k, v)| format!("{}: {}", k, v))
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        write!(
+            f,
+            concat!("<file id: {}>\n", "{}\n", "</file>\n"),
+            self.id,
+            if self.additional_props.is_empty() {
+                self.text.clone()
+            } else {
+                format!("<metadata {} />\n{}", metadata, self.text)
+            }
+        )
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ToolDefinition {
     pub name: String,

--- a/rig-core/src/completion.rs
+++ b/rig-core/src/completion.rs
@@ -122,13 +122,6 @@ pub struct Document {
 
 impl std::fmt::Display for Document {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let metadata = self
-            .additional_props
-            .iter()
-            .map(|(k, v)| format!("{}: {:?}", k, v))
-            .collect::<Vec<_>>()
-            .join(" ");
-
         write!(
             f,
             concat!("<file id: {}>\n", "{}\n", "</file>\n"),
@@ -136,6 +129,13 @@ impl std::fmt::Display for Document {
             if self.additional_props.is_empty() {
                 self.text.clone()
             } else {
+                let mut sorted_props = self.additional_props.iter().collect::<Vec<_>>();
+                sorted_props.sort_by(|a, b| a.0.cmp(b.0));
+                let metadata = sorted_props
+                    .iter()
+                    .map(|(k, v)| format!("{}: {:?}", k, v))
+                    .collect::<Vec<_>>()
+                    .join(" ");
                 format!("<metadata {} />\n{}", metadata, self.text)
             }
         )

--- a/rig-core/src/providers/anthropic/completion.rs
+++ b/rig-core/src/providers/anthropic/completion.rs
@@ -157,21 +157,7 @@ impl completion::CompletionModel for CompletionModel {
         &self,
         completion_request: completion::CompletionRequest,
     ) -> Result<completion::CompletionResponse<CompletionResponse>, CompletionError> {
-        // Add context documents to chat history
-        let prompt_content = if !completion_request.documents.is_empty() {
-            format!(
-                "<attachments>\n{}</attachments>\n\n{}",
-                completion_request
-                    .documents
-                    .iter()
-                    .map(|doc| doc.to_string())
-                    .collect::<Vec<_>>()
-                    .join("\n"),
-                completion_request.prompt
-            )
-        } else {
-            completion_request.prompt
-        };
+        let prompt_with_context = completion_request.prompt_with_context();
 
         let request = json!({
             "model": self.model,
@@ -181,7 +167,7 @@ impl completion::CompletionModel for CompletionModel {
                 .map(Message::from)
                 .chain(iter::once(Message {
                     role: "user".to_owned(),
-                    content: prompt_content,
+                    content: prompt_with_context,
                 }))
                 .collect::<Vec<_>>(),
             "max_tokens": completion_request.max_tokens,

--- a/rig-core/src/providers/openai.rs
+++ b/rig-core/src/providers/openai.rs
@@ -492,25 +492,12 @@ impl completion::CompletionModel for CompletionModel {
         full_history.append(&mut completion_request.chat_history);
 
         // Add context documents to chat history
-        let prompt_content = if !completion_request.documents.is_empty() {
-            format!(
-                "<attachments>\n{}</attachments>\n\n{}",
-                completion_request
-                    .documents
-                    .iter()
-                    .map(|doc| doc.to_string())
-                    .collect::<Vec<_>>()
-                    .join("\n"),
-                completion_request.prompt
-            )
-        } else {
-            completion_request.prompt
-        };
+        let prompt_with_context = completion_request.prompt_with_context();
 
         // Add context documents to chat history
         full_history.push(completion::Message {
             role: "user".into(),
-            content: prompt_content,
+            content: prompt_with_context,
         });
 
         let request = if completion_request.tools.is_empty() {

--- a/rig-core/src/providers/perplexity.rs
+++ b/rig-core/src/providers/perplexity.rs
@@ -227,17 +227,20 @@ impl completion::CompletionModel for CompletionModel {
         };
 
         // Add context documents to chat history
-        messages.append(
-            completion_request
-                .documents
-                .into_iter()
-                .map(|doc| completion::Message {
-                    role: "system".into(),
-                    content: serde_json::to_string(&doc).expect("Document should serialize"),
-                })
-                .collect::<Vec<_>>()
-                .as_mut(),
-        );
+        let prompt_content = if !completion_request.documents.is_empty() {
+            format!(
+                "<attachments>\n{}</attachments>\n\n{}",
+                completion_request
+                    .documents
+                    .iter()
+                    .map(|doc| doc.to_string())
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+                completion_request.prompt
+            )
+        } else {
+            completion_request.prompt
+        };
 
         // Add chat history to messages
         messages.extend(completion_request.chat_history);
@@ -245,7 +248,7 @@ impl completion::CompletionModel for CompletionModel {
         // Add user prompt to messages
         messages.push(completion::Message {
             role: "user".to_string(),
-            content: completion_request.prompt,
+            content: prompt_content,
         });
 
         let request = json!({

--- a/rig-core/src/providers/perplexity.rs
+++ b/rig-core/src/providers/perplexity.rs
@@ -227,20 +227,7 @@ impl completion::CompletionModel for CompletionModel {
         };
 
         // Add context documents to chat history
-        let prompt_content = if !completion_request.documents.is_empty() {
-            format!(
-                "<attachments>\n{}</attachments>\n\n{}",
-                completion_request
-                    .documents
-                    .iter()
-                    .map(|doc| doc.to_string())
-                    .collect::<Vec<_>>()
-                    .join("\n"),
-                completion_request.prompt
-            )
-        } else {
-            completion_request.prompt
-        };
+        let prompt_with_context = completion_request.prompt_with_context();
 
         // Add chat history to messages
         messages.extend(completion_request.chat_history);
@@ -248,7 +235,7 @@ impl completion::CompletionModel for CompletionModel {
         // Add user prompt to messages
         messages.push(completion::Message {
             role: "user".to_string(),
-            content: prompt_content,
+            content: prompt_with_context,
         });
 
         let request = json!({


### PR DESCRIPTION
Context documents get prepended to the prompt user message rather than to system messages.