### PR TITLE
New model provider: OpenAI GPT-4.5 Addition

### DIFF
--- a/rig-core/src/providers/openai.rs
+++ b/rig-core/src/providers/openai.rs
@@ -333,6 +333,7 @@ impl EmbeddingModel {
 // ================================================================
 // OpenAI Completion API
 // ================================================================
+
 /// `o3-mini` completion model
 pub const O3_MINI: &str = "o3-mini";
 /// `o3-mini-2025-01-31` completion model
@@ -349,6 +350,10 @@ pub const O1_PREVIEW_2024_09_12: &str = "o1-preview-2024-09-12";
 pub const O1_MINI: &str = "o1-mini";
 /// `o1-mini-2024-09-12` completion model
 pub const O1_MINI_2024_09_12: &str = "o1-mini-2024-09-12";
+/// `gpt-4.5-preview` completion model
+pub const GPT_4_5_PREVIEW: &str = "gpt-4.5-preview";
+/// `gpt-4.5-preview-2025-02-27` completion model
+pub const GPT_4_5_PREVIEW_2025_02_27: &str = "gpt-4.5-preview-2025-02-27";
 /// `gpt-4o` completion model
 pub const GPT_4O: &str = "gpt-4o";
 /// `gpt-4o-mini` completion model


### PR DESCRIPTION
This PR adds support for the new OpenAI GPT-4.5 models released in February 2025. The models added are:

gpt-4.5-preview
gpt-4.5-preview-2025-02-27

These models are now available through OpenAI's API and offer improved performance over previous GPT models.
Website: https://openai.com/
API Documentation: https://platform.openai.com/docs/api-reference

Testing

 Verified models are correctly added to constants
 Tested API calls with the new model identifiers
 Confirmed response handling works as expected with the new models
 Updated documentation to reflect new model capabilities

Checklist:

 My code follows the style guidelines of this project
 I have commented my code, particularly in hard-to-understand areas
 I have made corresponding changes to the documentation
 My changes generate no new warnings
 I have added tests that prove my fix is effective or that my feature works
 New and existing unit tests pass locally with my changes
 I've reviewed the provider API documentation and implemented the types of response accurately

Notes
The PR adds the new GPT-4.5 model constants following the same naming convention used for other OpenAI models. The constants include both the aliased version (gpt-4.5-preview) and the dated version (gpt-4.5-preview-2025-02-27).