### PR TITLE
feat: allow malformed json parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,10 +89,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+dependencies = [
+ "anstyle",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "anyhow"
@@ -1635,6 +1679,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
 name = "comfy-table"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2577,6 +2627,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.89",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "log",
 ]
 
 [[package]]
@@ -4349,6 +4420,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4403,6 +4480,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "json_partial"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a797a12150eabc72431dfc580a2a90f5a1c080966708cedea21a74c271ff2719"
+dependencies = [
+ "anyhow",
+ "log",
+ "regex",
+ "serde",
+ "serde_json",
+ "test-log",
 ]
 
 [[package]]
@@ -6965,6 +7056,7 @@ dependencies = [
  "bytes",
  "futures",
  "glob",
+ "json_partial",
  "lopdf",
  "ordered-float",
  "rayon",
@@ -7621,9 +7713,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
@@ -7661,9 +7753,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7683,9 +7775,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.133"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "indexmap 2.6.0",
  "itoa",
@@ -8698,6 +8790,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
+name = "test-log"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f46083d221181166e5b6f6b1e5f1d499f3a76888826e6cb1d057554157cd0f"
+dependencies = [
+ "env_logger",
+ "test-log-macros",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "888d0c3c6db53c0fdab160d2ed5e12ba745383d3e85813f2ea0f2b1475ab553f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
 name = "testcontainers"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9447,6 +9561,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/rig-core/Cargo.toml
+++ b/rig-core/Cargo.toml
@@ -30,6 +30,7 @@ rayon = { version = "1.10.0", optional = true }
 worker = { version = "0.5", optional = true }
 bytes = "1.9.0"
 async-stream = "0.3.6"
+json_partial = "0.1.0"
 
 [dev-dependencies]
 anyhow = "1.0.75"

--- a/rig-core/src/extractor.rs
+++ b/rig-core/src/extractor.rs
@@ -73,7 +73,7 @@ where
         // Use jsonish to extract JSON from the response (it will remove extra markdown or code block markers).
         let parsed = jsonish::parse(&summary, Default::default())
             .map_err(|e| <serde_json::Error as serde::de::Error>::custom(e.to_string()))
-            .map_err(|e| ExtractionError::DeserializationError(e))?;
+            .map_err(ExtractionError::DeserializationError)?;
 
         let value = jsonish_to_serde(&parsed);
         Ok(serde_json::from_value(value)?)

--- a/rig-core/src/extractor.rs
+++ b/rig-core/src/extractor.rs
@@ -39,6 +39,7 @@ use crate::{
     completion::{CompletionModel, Prompt, PromptError, ToolDefinition},
     tool::Tool,
 };
+use json_partial::jsonish::{self, jsonish_to_serde};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ExtractionError {
@@ -69,7 +70,13 @@ where
             return Err(ExtractionError::NoData);
         }
 
-        Ok(serde_json::from_str(&summary)?)
+        // Use jsonish to extract JSON from the response (it will remove extra markdown or code block markers).
+        let parsed = jsonish::parse(&summary, Default::default())
+            .map_err(|e| <serde_json::Error as serde::de::Error>::custom(e.to_string()))
+            .map_err(|e| ExtractionError::DeserializationError(e))?;
+
+        let value = jsonish_to_serde(&parsed);
+        Ok(serde_json::from_value(value)?)
     }
 }
 


### PR DESCRIPTION
addresses #227 

This PR aims at more robust parsing of LLM text to yield Json. and hence helps in parsing the struct. 

There are many ways json could be malformed when returned by LLM. 

1. ` ``` ` backticks

```
let response = r#"
    ```
    {
        "name": "Bob",
        "age": 42,
        "address": {
            "street": "789 Pine Rd",
            "city": "Metropolis",
            "country": "USA",
            "coordinates": {"lat": 40.7128, "lng": -74.0060}
        },
        "hobbies": [
            {"name": "Cooking", "years_active": 5, "proficiency": "intermediate"},
            {"name": "Cycling", "years_active": 10, "proficiency": "expert"}
        ]
    }
    ```
    "#;

```

2. ` ``` json ` backticks with tag `json`
3.  introductory string 

```
let response = r#"
    Here is your json response:
    
    {
        "name": "Bob",
        "age": 42,
        "address": {
            "street": "789 Pine Rd",
            "city": "Metropolis",
            "country": "USA",
            "coordinates": {"lat": 40.7128, "lng": -74.0060}
        },
        "hobbies": [
            {"name": "Cooking", "years_active": 5, "proficiency": "intermediate"},
            {"name": "Cycling", "years_active": 10, "proficiency": "expert"}
        ]
    }
    
    You can use this now.
    "#;
```

---

[Current approach ](https://github.com/0xPlaygrounds/rig/blob/ef1e1aff4a1727f53002c44c9ed4747dcc48c6c3/rig-core/src/extractor.rs#L72) using serde_json::from_str does not cover these cases. When parsing with [json_partial](https://crates.io/crates/json_partial), all these fixes are handled to give a struct.

---
P.S. I am the author of json_partial

more tests related to parsing json using json_partial can be seen at https://github.com/TwistingTwists/aiworker/blob/36eedcc280a624c3f30cfd5fc712a522d8dbb938/examples/structured-jsonish/src/main.rs#L117-L261
