### PR TITLE
feat: support extractor for deepseek

### DIFF
--- a/rig-core/examples/extractor_with_deepseek.rs
+++ b/rig-core/examples/extractor_with_deepseek.rs
@@ -1,0 +1,31 @@
+use rig::providers::deepseek;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, JsonSchema, Serialize)]
+/// A record representing a person
+struct Person {
+    /// The person's first name, if provided (null otherwise)
+    pub first_name: Option<String>,
+    /// The person's last name, if provided (null otherwise)
+    pub last_name: Option<String>,
+    /// The person's job, if provided (null otherwise)
+    pub job: Option<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    // Create DeepSeek client
+    let deepseek_client = deepseek::Client::from_env();
+
+    // Create extractor
+    let data_extractor = deepseek_client.extractor::<Person>("deepseek-chat").build();
+
+    let person = data_extractor
+        .extract("Hello my name is John Doe! I am a software engineer.")
+        .await?;
+
+    println!("DeepSeek: {}", serde_json::to_string_pretty(&person).unwrap());
+
+    Ok(())
+}

--- a/rig-core/examples/extractor_with_deepseek.rs
+++ b/rig-core/examples/extractor_with_deepseek.rs
@@ -19,7 +19,9 @@ async fn main() -> Result<(), anyhow::Error> {
     let deepseek_client = deepseek::Client::from_env();
 
     // Create extractor
-    let data_extractor = deepseek_client.extractor::<Person>("deepseek-chat").build();
+    let data_extractor = deepseek_client
+        .extractor::<Person>(deepseek::DEEPSEEK_CHAT)
+        .build();
 
     let person = data_extractor
         .extract("Hello my name is John Doe! I am a software engineer.")

--- a/rig-core/examples/extractor_with_deepseek.rs
+++ b/rig-core/examples/extractor_with_deepseek.rs
@@ -25,7 +25,10 @@ async fn main() -> Result<(), anyhow::Error> {
         .extract("Hello my name is John Doe! I am a software engineer.")
         .await?;
 
-    println!("DeepSeek: {}", serde_json::to_string_pretty(&person).unwrap());
+    println!(
+        "DeepSeek: {}",
+        serde_json::to_string_pretty(&person).unwrap()
+    );
 
     Ok(())
 }

--- a/rig-core/src/providers/deepseek.rs
+++ b/rig-core/src/providers/deepseek.rs
@@ -13,8 +13,8 @@ use crate::{
     extractor::ExtractorBuilder,
     json_utils,
 };
-use schemars::JsonSchema;
 use reqwest::Client as HttpClient;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 

--- a/rig-core/src/providers/deepseek.rs
+++ b/rig-core/src/providers/deepseek.rs
@@ -10,8 +10,10 @@
 //! ```
 use crate::{
     completion::{CompletionModel, CompletionRequest, CompletionResponse},
+    extractor::ExtractorBuilder,
     json_utils,
 };
+use schemars::JsonSchema;
 use reqwest::Client as HttpClient;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -65,6 +67,14 @@ impl Client {
     /// Optionally add an agent() convenience:
     pub fn agent(&self, model_name: &str) -> crate::agent::AgentBuilder<DeepSeekCompletionModel> {
         crate::agent::AgentBuilder::new(self.completion_model(model_name))
+    }
+
+    /// Create an extractor builder with the given completion model.
+    pub fn extractor<T: JsonSchema + for<'a> Deserialize<'a> + Serialize + Send + Sync>(
+        &self,
+        model: &str,
+    ) -> ExtractorBuilder<T, DeepSeekCompletionModel> {
+        ExtractorBuilder::new(self.completion_model(model))
     }
 }
 

--- a/rig-core/src/providers/deepseek.rs
+++ b/rig-core/src/providers/deepseek.rs
@@ -284,3 +284,5 @@ impl CompletionModel for DeepSeekCompletionModel {
 // ================================================================
 /// `deepseek-chat` completion model
 pub const DEEPSEEK_CHAT: &str = "deepseek-chat";
+/// `deepseek-reasoner` completion model
+pub const DEEPSEEK_REASONER: &str = "deepseek-reasoner";


### PR DESCRIPTION
example result: 

```bash
$ cargo r --example=extractor_with_deepseek
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.00s
DeepSeek: {
  "first_name": "John",
  "last_name": "Doe",
  "job": "software engineer"
}
```