### PR TITLE
chore: Add gpt-image-1 to OpenAI Image Generation

### DIFF
--- a/rig-core/src/providers/openai/image_generation.rs
+++ b/rig-core/src/providers/openai/image_generation.rs
@@ -12,6 +12,8 @@ use serde_json::json;
 pub const DALL_E_2: &str = "dall-e-2";
 pub const DALL_E_3: &str = "dall-e-3";
 
+pub const GPT_IMAGE_1: &str = "gpt-image-1";
+
 #[derive(Debug, Deserialize)]
 pub struct ImageGenerationData {
     pub b64_json: String,


### PR DESCRIPTION
This PR just adds a constant for `gpt-image-1`