### PR TITLE
feature: manage tool responses

### DIFF
--- a/rig-core/examples/agent_with_tools.rs
+++ b/rig-core/examples/agent_with_tools.rs
@@ -149,14 +149,13 @@ impl Tool for SearchTool {
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::DEBUG)
+        .with_max_level(tracing::Level::INFO)
         .with_target(false)
         .init();
 
     // Create OpenAI client
     let openai_client = providers::openai::Client::from_env();
 
-    /*
     // Create agent with a single context prompt and two tools
     let calculator_agent = openai_client
         .agent(providers::openai::GPT_4O)
@@ -172,8 +171,6 @@ async fn main() -> Result<(), anyhow::Error> {
         "OpenAI Calculator Agent: {}",
         calculator_agent.prompt("Calculate 2 - 5").await?
     );
-
-    */
 
     // Create agent with a single context prompt and a search tool
     let search_agent = openai_client

--- a/rig-core/examples/agent_with_tools.rs
+++ b/rig-core/examples/agent_with_tools.rs
@@ -90,6 +90,62 @@ impl Tool for Subtract {
     }
 }
 
+#[derive(Deserialize, Serialize)]
+struct SearchArgs {
+    pub query_string: String,
+}
+
+#[derive(Deserialize, Serialize)]
+struct SearchResult {
+    pub title: String,
+    pub url: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("Search error")]
+struct SearchError;
+
+#[derive(Deserialize, Serialize)]
+struct SearchTool;
+
+impl Tool for SearchTool {
+    const NAME: &'static str = "search";
+
+    type Error = SearchError;
+    type Args = SearchArgs;
+    type Output = SearchResult;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        serde_json::from_value(json!({
+            "name": "search",
+            "description": "Search for a website, it will return the title and URL",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query_string": {
+                        "type": "string",
+                        "description": "The query string to search for"
+                    },
+                }
+            }
+        }))
+        .expect("Tool Definition")
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        println!("[tool-call] Searching for: '{}'", args.query_string);
+
+        if args.query_string.to_lowercase().contains("rig") {
+            Ok(SearchResult {
+                title: "Rig Documentation".to_string(),
+                url: "https://docs.rig.ai".to_string(),
+            })
+        } else {
+            Err(SearchError)
+        }
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     tracing_subscriber::fmt()
@@ -100,6 +156,7 @@ async fn main() -> Result<(), anyhow::Error> {
     // Create OpenAI client
     let openai_client = providers::openai::Client::from_env();
 
+    /*
     // Create agent with a single context prompt and two tools
     let calculator_agent = openai_client
         .agent(providers::openai::GPT_4O)
@@ -114,6 +171,29 @@ async fn main() -> Result<(), anyhow::Error> {
     println!(
         "OpenAI Calculator Agent: {}",
         calculator_agent.prompt("Calculate 2 - 5").await?
+    );
+
+    */
+
+    // Create agent with a single context prompt and a search tool
+    let search_agent = openai_client
+        .agent(providers::openai::GPT_4O)
+        .preamble(
+            "You are an assistant helping to find useful information on the internet. \
+            If you can't find the information, you can use the search tool to find it. \
+            If search tool return an error just notify the user saying you could not find any result.",
+        )
+        .max_tokens(1024)
+        .tool(SearchTool)
+        .build();
+
+    // Prompt the agent and print the response
+    println!("Can you please let me know title and url of rig platform?");
+    println!(
+        "OpenAI Search Agent: {}",
+        search_agent
+            .prompt("Can you please let me know title and url of rig platform?")
+            .await?
     );
 
     Ok(())

--- a/rig-core/src/completion/message.rs
+++ b/rig-core/src/completion/message.rs
@@ -53,6 +53,15 @@ pub enum AssistantContent {
     ToolCall(ToolCall),
 }
 
+impl AssistantContent {
+    pub fn is_empty(&self) -> bool {
+        match self {
+            AssistantContent::Text(Text { text }) => text.is_empty(),
+            _ => false,
+        }
+    }
+}
+
 /// Tool result content containing information about a tool call and it's resulting content.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct ToolResult {
@@ -279,6 +288,15 @@ impl UserContent {
 
     /// Helper constructor to make creating user tool result content easier.
     pub fn tool_result(id: impl Into<String>, content: OneOrMany<ToolResultContent>) -> Self {
+        UserContent::ToolResult(ToolResult {
+            id: id.into(),
+            content,
+        })
+    }
+
+    /// Helper constructor to make creating user tool result from text easier.
+    pub fn tool_result_from_text_response(id: impl Into<String>, content: String) -> Self {
+        let content = OneOrMany::one(ToolResultContent::Text(content.into()));
         UserContent::ToolResult(ToolResult {
             id: id.into(),
             content,
@@ -522,6 +540,22 @@ impl From<Document> for Message {
     fn from(document: Document) -> Self {
         Message::User {
             content: OneOrMany::one(UserContent::Document(document)),
+        }
+    }
+}
+
+impl From<ToolCall> for Message {
+    fn from(tool_call: ToolCall) -> Self {
+        Message::Assistant {
+            content: OneOrMany::one(AssistantContent::ToolCall(tool_call)),
+        }
+    }
+}
+
+impl From<UserContent> for Message {
+    fn from(content: UserContent) -> Self {
+        Message::User {
+            content: OneOrMany::one(content),
         }
     }
 }

--- a/rig-core/src/providers/deepseek.rs
+++ b/rig-core/src/providers/deepseek.rs
@@ -8,19 +8,20 @@
 //!
 //! let deepseek_chat = client.completion_model(deepseek::DEEPSEEK_CHAT);
 //! ```
+use std::{convert::Infallible, str::FromStr};
+
 use crate::{
     completion::{self, CompletionError, CompletionModel, CompletionRequest},
     extractor::ExtractorBuilder,
     json_utils,
-    providers::openai::Message,
+    message::{self, AudioMediaType, ImageDetail},
+    one_or_many::string_or_one_or_many,
     OneOrMany,
 };
 use reqwest::Client as HttpClient;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use serde_json::json;
-
-use super::openai::AssistantContent;
+use serde_json::{json, Value};
 
 // ================================================================
 // Main DeepSeek Client
@@ -36,6 +37,18 @@ pub struct Client {
 impl Client {
     // Create a new DeepSeek client from an API key.
     pub fn new(api_key: &str) -> Self {
+        Self::from_url(api_key, DEEPSEEK_API_BASE_URL)
+    }
+
+    // If you prefer the environment variable approach:
+    pub fn from_env() -> Self {
+        let api_key = std::env::var("DEEPSEEK_API_KEY").expect("DEEPSEEK_API_KEY not set");
+
+        Self::new(&api_key)
+    }
+
+    // Handy for advanced usage, e.g. letting user override base_url or set timeouts:
+    pub fn from_url(api_key: &str, base_url: &str) -> Self {
         Self {
             base_url: base_url.to_string(),
             http_client: reqwest::Client::builder()
@@ -51,23 +64,6 @@ impl Client {
                 })
                 .build()
                 .expect("DeepSeek reqwest client should build"),
-        }
-    }
-
-    // If you prefer the environment variable approach:
-    pub fn from_env() -> Self {
-        let api_key = std::env::var("DEEPSEEK_API_KEY").expect("DEEPSEEK_API_KEY not set");
-
-        Self::new(&api_key)
-    }
-
-    // Handy for advanced usage, e.g. letting user override base_url or set timeouts:
-    pub fn from_url(api_key: &str, base_url: &str) -> Self {
-        // Possibly configure a custom HTTP client here if needed.
-        Self {
-            base_url: base_url.to_string(),
-            api_key: api_key.to_string(),
-            http_client: HttpClient::new(),
         }
     }
 
@@ -119,29 +115,444 @@ impl From<ApiErrorResponse> for CompletionError {
 /// The response shape from the DeepSeek API
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CompletionResponse {
-    // We'll match the JSON:
+    pub id: String,
+    pub object: String,
+    pub created: u64,
+    pub model: String,
+    pub system_fingerprint: Option<String>,
     pub choices: Vec<Choice>,
-    // you may want usage or other fields
+    pub usage: Option<Usage>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Choice {
+    pub index: usize,
     pub message: Message,
+    pub logprobs: Option<serde_json::Value>,
+    pub finish_reason: String,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(tag = "role", rename_all = "lowercase")]
+pub enum Message {
+    System {
+        #[serde(deserialize_with = "string_or_one_or_many")]
+        content: OneOrMany<SystemContent>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+    },
+    User {
+        #[serde(deserialize_with = "string_or_one_or_many")]
+        content: OneOrMany<UserContent>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+    },
+    Assistant {
+        #[serde(default, deserialize_with = "json_utils::string_or_vec")]
+        content: Vec<AssistantContent>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        refusal: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        audio: Option<AudioAssistant>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        #[serde(default, deserialize_with = "json_utils::null_or_vec")]
+        tool_calls: Vec<ToolCall>,
+    },
+    #[serde(rename = "tool")]
+    ToolResult {
+        tool_call_id: String,
+        content: OneOrMany<ToolResultContent>,
+    },
+}
+
+impl Message {
+    pub fn system(content: &str) -> Self {
+        Message::System {
+            content: OneOrMany::one(content.to_owned().into()),
+            name: None,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct AudioAssistant {
+    id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct SystemContent {
+    #[serde(default)]
+    r#type: SystemContentType,
+    text: String,
+}
+
+#[derive(Default, Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum SystemContentType {
+    #[default]
+    Text,
+}
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum AssistantContent {
+    Text { text: String },
+    Refusal { refusal: String },
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum UserContent {
+    Text { text: String },
+    Image { image_url: ImageUrl },
+    Audio { input_audio: InputAudio },
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct ImageUrl {
+    pub url: String,
+    #[serde(default)]
+    pub detail: ImageDetail,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct InputAudio {
+    pub data: String,
+    pub format: AudioMediaType,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct ToolResultContent {
+    text: String,
+    #[serde(default = "default_result_content")]
+    r#type: String,
+}
+
+fn default_result_content() -> String {
+    "text".to_string()
+}
+
+impl FromStr for ToolResultContent {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(s.to_owned().into())
+    }
+}
+
+impl From<String> for ToolResultContent {
+    fn from(s: String) -> Self {
+        ToolResultContent {
+            text: s,
+            r#type: default_result_content(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct ToolCall {
+    pub id: String,
+    #[serde(default)]
+    pub r#type: ToolType,
+    pub function: Function,
+}
+
+#[derive(Default, Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum ToolType {
+    #[default]
+    Function,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct ToolDefinition {
     pub r#type: String,
     pub function: completion::ToolDefinition,
 }
 
-impl From<crate::completion::ToolDefinition> for ToolDefinition {
-    fn from(tool: crate::completion::ToolDefinition) -> Self {
+impl From<completion::ToolDefinition> for ToolDefinition {
+    fn from(tool: completion::ToolDefinition) -> Self {
         Self {
             r#type: "function".into(),
             function: tool,
         }
     }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct Function {
+    pub name: String,
+    #[serde(with = "json_utils::stringified_json")]
+    pub arguments: serde_json::Value,
+}
+
+impl TryFrom<message::Message> for Vec<Message> {
+    type Error = message::MessageError;
+
+    fn try_from(message: message::Message) -> Result<Self, Self::Error> {
+        match message {
+            message::Message::User { content } => {
+                let (tool_results, other_content): (Vec<_>, Vec<_>) = content
+                    .into_iter()
+                    .partition(|content| matches!(content, message::UserContent::ToolResult(_)));
+
+                // If there are messages with both tool results and user content, openai will only
+                //  handle tool results. It's unlikely that there will be both.
+                if !tool_results.is_empty() {
+                    tool_results
+                        .into_iter()
+                        .map(|content| match content {
+                            message::UserContent::ToolResult(message::ToolResult {
+                                id,
+                                content,
+                            }) => Ok::<_, message::MessageError>(Message::ToolResult {
+                                tool_call_id: id,
+                                content: content.try_map(|content| match content {
+                                    message::ToolResultContent::Text(message::Text { text }) => {
+                                        Ok(text.into())
+                                    }
+                                    _ => Err(message::MessageError::ConversionError(
+                                        "Tool result content does not support non-text".into(),
+                                    )),
+                                })?,
+                            }),
+                            _ => unreachable!(),
+                        })
+                        .collect::<Result<Vec<_>, _>>()
+                } else {
+                    let other_content = OneOrMany::many(other_content).expect(
+                        "There must be other content here if there were no tool result content",
+                    );
+
+                    Ok(vec![Message::User {
+                        content: other_content.map(|content| match content {
+                            message::UserContent::Text(message::Text { text }) => {
+                                UserContent::Text { text }
+                            }
+                            message::UserContent::Image(message::Image {
+                                data, detail, ..
+                            }) => UserContent::Image {
+                                image_url: ImageUrl {
+                                    url: data,
+                                    detail: detail.unwrap_or_default(),
+                                },
+                            },
+                            message::UserContent::Document(message::Document { data, .. }) => {
+                                UserContent::Text { text: data }
+                            }
+                            message::UserContent::Audio(message::Audio {
+                                data,
+                                media_type,
+                                ..
+                            }) => UserContent::Audio {
+                                input_audio: InputAudio {
+                                    data,
+                                    format: match media_type {
+                                        Some(media_type) => media_type,
+                                        None => AudioMediaType::MP3,
+                                    },
+                                },
+                            },
+                            _ => unreachable!(),
+                        }),
+                        name: None,
+                    }])
+                }
+            }
+            message::Message::Assistant { content } => {
+                let (text_content, tool_calls) = content.into_iter().fold(
+                    (Vec::new(), Vec::new()),
+                    |(mut texts, mut tools), content| {
+                        match content {
+                            message::AssistantContent::Text(text) => texts.push(text),
+                            message::AssistantContent::ToolCall(tool_call) => tools.push(tool_call),
+                        }
+                        (texts, tools)
+                    },
+                );
+
+                // `OneOrMany` ensures at least one `AssistantContent::Text` or `ToolCall` exists,
+                //  so either `content` or `tool_calls` will have some content.
+                Ok(vec![Message::Assistant {
+                    content: text_content
+                        .into_iter()
+                        .map(|content| content.text.into())
+                        .collect::<Vec<_>>(),
+                    refusal: None,
+                    audio: None,
+                    name: None,
+                    tool_calls: tool_calls
+                        .into_iter()
+                        .map(|tool_call| tool_call.into())
+                        .collect::<Vec<_>>(),
+                }])
+            }
+        }
+    }
+}
+
+impl From<message::ToolCall> for ToolCall {
+    fn from(tool_call: message::ToolCall) -> Self {
+        Self {
+            id: tool_call.id,
+            r#type: ToolType::default(),
+            function: Function {
+                name: tool_call.function.name,
+                arguments: tool_call.function.arguments,
+            },
+        }
+    }
+}
+
+impl From<ToolCall> for message::ToolCall {
+    fn from(tool_call: ToolCall) -> Self {
+        Self {
+            id: tool_call.id,
+            function: message::ToolFunction {
+                name: tool_call.function.name,
+                arguments: tool_call.function.arguments,
+            },
+        }
+    }
+}
+
+impl TryFrom<Message> for message::Message {
+    type Error = message::MessageError;
+
+    fn try_from(message: Message) -> Result<Self, Self::Error> {
+        Ok(match message {
+            Message::User { content, .. } => message::Message::User {
+                content: content.map(|content| content.into()),
+            },
+            Message::Assistant {
+                content,
+                tool_calls,
+                ..
+            } => {
+                let mut content = content
+                    .into_iter()
+                    .map(|content| match content {
+                        AssistantContent::Text { text } => message::AssistantContent::text(text),
+
+                        // TODO: Currently, refusals are converted into text, but should be
+                        //  investigated for generalization.
+                        AssistantContent::Refusal { refusal } => {
+                            message::AssistantContent::text(refusal)
+                        }
+                    })
+                    .collect::<Vec<_>>();
+
+                content.extend(
+                    tool_calls
+                        .into_iter()
+                        .map(|tool_call| Ok(message::AssistantContent::ToolCall(tool_call.into())))
+                        .collect::<Result<Vec<_>, _>>()?,
+                );
+
+                message::Message::Assistant {
+                    content: OneOrMany::many(content).map_err(|_| {
+                        message::MessageError::ConversionError(
+                            "Neither `content` nor `tool_calls` was provided to the Message"
+                                .to_owned(),
+                        )
+                    })?,
+                }
+            }
+
+            Message::ToolResult {
+                tool_call_id,
+                content,
+            } => message::Message::User {
+                content: OneOrMany::one(message::UserContent::tool_result(
+                    tool_call_id,
+                    content.map(|content| message::ToolResultContent::text(content.text)),
+                )),
+            },
+
+            // System messages should get stripped out when converting message's, this is just a
+            // stop gap to avoid obnoxious error handling or panic occuring.
+            Message::System { content, .. } => message::Message::User {
+                content: content.map(|content| message::UserContent::text(content.text)),
+            },
+        })
+    }
+}
+
+impl From<UserContent> for message::UserContent {
+    fn from(content: UserContent) -> Self {
+        match content {
+            UserContent::Text { text } => message::UserContent::text(text),
+            UserContent::Image { image_url } => message::UserContent::image(
+                image_url.url,
+                Some(message::ContentFormat::default()),
+                None,
+                Some(image_url.detail),
+            ),
+            UserContent::Audio { input_audio } => message::UserContent::audio(
+                input_audio.data,
+                Some(message::ContentFormat::default()),
+                Some(input_audio.format),
+            ),
+        }
+    }
+}
+
+impl From<String> for AssistantContent {
+    fn from(s: String) -> Self {
+        AssistantContent::Text { text: s }
+    }
+}
+
+impl FromStr for AssistantContent {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(AssistantContent::Text {
+            text: s.to_string(),
+        })
+    }
+}
+
+impl From<String> for UserContent {
+    fn from(s: String) -> Self {
+        UserContent::Text { text: s }
+    }
+}
+
+impl FromStr for UserContent {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(UserContent::Text {
+            text: s.to_string(),
+        })
+    }
+}
+
+impl From<String> for SystemContent {
+    fn from(s: String) -> Self {
+        SystemContent {
+            r#type: SystemContentType::default(),
+            text: s,
+        }
+    }
+}
+
+impl FromStr for SystemContent {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(SystemContent {
+            r#type: SystemContentType::default(),
+            text: s.to_string(),
+        })
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Usage {
+    pub prompt_tokens: usize,
+    pub total_tokens: usize,
 }
 
 impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionResponse> {
@@ -165,6 +576,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                             completion::AssistantContent::text(refusal)
                         }
                     })
+                    .filter(|c| !c.is_empty())
                     .collect::<Vec<_>>();
 
                 content.extend(
@@ -240,7 +652,7 @@ impl CompletionModel for DeepSeekCompletionModel {
         full_history.extend(chat_history);
         full_history.extend(prompt);
 
-        let request = if completion_request.tools.is_empty() {
+        let mut request = if completion_request.tools.is_empty() {
             json!({
                 "model": self.model,
                 "messages": full_history,
@@ -256,29 +668,33 @@ impl CompletionModel for DeepSeekCompletionModel {
             })
         };
 
+        if let Some(params) = completion_request.additional_params {
+            request = json_utils::merge(request, params);
+        }
+
         let response = self
             .client
             .post("/chat/completions")
-            .json(
-                &if let Some(params) = completion_request.additional_params {
-                    json_utils::merge(request, params)
-                } else {
-                    request
-                },
-            )
+            .json(&request)
             .send()
             .await?;
 
         if response.status().is_success() {
-            let t = response.text().await?;
+            let t: Value = response.json().await?;
+            tracing::debug!(target: "rig", "DeepSeek completion success: \nRequest: \n{} \nResponse: \n{}",  
+                serde_json::to_string_pretty(&request).unwrap(),
+                serde_json::to_string_pretty(&t).unwrap(), );
 
-            match serde_json::from_str::<ApiResponse<CompletionResponse>>(&t)? {
+            match serde_json::from_value::<ApiResponse<CompletionResponse>>(t)? {
                 ApiResponse::Ok(response) => response.try_into(),
                 ApiResponse::Err(err) => Err(CompletionError::ProviderError(err.message)),
             }
         } else {
             let t = response.text().await?;
-            tracing::debug!(target: "rig", "DeepSeek completion error: {}", t);
+
+            tracing::debug!(target: "rig", "DeepSeek completion error: \nRequest: \n{} \n\nResponse: \n {}",
+                serde_json::to_string_pretty(&request).unwrap(),
+                t);
             Err(CompletionError::ProviderError(t))
         }
     }
@@ -296,7 +712,6 @@ pub const DEEPSEEK_REASONER: &str = "deepseek-reasoner";
 // Tests
 #[cfg(test)]
 mod tests {
-    use crate::providers::openai;
 
     use super::*;
 
@@ -307,7 +722,7 @@ mod tests {
         assert_eq!(choices.len(), 1);
         match &choices.first().unwrap().message {
             Message::Assistant { content, .. } => match &content[0] {
-                openai::AssistantContent::Text { text } => assert_eq!(text, "Hello, world!"),
+                AssistantContent::Text { text } => assert_eq!(text, "Hello, world!"),
                 _ => panic!("Expected text content"),
             },
             _ => panic!("Expected assistant message"),
@@ -322,7 +737,7 @@ mod tests {
         match result {
             Ok(response) => match &response.choices.first().unwrap().message {
                 Message::Assistant { content, .. } => match &content[0] {
-                    openai::AssistantContent::Text { text } => assert_eq!(text, "Hello, world!"),
+                    AssistantContent::Text { text } => assert_eq!(text, "Hello, world!"),
                     _ => panic!("Expected text content"),
                 },
                 _ => panic!("Expected assistant message"),
@@ -371,7 +786,7 @@ mod tests {
         match result {
             Ok(response) => match &response.choices.first().unwrap().message {
                 Message::Assistant { content, .. } => match &content[0] {
-                    openai::AssistantContent::Text { text } => assert_eq!(
+                    AssistantContent::Text { text } => assert_eq!(
                         text,
                         "Why don’t skeletons fight each other?  \nBecause they don’t have the guts! 😄"
                     ),

--- a/rig-core/src/providers/openai.rs
+++ b/rig-core/src/providers/openai.rs
@@ -928,7 +928,7 @@ impl completion::CompletionModel for CompletionModel {
 
         if response.status().is_success() {
             let t = response.text().await?;
-            tracing::debug!(target: "rig", "OpenAI completion error: {}", t);
+            tracing::debug!(target: "rig", "OpenAI completion success: {}", t);
 
             match serde_json::from_str::<ApiResponse<CompletionResponse>>(&t)? {
                 ApiResponse::Ok(response) => {
@@ -941,7 +941,9 @@ impl completion::CompletionModel for CompletionModel {
                 ApiResponse::Err(err) => Err(CompletionError::ProviderError(err.message)),
             }
         } else {
-            Err(CompletionError::ProviderError(response.text().await?))
+            let t = response.text().await?;
+            tracing::debug!(target: "rig", "OpenAI completion error: {}", t);
+            Err(CompletionError::ProviderError(t))
         }
     }
 }


### PR DESCRIPTION
It implements the next flow:
- human prompt
- agent respond with tool call
- tool is called
- tool response is sent back to agent
- assistant response is sent back to human

It works with OpenAI but I found an issue with DeepSeek and the serialization of content messages, when you send the tool call back to DeepSeek the content is empty and DeepSeek expects `content: ""`, however current serialization (based on OpenAI) is sending `content: []` which makes DeepSeek fail.

 

also fixes #274 