### PR TITLE
fix: dynamically pull rag text from chat history

### DIFF
--- a/rig-core/examples/rag_dynamic_tools_multi_turn.rs
+++ b/rig-core/examples/rag_dynamic_tools_multi_turn.rs
@@ -1,0 +1,186 @@
+use anyhow::Result;
+use rig::{
+    completion::{Prompt, ToolDefinition},
+    embeddings::EmbeddingsBuilder,
+    providers::openai::{Client, TEXT_EMBEDDING_ADA_002},
+    tool::{Tool, ToolEmbedding, ToolSet},
+    vector_store::in_memory_store::InMemoryVectorStore,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::env;
+
+#[derive(Deserialize)]
+struct OperationArgs {
+    x: i32,
+    y: i32,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("Math error")]
+struct MathError;
+
+#[derive(Debug, thiserror::Error)]
+#[error("Math error")]
+struct InitError;
+
+#[derive(Deserialize, Serialize)]
+struct Add;
+
+impl Tool for Add {
+    const NAME: &'static str = "add";
+
+    type Error = MathError;
+    type Args = OperationArgs;
+    type Output = i32;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        serde_json::from_value(json!({
+            "name": "add",
+            "description": "Add x and y together",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "x": {
+                        "type": "number",
+                        "description": "The first number to add"
+                    },
+                    "y": {
+                        "type": "number",
+                        "description": "The second number to add"
+                    }
+                }
+            }
+        }))
+        .expect("Tool Definition")
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        let result = args.x + args.y;
+        Ok(result)
+    }
+}
+
+impl ToolEmbedding for Add {
+    type InitError = InitError;
+    type Context = ();
+    type State = ();
+
+    fn init(_state: Self::State, _context: Self::Context) -> Result<Self, Self::InitError> {
+        Ok(Add)
+    }
+
+    fn embedding_docs(&self) -> Vec<String> {
+        vec!["Add x and y together".into()]
+    }
+
+    fn context(&self) -> Self::Context {}
+}
+
+#[derive(Deserialize, Serialize)]
+struct Subtract;
+
+impl Tool for Subtract {
+    const NAME: &'static str = "subtract";
+
+    type Error = MathError;
+    type Args = OperationArgs;
+    type Output = i32;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        serde_json::from_value(json!({
+            "name": "subtract",
+            "description": "Subtract y from x (i.e.: x - y)",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "x": {
+                        "type": "number",
+                        "description": "The number to subtract from"
+                    },
+                    "y": {
+                        "type": "number",
+                        "description": "The number to subtract"
+                    }
+                }
+            }
+        }))
+        .expect("Tool Definition")
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        let result = args.x - args.y;
+        Ok(result)
+    }
+}
+
+impl ToolEmbedding for Subtract {
+    type InitError = InitError;
+    type Context = ();
+    type State = ();
+
+    fn init(_state: Self::State, _context: Self::Context) -> Result<Self, Self::InitError> {
+        Ok(Subtract)
+    }
+
+    fn context(&self) -> Self::Context {}
+
+    fn embedding_docs(&self) -> Vec<String> {
+        vec!["Subtract y from x (i.e.: x - y)".into()]
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    // required to enable CloudWatch error logging by the runtime
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        // disable printing the name of the module in every log line.
+        .with_target(false)
+        .init();
+
+    // Create OpenAI client
+    let openai_api_key = env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set");
+    let openai_client = Client::new(&openai_api_key);
+
+    let embedding_model = openai_client.embedding_model(TEXT_EMBEDDING_ADA_002);
+
+    let toolset = ToolSet::builder()
+        .dynamic_tool(Add)
+        .dynamic_tool(Subtract)
+        .build();
+
+    let embeddings = EmbeddingsBuilder::new(embedding_model.clone())
+        .documents(toolset.schemas()?)?
+        .build()
+        .await?;
+
+    // Create vector store with the embeddings
+    let vector_store =
+        InMemoryVectorStore::from_documents_with_id_f(embeddings, |tool| tool.name.clone());
+
+    // Create vector store index
+    let index = vector_store.index(embedding_model);
+
+    // Create RAG agent with a single context prompt and a dynamic tool source
+    let calculator_rag = openai_client
+        .agent("gpt-4")
+        .preamble(
+            "You are a calculator here to help the user perform arithmetic operations.
+            Use the tools provided to answer the user's question and do not do any math on your own.",
+        )
+        // Add a dynamic tool source with a sample rate of 2 (i.e.: only
+        // 2 additional tool will be added to prompts)
+        .dynamic_tools(2, index, toolset)
+        .build();
+
+    // Prompt the agent and print the response
+    let response = calculator_rag
+        .prompt("Calculate (3 - 7) + 17")
+         .multi_turn(10)
+        .await?;
+
+    println!("{}", response);
+
+    Ok(())
+}

--- a/rig-core/examples/rag_dynamic_tools_multi_turn.rs
+++ b/rig-core/examples/rag_dynamic_tools_multi_turn.rs
@@ -177,7 +177,7 @@ async fn main() -> Result<(), anyhow::Error> {
     // Prompt the agent and print the response
     let response = calculator_rag
         .prompt("Calculate (3 - 7) + 17")
-         .multi_turn(10)
+        .multi_turn(10)
         .await?;
 
     println!("{}", response);

--- a/rig-core/src/agent/completion.rs
+++ b/rig-core/src/agent/completion.rs
@@ -69,11 +69,13 @@ impl<M: CompletionModel> Completion<M> for Agent<M> {
         let prompt = prompt.into();
 
         // Find the latest message in the chat history that contains RAG text
-        let rag_text = chat_history
-            .iter()
-            .rev()
-            .find_map(|message| message.rag_text());
-        let rag_text = rag_text.or_else(|| prompt.rag_text());
+        let rag_text = prompt.rag_text();
+        let rag_text = rag_text.or_else(|| {
+            chat_history
+                .iter()
+                .rev()
+                .find_map(|message| message.rag_text())
+        });
 
         let completion_request = self
             .model


### PR DESCRIPTION
Fixes #420 and supersedes #421 .

The main fix is via not gathering the raggable text from only the current prompt but also going up from latest to oldest methods.

Basically, if the prompt has no raggable text, traverse backwards up chat history until you find some.