### PR TITLE
Fix typos  "substract" → "subtract"

### DIFF
--- a/rig-core/examples/agent_with_deepseek.rs
+++ b/rig-core/examples/agent_with_deepseek.rs
@@ -100,11 +100,11 @@ impl Tool for Subtract {
                 "properties": {
                     "x": {
                         "type": "number",
-                        "description": "The number to substract from"
+                        "description": "The number to subtract from"
                     },
                     "y": {
                         "type": "number",
-                        "description": "The number to substract"
+                        "description": "The number to subtract"
                     }
                 }
             }

--- a/rig-core/examples/agent_with_grok.rs
+++ b/rig-core/examples/agent_with_grok.rs
@@ -190,11 +190,11 @@ impl Tool for Subtract {
                 "properties": {
                     "x": {
                         "type": "number",
-                        "description": "The number to substract from"
+                        "description": "The number to subtract from"
                     },
                     "y": {
                         "type": "number",
-                        "description": "The number to substract"
+                        "description": "The number to subtract"
                     }
                 }
             }

--- a/rig-core/examples/agent_with_tools.rs
+++ b/rig-core/examples/agent_with_tools.rs
@@ -71,11 +71,11 @@ impl Tool for Subtract {
                 "properties": {
                     "x": {
                         "type": "number",
-                        "description": "The number to substract from"
+                        "description": "The number to subtract from"
                     },
                     "y": {
                         "type": "number",
-                        "description": "The number to substract"
+                        "description": "The number to subtract"
                     }
                 }
             }

--- a/rig-core/examples/anthropic_streaming_with_tools.rs
+++ b/rig-core/examples/anthropic_streaming_with_tools.rs
@@ -68,11 +68,11 @@ impl Tool for Subtract {
                 "properties": {
                     "x": {
                         "type": "number",
-                        "description": "The number to substract from"
+                        "description": "The number to subtract from"
                     },
                     "y": {
                         "type": "number",
-                        "description": "The number to substract"
+                        "description": "The number to subtract"
                     }
                 },
                 "required": ["x", "y"]

--- a/rig-core/examples/calculator_chatbot.rs
+++ b/rig-core/examples/calculator_chatbot.rs
@@ -95,11 +95,11 @@ impl Tool for Subtract {
                 "properties": {
                     "x": {
                         "type": "number",
-                        "description": "The number to substract from"
+                        "description": "The number to subtract from"
                     },
                     "y": {
                         "type": "number",
-                        "description": "The number to substract"
+                        "description": "The number to subtract"
                     }
                 }
             }

--- a/rig-core/examples/rag_dynamic_tools.rs
+++ b/rig-core/examples/rag_dynamic_tools.rs
@@ -96,11 +96,11 @@ impl Tool for Subtract {
                 "properties": {
                     "x": {
                         "type": "number",
-                        "description": "The number to substract from"
+                        "description": "The number to subtract from"
                     },
                     "y": {
                         "type": "number",
-                        "description": "The number to substract"
+                        "description": "The number to subtract"
                     }
                 }
             }


### PR DESCRIPTION
- Updated `"substract"` → `"subtract"` in the following files:
  - `agent_with_deepseek.rs`
  - `agent_with_grok.rs`
  - `agent_with_tools.rs`
  - `anthropic_streaming_with_tools.rs`
  - `calculator_chatbot.rs`
  - `rag_dynamic_tools.rs`

## Type of Change  
- [x] Bug fix (non-breaking change that fixes an issue)  
