### PR TITLE
feat: add reqwest/rustls-tls support

### DIFF
--- a/rig-core/Cargo.toml
+++ b/rig-core/Cargo.toml
@@ -51,7 +51,13 @@ pdf = ["dep:lopdf"]
 epub = ["dep:epub", "dep:quick-xml"]
 rayon = ["dep:rayon"]
 worker = ["dep:worker"]
-reqwest-rustls = ["reqwest/rustls-tls"]
+# Replace "default-tls" with "rustls-tls" in "reqwest/default"
+reqwest-rustls = [
+    "reqwest/rustls-tls",
+    "reqwest/charset",
+    "reqwest/http2",
+    "reqwest/macos-system-configuration",
+]
 
 [[test]]
 name = "embed_macro"

--- a/rig-core/Cargo.toml
+++ b/rig-core/Cargo.toml
@@ -15,7 +15,7 @@ doctest = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reqwest = { version = "0.11.22", features = ["json", "stream", "multipart"] }
+reqwest = { version = "0.11.22", default-features = false, features = ["json", "stream", "multipart"] }
 serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
 tracing = "0.1.40"
@@ -44,12 +44,14 @@ serde_path_to_error = "0.1.16"
 base64 = "0.22.1"
 
 [features]
+default = ["reqwest/default"]
 all = ["derive", "pdf", "rayon"]
 derive = ["dep:rig-derive"]
 pdf = ["dep:lopdf"]
 epub = ["dep:epub", "dep:quick-xml"]
 rayon = ["dep:rayon"]
 worker = ["dep:worker"]
+reqwest-rustls = ["reqwest/rustls-tls"]
 
 [[test]]
 name = "embed_macro"


### PR DESCRIPTION
## What did I do?

Added `reqwest/rustls-tls` support to `rig-core`

## Why did I want to do this?

After making this change, I can use [cross](https://github.com/cross-rs/cross) to compile Linux binaries on macOS without encountering the `No package 'openssl' found` error:

```toml
rig-core = { version = "*", default-features = false, features = ["reqwest-rustls"] }
```

```bash
cross build --release --target x86_64-unknown-linux-musl
```
