### PR TITLE
fix(rig-qdrant): Rig Qdrant dependency

### DIFF
--- a/rig-qdrant/Cargo.toml
+++ b/rig-qdrant/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-qdrant"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/rig-qdrant/README.md
+++ b/rig-qdrant/README.md
@@ -1,5 +1,4 @@
 # Rig-Qdrant
-
 Vector store index integration for [Qdrant](https://qdrant.tech/). This integration supports dense vector retrieval using Rig's embedding providers. It is also extensible to allow all [hybrid queries](https://qdrant.tech/documentation/concepts/hybrid-queries/) supported by Qdrant.
 
 You can find end-to-end examples [here](https://github.com/0xPlaygrounds/rig/tree/main/rig-qdrant/examples).

--- a/rig-qdrant/examples/qdrant_vector_search.rs
+++ b/rig-qdrant/examples/qdrant_vector_search.rs
@@ -30,6 +30,8 @@ async fn main() -> Result<(), anyhow::Error> {
     let client = Qdrant::from_url("http://localhost:6334").build()?;
 
     // Create a collection with 1536 dimensions if it doesn't exist
+    // Note: Make sure the dimensions match the size of the embeddings returned by the 
+    // model you are using
     if !client.collection_exists(COLLECTION_NAME).await? {
         client
             .create_collection(


### PR DESCRIPTION
Fixes the Rig version used by the qdrant integration. Even though the companion crate's dependencies indicate `rig-core=0.4.0`, the deployed version still uses version `0.3.0` due to a CI snafu. This PR will trigger a new release of `rig-qdrant` with the proper Rig version.