### PR TITLE
feat: View static agent context

### DIFF
--- a/rig-core/src/completion.rs
+++ b/rig-core/src/completion.rs
@@ -283,11 +283,11 @@ impl PromptData {
         Self { preamble, prompt }
     }
 
-    pub fn preamble<'a>(&'a self) -> &'a Option<String> {
-        &self.preamble
+    pub fn preamble(&self) -> Option<String> {
+        self.preamble.to_owned()
     }
 
-    pub fn prompt<'a>(&'a self) -> &'a str {
+    pub fn prompt(&self) -> &str {
         &self.prompt
     }
 }


### PR DESCRIPTION
Fixes #239 to some degree by allowing a new `PromptData` struct to be pulled out of a completion request, as well as allowing a new `TracePrompt` struct that allows users to get traces of the prompt they've sent to the LLM.

We should probably make it more obvious that `CompletionBuilder` is a thing as it feels like there is a bit of a discoverability issue since all of the examples basically prioritise using the easiest way possible to do everything.