### PR TITLE
fix: anthropic tool use

### DIFF
--- a/rig-core/src/agent.rs
+++ b/rig-core/src/agent.rs
@@ -265,7 +265,7 @@ impl<M: CompletionModel> Chat for Agent<M> {
                 ..
             } => Ok(msg),
             CompletionResponse {
-                choice: ModelChoice::ToolCall(toolname, args),
+                choice: ModelChoice::ToolCall(toolname, _, args),
                 ..
             } => Ok(self.tools.call(&toolname, args.to_string()).await?),
         }

--- a/rig-core/src/completion.rs
+++ b/rig-core/src/completion.rs
@@ -221,8 +221,8 @@ pub enum ModelChoice {
     /// Represents a completion response as a message
     Message(String),
     /// Represents a completion response as a tool call of the form
-    /// `ToolCall(function_name, function_params)`.
-    ToolCall(String, serde_json::Value),
+    /// `ToolCall(function_name, id, function_params)`.
+    ToolCall(String, String, serde_json::Value),
 }
 
 /// Trait defining a completion model that can be used to generate completion responses.

--- a/rig-core/src/providers/anthropic/completion.rs
+++ b/rig-core/src/providers/anthropic/completion.rs
@@ -106,11 +106,13 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
 
     fn try_from(response: CompletionResponse) -> std::prelude::v1::Result<Self, Self::Error> {
         if let Some(tool_use) = response.content.iter().find_map(|content| match content {
-            Content::ToolUse { name, input, .. } => Some((name.clone(), input.clone())),
+            Content::ToolUse {
+                name, input, id, ..
+            } => Some((name.clone(), id.clone(), input.clone())),
             _ => None,
         }) {
             return Ok(completion::CompletionResponse {
-                choice: completion::ModelChoice::ToolCall(tool_use.0, tool_use.1),
+                choice: completion::ModelChoice::ToolCall(tool_use.0, tool_use.1, tool_use.2),
                 raw_response: response,
             });
         }

--- a/rig-core/src/providers/cohere.rs
+++ b/rig-core/src/providers/cohere.rs
@@ -328,6 +328,7 @@ impl From<CompletionResponse> for completion::CompletionResponse<CompletionRespo
         let model_response = if !tool_calls.is_empty() {
             completion::ModelChoice::ToolCall(
                 tool_calls.first().unwrap().name.clone(),
+                "".to_owned(),
                 tool_calls.first().unwrap().parameters.clone(),
             )
         } else {

--- a/rig-core/src/providers/eternalai.rs
+++ b/rig-core/src/providers/eternalai.rs
@@ -369,6 +369,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                 Ok(completion::CompletionResponse {
                     choice: completion::ModelChoice::ToolCall(
                         call.function.name.clone(),
+                        call.id.clone(),
                         serde_json::from_str(&call.function.arguments)?,
                     ),
                     raw_response: value,

--- a/rig-core/src/providers/gemini/completion.rs
+++ b/rig-core/src/providers/gemini/completion.rs
@@ -169,7 +169,7 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse<Generat
                         let args_value = serde_json::Value::Object(
                             function_call.args.clone().unwrap_or_default(),
                         );
-                        completion::ModelChoice::ToolCall(function_call.name.clone(), args_value)
+                        completion::ModelChoice::ToolCall(function_call.name.clone(), "".to_owned(), args_value)
                     }
                     _ => {
                         return Err(CompletionError::ResponseError(

--- a/rig-core/src/providers/gemini/completion.rs
+++ b/rig-core/src/providers/gemini/completion.rs
@@ -169,7 +169,11 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse<Generat
                         let args_value = serde_json::Value::Object(
                             function_call.args.clone().unwrap_or_default(),
                         );
-                        completion::ModelChoice::ToolCall(function_call.name.clone(), "".to_owned(), args_value)
+                        completion::ModelChoice::ToolCall(
+                            function_call.name.clone(),
+                            "".to_owned(),
+                            args_value,
+                        )
                     }
                     _ => {
                         return Err(CompletionError::ResponseError(

--- a/rig-core/src/providers/openai.rs
+++ b/rig-core/src/providers/openai.rs
@@ -393,6 +393,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                 Ok(completion::CompletionResponse {
                     choice: completion::ModelChoice::ToolCall(
                         call.function.name.clone(),
+                        "".to_owned(),
                         serde_json::from_str(&call.function.arguments)?,
                     ),
                     raw_response: value,

--- a/rig-core/src/providers/xai/completion.rs
+++ b/rig-core/src/providers/xai/completion.rs
@@ -136,6 +136,7 @@ pub mod xai_api_types {
                     Ok(completion::CompletionResponse {
                         choice: completion::ModelChoice::ToolCall(
                             call.function.name.clone(),
+                            "".to_owned(),
                             serde_json::from_str(&call.function.arguments)?,
                         ),
                         raw_response: value,


### PR DESCRIPTION
anthropic currently sends back a vec on `Content` structs. Before the fix we were matching on the first element of that. The first element of a ToolUse is rarely ever the tool but more often text so we were never actually getting the tool use as a CompletionResponse

The PR first tries to find a tool use in the vec then some text