### PR TITLE
fix: fix grammar mistake

### DIFF
--- a/rig-core/examples/agent_with_context.rs
+++ b/rig-core/examples/agent_with_context.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), anyhow::Error> {
     // Create an agent with multiple context documents
     let agent = AgentBuilder::new(model)
         .context("Definition of a *flurbo*: A flurbo is a green alien that lives on cold planets")
-        .context("Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.")
+        .context("Definition of a *glarb-glarb*: A glarb-glarb is an ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.")
         .context("Definition of a *linglingdong*: A term used by inhabitants of the far side of the moon to describe humans.")
         .build();
 


### PR DESCRIPTION
Noticed a grammar issue in the documentation: "a ancient tool" → "an ancient tool."
Since *ancient* starts with a vowel sound, "an" is the correct article.

Fixed it to improve clarity.