### PR TITLE
`impl {Debug,Clone} for CompletionRequest`

### DIFF
--- a/rig-core/src/completion/request.rs
+++ b/rig-core/src/completion/request.rs
@@ -242,6 +242,7 @@ pub trait CompletionModel: Clone + Send + Sync {
 }
 
 /// Struct representing a general completion request that can be sent to a completion model provider.
+#[derive(Debug, Clone)]
 pub struct CompletionRequest {
     /// The preamble to be sent to the completion model provider
     pub preamble: Option<String>,


### PR DESCRIPTION
The `Clone` impl is useful when implementing some retry/fallback logic, the fact that `Debug` was also missing seemed to suggest its absence wasn't intentional.