### PR TITLE
fix: deepseek function call conversion typo

### DIFF
--- a/rig-core/src/providers/deepseek.rs
+++ b/rig-core/src/providers/deepseek.rs
@@ -340,7 +340,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                         .iter()
                         .map(|call| {
                             completion::AssistantContent::tool_call(
-                                &call.function.name,
+                                &call.id,
                                 &call.function.name,
                                 call.function.arguments.clone(),
                             )


### PR DESCRIPTION
Following on from #370, we appear to have missed a very minor detail that would otherwise cause the deepseek function calling stuff to not work.

Thanks @byeblack for the catch!

(edit: Review is *probably* not required here, however seeing as it looks like we're planning to release relatively soon if not next week I've opted to give a heads up just in case)