### PR TITLE
feat: SSE/JSONL decoders ported from Anthropic TS SDK

### DIFF
--- a/rig-core/src/agent.rs
+++ b/rig-core/src/agent.rs
@@ -475,7 +475,7 @@ impl<M: CompletionModel> AgentBuilder<M> {
 impl<M: StreamingCompletionModel> StreamingCompletion<M> for Agent<M> {
     async fn stream_completion(
         &self,
-        prompt: &str,
+        prompt: impl Into<Message> + Send,
         chat_history: Vec<Message>,
     ) -> Result<CompletionRequestBuilder<M>, CompletionError> {
         // Reuse the existing completion implementation to build the request

--- a/rig-core/src/providers/anthropic/decoders/jsonl.rs
+++ b/rig-core/src/providers/anthropic/decoders/jsonl.rs
@@ -1,0 +1,163 @@
+use crate::providers::anthropic::decoders::line::LineDecoder;
+use futures::{Stream, StreamExt};
+use serde::de::DeserializeOwned;
+use serde::de::Error;
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum JSONLDecoderError {
+    #[error("Failed to parse JSON: {0}")]
+    ParseError(#[from] serde_json::Error),
+
+    #[error("Response has no body")]
+    NoBodyError,
+}
+
+/// Decoder for JSON Lines format, where each line is a separate JSON object.
+///
+/// This struct allows processing a stream of bytes, decoding them into lines,
+/// and then parsing each line as a JSON object of type T.
+pub struct JSONLDecoder<T, S>
+where
+    T: DeserializeOwned + Unpin,
+    S: Stream<Item = Result<Vec<u8>, std::io::Error>> + Unpin,
+{
+    stream: S,
+    line_decoder: LineDecoder,
+    buffer: Vec<T>,
+    _phantom: PhantomData<T>,
+}
+
+impl<T, S> JSONLDecoder<T, S>
+where
+    T: DeserializeOwned + Unpin,
+    S: Stream<Item = Result<Vec<u8>, std::io::Error>> + Unpin,
+{
+    /// Create a new JSONLDecoder from a byte stream
+    pub fn new(stream: S) -> Self {
+        Self {
+            stream,
+            line_decoder: LineDecoder::new(),
+            buffer: Vec::new(),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Process a chunk of data, returning a Result with any JSON parsing errors
+    fn process_chunk(&mut self, chunk: &[u8]) -> Result<Vec<T>, JSONLDecoderError> {
+        let lines = self.line_decoder.decode(chunk);
+        let mut results = Vec::with_capacity(lines.len());
+
+        for line in lines {
+            // Skip empty lines
+            if line.trim().is_empty() {
+                continue;
+            }
+
+            let value: T = serde_json::from_str(&line)?;
+            results.push(value);
+        }
+
+        Ok(results)
+    }
+
+    /// Flush any remaining data in the line decoder and parse it
+    fn flush(&mut self) -> Result<Vec<T>, JSONLDecoderError> {
+        let lines = self.line_decoder.flush();
+        let mut results = Vec::with_capacity(lines.len());
+
+        for line in lines {
+            // Skip empty lines
+            if line.trim().is_empty() {
+                continue;
+            }
+
+            let value: T = serde_json::from_str(&line)?;
+            results.push(value);
+        }
+
+        Ok(results)
+    }
+}
+
+impl<T, S> Stream for JSONLDecoder<T, S>
+where
+    T: DeserializeOwned + Unpin,
+    S: Stream<Item = Result<Vec<u8>, std::io::Error>> + Unpin,
+{
+    type Item = Result<T, JSONLDecoderError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // Get a mutable reference to self
+        let this = self.get_mut();
+
+        // Return any buffered items first
+        if !this.buffer.is_empty() {
+            return Poll::Ready(Some(Ok(this.buffer.remove(0))));
+        }
+
+        // Poll the underlying stream
+        match this.stream.poll_next_unpin(cx) {
+            Poll::Ready(Some(Ok(chunk))) => {
+                // Process the chunk
+                match this.process_chunk(&chunk) {
+                    Ok(mut parsed) => {
+                        // If we got any items, buffer them and return the first one
+                        if !parsed.is_empty() {
+                            let item = parsed.remove(0);
+                            this.buffer.append(&mut parsed);
+                            Poll::Ready(Some(Ok(item)))
+                        } else {
+                            // No items yet, try again
+                            Pin::new(this).poll_next(cx)
+                        }
+                    }
+                    Err(e) => Poll::Ready(Some(Err(e))),
+                }
+            }
+            Poll::Ready(Some(Err(e))) => {
+                // Propagate stream errors
+                Poll::Ready(Some(Err(JSONLDecoderError::ParseError(
+                    serde_json::Error::custom(format!("Stream error: {}", e)),
+                ))))
+            }
+            Poll::Ready(None) => {
+                // Stream is done, flush any remaining data
+                match this.flush() {
+                    Ok(mut parsed) => {
+                        if !parsed.is_empty() {
+                            let item = parsed.remove(0);
+                            this.buffer.append(&mut parsed);
+                            Poll::Ready(Some(Ok(item)))
+                        } else {
+                            // Nothing left
+                            Poll::Ready(None)
+                        }
+                    }
+                    Err(e) => Poll::Ready(Some(Err(e))),
+                }
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// Create a JSONLDecoder from a response with a body stream
+#[cfg(feature = "reqwest")]
+pub fn from_response<T>(
+    response: reqwest::Response,
+) -> Result<impl Stream<Item = Result<T, JSONLDecoderError>>, JSONLDecoderError>
+where
+    T: DeserializeOwned + 'static,
+{
+    let stream = response.bytes_stream().map(|result| {
+        result
+            .map_err(std::io::Error::other)
+            .map(|bytes| bytes.to_vec())
+    });
+
+    Ok(JSONLDecoder::new(stream))
+}

--- a/rig-core/src/providers/anthropic/decoders/jsonl.rs
+++ b/rig-core/src/providers/anthropic/decoders/jsonl.rs
@@ -1,3 +1,4 @@
+//! JSONL is currently not used, it might be used when Anthropic batches beta feature is used.
 use crate::providers::anthropic::decoders::line::LineDecoder;
 use futures::{Stream, StreamExt};
 use serde::de::DeserializeOwned;

--- a/rig-core/src/providers/anthropic/decoders/jsonl.rs
+++ b/rig-core/src/providers/anthropic/decoders/jsonl.rs
@@ -144,19 +144,3 @@ where
         }
     }
 }
-
-/// Create a JSONLDecoder from a response with a body stream
-pub fn from_response<T>(
-    response: reqwest::Response,
-) -> Result<Pin<Box<dyn Stream<Item = Result<T, JSONLDecoderError>> + Send>>, JSONLDecoderError>
-where
-    T: DeserializeOwned + Send + Unpin + 'static,
-{
-    let stream = response.bytes_stream().map(|result| {
-        result
-            .map_err(std::io::Error::other)
-            .map(|bytes| bytes.to_vec())
-    });
-
-    Ok(Box::pin(JSONLDecoder::new(stream)))
-}

--- a/rig-core/src/providers/anthropic/decoders/jsonl.rs
+++ b/rig-core/src/providers/anthropic/decoders/jsonl.rs
@@ -146,12 +146,11 @@ where
 }
 
 /// Create a JSONLDecoder from a response with a body stream
-#[cfg(feature = "reqwest")]
 pub fn from_response<T>(
     response: reqwest::Response,
-) -> Result<impl Stream<Item = Result<T, JSONLDecoderError>>, JSONLDecoderError>
+) -> Result<Pin<Box<dyn Stream<Item = Result<T, JSONLDecoderError>> + Send>>, JSONLDecoderError>
 where
-    T: DeserializeOwned + 'static,
+    T: DeserializeOwned + Send + Unpin + 'static,
 {
     let stream = response.bytes_stream().map(|result| {
         result
@@ -159,5 +158,5 @@ where
             .map(|bytes| bytes.to_vec())
     });
 
-    Ok(JSONLDecoder::new(stream))
+    Ok(Box::pin(JSONLDecoder::new(stream)))
 }

--- a/rig-core/src/providers/anthropic/decoders/line.rs
+++ b/rig-core/src/providers/anthropic/decoders/line.rs
@@ -7,6 +7,12 @@ pub struct LineDecoder {
     carriage_return_index: Option<usize>,
 }
 
+impl Default for LineDecoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl LineDecoder {
     /// Create a new LineDecoder
     pub fn new() -> Self {
@@ -104,8 +110,8 @@ fn find_newline_index(buffer: &[u8], start_index: Option<usize>) -> Option<Newli
 
     let start = start_index.unwrap_or(0);
 
-    for i in start..buffer.len() {
-        if buffer[i] == NEWLINE {
+    for (i, &byte) in buffer.iter().enumerate().skip(start) {
+        if byte == NEWLINE {
             return Some(NewlineIndex {
                 preceding: i,
                 index: i + 1,
@@ -113,7 +119,7 @@ fn find_newline_index(buffer: &[u8], start_index: Option<usize>) -> Option<Newli
             });
         }
 
-        if buffer[i] == CARRIAGE {
+        if byte == CARRIAGE {
             return Some(NewlineIndex {
                 preceding: i,
                 index: i + 1,

--- a/rig-core/src/providers/anthropic/decoders/line.rs
+++ b/rig-core/src/providers/anthropic/decoders/line.rs
@@ -1,0 +1,379 @@
+use std::str;
+
+/// A line decoder that handles incrementally reading lines from text.
+/// Ported from JavaScript implementation.
+pub struct LineDecoder {
+    buffer: Vec<u8>,
+    carriage_return_index: Option<usize>,
+}
+
+impl LineDecoder {
+    /// Create a new LineDecoder
+    pub fn new() -> Self {
+        LineDecoder {
+            buffer: Vec::new(),
+            carriage_return_index: None,
+        }
+    }
+
+    /// Decode a chunk of data into lines
+    pub fn decode(&mut self, chunk: &[u8]) -> Vec<String> {
+        if chunk.is_empty() {
+            return Vec::new();
+        }
+
+        // Append the new chunk to the buffer
+        self.buffer.extend_from_slice(chunk);
+
+        let mut lines = Vec::new();
+
+        // Process lines while we can find newlines
+        while let Some(pattern_index) = find_newline_index(&self.buffer, self.carriage_return_index)
+        {
+            if pattern_index.carriage && self.carriage_return_index.is_none() {
+                // Skip until we either get a corresponding `\n`, a new `\r` or nothing
+                self.carriage_return_index = Some(pattern_index.index);
+                continue;
+            }
+
+            // We got double \r or \rtext\n
+            if let Some(cr_index) = self.carriage_return_index {
+                if pattern_index.index != cr_index + 1 || pattern_index.carriage {
+                    if cr_index > 0 {
+                        let line = decode_text(&self.buffer[0..cr_index - 1]);
+                        lines.push(line);
+                    } else {
+                        // Handle edge case for carriage return at beginning
+                        lines.push(String::new());
+                    }
+
+                    if cr_index < self.buffer.len() {
+                        self.buffer = self.buffer[cr_index..].to_vec();
+                    } else {
+                        self.buffer.clear();
+                    }
+                    self.carriage_return_index = None;
+                    continue;
+                }
+            }
+
+            let end_index = if self.carriage_return_index.is_some() {
+                pattern_index.preceding - 1
+            } else {
+                pattern_index.preceding
+            };
+
+            if end_index > 0 {
+                let line = decode_text(&self.buffer[0..end_index]);
+                lines.push(line);
+            } else {
+                lines.push(String::new());
+            }
+
+            if pattern_index.index < self.buffer.len() {
+                self.buffer = self.buffer[pattern_index.index..].to_vec();
+            } else {
+                self.buffer.clear();
+            }
+            self.carriage_return_index = None;
+        }
+
+        lines
+    }
+
+    /// Flush any remaining data in the buffer
+    pub fn flush(&mut self) -> Vec<String> {
+        if self.buffer.is_empty() {
+            return Vec::new();
+        }
+        self.decode("\n".as_bytes())
+    }
+}
+
+/// Helper structure for newline index information
+struct NewlineIndex {
+    preceding: usize,
+    index: usize,
+    carriage: bool,
+}
+
+/// Find the index of the next newline character in the buffer
+fn find_newline_index(buffer: &[u8], start_index: Option<usize>) -> Option<NewlineIndex> {
+    const NEWLINE: u8 = 0x0a; // \n
+    const CARRIAGE: u8 = 0x0d; // \r
+
+    let start = start_index.unwrap_or(0);
+
+    for i in start..buffer.len() {
+        if buffer[i] == NEWLINE {
+            return Some(NewlineIndex {
+                preceding: i,
+                index: i + 1,
+                carriage: false,
+            });
+        }
+
+        if buffer[i] == CARRIAGE {
+            return Some(NewlineIndex {
+                preceding: i,
+                index: i + 1,
+                carriage: true,
+            });
+        }
+    }
+
+    None
+}
+
+/// Find the index after a double newline pattern in the buffer
+pub fn find_double_newline_index(buffer: &[u8]) -> isize {
+    const NEWLINE: u8 = 0x0a; // \n
+    const CARRIAGE: u8 = 0x0d; // \r
+
+    for i in 0..buffer.len().saturating_sub(1) {
+        // Check for \n\n pattern
+        if buffer[i] == NEWLINE && buffer[i + 1] == NEWLINE {
+            return (i + 2) as isize;
+        }
+
+        // Check for \r\r pattern
+        if buffer[i] == CARRIAGE && buffer[i + 1] == CARRIAGE {
+            return (i + 2) as isize;
+        }
+
+        // Check for \r\n\r\n pattern
+        if i + 3 < buffer.len()
+            && buffer[i] == CARRIAGE
+            && buffer[i + 1] == NEWLINE
+            && buffer[i + 2] == CARRIAGE
+            && buffer[i + 3] == NEWLINE
+        {
+            return (i + 4) as isize;
+        }
+    }
+
+    -1
+}
+
+/// Decode a byte slice into a UTF-8 string
+fn decode_text(bytes: &[u8]) -> String {
+    match str::from_utf8(bytes) {
+        Ok(s) => s.to_string(),
+        Err(_) => {
+            // Handle invalid UTF-8 by replacing invalid sequences
+            String::from_utf8_lossy(bytes).to_string()
+        }
+    }
+}
+
+/// Decode multiple chunks of data, with an option to flush
+pub fn decode_chunks(chunks: &[&[u8]], flush: bool) -> Vec<String> {
+    let mut decoder = LineDecoder::new();
+    let mut lines = Vec::new();
+
+    for chunk in chunks {
+        lines.extend(decoder.decode(chunk));
+    }
+
+    if flush {
+        lines.extend(decoder.flush());
+    }
+
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn str_chunks(chunks: &[&str]) -> Vec<Vec<u8>> {
+        chunks.iter().map(|s| s.as_bytes().to_vec()).collect()
+    }
+
+    fn decode_string_chunks(chunks: &[&str], flush: bool) -> Vec<String> {
+        let byte_chunks: Vec<&[u8]> = chunks.iter().map(|s| s.as_bytes()).collect();
+        decode_chunks(&byte_chunks, flush)
+    }
+
+    #[test]
+    fn test_basic() {
+        // baz is not included because the line hasn't ended yet
+        assert_eq!(
+            decode_string_chunks(&["foo", " bar\nbaz"], false),
+            vec!["foo bar"]
+        );
+    }
+
+    #[test]
+    fn test_basic_with_cr() {
+        assert_eq!(
+            decode_string_chunks(&["foo", " bar\r\nbaz"], false),
+            vec!["foo bar"]
+        );
+        assert_eq!(
+            decode_string_chunks(&["foo", " bar\r\nbaz"], true),
+            vec!["foo bar", "baz"]
+        );
+    }
+
+    #[test]
+    fn test_trailing_new_lines() {
+        assert_eq!(
+            decode_string_chunks(&["foo", " bar", "baz\n", "thing\n"], false),
+            vec!["foo barbaz", "thing"]
+        );
+    }
+
+    #[test]
+    fn test_trailing_new_lines_with_cr() {
+        assert_eq!(
+            decode_string_chunks(&["foo", " bar", "baz\r\n", "thing\r\n"], false),
+            vec!["foo barbaz", "thing"]
+        );
+    }
+
+    #[test]
+    fn test_escaped_new_lines() {
+        assert_eq!(
+            decode_string_chunks(&["foo", " bar\\nbaz\n"], false),
+            vec!["foo bar\\nbaz"]
+        );
+    }
+
+    #[test]
+    fn test_escaped_new_lines_with_cr() {
+        assert_eq!(
+            decode_string_chunks(&["foo", " bar\\r\\nbaz\n"], false),
+            vec!["foo bar\\r\\nbaz"]
+        );
+    }
+
+    #[test]
+    fn test_cr_and_lf_split_across_chunks() {
+        assert_eq!(
+            decode_string_chunks(&["foo\r", "\n", "bar"], true),
+            vec!["foo", "bar"]
+        );
+    }
+
+    #[test]
+    fn test_single_cr() {
+        assert_eq!(
+            decode_string_chunks(&["foo\r", "bar"], true),
+            vec!["foo", "bar"]
+        );
+    }
+
+    #[test]
+    fn test_double_cr() {
+        assert_eq!(
+            decode_string_chunks(&["foo\r", "bar\r"], true),
+            vec!["foo", "bar"]
+        );
+        assert_eq!(
+            decode_string_chunks(&["foo\r", "\r", "bar"], true),
+            vec!["foo", "", "bar"]
+        );
+        // implementation detail that we don't yield the single \r line until a new \r or \n is encountered
+        assert_eq!(
+            decode_string_chunks(&["foo\r", "\r", "bar"], false),
+            vec!["foo"]
+        );
+    }
+
+    #[test]
+    fn test_double_cr_then_crlf() {
+        assert_eq!(
+            decode_string_chunks(&["foo\r", "\r", "\r", "\n", "bar", "\n"], false),
+            vec!["foo", "", "", "bar"]
+        );
+        assert_eq!(
+            decode_string_chunks(&["foo\n", "\n", "\n", "bar", "\n"], false),
+            vec!["foo", "", "", "bar"]
+        );
+    }
+
+    #[test]
+    fn test_double_newline() {
+        assert_eq!(
+            decode_string_chunks(&["foo\n\nbar"], true),
+            vec!["foo", "", "bar"]
+        );
+        assert_eq!(
+            decode_string_chunks(&["foo", "\n", "\nbar"], true),
+            vec!["foo", "", "bar"]
+        );
+        assert_eq!(
+            decode_string_chunks(&["foo\n", "\n", "bar"], true),
+            vec!["foo", "", "bar"]
+        );
+        assert_eq!(
+            decode_string_chunks(&["foo", "\n", "\n", "bar"], true),
+            vec!["foo", "", "bar"]
+        );
+    }
+
+    #[test]
+    fn test_multi_byte_characters_across_chunks() {
+        let mut decoder = LineDecoder::new();
+
+        // bytes taken from the string 'известни' and arbitrarily split
+        // so that some multi-byte characters span multiple chunks
+        assert_eq!(decoder.decode(&[0xd0]), Vec::<String>::new());
+        assert_eq!(
+            decoder.decode(&[0xb8, 0xd0, 0xb7, 0xd0]),
+            Vec::<String>::new()
+        );
+        assert_eq!(
+            decoder.decode(&[0xb2, 0xd0, 0xb5, 0xd1, 0x81, 0xd1, 0x82, 0xd0, 0xbd, 0xd0, 0xb8]),
+            Vec::<String>::new()
+        );
+
+        let decoded = decoder.decode(&[0xa]);
+        assert_eq!(decoded, vec!["известни"]);
+    }
+
+    #[test]
+    fn test_flushing_trailing_newlines() {
+        assert_eq!(
+            decode_string_chunks(&["foo\n", "\nbar"], true),
+            vec!["foo", "", "bar"]
+        );
+    }
+
+    #[test]
+    fn test_flushing_empty_buffer() {
+        assert_eq!(decode_string_chunks(&[], true), Vec::<String>::new());
+    }
+
+    #[test]
+    fn test_find_double_newline_index() {
+        // Test \n\n patterns
+        assert_eq!(find_double_newline_index("foo\n\nbar".as_bytes()), 5);
+        assert_eq!(find_double_newline_index("\n\nbar".as_bytes()), 2);
+        assert_eq!(find_double_newline_index("foo\n\n".as_bytes()), 5);
+        assert_eq!(find_double_newline_index("\n\n".as_bytes()), 2);
+
+        // Test \r\r patterns
+        assert_eq!(find_double_newline_index("foo\r\rbar".as_bytes()), 5);
+        assert_eq!(find_double_newline_index("\r\rbar".as_bytes()), 2);
+        assert_eq!(find_double_newline_index("foo\r\r".as_bytes()), 5);
+        assert_eq!(find_double_newline_index("\r\r".as_bytes()), 2);
+
+        // Test \r\n\r\n patterns
+        assert_eq!(find_double_newline_index("foo\r\n\r\nbar".as_bytes()), 7);
+        assert_eq!(find_double_newline_index("\r\n\r\nbar".as_bytes()), 4);
+        assert_eq!(find_double_newline_index("foo\r\n\r\n".as_bytes()), 7);
+        assert_eq!(find_double_newline_index("\r\n\r\n".as_bytes()), 4);
+
+        // Test not found cases
+        assert_eq!(find_double_newline_index("foo\nbar".as_bytes()), -1);
+        assert_eq!(find_double_newline_index("foo\rbar".as_bytes()), -1);
+        assert_eq!(find_double_newline_index("foo\r\nbar".as_bytes()), -1);
+        assert_eq!(find_double_newline_index("".as_bytes()), -1);
+
+        // Test incomplete patterns
+        assert_eq!(find_double_newline_index("foo\r\n\r".as_bytes()), -1);
+        assert_eq!(find_double_newline_index("foo\r\n".as_bytes()), -1);
+    }
+}

--- a/rig-core/src/providers/anthropic/decoders/line.rs
+++ b/rig-core/src/providers/anthropic/decoders/line.rs
@@ -186,10 +186,6 @@ pub fn decode_chunks(chunks: &[&[u8]], flush: bool) -> Vec<String> {
 mod tests {
     use super::*;
 
-    fn str_chunks(chunks: &[&str]) -> Vec<Vec<u8>> {
-        chunks.iter().map(|s| s.as_bytes().to_vec()).collect()
-    }
-
     fn decode_string_chunks(chunks: &[&str], flush: bool) -> Vec<String> {
         let byte_chunks: Vec<&[u8]> = chunks.iter().map(|s| s.as_bytes()).collect();
         decode_chunks(&byte_chunks, flush)

--- a/rig-core/src/providers/anthropic/decoders/mod.rs
+++ b/rig-core/src/providers/anthropic/decoders/mod.rs
@@ -2,7 +2,7 @@
  * The code from this module is a Rust port of the
  * https://github.com/anthropics/anthropic-sdk-typescript/tree/main decoders
  *
- * The original code is licensed under PBT license
+ * The original code is licensed under MIT license
  * https://github.com/anthropics/anthropic-sdk-typescript/blob/main/LICENSE
  */
 pub mod jsonl;

--- a/rig-core/src/providers/anthropic/decoders/mod.rs
+++ b/rig-core/src/providers/anthropic/decoders/mod.rs
@@ -1,0 +1,9 @@
+/*
+ * The code from this module is a Rust port of the
+ * https://github.com/anthropics/anthropic-sdk-typescript/tree/main decoders
+ *
+ * The original code is licensed under PBT license
+ * https://github.com/anthropics/anthropic-sdk-typescript/blob/main/LICENSE
+ */
+pub mod jsonl;
+pub mod line;

--- a/rig-core/src/providers/anthropic/decoders/mod.rs
+++ b/rig-core/src/providers/anthropic/decoders/mod.rs
@@ -7,3 +7,4 @@
  */
 pub mod jsonl;
 pub mod line;
+pub mod sse;

--- a/rig-core/src/providers/anthropic/decoders/sse.rs
+++ b/rig-core/src/providers/anthropic/decoders/sse.rs
@@ -30,6 +30,12 @@ pub struct SSEDecoder {
     chunks: Vec<String>,
 }
 
+impl Default for SSEDecoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SSEDecoder {
     /// Create a new SSE decoder
     pub fn new() -> Self {
@@ -88,8 +94,8 @@ impl SSEDecoder {
         };
 
         // Trim leading space from value as per SSE spec
-        let value = if value.starts_with(' ') {
-            &value[1..]
+        let value = if let Some(stripped) = value.strip_prefix(' ') {
+            stripped
         } else {
             value
         };

--- a/rig-core/src/providers/anthropic/decoders/sse.rs
+++ b/rig-core/src/providers/anthropic/decoders/sse.rs
@@ -1,0 +1,186 @@
+use super::line::{self, LineDecoder};
+use futures::{Stream, StreamExt};
+use std::fmt::Debug;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum SSEDecoderError {
+    #[error("Failed to parse SSE: {0}")]
+    ParseError(String),
+
+    #[error("Failed to decode UTF-8: {0}")]
+    Utf8Error(#[from] std::string::FromUtf8Error),
+
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+}
+
+/// Server-Sent Event with event name, data, and raw lines
+#[derive(Debug, Clone)]
+pub struct ServerSentEvent {
+    pub event: Option<String>,
+    pub data: String,
+    pub raw: Vec<String>,
+}
+
+/// SSE Decoder for parsing Server-Sent Events (SSE) format
+pub struct SSEDecoder {
+    data: Vec<String>,
+    event: Option<String>,
+    chunks: Vec<String>,
+}
+
+impl SSEDecoder {
+    /// Create a new SSE decoder
+    pub fn new() -> Self {
+        Self {
+            data: Vec::new(),
+            event: None,
+            chunks: Vec::new(),
+        }
+    }
+
+    /// Decode a line of SSE text, returning an event if complete
+    pub fn decode(&mut self, line: &str) -> Option<ServerSentEvent> {
+        let mut line = line.to_string();
+
+        // Handle carriage returns as per TypeScript impl
+        if line.ends_with('\r') {
+            line = line[0..line.len() - 1].to_string();
+        }
+
+        // Empty line signals the end of an event
+        if line.is_empty() {
+            // If we don't have any data or event, just return None
+            if self.event.is_none() && self.data.is_empty() {
+                return None;
+            }
+
+            // Create the SSE event
+            let sse = ServerSentEvent {
+                event: self.event.clone(),
+                data: self.data.join("\n"),
+                raw: self.chunks.clone(),
+            };
+
+            // Reset state
+            self.event = None;
+            self.data.clear();
+            self.chunks.clear();
+
+            return Some(sse);
+        }
+
+        // Add to raw chunks
+        self.chunks.push(line.clone());
+
+        // Ignore comments
+        if line.starts_with(':') {
+            return None;
+        }
+
+        // Parse field:value format
+        let parts: Vec<&str> = line.splitn(2, ':').collect();
+        let (field_name, value) = match parts.as_slice() {
+            [field] => (*field, ""),
+            [field, value] => (*field, *value),
+            _ => unreachable!(),
+        };
+
+        // Trim leading space from value as per SSE spec
+        let value = if value.starts_with(' ') {
+            &value[1..]
+        } else {
+            value
+        };
+
+        // Process fields
+        match field_name {
+            "event" => self.event = Some(value.to_string()),
+            "data" => self.data.push(value.to_string()),
+            _ => {} // Ignore other fields
+        }
+
+        None
+    }
+}
+
+/// Process a byte stream to extract SSE messages
+pub fn iter_sse_messages<S>(
+    mut stream: S,
+) -> impl Stream<Item = Result<ServerSentEvent, SSEDecoderError>>
+where
+    S: Stream<Item = Result<Vec<u8>, std::io::Error>> + Unpin,
+{
+    let mut sse_decoder = SSEDecoder::new();
+    let mut line_decoder = LineDecoder::new();
+    let mut buffer = Vec::new();
+
+    async_stream::stream! {
+        while let Some(chunk_result) = stream.next().await {
+            let chunk = match chunk_result {
+                Ok(c) => c,
+                Err(e) => {
+                    yield Err(SSEDecoderError::IoError(e));
+                    continue;
+                }
+            };
+
+            // Process bytes through SSE chunking
+            buffer.extend_from_slice(&chunk);
+
+            // Extract chunks at double newlines
+            while let Some((chunk_data, remaining)) = extract_sse_chunk(&buffer) {
+                buffer = remaining;
+
+                // Process the chunk lines
+                for line in line_decoder.decode(&chunk_data) {
+                    if let Some(sse) = sse_decoder.decode(&line) {
+                        yield Ok(sse);
+                    }
+                }
+            }
+        }
+
+        // Process any remaining data
+        for line in line_decoder.flush() {
+            if let Some(sse) = sse_decoder.decode(&line) {
+                yield Ok(sse);
+            }
+        }
+
+        // Force final event if we have pending data
+        if !sse_decoder.data.is_empty() || sse_decoder.event.is_some() {
+            if let Some(sse) = sse_decoder.decode("") {
+                yield Ok(sse);
+            }
+        }
+    }
+}
+
+/// Extract an SSE chunk up to a double newline
+fn extract_sse_chunk(buffer: &[u8]) -> Option<(Vec<u8>, Vec<u8>)> {
+    let pattern_index = line::find_double_newline_index(buffer);
+
+    if pattern_index <= 0 {
+        return None;
+    }
+
+    let pattern_index = pattern_index as usize;
+    let chunk = buffer[0..pattern_index].to_vec();
+    let remaining = buffer[pattern_index..].to_vec();
+
+    Some((chunk, remaining))
+}
+
+pub fn from_response(
+    response: reqwest::Response,
+) -> impl Stream<Item = Result<ServerSentEvent, SSEDecoderError>> {
+    let stream = response.bytes_stream().map(|result| {
+        result
+            .map_err(std::io::Error::other)
+            .map(|bytes| bytes.to_vec())
+    });
+
+    iter_sse_messages(stream)
+}

--- a/rig-core/src/providers/anthropic/mod.rs
+++ b/rig-core/src/providers/anthropic/mod.rs
@@ -11,6 +11,7 @@
 
 pub mod client;
 pub mod completion;
+pub mod decoders;
 pub mod streaming;
 
 pub use client::{Client, ClientBuilder};

--- a/rig-core/src/streaming.rs
+++ b/rig-core/src/streaming.rs
@@ -71,7 +71,7 @@ pub trait StreamingCompletion<M: StreamingCompletionModel> {
     /// Generate a streaming completion from a request
     fn stream_completion(
         &self,
-        prompt: &str,
+        prompt: impl Into<Message> + Send,
         chat_history: Vec<Message>,
     ) -> impl Future<Output = Result<CompletionRequestBuilder<M>, CompletionError>>;
 }


### PR DESCRIPTION
This fixes the issue with trailing whitespace JSONL and improves the flow of accumulating/streaming chunked outputs

The logic can likely be reused with minimal change for other providers