### PR TITLE
refactor: remove DocumentEmbeddings from in memory vector store

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ name: Lint & Test
 on:
   pull_request:
     branches:
-      - main
+      - "*"
   push:
     branches:
       - main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ name: Lint & Test
 on:
   pull_request:
     branches:
-      - "*"
+      - "**"
   push:
     branches:
       - main

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3305,9 +3305,9 @@ checksum = "e296cf87e61c9cfc1a61c3c63a0f7f286ed4554e0e22be84e8a38e1d264a2a29"
 
 [[package]]
 name = "openssl"
-version = "0.10.64"
+version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
  "bitflags 2.5.0",
  "cfg-if",
@@ -3337,9 +3337,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.102"
+version = "0.9.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
 dependencies = [
  "cc",
  "libc",

--- a/rig-core/examples/calculator_chatbot.rs
+++ b/rig-core/examples/calculator_chatbot.rs
@@ -2,10 +2,10 @@ use anyhow::Result;
 use rig::{
     cli_chatbot::cli_chatbot,
     completion::ToolDefinition,
-    embeddings::EmbeddingsBuilder,
+    embeddings::{DocumentEmbeddings, EmbeddingsBuilder},
     providers::openai::{Client, TEXT_EMBEDDING_ADA_002},
     tool::{Tool, ToolEmbedding, ToolSet},
-    vector_store::{in_memory_store::InMemoryVectorStore, VectorStore},
+    vector_store::in_memory_store::InMemoryVectorStore,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -251,9 +251,19 @@ async fn main() -> Result<(), anyhow::Error> {
         .build()
         .await?;
 
-    let mut store = InMemoryVectorStore::default();
-    store.add_documents(embeddings).await?;
-    let index = store.index(embedding_model);
+    let vector_store = InMemoryVectorStore::default().add_documents(
+        embeddings
+            .into_iter()
+            .map(
+                |DocumentEmbeddings {
+                     id,
+                     document,
+                     embeddings,
+                 }| { (id, document, embeddings) },
+            )
+            .collect(),
+    )?;
+    let index = vector_store.index(embedding_model);
 
     // Create RAG agent with a single context prompt and a dynamic tool source
     let calculator_rag = openai_client

--- a/rig-core/examples/calculator_chatbot.rs
+++ b/rig-core/examples/calculator_chatbot.rs
@@ -251,19 +251,20 @@ async fn main() -> Result<(), anyhow::Error> {
         .build()
         .await?;
 
-    let vector_store = InMemoryVectorStore::default().add_documents(
-        embeddings
-            .into_iter()
-            .map(
-                |DocumentEmbeddings {
-                     id,
-                     document,
-                     embeddings,
-                 }| { (id, document, embeddings) },
-            )
-            .collect(),
-    )?;
-    let index = vector_store.index(embedding_model);
+    let index = InMemoryVectorStore::default()
+        .add_documents(
+            embeddings
+                .into_iter()
+                .map(
+                    |DocumentEmbeddings {
+                         id,
+                         document,
+                         embeddings,
+                     }| { (id, document, embeddings) },
+                )
+                .collect(),
+        )?
+        .index(embedding_model);
 
     // Create RAG agent with a single context prompt and a dynamic tool source
     let calculator_rag = openai_client

--- a/rig-core/examples/rag.rs
+++ b/rig-core/examples/rag.rs
@@ -2,9 +2,9 @@ use std::env;
 
 use rig::{
     completion::Prompt,
-    embeddings::EmbeddingsBuilder,
+    embeddings::{DocumentEmbeddings, EmbeddingsBuilder},
     providers::openai::{Client, TEXT_EMBEDDING_ADA_002},
-    vector_store::{in_memory_store::InMemoryVectorStore, VectorStore},
+    vector_store::in_memory_store::InMemoryVectorStore,
 };
 
 #[tokio::main]
@@ -25,7 +25,18 @@ async fn main() -> Result<(), anyhow::Error> {
         .build()
         .await?;
 
-    vector_store.add_documents(embeddings).await?;
+    let vector_store = vector_store.add_documents(
+        embeddings
+            .into_iter()
+            .map(
+                |DocumentEmbeddings {
+                     id,
+                     document,
+                     embeddings,
+                 }| { (id, document, embeddings) },
+            )
+            .collect(),
+    )?;
 
     // Create vector store index
     let index = vector_store.index(embedding_model);

--- a/rig-core/examples/rag_dynamic_tools.rs
+++ b/rig-core/examples/rag_dynamic_tools.rs
@@ -160,21 +160,20 @@ async fn main() -> Result<(), anyhow::Error> {
         .build()
         .await?;
 
-    let vector_store = InMemoryVectorStore::default().add_documents(
-        embeddings
-            .into_iter()
-            .map(
-                |DocumentEmbeddings {
-                     id,
-                     document,
-                     embeddings,
-                 }| { (id, document, embeddings) },
-            )
-            .collect(),
-    )?;
-
-    // Create vector store index
-    let index = vector_store.index(embedding_model);
+    let index = InMemoryVectorStore::default()
+        .add_documents(
+            embeddings
+                .into_iter()
+                .map(
+                    |DocumentEmbeddings {
+                         id,
+                         document,
+                         embeddings,
+                     }| { (id, document, embeddings) },
+                )
+                .collect(),
+        )?
+        .index(embedding_model);
 
     // Create RAG agent with a single context prompt and a dynamic tool source
     let calculator_rag = openai_client

--- a/rig-core/examples/vector_search.rs
+++ b/rig-core/examples/vector_search.rs
@@ -3,10 +3,7 @@ use std::env;
 use rig::{
     embeddings::{DocumentEmbeddings, EmbeddingsBuilder},
     providers::openai::{Client, TEXT_EMBEDDING_ADA_002},
-    vector_store::{
-        in_memory_store::{InMemoryVectorIndex, InMemoryVectorStore},
-        VectorStoreIndex,
-    },
+    vector_store::{in_memory_store::InMemoryVectorStore, VectorStoreIndex},
 };
 
 #[tokio::main]
@@ -24,20 +21,20 @@ async fn main() -> Result<(), anyhow::Error> {
         .build()
         .await?;
 
-    let vector_store = InMemoryVectorStore::default().add_documents(
-        embeddings
-            .into_iter()
-            .map(
-                |DocumentEmbeddings {
-                     id,
-                     document,
-                     embeddings,
-                 }| { (id, document, embeddings) },
-            )
-            .collect(),
-    )?;
-
-    let index = vector_store.index(model);
+    let index = InMemoryVectorStore::default()
+        .add_documents(
+            embeddings
+                .into_iter()
+                .map(
+                    |DocumentEmbeddings {
+                         id,
+                         document,
+                         embeddings,
+                     }| { (id, document, embeddings) },
+                )
+                .collect(),
+        )?
+        .index(model);
 
     let results = index
         .top_n::<DocumentEmbeddings>("What is a linglingdong?", 1)

--- a/rig-core/examples/vector_search.rs
+++ b/rig-core/examples/vector_search.rs
@@ -37,10 +37,10 @@ async fn main() -> Result<(), anyhow::Error> {
         .index(model);
 
     let results = index
-        .top_n::<DocumentEmbeddings>("What is a linglingdong?", 1)
+        .top_n::<String>("What is a linglingdong?", 1)
         .await?
         .into_iter()
-        .map(|(score, id, doc)| (score, id, doc.document))
+        .map(|(score, id, doc)| (score, id, doc))
         .collect::<Vec<_>>();
 
     println!("Results: {:?}", results);

--- a/rig-core/examples/vector_search_cohere.rs
+++ b/rig-core/examples/vector_search_cohere.rs
@@ -38,10 +38,10 @@ async fn main() -> Result<(), anyhow::Error> {
         .index(search_model);
 
     let results = index
-        .top_n::<DocumentEmbeddings>("What is a linglingdong?", 1)
+        .top_n::<String>("What is a linglingdong?", 1)
         .await?
         .into_iter()
-        .map(|(score, id, doc)| (score, id, doc.document))
+        .map(|(score, id, doc)| (score, id, doc))
         .collect::<Vec<_>>();
 
     println!("Results: {:?}", results);

--- a/rig-core/examples/vector_search_cohere.rs
+++ b/rig-core/examples/vector_search_cohere.rs
@@ -22,20 +22,20 @@ async fn main() -> Result<(), anyhow::Error> {
         .build()
         .await?;
 
-    let vector_store = InMemoryVectorStore::default().add_documents(
-        embeddings
-            .into_iter()
-            .map(
-                |DocumentEmbeddings {
-                     id,
-                     document,
-                     embeddings,
-                 }| { (id, document, embeddings) },
-            )
-            .collect(),
-    )?;
-
-    let index = vector_store.index(search_model);
+    let index = InMemoryVectorStore::default()
+        .add_documents(
+            embeddings
+                .into_iter()
+                .map(
+                    |DocumentEmbeddings {
+                         id,
+                         document,
+                         embeddings,
+                     }| { (id, document, embeddings) },
+                )
+                .collect(),
+        )?
+        .index(search_model);
 
     let results = index
         .top_n::<DocumentEmbeddings>("What is a linglingdong?", 1)

--- a/rig-core/src/vector_store/in_memory_store.rs
+++ b/rig-core/src/vector_store/in_memory_store.rs
@@ -7,28 +7,27 @@ use std::{
 use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
 
-use super::{VectorStore, VectorStoreError, VectorStoreIndex};
-use crate::embeddings::{DocumentEmbeddings, Embedding, EmbeddingModel, EmbeddingsBuilder};
+use super::{VectorStoreError, VectorStoreIndex};
+use crate::embeddings::{Embedding, EmbeddingModel};
 
 /// InMemoryVectorStore is a simple in-memory vector store that stores embeddings
 /// in-memory using a HashMap.
-#[derive(Clone, Default, Deserialize, Serialize)]
-pub struct InMemoryVectorStore {
+#[derive(Clone, Default)]
+pub struct InMemoryVectorStore<D: Serialize> {
     /// The embeddings are stored in a HashMap with the document ID as the key.
-    embeddings: HashMap<String, DocumentEmbeddings>,
+    embeddings: HashMap<String, (D, Vec<Embedding>)>,
 }
 
-impl InMemoryVectorStore {
+impl<D: Serialize + Eq> InMemoryVectorStore<D> {
     /// Implement vector search on InMemoryVectorStore.
     /// To be used by implementations of top_n and top_n_ids methods on VectorStoreIndex trait for InMemoryVectorStore.
-    fn vector_search(&self, prompt_embedding: &Embedding, n: usize) -> EmbeddingRanking {
+    fn vector_search(&self, prompt_embedding: &Embedding, n: usize) -> EmbeddingRanking<D> {
         // Sort documents by best embedding distance
-        let mut docs: EmbeddingRanking = BinaryHeap::new();
+        let mut docs = BinaryHeap::new();
 
-        for (id, doc_embeddings) in self.embeddings.iter() {
+        for (id, (doc, embeddings)) in self.embeddings.iter() {
             // Get the best context for the document given the prompt
-            if let Some((distance, embed_doc)) = doc_embeddings
-                .embeddings
+            if let Some((distance, embed_doc)) = embeddings
                 .iter()
                 .map(|embedding| {
                     (
@@ -38,12 +37,7 @@ impl InMemoryVectorStore {
                 })
                 .min_by(|a, b| a.0.cmp(&b.0))
             {
-                docs.push(Reverse(RankingItem(
-                    distance,
-                    id,
-                    doc_embeddings,
-                    embed_doc,
-                )));
+                docs.push(Reverse(RankingItem(distance, id, doc, embed_doc)));
             };
 
             // If the heap size exceeds n, pop the least old element.
@@ -63,77 +57,59 @@ impl InMemoryVectorStore {
 
         docs
     }
-}
 
-/// RankingItem(distance, document_id, document, embed_doc)
-#[derive(Eq, PartialEq)]
-struct RankingItem<'a>(
-    OrderedFloat<f64>,
-    &'a String,
-    &'a DocumentEmbeddings,
-    &'a String,
-);
-
-impl Ord for RankingItem<'_> {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.0.cmp(&other.0)
-    }
-}
-
-impl PartialOrd for RankingItem<'_> {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-type EmbeddingRanking<'a> = BinaryHeap<Reverse<RankingItem<'a>>>;
-
-impl VectorStore for InMemoryVectorStore {
-    type Q = ();
-
-    async fn add_documents(
-        &mut self,
-        documents: Vec<DocumentEmbeddings>,
-    ) -> Result<(), VectorStoreError> {
-        for doc in documents {
-            self.embeddings.insert(doc.id.clone(), doc);
+    pub fn add_documents(
+        mut self,
+        documents: Vec<(String, D, Vec<Embedding>)>,
+    ) -> Result<Self, VectorStoreError> {
+        for (id, doc, embeddings) in documents {
+            self.embeddings.insert(id, (doc, embeddings));
         }
 
-        Ok(())
+        Ok(self)
     }
 
-    async fn get_document<T: for<'a> Deserialize<'a>>(
+    /// Get the document by its id and deserialize it into the given type
+    pub fn get_document<T: for<'a> Deserialize<'a>>(
         &self,
         id: &str,
     ) -> Result<Option<T>, VectorStoreError> {
         Ok(self
             .embeddings
             .get(id)
-            .map(|document| serde_json::from_value(document.document.clone()))
+            .map(|(doc, _)| serde_json::from_str(&serde_json::to_string(doc)?))
             .transpose()?)
     }
 
-    async fn get_document_embeddings(
-        &self,
-        id: &str,
-    ) -> Result<Option<DocumentEmbeddings>, VectorStoreError> {
-        Ok(self.embeddings.get(id).cloned())
-    }
-
-    async fn get_document_by_query(
-        &self,
-        _query: Self::Q,
-    ) -> Result<Option<DocumentEmbeddings>, VectorStoreError> {
-        Ok(None)
+    pub fn get_document_embeddings(&self, id: &str) -> Result<Option<&D>, VectorStoreError> {
+        Ok(self.embeddings.get(id).map(|(doc, _)| doc))
     }
 }
 
-impl InMemoryVectorStore {
-    pub fn index<M: EmbeddingModel>(self, model: M) -> InMemoryVectorIndex<M> {
+/// RankingItem(distance, document_id, document, embed_doc)
+#[derive(Eq, PartialEq)]
+struct RankingItem<'a, D: Serialize>(OrderedFloat<f64>, &'a String, &'a D, &'a String);
+
+impl<D: Serialize + Eq> Ord for RankingItem<'_, D> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl<D: Serialize + Eq> PartialOrd for RankingItem<'_, D> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+type EmbeddingRanking<'a, D> = BinaryHeap<Reverse<RankingItem<'a, D>>>;
+
+impl<D: Serialize> InMemoryVectorStore<D> {
+    pub fn index<M: EmbeddingModel>(self, model: M) -> InMemoryVectorIndex<M, D> {
         InMemoryVectorIndex::new(model, self)
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (&String, &DocumentEmbeddings)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &(D, Vec<Embedding>))> {
         self.embeddings.iter()
     }
 
@@ -144,54 +120,19 @@ impl InMemoryVectorStore {
     pub fn is_empty(&self) -> bool {
         self.embeddings.is_empty()
     }
-
-    /// Uitilty method to create an InMemoryVectorStore from a list of embeddings.
-    pub async fn from_embeddings(
-        embeddings: Vec<DocumentEmbeddings>,
-    ) -> Result<Self, VectorStoreError> {
-        let mut store = Self::default();
-        store.add_documents(embeddings).await?;
-        Ok(store)
-    }
-
-    /// Create an InMemoryVectorStore from a list of documents.
-    /// The documents are serialized to JSON and embedded using the provided embedding model.
-    /// The resulting embeddings are stored in an InMemoryVectorStore created by the method.
-    pub async fn from_documents<M: EmbeddingModel, T: Serialize>(
-        embedding_model: M,
-        documents: &[(String, T)],
-    ) -> Result<Self, VectorStoreError> {
-        let embeddings = documents
-            .iter()
-            .fold(
-                EmbeddingsBuilder::new(embedding_model),
-                |builder, (id, doc)| {
-                    builder.json_document(
-                        id,
-                        serde_json::to_value(doc).expect("Document should be serializable"),
-                        vec![serde_json::to_string(doc).expect("Document should be serializable")],
-                    )
-                },
-            )
-            .build()
-            .await?;
-
-        let store = Self::from_embeddings(embeddings).await?;
-        Ok(store)
-    }
 }
 
-pub struct InMemoryVectorIndex<M: EmbeddingModel> {
+pub struct InMemoryVectorIndex<M: EmbeddingModel, D: Serialize> {
     model: M,
-    pub store: InMemoryVectorStore,
+    pub store: InMemoryVectorStore<D>,
 }
 
-impl<M: EmbeddingModel> InMemoryVectorIndex<M> {
-    pub fn new(model: M, store: InMemoryVectorStore) -> Self {
+impl<M: EmbeddingModel, D: Serialize> InMemoryVectorIndex<M, D> {
+    pub fn new(model: M, store: InMemoryVectorStore<D>) -> Self {
         Self { model, store }
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (&String, &DocumentEmbeddings)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &(D, Vec<Embedding>))> {
         self.store.iter()
     }
 
@@ -202,49 +143,11 @@ impl<M: EmbeddingModel> InMemoryVectorIndex<M> {
     pub fn is_empty(&self) -> bool {
         self.store.is_empty()
     }
-
-    /// Create an InMemoryVectorIndex from a list of documents.
-    /// The documents are serialized to JSON and embedded using the provided embedding model.
-    /// The resulting embeddings are stored in an InMemoryVectorStore created by the method.
-    /// The InMemoryVectorIndex is then created from the store and the provided query model.
-    pub async fn from_documents<T: Serialize>(
-        embedding_model: M,
-        query_model: M,
-        documents: &[(String, T)],
-    ) -> Result<Self, VectorStoreError> {
-        let mut store = InMemoryVectorStore::default();
-
-        let embeddings = documents
-            .iter()
-            .fold(
-                EmbeddingsBuilder::new(embedding_model),
-                |builder, (id, doc)| {
-                    builder.json_document(
-                        id,
-                        serde_json::to_value(doc).expect("Document should be serializable"),
-                        vec![serde_json::to_string(doc).expect("Document should be serializable")],
-                    )
-                },
-            )
-            .build()
-            .await?;
-
-        store.add_documents(embeddings).await?;
-        Ok(store.index(query_model))
-    }
-
-    /// Utility method to create an InMemoryVectorIndex from a list of embeddings
-    /// and an embedding model.
-    pub async fn from_embeddings(
-        query_model: M,
-        embeddings: Vec<DocumentEmbeddings>,
-    ) -> Result<Self, VectorStoreError> {
-        let store = InMemoryVectorStore::from_embeddings(embeddings).await?;
-        Ok(store.index(query_model))
-    }
 }
 
-impl<M: EmbeddingModel + std::marker::Sync> VectorStoreIndex for InMemoryVectorIndex<M> {
+impl<M: EmbeddingModel + std::marker::Sync, D: Serialize + Sync + Send + Eq> VectorStoreIndex
+    for InMemoryVectorIndex<M, D>
+{
     async fn top_n<T: for<'a> Deserialize<'a>>(
         &self,
         query: &str,
@@ -256,12 +159,11 @@ impl<M: EmbeddingModel + std::marker::Sync> VectorStoreIndex for InMemoryVectorI
 
         // Return n best
         docs.into_iter()
-            .map(|Reverse(RankingItem(distance, _, doc, _))| {
-                let doc_value = serde_json::to_value(doc).map_err(VectorStoreError::JsonError)?;
+            .map(|Reverse(RankingItem(distance, id, doc, _))| {
                 Ok((
                     distance.0,
-                    doc.id.clone(),
-                    serde_json::from_value(doc_value).map_err(VectorStoreError::JsonError)?,
+                    id.clone(),
+                    serde_json::from_str(&serde_json::to_string(doc)?)?,
                 ))
             })
             .collect::<Result<Vec<_>, _>>()
@@ -278,7 +180,7 @@ impl<M: EmbeddingModel + std::marker::Sync> VectorStoreIndex for InMemoryVectorI
 
         // Return n best
         docs.into_iter()
-            .map(|Reverse(RankingItem(distance, _, doc, _))| Ok((distance.0, doc.id.clone())))
+            .map(|Reverse(RankingItem(distance, id, _, _))| Ok((distance.0, id.clone())))
             .collect::<Result<Vec<_>, _>>()
     }
 }

--- a/rig-core/src/vector_store/in_memory_store.rs
+++ b/rig-core/src/vector_store/in_memory_store.rs
@@ -52,7 +52,7 @@ impl<D: Serialize + Eq> InMemoryVectorStore<D> {
         tracing::info!(target: "rig",
             "Selected documents: {}",
             docs.iter()
-                .map(|Reverse(RankingItem(distance, id, _, embed_doc))| format!("{} ({}). Specific match: {}", id, distance, embed_doc))
+                .map(|Reverse(RankingItem(distance, id, _, _))| format!("{} ({})", id, distance))
                 .collect::<Vec<String>>()
                 .join(", ")
         );

--- a/rig-core/src/vector_store/mod.rs
+++ b/rig-core/src/vector_store/mod.rs
@@ -2,7 +2,7 @@ use futures::future::BoxFuture;
 use serde::Deserialize;
 use serde_json::Value;
 
-use crate::embeddings::{DocumentEmbeddings, EmbeddingError};
+use crate::embeddings::EmbeddingError;
 
 pub mod in_memory_store;
 
@@ -17,36 +17,6 @@ pub enum VectorStoreError {
 
     #[error("Datastore error: {0}")]
     DatastoreError(#[from] Box<dyn std::error::Error + Send + Sync>),
-}
-
-/// Trait for vector stores
-pub trait VectorStore: Send + Sync {
-    /// Query type for the vector store
-    type Q;
-
-    /// Add a list of documents to the vector store
-    fn add_documents(
-        &mut self,
-        documents: Vec<DocumentEmbeddings>,
-    ) -> impl std::future::Future<Output = Result<(), VectorStoreError>> + Send;
-
-    /// Get the embeddings of a document by its id
-    fn get_document_embeddings(
-        &self,
-        id: &str,
-    ) -> impl std::future::Future<Output = Result<Option<DocumentEmbeddings>, VectorStoreError>> + Send;
-
-    /// Get the document by its id and deserialize it into the given type
-    fn get_document<T: for<'a> Deserialize<'a>>(
-        &self,
-        id: &str,
-    ) -> impl std::future::Future<Output = Result<Option<T>, VectorStoreError>> + Send;
-
-    /// Get the document by a query and deserialize it into the given type
-    fn get_document_by_query(
-        &self,
-        query: Self::Q,
-    ) -> impl std::future::Future<Output = Result<Option<DocumentEmbeddings>, VectorStoreError>> + Send;
 }
 
 /// Trait for vector store indexes

--- a/rig-mongodb/examples/vector_search_mongodb.rs
+++ b/rig-mongodb/examples/vector_search_mongodb.rs
@@ -44,11 +44,9 @@ async fn main() -> Result<(), anyhow::Error> {
         Err(e) => println!("Error adding documents: {:?}", e),
     }
 
-    let vector_store = MongoDbVectorStore::new(collection);
-
     // Create a vector index on our vector store
     // IMPORTANT: Reuse the same model that was used to generate the embeddings
-    let index = vector_store.index(model, "vector_index", SearchParams::default());
+    let index = MongoDbVectorStore::new(collection).index(model, "vector_index", SearchParams::default());
 
     // Query the index
     let results = index

--- a/rig-mongodb/examples/vector_search_mongodb.rs
+++ b/rig-mongodb/examples/vector_search_mongodb.rs
@@ -4,7 +4,7 @@ use std::env;
 use rig::{
     embeddings::{DocumentEmbeddings, EmbeddingsBuilder},
     providers::openai::{Client, TEXT_EMBEDDING_ADA_002},
-    vector_store::{VectorStore, VectorStoreIndex},
+    vector_store::VectorStoreIndex,
 };
 use rig_mongodb::{MongoDbVectorStore, SearchParams};
 
@@ -29,8 +29,6 @@ async fn main() -> Result<(), anyhow::Error> {
         .database("knowledgebase")
         .collection("context");
 
-    let mut vector_store = MongoDbVectorStore::new(collection);
-
     // Select the embedding model and generate our embeddings
     let model = openai_client.embedding_model(TEXT_EMBEDDING_ADA_002);
 
@@ -41,11 +39,12 @@ async fn main() -> Result<(), anyhow::Error> {
         .build()
         .await?;
 
-    // Add embeddings to vector store
-    match vector_store.add_documents(embeddings).await {
+    match collection.insert_many(embeddings, None).await {
         Ok(_) => println!("Documents added successfully"),
         Err(e) => println!("Error adding documents: {:?}", e),
     }
+
+    let vector_store = MongoDbVectorStore::new(collection);
 
     // Create a vector index on our vector store
     // IMPORTANT: Reuse the same model that was used to generate the embeddings

--- a/rig-mongodb/examples/vector_search_mongodb.rs
+++ b/rig-mongodb/examples/vector_search_mongodb.rs
@@ -46,7 +46,8 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Create a vector index on our vector store
     // IMPORTANT: Reuse the same model that was used to generate the embeddings
-    let index = MongoDbVectorStore::new(collection).index(model, "vector_index", SearchParams::default());
+    let index =
+        MongoDbVectorStore::new(collection).index(model, "vector_index", SearchParams::default());
 
     // Query the index
     let results = index


### PR DESCRIPTION
1. Refactor in memory vector store
2. Remove `VectorStore` trait
3. All other changes are side-effects of this