### PR TITLE
fix(ollama): use lower-case key for `ToolResult` serialization

### DIFF
--- a/rig-core/src/providers/ollama.rs
+++ b/rig-core/src/providers/ollama.rs
@@ -602,7 +602,7 @@ pub enum Message {
         #[serde(skip_serializing_if = "Option::is_none")]
         name: Option<String>,
     },
-    #[serde(rename = "Tool")]
+    #[serde(rename = "tool")]
     ToolResult { name: String, content: String },
 }
 


### PR DESCRIPTION
`serde` attributes don't stack like this, so we would send `"role": "Tool"`.