### PR TITLE
feat: impl From<mcp_core::types::Tool> for ToolDefinition

### DIFF
--- a/rig-core/src/tool.rs
+++ b/rig-core/src/tool.rs
@@ -205,6 +205,17 @@ where
 }
 
 #[cfg(feature = "mcp")]
+impl From<mcp_core::types::Tool> for ToolDefinition {
+    fn from(val: mcp_core::types::Tool) -> Self {
+        Self {
+            name: val.name,
+            description: val.description.unwrap_or_default(),
+            parameters: val.input_schema,
+        }
+    }
+}
+
+#[cfg(feature = "mcp")]
 #[derive(Debug, thiserror::Error)]
 #[error("MCP tool error: {0}")]
 pub struct McpToolError(String);

--- a/rig-core/src/tool.rs
+++ b/rig-core/src/tool.rs
@@ -205,6 +205,17 @@ where
 }
 
 #[cfg(feature = "mcp")]
+impl From<&mcp_core::types::Tool> for ToolDefinition {
+    fn from(val: &mcp_core::types::Tool) -> Self {
+        Self {
+            name: val.name.to_owned(),
+            description: val.description.to_owned().unwrap_or_default(),
+            parameters: val.input_schema.to_owned(),
+        }
+    }
+}
+
+#[cfg(feature = "mcp")]
 impl From<mcp_core::types::Tool> for ToolDefinition {
     fn from(val: mcp_core::types::Tool) -> Self {
         Self {


### PR DESCRIPTION
Self explanatory. Fixes #383 

Potential queries:
- The description is actually an Option<String> in `mcp-core`'s version of description. I have set it to produce an empty String if the unwrap fails. Do we want to handle this differently?
