### PR TITLE
fix(extractor): correct typo in extractor prompt

### DIFF
--- a/rig-core/src/extractor.rs
+++ b/rig-core/src/extractor.rs
@@ -124,7 +124,7 @@ impl<T: JsonSchema + for<'a> Deserialize<'a> + Serialize + Send + Sync, M: Compl
                     You are an AI assistant whose purpose is to extract structured data from the provided text.\n\
                     You will have access to a `submit` function that defines the structure of the data to extract from the provided text.\n\
                     Use the `submit` function to submit the structured data.\n\
-                    Be sure to fill out every field and ALWAYS CALL THE `submit` function, event with default values!!!.
+                    Be sure to fill out every field and ALWAYS CALL THE `submit` function, even with default values!!!.
                 ")
                 .tool(SubmitTool::<T> {_t: PhantomData}),
             _t: PhantomData,


### PR DESCRIPTION
Fix a typo by changing "event with default values" to "even with default values" in the extractor prompt.