### PR TITLE
fix: update broken link 

### DIFF
--- a/rig-neo4j/src/lib.rs
+++ b/rig-neo4j/src/lib.rs
@@ -1,6 +1,6 @@
 //! A Rig vector store for Neo4j.
 //!
-//! This crate is a companion crate to the [rig-core crate](https://github.com/rig-ai/rig-core).
+//! This crate is a companion crate to the [rig-core crate](https://github.com/RIG-AI/RIG_AI).
 //! It provides a vector store implementation that uses Neo4j as the underlying datastore.
 //!
 //! See the [README](https://github.com/0xPlaygrounds/rig/tree/main/rig-neo4j) for more information.

--- a/rig-neo4j/src/lib.rs
+++ b/rig-neo4j/src/lib.rs
@@ -1,6 +1,6 @@
 //! A Rig vector store for Neo4j.
 //!
-//! This crate is a companion crate to the [rig-core crate](https://github.com/RIG-AI/RIG_AI).
+//! This crate is a companion crate to the [rig-core crate](https://github.com/0xPlaygrounds/rig).
 //! It provides a vector store implementation that uses Neo4j as the underlying datastore.
 //!
 //! See the [README](https://github.com/0xPlaygrounds/rig/tree/main/rig-neo4j) for more information.


### PR DESCRIPTION
I found that the previous link pointed to a non-existing repository.
I updated it to the current working repository RIG_AI/RIG_AI, as there are no other available alternatives at the moment.
If you have a better or more specific repository in mind, please suggest it, and I will update the link accordingly.