### PR TITLE
docs(readme): Add light-theme logo and mongodb logo for companion crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 <p align="center">
-<img src="img/rig_logo.svg" alt="Rig Logo" style="width: 75%; height: 75%;"><br>
+<picture>
+    <source media="(prefers-color-scheme: dark)" srcset="img/rig_logo_dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="img/rig_logo.svg">
+    <img src="img/rig_logo.svg" style="width: 40%; height: 40%;" alt="Rig logo">
+</picture>
+<br>
 <a href="https://crates.io/crates/rig-core"><img src="https://img.shields.io/crates/v/rig-core.svg" /></a>
 &nbsp;
 <a href="https://discord.gg/playgrounds"><img src="https://img.shields.io/discord/511303648119226382?color=%236d82cc&label=Discord&logo=discord&logoColor=white" /></a>
@@ -12,7 +17,7 @@
 </p>
 &nbsp;
 
-> [!WARNING]  
+> [!WARNING]
 > Here be dragons! Rig is **alpha** software and **will** contain breaking changes as it evolves. We'll annotate them and highlight migration paths as we encounter them.
 
 

--- a/img/rig_logo_dark.svg
+++ b/img/rig_logo_dark.svg
@@ -3,8 +3,8 @@
   <defs>
     <style>
       .cls-1 {
-        fill: black;
-        stroke-width: 10px;
+        fill: white;
+        stroke-width: 0px;
       }
     </style>
   </defs>

--- a/rig-mongodb/README.md
+++ b/rig-mongodb/README.md
@@ -1,2 +1,34 @@
-# Rig-mongodb
-This project implements a Rig vector store based on MongoDB.
+
+
+<div style="display: flex; align-items: center; justify-content: center;">\
+    <picture>
+        <source media="(prefers-color-scheme: dark)" srcset="../img/rig_logo_dark.svg">
+        <source media="(prefers-color-scheme: light)" srcset="../img/rig_logo.svg">
+        <img src="../img/rig_logo.svg" width="200" alt="Rig logo">
+    </picture>
+    <span style="font-size: 48px; margin: 0 20px; font-weight: regular; font-family: Open Sans, sans-serif;"> + </span>
+    <picture>
+        <source media="(prefers-color-scheme: dark)" srcset="https://companieslogo.com/img/orig/MDB_BIG.D-96d632a9.png?t=1720244492">
+        <source media="(prefers-color-scheme: light)" srcset="https://cdn.iconscout.com/icon/free/png-256/free-mongodb-logo-icon-download-in-svg-png-gif-file-formats--wordmark-programming-langugae-freebies-pack-logos-icons-1175140.png?f=webp&w=256">
+        <img src="https://cdn.iconscout.com/icon/free/png-256/free-mongodb-logo-icon-download-in-svg-png-gif-file-formats--wordmark-programming-langugae-freebies-pack-logos-icons-1175140.png?f=webp&w=256" width="200" alt="MongoDB logo">
+    </picture>
+</div>
+
+<br><br>
+
+## Rig-MongoDB
+This companion crate implements a Rig vector store based on MongoDB.
+
+## Usage
+
+Add the companion crate to your `Cargo.toml`, along with the rig-core crate:
+
+```toml
+[dependencies]
+rig-mongodb = "0.1.2"
+rig-core = "0.2.1"
+```
+
+You can also run `cargo add rig-mongodb rig-core` to add the most recent versions of the dependencies to your project.
+
+See the [examples](./examples) folder for usage examples.

--- a/rig-mongodb/examples/vector_search_mongodb.rs
+++ b/rig-mongodb/examples/vector_search_mongodb.rs
@@ -1,12 +1,12 @@
 use mongodb::{options::ClientOptions, Client as MongoClient, Collection};
-use std::env;
-
+use rig::vector_store::VectorStore;
 use rig::{
     embeddings::{DocumentEmbeddings, EmbeddingsBuilder},
     providers::openai::{Client, TEXT_EMBEDDING_ADA_002},
-    vector_store::{VectorStore, VectorStoreIndex},
+    vector_store::VectorStoreIndex,
 };
 use rig_mongodb::{MongoDbVectorStore, SearchParams};
+use std::env;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {


### PR DESCRIPTION

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2-R7): Updated the logo display to support dark and light themes using the `<picture>` element. Adjusted the size of the logo for better visual consistency.
* [`rig-mongodb/README.md`](diffhunk://#diff-5a83ec9b688de8821f3207fbc086d8df6ce3b9afe68579b6bca7cc2769ee026bL1-R34): Enhanced the README with a new logo display, added usage instructions, and provided guidance on adding the crate to a `Cargo.toml` file.
