### PR TITLE
Donot use async closure + Bump mcp-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6519,9 +6519,9 @@ dependencies = [
 
 [[package]]
 name = "mcp-core"
-version = "0.1.42"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a8e4375fe44579ffd9c7a8d682059ee33f1bf2bf36cad94cbe1ebff2e5b111"
+checksum = "2766f3db0a24119127ba5e380539f2a6351210456a6911de28dbaa8ce2761080"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -6540,9 +6540,9 @@ dependencies = [
 
 [[package]]
 name = "mcp-core-macros"
-version = "0.1.11"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe81fc0467c71468ab49044e0ffadf7596931cc62d61e63bfe7865fb8725a5d7"
+checksum = "8ea671b2ae3ba45f473c21f1c9a0effd890c3fdb0c1f2dcc55882c9f6403214c"
 dependencies = [
  "async-trait",
  "convert_case 0.6.0",

--- a/rig-core/Cargo.toml
+++ b/rig-core/Cargo.toml
@@ -49,8 +49,8 @@ tracing-subscriber = "0.3.18"
 tokio-test = "0.4.4"
 serde_path_to_error = "0.1.16"
 base64 = "0.22.1"
-mcp-core = { version = "0.1.42", features = ["sse"] }
-mcp-core-macros = { version = "0.1.1" }
+mcp-core = { version = "0.1.46", features = ["sse"] }
+mcp-core-macros = { version = "0.1.22" }
 
 [features]
 default = ["reqwest/default"]

--- a/rig-core/examples/mcp_tool.rs
+++ b/rig-core/examples/mcp_tool.rs
@@ -16,7 +16,14 @@ use serde_json::json;
 #[tool(
     name = "Add",
     description = "Adds two numbers together.",
-    params(a = "The first number to add", b = "The second number to add")
+    params(a = "The first number to add", b = "The second number to add"),
+    annotations(
+        title = "Add",
+        readOnlyHint = false,
+        destructiveHint = false,
+        idempotentHint = false,
+        openWorldHint = false
+    )
 )]
 async fn add_tool(a: f64, b: f64) -> Result<ToolResponseContent> {
     Ok(tool_text_content!((a + b).to_string()))

--- a/rig-core/src/agent/prompt_request.rs
+++ b/rig-core/src/agent/prompt_request.rs
@@ -133,7 +133,7 @@ impl<M: CompletionModel> PromptRequest<'_, M> {
             }
 
             let tool_content = stream::iter(tool_calls)
-                .then(async |choice| {
+                .then(|choice| async move {
                     if let AssistantContent::ToolCall(tool_call) = choice {
                         let output = agent
                             .tools

--- a/rig-core/src/tool.rs
+++ b/rig-core/src/tool.rs
@@ -298,6 +298,9 @@ where
                     mcp_core::types::ToolResponseContent::Image { data, mime_type } => {
                         format!("data:{};base64,{}", mime_type, data)
                     }
+                    mcp_core::types::ToolResponseContent::Audio { data, mime_type } => {
+                        format!("data:{};base64,{}", mime_type, data)
+                    }
                     mcp_core::types::ToolResponseContent::Resource {
                         resource: mcp_core::types::ResourceContents { uri, mime_type },
                     } => {


### PR DESCRIPTION
## Proposed Changes

- Remove use of async closure 
> ~Async closures are unstable in Rust 2021 edition, but are stabilized in Rust 2024 edition~, needs rust 1.85
- Bump mcp-core , mcp-core-macros and address compile errors 
> 1. fix missing match case
> 2. add annotations in tool macro use