### PR TITLE
Fix wrong handling for Qwen's responses when using tools

### DIFF
--- a/rig-core/src/providers/openai.rs
+++ b/rig-core/src/providers/openai.rs
@@ -424,10 +424,15 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             } => {
                 let mut content = content
                     .iter()
-                    .map(|c| match c {
-                        AssistantContent::Text { text } => completion::AssistantContent::text(text),
-                        AssistantContent::Refusal { refusal } => {
-                            completion::AssistantContent::text(refusal)
+                    .filter_map(|c| {
+                        let s = match c {
+                            AssistantContent::Text {text} => text,
+                            AssistantContent::Refusal {refusal} => refusal,
+                        };
+                        if s.is_empty() {
+                            None
+                        } else {
+                            Some(completion::AssistantContent::text(s))
                         }
                     })
                     .collect::<Vec<_>>();


### PR DESCRIPTION
Fix empty content field handling when using Qwen2.5 with tools via OpenAI-compatible API. This PR skips processing empty content strings to ensure program stability, as valid tool calls may return empty content in the API response.