### PR TITLE
Add new Gemini models

### DIFF
--- a/rig-core/src/providers/gemini/completion.rs
+++ b/rig-core/src/providers/gemini/completion.rs
@@ -2,7 +2,20 @@
 //! Google Gemini Completion Integration
 //! From [Gemini API Reference](https://ai.google.dev/api/generate-content)
 // ================================================================
-
+/// `gemini-2.5-pro-preview-06-05` completion model
+pub const GEMINI_2_5_PRO_PREVIEW_06_05: &str = "gemini-2.5-pro-preview-06-05";
+/// `gemini-2.5-pro-preview-05-06` completion model
+pub const GEMINI_2_5_PRO_PREVIEW_05_06: &str = "gemini-2.5-pro-preview-05-06";
+/// `gemini-2.5-pro-preview-03-25` completion model
+pub const GEMINI_2_5_PRO_PREVIEW_03_25: &str = "gemini-2.5-pro-preview-03-25";
+/// `gemini-2.5-flash-preview-05-20` completion model
+pub const GEMINI_2_5_FLASH_PREVIEW_05_20: &str = "gemini-2.5-flash-preview-05-20";
+/// `gemini-2.5-flash-preview-04-17` completion model
+pub const GEMINI_2_5_FLASH_PREVIEW_04_17: &str = "gemini-2.5-flash-preview-04-17";
+/// `gemini-2.5-pro-exp-03-25` experimental completion model
+pub const GEMINI_2_5_PRO_EXP_03_25: &str = "gemini-2.5-pro-exp-03-25";
+/// `gemini-2.0-flash-lite` completion model
+pub const GEMINI_2_0_FLASH_LITE: &str = "gemini-2.0-flash-lite";
 /// `gemini-2.0-flash` completion model
 pub const GEMINI_2_0_FLASH: &str = "gemini-2.0-flash";
 /// `gemini-1.5-flash` completion model


### PR DESCRIPTION
## What's new

- Added Gemini 2.5 Pro preview models:
  - `gemini-2.5-pro-preview-06-05`
  - `gemini-2.5-pro-preview-05-06` 
  - `gemini-2.5-pro-preview-03-25`
- Added Gemini 2.5 Flash preview models:
  - `gemini-2.5-flash-preview-05-20`
  - `gemini-2.5-flash-preview-04-17`
- Added experimental Gemini 2.5 Pro model:
  - `gemini-2.5-pro-exp-03-25`
- Added Gemini 2.0 Flash Lite model:
  - `gemini-2.0-flash-lite`

## Description

This PR adds support for the latest Gemini model variants including preview versions and the new Flash Lite model. All models are added as string constants to maintain consistency with the existing codebase patterns.

## Testing

- [ ] Models compile correctly
- [ ] Constants follow existing naming conventions
- [ ] Documentation strings are consistent