### PR TITLE
chore(fastembed): update fastembed version

### DIFF
--- a/rig-fastembed/Cargo.toml
+++ b/rig-fastembed/Cargo.toml
@@ -13,7 +13,7 @@ serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
 tracing = "0.1.40"
 schemars = "0.8.16"
-fastembed = "4.4.0"
+fastembed = "4.6.0"
 
 [dev-dependencies]
 anyhow = "1.0.75"

--- a/rig-fastembed/src/lib.rs
+++ b/rig-fastembed/src/lib.rs
@@ -171,6 +171,7 @@ pub fn fetch_model_ndims(model: &FastembedModel) -> usize {
         | FastembedModel::MxbaiEmbedLargeV1
         | FastembedModel::MxbaiEmbedLargeV1Q
         | FastembedModel::GTELargeENV15
+        | FastembedModel::ModernBertEmbedLarge
         | FastembedModel::GTELargeENV15Q => 1024,
     }
 }


### PR DESCRIPTION
Fixes #390. The source of the issue was a breaking change.