### PR TITLE
feat(rig-760): enable reasoning for openrouter

### DIFF
--- a/rig-core/examples/openrouter_reasoning.rs
+++ b/rig-core/examples/openrouter_reasoning.rs
@@ -1,0 +1,56 @@
+use anyhow::{anyhow, Result};
+use rig::completion::Completion;
+use rig::prelude::*;
+use rig::providers::openrouter::Message;
+
+use rig::providers;
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    tracing_subscriber::fmt().init();
+
+    tracing::info!("Trying to prompt an agent with reasoning effort added...");
+
+    let reasoning = json!({
+        "effort": "medium"
+    });
+
+    // Create agent with a single context prompt and two tools
+    let calculator_agent = providers::openrouter::Client::from_env()
+        .agent("google/gemini-2.5-flash-preview-05-20:thinking")
+        .preamble("You are a helpful assistant.")
+        .max_tokens(1024)
+        .additional_params(reasoning)
+        .build();
+
+    tracing::info!("Hello, Gemini!");
+
+    let response = calculator_agent
+        .completion("Hello, Gemini!", Vec::new())
+        .await
+        .unwrap()
+        .send()
+        .await
+        .unwrap()
+        .raw_response;
+
+    let Message::Assistant {
+        content, reasoning, ..
+    } = response.choices.into_iter().next().unwrap().message
+    else {
+        return Err(anyhow!(
+            "Attempted to get first message in the response but it wasn't an assistant message"
+        ));
+    };
+
+    tracing::info!("Content: {content:?}");
+
+    let Some(reasoning) = reasoning else {
+        return Err(anyhow!("No reasoning tokens were used"));
+    };
+
+    tracing::info!("Reasoning: {reasoning}");
+
+    Ok(())
+}

--- a/rig-core/examples/openrouter_streaming_with_tools.rs
+++ b/rig-core/examples/openrouter_streaming_with_tools.rs
@@ -95,9 +95,9 @@ async fn main() -> Result<(), anyhow::Error> {
     let calculator_agent = providers::openrouter::Client::from_env()
         .agent(providers::openrouter::GEMINI_FLASH_2_0)
         .preamble(
-            "You are a calculator here to help the user perform arithmetic 
-            operations. Use the tools provided to answer the user's question. 
-            make your answer long, so we can test the streaming functionality, 
+            "You are a calculator here to help the user perform arithmetic
+            operations. Use the tools provided to answer the user's question.
+            make your answer long, so we can test the streaming functionality,
             like 20 words",
         )
         .max_tokens(1024)

--- a/rig-core/src/providers/openrouter/completion.rs
+++ b/rig-core/src/providers/openrouter/completion.rs
@@ -1,16 +1,18 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use super::client::{ApiErrorResponse, ApiResponse, Client, Usage};
+use crate::message::AudioMediaType;
+use crate::one_or_many::string_or_one_or_many;
 
 use crate::{
     completion::{self, CompletionError, CompletionRequest},
-    json_utils,
-    providers::openai::Message,
+    json_utils, message,
+    providers::openai::{AudioAssistant, SystemContent, ToolCall, ToolResultContent, UserContent},
     OneOrMany,
 };
 use serde_json::{json, Value};
 
-use crate::providers::openai::AssistantContent;
+use crate::providers::openai::{AssistantContent, ImageUrl, InputAudio};
 use crate::providers::openrouter::streaming::FinalCompletionResponse;
 use crate::streaming::StreamingCompletionResponse;
 
@@ -212,5 +214,164 @@ impl completion::CompletionModel for CompletionModel {
         completion_request: CompletionRequest,
     ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
         CompletionModel::stream(self, completion_request).await
+    }
+}
+
+/// A re-implementation of the OpenAI router for OpenRouter.
+/// Differences:
+/// - includes `reasoning` field in Assistant message
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+#[serde(tag = "role", rename_all = "lowercase")]
+pub enum Message {
+    #[serde(alias = "developer")]
+    System {
+        #[serde(deserialize_with = "string_or_one_or_many")]
+        content: OneOrMany<SystemContent>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+    },
+    User {
+        #[serde(deserialize_with = "string_or_one_or_many")]
+        content: OneOrMany<UserContent>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+    },
+    Assistant {
+        #[serde(default, deserialize_with = "json_utils::string_or_vec")]
+        content: Vec<AssistantContent>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        refusal: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reasoning: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        audio: Option<AudioAssistant>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        #[serde(
+            default,
+            deserialize_with = "json_utils::null_or_vec",
+            skip_serializing_if = "Vec::is_empty"
+        )]
+        tool_calls: Vec<ToolCall>,
+    },
+    #[serde(rename = "tool")]
+    ToolResult {
+        tool_call_id: String,
+        content: OneOrMany<ToolResultContent>,
+    },
+}
+
+impl Message {
+    pub fn system(content: &str) -> Self {
+        Message::System {
+            content: OneOrMany::one(content.to_owned().into()),
+            name: None,
+        }
+    }
+}
+
+impl TryFrom<message::Message> for Vec<Message> {
+    type Error = message::MessageError;
+
+    fn try_from(message: message::Message) -> Result<Self, Self::Error> {
+        match message {
+            message::Message::User { content } => {
+                let (tool_results, other_content): (Vec<_>, Vec<_>) = content
+                    .into_iter()
+                    .partition(|content| matches!(content, message::UserContent::ToolResult(_)));
+
+                // If there are messages with both tool results and user content, openai will only
+                //  handle tool results. It's unlikely that there will be both.
+                if !tool_results.is_empty() {
+                    tool_results
+                        .into_iter()
+                        .map(|content| match content {
+                            message::UserContent::ToolResult(message::ToolResult {
+                                id,
+                                content,
+                            }) => Ok::<_, message::MessageError>(Message::ToolResult {
+                                tool_call_id: id,
+                                content: content.try_map(|content| match content {
+                                    message::ToolResultContent::Text(message::Text { text }) => {
+                                        Ok(text.into())
+                                    }
+                                    _ => Err(message::MessageError::ConversionError(
+                                        "Tool result content does not support non-text".into(),
+                                    )),
+                                })?,
+                            }),
+                            _ => unreachable!(),
+                        })
+                        .collect::<Result<Vec<_>, _>>()
+                } else {
+                    let other_content = OneOrMany::many(other_content).expect(
+                        "There must be other content here if there were no tool result content",
+                    );
+
+                    Ok(vec![Message::User {
+                        content: other_content.map(|content| match content {
+                            message::UserContent::Text(message::Text { text }) => {
+                                UserContent::Text { text }
+                            }
+                            message::UserContent::Image(message::Image {
+                                data, detail, ..
+                            }) => UserContent::Image {
+                                image_url: ImageUrl {
+                                    url: data,
+                                    detail: detail.unwrap_or_default(),
+                                },
+                            },
+                            message::UserContent::Document(message::Document { data, .. }) => {
+                                UserContent::Text { text: data }
+                            }
+                            message::UserContent::Audio(message::Audio {
+                                data,
+                                media_type,
+                                ..
+                            }) => UserContent::Audio {
+                                input_audio: InputAudio {
+                                    data,
+                                    format: match media_type {
+                                        Some(media_type) => media_type,
+                                        None => AudioMediaType::MP3,
+                                    },
+                                },
+                            },
+                            _ => unreachable!(),
+                        }),
+                        name: None,
+                    }])
+                }
+            }
+            message::Message::Assistant { content } => {
+                let (text_content, tool_calls) = content.into_iter().fold(
+                    (Vec::new(), Vec::new()),
+                    |(mut texts, mut tools), content| {
+                        match content {
+                            message::AssistantContent::Text(text) => texts.push(text),
+                            message::AssistantContent::ToolCall(tool_call) => tools.push(tool_call),
+                        }
+                        (texts, tools)
+                    },
+                );
+
+                // `OneOrMany` ensures at least one `AssistantContent::Text` or `ToolCall` exists,
+                //  so either `content` or `tool_calls` will have some content.
+                Ok(vec![Message::Assistant {
+                    content: text_content
+                        .into_iter()
+                        .map(|content| content.text.into())
+                        .collect::<Vec<_>>(),
+                    refusal: None,
+                    reasoning: None,
+                    audio: None,
+                    name: None,
+                    tool_calls: tool_calls
+                        .into_iter()
+                        .map(|tool_call| tool_call.into())
+                        .collect::<Vec<_>>(),
+                }])
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #476 
Fixes RIG-760

Marked as draft until an agreement is reached that this is the final implementation.

The reason why this is a draft is because it's currently unclear whether we either want to do this, or to have an `additional_params` variable (of `serde_json::Map<String, serde_json::Value>` type) to soak up all extra parameters in the OpenAI message type (using `serde::flatten`).