### PR TITLE
fix(mongodb): remove embeddings from `top_n` lookup

### DIFF
--- a/rig-core/src/vector_store/mod.rs
+++ b/rig-core/src/vector_store/mod.rs
@@ -17,6 +17,9 @@ pub enum VectorStoreError {
 
     #[error("Datastore error: {0}")]
     DatastoreError(#[from] Box<dyn std::error::Error + Send + Sync>),
+
+    #[error("Vector store error: {0}")]
+    Error(String),
 }
 
 /// Trait for vector stores

--- a/rig-core/src/vector_store/mod.rs
+++ b/rig-core/src/vector_store/mod.rs
@@ -17,9 +17,6 @@ pub enum VectorStoreError {
 
     #[error("Datastore error: {0}")]
     DatastoreError(#[from] Box<dyn std::error::Error + Send + Sync>),
-
-    #[error("Vector store error: {0}")]
-    Error(String),
 }
 
 /// Trait for vector stores

--- a/rig-mongodb/examples/vector_search_mongodb.rs
+++ b/rig-mongodb/examples/vector_search_mongodb.rs
@@ -5,7 +5,7 @@ use rig::{
     providers::openai::{Client, TEXT_EMBEDDING_ADA_002},
     vector_store::VectorStoreIndex,
 };
-use rig_mongodb::{MongoDbVectorStore, SearchParams};
+use rig_mongodb::{DocumentResponse, MongoDbVectorStore, SearchParams};
 use std::env;
 
 #[tokio::main]
@@ -53,7 +53,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Query the index
     let results = index
-        .top_n::<DocumentEmbeddings>("What is a linglingdong?", 1)
+        .top_n::<DocumentResponse>("What is a linglingdong?", 1)
         .await?
         .into_iter()
         .map(|(score, id, doc)| (score, id, doc.document))

--- a/rig-mongodb/examples/vector_search_mongodb.rs
+++ b/rig-mongodb/examples/vector_search_mongodb.rs
@@ -1,12 +1,21 @@
+use mongodb::bson;
 use mongodb::{options::ClientOptions, Client as MongoClient, Collection};
 use rig::vector_store::VectorStore;
 use rig::{
-    embeddings::{DocumentEmbeddings, EmbeddingsBuilder},
+    embeddings::{EmbeddingsBuilder},
     providers::openai::{Client, TEXT_EMBEDDING_ADA_002},
     vector_store::VectorStoreIndex,
 };
-use rig_mongodb::{DocumentResponse, MongoDbVectorStore, SearchParams};
+use rig_mongodb::{MongoDbVectorStore, SearchParams};
+use serde::{Deserialize, Serialize};
 use std::env;
+
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Debug)]
+pub struct DocumentResponse {
+    #[serde(rename = "_id")]
+    pub id: String,
+    pub document: serde_json::Value,
+}
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
@@ -25,7 +34,7 @@ async fn main() -> Result<(), anyhow::Error> {
         MongoClient::with_options(options).expect("MongoDB client options should be valid");
 
     // Initialize MongoDB vector store
-    let collection: Collection<DocumentEmbeddings> = mongodb_client
+    let collection: Collection<bson::Document> = mongodb_client
         .database("knowledgebase")
         .collection("context");
 

--- a/rig-mongodb/examples/vector_search_mongodb.rs
+++ b/rig-mongodb/examples/vector_search_mongodb.rs
@@ -2,7 +2,7 @@ use mongodb::bson;
 use mongodb::{options::ClientOptions, Client as MongoClient, Collection};
 use rig::vector_store::VectorStore;
 use rig::{
-    embeddings::{EmbeddingsBuilder},
+    embeddings::EmbeddingsBuilder,
     providers::openai::{Client, TEXT_EMBEDDING_ADA_002},
     vector_store::VectorStoreIndex,
 };

--- a/rig-mongodb/examples/vector_search_mongodb.rs
+++ b/rig-mongodb/examples/vector_search_mongodb.rs
@@ -49,7 +49,9 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Create a vector index on our vector store
     // IMPORTANT: Reuse the same model that was used to generate the embeddings
-    let index = vector_store.index(model, "vector_index", SearchParams::default());
+    let index = vector_store
+        .index(model, "vector_index", SearchParams::default())
+        .await?;
 
     // Query the index
     let results = index

--- a/rig-mongodb/src/lib.rs
+++ b/rig-mongodb/src/lib.rs
@@ -235,13 +235,9 @@ impl<M: EmbeddingModel + std::marker::Sync + Send> VectorStoreIndex for MongoDbV
 
         let mut results = Vec::new();
         while let Some(doc) = cursor.next().await {
-            let mut doc = doc.map_err(mongodb_to_rig_error)?;
+            let doc = doc.map_err(mongodb_to_rig_error)?;
             let score = doc.get("score").expect("score").as_f64().expect("f64");
             let id = doc.get("_id").expect("_id").to_string();
-            // // Remove the embeddings field from the document
-            // if let Some(val) = doc.get_mut(EMBEDDINGS_FIELD) {
-            //     val.take();
-            // }
             let doc_t: T = serde_json::from_value(doc).map_err(VectorStoreError::JsonError)?;
             results.push((score, id, doc_t));
         }


### PR DESCRIPTION
Eliminate the embeddings field from the top_n lookup results to streamline the response structure. Also adds a `DocumentResponse` type that doesn't include the embeddings field to be used with `top_n` responses.

Additionally, this PR un-hardcoded `embeddings.vec` and dynamically looks up the embedded field from the vector search index (which also confirms whether it exists or not properly during construction).

## Implementation
> We remove the embeddings.vec field via an aggregation pipeline step after we've performed our vector search. I also noticed that embeddings.vec is hardcoded within the mongodb implementation. I didn't want to abstract that in this PR so i've also used the same const for the filtering.

Update: We make a call to mongodb to check all search indexes. We only handle 1 index w/ 1 indexed embedded field but this could be updated in the future if needed.