### PR TITLE
chore: fixed broken link xaiAPI in `completion.rs`

### DIFF
--- a/rig-core/src/providers/xai/completion.rs
+++ b/rig-core/src/providers/xai/completion.rs
@@ -1,6 +1,6 @@
 // ================================================================
 //! xAI Completion Integration
-//! From [xAI Reference](https://docs.x.ai/api/endpoints#chat-completions)
+//! From [xAI Reference](https://docs.x.ai/docs/api-reference#chat-completions)
 // ================================================================
 
 use crate::{


### PR DESCRIPTION
Hi! I fixed broken xAI API reference link in `completion.rs` - updated old endpoint URL (`docs.x.ai/api/endpoints#chat-completions`) to current docs structure (`docs.x.ai/docs/api-reference#chat-completions`). Verified new link works and points to correct API documentation.