### PR TITLE
Fix: Remove broken xAI reference link in embedding.rs

### DIFF
--- a/rig-core/src/providers/xai/embedding.rs
+++ b/rig-core/src/providers/xai/embedding.rs
@@ -1,6 +1,6 @@
 // ================================================================
 //! xAI Embeddings Integration
-//! From [xAI Reference]()
+//! From [xAI Reference](https://api.x.ai/docs/#/v1/handle_embedding_request)
 // ================================================================
 
 use serde::Deserialize;

--- a/rig-core/src/providers/xai/embedding.rs
+++ b/rig-core/src/providers/xai/embedding.rs
@@ -1,6 +1,6 @@
 // ================================================================
 //! xAI Embeddings Integration
-//! From [xAI Reference](https://docs.x.ai/api/endpoints#create-embeddings)
+//! From [xAI Reference]()
 // ================================================================
 
 use serde::Deserialize;


### PR DESCRIPTION
Found a broken link to xAI documentation in embedding.rs.
Since the reference URL no longer works, we removed the link to prevent confusion and keep the documentation clean.