### PR TITLE
fix: mongodb integration test

### DIFF
--- a/rig-mongodb/tests/integration_tests.rs
+++ b/rig-mongodb/tests/integration_tests.rs
@@ -94,7 +94,7 @@ async fn vector_search_test() {
 async fn create_search_index(collection: &Collection<bson::Document>) {
     let mut attempts = 0;
     let max_attempts = 5;
-    
+
     while attempts < max_attempts {
         match collection
             .create_search_index(
@@ -115,13 +115,19 @@ async fn create_search_index(collection: &Collection<bson::Document>) {
         {
             Ok(_) => return,
             Err(_) => {
-                println!("Waiting for MongoDB to be ready... Attempts remaining: {}", max_attempts - attempts - 1);
+                println!(
+                    "Waiting for MongoDB to be ready... Attempts remaining: {}",
+                    max_attempts - attempts - 1
+                );
                 sleep(Duration::from_secs(5)).await;
                 attempts += 1;
             }
         }
     }
-    panic!("Failed to create search index after {} attempts", max_attempts);
+    panic!(
+        "Failed to create search index after {} attempts",
+        max_attempts
+    );
 }
 
 async fn bootstrap_collection(host: String, port: u16) -> Collection<bson::Document> {

--- a/rig-mongodb/tests/integration_tests.rs
+++ b/rig-mongodb/tests/integration_tests.rs
@@ -117,12 +117,13 @@ async fn create_search_index(collection: &Collection<bson::Document>) {
             Ok(_) => {
                 // Wait for index to be available
                 for _ in 0..max_attempts {
-                    let indexes = collection.list_search_indexes()
+                    let indexes = collection
+                        .list_search_indexes()
                         .await
                         .unwrap()
                         .collect::<Vec<_>>()
                         .await;
-                    
+
                     if indexes.iter().any(|idx| {
                         idx.as_ref()
                             .ok()
@@ -136,13 +137,19 @@ async fn create_search_index(collection: &Collection<bson::Document>) {
                 panic!("Index creation verified but index not found");
             }
             Err(_) => {
-                println!("Waiting for MongoDB... {} attempts remaining", max_attempts - attempt - 1);
+                println!(
+                    "Waiting for MongoDB... {} attempts remaining",
+                    max_attempts - attempt - 1
+                );
                 sleep(Duration::from_secs(5)).await;
             }
         }
     }
 
-    panic!("Failed to create search index after {} attempts", max_attempts);
+    panic!(
+        "Failed to create search index after {} attempts",
+        max_attempts
+    );
 }
 
 async fn bootstrap_collection(host: String, port: u16) -> Collection<bson::Document> {

--- a/rig-mongodb/tests/integration_tests.rs
+++ b/rig-mongodb/tests/integration_tests.rs
@@ -61,7 +61,7 @@ async fn vector_search_test() {
     collection.insert_many(embeddings).await.unwrap();
 
     // Wait for the new documents to be indexed
-    sleep(Duration::from_secs(30)).await;
+    sleep(Duration::from_secs(5)).await;
 
     // Create a vector index on our vector store.
     // Note: a vector index called "vector_index" must exist on the MongoDB collection you are querying.

--- a/rig-mongodb/tests/integration_tests.rs
+++ b/rig-mongodb/tests/integration_tests.rs
@@ -30,6 +30,39 @@ const DATABASE_NAME: &str = "rig";
 const USERNAME: &str = "riguser";
 const PASSWORD: &str = "rigpassword";
 
+async fn create_search_index(collection: &Collection<bson::Document>) {
+    let mut attempts = 0;
+    let max_attempts = 5;
+    
+    while attempts < max_attempts {
+        match collection
+            .create_search_index(
+                SearchIndexModel::builder()
+                    .name(Some(VECTOR_SEARCH_INDEX_NAME.to_string()))
+                    .index_type(Some(mongodb::SearchIndexType::VectorSearch))
+                    .definition(doc! {
+                        "fields": [{
+                            "numDimensions": 1536,
+                            "path": "embedding",
+                            "similarity": "cosine",
+                            "type": "vector"
+                        }]
+                    })
+                    .build(),
+            )
+            .await
+        {
+            Ok(_) => return,
+            Err(_) => {
+                println!("Waiting for MongoDB to be ready... Attempts remaining: {}", max_attempts - attempts - 1);
+                sleep(Duration::from_secs(5)).await;
+                attempts += 1;
+            }
+        }
+    }
+    panic!("Failed to create search index after {} attempts", max_attempts);
+}
+
 #[tokio::test]
 async fn vector_search_test() {
     // Initialize OpenAI client
@@ -114,24 +147,8 @@ async fn bootstrap_collection(host: String, port: u16) -> Collection<bson::Docum
         .database(DATABASE_NAME)
         .collection(COLLECTION_NAME);
 
-    // Create a vector search index on the collection
-    collection
-        .create_search_index(
-            SearchIndexModel::builder()
-                .name(Some(VECTOR_SEARCH_INDEX_NAME.to_string()))
-                .index_type(Some(mongodb::SearchIndexType::VectorSearch))
-                .definition(doc! {
-                    "fields": [{
-                        "numDimensions": 1536,
-                        "path": "embedding",
-                        "similarity": "cosine",
-                        "type": "vector"
-                    }]
-                })
-                .build(),
-        )
-        .await
-        .expect("Failed to create search index");
+    // Create the search index
+    create_search_index(&collection).await;
 
     collection
 }

--- a/rig-mongodb/tests/integration_tests.rs
+++ b/rig-mongodb/tests/integration_tests.rs
@@ -97,6 +97,7 @@ async fn create_search_index(collection: &Collection<bson::Document>) {
     let mut attempts = 0;
     let max_attempts = 5;
 
+    // Create the search index
     while attempts < max_attempts {
         match collection
             .create_search_index(


### PR DESCRIPTION
Previously, the mongo integration test was failing with `Error connecting to Search Index Management service.`. This is because it takes a bit of time for the container to initialize the service.

The extra delay added in #153 doesn't quite fix the issue because the index creation happens before the delay.

Our integration tests will now retry a couple of times before attempting to create the index.