### PR TITLE
fix(openai): skip serializing empty tool_calls vector

### DIFF
--- a/rig-core/src/providers/openai.rs
+++ b/rig-core/src/providers/openai.rs
@@ -491,7 +491,11 @@ pub enum Message {
         audio: Option<AudioAssistant>,
         #[serde(skip_serializing_if = "Option::is_none")]
         name: Option<String>,
-        #[serde(default, deserialize_with = "json_utils::null_or_vec")]
+        #[serde(
+            default,
+            deserialize_with = "json_utils::null_or_vec",
+            skip_serializing_if = "Vec::is_empty"
+        )]
         tool_calls: Vec<ToolCall>,
     },
     #[serde(rename = "tool")]


### PR DESCRIPTION
OpenAI was returning an error in completion requests because outgoing "tool_calls" vector was being serialized as "[]" (empty vec) if there were no tool calls. This should fix it :)

Error that was being received:

```
 |  ProviderError: {
 |    "error": {
 |      "message": "Invalid 'messages[2].tool_calls': empty array. Expected an array with minimum length 1, but got an empty array instead.",
 |      "type": "invalid_request_error",
 |      "param": "messages[2].tool_calls",
 |      "code": "empty_array"
 |    }
 |  }
 ```