### PR TITLE
Fix spelling errors in `Makefile` and `message.rs`**

### DIFF
--- a/rig-core/src/completion/message.rs
+++ b/rig-core/src/completion/message.rs
@@ -141,7 +141,7 @@ pub enum MediaType {
 }
 
 /// Describes the image media type of the content. Not every provider supports every media type.
-/// Convertable to and from MIME type strings.
+/// Convertible to and from MIME type strings.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum ImageMediaType {
@@ -155,7 +155,7 @@ pub enum ImageMediaType {
 
 /// Describes the document media type of the content. Not every provider supports every media type.
 /// Includes also programming languages as document types for providers who support code running.
-/// Convertable to and from MIME type strings.
+/// Convertible to and from MIME type strings.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum DocumentMediaType {
@@ -172,7 +172,7 @@ pub enum DocumentMediaType {
 }
 
 /// Describes the audio media type of the content. Not every provider supports every media type.
-/// Convertable to and from MIME type strings.
+/// Convertible to and from MIME type strings.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum AudioMediaType {

--- a/rig-postgres/Makefile
+++ b/rig-postgres/Makefile
@@ -18,8 +18,8 @@ gitRebase:
 		git rebase $(DEFAULT_BRANCH)
 		git push --force origin $(CURRENT_BRANCH)
 
-.PHONY: gitAmmend
-gitAmmend:
+.PHONY: gitAmend
+gitAmend:
 	git add . && git commit --amend --no-edit && git push --force origin $(CURRENT_BRANCH)
 
 


### PR DESCRIPTION
- Fixes misspelled words (`Convertable` → `Convertible`) in `message.rs`.  
- Corrects `gitAmmend` → `gitAmend` in `Makefile` for proper command naming.  
