### PR TITLE
Fix 404 POST response message from Ollama due to wrong endpoint url

### DIFF
--- a/rig-core/examples/agent_with_ollama.rs
+++ b/rig-core/examples/agent_with_ollama.rs
@@ -5,7 +5,7 @@ use rig::{completion::Prompt, providers};
 async fn main() -> Result<(), anyhow::Error> {
     // Create an OpenAI client with a custom base url, a local ollama endpoint
     // The API Key is unnecessary for most local endpoints
-    let client = providers::openai::Client::from_url("ollama", "http://localhost:11434");
+    let client = providers::openai::Client::from_url("ollama", "http://localhost:11434/v1");
 
     // Create agent with a single context prompt
     let comedian_agent = client


### PR DESCRIPTION
The current ollama URL throws an 404 (not found) error message. This PR fixes the bug