### PR TITLE
feat: add reqwest/rustls-tls support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4478,19 +4478,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper 0.14.32",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
-name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
@@ -7808,12 +7795,10 @@ dependencies = [
  "http-body 0.4.6",
  "hyper 0.14.32",
  "hyper-rustls 0.24.2",
- "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -7825,7 +7810,6 @@ dependencies = [
  "sync_wrapper 0.1.2",
  "system-configuration 0.5.1",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls 0.24.1",
  "tower-service",
  "url",
@@ -7853,7 +7837,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.6.0",
  "hyper-rustls 0.27.5",
- "hyper-tls 0.6.0",
+ "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -7993,7 +7977,7 @@ version = "0.2.2"
 dependencies = [
  "anyhow",
  "ethers",
- "reqwest 0.11.27",
+ "reqwest 0.12.12",
  "rig-core",
  "schemars",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4490,6 +4490,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7792,12 +7808,11 @@ dependencies = [
  "http-body 0.4.6",
  "hyper 0.14.32",
  "hyper-rustls 0.24.2",
- "hyper-tls",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "mime_guess",
  "native-tls",
  "once_cell",
  "percent-encoding",
@@ -7808,16 +7823,14 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
- "system-configuration",
+ "system-configuration 0.5.1",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.24.1",
- "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
  "webpki-roots 0.25.4",
  "winreg",
@@ -7831,6 +7844,7 @@ checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
  "h2 0.4.7",
@@ -7839,12 +7853,14 @@ dependencies = [
  "http-body-util",
  "hyper 1.6.0",
  "hyper-rustls 0.27.5",
+ "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -7857,7 +7873,9 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
+ "system-configuration 0.6.1",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls 0.26.1",
  "tokio-util",
  "tower 0.5.2",
@@ -7945,7 +7963,7 @@ dependencies = [
  "ordered-float",
  "quick-xml 0.37.2",
  "rayon",
- "reqwest 0.11.27",
+ "reqwest 0.12.12",
  "rig-derive",
  "schemars",
  "serde",
@@ -9816,7 +9834,18 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
- "system-configuration-sys",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.8.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys 0.6.0",
 ]
 
 [[package]]
@@ -9824,6 +9853,16 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",

--- a/rig-core/Cargo.toml
+++ b/rig-core/Cargo.toml
@@ -51,7 +51,13 @@ pdf = ["dep:lopdf"]
 epub = ["dep:epub", "dep:quick-xml"]
 rayon = ["dep:rayon"]
 worker = ["dep:worker"]
-reqwest-rustls = ["reqwest/rustls-tls"]
+# Replace "default-tls" with "rustls-tls" in "reqwest/default"
+reqwest-rustls = [
+    "reqwest/rustls-tls",
+    "reqwest/charset",
+    "reqwest/http2",
+    "reqwest/macos-system-configuration",
+]
 
 [[test]]
 name = "embed_macro"

--- a/rig-core/Cargo.toml
+++ b/rig-core/Cargo.toml
@@ -15,7 +15,7 @@ doctest = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reqwest = { version = "0.11.22", default-features = false, features = ["json", "stream", "multipart"] }
+reqwest = { version = "0.12.12", default-features = false, features = ["json", "stream", "multipart"] }
 serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
 tracing = "0.1.40"

--- a/rig-core/Cargo.toml
+++ b/rig-core/Cargo.toml
@@ -15,7 +15,7 @@ doctest = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-reqwest = { version = "0.11.22", features = ["json", "stream", "multipart"] }
+reqwest = { version = "0.11.22", default-features = false, features = ["json", "stream", "multipart"] }
 serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
 tracing = "0.1.40"
@@ -44,12 +44,14 @@ serde_path_to_error = "0.1.16"
 base64 = "0.22.1"
 
 [features]
+default = ["reqwest/default"]
 all = ["derive", "pdf", "rayon"]
 derive = ["dep:rig-derive"]
 pdf = ["dep:lopdf"]
 epub = ["dep:epub", "dep:quick-xml"]
 rayon = ["dep:rayon"]
 worker = ["dep:worker"]
+reqwest-rustls = ["reqwest/rustls-tls"]
 
 [[test]]
 name = "embed_macro"

--- a/rig-eternalai/Cargo.toml
+++ b/rig-eternalai/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/0xPlaygrounds/rig"
 [dependencies]
 rig-core = { path = "../rig-core", version = "0.9.1" }
 ethers = "2.0.14"
-reqwest = { version = "0.11.22", features = ["json"] }
+reqwest = { version = "0.12.12", features = ["json"] }
 serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
 tracing = "0.1.40"


### PR DESCRIPTION
## What did I do?

Added `reqwest/rustls-tls` support to `rig-core`

## Why did I want to do this?

After making this change, I can use [cross](https://github.com/cross-rs/cross) to compile Linux binaries on macOS without encountering the `No package 'openssl' found` error:

Cargo.toml:
```toml
rig-core = { version = "*", default-features = false, features = ["reqwest-rustls"] }
```

Build command:
```bash
cross build --release --target x86_64-unknown-linux-musl
```

## Relevant context

https://discord.com/channels/896944341598208070/1280574327141695609/1333908613261164695