### PR TITLE
fix: update broken Neo4j plugin docs link

### DIFF
--- a/rig-neo4j/src/lib.rs
+++ b/rig-neo4j/src/lib.rs
@@ -14,7 +14,7 @@
 //! file from /products to /plugins in the Neo4j home directory, or, if you are using Docker, by starting
 //! the Docker container with the extra parameter `--env NEO4J_PLUGINS='["genai"]'`.
 //!
-//! For more information, see [Operations Manual → Configure plugins](https://neo4j.com/docs/operations-manual/current/plugins/configure/).
+//! For more information, see [Operations Manual → Configure plugins](https://neo4j.com/docs/upgrade-migration-guide/current/version-5/migration/install-and-configure/#_plugins).
 //!
 //! ### Pre-existing Vector Index
 //!


### PR DESCRIPTION
Replaced outdated Neo4j Operations Manual link with the current valid URL from the Neo4j Upgrade & Migration Guide.
Old link was returning 404 — now points to the section on plugin configuration in Neo4j 5.