### PR TITLE
docs: add buttons to readme & contributing update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thank you for considering contributing to Rig! Here are some guidelines to help you get started.
 
+General guidelines and requested contributions can be found in the [How to Contribute](https://docs.rig.rs/docs/7_how-to-contribute) section of the documentation.
+
 ## Issues
 
 Before reporting an issue, please check existing or similar issues that are currently tracked.
@@ -11,6 +13,8 @@ Before reporting an issue, please check existing or similar issues that are curr
 Contributions are always encouraged and welcome. Before creating a pull request, create a new issue that tracks that pull request describing the problem in more detail. Pull request descriptions should include information about it's implementation, especially if it makes changes to existing abstractions.
 
 PRs should be small and focused and should avoid interacting with multiple facets of the library. This may result in a larger PR being split into two or more smaller PRs. Commit messages should follow the [Conventional Commit](conventionalcommits.org/en/v1.0.0) format (prefixing with `feat`, `fix`, etc.) as this integrates into our auto-releases via a [release-plz](https://github.com/MarcoIeni/release-plz) Github action.
+
+**Working on your first Pull Request?** You can learn how from this *free* series [How to Contribute to an Open Source Project on GitHub](https://kcd.im/pull-request) 
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@
 </p>
 &nbsp;
 
+
+<div align="center">
+
+[📑 Docs](https://docs.rig.rs)
+<span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+[🌐 Website](https://rig.rs)
+<span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+[🤝 Contribute](https://github.com/0xPlaygrounds/rig/issues/new)
+<span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+[✍🏽 Blogs](https://docs.rig.rs/guides)
+
+</div>
+
 ✨ If you would like to help spread the word about Rig, please consider starring the repo!
 
 > [!WARNING]


### PR DESCRIPTION

This pull request includes updates to the `CONTRIBUTING.md` and `README.md` files to improve documentation and provide additional resources for contributors. The most important changes include adding general guidelines for contributions, providing a resource for first-time pull request contributors, and enhancing the README with links to documentation, the website, contribution guidelines, and blogs.

Documentation improvements:

* [`CONTRIBUTING.md`](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R5-R6): Added a link to the general guidelines and requested contributions section in the documentation.
* [`CONTRIBUTING.md`](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R17-R18): Included a resource link for first-time pull request contributors to a free series on how to contribute to an open-source project on GitHub.

Enhancements to README:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R26-R38): Added a centered section with links to the documentation, website, contribution guidelines, and blogs to provide easy access to important resources.