### PR TITLE
chore: Improved test assertion style for better readability

### DIFF
--- a/rig-core/src/loaders/file.rs
+++ b/rig-core/src/loaders/file.rs
@@ -268,6 +268,6 @@ mod tests {
         expected.sort();
 
         assert!(!actual.is_empty());
-        assert!(expected == actual)
+        assert_eq!(expected, actual);
     }
 }


### PR DESCRIPTION
I replaced `assert!(expected == actual)` with `assert_eq!(expected, actual)` in the test. While both work, `assert_eq!` is more idiomatic in Rust as it provides better output for debugging by automatically displaying the values when the assertion fails.

p.s. Change improves the readability and overall quality of the tests.