### PR TITLE
fix(anthropic): Only PDF docs are supported by their API

### DIFF
--- a/rig-core/src/providers/anthropic/completion.rs
+++ b/rig-core/src/providers/anthropic/completion.rs
@@ -5,7 +5,7 @@ use std::{convert::Infallible, str::FromStr};
 use crate::{
     completion::{self, CompletionError},
     json_utils,
-    message::{self, MessageError},
+    message::{self, DocumentMediaType, MessageError},
     one_or_many::string_or_one_or_many,
     OneOrMany,
 };
@@ -216,6 +216,9 @@ pub enum ImageFormat {
     WEBP,
 }
 
+/// The document format to be used.
+///
+/// Currently, Anthropic only supports PDF for text documents over the API (within a message). You can find more information about this here: <https://docs.anthropic.com/en/docs/build-with-claude/pdf-support>
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum DocumentFormat {
@@ -288,6 +291,19 @@ impl From<ImageFormat> for message::ImageMediaType {
             ImageFormat::GIF => message::ImageMediaType::GIF,
             ImageFormat::WEBP => message::ImageMediaType::WEBP,
         }
+    }
+}
+
+impl TryFrom<DocumentMediaType> for DocumentFormat {
+    type Error = MessageError;
+    fn try_from(value: DocumentMediaType) -> Result<Self, Self::Error> {
+        if !matches!(value, DocumentMediaType::PDF) {
+            return Err(MessageError::ConversionError(
+                "Anthropic only supports PDF documents".to_string(),
+            ));
+        };
+
+        Ok(DocumentFormat::PDF)
     }
 }
 
@@ -366,10 +382,20 @@ impl TryFrom<message::Message> for Message {
                         };
                         Ok(Content::Image { source })
                     }
-                    message::UserContent::Document(message::Document { data, format, .. }) => {
+                    message::UserContent::Document(message::Document {
+                        data,
+                        format,
+                        media_type,
+                    }) => {
+                        let Some(media_type) = media_type else {
+                            return Err(MessageError::ConversionError(
+                                "Document media type is required".to_string(),
+                            ));
+                        };
+
                         let source = DocumentSource {
                             data,
-                            media_type: DocumentFormat::PDF,
+                            media_type: media_type.try_into()?,
                             r#type: match format {
                                 Some(format) => format.try_into()?,
                                 None => SourceType::BASE64,


### PR DESCRIPTION
In reference to #446, it was noticed that the business logic for Anthropic's documents actually only support PDF. We should be enforcing this in our own API to ensure that users see the expected behaviour rather than automatically setting it to PDF.