### PR TITLE
fix: system and developer messages for openai

### DIFF
--- a/rig-core/src/providers/openai/completion.rs
+++ b/rig-core/src/providers/openai/completion.rs
@@ -177,6 +177,7 @@ pub struct Choice {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 #[serde(tag = "role", rename_all = "lowercase")]
 pub enum Message {
+    #[serde(alias = "developer")]
     System {
         #[serde(deserialize_with = "string_or_one_or_many")]
         content: OneOrMany<SystemContent>,
@@ -652,11 +653,8 @@ impl CompletionModel {
             .map(|msg| {
                 let mut val = serde_json::to_value(&msg)?;
                 if let Message::System { .. } = msg {
-                    // TODO: better detection of `o` models
-                    if self.model.starts_with('o') {
-                        if let Some(obj) = val.as_object_mut() {
-                            obj.insert("role".to_string(), json!("developer"));
-                        }
+                    if let Some(obj) = val.as_object_mut() {
+                        obj.insert("role".to_string(), json!("developer"));
                     }
                 }
                 Ok(val)

--- a/rig-core/src/providers/openai/completion.rs
+++ b/rig-core/src/providers/openai/completion.rs
@@ -648,28 +648,6 @@ impl CompletionModel {
                 .collect::<Vec<_>>(),
         );
 
-        // o1-mini crashes if not using `developer` role for system messages. We can't globally
-        //  change openai due to other providers that can be used with openai.
-        //
-        // I'm hesitant to only chk models that start with `o` as that can interfere with other
-        //  providers.
-        let full_history = if self.model.starts_with("o1-mini") {
-            full_history
-                .into_iter()
-                .map(|msg| {
-                    let mut val = serde_json::to_value(&msg)?;
-                    if let Message::System { .. } = msg {
-                        if let Some(obj) = val.as_object_mut() {
-                            obj.insert("role".to_string(), json!("developer"));
-                        }
-                    }
-                    Ok(val)
-                })
-                .collect::<Result<Value, serde_json::Error>>()?
-        } else {
-            serde_json::to_value(&full_history)?
-        };
-
         let request = if completion_request.tools.is_empty() {
             json!({
                 "model": self.model,

--- a/rig-core/src/providers/openai/completion.rs
+++ b/rig-core/src/providers/openai/completion.rs
@@ -648,18 +648,27 @@ impl CompletionModel {
                 .collect::<Vec<_>>(),
         );
 
-        let full_history = full_history
-            .into_iter()
-            .map(|msg| {
-                let mut val = serde_json::to_value(&msg)?;
-                if let Message::System { .. } = msg {
-                    if let Some(obj) = val.as_object_mut() {
-                        obj.insert("role".to_string(), json!("developer"));
+        // o1-mini crashes if not using `developer` role for system messages. We can't globally
+        //  change openai due to other providers that can be used with openai.
+        // 
+        // I'm hesitant to only chk models that start with `o` as that can interfere with other
+        //  providers.
+        let full_history = if self.model.starts_with("o1-mini") {
+            full_history
+                .into_iter()
+                .map(|msg| {
+                    let mut val = serde_json::to_value(&msg)?;
+                    if let Message::System { .. } = msg {
+                        if let Some(obj) = val.as_object_mut() {
+                            obj.insert("role".to_string(), json!("developer"));
+                        }
                     }
-                }
-                Ok(val)
-            })
-            .collect::<Result<Vec<Value>, serde_json::Error>>()?;
+                    Ok(val)
+                })
+                .collect::<Result<Value, serde_json::Error>>()?
+        } else {
+            serde_json::to_value(&full_history)?
+        };
 
         let request = if completion_request.tools.is_empty() {
             json!({

--- a/rig-core/src/providers/openai/completion.rs
+++ b/rig-core/src/providers/openai/completion.rs
@@ -650,7 +650,7 @@ impl CompletionModel {
 
         // o1-mini crashes if not using `developer` role for system messages. We can't globally
         //  change openai due to other providers that can be used with openai.
-        // 
+        //
         // I'm hesitant to only chk models that start with `o` as that can interfere with other
         //  providers.
         let full_history = if self.model.starts_with("o1-mini") {


### PR DESCRIPTION
Using `developer` only for `o1-mini` instead of all models.

Reasoning:
- Some people use the openai client for other providers
- Checking for models that start with `o` is fallible for alternative providers
- `system` messages work for the newer reasoning models.