### PR TITLE
fix: rig tool macro struct not public

### DIFF
--- a/rig-core/rig-core-derive/src/lib.rs
+++ b/rig-core/rig-core-derive/src/lib.rs
@@ -288,7 +288,7 @@ pub fn rig_tool(args: TokenStream, input: TokenStream) -> TokenStream {
 
     let expanded = quote! {
         #[derive(serde::Deserialize)]
-        struct #params_struct_name {
+        pub(crate) struct #params_struct_name {
             #(#param_names: #param_types,)*
         }
 


### PR DESCRIPTION
Fixes #406