### PR TITLE
fix: Update of xAI model list [issue #485]

### DIFF
--- a/rig-core/examples/agent_with_grok.rs
+++ b/rig-core/examples/agent_with_grok.rs
@@ -36,7 +36,7 @@ fn client() -> providers::xai::Client {
 /// Create a partial xAI agent (grok)
 fn partial_agent() -> AgentBuilder<providers::xai::completion::CompletionModel> {
     let client = client();
-    client.agent(providers::xai::GROK_BETA)
+    client.agent(providers::xai::GROK_3_MINI)
 }
 
 /// Create an xAI agent (grok) with a preamble
@@ -84,7 +84,7 @@ async fn tools() -> Result<(), anyhow::Error> {
 /// This example loads in all the rust examples from the rig-core crate and uses them as\\
 ///  context for the agent
 async fn loaders() -> Result<(), anyhow::Error> {
-    let model = client().completion_model(providers::xai::GROK_BETA);
+    let model = client().completion_model(providers::xai::GROK_3_MINI);
 
     // Load in all the rust examples
     let examples = FileLoader::with_glob("rig-core/examples/*.rs")?
@@ -110,7 +110,7 @@ async fn loaders() -> Result<(), anyhow::Error> {
 }
 
 async fn context() -> Result<(), anyhow::Error> {
-    let model = client().completion_model(providers::xai::GROK_BETA);
+    let model = client().completion_model(providers::xai::GROK_3_MINI);
 
     // Create an agent with multiple context documents
     let agent = AgentBuilder::new(model)

--- a/rig-core/examples/xai_streaming.rs
+++ b/rig-core/examples/xai_streaming.rs
@@ -5,7 +5,7 @@ use rig::streaming::{stream_to_stdout, StreamingPrompt};
 async fn main() -> Result<(), anyhow::Error> {
     // Create streaming agent with a single context prompt
     let agent = xai::Client::from_env()
-        .agent(xai::GROK_BETA)
+        .agent(xai::GROK_3_MINI)
         .preamble("Be precise and concise.")
         .temperature(0.5)
         .build();

--- a/rig-core/src/providers/xai/client.rs
+++ b/rig-core/src/providers/xai/client.rs
@@ -134,7 +134,7 @@ impl Client {
     /// // Initialize the xAI client
     /// let xai = Client::new("your-xai-api-key");
     ///
-    /// let agent = xai.agent(xai::completion::GROK_BETA)
+    /// let agent = xai.agent(xai::completion::GROK_3_MINI)
     ///    .preamble("You are comedian AI with a mission to make people laugh.")
     ///    .temperature(0.0)
     ///    .build();

--- a/rig-core/src/providers/xai/completion.rs
+++ b/rig-core/src/providers/xai/completion.rs
@@ -13,8 +13,14 @@ use super::client::{xai_api_types::ApiResponse, Client};
 use serde_json::{json, Value};
 use xai_api_types::{CompletionResponse, ToolDefinition};
 
-/// `grok-beta` completion model
-pub const GROK_BETA: &str = "grok-beta";
+/// xAI completion models as of 2025-06-04
+pub const GROK_2_1212: &str = "grok-2-1212";
+pub const GROK_2_VISION_1212: &str = "grok-2-vision-1212";
+pub const GROK_3: &str = "grok-3";
+pub const GROK_3_FAST: &str = "grok-3-fast";
+pub const GROK_3_MINI: &str = "grok-3-mini";
+pub const GROK_3_MINI_FAST: &str = "grok-3-mini-fast";
+pub const GROK_2_IMAGE_1212: &str = "grok-2-image-1212";
 
 // =================================================================
 // Rig Implementation Types

--- a/rig-core/src/providers/xai/mod.rs
+++ b/rig-core/src/providers/xai/mod.rs
@@ -15,5 +15,5 @@ pub mod embedding;
 pub mod streaming;
 
 pub use client::Client;
-pub use completion::GROK_BETA;
+pub use completion::GROK_3_MINI;
 pub use embedding::EMBEDDING_V1;


### PR DESCRIPTION
- removed deprecated GROK_BETA
- added the following: grok-2-1212

> 1. grok-2-vision-1212
> 2. grok-3
> 3. grok-3-fast
> 4. grok-3-mini
> 5. grok-3-mini-fast
> 6. grok-2-image-1212