### PR TITLE
Fix Clippy warnings for doc indentation and Error::other usage

### DIFF
--- a/rig-core/src/streaming.rs
+++ b/rig-core/src/streaming.rs
@@ -102,7 +102,7 @@ pub async fn stream_to_stdout<M: StreamingCompletionModel>(
                     .tools
                     .call(&name, params.to_string())
                     .await
-                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
+                    .map_err(|e| std::io::Error::other(e.to_string()))?;
                 println!("\nResult: {}", res);
             }
             Err(e) => {

--- a/rig-neo4j/src/lib.rs
+++ b/rig-neo4j/src/lib.rs
@@ -277,7 +277,7 @@ impl Neo4jClient {
     /// ### Arguments
     /// * `index_name` - The name of the index to create.
     /// * `node_label` - The label of the nodes to which the index will be applied. For example, if your nodes have
-    ///                  the label `:Movie`, pass "Movie" as the `node_label` parameter.
+    ///   the label `:Movie`, pass "Movie" as the `node_label` parameter.
     /// * `embedding_prop_name` (optional) - The name of the property that contains the embedding vectors. Defaults to "embedding".
     ///
     pub async fn create_vector_index(

--- a/rig-neo4j/src/vector_index.rs
+++ b/rig-neo4j/src/vector_index.rs
@@ -211,7 +211,7 @@ impl<M: EmbeddingModel + std::marker::Sync + Send> VectorStoreIndex for Neo4jVec
     /// #### Generic Type Parameters
     ///
     /// - `T`: The type used to deserialize the result from the Neo4j query.
-    ///        It must implement the `serde::Deserialize` trait.
+    ///   It must implement the `serde::Deserialize` trait.
     ///
     /// #### Returns
     ///

--- a/rig-qdrant/src/lib.rs
+++ b/rig-qdrant/src/lib.rs
@@ -29,7 +29,7 @@ impl<M: EmbeddingModel> QdrantVectorStore<M> {
     /// * `client` - Qdrant client instance
     /// * `model` - Embedding model instance
     /// * `query_params` - Search parameters for vector queries
-    ///     Reference: <https://api.qdrant.tech/v-1-12-x/api-reference/search/query-points>
+    ///   Reference: <https://api.qdrant.tech/v-1-12-x/api-reference/search/query-points>
     pub fn new(client: Qdrant, model: M, query_params: QueryPoints) -> Self {
         Self {
             client,


### PR DESCRIPTION
**Summary**
- Cleaned up some doc comments that Clippy flagged for over-indentation.
- Switched from `std::io::Error::new(ErrorKind::Other, ...)` to `Error::other(...)` in a couple of places to satisfy Clippy’s rules.

**Details**
- In `rig-qdrant` and `rig-neo4j`, I reduced extra whitespace in a few doc comments so they line up properly.
- In `rig-core`, changed `Error::new(...)` calls to `Error::other(...)` for a tidier approach.

Everything still builds fine under `cargo clippy --all -- -D warnings`, with no new warnings.
