### PR TITLE
Fix typo in AudioGenerationModel field name

### DIFF
--- a/rig-core/src/providers/hyperbolic.rs
+++ b/rig-core/src/providers/hyperbolic.rs
@@ -548,14 +548,14 @@ mod audio_generation {
     #[derive(Clone)]
     pub struct AudioGenerationModel {
         client: Client,
-        pub langauge: String,
+        pub language: String,
     }
 
     impl AudioGenerationModel {
         pub(crate) fn new(client: Client, language: &str) -> AudioGenerationModel {
             Self {
                 client,
-                langauge: language.to_string(),
+                language: language.to_string(),
             }
         }
     }
@@ -591,7 +591,7 @@ mod audio_generation {
         ) -> Result<audio_generation::AudioGenerationResponse<Self::Response>, AudioGenerationError>
         {
             let request = json!({
-                "language": self.langauge,
+                "language": self.language,
                 "speaker": request.voice,
                 "text": request.text,
                 "speed": request.speed


### PR DESCRIPTION
Description: 
Corrected a spelling error in the AudioGenerationModel struct by changing "langauge" to "language" in three places:
- The struct field declaration
- The constructor assignment
- The JSON request parameter