### PR TITLE
feat: add local model support and examples

### DIFF
--- a/rig-core/Cargo.toml
+++ b/rig-core/Cargo.toml
@@ -64,3 +64,7 @@ required-features = ["derive"]
 [[example]]
 name = "xai_embeddings"
 required-features = ["derive"] 
+
+[[example]]
+name = "local_embeddings"
+required-features = ["derive"]

--- a/rig-core/examples/collab_local.rs
+++ b/rig-core/examples/collab_local.rs
@@ -5,22 +5,22 @@ use rig::{
     providers::local,
 };
 
-struct Debater {
-    local_debater_1: Agent<local::CompletionModel>,
-    local_debater_2: Agent<local::CompletionModel>,
+struct Collaborator {
+    local_agent_1: Agent<local::CompletionModel>,
+    local_agent_2: Agent<local::CompletionModel>,
 }
 
-impl Debater {
+impl Collaborator {
     fn new(position_a: &str, position_b: &str) -> Self {
         let local1 = local::Client::new();
         let local2 = local::Client::new();
 
         Self {
-            local_debater_1: local1
+            local_agent_1: local1
                 .agent("llama3.1:8b-instruct-q8_0")
                 .preamble(position_a)
                 .build(),
-            local_debater_2: local2
+            local_agent_2: local2
                 .agent("llama3.1:8b-instruct-q8_0")
                 .preamble(position_b)
                 .build(),
@@ -37,11 +37,14 @@ impl Debater {
             let prompt_a = if let Some(msg_b) = &last_resp_b {
                 msg_b.clone()
             } else {
-                "Plead your case!".into()
+                "Let's start improving prompts!".into()
             };
 
-            let resp_a = self.local_debater_1.chat(&prompt_a, history_a.clone()).await?;
-            println!("GPT-4:\n{}", resp_a);
+            let resp_a = self
+                .local_agent_1
+                .chat(&prompt_a, history_a.clone())
+                .await?;
+            println!("Agent 1:\n{}", resp_a);
             history_a.push(Message {
                 role: "user".into(),
                 content: prompt_a.clone(),
@@ -52,8 +55,8 @@ impl Debater {
             });
             println!("================================================================");
 
-            let resp_b = self.local_debater_2.chat(&resp_a, history_b.clone()).await?;
-            println!("Coral:\n{}", resp_b);
+            let resp_b = self.local_agent_2.chat(&resp_a, history_b.clone()).await?;
+            println!("Agent 2:\n{}", resp_b);
             println!("================================================================");
 
             history_b.push(Message {
@@ -75,25 +78,27 @@ impl Debater {
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     // Create model
-    let debator = Debater::new(
+    let collaborator = Collaborator::new(
         "\
-        You believe that religion is a useful concept. \
-        This could be for security, financial, ethical, philosophical, metaphysical, religious or any kind of other reason. \
-        You choose what your arguments are. \
-        I will argue against you and you must rebuke me and try to convince me that I am wrong. \
-        Make your statements short and concise. \
+        You are a prompt engineering expert focused on improving AI model performance. \
+        Your goal is to collaborate with another AI to iteratively refine and improve prompts. \
+        Analyze the previous response and suggest specific improvements to make prompts more effective. \
+        Consider aspects like clarity, specificity, context-setting, and task framing. \
+        Keep your suggestions focused and actionable. \
+        Format: Start with 'Suggested improvements:' followed by your specific recommendations. \
         ",
         "\
-        You believe that religion is a harmful concept. \
-        This could be for security, financial, ethical, philosophical, metaphysical, religious or any kind of other reason. \
-        You choose what your arguments are. \
-        I will argue against you and you must rebuke me and try to convince me that I am wrong. \
-        Make your statements short and concise. \
+        You are a prompt engineering expert focused on improving AI model performance. \
+        Your goal is to collaborate with another AI to iteratively refine and improve prompts. \
+        Review the suggested improvements and either build upon them or propose alternative approaches. \
+        Consider practical implementation and potential edge cases. \
+        Keep your response constructive and specific. \
+        Format: Start with 'Building on that:' followed by your refined suggestions. \
         ",
     );
 
-    // Run the debate for 4 rounds
-    debator.rounds(4).await?;
+    // Run the collaboration for 4 rounds
+    collaborator.rounds(4).await?;
 
     Ok(())
 }

--- a/rig-core/examples/debate_local.rs
+++ b/rig-core/examples/debate_local.rs
@@ -1,0 +1,99 @@
+use anyhow::Result;
+use rig::{
+    agent::Agent,
+    completion::{Chat, Message},
+    providers::local,
+};
+
+struct Debater {
+    local_debater_1: Agent<local::CompletionModel>,
+    local_debater_2: Agent<local::CompletionModel>,
+}
+
+impl Debater {
+    fn new(position_a: &str, position_b: &str) -> Self {
+        let local1 = local::Client::new();
+        let local2 = local::Client::new();
+
+        Self {
+            local_debater_1: local1
+                .agent("llama3.1:8b-instruct-q8_0")
+                .preamble(position_a)
+                .build(),
+            local_debater_2: local2
+                .agent("llama3.1:8b-instruct-q8_0")
+                .preamble(position_b)
+                .build(),
+        }
+    }
+
+    async fn rounds(&self, n: usize) -> Result<()> {
+        let mut history_a: Vec<Message> = vec![];
+        let mut history_b: Vec<Message> = vec![];
+
+        let mut last_resp_b: Option<String> = None;
+
+        for _ in 0..n {
+            let prompt_a = if let Some(msg_b) = &last_resp_b {
+                msg_b.clone()
+            } else {
+                "Plead your case!".into()
+            };
+
+            let resp_a = self.local_debater_1.chat(&prompt_a, history_a.clone()).await?;
+            println!("GPT-4:\n{}", resp_a);
+            history_a.push(Message {
+                role: "user".into(),
+                content: prompt_a.clone(),
+            });
+            history_a.push(Message {
+                role: "assistant".into(),
+                content: resp_a.clone(),
+            });
+            println!("================================================================");
+
+            let resp_b = self.local_debater_2.chat(&resp_a, history_b.clone()).await?;
+            println!("Coral:\n{}", resp_b);
+            println!("================================================================");
+
+            history_b.push(Message {
+                role: "user".into(),
+                content: resp_a.clone(),
+            });
+            history_b.push(Message {
+                role: "assistant".into(),
+                content: resp_b.clone(),
+            });
+
+            last_resp_b = Some(resp_b)
+        }
+
+        Ok(())
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    // Create model
+    let debator = Debater::new(
+        "\
+        You believe that religion is a useful concept. \
+        This could be for security, financial, ethical, philosophical, metaphysical, religious or any kind of other reason. \
+        You choose what your arguments are. \
+        I will argue against you and you must rebuke me and try to convince me that I am wrong. \
+        Make your statements short and concise. \
+        ",
+        "\
+        You believe that religion is a harmful concept. \
+        This could be for security, financial, ethical, philosophical, metaphysical, religious or any kind of other reason. \
+        You choose what your arguments are. \
+        I will argue against you and you must rebuke me and try to convince me that I am wrong. \
+        Make your statements short and concise. \
+        ",
+    );
+
+    // Run the debate for 4 rounds
+    debator.rounds(4).await?;
+
+    Ok(())
+}

--- a/rig-core/examples/local.rs
+++ b/rig-core/examples/local.rs
@@ -1,0 +1,16 @@
+use rig::{completion::Prompt, providers::local};
+
+#[tokio::main]
+async fn main() {
+    let ollama_client = local::Client::new();
+
+    let llama3 = ollama_client.agent("llama3.1:8b-instruct-q8_0").build();
+
+    // Prompt the model and print its response
+    let response = llama3
+        .prompt("Who are you?")
+        .await
+        .expect("Failed to prompt ollama");
+
+    println!("Ollama: {response}");
+}

--- a/rig-core/examples/local_agent_with_tools.rs
+++ b/rig-core/examples/local_agent_with_tools.rs
@@ -1,0 +1,131 @@
+use anyhow::Result;
+use rig::{
+    completion::{Chat, Prompt, ToolDefinition},
+    providers,
+    tool::Tool,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tracing::{debug, info_span, Instrument};
+use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+
+#[derive(Deserialize)]
+struct OperationArgs {
+    x: i32,
+    y: i32,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("Math error")]
+struct MathError;
+
+#[derive(Deserialize, Serialize)]
+struct Adder;
+impl Tool for Adder {
+    const NAME: &'static str = "add";
+
+    type Error = MathError;
+    type Args = OperationArgs;
+    type Output = i32;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: "add".to_string(),
+            description: "Add x and y together".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "x": {
+                        "type": "number",
+                        "description": "The first number to add"
+                    },
+                    "y": {
+                        "type": "number",
+                        "description": "The second number to add"
+                    }
+                }
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        tracing::info!("Adding {} and {}", args.x, args.y);
+        let result = args.x + args.y;
+        Ok(result)
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+struct Subtract;
+impl Tool for Subtract {
+    const NAME: &'static str = "subtract";
+
+    type Error = MathError;
+    type Args = OperationArgs;
+    type Output = i32;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        serde_json::from_value(json!({
+            "name": "subtract",
+            "description": "Subtract y from x (i.e.: x - y)",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "x": {
+                        "type": "number",
+                        "description": "The number to substract from"
+                    },
+                    "y": {
+                        "type": "number",
+                        "description": "The number to substract"
+                    }
+                }
+            }
+        }))
+        .expect("Tool Definition")
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        tracing::info!("Subtracting {} from {}", args.y, args.x);
+        let result = args.x - args.y;
+        Ok(result)
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    // Initialize tracing
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(
+            EnvFilter::from_default_env()
+                .add_directive("rig=debug".parse()?)
+                .add_directive("local_agent_with_tools=debug".parse()?),
+        )
+        .init();
+
+    // Create local client
+    let local = providers::local::Client::new();
+
+    let span = info_span!("calculator_agent");
+
+    // Create agent with a single context prompt and two tools
+    let calculator_agent = local
+        .agent("llama3.1:8b-instruct-q8_0")
+        .preamble("You are a calculator here to help the user perform arithmetic operations. Use the tools provided to answer the user's question.")
+        .tool(Adder)
+        .tool(Subtract)
+        .max_tokens(1024)
+        .build();
+
+    // Prompt the agent and print the response
+    let prompt = "Calculate 2 - 5";
+    debug!(?prompt, "Raw prompt");
+
+    let response = calculator_agent.prompt(prompt).instrument(span).await?;
+
+    debug!(?response, "Raw response");
+    println!("Calculator Agent: {}", response);
+
+    Ok(())
+}

--- a/rig-core/examples/local_agent_with_tools.rs
+++ b/rig-core/examples/local_agent_with_tools.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use rig::{
-    completion::{Chat, Prompt, ToolDefinition},
+    completion::{Prompt, ToolDefinition},
     providers,
     tool::Tool,
 };

--- a/rig-core/examples/local_embeddings.rs
+++ b/rig-core/examples/local_embeddings.rs
@@ -1,0 +1,30 @@
+use rig::providers::local;
+use rig::Embed;
+
+#[derive(Embed, Debug)]
+struct Greetings {
+    #[embed]
+    message: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    // Initialize the local client
+    let client = local::Client::new();
+
+    let embeddings = client
+        .embeddings("mxbai-embed-large")
+        .document(Greetings {
+            message: "Hello, world!".to_string(),
+        })?
+        .document(Greetings {
+            message: "Goodbye, world!".to_string(),
+        })?
+        .build()
+        .await
+        .expect("Failed to embed documents");
+
+    println!("{:?}", embeddings);
+
+    Ok(())
+}

--- a/rig-core/src/providers/local.rs
+++ b/rig-core/src/providers/local.rs
@@ -60,7 +60,6 @@ impl Client {
     /// Create a new Local client from the `LOCAL_API_KEY` environment variable.
     /// Panics if the environment variable is not set.
     pub fn from_env() -> Self {
-        let api_key = std::env::var("LOCAL_API_KEY").expect("LOCAL_API_KEY not set");
         Self::new()
     }
 
@@ -95,6 +94,12 @@ impl Client {
         model: &str,
     ) -> ExtractorBuilder<T, CompletionModel> {
         ExtractorBuilder::new(self.completion_model(model))
+    }
+}
+
+impl Default for Client {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -280,9 +285,13 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                 );
 
                 // Validate the arguments are valid JSON
-                let parsed_args: serde_json::Value = serde_json::from_str(&call.function.arguments).map_err(|e| {
-                    CompletionError::ResponseError(format!("Invalid tool arguments JSON: {}", e))
-                })?;
+                let parsed_args: serde_json::Value = serde_json::from_str(&call.function.arguments)
+                    .map_err(|e| {
+                        CompletionError::ResponseError(format!(
+                            "Invalid tool arguments JSON: {}",
+                            e
+                        ))
+                    })?;
 
                 // Validate it's a JSON object
                 if !parsed_args.is_object() {

--- a/rig-core/src/providers/local.rs
+++ b/rig-core/src/providers/local.rs
@@ -1,0 +1,482 @@
+//! Local API client and Rig integration
+//!
+//! # Example
+//! ```
+//! use rig::providers::local;
+//!
+//! let client = local::Client::new();
+//!
+//! let model = client.completion_model("llama3.1:8b-instruct-q8_0");
+//! ```
+
+use crate::{
+    agent::AgentBuilder,
+    completion::{self, CompletionError, CompletionRequest},
+    embeddings::{self, EmbeddingError, EmbeddingsBuilder},
+    extractor::ExtractorBuilder,
+    json_utils, Embed,
+};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+// ================================================================
+// Main Local Client
+// ================================================================
+const DEFAULT_API_BASE_URL: &str = "http://localhost:11434"; // Ollama and LM Studio endpoint
+
+#[derive(Clone)]
+pub struct Client {
+    base_url: String,
+    http_client: reqwest::Client,
+}
+
+impl Client {
+    /// Create a new Local client with an optional API key, using the default endpoint (ollama).
+    pub fn new() -> Self {
+        Self::from_url("", DEFAULT_API_BASE_URL)
+    }
+
+    /// Create a new Local client with the given API key and base API URL.
+    pub fn from_url(api_key: &str, base_url: &str) -> Self {
+        Self {
+            base_url: base_url.to_string(),
+            http_client: reqwest::Client::builder()
+                .default_headers({
+                    let mut headers = reqwest::header::HeaderMap::new();
+                    headers.insert(
+                        "Authorization",
+                        format!("Bearer {}", api_key)
+                            .parse()
+                            .expect("Bearer token should parse"),
+                    );
+                    headers
+                })
+                .build()
+                .expect("Local reqwest client should build"),
+        }
+    }
+
+    /// Create a new Local client from the `LOCAL_API_KEY` environment variable.
+    /// Panics if the environment variable is not set.
+    pub fn from_env() -> Self {
+        let api_key = std::env::var("LOCAL_API_KEY").expect("LOCAL_API_KEY not set");
+        Self::new()
+    }
+
+    fn post(&self, path: &str) -> reqwest::RequestBuilder {
+        let url = format!("{}/{}", self.base_url, path).replace("//", "/");
+        self.http_client.post(url)
+    }
+
+    /// Create an embedding model with the given name.
+    pub fn embedding_model(&self, model: &str) -> EmbeddingModel {
+        EmbeddingModel::new(self.clone(), model, 1536) // Default to 1536 dimensions
+    }
+
+    /// Create an embedding builder with the given embedding model.
+    pub fn embeddings<D: Embed>(&self, model: &str) -> EmbeddingsBuilder<EmbeddingModel, D> {
+        EmbeddingsBuilder::new(self.embedding_model(model))
+    }
+
+    /// Create a completion model with the given name.
+    pub fn completion_model(&self, model: &str) -> CompletionModel {
+        CompletionModel::new(self.clone(), model)
+    }
+
+    /// Create an agent builder with the given completion model.
+    pub fn agent(&self, model: &str) -> AgentBuilder<CompletionModel> {
+        AgentBuilder::new(self.completion_model(model))
+    }
+
+    /// Create an extractor builder with the given completion model.
+    pub fn extractor<T: JsonSchema + for<'a> Deserialize<'a> + Serialize + Send + Sync>(
+        &self,
+        model: &str,
+    ) -> ExtractorBuilder<T, CompletionModel> {
+        ExtractorBuilder::new(self.completion_model(model))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiErrorResponse {
+    message: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum ApiResponse<T> {
+    Ok(T),
+    Err(ApiErrorResponse),
+}
+
+// ================================================================
+// Local Embedding API
+// ================================================================
+
+#[derive(Debug, Deserialize)]
+pub struct EmbeddingResponse {
+    pub object: String,
+    pub data: Vec<EmbeddingData>,
+    pub model: String,
+    pub usage: Usage,
+}
+
+impl From<ApiErrorResponse> for EmbeddingError {
+    fn from(err: ApiErrorResponse) -> Self {
+        EmbeddingError::ProviderError(err.message)
+    }
+}
+
+impl From<ApiResponse<EmbeddingResponse>> for Result<EmbeddingResponse, EmbeddingError> {
+    fn from(value: ApiResponse<EmbeddingResponse>) -> Self {
+        match value {
+            ApiResponse::Ok(response) => Ok(response),
+            ApiResponse::Err(err) => Err(EmbeddingError::ProviderError(err.message)),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct EmbeddingData {
+    pub object: String,
+    pub embedding: Vec<f64>,
+    pub index: usize,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Usage {
+    pub prompt_tokens: usize,
+    pub total_tokens: usize,
+}
+
+impl std::fmt::Display for Usage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Prompt tokens: {} Total tokens: {}",
+            self.prompt_tokens, self.total_tokens
+        )
+    }
+}
+
+#[derive(Clone)]
+pub struct EmbeddingModel {
+    client: Client,
+    pub model: String,
+    ndims: usize,
+}
+
+impl embeddings::EmbeddingModel for EmbeddingModel {
+    const MAX_DOCUMENTS: usize = 1024;
+
+    fn ndims(&self) -> usize {
+        self.ndims
+    }
+
+    async fn embed_texts(
+        &self,
+        documents: impl IntoIterator<Item = String>,
+    ) -> Result<Vec<embeddings::Embedding>, EmbeddingError> {
+        let documents = documents.into_iter().collect::<Vec<_>>();
+
+        let response = self
+            .client
+            .post("/v1/embeddings")
+            .json(&json!({
+                "model": self.model,
+                "input": documents,
+            }))
+            .send()
+            .await?;
+
+        if response.status().is_success() {
+            match response.json::<ApiResponse<EmbeddingResponse>>().await? {
+                ApiResponse::Ok(response) => {
+                    tracing::info!(target: "rig",
+                        "Local embedding token usage: {}",
+                        response.usage
+                    );
+
+                    if response.data.len() != documents.len() {
+                        return Err(EmbeddingError::ResponseError(
+                            "Response data length does not match input length".into(),
+                        ));
+                    }
+
+                    Ok(response
+                        .data
+                        .into_iter()
+                        .zip(documents.into_iter())
+                        .map(|(embedding, document)| embeddings::Embedding {
+                            document,
+                            vec: embedding.embedding,
+                        })
+                        .collect())
+                }
+                ApiResponse::Err(err) => Err(EmbeddingError::ProviderError(err.message)),
+            }
+        } else {
+            Err(EmbeddingError::ProviderError(response.text().await?))
+        }
+    }
+}
+
+impl EmbeddingModel {
+    pub fn new(client: Client, model: &str, ndims: usize) -> Self {
+        Self {
+            client,
+            model: model.to_string(),
+            ndims,
+        }
+    }
+}
+
+// ================================================================
+// Local Completion API
+// ================================================================
+
+#[derive(Debug, Deserialize)]
+pub struct CompletionResponse {
+    pub id: String,
+    pub object: String,
+    pub created: u64,
+    pub model: String,
+    pub system_fingerprint: Option<String>,
+    pub choices: Vec<Choice>,
+    pub usage: Option<Usage>,
+}
+
+impl From<ApiErrorResponse> for CompletionError {
+    fn from(err: ApiErrorResponse) -> Self {
+        CompletionError::ProviderError(err.message)
+    }
+}
+
+impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionResponse> {
+    type Error = CompletionError;
+
+    fn try_from(value: CompletionResponse) -> std::prelude::v1::Result<Self, Self::Error> {
+        tracing::debug!(target: "rig", ?value, "Processing completion response");
+        match value.choices.as_slice() {
+            // First check for tool calls
+            [Choice {
+                message:
+                    Message {
+                        tool_calls: Some(calls),
+                        ..
+                    },
+                ..
+            }, ..] => {
+                tracing::debug!(target: "rig", ?calls, "Received tool calls");
+                let call = calls.first().ok_or_else(|| {
+                    CompletionError::ResponseError("Tool selection is empty".into())
+                })?;
+
+                tracing::info!(target: "rig",
+                    tool_name = ?call.function.name,
+                    args = ?call.function.arguments,
+                    "Processing tool call"
+                );
+
+                // Validate the arguments are valid JSON
+                let parsed_args: serde_json::Value = serde_json::from_str(&call.function.arguments).map_err(|e| {
+                    CompletionError::ResponseError(format!("Invalid tool arguments JSON: {}", e))
+                })?;
+
+                // Validate it's a JSON object
+                if !parsed_args.is_object() {
+                    return Err(CompletionError::ResponseError(
+                        "Tool arguments must be a JSON object".into(),
+                    ));
+                }
+
+                tracing::debug!(target: "rig", ?parsed_args, "Parsed and validated tool arguments");
+
+                Ok(completion::CompletionResponse {
+                    choice: completion::ModelChoice::ToolCall(
+                        call.function.name.clone(),
+                        parsed_args,
+                    ),
+                    raw_response: value,
+                })
+            }
+            // Then check for content
+            [Choice {
+                message:
+                    Message {
+                        content: Some(content),
+                        tool_calls: None,
+                        ..
+                    },
+                ..
+            }, ..] => {
+                tracing::debug!(target: "rig", content_length = content.len(), "Received text response");
+                Ok(completion::CompletionResponse {
+                    choice: completion::ModelChoice::Message(content.to_string()),
+                    raw_response: value,
+                })
+            }
+            _ => {
+                tracing::error!(
+                    target: "rig",
+                    choices = ?value.choices,
+                    "Response contained neither valid message nor tool calls"
+                );
+                Err(CompletionError::ResponseError(
+                    "Response did not contain a valid message or tool call".into(),
+                ))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Choice {
+    pub index: usize,
+    pub message: Message,
+    pub logprobs: Option<serde_json::Value>,
+    pub finish_reason: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Message {
+    pub role: String,
+    pub content: Option<String>,
+    pub tool_calls: Option<Vec<ToolCall>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ToolCall {
+    pub id: String,
+    pub r#type: String,
+    pub function: Function,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ToolDefinition {
+    pub r#type: String,
+    pub function: completion::ToolDefinition,
+}
+
+impl From<completion::ToolDefinition> for ToolDefinition {
+    fn from(tool: completion::ToolDefinition) -> Self {
+        Self {
+            r#type: "function".into(),
+            function: tool,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Function {
+    pub name: String,
+    pub arguments: String,
+}
+
+#[derive(Clone)]
+pub struct CompletionModel {
+    client: Client,
+    pub model: String,
+}
+
+impl CompletionModel {
+    pub fn new(client: Client, model: &str) -> Self {
+        Self {
+            client,
+            model: model.to_string(),
+        }
+    }
+}
+
+impl completion::CompletionModel for CompletionModel {
+    type Response = CompletionResponse;
+
+    async fn completion(
+        &self,
+        mut completion_request: CompletionRequest,
+    ) -> Result<completion::CompletionResponse<CompletionResponse>, CompletionError> {
+        // Add preamble to chat history (if available)
+        let mut full_history = if let Some(preamble) = &completion_request.preamble {
+            tracing::debug!(target: "rig", system_prompt = ?preamble, "System prompt");
+            vec![completion::Message {
+                role: "system".into(),
+                content: preamble.clone(),
+            }]
+        } else {
+            vec![]
+        };
+
+        // Extend existing chat history
+        full_history.append(&mut completion_request.chat_history);
+
+        // Add context documents to chat history
+        let prompt_with_context = completion_request.prompt_with_context();
+        tracing::debug!(target: "rig", prompt = ?prompt_with_context, "User prompt with context");
+
+        // Add context documents to chat history
+        full_history.push(completion::Message {
+            role: "user".into(),
+            content: prompt_with_context,
+        });
+
+        let request = if completion_request.tools.is_empty() {
+            tracing::debug!(target: "rig", "No tools provided in request");
+            json!({
+                "model": self.model,
+                "messages": full_history,
+                "temperature": completion_request.temperature,
+            })
+        } else {
+            let tools: Vec<ToolDefinition> = completion_request
+                .tools
+                .into_iter()
+                .map(ToolDefinition::from)
+                .collect();
+            tracing::info!(target: "rig", tool_count = tools.len(), ?tools, "Sending tools to model");
+            json!({
+                "model": self.model,
+                "messages": full_history,
+                "temperature": completion_request.temperature,
+                "tools": tools,
+                "tool_choice": "auto",
+            })
+        };
+
+        tracing::debug!(target: "rig", ?request, "Request to local model");
+
+        let response = self
+            .client
+            .post("/v1/chat/completions")
+            .json(
+                &if let Some(params) = completion_request.additional_params {
+                    json_utils::merge(request, params)
+                } else {
+                    request
+                },
+            )
+            .send()
+            .await?;
+
+        if response.status().is_success() {
+            match response.json::<ApiResponse<CompletionResponse>>().await? {
+                ApiResponse::Ok(response) => {
+                    tracing::info!(target: "rig",
+                        "Local completion token usage: {:?}",
+                        response.usage.clone().map(|usage| format!("{usage}")).unwrap_or("N/A".to_string())
+                    );
+                    tracing::debug!(target: "rig", ?response, "Raw response from local model");
+                    response.try_into()
+                }
+                ApiResponse::Err(err) => {
+                    tracing::error!(target: "rig", error = ?err.message, "Local model error");
+                    Err(CompletionError::ProviderError(err.message))
+                }
+            }
+        } else {
+            let error_text = response.text().await?;
+            tracing::error!(target: "rig", error = ?error_text, "Local model HTTP error");
+            Err(CompletionError::ProviderError(error_text))
+        }
+    }
+}

--- a/rig-core/src/providers/mod.rs
+++ b/rig-core/src/providers/mod.rs
@@ -6,6 +6,7 @@
 //! - Perplexity
 //! - Anthropic
 //! - Google Gemini
+//! - Local (with configurable endpoint)
 //!
 //! Each provider has its own module, which contains a `Client` implementation that can
 //! be used to initialize completion and embedding models and execute requests to those models.
@@ -43,6 +44,7 @@
 pub mod anthropic;
 pub mod cohere;
 pub mod gemini;
+pub mod local;
 pub mod openai;
 pub mod perplexity;
 pub mod xai;


### PR DESCRIPTION
this PR adds a `client` impl for calling local models, such as ollama and lm studio. it also duplicates some examples, such as simple chat, embeddings and tools calls. it also adds a collab example with local models, that demonstrates models working together to find a good prompt for themselves.

I have verified all of the examples work for me, on an M1 Max w/ ollama latest.