### PR TITLE
refactor(vector-store): update generics

### DIFF
--- a/rig-core/examples/calculator_chatbot.rs
+++ b/rig-core/examples/calculator_chatbot.rs
@@ -252,7 +252,12 @@ async fn main() -> Result<(), anyhow::Error> {
         .await?;
 
     let index = InMemoryVectorStore::default()
-        .add_tools(embeddings)?
+        .add_documents(
+            embeddings
+                .into_iter()
+                .map(|(tool, embedding_vec)| (tool.name.clone(), tool, embedding_vec))
+                .collect(),
+        )?
         .index(embedding_model);
 
     // Create RAG agent with a single context prompt and a dynamic tool source

--- a/rig-core/examples/calculator_chatbot.rs
+++ b/rig-core/examples/calculator_chatbot.rs
@@ -252,12 +252,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .await?;
 
     let index = InMemoryVectorStore::default()
-        .add_documents(
-            embeddings
-                .into_iter()
-                .map(|(tool, embedding)| (tool.name.clone(), tool, embedding))
-                .collect(),
-        )?
+        .add_tools(embeddings)?
         .index(embedding_model);
 
     // Create RAG agent with a single context prompt and a dynamic tool source

--- a/rig-core/examples/rag_dynamic_tools.rs
+++ b/rig-core/examples/rag_dynamic_tools.rs
@@ -161,7 +161,12 @@ async fn main() -> Result<(), anyhow::Error> {
         .await?;
 
     let index = InMemoryVectorStore::default()
-        .add_tools(embeddings)?
+        .add_documents(
+            embeddings
+                .into_iter()
+                .map(|(tool, embedding_vec)| (tool.name.clone(), tool, embedding_vec))
+                .collect(),
+        )?
         .index(embedding_model);
 
     // Create RAG agent with a single context prompt and a dynamic tool source

--- a/rig-core/examples/rag_dynamic_tools.rs
+++ b/rig-core/examples/rag_dynamic_tools.rs
@@ -161,12 +161,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .await?;
 
     let index = InMemoryVectorStore::default()
-        .add_documents(
-            embeddings
-                .into_iter()
-                .map(|(tool, embedding)| (tool.name.clone(), tool, embedding))
-                .collect(),
-        )?
+        .add_tools(embeddings)?
         .index(embedding_model);
 
     // Create RAG agent with a single context prompt and a dynamic tool source

--- a/rig-core/examples/vector_search.rs
+++ b/rig-core/examples/vector_search.rs
@@ -68,7 +68,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .index(model);
 
     let results = index
-        .top_n::<FakeDefinition>("I need to buy something in a fictional universe. What type of money can I use for this?", 1)
+        .top_n("I need to buy something in a fictional universe. What type of money can I use for this?", 1)
         .await?
         .into_iter()
         .map(|(score, id, doc)| (score, id, doc.word))

--- a/rig-core/src/embeddings/embeddable.rs
+++ b/rig-core/src/embeddings/embeddable.rs
@@ -158,3 +158,47 @@ impl<T: Embeddable> Embeddable for Vec<T> {
         OneOrMany::merge(items).map_err(EmbeddableError::new)
     }
 }
+
+// #[derive(serde::Deserialize, serde::Serialize, Clone, Eq, PartialEq)]
+// pub struct EmbeddableEmbeddable(serde_json::Value);
+
+// impl EmbeddableEmbeddable {
+//     pub fn new(item: impl serde::Serialize) -> serde_json::Result<Self> {
+//         Ok(Self(serde_json::to_value(item)?))
+//     }
+
+//     pub fn cast<T: for<'a> Deserialize<'a>>(&self) -> serde_json::Result<T> {
+//         serde_json::from_value(self.0.clone())
+//     }
+// }
+
+// impl<I> crate::vector_store::VectorStoreIndexDyn for I
+// where
+//     I: crate::vector_store::VectorStoreIndex<EmbeddableEmbeddable>,
+// {
+//     fn top_n<'a>(
+//         &'a self,
+//         query: &'a str,
+//         n: usize,
+//     ) -> futures::future::BoxFuture<'a, crate::vector_store::TopNResults> {
+//         Box::pin(async move {
+//             Ok(self
+//                 .top_n(query, n)
+//                 .await?
+//                 .into_iter()
+//                 .map(|(distance, id, embeddable)| (distance, id, embeddable.0))
+//                 .collect())
+//         })
+//     }
+
+//     fn top_n_ids<'a>(
+//         &'a self,
+//         query: &'a str,
+//         n: usize,
+//     ) -> futures::future::BoxFuture<
+//         'a,
+//         Result<Vec<(f64, String)>, crate::vector_store::VectorStoreError>,
+//     > {
+//         Box::pin(self.top_n_ids(query, n))
+//     }
+// }

--- a/rig-core/src/embeddings/tool.rs
+++ b/rig-core/src/embeddings/tool.rs
@@ -1,10 +1,10 @@
 use crate::{tool::ToolEmbeddingDyn, Embeddable, OneOrMany};
-use serde::{Deserialize};
+use serde::{Deserialize, Serialize};
 
 use super::embeddable::EmbeddableError;
 
 /// Used by EmbeddingsBuilder to embed anything that implements ToolEmbedding.
-#[derive(Clone, Deserialize, Default, Eq, PartialEq)]
+#[derive(Clone, Deserialize, Serialize, Default, Eq, PartialEq)]
 pub struct EmbeddableTool {
     pub name: String,
     pub context: serde_json::Value,

--- a/rig-core/src/embeddings/tool.rs
+++ b/rig-core/src/embeddings/tool.rs
@@ -1,10 +1,10 @@
 use crate::{tool::ToolEmbeddingDyn, Embeddable, OneOrMany};
-use serde::Serialize;
+use serde::{Deserialize};
 
 use super::embeddable::EmbeddableError;
 
 /// Used by EmbeddingsBuilder to embed anything that implements ToolEmbedding.
-#[derive(Clone, Serialize, Default, Eq, PartialEq)]
+#[derive(Clone, Deserialize, Default, Eq, PartialEq)]
 pub struct EmbeddableTool {
     pub name: String,
     pub context: serde_json::Value,

--- a/rig-core/src/embeddings/tool.rs
+++ b/rig-core/src/embeddings/tool.rs
@@ -1,4 +1,8 @@
-use crate::{tool::ToolEmbeddingDyn, Embeddable, OneOrMany};
+use crate::{
+    tool::ToolEmbeddingDyn,
+    vector_store::{VectorStoreError, VectorStoreIndex, VectorStoreIndexDyn},
+    Embeddable, OneOrMany,
+};
 use serde::{Deserialize, Serialize};
 
 use super::embeddable::EmbeddableError;
@@ -27,5 +31,41 @@ impl EmbeddableTool {
             context: tool.context().map_err(EmbeddableError::new)?,
             embedding_docs: tool.embedding_docs(),
         })
+    }
+}
+
+impl<I> VectorStoreIndexDyn for I
+where
+    I: VectorStoreIndex<EmbeddableTool>,
+{
+    fn top_n<'a>(
+        &'a self,
+        query: &'a str,
+        n: usize,
+    ) -> futures::future::BoxFuture<'a, crate::vector_store::TopNResults> {
+        Box::pin(async move {
+            self.top_n(query, n)
+                .await?
+                .into_iter()
+                .map(|(distance, id, tool)| {
+                    Ok((
+                        distance,
+                        id,
+                        serde_json::to_value(tool).map_err(VectorStoreError::JsonError)?,
+                    ))
+                })
+                .collect::<Result<Vec<_>, _>>()
+        })
+    }
+
+    fn top_n_ids<'a>(
+        &'a self,
+        query: &'a str,
+        n: usize,
+    ) -> futures::future::BoxFuture<
+        'a,
+        Result<Vec<(f64, String)>, crate::vector_store::VectorStoreError>,
+    > {
+        Box::pin(self.top_n_ids(query, n))
     }
 }

--- a/rig-core/src/vector_store/in_memory_store.rs
+++ b/rig-core/src/vector_store/in_memory_store.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 
 use super::{VectorStoreError, VectorStoreIndex};
 use crate::{
-    embeddings::{tool::EmbeddableTool, Embedding, EmbeddingModel},
+    embeddings::{Embedding, EmbeddingModel},
     OneOrMany,
 };
 
@@ -76,27 +76,45 @@ impl<T: for<'a> Deserialize<'a> + Eq + Clone> InMemoryVectorStore<T> {
         Ok(self)
     }
 
+    // pub fn add_documents_test(
+    //     mut self,
+    //     embeddable: Vec<(T, OneOrMany<Embedding>)>,
+    // ) -> Result<Self, VectorStoreError> {
+    //     for (document, embeddings) in embeddable {
+    //         self.embeddings.insert(
+    //             "some_id".to_string(),
+    //             (
+    //                 crate::embeddings::embeddable::EmbeddableEmbeddable::new(document)
+    //                     .map_err(VectorStoreError::JsonError)?,
+    //                 embeddings,
+    //             ),
+    //         );
+    //     }
+
+    //     Ok(self)
+    // }
+
     /// Add objects of type EmbeddableTool to the store.
     /// Returns the store with the added documents.
-    pub fn add_tools(
-        mut self,
-        documents: Vec<(EmbeddableTool, OneOrMany<Embedding>)>,
-    ) -> Result<Self, VectorStoreError> {
-        for (tool, embeddings) in documents {
-            self.embeddings.insert(
-                tool.name.clone(),
-                (
-                    serde_json::from_value(
-                        serde_json::to_value(tool).map_err(VectorStoreError::JsonError)?,
-                    )
-                    .map_err(VectorStoreError::JsonError)?,
-                    embeddings,
-                ),
-            );
-        }
+    // pub fn add_tools(
+    //     mut self,
+    //     documents: Vec<(EmbeddableTool, OneOrMany<Embedding>)>,
+    // ) -> Result<Self, VectorStoreError> {
+    //     for (tool, embeddings) in documents {
+    //         self.embeddings.insert(
+    //             tool.name.clone(),
+    //             (
+    //                 serde_json::from_value(
+    //                     serde_json::to_value(tool).map_err(VectorStoreError::JsonError)?,
+    //                 )
+    //                 .map_err(VectorStoreError::JsonError)?,
+    //                 embeddings,
+    //             ),
+    //         );
+    //     }
 
-        Ok(self)
-    }
+    //     Ok(self)
+    // }
 
     /// Get the document by its id and deserialize it into the given type.
     pub fn get_document(&self, id: &str) -> Result<Option<T>, VectorStoreError> {

--- a/rig-core/src/vector_store/mod.rs
+++ b/rig-core/src/vector_store/mod.rs
@@ -52,20 +52,13 @@ pub trait VectorStoreIndexDyn: Send + Sync {
     ) -> BoxFuture<'a, Result<Vec<(f64, String)>, VectorStoreError>>;
 }
 
-impl<T: for<'a> Deserialize<'a> + Serialize + Send, I: VectorStoreIndex<T>> VectorStoreIndexDyn for I {
+impl<I: VectorStoreIndex<Value>> VectorStoreIndexDyn for I {
     fn top_n<'a>(
         &'a self,
         query: &'a str,
         n: usize,
     ) -> BoxFuture<'a, Result<Vec<(f64, String, Value)>, VectorStoreError>> {
-        Box::pin(async move {
-            self.top_n(query, n).await.map(|results| {
-                results
-                    .into_iter()
-                    .map(|(score, id, doc)| (score, id, serde_json::to_value(&doc).unwrap()))
-                    .collect()
-            })
-        })
+        Box::pin(self.top_n(query, n))
     }
 
     fn top_n_ids<'a>(

--- a/rig-core/src/vector_store/mod.rs
+++ b/rig-core/src/vector_store/mod.rs
@@ -52,20 +52,20 @@ pub trait VectorStoreIndexDyn: Send + Sync {
     ) -> BoxFuture<'a, Result<Vec<(f64, String)>, VectorStoreError>>;
 }
 
-impl<I: VectorStoreIndex<Value>> VectorStoreIndexDyn for I {
-    fn top_n<'a>(
-        &'a self,
-        query: &'a str,
-        n: usize,
-    ) -> BoxFuture<'a, Result<Vec<(f64, String, Value)>, VectorStoreError>> {
-        Box::pin(self.top_n(query, n))
-    }
+// impl<I: VectorStoreIndex<Value>> VectorStoreIndexDyn for I {
+//     fn top_n<'a>(
+//         &'a self,
+//         query: &'a str,
+//         n: usize,
+//     ) -> BoxFuture<'a, Result<Vec<(f64, String, Value)>, VectorStoreError>> {
+//         Box::pin(self.top_n(query, n))
+//     }
 
-    fn top_n_ids<'a>(
-        &'a self,
-        query: &'a str,
-        n: usize,
-    ) -> BoxFuture<'a, Result<Vec<(f64, String)>, VectorStoreError>> {
-        Box::pin(self.top_n_ids(query, n))
-    }
-}
+//     fn top_n_ids<'a>(
+//         &'a self,
+//         query: &'a str,
+//         n: usize,
+//     ) -> BoxFuture<'a, Result<Vec<(f64, String)>, VectorStoreError>> {
+//         Box::pin(self.top_n_ids(query, n))
+//     }
+// }

--- a/rig-core/src/vector_store/mod.rs
+++ b/rig-core/src/vector_store/mod.rs
@@ -1,5 +1,5 @@
 use futures::future::BoxFuture;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use serde_json::Value;
 
 use crate::embeddings::EmbeddingError;
@@ -22,7 +22,7 @@ pub enum VectorStoreError {
 /// Trait for vector store indexes
 pub trait VectorStoreIndex<T>: Send + Sync
 where
-    T: for<'a> Deserialize<'a> + std::marker::Send,
+    T: for<'a> Deserialize<'a> + Send,
 {
     /// Get the top n documents based on the distance to the given query.
     /// The result is a list of tuples of the form (score, id, document)

--- a/rig-lancedb/examples/vector_search_local_ann.rs
+++ b/rig-lancedb/examples/vector_search_local_ann.rs
@@ -8,7 +8,7 @@ use rig::{
     embeddings::{builder::EmbeddingsBuilder, embedding::EmbeddingModel},
     providers::openai::{Client, TEXT_EMBEDDING_ADA_002},
 };
-use rig_lancedb::{LanceDbVectorStore, SearchParams};
+use rig_lancedb::{LanceDbVectorIndex, SearchParams};
 
 #[path = "./fixtures/lib.rs"]
 mod fixture;
@@ -62,7 +62,7 @@ async fn main() -> Result<(), anyhow::Error> {
     // Define search_params params that will be used by the vector store to perform the vector search.
     let search_params = SearchParams::default();
     let vector_store =
-        LanceDbVectorStore::<_, FakeDefinition>::new(table, model, "id", search_params).await?;
+        LanceDbVectorIndex::<_, FakeDefinition>::new(table, model, "id", search_params).await?;
 
     // Query the index. Get entire matching objects as result.
     let results = vector_store

--- a/rig-lancedb/examples/vector_search_local_ann.rs
+++ b/rig-lancedb/examples/vector_search_local_ann.rs
@@ -61,14 +61,22 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Define search_params params that will be used by the vector store to perform the vector search.
     let search_params = SearchParams::default();
-    let vector_store = LanceDbVectorStore::new(table, model, "id", search_params).await?;
+    let vector_store =
+        LanceDbVectorStore::<_, FakeDefinition>::new(table, model, "id", search_params).await?;
 
-    // Query the index
+    // Query the index. Get entire matching objects as result.
     let results = vector_store
-        .top_n::<FakeDefinition>("My boss says I zindle too much, what does that mean?", 1)
+        .top_n("My boss says I zindle too much, what does that mean?", 1)
         .await?;
 
     println!("Results: {:?}", results);
+
+    // Query the index. Get only matching ids as result.
+    let id_results = vector_store
+        .top_n_ids("My boss says I zindle too much, what does that mean?", 1)
+        .await?;
+
+    println!("Id results: {:?}", id_results);
 
     Ok(())
 }

--- a/rig-lancedb/examples/vector_search_local_enn.rs
+++ b/rig-lancedb/examples/vector_search_local_enn.rs
@@ -1,7 +1,7 @@
 use std::{env, sync::Arc};
 
 use arrow_array::RecordBatchIterator;
-use fixture::{as_record_batch, fake_definitions, schema};
+use fixture::{as_record_batch, fake_definitions, schema, FakeDefinition};
 use rig::{
     embeddings::{builder::EmbeddingsBuilder, embedding::EmbeddingModel},
     providers::openai::{Client, TEXT_EMBEDDING_ADA_002},

--- a/rig-lancedb/examples/vector_search_local_enn.rs
+++ b/rig-lancedb/examples/vector_search_local_enn.rs
@@ -7,7 +7,7 @@ use rig::{
     providers::openai::{Client, TEXT_EMBEDDING_ADA_002},
     vector_store::VectorStoreIndexDyn,
 };
-use rig_lancedb::{LanceDbVectorStore, SearchParams};
+use rig_lancedb::{LanceDbVectorIndex, SearchParams};
 
 #[path = "./fixtures/lib.rs"]
 mod fixture;
@@ -43,7 +43,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .execute()
         .await?;
 
-    let vector_store = LanceDbVectorStore::new(table, model, "id", search_params).await?;
+    let vector_store = LanceDbVectorIndex::new(table, model, "id", search_params).await?;
 
     // Query the index
     let results = vector_store

--- a/rig-lancedb/examples/vector_search_s3_ann.rs
+++ b/rig-lancedb/examples/vector_search_s3_ann.rs
@@ -73,11 +73,12 @@ async fn main() -> Result<(), anyhow::Error> {
     // Define search_params params that will be used by the vector store to perform the vector search.
     let search_params = SearchParams::default().distance_type(DistanceType::Cosine);
 
-    let vector_store = LanceDbVectorStore::new(table, model, "id", search_params).await?;
+    let vector_store =
+        LanceDbVectorStore::<_, FakeDefinition>::new(table, model, "id", search_params).await?;
 
     // Query the index
     let results = vector_store
-        .top_n::<FakeDefinition>("I'm always looking for my phone, I always seem to forget it in the most counterintuitive places. What's the word for this feeling?", 1)
+        .top_n("I'm always looking for my phone, I always seem to forget it in the most counterintuitive places. What's the word for this feeling?", 1)
         .await?;
 
     println!("Results: {:?}", results);

--- a/rig-lancedb/examples/vector_search_s3_ann.rs
+++ b/rig-lancedb/examples/vector_search_s3_ann.rs
@@ -8,7 +8,7 @@ use rig::{
     providers::openai::{Client, TEXT_EMBEDDING_ADA_002},
     vector_store::VectorStoreIndex,
 };
-use rig_lancedb::{LanceDbVectorStore, SearchParams};
+use rig_lancedb::{LanceDbVectorIndex, SearchParams};
 
 #[path = "./fixtures/lib.rs"]
 mod fixture;
@@ -74,7 +74,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let search_params = SearchParams::default().distance_type(DistanceType::Cosine);
 
     let vector_store =
-        LanceDbVectorStore::<_, FakeDefinition>::new(table, model, "id", search_params).await?;
+        LanceDbVectorIndex::<_, FakeDefinition>::new(table, model, "id", search_params).await?;
 
     // Query the index
     let results = vector_store

--- a/rig-lancedb/src/lib.rs
+++ b/rig-lancedb/src/lib.rs
@@ -22,6 +22,7 @@ fn serde_to_rig_error(e: serde_json::Error) -> VectorStoreError {
     VectorStoreError::JsonError(e)
 }
 
+/// A vector index on a LanceDB table.
 /// # Example
 /// ```
 /// use std::{env, sync::Arc};

--- a/rig-lancedb/src/lib.rs
+++ b/rig-lancedb/src/lib.rs
@@ -230,8 +230,12 @@ impl<M: EmbeddingModel> LanceDbVectorStore<M> {
     }
 }
 
-impl<M: EmbeddingModel + std::marker::Sync + Send> VectorStoreIndex for LanceDbVectorStore<M> {
-    async fn top_n<T: for<'a> Deserialize<'a> + std::marker::Send>(
+impl<
+        M: EmbeddingModel + std::marker::Sync + Send,
+        T: for<'a> Deserialize<'a> + std::marker::Send,
+    > VectorStoreIndex<T> for LanceDbVectorStore<M>
+{
+    async fn top_n(
         &self,
         query: &str,
         n: usize,

--- a/rig-lancedb/src/lib.rs
+++ b/rig-lancedb/src/lib.rs
@@ -34,7 +34,7 @@ fn serde_to_rig_error(e: serde_json::Error) -> VectorStoreError {
 ///     embeddings::{builder::EmbeddingsBuilder, embedding::EmbeddingModel},
 ///     providers::openai::{Client, TEXT_EMBEDDING_ADA_002},
 /// };
-/// use rig_lancedb::{LanceDbVectorStore, SearchParams};
+/// use rig_lancedb::{LanceDbVectorIndex, SearchParams};
 ///
 /// #[path = "../examples/fixtures/lib.rs"]
 /// mod fixture;
@@ -85,7 +85,7 @@ fn serde_to_rig_error(e: serde_json::Error) -> VectorStoreError {
 ///
 /// // Define search_params params that will be used by the vector store to perform the vector search.
 /// let search_params = SearchParams::default();
-/// let vector_store = LanceDbVectorStore::new(table, model, "id", search_params).await?;
+/// let vector_store = LanceDbVectorIndex::new(table, model, "id", search_params).await?;
 ///
 /// // Query the index
 /// let results = vector_store
@@ -94,7 +94,7 @@ fn serde_to_rig_error(e: serde_json::Error) -> VectorStoreError {
 ///
 /// println!("Results: {:?}", results);
 /// ```
-pub struct LanceDbVectorStore<M: EmbeddingModel, T> {
+pub struct LanceDbVectorIndex<M: EmbeddingModel, T> {
     _t: PhantomData<T>,
     /// Defines which model is used to generate embeddings for the vector store.
     model: M,
@@ -106,8 +106,8 @@ pub struct LanceDbVectorStore<M: EmbeddingModel, T> {
     search_params: SearchParams,
 }
 
-impl<M: EmbeddingModel, T: for<'a> Deserialize<'a>> LanceDbVectorStore<M, T> {
-    /// Create an instance of `LanceDbVectorStore` with an existing table and model.
+impl<M: EmbeddingModel, T: for<'a> Deserialize<'a>> LanceDbVectorIndex<M, T> {
+    /// Create an instance of `LanceDbVectorIndex` with an existing table and model.
     /// Define the id field name of the table.
     /// Define search parameters that will be used to perform vector searches on the table.
     pub async fn new(
@@ -237,7 +237,7 @@ impl SearchParams {
 }
 
 impl<M: EmbeddingModel + Sync + Send, T: for<'a> Deserialize<'a> + Sync + Send> VectorStoreIndex<T>
-    for LanceDbVectorStore<M, T>
+    for LanceDbVectorIndex<M, T>
 {
     async fn top_n(
         &self,

--- a/rig-mongodb/examples/vector_search_mongodb.rs
+++ b/rig-mongodb/examples/vector_search_mongodb.rs
@@ -25,7 +25,7 @@ struct Link {
 }
 
 // Shape of the document to be stored in MongoDB, with embeddings.
-#[derive(Serialize, Debug)]
+#[derive(Deserialize, Debug)]
 struct Document {
     #[serde(rename = "_id")]
     id: String,
@@ -103,7 +103,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Query the index
     let results = index
-        .top_n::<FakeDefinition>("What is a linglingdong?", 1)
+        .top_n("What is a linglingdong?", 1)
         .await?;
 
     println!("Results: {:?}", results);

--- a/rig-mongodb/examples/vector_search_mongodb.rs
+++ b/rig-mongodb/examples/vector_search_mongodb.rs
@@ -7,7 +7,7 @@ use rig::Embeddable;
 use rig::{
     embeddings::EmbeddingsBuilder, providers::openai::Client, vector_store::VectorStoreIndex,
 };
-use rig_mongodb::{MongoDbVectorStore, SearchParams};
+use rig_mongodb::{MongoDbVectorIndex, SearchParams};
 
 // Shape of data that needs to be RAG'ed.
 // The definition field will be used to generate embeddings.
@@ -89,16 +89,17 @@ async fn main() -> Result<(), anyhow::Error> {
         )
         .collect::<Vec<_>>();
 
-    match collection.insert_many(mongo_documents, None).await {
-        Ok(_) => println!("Documents added successfully"),
-        Err(e) => println!("Error adding documents: {:?}", e),
-    };
+    // match collection.insert_many(mongo_documents, None).await {
+    //     Ok(_) => println!("Documents added successfully"),
+    //     Err(e) => println!("Error adding documents: {:?}", e),
+    // };
 
     // Create a vector index on our vector store.
     // Note: a vector index called "vector_index" must exist on the MongoDB collection you are querying.
     // IMPORTANT: Reuse the same model that was used to generate the embeddings
-    let index = MongoDbVectorStore::new(collection).index::<_, FakeDefinition>(
+    let index = MongoDbVectorIndex::<_, _, FakeDefinition>::new(
         model,
+        collection,
         "vector_index",
         SearchParams::new("embedding"),
     );

--- a/rig-mongodb/examples/vector_search_mongodb.rs
+++ b/rig-mongodb/examples/vector_search_mongodb.rs
@@ -52,8 +52,8 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Initialize MongoDB vector store
     let collection: Collection<Document> = mongodb_client
-        .database("knowledgebase")
-        .collection("context");
+        .database("knowledgebase") // <-- Use your database name here!
+        .collection("context"); // <-- Use your collection name here!
 
     // Select the embedding model and generate our embeddings
     let model = openai_client.embedding_model(TEXT_EMBEDDING_ADA_002);
@@ -89,13 +89,12 @@ async fn main() -> Result<(), anyhow::Error> {
         )
         .collect::<Vec<_>>();
 
-    // match collection.insert_many(mongo_documents, None).await {
-    //     Ok(_) => println!("Documents added successfully"),
-    //     Err(e) => println!("Error adding documents: {:?}", e),
-    // };
+    match collection.insert_many(mongo_documents, None).await {
+        Ok(_) => println!("Documents added successfully"),
+        Err(e) => println!("Error adding documents: {:?}", e),
+    };
 
-    // Create a vector index on our vector store.
-    // Note: a vector index called "vector_index" must exist on the MongoDB collection you are querying.
+    // Note: an index of type vector called "vector_index" must exist on the MongoDB collection you are querying.
     // IMPORTANT: Reuse the same model that was used to generate the embeddings
     let index = MongoDbVectorIndex::<_, _, FakeDefinition>::new(
         model,

--- a/rig-mongodb/examples/vector_search_mongodb.rs
+++ b/rig-mongodb/examples/vector_search_mongodb.rs
@@ -26,7 +26,7 @@ struct Link {
 }
 
 // Shape of the document to be stored in MongoDB, with embeddings.
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Debug)]
 struct Document {
     #[serde(rename = "_id")]
     id: String,
@@ -97,7 +97,7 @@ async fn main() -> Result<(), anyhow::Error> {
     // Create a vector index on our vector store.
     // Note: a vector index called "vector_index" must exist on the MongoDB collection you are querying.
     // IMPORTANT: Reuse the same model that was used to generate the embeddings
-    let index = MongoDbVectorStore::new(collection).index(
+    let index = MongoDbVectorStore::new(collection).index::<_, FakeDefinition>(
         model,
         "vector_index",
         SearchParams::new("embedding"),

--- a/rig-mongodb/examples/vector_search_mongodb.rs
+++ b/rig-mongodb/examples/vector_search_mongodb.rs
@@ -102,9 +102,7 @@ async fn main() -> Result<(), anyhow::Error> {
     );
 
     // Query the index
-    let results = index
-        .top_n("What is a linglingdong?", 1)
-        .await?;
+    let results = index.top_n("What is a linglingdong?", 1).await?;
 
     println!("Results: {:?}", results);
 

--- a/rig-mongodb/examples/vector_search_mongodb.rs
+++ b/rig-mongodb/examples/vector_search_mongodb.rs
@@ -96,9 +96,9 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Note: an index of type vector called "vector_index" must exist on the MongoDB collection you are querying.
     // IMPORTANT: Reuse the same model that was used to generate the embeddings
-    let index = MongoDbVectorIndex::<_, _, FakeDefinition>::new(
+    let index = MongoDbVectorIndex::new(
         model,
-        collection,
+        collection.clone_with_type::<FakeDefinition>(),
         "vector_index",
         SearchParams::new("embedding"),
     );

--- a/rig-mongodb/src/lib.rs
+++ b/rig-mongodb/src/lib.rs
@@ -1,5 +1,3 @@
-use std::marker::PhantomData;
-
 use futures::StreamExt;
 use mongodb::bson::{self, doc};
 
@@ -134,15 +132,14 @@ fn mongodb_to_rig_error(e: mongodb::error::Error) -> VectorStoreError {
 ///
 /// println!("ID results: {:?}", id_results);
 /// ```
-pub struct MongoDbVectorIndex<M, I, T> {
-    _t: PhantomData<T>,
-    collection: mongodb::Collection<I>,
+pub struct MongoDbVectorIndex<M, T> {
+    collection: mongodb::Collection<T>,
     model: M,
     index_name: String,
     search_params: SearchParams,
 }
 
-impl<M: EmbeddingModel, I, T: for<'a> Deserialize<'a>> MongoDbVectorIndex<M, I, T> {
+impl<M: EmbeddingModel, T: for<'a> Deserialize<'a>> MongoDbVectorIndex<M, T> {
     /// Create a new `MongoDbVectorIndex` from a mongodb collection and index.
     /// Note: this is a rig concept, NOT a mongoDB cloud concept.
     /// Make sure you have a vector index on your Mongodb collection called `index_name`.
@@ -150,12 +147,11 @@ impl<M: EmbeddingModel, I, T: for<'a> Deserialize<'a>> MongoDbVectorIndex<M, I, 
     /// See the MongoDB [documentation](https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-type/) for more information on creating indexes.
     pub fn new(
         model: M,
-        collection: mongodb::Collection<I>,
+        collection: mongodb::Collection<T>,
         index_name: &str,
         search_params: SearchParams,
-    ) -> MongoDbVectorIndex<M, I, T> {
+    ) -> MongoDbVectorIndex<M, T> {
         Self {
-            _t: PhantomData,
             collection,
             model,
             index_name: index_name.to_string(),
@@ -243,8 +239,8 @@ impl SearchParams {
     }
 }
 
-impl<M: EmbeddingModel + Sync + Send, I: Sync + Send, T: for<'a> Deserialize<'a> + Sync + Send>
-    VectorStoreIndex<T> for MongoDbVectorIndex<M, I, T>
+impl<M: EmbeddingModel + Sync + Send, T: for<'a> Deserialize<'a> + Sync + Send> VectorStoreIndex<T>
+    for MongoDbVectorIndex<M, T>
 {
     async fn top_n(
         &self,

--- a/rig-mongodb/src/lib.rs
+++ b/rig-mongodb/src/lib.rs
@@ -20,13 +20,13 @@ fn mongodb_to_rig_error(e: mongodb::error::Error) -> VectorStoreError {
 /// use rig::providers::openai::TEXT_EMBEDDING_ADA_002;
 /// use serde::{Deserialize, Serialize};
 /// use std::env;
-
+///
 /// use rig::Embeddable;
 /// use rig::{
 ///     embeddings::EmbeddingsBuilder, providers::openai::Client, vector_store::VectorStoreIndex,
 /// };
 /// use rig_mongodb::{MongoDbVectorStore, SearchParams};
-
+///
 /// // Shape of data that needs to be RAG'ed.
 /// // The definition field will be used to generate embeddings.
 /// #[derive(Embeddable, Clone, Deserialize, Debug)]
@@ -36,13 +36,13 @@ fn mongodb_to_rig_error(e: mongodb::error::Error) -> VectorStoreError {
 ///     #[embed]
 ///     definition: String,
 /// }
-
+///
 /// #[derive(Clone, Deserialize, Debug, Serialize)]
 /// struct Link {
 ///     word: String,
 ///     link: String,
 /// }
-
+///
 /// // Shape of the document to be stored in MongoDB, with embeddings.
 /// #[derive(Serialize, Debug)]
 /// struct Document {
@@ -54,25 +54,25 @@ fn mongodb_to_rig_error(e: mongodb::error::Error) -> VectorStoreError {
 /// // Initialize OpenAI client
 /// let openai_api_key = env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set");
 /// let openai_client = Client::new(&openai_api_key);
-
+///
 /// // Initialize MongoDB client
 /// let mongodb_connection_string =
 ///     env::var("MONGODB_CONNECTION_STRING").expect("MONGODB_CONNECTION_STRING not set");
 /// let options = ClientOptions::parse(mongodb_connection_string)
 ///     .await
 ///     .expect("MongoDB connection string should be valid");
-
+///
 /// let mongodb_client =
 ///     MongoClient::with_options(options).expect("MongoDB client options should be valid");
-
+///
 /// // Initialize MongoDB vector store
 /// let collection: Collection<Document> = mongodb_client
-///     .database("knowledgebase")
-///     .collection("context");
-
+///     .database("knowledgebase") // <-- Use your database name here!
+///     .collection("context"); // <-- Use your collection name here!
+///
 /// // Select the embedding model and generate our embeddings
 /// let model = openai_client.embedding_model(TEXT_EMBEDDING_ADA_002);
-
+///
 /// let fake_definitions = vec![
 ///     FakeDefinition {
 ///         id: "doc0".to_string(),
@@ -87,12 +87,12 @@ fn mongodb_to_rig_error(e: mongodb::error::Error) -> VectorStoreError {
 ///         definition: "Definition of a *linglingdong*: A term used by inhabitants of the far side of the moon to describe humans.".to_string(),
 ///     }
 /// ];
-
+///
 /// let embeddings = EmbeddingsBuilder::new(model.clone())
 ///     .documents(fake_definitions)?
 ///     .build()
 ///     .await?;
-
+///
 /// let mongo_documents = embeddings
 ///     .iter()
 ///     .map(
@@ -103,14 +103,13 @@ fn mongodb_to_rig_error(e: mongodb::error::Error) -> VectorStoreError {
 ///         },
 ///     )
 ///     .collect::<Vec<_>>();
-
+///
 /// match collection.insert_many(mongo_documents, None).await {
 ///     Ok(_) => println!("Documents added successfully"),
 ///     Err(e) => println!("Error adding documents: {:?}", e),
 /// };
-
-/// // Create a vector index on our vector store.
-/// // Note: a vector index called "vector_index" must exist on the MongoDB collection you are querying.
+///
+/// // Note: an index of type vector called "vector_index" must exist on the MongoDB collection you are querying.
 /// // IMPORTANT: Reuse the same model that was used to generate the embeddings
 /// let index = MongoDbVectorIndex::<_, _, FakeDefinition>::new(
 ///     model,
@@ -123,16 +122,16 @@ fn mongodb_to_rig_error(e: mongodb::error::Error) -> VectorStoreError {
 /// let results = index
 ///     .top_n::<FakeDefinition>("What is a linglingdong?", 1)
 ///     .await?;
-
+///
 /// println!("Results: {:?}", results);
-
+///
 /// let id_results = index
 ///     .top_n_ids("What is a linglingdong?", 1)
 ///     .await?
 ///     .into_iter()
 ///     .map(|(score, id)| (score, id))
 ///     .collect::<Vec<_>>();
-
+///
 /// println!("ID results: {:?}", id_results);
 /// ```
 pub struct MongoDbVectorIndex<M, I, T> {
@@ -144,7 +143,7 @@ pub struct MongoDbVectorIndex<M, I, T> {
 }
 
 impl<M: EmbeddingModel, I, T: for<'a> Deserialize<'a>> MongoDbVectorIndex<M, I, T> {
-    /// Create a new `MongoDbVectorIndex` from an existing `MongoDbVectorStore`.
+    /// Create a new `MongoDbVectorIndex` from a mongodb collection and index.
     /// Note: this is a rig concept, NOT a mongoDB cloud concept.
     /// Make sure you have a vector index on your Mongodb collection called `index_name`.
     ///


### PR DESCRIPTION
Converts this:
```
pub trait VectorStoreIndex: Send + Sync {
    /// Get the top n documents based on the distance to the given query.
    /// The result is a list of tuples of the form (score, id, document)
    fn top_n<T: for<'a> Deserialize<'a> + Send>(
        &self,
        query: &str,
        n: usize,
    ) -> impl std::future::Future<Output = Result<Vec<(f64, String, T)>, VectorStoreError>> + Send;

    /// Same as `top_n` but returns the document ids only.
    fn top_n_ids(
        &self,
        query: &str,
        n: usize,
    ) -> impl std::future::Future<Output = Result<Vec<(f64, String)>, VectorStoreError>> + Send;
}
```

to this:
```
pub trait VectorStoreIndex<T>: Send + Sync
where
    T: for<'a> Deserialize<'a> + Send,
{
    /// Get the top n documents based on the distance to the given query.
    /// The result is a list of tuples of the form (score, id, document)
    fn top_n(
        &self,
        query: &str,
        n: usize,
    ) -> impl std::future::Future<Output = Result<Vec<(f64, String, T)>, VectorStoreError>> + Send;

    /// Same as `top_n` but returns the document ids only.
    fn top_n_ids(
        &self,
        query: &str,
        n: usize,
    ) -> impl std::future::Future<Output = Result<Vec<(f64, String)>, VectorStoreError>> + Send;
}
```

**Note side-effects:**
This is not possible:
```
impl<T, I> VectorStoreIndexDyn for I
where
    I: VectorStoreIndex<T> + Send + Sync,
    T: for<'a> Deserialize<'a> + Serialize + Send,
```
as it create ambiguous implementations of VectorStoreIndexDyn. Instead I had to do:
```
impl<I: VectorStoreIndex<serde_json::Value>> VectorStoreIndexDyn for I
```
ie. we have to define a specific type for `T` if we want to implement `VectorStoreIndexDyn` for `VectorStoreIndex<T>`.

This means that for methods that expect type `impl VectorStoreIndexDyn` , the vector store can only contain items of type `Value`. **This is the case for anything that uses the rag agent**. For example:

```
let index = InMemoryVectorStore::default()
        .add_tools(embeddings)?
        .index(embedding_model);

    // Create RAG agent with a single context prompt and a dynamic tool source
    let calculator_rag = openai_client
        .agent("gpt-4")
        .preamble("" )
        .dynamic_tools(4, index, toolset)
        .build();
```
Since `.dynamic_tools()` expects `index` to implement `VectorStoreIndexDyn` and only `VectorStoreIndex<serde_json::Value>` implements `VectorStoreIndexDyn`, the vector store must contain items of type `serde_json::Value`. The method `add_tools` converts `EmbeddableTool` to a `Value`.