### PR TITLE
Fix/anthropic bad request

### DIFF
--- a/rig-core/src/json_utils.rs
+++ b/rig-core/src/json_utils.rs
@@ -9,3 +9,14 @@ pub fn merge(a: serde_json::Value, b: serde_json::Value) -> serde_json::Value {
         (a, _) => a,
     }
 }
+
+pub fn merge_inplace(a: &mut serde_json::Value, b: serde_json::Value) {
+    match (a, b) {
+        (serde_json::Value::Object(a_map), serde_json::Value::Object(b_map)) => {
+            b_map.into_iter().for_each(|(key, value)| {
+                a_map.insert(key, value);
+            });
+        }
+        _ => {}
+    }
+}

--- a/rig-core/src/json_utils.rs
+++ b/rig-core/src/json_utils.rs
@@ -1,11 +1,11 @@
 pub fn merge(a: serde_json::Value, b: serde_json::Value) -> serde_json::Value {
-    match (a.clone(), b) {
-        (serde_json::Value::Object(mut a), serde_json::Value::Object(b)) => {
-            b.into_iter().for_each(|(key, value)| {
-                a.insert(key.clone(), value.clone());
+    match (a, b) {
+        (serde_json::Value::Object(mut a_map), serde_json::Value::Object(b_map)) => {
+            b_map.into_iter().for_each(|(key, value)| {
+                a_map.insert(key, value);
             });
-            serde_json::Value::Object(a)
+            serde_json::Value::Object(a_map)
         }
-        _ => a,
+        (a, _) => a,
     }
 }

--- a/rig-core/src/json_utils.rs
+++ b/rig-core/src/json_utils.rs
@@ -11,12 +11,9 @@ pub fn merge(a: serde_json::Value, b: serde_json::Value) -> serde_json::Value {
 }
 
 pub fn merge_inplace(a: &mut serde_json::Value, b: serde_json::Value) {
-    match (a, b) {
-        (serde_json::Value::Object(a_map), serde_json::Value::Object(b_map)) => {
-            b_map.into_iter().for_each(|(key, value)| {
-                a_map.insert(key, value);
-            });
-        }
-        _ => {}
+    if let (serde_json::Value::Object(a_map), serde_json::Value::Object(b_map)) = (a, b) {
+        b_map.into_iter().for_each(|(key, value)| {
+            a_map.insert(key, value);
+        });
     }
 }

--- a/rig-core/src/providers/anthropic/client.rs
+++ b/rig-core/src/providers/anthropic/client.rs
@@ -113,6 +113,13 @@ impl Client {
         }
     }
 
+    /// Create a new Anthropic client from the `ANTHROPIC_API_KEY` environment variable.
+    /// Panics if the environment variable is not set.
+    pub fn from_env() -> Self {
+        let api_key = std::env::var("ANTHROPIC_API_KEY").expect("ANTHROPIC_API_KEY not set");
+        ClientBuilder::new(&api_key).build()
+    }
+
     pub fn post(&self, path: &str) -> reqwest::RequestBuilder {
         let url = format!("{}/{}", self.base_url, path).replace("//", "/");
         self.http_client.post(url)

--- a/rig-core/src/providers/anthropic/completion.rs
+++ b/rig-core/src/providers/anthropic/completion.rs
@@ -47,16 +47,14 @@ pub struct CompletionResponse {
 pub enum Content {
     String(String),
     Text {
+        r#type: String,
         text: String,
-        #[serde(rename = "type")]
-        content_type: String,
     },
     ToolUse {
+        r#type: String,
         id: String,
         name: String,
-        input: String,
-        #[serde(rename = "type")]
-        content_type: String,
+        input: serde_json::Value,
     },
 }
 
@@ -73,7 +71,6 @@ pub struct ToolDefinition {
     pub name: String,
     pub description: Option<String>,
     pub input_schema: serde_json::Value,
-    pub cache_control: Option<CacheControl>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -96,7 +93,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             [Content::ToolUse { name, input, .. }, ..] => Ok(completion::CompletionResponse {
                 choice: completion::ModelChoice::ToolCall(
                     name.clone(),
-                    serde_json::from_str(input)?,
+                    input.clone(),
                 ),
                 raw_response: response,
             }),
@@ -157,9 +154,20 @@ impl completion::CompletionModel for CompletionModel {
         &self,
         completion_request: completion::CompletionRequest,
     ) -> Result<completion::CompletionResponse<CompletionResponse>, CompletionError> {
+        // Note: Ideally we'd introduce provider-specific Request models to handle the
+        // specific requirements of each provider. For now, we just manually check while
+        // building the request as a raw JSON document.
+
         let prompt_with_context = completion_request.prompt_with_context();
 
-        let request = json!({
+        // Check if max_tokens is set, required for Anthropic
+        if completion_request.max_tokens.is_none() {
+            return Err(CompletionError::RequestError(
+                "max_tokens must be set for Anthropic".into(),
+            ));
+        }
+
+        let mut request = json!({
             "model": self.model,
             "messages": completion_request
                 .chat_history
@@ -172,24 +180,33 @@ impl completion::CompletionModel for CompletionModel {
                 .collect::<Vec<_>>(),
             "max_tokens": completion_request.max_tokens,
             "system": completion_request.preamble.unwrap_or("".to_string()),
-            "temperature": completion_request.temperature,
-            "tools": completion_request
-                .tools
-                .into_iter()
-                .map(|tool| ToolDefinition {
-                    name: tool.name,
-                    description: Some(tool.description),
-                    input_schema: tool.parameters,
-                    cache_control: None,
-                })
-                .collect::<Vec<_>>(),
         });
 
-        let request = if let Some(ref params) = completion_request.additional_params {
-            json_utils::merge(request, params.clone())
-        } else {
-            request
-        };
+        if let Some(temperature) = completion_request.temperature {
+            json_utils::merge_inplace(&mut request, json!({ "temperature": temperature }));
+        }
+
+        if !completion_request.tools.is_empty() {
+            json_utils::merge_inplace(
+                &mut request,
+                json!({
+                    "tools": completion_request
+                        .tools
+                        .into_iter()
+                        .map(|tool| ToolDefinition {
+                            name: tool.name,
+                            description: Some(tool.description),
+                            input_schema: tool.parameters,
+                        })
+                        .collect::<Vec<_>>(),
+                    "tool_choice": ToolChoice::Auto,
+                }),
+            );
+        }
+
+        if let Some(ref params) = completion_request.additional_params {
+            json_utils::merge_inplace(&mut request, params.clone())
+        }
 
         let response = self
             .client

--- a/rig-core/src/providers/anthropic/completion.rs
+++ b/rig-core/src/providers/anthropic/completion.rs
@@ -91,10 +91,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                 })
             }
             [Content::ToolUse { name, input, .. }, ..] => Ok(completion::CompletionResponse {
-                choice: completion::ModelChoice::ToolCall(
-                    name.clone(),
-                    input.clone(),
-                ),
+                choice: completion::ModelChoice::ToolCall(name.clone(), input.clone()),
                 raw_response: response,
             }),
             _ => Err(CompletionError::ResponseError(

--- a/rig-core/src/providers/cohere.rs
+++ b/rig-core/src/providers/cohere.rs
@@ -57,6 +57,13 @@ impl Client {
         }
     }
 
+    /// Create a new Cohere client from the `COHERE_API_KEY` environment variable.
+    /// Panics if the environment variable is not set.
+    pub fn from_env() -> Self {
+        let api_key = std::env::var("COHERE_API_KEY").expect("COHERE_API_KEY not set");
+        Self::new(&api_key)
+    }
+
     pub fn post(&self, path: &str) -> reqwest::RequestBuilder {
         let url = format!("{}/{}", self.base_url, path).replace("//", "/");
         self.http_client.post(url)

--- a/rig-core/src/providers/openai.rs
+++ b/rig-core/src/providers/openai.rs
@@ -251,30 +251,31 @@ impl embeddings::EmbeddingModel for EmbeddingModel {
                 "input": documents,
             }))
             .send()
-            .await?
-            .error_for_status()?
-            .json::<ApiResponse<EmbeddingResponse>>()
             .await?;
 
-        match response {
-            ApiResponse::Ok(response) => {
-                if response.data.len() != documents.len() {
-                    return Err(EmbeddingError::ResponseError(
-                        "Response data length does not match input length".into(),
-                    ));
-                }
+        if response.status().is_success() {
+            match response.json::<ApiResponse<EmbeddingResponse>>().await? {
+                ApiResponse::Ok(response) => {
+                    if response.data.len() != documents.len() {
+                        return Err(EmbeddingError::ResponseError(
+                            "Response data length does not match input length".into(),
+                        ));
+                    }
 
-                Ok(response
-                    .data
-                    .into_iter()
-                    .zip(documents.into_iter())
-                    .map(|(embedding, document)| embeddings::Embedding {
-                        document,
-                        vec: embedding.embedding,
-                    })
-                    .collect())
+                    Ok(response
+                        .data
+                        .into_iter()
+                        .zip(documents.into_iter())
+                        .map(|(embedding, document)| embeddings::Embedding {
+                            document,
+                            vec: embedding.embedding,
+                        })
+                        .collect())
+                }
+                ApiResponse::Err(err) => Err(EmbeddingError::ProviderError(err.message)),
             }
-            ApiResponse::Err(err) => Err(EmbeddingError::ProviderError(err.message)),
+        } else {
+            Err(EmbeddingError::ProviderError(response.text().await?))
         }
     }
 }
@@ -510,14 +511,15 @@ impl completion::CompletionModel for CompletionModel {
                 },
             )
             .send()
-            .await?
-            .error_for_status()?
-            .json::<ApiResponse<CompletionResponse>>()
             .await?;
 
-        match response {
-            ApiResponse::Ok(response) => response.try_into(),
-            ApiResponse::Err(err) => Err(CompletionError::ProviderError(err.message)),
+        if response.status().is_success() {
+            match response.json::<ApiResponse<CompletionResponse>>().await? {
+                ApiResponse::Ok(response) => response.try_into(),
+                ApiResponse::Err(err) => Err(CompletionError::ProviderError(err.message)),
+            }
+        } else {
+            Err(CompletionError::ProviderError(response.text().await?))
         }
     }
 }


### PR DESCRIPTION
## Description

Fixes multiple bugs with the Anthropic integration related to request generation and response handling. Also adds the `from_env` constructor to Anthropic and Cohere's provider clients, as well as proper provider error reporting.

Fixes #66 
Fixes #65 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix
- [x] New feature

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce your results.

- [ ] Ran the `anthropic_agent` example without specifying `temperature` (succeeded)
- [ ] Ran the `anthropic_agent` example without specifying `max_tokens` (failed as expected with proper error message)
- [ ] Ran the `agent_with_tools` example with a Anthropic's `CLAUDE_3_HAIKU` (succeeded)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
  - Will be added with other integration tests at some later point 
- [x] New and existing unit tests pass locally with my changes

## Notes
These bugs highlight the need for typed provider specific Request models so that these kinds of errors can be caught earlier while reducing the need for manipulating raw JSON while building the underlying request (which is error prone)