### PR TITLE
docs(ollama-example): implement example showcasing ollama

### DIFF
--- a/rig-core/examples/agent_with_ollama.rs
+++ b/rig-core/examples/agent_with_ollama.rs
@@ -1,0 +1,21 @@
+/// This example requires that you have the [`ollama`](https://ollama.com) server running locally.
+use rig::{completion::Prompt, providers};
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    // Create an OpenAI client with a custom base url, a local ollama endpoint
+    // The API Key is unnecessary for most local endpoints
+    let client = providers::openai::Client::from_url("ollama", "http://localhost:11434");
+
+    // Create agent with a single context prompt
+    let comedian_agent = client
+        .agent("llama3.2:latest")
+        .preamble("You are a comedian here to entertain the user using humour and jokes.")
+        .build();
+
+    // Prompt the agent and print the response
+    let response = comedian_agent.prompt("Entertain me!").await?;
+    println!("{}", response);
+
+    Ok(())
+}


### PR DESCRIPTION
This example showcases using [ollama](ollama.com) via a custom endpoint in the `OpenAI` client. Should be accompanied with a blog post showcasing local model support!