### PR TITLE
fix(openai): serde rename for image_url UserContent

### DIFF
--- a/rig-core/src/providers/openai.rs
+++ b/rig-core/src/providers/openai.rs
@@ -1164,7 +1164,7 @@ mod tests {
                     "text": "What's in this image?"
                 },
                 {
-                    "type": "image",
+                    "type": "image_url",
                     "image_url": {
                         "url": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
                     }

--- a/rig-core/src/providers/openai.rs
+++ b/rig-core/src/providers/openai.rs
@@ -548,9 +548,16 @@ pub enum AssistantContent {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum UserContent {
-    Text { text: String },
-    Image { image_url: ImageUrl },
-    Audio { input_audio: InputAudio },
+    Text {
+        text: String,
+    },
+    #[serde(rename = "image_url")]
+    Image {
+        image_url: ImageUrl,
+    },
+    Audio {
+        input_audio: InputAudio,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]


### PR DESCRIPTION
Fixes #349 

I am wondering if we should change the enum variant to just say `ImageUrl` instead of `Image` as that more accurately describes the variant.