### PR TITLE
feat: Qdrant support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,6 +365,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,6 +745,53 @@ dependencies = [
  "aws-smithy-types",
  "rustc_version 0.4.1",
  "tracing",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504e3947307ac8326a5437504c517c4b56716c9d98fac0028c2acc7ca47d70ae"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper 1.0.1",
+ "tower 0.5.1",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 1.0.1",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -1556,6 +1625,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.10",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.79",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2201,6 +2301,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2239,6 +2340,20 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
+ "tower-service",
+ "webpki-roots 0.26.6",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
+dependencies = [
+ "hyper 1.4.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
  "tower-service",
 ]
 
@@ -2498,7 +2613,7 @@ dependencies = [
  "moka",
  "object_store",
  "pin-project",
- "prost",
+ "prost 0.12.6",
  "prost-build",
  "rand",
  "roaring",
@@ -2557,7 +2672,7 @@ dependencies = [
  "num_cpus",
  "object_store",
  "pin-project",
- "prost",
+ "prost 0.12.6",
  "rand",
  "roaring",
  "serde_json",
@@ -2591,7 +2706,7 @@ dependencies = [
  "lance-core",
  "lazy_static",
  "log",
- "prost",
+ "prost 0.12.6",
  "snafu",
  "tokio",
 ]
@@ -2620,9 +2735,9 @@ dependencies = [
  "lance-core",
  "log",
  "num-traits",
- "prost",
+ "prost 0.12.6",
  "prost-build",
- "prost-types",
+ "prost-types 0.12.6",
  "rand",
  "snafu",
  "tokio",
@@ -2656,9 +2771,9 @@ dependencies = [
  "log",
  "num-traits",
  "object_store",
- "prost",
+ "prost 0.12.6",
  "prost-build",
- "prost-types",
+ "prost-types 0.12.6",
  "roaring",
  "snafu",
  "tempfile",
@@ -2704,7 +2819,7 @@ dependencies = [
  "moka",
  "num-traits",
  "object_store",
- "prost",
+ "prost 0.12.6",
  "prost-build",
  "rand",
  "rayon",
@@ -2750,7 +2865,7 @@ dependencies = [
  "object_store",
  "path_abs",
  "pin-project",
- "prost",
+ "prost 0.12.6",
  "prost-build",
  "rand",
  "shellexpand",
@@ -2811,9 +2926,9 @@ dependencies = [
  "lazy_static",
  "log",
  "object_store",
- "prost",
+ "prost 0.12.6",
  "prost-build",
- "prost-types",
+ "prost-types 0.12.6",
  "rand",
  "rangemap",
  "roaring",
@@ -3080,6 +3195,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3225,7 +3346,7 @@ dependencies = [
  "trust-dns-resolver",
  "typed-builder",
  "uuid",
- "webpki-roots",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
@@ -3740,7 +3861,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.12.6",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.3",
 ]
 
 [[package]]
@@ -3757,8 +3888,8 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost",
- "prost-types",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
  "regex",
  "syn 2.0.79",
  "tempfile",
@@ -3778,12 +3909,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
- "prost",
+ "prost 0.12.6",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670"
+dependencies = [
+ "prost 0.13.3",
 ]
 
 [[package]]
@@ -3795,6 +3948,24 @@ dependencies = [
  "bitflags 2.6.0",
  "memchr",
  "unicase",
+]
+
+[[package]]
+name = "qdrant-client"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbff72d38eac3860f5888f02d4688690de6cdc77c901112d3b0788694afc1d37"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "futures-util",
+ "prost 0.13.3",
+ "prost-types 0.13.3",
+ "reqwest 0.12.8",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tonic",
 ]
 
 [[package]]
@@ -4104,6 +4275,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots 0.26.6",
  "windows-registry",
 ]
 
@@ -4163,6 +4335,18 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "rig-qdrant"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "qdrant-client",
+ "rig-core",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -4291,6 +4475,7 @@ version = "0.23.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "415d9944693cb90382053259f89fbb077ea730ad7273047ec63b19bc9b160ba8"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -5263,6 +5448,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "flate2",
+ "h2 0.4.6",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.13.3",
+ "rustls-native-certs 0.8.0",
+ "rustls-pemfile 2.2.0",
+ "socket2 0.5.7",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 0.1.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
 name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5646,6 +5905,15 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "weezl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,3 @@
 [workspace]
 resolver = "2"
-members = [
-    "rig-core", "rig-lancedb",
-    "rig-mongodb",
-]
+members = ["rig-core", "rig-lancedb", "rig-mongodb", "rig-qdrant"]

--- a/rig-core/examples/vector_search.rs
+++ b/rig-core/examples/vector_search.rs
@@ -36,7 +36,6 @@ async fn main() -> Result<(), anyhow::Error> {
         .top_n_ids("What is a linglingdong?", 1)
         .await?
         .into_iter()
-        .map(|(score, id)| (score, id))
         .collect::<Vec<_>>();
 
     println!("ID results: {:?}", id_results);

--- a/rig-mongodb/examples/vector_search_mongodb.rs
+++ b/rig-mongodb/examples/vector_search_mongodb.rs
@@ -65,7 +65,6 @@ async fn main() -> Result<(), anyhow::Error> {
         .top_n_ids("What is a linglingdong?", 1)
         .await?
         .into_iter()
-        .map(|(score, id)| (score, id))
         .collect::<Vec<_>>();
 
     println!("ID results: {:?}", id_results);

--- a/rig-qdrant/Cargo.toml
+++ b/rig-qdrant/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "rig-qdrant"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+readme = "README.md"
+description = "Rig vector store index integration for Qdrant. https://qdrant.tech"
+repository = "https://github.com/0xPlaygrounds/rig"
+
+[dependencies]
+rig-core = { path = "../rig-core", version = "0.3.0" }
+serde_json = "1.0.128"
+serde = "1.0.210"
+qdrant-client = "1.12.1"
+
+[dev-dependencies]
+tokio = { version = "1.40.0", features = ["rt-multi-thread"] }
+anyhow = "1.0.89"

--- a/rig-qdrant/LICENSE
+++ b/rig-qdrant/LICENSE
@@ -1,0 +1,7 @@
+Copyright (c) 2024, Playgrounds Analytics Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/rig-qdrant/README.md
+++ b/rig-qdrant/README.md
@@ -1,0 +1,5 @@
+# Rig-Qdrant
+
+Vector store index integration for [Qdrant](https://qdrant.tech/). This integration supports dense vector retrieval using Rig's embedding providers. It is also extensible to allow all [hybrid queries](https://qdrant.tech/documentation/concepts/hybrid-queries/) supported by Qdrant.
+
+You can find end-to-end examples [here](https://github.com/0xPlaygrounds/rig/tree/main/rig-qdrant/examples).

--- a/rig-qdrant/examples/qdrant_vector_search.rs
+++ b/rig-qdrant/examples/qdrant_vector_search.rs
@@ -1,4 +1,9 @@
 // To run this example:
+//
+// export OPENAI_API_KEY=<YOUR-API-KEY>
+//
+// docker run -p 6333:63333 -p 6334:6334 qdrant/qdrant
+//
 // cargo run --release --example qdrant_vector_search
 
 use std::env;

--- a/rig-qdrant/examples/qdrant_vector_search.rs
+++ b/rig-qdrant/examples/qdrant_vector_search.rs
@@ -1,10 +1,10 @@
 // To run this example:
 //
 // export OPENAI_API_KEY=<YOUR-API-KEY>
-//
-// docker run -p 6333:63333 -p 6334:6334 qdrant/qdrant
-//
+// docker run -p 6333:6333 -p 6334:6334 qdrant/qdrant
 // cargo run --release --example qdrant_vector_search
+//
+// You can view the data at http://localhost:6333/dashboard
 
 use std::env;
 

--- a/rig-qdrant/examples/qdrant_vector_search.rs
+++ b/rig-qdrant/examples/qdrant_vector_search.rs
@@ -1,0 +1,80 @@
+// To run this example:
+// cargo run --release --example qdrant_vector_search
+
+use std::env;
+
+use qdrant_client::{
+    qdrant::{
+        CreateCollectionBuilder, Distance, PointStruct, QueryPointsBuilder, UpsertPointsBuilder,
+        VectorParamsBuilder,
+    },
+    Payload, Qdrant,
+};
+use rig::{
+    embeddings::EmbeddingsBuilder,
+    providers::openai::{Client, TEXT_EMBEDDING_ADA_002},
+    vector_store::VectorStoreIndex,
+};
+use rig_qdrant::QdrantVectorStore;
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    const COLLECTION_NAME: &str = "rig-collection";
+
+    let client = Qdrant::from_url("http://localhost:6334").build()?;
+
+    // Create a collection with 1536 dimensions if it doesn't exist
+    if !client.collection_exists(COLLECTION_NAME).await? {
+        client
+            .create_collection(
+                CreateCollectionBuilder::new(COLLECTION_NAME)
+                    .vectors_config(VectorParamsBuilder::new(1536, Distance::Cosine)),
+            )
+            .await?;
+    }
+
+    // Initialize OpenAI client.
+    // Get your API key from https://platform.openai.com/api-keys
+    let openai_api_key = env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set");
+    let openai_client = Client::new(&openai_api_key);
+
+    let model = openai_client.embedding_model(TEXT_EMBEDDING_ADA_002);
+
+    let documents = EmbeddingsBuilder::new(model.clone())
+        .simple_document("0981d983-a5f8-49eb-89ea-f7d3b2196d2e", "Definition of a *flurbo*: A flurbo is a green alien that lives on cold planets")
+        .simple_document("62a36d43-80b6-4fd6-990c-f75bb02287d1", "Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.")
+        .simple_document("f9e17d59-32e5-440c-be02-b2759a654824", "Definition of a *linglingdong*: A term used by inhabitants of the far side of the moon to describe humans.")
+        .build()
+        .await?;
+
+    let points: Vec<PointStruct> = documents
+        .into_iter()
+        .map(|d| {
+            let vec: Vec<f32> = d.embeddings[0].vec.iter().map(|&x| x as f32).collect();
+            PointStruct::new(
+                d.id,
+                vec,
+                Payload::try_from(json!({
+                    "document": d.document,
+                }))
+                .unwrap(),
+            )
+        })
+        .collect();
+
+    client
+        .upsert_points(UpsertPointsBuilder::new(COLLECTION_NAME, points))
+        .await?;
+
+    let query_params = QueryPointsBuilder::new(COLLECTION_NAME).with_payload(true);
+    let vector_store = QdrantVectorStore::new(client, model, query_params.build());
+
+    let results = vector_store
+        .top_n::<serde_json::Value>("What is a linglingdong?", 1)
+        .await?;
+
+    println!("Results: {:?}", results);
+
+    Ok(())
+}

--- a/rig-qdrant/src/lib.rs
+++ b/rig-qdrant/src/lib.rs
@@ -7,14 +7,13 @@ use rig::{
     vector_store::{VectorStoreError, VectorStoreIndex},
 };
 use serde::Deserialize;
-use std::sync::Arc;
 
 /// Represents a vector store implementation using Qdrant - https://qdrant.tech/ as the backend.
 pub struct QdrantVectorStore<M: EmbeddingModel> {
     /// Model used to generate embeddings for the vector store
-    model: Arc<M>,
+    model: M,
     /// Client instance for Qdrant server communication
-    client: Arc<Qdrant>,
+    client: Qdrant,
     /// Default search parameters
     query_params: QueryPoints,
 }
@@ -29,8 +28,8 @@ impl<M: EmbeddingModel> QdrantVectorStore<M> {
     ///     Reference: https://api.qdrant.tech/v-1-12-x/api-reference/search/query-points
     pub fn new(client: Qdrant, model: M, query_params: QueryPoints) -> Self {
         Self {
-            client: Arc::new(client),
-            model: Arc::new(model),
+            client,
+            model,
             query_params,
         }
     }

--- a/rig-qdrant/src/lib.rs
+++ b/rig-qdrant/src/lib.rs
@@ -1,0 +1,124 @@
+use qdrant_client::{
+    qdrant::{point_id::PointIdOptions, PointId, Query, QueryPoints},
+    Qdrant,
+};
+use rig::{
+    embeddings::EmbeddingModel,
+    vector_store::{VectorStoreError, VectorStoreIndex},
+};
+use serde::Deserialize;
+use std::sync::Arc;
+
+/// Represents a vector store implementation using Qdrant - https://qdrant.tech/ as the backend.
+pub struct QdrantVectorStore<M: EmbeddingModel> {
+    /// Model used to generate embeddings for the vector store
+    model: Arc<M>,
+    /// Client instance for Qdrant server communication
+    client: Arc<Qdrant>,
+    /// Default search parameters
+    query_params: QueryPoints,
+}
+
+impl<M: EmbeddingModel> QdrantVectorStore<M> {
+    /// Creates a new instance of QdrantVectorStore.
+    ///
+    /// # Arguments
+    /// * `client` - Qdrant client instance
+    /// * `model` - Embedding model instance
+    /// * `query_params` - Search parameters for vector queries
+    ///     Reference: https://api.qdrant.tech/v-1-12-x/api-reference/search/query-points
+    pub fn new(client: Qdrant, model: M, query_params: QueryPoints) -> Self {
+        Self {
+            client: Arc::new(client),
+            model: Arc::new(model),
+            query_params,
+        }
+    }
+
+    async fn generate_query_vector(&self, query: &str) -> Result<Vec<f32>, VectorStoreError> {
+        let embedding = self.model.embed_document(query).await?;
+        Ok(embedding.vec.iter().map(|&x| x as f32).collect())
+    }
+
+    fn prepare_query_params(&self, query: Option<Query>, limit: usize) -> QueryPoints {
+        let mut params = self.query_params.clone();
+        params.query = query;
+        params.limit = Some(limit as u64);
+        params
+    }
+}
+
+/// Converts a PointId to its string representation.
+fn stringify_id(id: PointId) -> Result<String, VectorStoreError> {
+    match id.point_id_options {
+        Some(PointIdOptions::Num(num)) => Ok(num.to_string()),
+        Some(PointIdOptions::Uuid(uuid)) => Ok(uuid.to_string()),
+        None => Err(VectorStoreError::DatastoreError(
+            "Invalid point ID format".into(),
+        )),
+    }
+}
+
+impl<M: EmbeddingModel + std::marker::Sync + Send> VectorStoreIndex for QdrantVectorStore<M> {
+    async fn top_n<T: for<'a> Deserialize<'a> + Send>(
+        &self,
+        query: &str,
+        n: usize,
+    ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {
+        let query = match self.query_params.query {
+            Some(ref q) => Some(q.clone()),
+            None => Some(Query::new_nearest(self.generate_query_vector(query).await?)),
+        };
+
+        let params = self.prepare_query_params(query, n);
+        let result = self
+            .client
+            .query(params)
+            .await
+            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+
+        result
+            .result
+            .into_iter()
+            .map(|item| {
+                let id =
+                    stringify_id(item.id.ok_or_else(|| {
+                        VectorStoreError::DatastoreError("Missing point ID".into())
+                    })?)?;
+                let score = item.score as f64;
+                let payload = serde_json::from_value(serde_json::to_value(item.payload)?)?;
+                Ok((score, id, payload))
+            })
+            .collect()
+    }
+
+    async fn top_n_ids(
+        &self,
+        query: &str,
+        n: usize,
+    ) -> Result<Vec<(f64, String)>, VectorStoreError> {
+        let query = match self.query_params.query {
+            Some(ref q) => Some(q.clone()),
+            None => Some(Query::new_nearest(self.generate_query_vector(query).await?)),
+        };
+
+        let params = self.prepare_query_params(query, n);
+        let points = self
+            .client
+            .query(params)
+            .await
+            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?
+            .result;
+
+        points
+            .into_iter()
+            .map(|point| {
+                let id =
+                    stringify_id(point.id.ok_or_else(|| {
+                        VectorStoreError::DatastoreError("Missing point ID".into())
+                    })?)?;
+                Ok((point.score as f64, id))
+            })
+            .collect()
+    }
+}

--- a/rig-qdrant/src/lib.rs
+++ b/rig-qdrant/src/lib.rs
@@ -8,7 +8,7 @@ use rig::{
 };
 use serde::Deserialize;
 
-/// Represents a vector store implementation using Qdrant - https://qdrant.tech/ as the backend.
+/// Represents a vector store implementation using Qdrant - <https://qdrant.tech/> as the backend.
 pub struct QdrantVectorStore<M: EmbeddingModel> {
     /// Model used to generate embeddings for the vector store
     model: M,
@@ -25,7 +25,7 @@ impl<M: EmbeddingModel> QdrantVectorStore<M> {
     /// * `client` - Qdrant client instance
     /// * `model` - Embedding model instance
     /// * `query_params` - Search parameters for vector queries
-    ///     Reference: https://api.qdrant.tech/v-1-12-x/api-reference/search/query-points
+    ///     Reference: <https://api.qdrant.tech/v-1-12-x/api-reference/search/query-points>
     pub fn new(client: Qdrant, model: M, query_params: QueryPoints) -> Self {
         Self {
             client,


### PR DESCRIPTION
## Description

Adds support for Qdrant - https://qdrant.tech/ to be used as vector store in Rig.

Resolves #2 


## Testing 

I've QA tested and you can run the example with

```bash
export OPENAI_API_KEY=sk-********
```

```bash
docker run -p 6333:6333 -p 6334:6334 qdrant/qdrant
```

```bash
cargo run --release --example qdrant_vector_search
```

You can view the data at http://localhost:6333/dashboard 


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I've reviewed the vector store API documentation and implemented the types of response accurately
