### PR TITLE
fix: function call conversion typo

### DIFF
--- a/rig-core/src/providers/deepseek.rs
+++ b/rig-core/src/providers/deepseek.rs
@@ -340,7 +340,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                         .iter()
                         .map(|call| {
                             completion::AssistantContent::tool_call(
-                                &call.function.name,
+                                &call.id,
                                 &call.function.name,
                                 call.function.arguments.clone(),
                             )

--- a/rig-core/src/providers/huggingface/completion.rs
+++ b/rig-core/src/providers/huggingface/completion.rs
@@ -452,7 +452,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                         .iter()
                         .map(|call| {
                             completion::AssistantContent::tool_call(
-                                &call.function.name,
+                                &call.id,
                                 &call.function.name,
                                 call.function.arguments.clone(),
                             )

--- a/rig-core/src/providers/hyperbolic.rs
+++ b/rig-core/src/providers/hyperbolic.rs
@@ -261,7 +261,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                         .iter()
                         .map(|call| {
                             completion::AssistantContent::tool_call(
-                                &call.function.name,
+                                &call.id,
                                 &call.function.name,
                                 call.function.arguments.clone(),
                             )

--- a/rig-core/src/providers/openrouter.rs
+++ b/rig-core/src/providers/openrouter.rs
@@ -204,7 +204,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                         .iter()
                         .map(|call| {
                             completion::AssistantContent::tool_call(
-                                &call.function.name,
+                                &call.id,
                                 &call.function.name,
                                 call.function.arguments.clone(),
                             )

--- a/rig-core/src/providers/xai/completion.rs
+++ b/rig-core/src/providers/xai/completion.rs
@@ -158,7 +158,7 @@ pub mod xai_api_types {
                             .iter()
                             .map(|call| {
                                 completion::AssistantContent::tool_call(
-                                    &call.function.name,
+                                    &call.id,
                                     &call.function.name,
                                     call.function.arguments.clone(),
                                 )

--- a/rig-eternalai/src/providers/eternalai.rs
+++ b/rig-eternalai/src/providers/eternalai.rs
@@ -383,7 +383,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                         .iter()
                         .map(|call| {
                             completion::AssistantContent::tool_call(
-                                &call.function.name,
+                                &call.id,
                                 &call.function.name,
                                 call.function.arguments.clone(),
                             )


### PR DESCRIPTION
Following on from #414 ,In fact, not only Deepseek, but other providers besides OpenAI and Anthropic also have the same issue.