### PR TITLE
Feat: small improvements + fixes + tests

### DIFF
--- a/rig-core/Cargo.toml
+++ b/rig-core/Cargo.toml
@@ -35,8 +35,8 @@ tracing-subscriber = "0.3.18"
 tokio-test = "0.4.4"
 
 [features]
+all = ["derive", "pdf"]
 derive = ["dep:rig-derive"]
-all = ["pdf"]
 pdf = ["dep:lopdf"]
 
 [[test]]

--- a/rig-core/examples/rag.rs
+++ b/rig-core/examples/rag.rs
@@ -22,6 +22,12 @@ struct WordDefinition {
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
+    // Initialize tracing
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .with_target(false)
+        .init();
+
     // Create OpenAI client
     let openai_api_key = env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set");
     let openai_client = Client::new(&openai_api_key);

--- a/rig-core/examples/rag.rs
+++ b/rig-core/examples/rag.rs
@@ -10,11 +10,12 @@ use rig::{
 use serde::Serialize;
 
 // Data to be RAGged.
-// A vector search needs to be performed on the `definitions` field, so we derive the `Embed` trait for `FakeDefinition`
+// A vector search needs to be performed on the `definitions` field, so we derive the `Embed` trait for `WordDefinition`
 // and tag that field with `#[embed]`.
 #[derive(Embed, Serialize, Clone, Debug, Eq, PartialEq, Default)]
-struct FakeDefinition {
+struct WordDefinition {
     id: String,
+    word: String,
     #[embed]
     definitions: Vec<String>,
 }
@@ -30,25 +31,28 @@ async fn main() -> Result<(), anyhow::Error> {
     // Generate embeddings for the definitions of all the documents using the specified embedding model.
     let embeddings = EmbeddingsBuilder::new(embedding_model.clone())
         .documents(vec![
-            FakeDefinition {
+            WordDefinition {
                 id: "doc0".to_string(),
+                word: "flurbo".to_string(),
                 definitions: vec![
-                    "Definition of a *flurbo*: A flurbo is a green alien that lives on cold planets.".to_string(),
-                    "Definition of a *flurbo*: A fictional digital currency that originated in the animated series Rick and Morty.".to_string()
+                    "1. *flurbo* (name): A flurbo is a green alien that lives on cold planets.".to_string(),
+                    "2. *flurbo* (name): A fictional digital currency that originated in the animated series Rick and Morty.".to_string()
                 ]
             },
-            FakeDefinition {
+            WordDefinition {
                 id: "doc1".to_string(),
+                word: "glarb-glarb".to_string(),
                 definitions: vec![
-                    "Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
-                    "Definition of a *glarb-glarb*: A fictional creature found in the distant, swampy marshlands of the planet Glibbo in the Andromeda galaxy.".to_string()
+                    "1. *glarb-glarb* (noun): A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
+                    "2. *glarb-glarb* (noun): A fictional creature found in the distant, swampy marshlands of the planet Glibbo in the Andromeda galaxy.".to_string()
                 ]
             },
-            FakeDefinition {
+            WordDefinition {
                 id: "doc2".to_string(),
+                word: "linglingdong".to_string(),
                 definitions: vec![
-                    "Definition of a *linglingdong*: A term used by inhabitants of the far side of the moon to describe humans.".to_string(),
-                    "Definition of a *linglingdong*: A rare, mystical instrument crafted by the ancient monks of the Nebulon Mountain Ranges on the planet Quarm.".to_string()
+                    "1. *linglingdong* (noun): A term used by inhabitants of the far side of the moon to describe humans.".to_string(),
+                    "2. *linglingdong* (noun): A rare, mystical instrument crafted by the ancient monks of the Nebulon Mountain Ranges on the planet Quarm.".to_string()
                 ]
             },
         ])?

--- a/rig-core/examples/rag_dynamic_tools.rs
+++ b/rig-core/examples/rag_dynamic_tools.rs
@@ -137,11 +137,6 @@ async fn main() -> Result<(), anyhow::Error> {
         .with_max_level(tracing::Level::INFO)
         // disable printing the name of the module in every log line.
         .with_target(false)
-        // this needs to be set to false, otherwise ANSI color codes will
-        // show up in a confusing manner in CloudWatch logs.
-        .with_ansi(false)
-        // disabling time is handy because CloudWatch will add the ingestion time.
-        .without_time()
         .init();
 
     // Create OpenAI client

--- a/rig-core/examples/vector_search.rs
+++ b/rig-core/examples/vector_search.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 // Shape of data that needs to be RAG'ed.
 // The definition field will be used to generate embeddings.
 #[derive(Embed, Clone, Deserialize, Debug, Serialize, Eq, PartialEq, Default)]
-struct FakeDefinition {
+struct WordDefinition {
     id: String,
     word: String,
     #[embed]
@@ -28,7 +28,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let embeddings = EmbeddingsBuilder::new(model.clone())
         .documents(vec![
-            FakeDefinition {
+            WordDefinition {
                 id: "doc0".to_string(),
                 word: "flurbo".to_string(),
                 definitions: vec![
@@ -36,7 +36,7 @@ async fn main() -> Result<(), anyhow::Error> {
                     "A fictional digital currency that originated in the animated series Rick and Morty.".to_string()
                 ]
             },
-            FakeDefinition {
+            WordDefinition {
                 id: "doc1".to_string(),
                 word: "glarb-glarb".to_string(),
                 definitions: vec![
@@ -44,7 +44,7 @@ async fn main() -> Result<(), anyhow::Error> {
                     "A fictional creature found in the distant, swampy marshlands of the planet Glibbo in the Andromeda galaxy.".to_string()
                 ]
             },
-            FakeDefinition {
+            WordDefinition {
                 id: "doc2".to_string(),
                 word: "linglingdong".to_string(),
                 definitions: vec![
@@ -61,7 +61,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .index(model);
 
     let results = index
-        .top_n::<FakeDefinition>("I need to buy something in a fictional universe. What type of money can I use for this?", 1)
+        .top_n::<WordDefinition>("I need to buy something in a fictional universe. What type of money can I use for this?", 1)
         .await?
         .into_iter()
         .map(|(score, id, doc)| (score, id, doc.word))

--- a/rig-core/examples/vector_search_cohere.rs
+++ b/rig-core/examples/vector_search_cohere.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 // Shape of data that needs to be RAG'ed.
 // The definition field will be used to generate embeddings.
 #[derive(Embed, Clone, Deserialize, Debug, Serialize, Eq, PartialEq, Default)]
-struct FakeDefinition {
+struct WordDefinition {
     id: String,
     word: String,
     #[embed]
@@ -29,7 +29,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let embeddings = EmbeddingsBuilder::new(document_model.clone())
         .documents(vec![
-            FakeDefinition {
+            WordDefinition {
                 id: "doc0".to_string(),
                 word: "flurbo".to_string(),
                 definitions: vec![
@@ -37,7 +37,7 @@ async fn main() -> Result<(), anyhow::Error> {
                     "A fictional digital currency that originated in the animated series Rick and Morty.".to_string()
                 ]
             },
-            FakeDefinition {
+            WordDefinition {
                 id: "doc1".to_string(),
                 word: "glarb-glarb".to_string(),
                 definitions: vec![
@@ -45,7 +45,7 @@ async fn main() -> Result<(), anyhow::Error> {
                     "A fictional creature found in the distant, swampy marshlands of the planet Glibbo in the Andromeda galaxy.".to_string()
                 ]
             },
-            FakeDefinition {
+            WordDefinition {
                 id: "doc2".to_string(),
                 word: "linglingdong".to_string(),
                 definitions: vec![
@@ -62,7 +62,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .index(search_model);
 
     let results = index
-        .top_n::<FakeDefinition>(
+        .top_n::<WordDefinition>(
             "Which instrument is found in the Nebulon Mountain Ranges?",
             1,
         )

--- a/rig-core/src/embeddings/builder.rs
+++ b/rig-core/src/embeddings/builder.rs
@@ -13,40 +13,7 @@ use crate::{
 
 /// Builder for creating a collection of embeddings from a vector of documents of type `T`.
 /// Accumulate documents such that they can be embedded in a single batch to limit api calls to the provider.
-pub struct EmbeddingsBuilder<M: EmbeddingModel, T: Embed> {
-    model: M,
-    documents: Vec<(T, Vec<String>)>,
-}
-
-impl<M: EmbeddingModel, T: Embed> EmbeddingsBuilder<M, T> {
-    /// Create a new embedding builder with the given embedding model
-    pub fn new(model: M) -> Self {
-        Self {
-            model,
-            documents: vec![],
-        }
-    }
-
-    /// Add a document that implements `Embed` to the builder.
-    pub fn document(mut self, document: T) -> Result<Self, EmbedError> {
-        let mut embedder = TextEmbedder::default();
-        document.embed(&mut embedder)?;
-
-        self.documents.push((document, embedder.texts));
-
-        Ok(self)
-    }
-
-    /// Add many documents that implement `Embed` to the builder.
-    pub fn documents(self, documents: impl IntoIterator<Item = T>) -> Result<Self, EmbedError> {
-        let builder = documents
-            .into_iter()
-            .try_fold(self, |builder, doc| builder.document(doc))?;
-
-        Ok(builder)
-    }
-}
-
+///
 /// # Example
 /// ```rust
 /// use std::env;
@@ -105,6 +72,40 @@ impl<M: EmbeddingModel, T: Embed> EmbeddingsBuilder<M, T> {
 ///     .build()
 ///     .await?;
 /// ```
+pub struct EmbeddingsBuilder<M: EmbeddingModel, T: Embed> {
+    model: M,
+    documents: Vec<(T, Vec<String>)>,
+}
+
+impl<M: EmbeddingModel, T: Embed> EmbeddingsBuilder<M, T> {
+    /// Create a new embedding builder with the given embedding model
+    pub fn new(model: M) -> Self {
+        Self {
+            model,
+            documents: vec![],
+        }
+    }
+
+    /// Add a document that implements `Embed` to the builder.
+    pub fn document(mut self, document: T) -> Result<Self, EmbedError> {
+        let mut embedder = TextEmbedder::default();
+        document.embed(&mut embedder)?;
+
+        self.documents.push((document, embedder.texts));
+
+        Ok(self)
+    }
+
+    /// Add many documents that implement `Embed` to the builder.
+    pub fn documents(self, documents: impl IntoIterator<Item = T>) -> Result<Self, EmbedError> {
+        let builder = documents
+            .into_iter()
+            .try_fold(self, |builder, doc| builder.document(doc))?;
+
+        Ok(builder)
+    }
+}
+
 impl<M: EmbeddingModel, T: Embed + Send> EmbeddingsBuilder<M, T> {
     /// Generate embeddings for all documents in the builder.
     /// Returns a vector of tuples, where the first element is the document and the second element is the embeddings (either one embedding or many).

--- a/rig-core/src/embeddings/builder.rs
+++ b/rig-core/src/embeddings/builder.rs
@@ -62,7 +62,7 @@ impl<M: EmbeddingModel, T: Embed> EmbeddingsBuilder<M, T> {
 /// // Shape of data that needs to be RAG'ed.
 /// // The definition field will be used to generate embeddings.
 /// #[derive(Embed, Clone, Deserialize, Debug, Serialize, Eq, PartialEq, Default)]
-/// struct FakeDefinition {
+/// struct WordDefinition {
 ///     id: String,
 ///     word: String,
 ///     #[embed]
@@ -77,7 +77,7 @@ impl<M: EmbeddingModel, T: Embed> EmbeddingsBuilder<M, T> {
 ///
 /// let embeddings = EmbeddingsBuilder::new(model.clone())
 ///     .documents(vec![
-///         FakeDefinition {
+///         WordDefinition {
 ///             id: "doc0".to_string(),
 ///             word: "flurbo".to_string(),
 ///             definitions: vec![
@@ -85,7 +85,7 @@ impl<M: EmbeddingModel, T: Embed> EmbeddingsBuilder<M, T> {
 ///                 "A fictional digital currency that originated in the animated series Rick and Morty.".to_string()
 ///             ]
 ///         },
-///         FakeDefinition {
+///         WordDefinition {
 ///             id: "doc1".to_string(),
 ///             word: "glarb-glarb".to_string(),
 ///             definitions: vec![
@@ -93,7 +93,7 @@ impl<M: EmbeddingModel, T: Embed> EmbeddingsBuilder<M, T> {
 ///                 "A fictional creature found in the distant, swampy marshlands of the planet Glibbo in the Andromeda galaxy.".to_string()
 ///             ]
 ///         },
-///         FakeDefinition {
+///         WordDefinition {
 ///             id: "doc2".to_string(),
 ///             word: "linglingdong".to_string(),
 ///             definitions: vec![
@@ -198,12 +198,12 @@ mod tests {
     }
 
     #[derive(Clone, Debug)]
-    struct FakeDefinition {
+    struct WordDefinition {
         id: String,
         definitions: Vec<String>,
     }
 
-    impl Embed for FakeDefinition {
+    impl Embed for WordDefinition {
         fn embed(&self, embedder: &mut TextEmbedder) -> Result<(), EmbedError> {
             for definition in &self.definitions {
                 embedder.embed(definition.clone());
@@ -212,16 +212,16 @@ mod tests {
         }
     }
 
-    fn fake_definitions_multiple_text() -> Vec<FakeDefinition> {
+    fn fake_definitions_multiple_text() -> Vec<WordDefinition> {
         vec![
-            FakeDefinition {
+            WordDefinition {
                 id: "doc0".to_string(),
                 definitions: vec![
                     "A green alien that lives on cold planets.".to_string(),
                     "A fictional digital currency that originated in the animated series Rick and Morty.".to_string()
                 ]
             },
-            FakeDefinition {
+            WordDefinition {
                 id: "doc1".to_string(),
                 definitions: vec![
                     "An ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
@@ -231,13 +231,13 @@ mod tests {
         ]
     }
 
-    fn fake_definitions_multiple_text_2() -> Vec<FakeDefinition> {
+    fn fake_definitions_multiple_text_2() -> Vec<WordDefinition> {
         vec![
-            FakeDefinition {
+            WordDefinition {
                 id: "doc2".to_string(),
                 definitions: vec!["Another fake definitions".to_string()],
             },
-            FakeDefinition {
+            WordDefinition {
                 id: "doc3".to_string(),
                 definitions: vec!["Some fake definition".to_string()],
             },
@@ -245,25 +245,25 @@ mod tests {
     }
 
     #[derive(Clone, Debug)]
-    struct FakeDefinitionSingle {
+    struct WordDefinitionSingle {
         id: String,
         definition: String,
     }
 
-    impl Embed for FakeDefinitionSingle {
+    impl Embed for WordDefinitionSingle {
         fn embed(&self, embedder: &mut TextEmbedder) -> Result<(), EmbedError> {
             embedder.embed(self.definition.clone());
             Ok(())
         }
     }
 
-    fn fake_definitions_single_text() -> Vec<FakeDefinitionSingle> {
+    fn fake_definitions_single_text() -> Vec<WordDefinitionSingle> {
         vec![
-            FakeDefinitionSingle {
+            WordDefinitionSingle {
                 id: "doc0".to_string(),
                 definition: "A green alien that lives on cold planets.".to_string(),
             },
-            FakeDefinitionSingle {
+            WordDefinitionSingle {
                 id: "doc1".to_string(),
                 definition: "An ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
             }

--- a/rig-core/src/embeddings/builder.rs
+++ b/rig-core/src/embeddings/builder.rs
@@ -174,9 +174,9 @@ mod tests {
     use super::EmbeddingsBuilder;
 
     #[derive(Clone)]
-    struct FakeModel;
+    struct Model;
 
-    impl EmbeddingModel for FakeModel {
+    impl EmbeddingModel for Model {
         const MAX_DOCUMENTS: usize = 5;
 
         fn ndims(&self) -> usize {
@@ -212,7 +212,7 @@ mod tests {
         }
     }
 
-    fn fake_definitions_multiple_text() -> Vec<WordDefinition> {
+    fn definitions_multiple_text() -> Vec<WordDefinition> {
         vec![
             WordDefinition {
                 id: "doc0".to_string(),
@@ -231,7 +231,7 @@ mod tests {
         ]
     }
 
-    fn fake_definitions_multiple_text_2() -> Vec<WordDefinition> {
+    fn definitions_multiple_text_2() -> Vec<WordDefinition> {
         vec![
             WordDefinition {
                 id: "doc2".to_string(),
@@ -257,7 +257,7 @@ mod tests {
         }
     }
 
-    fn fake_definitions_single_text() -> Vec<WordDefinitionSingle> {
+    fn definitions_single_text() -> Vec<WordDefinitionSingle> {
         vec![
             WordDefinitionSingle {
                 id: "doc0".to_string(),
@@ -272,9 +272,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_build_multiple_text() {
-        let fake_definitions = fake_definitions_multiple_text();
+        let fake_definitions = definitions_multiple_text();
 
-        let fake_model = FakeModel;
+        let fake_model = Model;
         let mut result = EmbeddingsBuilder::new(fake_model)
             .documents(fake_definitions)
             .unwrap()
@@ -306,9 +306,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_build_single_text() {
-        let fake_definitions = fake_definitions_single_text();
+        let fake_definitions = definitions_single_text();
 
-        let fake_model = FakeModel;
+        let fake_model = Model;
         let mut result = EmbeddingsBuilder::new(fake_model)
             .documents(fake_definitions)
             .unwrap()
@@ -340,10 +340,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_build_multiple_and_single_text() {
-        let fake_definitions = fake_definitions_multiple_text();
-        let fake_definitions_single = fake_definitions_multiple_text_2();
+        let fake_definitions = definitions_multiple_text();
+        let fake_definitions_single = definitions_multiple_text_2();
 
-        let fake_model = FakeModel;
+        let fake_model = Model;
         let mut result = EmbeddingsBuilder::new(fake_model)
             .documents(fake_definitions)
             .unwrap()
@@ -377,10 +377,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_build_string() {
-        let bindings = fake_definitions_multiple_text();
+        let bindings = definitions_multiple_text();
         let fake_definitions = bindings.iter().map(|def| def.definitions.clone());
 
-        let fake_model = FakeModel;
+        let fake_model = Model;
         let mut result = EmbeddingsBuilder::new(fake_model)
             .documents(fake_definitions)
             .unwrap()

--- a/rig-core/src/embeddings/embed.rs
+++ b/rig-core/src/embeddings/embed.rs
@@ -29,7 +29,7 @@ impl EmbedError {
 /// use std::env;
 ///
 /// use serde::{Deserialize, Serialize};
-/// use rig::{Embed, embeddings::{TextEmbedder, EmbedError, to_texts}};
+/// use rig::{Embed, embeddings::{TextEmbedder, EmbedError}};
 ///
 /// struct WordDefinition {
 ///     id: String,
@@ -58,7 +58,7 @@ impl EmbedError {
 ///    definitions: "a fruit, a tech company".to_string(),
 /// };
 ///
-/// assert_eq!(to_texts(fake_definition).unwrap(), vec!["a fruit", " a tech company"]);
+/// assert_eq!(embeddings::to_texts(fake_definition).unwrap(), vec!["a fruit", " a tech company"]);
 /// ```
 pub trait Embed {
     fn embed(&self, embedder: &mut TextEmbedder) -> Result<(), EmbedError>;

--- a/rig-core/src/embeddings/embed.rs
+++ b/rig-core/src/embeddings/embed.rs
@@ -31,13 +31,13 @@ impl EmbedError {
 /// use serde::{Deserialize, Serialize};
 /// use rig::{Embed, embeddings::{TextEmbedder, EmbedError, to_texts}};
 ///
-/// struct FakeDefinition {
+/// struct WordDefinition {
 ///     id: String,
 ///     word: String,
 ///     definitions: String,
 /// }
 ///
-/// impl Embed for FakeDefinition {
+/// impl Embed for WordDefinition {
 ///     fn embed(&self, embedder: &mut TextEmbedder) -> Result<(), EmbedError> {
 ///        // Embeddings only need to be generated for `definition` field.
 ///        // Split the definitions by comma and collect them into a vector of strings.
@@ -52,7 +52,7 @@ impl EmbedError {
 ///     }
 /// }
 ///
-/// let fake_definition = FakeDefinition {
+/// let fake_definition = WordDefinition {
 ///    id: "1".to_string(),
 ///    word: "apple".to_string(),
 ///    definitions: "a fruit, a tech company".to_string(),

--- a/rig-core/src/embeddings/embed.rs
+++ b/rig-core/src/embeddings/embed.rs
@@ -174,6 +174,12 @@ impl Embed for serde_json::Value {
     }
 }
 
+impl<T: Embed> Embed for &T {
+    fn embed(&self, embedder: &mut TextEmbedder) -> Result<(), EmbedError> {
+        (*self).embed(embedder)
+    }
+}
+ 
 impl<T: Embed> Embed for Vec<T> {
     fn embed(&self, embedder: &mut TextEmbedder) -> Result<(), EmbedError> {
         for item in self {

--- a/rig-core/src/embeddings/embed.rs
+++ b/rig-core/src/embeddings/embed.rs
@@ -179,7 +179,7 @@ impl<T: Embed> Embed for &T {
         (*self).embed(embedder)
     }
 }
- 
+
 impl<T: Embed> Embed for Vec<T> {
     fn embed(&self, embedder: &mut TextEmbedder) -> Result<(), EmbedError> {
         for item in self {

--- a/rig-core/src/lib.rs
+++ b/rig-core/src/lib.rs
@@ -91,7 +91,7 @@ pub mod tool;
 pub mod vector_store;
 
 // Re-export commonly used types and traits
-pub use embeddings::{to_texts, Embed};
+pub use embeddings::Embed;
 pub use one_or_many::{EmptyListError, OneOrMany};
 
 #[cfg(feature = "derive")]

--- a/rig-core/src/loaders/file.rs
+++ b/rig-core/src/loaders/file.rs
@@ -162,7 +162,7 @@ impl<'a, T: 'a> FileLoader<'a, Result<T, FileLoaderError>> {
     }
 }
 
-impl<'a> FileLoader<'a, Result<PathBuf, FileLoaderError>> {
+impl FileLoader<'_, Result<PathBuf, FileLoaderError>> {
     /// Creates a new [FileLoader] using a glob pattern to match files.
     ///
     /// # Example
@@ -227,7 +227,7 @@ impl<'a, T> IntoIterator for FileLoader<'a, T> {
     }
 }
 
-impl<'a, T> Iterator for IntoIter<'a, T> {
+impl<T> Iterator for IntoIter<'_, T> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/rig-core/src/loaders/pdf.rs
+++ b/rig-core/src/loaders/pdf.rs
@@ -335,7 +335,7 @@ impl<'a, T: 'a> PdfFileLoader<'a, Result<T, PdfLoaderError>> {
     }
 }
 
-impl<'a> PdfFileLoader<'a, Result<PathBuf, FileLoaderError>> {
+impl PdfFileLoader<'_, Result<PathBuf, FileLoaderError>> {
     /// Creates a new [PdfFileLoader] using a glob pattern to match files.
     ///
     /// # Example
@@ -396,7 +396,7 @@ impl<'a, T> IntoIterator for PdfFileLoader<'a, T> {
     }
 }
 
-impl<'a, T> Iterator for IntoIter<'a, T> {
+impl<T> Iterator for IntoIter<'_, T> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/rig-core/src/providers/openai.rs
+++ b/rig-core/src/providers/openai.rs
@@ -219,7 +219,7 @@ pub struct EmbeddingData {
     pub index: usize,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct Usage {
     pub prompt_tokens: usize,
     pub total_tokens: usize,
@@ -229,7 +229,7 @@ impl std::fmt::Display for Usage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Prompt tokens: {}\nTotal tokens: {}",
+            "Prompt tokens: {} Total tokens: {}",
             self.prompt_tokens, self.total_tokens
         )
     }
@@ -535,7 +535,7 @@ impl completion::CompletionModel for CompletionModel {
                 ApiResponse::Ok(response) => {
                     tracing::info!(target: "rig",
                         "OpenAI completion token usage: {:?}",
-                        response.usage
+                        response.usage.clone().map(|usage| format!("{usage}")).unwrap_or("N/A".to_string())
                     );
                     response.try_into()
                 }

--- a/rig-core/src/providers/perplexity.rs
+++ b/rig-core/src/providers/perplexity.rs
@@ -155,7 +155,7 @@ impl std::fmt::Display for Usage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Prompt tokens: {}\nCompletion tokens: {}\nTotal tokens: {}",
+            "Prompt tokens: {}\nCompletion tokens: {} Total tokens: {}",
             self.prompt_tokens, self.completion_tokens, self.total_tokens
         )
     }

--- a/rig-core/tests/embed_macro.rs
+++ b/rig-core/tests/embed_macro.rs
@@ -4,29 +4,31 @@ use rig::{
 };
 use serde::Serialize;
 
-fn serialize(embedder: &mut TextEmbedder, definition: Definition) -> Result<(), EmbedError> {
-    embedder.embed(serde_json::to_string(&definition).map_err(EmbedError::new)?);
-
-    Ok(())
-}
-
-#[derive(Embed)]
-struct WordDefinition {
-    id: String,
-    word: String,
-    #[embed(embed_with = "serialize")]
-    definition: Definition,
-}
-
-#[derive(Serialize, Clone)]
-struct Definition {
-    word: String,
-    link: String,
-    speech: String,
-}
-
 #[test]
 fn test_custom_embed() {
+    #[derive(Embed)]
+    struct WordDefinition {
+        #[allow(dead_code)]
+        id: String,
+        #[allow(dead_code)]
+        word: String,
+        #[embed(embed_with = "custom_embedding_function")]
+        definition: Definition,
+    }
+    
+    #[derive(Serialize, Clone)]
+    struct Definition {
+        word: String,
+        link: String,
+        speech: String,
+    }    
+
+    fn custom_embedding_function(embedder: &mut TextEmbedder, definition: Definition) -> Result<(), EmbedError> {
+        embedder.embed(serde_json::to_string(&definition).map_err(EmbedError::new)?);
+    
+        Ok(())
+    }
+    
     let fake_definition = WordDefinition {
         id: "doc1".to_string(),
         word: "house".to_string(),
@@ -37,30 +39,38 @@ fn test_custom_embed() {
         },
     };
 
-    println!(
-        "WordDefinition: {}, {}",
-        fake_definition.id, fake_definition.word
-    );
-
     assert_eq!(
         to_texts(fake_definition).unwrap().first().unwrap().clone(),
             "{\"word\":\"a building in which people live; residence for human beings.\",\"link\":\"https://www.dictionary.com/browse/house\",\"speech\":\"noun\"}".to_string()
-
         )
-}
-
-#[derive(Embed)]
-struct WordDefinition2 {
-    id: String,
-    #[embed]
-    word: String,
-    #[embed(embed_with = "serialize")]
-    definition: Definition,
 }
 
 #[test]
 fn test_custom_and_basic_embed() {
-    let fake_definition = WordDefinition2 {
+    #[derive(Embed)]
+    struct WordDefinition {
+        #[allow(dead_code)]
+        id: String,
+        #[embed]
+        word: String,
+        #[embed(embed_with = "custom_embedding_function")]
+        definition: Definition,
+    }
+
+    #[derive(Serialize, Clone)]
+    struct Definition {
+        word: String,
+        link: String,
+        speech: String,
+    }    
+
+    fn custom_embedding_function(embedder: &mut TextEmbedder, definition: Definition) -> Result<(), EmbedError> {
+        embedder.embed(serde_json::to_string(&definition).map_err(EmbedError::new)?);
+    
+        Ok(())
+    }
+
+    let fake_definition = WordDefinition {
         id: "doc1".to_string(),
         word: "house".to_string(),
         definition: Definition {
@@ -69,11 +79,6 @@ fn test_custom_and_basic_embed() {
             link: "https://www.dictionary.com/browse/house".to_string(),
         },
     };
-
-    println!(
-        "WordDefinition: {}, {}",
-        fake_definition.id, fake_definition.word
-    );
 
     let texts = to_texts(fake_definition).unwrap();
 
@@ -85,27 +90,25 @@ fn test_custom_and_basic_embed() {
     )
 }
 
-#[derive(Embed)]
-struct WordDefinition3 {
-    id: String,
-    word: String,
-    #[embed]
-    definition: String,
-}
-
 #[test]
 fn test_single_embed() {
+    #[derive(Embed)]
+    struct WordDefinition {
+        #[allow(dead_code)]
+        id: String,
+        #[allow(dead_code)]
+        word: String,
+        #[embed]
+        definition: String,
+    }
+
     let definition = "a building in which people live; residence for human beings.".to_string();
 
-    let fake_definition = WordDefinition3 {
+    let fake_definition = WordDefinition {
         id: "doc1".to_string(),
         word: "house".to_string(),
         definition: definition.clone(),
     };
-    println!(
-        "WordDefinition3: {}, {}",
-        fake_definition.id, fake_definition.word
-    );
 
     assert_eq!(
         to_texts(fake_definition).unwrap().first().unwrap().clone(),
@@ -113,23 +116,21 @@ fn test_single_embed() {
     )
 }
 
-#[derive(Embed)]
-struct Company {
-    id: String,
-    company: String,
-    #[embed]
-    employee_ages: Vec<i32>,
-}
-
 #[test]
 fn test_multiple_embed_strings() {
+    #[derive(Embed)]
+    struct Company {
+        id: String,
+        company: String,
+        #[embed]
+        employee_ages: Vec<i32>,
+    }
+
     let company = Company {
         id: "doc1".to_string(),
         company: "Google".to_string(),
         employee_ages: vec![25, 30, 35, 40],
     };
-
-    println!("Company: {}, {}", company.id, company.company);
 
     assert_eq!(
         to_texts(company).unwrap(),
@@ -142,24 +143,23 @@ fn test_multiple_embed_strings() {
     );
 }
 
-#[derive(Embed)]
-struct Company2 {
-    id: String,
-    #[embed]
-    company: String,
-    #[embed]
-    employee_ages: Vec<i32>,
-}
-
 #[test]
 fn test_multiple_embed_tags() {
-    let company = Company2 {
+    #[derive(Embed)]
+    struct Company {
+        #[allow(dead_code)]
+        id: String,
+        #[embed]
+        company: String,
+        #[embed]
+        employee_ages: Vec<i32>,
+    }
+    
+    let company = Company {
         id: "doc1".to_string(),
         company: "Google".to_string(),
         employee_ages: vec![25, 30, 35, 40],
     };
-
-    println!("Company: {}", company.id);
 
     assert_eq!(
         to_texts(company).unwrap(),

--- a/rig-core/tests/embed_macro.rs
+++ b/rig-core/tests/embed_macro.rs
@@ -1,5 +1,5 @@
 use rig::{
-    embeddings::{embed::EmbedError, TextEmbedder},
+    embeddings::{self, embed::EmbedError, TextEmbedder},
     Embed,
 };
 use serde::Serialize;

--- a/rig-core/tests/embed_macro.rs
+++ b/rig-core/tests/embed_macro.rs
@@ -11,7 +11,7 @@ fn serialize(embedder: &mut TextEmbedder, definition: Definition) -> Result<(), 
 }
 
 #[derive(Embed)]
-struct FakeDefinition {
+struct WordDefinition {
     id: String,
     word: String,
     #[embed(embed_with = "serialize")]
@@ -27,7 +27,7 @@ struct Definition {
 
 #[test]
 fn test_custom_embed() {
-    let fake_definition = FakeDefinition {
+    let fake_definition = WordDefinition {
         id: "doc1".to_string(),
         word: "house".to_string(),
         definition: Definition {
@@ -38,7 +38,7 @@ fn test_custom_embed() {
     };
 
     println!(
-        "FakeDefinition: {}, {}",
+        "WordDefinition: {}, {}",
         fake_definition.id, fake_definition.word
     );
 
@@ -50,7 +50,7 @@ fn test_custom_embed() {
 }
 
 #[derive(Embed)]
-struct FakeDefinition2 {
+struct WordDefinition2 {
     id: String,
     #[embed]
     word: String,
@@ -60,7 +60,7 @@ struct FakeDefinition2 {
 
 #[test]
 fn test_custom_and_basic_embed() {
-    let fake_definition = FakeDefinition2 {
+    let fake_definition = WordDefinition2 {
         id: "doc1".to_string(),
         word: "house".to_string(),
         definition: Definition {
@@ -71,7 +71,7 @@ fn test_custom_and_basic_embed() {
     };
 
     println!(
-        "FakeDefinition: {}, {}",
+        "WordDefinition: {}, {}",
         fake_definition.id, fake_definition.word
     );
 
@@ -86,7 +86,7 @@ fn test_custom_and_basic_embed() {
 }
 
 #[derive(Embed)]
-struct FakeDefinition3 {
+struct WordDefinition3 {
     id: String,
     word: String,
     #[embed]
@@ -97,13 +97,13 @@ struct FakeDefinition3 {
 fn test_single_embed() {
     let definition = "a building in which people live; residence for human beings.".to_string();
 
-    let fake_definition = FakeDefinition3 {
+    let fake_definition = WordDefinition3 {
         id: "doc1".to_string(),
         word: "house".to_string(),
         definition: definition.clone(),
     };
     println!(
-        "FakeDefinition3: {}, {}",
+        "WordDefinition3: {}, {}",
         fake_definition.id, fake_definition.word
     );
 

--- a/rig-core/tests/embed_macro.rs
+++ b/rig-core/tests/embed_macro.rs
@@ -179,7 +179,7 @@ fn test_embed_vec_string() {
             "Bob".to_string(),
             "Charlie".to_string(),
             "David".to_string()
-       ]
+        ]
     );
 }
 

--- a/rig-core/tests/embed_macro.rs
+++ b/rig-core/tests/embed_macro.rs
@@ -121,7 +121,7 @@ fn test_single_embed() {
 }
 
 #[test]
-fn test_multiple_embed_strings() {
+fn test_embed_vec_non_string() {
     #[derive(Embed)]
     struct Company {
         #[allow(dead_code)]
@@ -146,6 +146,40 @@ fn test_multiple_embed_strings() {
             "35".to_string(),
             "40".to_string()
         ]
+    );
+}
+
+#[test]
+fn test_embed_vec_string() {
+    #[derive(Embed)]
+    struct Company {
+        #[allow(dead_code)]
+        id: String,
+        #[allow(dead_code)]
+        company: String,
+        #[embed]
+        employee_names: Vec<String>,
+    }
+
+    let company = Company {
+        id: "doc1".to_string(),
+        company: "Google".to_string(),
+        employee_names: vec![
+            "Alice".to_string(),
+            "Bob".to_string(),
+            "Charlie".to_string(),
+            "David".to_string(),
+        ],
+    };
+
+    assert_eq!(
+        to_texts(company).unwrap(),
+        vec![
+            "Alice".to_string(),
+            "Bob".to_string(),
+            "Charlie".to_string(),
+            "David".to_string()
+       ]
     );
 }
 

--- a/rig-core/tests/embed_macro.rs
+++ b/rig-core/tests/embed_macro.rs
@@ -120,7 +120,9 @@ fn test_single_embed() {
 fn test_multiple_embed_strings() {
     #[derive(Embed)]
     struct Company {
+        #[allow(dead_code)]
         id: String,
+        #[allow(dead_code)]
         company: String,
         #[embed]
         employee_ages: Vec<i32>,

--- a/rig-core/tests/embed_macro.rs
+++ b/rig-core/tests/embed_macro.rs
@@ -1,6 +1,6 @@
 use rig::{
     embeddings::{embed::EmbedError, TextEmbedder},
-    to_texts, Embed,
+    Embed,
 };
 use serde::Serialize;
 
@@ -43,7 +43,7 @@ fn test_custom_embed() {
     };
 
     assert_eq!(
-        to_texts(definition).unwrap(),
+        embeddings::to_texts(definition).unwrap(),
             vec!["{\"word\":\"a building in which people live; residence for human beings.\",\"link\":\"https://www.dictionary.com/browse/house\",\"speech\":\"noun\"}".to_string()]
         )
 }
@@ -86,7 +86,7 @@ fn test_custom_and_basic_embed() {
         },
     };
 
-    let texts = to_texts(definition).unwrap();
+    let texts = embeddings::to_texts(definition).unwrap();
 
     assert_eq!(
         texts,
@@ -117,7 +117,10 @@ fn test_single_embed() {
         definition: definition.clone(),
     };
 
-    assert_eq!(to_texts(word_definition).unwrap(), vec![definition])
+    assert_eq!(
+        embeddings::to_texts(word_definition).unwrap(),
+        vec![definition]
+    )
 }
 
 #[test]
@@ -139,7 +142,7 @@ fn test_embed_vec_non_string() {
     };
 
     assert_eq!(
-        to_texts(company).unwrap(),
+        embeddings::to_texts(company).unwrap(),
         vec![
             "25".to_string(),
             "30".to_string(),
@@ -173,7 +176,7 @@ fn test_embed_vec_string() {
     };
 
     assert_eq!(
-        to_texts(company).unwrap(),
+        embeddings::to_texts(company).unwrap(),
         vec![
             "Alice".to_string(),
             "Bob".to_string(),
@@ -202,7 +205,7 @@ fn test_multiple_embed_tags() {
     };
 
     assert_eq!(
-        to_texts(company).unwrap(),
+        embeddings::to_texts(company).unwrap(),
         vec![
             "Google".to_string(),
             "25".to_string(),

--- a/rig-core/tests/embed_macro.rs
+++ b/rig-core/tests/embed_macro.rs
@@ -15,21 +15,24 @@ fn test_custom_embed() {
         #[embed(embed_with = "custom_embedding_function")]
         definition: Definition,
     }
-    
+
     #[derive(Serialize, Clone)]
     struct Definition {
         word: String,
         link: String,
         speech: String,
-    }    
+    }
 
-    fn custom_embedding_function(embedder: &mut TextEmbedder, definition: Definition) -> Result<(), EmbedError> {
+    fn custom_embedding_function(
+        embedder: &mut TextEmbedder,
+        definition: Definition,
+    ) -> Result<(), EmbedError> {
         embedder.embed(serde_json::to_string(&definition).map_err(EmbedError::new)?);
-    
+
         Ok(())
     }
-    
-    let fake_definition = WordDefinition {
+
+    let definition = WordDefinition {
         id: "doc1".to_string(),
         word: "house".to_string(),
         definition: Definition {
@@ -40,8 +43,8 @@ fn test_custom_embed() {
     };
 
     assert_eq!(
-        to_texts(fake_definition).unwrap().first().unwrap().clone(),
-            "{\"word\":\"a building in which people live; residence for human beings.\",\"link\":\"https://www.dictionary.com/browse/house\",\"speech\":\"noun\"}".to_string()
+        to_texts(definition).unwrap(),
+            vec!["{\"word\":\"a building in which people live; residence for human beings.\",\"link\":\"https://www.dictionary.com/browse/house\",\"speech\":\"noun\"}".to_string()]
         )
 }
 
@@ -62,15 +65,18 @@ fn test_custom_and_basic_embed() {
         word: String,
         link: String,
         speech: String,
-    }    
+    }
 
-    fn custom_embedding_function(embedder: &mut TextEmbedder, definition: Definition) -> Result<(), EmbedError> {
+    fn custom_embedding_function(
+        embedder: &mut TextEmbedder,
+        definition: Definition,
+    ) -> Result<(), EmbedError> {
         embedder.embed(serde_json::to_string(&definition).map_err(EmbedError::new)?);
-    
+
         Ok(())
     }
 
-    let fake_definition = WordDefinition {
+    let definition = WordDefinition {
         id: "doc1".to_string(),
         word: "house".to_string(),
         definition: Definition {
@@ -80,14 +86,15 @@ fn test_custom_and_basic_embed() {
         },
     };
 
-    let texts = to_texts(fake_definition).unwrap();
-
-    assert_eq!(texts.first().unwrap().clone(), "house".to_string());
+    let texts = to_texts(definition).unwrap();
 
     assert_eq!(
-        texts.last().unwrap().clone(),
-        "{\"word\":\"a building in which people live; residence for human beings.\",\"link\":\"https://www.dictionary.com/browse/house\",\"speech\":\"noun\"}".to_string()
-    )
+        texts,
+        vec![
+            "house".to_string(),
+            "{\"word\":\"a building in which people live; residence for human beings.\",\"link\":\"https://www.dictionary.com/browse/house\",\"speech\":\"noun\"}".to_string()
+        ]
+    );
 }
 
 #[test]
@@ -104,16 +111,13 @@ fn test_single_embed() {
 
     let definition = "a building in which people live; residence for human beings.".to_string();
 
-    let fake_definition = WordDefinition {
+    let word_definition = WordDefinition {
         id: "doc1".to_string(),
         word: "house".to_string(),
         definition: definition.clone(),
     };
 
-    assert_eq!(
-        to_texts(fake_definition).unwrap().first().unwrap().clone(),
-        definition
-    )
+    assert_eq!(to_texts(word_definition).unwrap(), vec![definition])
 }
 
 #[test]
@@ -156,7 +160,7 @@ fn test_multiple_embed_tags() {
         #[embed]
         employee_ages: Vec<i32>,
     }
-    
+
     let company = Company {
         id: "doc1".to_string(),
         company: "Google".to_string(),

--- a/rig-lancedb/examples/fixtures/lib.rs
+++ b/rig-lancedb/examples/fixtures/lib.rs
@@ -7,23 +7,23 @@ use rig::{Embed, OneOrMany};
 use serde::Deserialize;
 
 #[derive(Embed, Clone, Deserialize, Debug)]
-pub struct FakeDefinition {
+pub struct WordDefinition {
     pub id: String,
     #[embed]
     pub definition: String,
 }
 
-pub fn fake_definitions() -> Vec<FakeDefinition> {
+pub fn fake_definitions() -> Vec<WordDefinition> {
     vec![
-        FakeDefinition {
+        WordDefinition {
             id: "doc0".to_string(),
             definition: "Definition of *flumbrel (noun)*: a small, seemingly insignificant item that you constantly lose or misplace, such as a pen, hair tie, or remote control.".to_string()
         },
-        FakeDefinition {
+        WordDefinition {
             id: "doc1".to_string(),
             definition: "Definition of *zindle (verb)*: to pretend to be working on something important while actually doing something completely unrelated or unproductive.".to_string()
         },
-        FakeDefinition {
+        WordDefinition {
             id: "doc2".to_string(),
             definition: "Definition of a *linglingdong*: A term used by inhabitants of the far side of the moon to describe humans.".to_string()
         }
@@ -46,22 +46,22 @@ pub fn schema(dims: usize) -> Schema {
     ]))
 }
 
-// Convert FakeDefinition objects and their embedding to a RecordBatch.
+// Convert WordDefinition objects and their embedding to a RecordBatch.
 pub fn as_record_batch(
-    records: Vec<(FakeDefinition, OneOrMany<Embedding>)>,
+    records: Vec<(WordDefinition, OneOrMany<Embedding>)>,
     dims: usize,
 ) -> Result<RecordBatch, lancedb::arrow::arrow_schema::ArrowError> {
     let id = StringArray::from_iter_values(
         records
             .iter()
-            .map(|(FakeDefinition { id, .. }, _)| id)
+            .map(|(WordDefinition { id, .. }, _)| id)
             .collect::<Vec<_>>(),
     );
 
     let definition = StringArray::from_iter_values(
         records
             .iter()
-            .map(|(FakeDefinition { definition, .. }, _)| definition)
+            .map(|(WordDefinition { definition, .. }, _)| definition)
             .collect::<Vec<_>>(),
     );
 

--- a/rig-lancedb/examples/vector_search_local_ann.rs
+++ b/rig-lancedb/examples/vector_search_local_ann.rs
@@ -1,7 +1,7 @@
 use std::{env, sync::Arc};
 
 use arrow_array::RecordBatchIterator;
-use fixture::{as_record_batch, fake_definitions, schema, FakeDefinition};
+use fixture::{as_record_batch, fake_definitions, schema, WordDefinition};
 use lancedb::index::vector::IvfPqIndexBuilder;
 use rig::{
     embeddings::{EmbeddingModel, EmbeddingsBuilder},
@@ -31,7 +31,7 @@ async fn main() -> Result<(), anyhow::Error> {
         // Note: need at least 256 rows in order to create an index so copy the definition 256 times for testing purposes.
         .documents(
             (0..256)
-                .map(|i| FakeDefinition {
+                .map(|i| WordDefinition {
                     id: format!("doc{}", i),
                     definition: "Definition of *flumbuzzle (noun)*: A sudden, inexplicable urge to rearrange or reorganize small objects, such as desk items or books, for no apparent reason.".to_string()
                 })
@@ -65,7 +65,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Query the index
     let results = vector_store_index
-        .top_n::<FakeDefinition>("My boss says I zindle too much, what does that mean?", 1)
+        .top_n::<WordDefinition>("My boss says I zindle too much, what does that mean?", 1)
         .await?;
 
     println!("Results: {:?}", results);

--- a/rig-lancedb/examples/vector_search_s3_ann.rs
+++ b/rig-lancedb/examples/vector_search_s3_ann.rs
@@ -1,7 +1,7 @@
 use std::{env, sync::Arc};
 
 use arrow_array::RecordBatchIterator;
-use fixture::{as_record_batch, fake_definitions, schema, FakeDefinition};
+use fixture::{as_record_batch, fake_definitions, schema, WordDefinition};
 use lancedb::{index::vector::IvfPqIndexBuilder, DistanceType};
 use rig::{
     embeddings::{EmbeddingModel, EmbeddingsBuilder},
@@ -37,7 +37,7 @@ async fn main() -> Result<(), anyhow::Error> {
         // Note: need at least 256 rows in order to create an index so copy the definition 256 times for testing purposes.
         .documents(
             (0..256)
-                .map(|i| FakeDefinition {
+                .map(|i| WordDefinition {
                     id: format!("doc{}", i),
                     definition: "Definition of *flumbuzzle (noun)*: A sudden, inexplicable urge to rearrange or reorganize small objects, such as desk items or books, for no apparent reason.".to_string()
                 })
@@ -77,7 +77,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Query the index
     let results = vector_store
-        .top_n::<FakeDefinition>("I'm always looking for my phone, I always seem to forget it in the most counterintuitive places. What's the word for this feeling?", 1)
+        .top_n::<WordDefinition>("I'm always looking for my phone, I always seem to forget it in the most counterintuitive places. What's the word for this feeling?", 1)
         .await?;
 
     println!("Results: {:?}", results);

--- a/rig-lancedb/src/utils/deserializer.rs
+++ b/rig-lancedb/src/utils/deserializer.rs
@@ -356,9 +356,9 @@ fn type_matcher(column: &Arc<dyn Array>) -> Result<Vec<Value>, VectorStoreError>
     }
 }
 
-///////////////////////////////////////////////////////////////////////////////////
-/// Everything below includes helpers for the recursive function `type_matcher`.///
-///////////////////////////////////////////////////////////////////////////////////
+// ================================================================
+// Everything below includes helpers for the recursive function `type_matcher`
+// ================================================================
 
 /// Trait used to "deserialize" an arrow_array::Array as as list of primitive objects.
 trait DeserializePrimitiveArray {

--- a/rig-mongodb/examples/vector_search_mongodb.rs
+++ b/rig-mongodb/examples/vector_search_mongodb.rs
@@ -11,7 +11,7 @@ use rig_mongodb::{MongoDbVectorIndex, SearchParams};
 // Shape of data that needs to be RAG'ed.
 // The definition field will be used to generate embeddings.
 #[derive(Embed, Clone, Deserialize, Debug)]
-struct FakeDefinition {
+struct WordDefinition {
     #[serde(rename = "_id")]
     id: String,
     #[embed]
@@ -58,15 +58,15 @@ async fn main() -> Result<(), anyhow::Error> {
     let model = openai_client.embedding_model(TEXT_EMBEDDING_ADA_002);
 
     let fake_definitions = vec![
-        FakeDefinition {
+        WordDefinition {
             id: "doc0".to_string(),
             definition: "Definition of a *flurbo*: A flurbo is a green alien that lives on cold planets".to_string(),
         },
-        FakeDefinition {
+        WordDefinition {
             id: "doc1".to_string(),
             definition: "Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
         },
-        FakeDefinition {
+        WordDefinition {
             id: "doc2".to_string(),
             definition: "Definition of a *linglingdong*: A term used by inhabitants of the far side of the moon to describe humans.".to_string(),
         }
@@ -80,7 +80,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let mongo_documents = embeddings
         .iter()
         .map(
-            |(FakeDefinition { id, definition, .. }, embedding)| Document {
+            |(WordDefinition { id, definition, .. }, embedding)| Document {
                 id: id.clone(),
                 definition: definition.clone(),
                 embedding: embedding.first().vec.clone(),
@@ -101,7 +101,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Query the index
     let results = index
-        .top_n::<FakeDefinition>("What is a linglingdong?", 1)
+        .top_n::<WordDefinition>("What is a linglingdong?", 1)
         .await?;
 
     println!("Results: {:?}", results);

--- a/rig-neo4j/examples/vector_search_simple.rs
+++ b/rig-neo4j/examples/vector_search_simple.rs
@@ -21,7 +21,7 @@ use rig_neo4j::{
 };
 
 #[derive(Embed, Clone, Debug)]
-pub struct FakeDefinition {
+pub struct WordDefinition {
     pub id: String,
     #[embed]
     pub definition: String,
@@ -44,15 +44,15 @@ async fn main() -> Result<(), anyhow::Error> {
     let model = openai_client.embedding_model(TEXT_EMBEDDING_ADA_002);
 
     let embeddings = EmbeddingsBuilder::new(model.clone())
-        .document(FakeDefinition {
+        .document(WordDefinition {
             id: "doc0".to_string(),
             definition: "Definition of a *flurbo*: A flurbo is a green alien that lives on cold planets".to_string(),
         })?
-        .document(FakeDefinition {
+        .document(WordDefinition {
             id: "doc1".to_string(),
             definition: "Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
         })?
-        .document(FakeDefinition {
+        .document(WordDefinition {
             id: "doc2".to_string(),
             definition: "Definition of a *linglingdong*: A term used by inhabitants of the far side of the moon to describe humans.".to_string(),
         })?

--- a/rig-qdrant/examples/qdrant_vector_search.rs
+++ b/rig-qdrant/examples/qdrant_vector_search.rs
@@ -25,7 +25,7 @@ use rig_qdrant::QdrantVectorStore;
 use serde_json::json;
 
 #[derive(Embed)]
-struct FakeDefinition {
+struct WordDefinition {
     id: String,
     #[embed]
     definition: String,
@@ -57,15 +57,15 @@ async fn main() -> Result<(), anyhow::Error> {
     let model = openai_client.embedding_model(TEXT_EMBEDDING_ADA_002);
 
     let documents = EmbeddingsBuilder::new(model.clone())
-        .document(FakeDefinition {
+        .document(WordDefinition {
             id: "0981d983-a5f8-49eb-89ea-f7d3b2196d2e".to_string(),
             definition: "Definition of a *flurbo*: A flurbo is a green alien that lives on cold planets".to_string(),
         })?
-        .document(FakeDefinition {
+        .document(WordDefinition {
             id: "62a36d43-80b6-4fd6-990c-f75bb02287d1".to_string(),
             definition: "Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
         })?
-        .document(FakeDefinition {
+        .document(WordDefinition {
             id: "f9e17d59-32e5-440c-be02-b2759a654824".to_string(),
             definition: "Definition of a *linglingdong*: A term used by inhabitants of the far side of the moon to describe humans.".to_string(),
         })?


### PR DESCRIPTION
- Improve/cleanup some docstrings and examples
- Add `impl<T: Embed> Embed for &T`
- Remove `to_texts` lib-wide re-export
- Fix clippy warnings from latest version (1.83)
- Add `derive` feature flag to `all` feature flag