### PR TITLE
feat(rig-764): gitignore .envrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
-.env
 target/
 .DS_Store
 .idea/
 .vscode/
 .devcontainer/
+
+# env
+.env
+.envrc


### PR DESCRIPTION
`.envrc` is used by [direnv](https://direnv.net/), a program you can use to automatically set env vars upon entering a directory rather than having to spend time remembering what they are.

I'm currently pretty careful about not accidentally committing it, but needless to say we should probably gitignore it for any future contributors.