### PR TITLE
feat(openai): add OpenAI model constants

### DIFF
--- a/rig-core/src/providers/openai.rs
+++ b/rig-core/src/providers/openai.rs
@@ -317,13 +317,13 @@ impl EmbeddingModel {
 // OpenAI Completion API
 // ================================================================
 /// `o3-mini` completion model
-pub const O3_MINI: &str = "o3-mini"
+pub const O3_MINI: &str = "o3-mini";
 /// `o3-mini-2025-01-31` completion model
-pub const O3_MINI_2025_01_31: &str = "o3-mini-2025-01-31"
+pub const O3_MINI_2025_01_31: &str = "o3-mini-2025-01-31";
 /// 'o1' completion model
-pub const O1: &str = "o1"
+pub const O1: &str = "o1";
 /// `o1-2024-12-17` completion model
-pub const O1_2024_12_17: &str = "o1-2024-12-17"
+pub const O1_2024_12_17: &str = "o1-2024-12-17";
 /// `o1-preview` completion model
 pub const O1_PREVIEW: &str = "o1-preview";
 /// `o1-preview-2024-09-12` completion model

--- a/rig-core/src/providers/openai.rs
+++ b/rig-core/src/providers/openai.rs
@@ -316,6 +316,14 @@ impl EmbeddingModel {
 // ================================================================
 // OpenAI Completion API
 // ================================================================
+/// `o3-mini` completion model
+pub const O3_MINI: &str = "o3-mini"
+/// `o3-mini-2025-01-31` completion model
+pub const O3_MINI_2025_01_31: &str = "o3-mini-2025-01-31"
+/// 'o1' completion model
+pub const O1: &str = "o1"
+/// `o1-2024-12-17` completion model
+pub const O1_2024_12_17: &str = "o1-2024-12-17"
 /// `o1-preview` completion model
 pub const O1_PREVIEW: &str = "o1-preview";
 /// `o1-preview-2024-09-12` completion model


### PR DESCRIPTION
# New model provider: OpenAI Additional Models

## Description

Adding constants for OpenAI's latest model offerings to the OpenAI provider in RIG.

Provider website: https://openai.com
API documentation: https://platform.openai.com/docs/models

Added constants:
- O3_MINI: OpenAI's most efficient high-context model
- O3_MINI_2025_01_31: Date-specific version of O3-mini
- O1: OpenAI's base model
- O1_2024_12_17: Date-specific version of O1

These additions make it easier for RIG users to access OpenAI's newer, more cost-efficient models directly through the framework.

## Testing

- [x] Verified constant naming matches OpenAI's official model names
- [x] Confirmed models are accessible through OpenAI API
- [x] Tested model constants in a real application (Cainam Core)
- [x] Documentation comments follow RIG's format

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code with proper doc comments for each constant
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] The constants match the official model names from OpenAI
- [x] I've reviewed OpenAI's API documentation to ensure accuracy

## Notes

This is a minimal change that only adds constants for new OpenAI models. The O3-MINI model in particular offers improved efficiency for high-context operations, making it a valuable addition to the available model options in RIG.

## Contact

x.com/affaanmustafa