### PR TITLE
feat(rig-754): support custom client configurations

### DIFF
--- a/rig-core/src/providers/anthropic/client.rs
+++ b/rig-core/src/providers/anthropic/client.rs
@@ -1,5 +1,4 @@
 //! Anthropic client api implementation
-
 use super::completion::{CompletionModel, ANTHROPIC_VERSION_LATEST};
 use crate::client::{impl_conversion_traits, CompletionClient, ProviderClient};
 
@@ -68,10 +67,27 @@ impl<'a> ClientBuilder<'a> {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Client {
+    /// The base URL
     base_url: String,
+    /// The API key
+    api_key: String,
+    /// The underlying HTTP client
     http_client: reqwest::Client,
+    /// Default headers that will be automatically added to any given request with this client (API key, Anthropic Version and any betas that have been added)
+    default_headers: reqwest::header::HeaderMap,
+}
+
+impl std::fmt::Debug for Client {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Client")
+            .field("base_url", &self.base_url)
+            .field("http_client", &self.http_client)
+            .field("api_key", &"<REDACTED>")
+            .field("default_headers", &self.default_headers)
+            .finish()
+    }
 }
 
 impl Client {
@@ -83,35 +99,45 @@ impl Client {
     ///   - This should really never happen.
     /// - If the reqwest client cannot be built (if the TLS backend cannot be initialized).
     pub fn new(api_key: &str, base_url: &str, betas: Option<Vec<&str>>, version: &str) -> Self {
+        let mut default_headers = reqwest::header::HeaderMap::new();
+        default_headers.insert(
+            "anthropic-version",
+            version.parse().expect("Anthropic version should parse"),
+        );
+        if let Some(betas) = betas {
+            default_headers.insert(
+                "anthropic-beta",
+                betas
+                    .join(",")
+                    .parse()
+                    .expect("Anthropic betas should parse"),
+            );
+        };
+
         Self {
             base_url: base_url.to_string(),
+            api_key: api_key.to_string(),
+            default_headers,
             http_client: reqwest::Client::builder()
-                .default_headers({
-                    let mut headers = reqwest::header::HeaderMap::new();
-                    headers.insert("x-api-key", api_key.parse().expect("API key should parse"));
-                    headers.insert(
-                        "anthropic-version",
-                        version.parse().expect("Anthropic version should parse"),
-                    );
-                    if let Some(betas) = betas {
-                        headers.insert(
-                            "anthropic-beta",
-                            betas
-                                .join(",")
-                                .parse()
-                                .expect("Anthropic betas should parse"),
-                        );
-                    }
-                    headers
-                })
                 .build()
                 .expect("Anthropic reqwest client should build"),
         }
     }
 
+    /// Use your own `reqwest::Client`.
+    /// The default headers will be automatically attached upon trying to make a request.
+    pub fn with_custom_client(mut self, client: reqwest::Client) -> Self {
+        self.http_client = client;
+
+        self
+    }
+
     pub fn post(&self, path: &str) -> reqwest::RequestBuilder {
         let url = format!("{}/{}", self.base_url, path).replace("//", "/");
-        self.http_client.post(url)
+        self.http_client
+            .post(url)
+            .header("X-Api-Key", &self.api_key)
+            .headers(self.default_headers.clone())
     }
 }
 

--- a/rig-core/src/providers/azure.rs
+++ b/rig-core/src/providers/azure.rs
@@ -20,6 +20,7 @@ use crate::{
     providers::openai,
     transcription::{self, TranscriptionError},
 };
+use reqwest::header::AUTHORIZATION;
 use reqwest::multipart::Part;
 use serde::Deserialize;
 use serde_json::json;
@@ -27,11 +28,23 @@ use serde_json::json;
 // Main Azure OpenAI Client
 // ================================================================
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Client {
     api_version: String,
     azure_endpoint: String,
+    auth: AzureOpenAIAuth,
     http_client: reqwest::Client,
+}
+
+impl std::fmt::Debug for Client {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Client")
+            .field("azure_endpoint", &self.azure_endpoint)
+            .field("http_client", &self.http_client)
+            .field("auth", &"<REDACTED>")
+            .field("api_version", &self.api_version)
+            .finish()
+    }
 }
 
 #[derive(Clone)]
@@ -40,9 +53,35 @@ pub enum AzureOpenAIAuth {
     Token(String),
 }
 
+impl std::fmt::Debug for AzureOpenAIAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ApiKey(_) => write!(f, "API key <REDACTED>"),
+            Self::Token(_) => write!(f, "Token <REDACTED>"),
+        }
+    }
+}
+
 impl From<String> for AzureOpenAIAuth {
     fn from(token: String) -> Self {
         AzureOpenAIAuth::Token(token)
+    }
+}
+
+impl AzureOpenAIAuth {
+    fn as_header(&self) -> (reqwest::header::HeaderName, reqwest::header::HeaderValue) {
+        match self {
+            AzureOpenAIAuth::ApiKey(api_key) => (
+                "api-key".parse().expect("Header value should parse"),
+                api_key.parse().expect("API key should parse"),
+            ),
+            AzureOpenAIAuth::Token(token) => (
+                AUTHORIZATION,
+                format!("Bearer {token}")
+                    .parse()
+                    .expect("Token should parse"),
+            ),
+        }
     }
 }
 
@@ -55,29 +94,22 @@ impl Client {
     /// * `api_version` - API version to use (e.g., "2024-10-21" for GA, "2024-10-01-preview" for preview)
     /// * `azure_endpoint` - Azure OpenAI endpoint URL, for example: https://{your-resource-name}.openai.azure.com
     pub fn new(auth: impl Into<AzureOpenAIAuth>, api_version: &str, azure_endpoint: &str) -> Self {
-        let mut headers = reqwest::header::HeaderMap::new();
-        match auth.into() {
-            AzureOpenAIAuth::ApiKey(api_key) => {
-                headers.insert("api-key", api_key.parse().expect("API key should parse"));
-            }
-            AzureOpenAIAuth::Token(token) => {
-                headers.insert(
-                    "Authorization",
-                    format!("Bearer {token}")
-                        .parse()
-                        .expect("Token should parse"),
-                );
-            }
-        }
-
         Self {
             api_version: api_version.to_string(),
+            auth: auth.into(),
             azure_endpoint: azure_endpoint.to_string(),
             http_client: reqwest::Client::builder()
-                .default_headers(headers)
                 .build()
                 .expect("Azure OpenAI reqwest client should build"),
         }
+    }
+
+    /// Use your own `reqwest::Client`.
+    /// The required headers will be automatically attached upon trying to make a request.
+    pub fn with_custom_client(mut self, client: reqwest::Client) -> Self {
+        self.http_client = client;
+
+        self
     }
 
     /// Creates a new Azure OpenAI client from an API key.
@@ -116,7 +148,9 @@ impl Client {
             self.azure_endpoint, deployment_id, self.api_version
         )
         .replace("//", "/");
-        self.http_client.post(url)
+
+        let (key, value) = self.auth.as_header();
+        self.http_client.post(url).header(key, value)
     }
 
     fn post_chat_completion(&self, deployment_id: &str) -> reqwest::RequestBuilder {
@@ -125,7 +159,8 @@ impl Client {
             self.azure_endpoint, deployment_id, self.api_version
         )
         .replace("//", "/");
-        self.http_client.post(url)
+        let (key, value) = self.auth.as_header();
+        self.http_client.post(url).header(key, value)
     }
 
     fn post_transcription(&self, deployment_id: &str) -> reqwest::RequestBuilder {
@@ -134,7 +169,8 @@ impl Client {
             self.azure_endpoint, deployment_id, self.api_version
         )
         .replace("//", "/");
-        self.http_client.post(url)
+        let (key, value) = self.auth.as_header();
+        self.http_client.post(url).header(key, value)
     }
 
     #[cfg(feature = "image")]
@@ -144,7 +180,8 @@ impl Client {
             self.azure_endpoint, deployment_id, self.api_version
         )
         .replace("//", "/");
-        self.http_client.post(url)
+        let (key, value) = self.auth.as_header();
+        self.http_client.post(url).header(key, value)
     }
 
     #[cfg(feature = "audio")]
@@ -154,7 +191,8 @@ impl Client {
             self.azure_endpoint, deployment_id, self.api_version
         )
         .replace("//", "/");
-        self.http_client.post(url)
+        let (key, value) = self.auth.as_header();
+        self.http_client.post(url).header(key, value)
     }
 }
 

--- a/rig-core/src/providers/cohere/client.rs
+++ b/rig-core/src/providers/cohere/client.rs
@@ -24,6 +24,7 @@ const COHERE_API_BASE_URL: &str = "https://api.cohere.ai";
 #[derive(Clone, Debug)]
 pub struct Client {
     base_url: String,
+    api_key: String,
     http_client: reqwest::Client,
 }
 
@@ -35,25 +36,24 @@ impl Client {
     pub fn from_url(api_key: &str, base_url: &str) -> Self {
         Self {
             base_url: base_url.to_string(),
+            api_key: api_key.to_string(),
             http_client: reqwest::Client::builder()
-                .default_headers({
-                    let mut headers = reqwest::header::HeaderMap::new();
-                    headers.insert(
-                        "Authorization",
-                        format!("Bearer {api_key}")
-                            .parse()
-                            .expect("Bearer token should parse"),
-                    );
-                    headers
-                })
                 .build()
                 .expect("Cohere reqwest client should build"),
         }
     }
 
+    /// Use your own `reqwest::Client`.
+    /// The API key will be automatically attached upon trying to make a request, so you shouldn't need to add it as a default header.
+    pub fn with_custom_client(mut self, client: reqwest::Client) -> Self {
+        self.http_client = client;
+
+        self
+    }
+
     pub fn post(&self, path: &str) -> reqwest::RequestBuilder {
         let url = format!("{}/{}", self.base_url, path).replace("//", "/");
-        self.http_client.post(url)
+        self.http_client.post(url).bearer_auth(&self.api_key)
     }
 
     pub fn embeddings<D: Embed>(

--- a/rig-core/src/providers/cohere/client.rs
+++ b/rig-core/src/providers/cohere/client.rs
@@ -21,11 +21,21 @@ pub enum ApiResponse<T> {
 // ================================================================
 const COHERE_API_BASE_URL: &str = "https://api.cohere.ai";
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Client {
     base_url: String,
     api_key: String,
     http_client: reqwest::Client,
+}
+
+impl std::fmt::Debug for Client {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Client")
+            .field("base_url", &self.base_url)
+            .field("http_client", &self.http_client)
+            .field("api_key", &"<REDACTED>")
+            .finish()
+    }
 }
 
 impl Client {

--- a/rig-core/src/providers/gemini/client.rs
+++ b/rig-core/src/providers/gemini/client.rs
@@ -72,7 +72,9 @@ impl Client {
             format!("{}/{}?alt=sse&key={}", self.base_url, path, self.api_key).replace("//", "/");
 
         tracing::debug!("POST {}/{}?alt=sse&key={}", self.base_url, path, "****");
-        self.http_client.post(url)
+        self.http_client
+            .post(url)
+            .headers(self.default_headers.clone())
     }
 
     /// Create an agent builder with the given completion model.

--- a/rig-core/src/providers/groq.rs
+++ b/rig-core/src/providers/groq.rs
@@ -32,10 +32,21 @@ use serde_json::{json, Value};
 // ================================================================
 const GROQ_API_BASE_URL: &str = "https://api.groq.com/openai/v1";
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Client {
     base_url: String,
+    api_key: String,
     http_client: reqwest::Client,
+}
+
+impl std::fmt::Debug for Client {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Client")
+            .field("base_url", &self.base_url)
+            .field("http_client", &self.http_client)
+            .field("api_key", &"<REDACTED>")
+            .finish()
+    }
 }
 
 impl Client {
@@ -48,25 +59,24 @@ impl Client {
     pub fn from_url(api_key: &str, base_url: &str) -> Self {
         Self {
             base_url: base_url.to_string(),
+            api_key: api_key.to_string(),
             http_client: reqwest::Client::builder()
-                .default_headers({
-                    let mut headers = reqwest::header::HeaderMap::new();
-                    headers.insert(
-                        "Authorization",
-                        format!("Bearer {api_key}")
-                            .parse()
-                            .expect("Bearer token should parse"),
-                    );
-                    headers
-                })
                 .build()
                 .expect("Groq reqwest client should build"),
         }
     }
 
+    /// Use your own `reqwest::Client`.
+    /// The required headers will be automatically attached upon trying to make a request.
+    pub fn with_custom_client(mut self, client: reqwest::Client) -> Self {
+        self.http_client = client;
+
+        self
+    }
+
     fn post(&self, path: &str) -> reqwest::RequestBuilder {
         let url = format!("{}/{}", self.base_url, path).replace("//", "/");
-        self.http_client.post(url)
+        self.http_client.post(url).bearer_auth(&self.api_key)
     }
 }
 

--- a/rig-core/src/providers/huggingface/client.rs
+++ b/rig-core/src/providers/huggingface/client.rs
@@ -188,6 +188,14 @@ impl Client {
         }
     }
 
+    /// Use your own `reqwest::Client`.
+    /// The API key will be automatically attached upon trying to make a request, so you shouldn't need to add it as a default header.
+    pub fn with_custom_client(mut self, client: reqwest::Client) -> Self {
+        self.http_client = client;
+
+        self
+    }
+
     pub(crate) fn post(&self, path: &str) -> reqwest::RequestBuilder {
         let url = format!("{}/{}", self.base_url, path).replace("//", "/");
         self.http_client

--- a/rig-core/src/providers/hyperbolic.rs
+++ b/rig-core/src/providers/hyperbolic.rs
@@ -32,10 +32,21 @@ use serde_json::{json, Value};
 // ================================================================
 const HYPERBOLIC_API_BASE_URL: &str = "https://api.hyperbolic.xyz/v1";
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Client {
     base_url: String,
+    api_key: String,
     http_client: reqwest::Client,
+}
+
+impl std::fmt::Debug for Client {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Client")
+            .field("base_url", &self.base_url)
+            .field("http_client", &self.http_client)
+            .field("api_key", &"<REDACTED>")
+            .finish()
+    }
 }
 
 impl Client {
@@ -48,25 +59,24 @@ impl Client {
     pub fn from_url(api_key: &str, base_url: &str) -> Self {
         Self {
             base_url: base_url.to_string(),
+            api_key: api_key.to_string(),
             http_client: reqwest::Client::builder()
-                .default_headers({
-                    let mut headers = reqwest::header::HeaderMap::new();
-                    headers.insert(
-                        "Authorization",
-                        format!("Bearer {api_key}")
-                            .parse()
-                            .expect("Bearer token should parse"),
-                    );
-                    headers
-                })
                 .build()
                 .expect("OpenAI reqwest client should build"),
         }
     }
 
+    /// Use your own `reqwest::Client`.
+    /// The required headers will be automatically attached upon trying to make a request.
+    pub fn with_custom_client(mut self, client: reqwest::Client) -> Self {
+        self.http_client = client;
+
+        self
+    }
+
     fn post(&self, path: &str) -> reqwest::RequestBuilder {
         let url = format!("{}/{}", self.base_url, path).replace("//", "/");
-        self.http_client.post(url)
+        self.http_client.post(url).bearer_auth(&self.api_key)
     }
 }
 

--- a/rig-core/src/providers/mistral/client.rs
+++ b/rig-core/src/providers/mistral/client.rs
@@ -9,10 +9,21 @@ use crate::impl_conversion_traits;
 
 const MISTRAL_API_BASE_URL: &str = "https://api.mistral.ai";
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Client {
     base_url: String,
+    api_key: String,
     http_client: reqwest::Client,
+}
+
+impl std::fmt::Debug for Client {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Client")
+            .field("base_url", &self.base_url)
+            .field("http_client", &self.http_client)
+            .field("api_key", &"<REDACTED>")
+            .finish()
+    }
 }
 
 impl Client {
@@ -23,25 +34,24 @@ impl Client {
     pub fn from_url(api_key: &str, base_url: &str) -> Self {
         Self {
             base_url: base_url.to_string(),
+            api_key: api_key.to_string(),
             http_client: reqwest::Client::builder()
-                .default_headers({
-                    let mut headers = reqwest::header::HeaderMap::new();
-                    headers.insert(
-                        "Authorization",
-                        format!("Bearer {api_key}")
-                            .parse()
-                            .expect("Bearer token should parse"),
-                    );
-                    headers
-                })
                 .build()
                 .expect("Mistral reqwest client should build"),
         }
     }
 
+    /// Use your own `reqwest::Client`.
+    /// The required headers will be automatically attached upon trying to make a request.
+    pub fn with_custom_client(mut self, client: reqwest::Client) -> Self {
+        self.http_client = client;
+
+        self
+    }
+
     pub(crate) fn post(&self, path: &str) -> reqwest::RequestBuilder {
         let url = format!("{}/{}", self.base_url, path).replace("//", "/");
-        self.http_client.post(url)
+        self.http_client.post(url).bearer_auth(&self.api_key)
     }
 }
 

--- a/rig-core/src/providers/moonshot.rs
+++ b/rig-core/src/providers/moonshot.rs
@@ -27,10 +27,21 @@ use serde_json::{json, Value};
 // ================================================================
 const MOONSHOT_API_BASE_URL: &str = "https://api.moonshot.cn/v1";
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Client {
     base_url: String,
+    api_key: String,
     http_client: reqwest::Client,
+}
+
+impl std::fmt::Debug for Client {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Client")
+            .field("base_url", &self.base_url)
+            .field("http_client", &self.http_client)
+            .field("api_key", &"<REDACTED>")
+            .finish()
+    }
 }
 
 impl Client {
@@ -43,25 +54,24 @@ impl Client {
     pub fn from_url(api_key: &str, base_url: &str) -> Self {
         Self {
             base_url: base_url.to_string(),
+            api_key: api_key.to_string(),
             http_client: reqwest::Client::builder()
-                .default_headers({
-                    let mut headers = reqwest::header::HeaderMap::new();
-                    headers.insert(
-                        "Authorization",
-                        format!("Bearer {api_key}")
-                            .parse()
-                            .expect("Bearer token should parse"),
-                    );
-                    headers
-                })
                 .build()
                 .expect("Moonshot reqwest client should build"),
         }
     }
 
+    /// Use your own `reqwest::Client`.
+    /// The required headers will be automatically attached upon trying to make a request.
+    pub fn with_custom_client(mut self, client: reqwest::Client) -> Self {
+        self.http_client = client;
+
+        self
+    }
+
     fn post(&self, path: &str) -> reqwest::RequestBuilder {
         let url = format!("{}/{}", self.base_url, path).replace("//", "/");
-        self.http_client.post(url)
+        self.http_client.post(url).bearer_auth(&self.api_key)
     }
 }
 

--- a/rig-core/src/providers/ollama.rs
+++ b/rig-core/src/providers/ollama.rs
@@ -84,6 +84,15 @@ impl Client {
                 .expect("Ollama reqwest client should build"),
         }
     }
+
+    /// Use your own `reqwest::Client`.
+    /// The required headers will be automatically attached upon trying to make a request.
+    pub fn with_custom_client(mut self, client: reqwest::Client) -> Self {
+        self.http_client = client;
+
+        self
+    }
+
     fn post(&self, path: &str) -> reqwest::RequestBuilder {
         let url = format!("{}/{}", self.base_url, path);
         self.http_client.post(url)

--- a/rig-core/src/providers/openai/client.rs
+++ b/rig-core/src/providers/openai/client.rs
@@ -22,10 +22,22 @@ use serde::Deserialize;
 // Main OpenAI Client
 // ================================================================
 const OPENAI_API_BASE_URL: &str = "https://api.openai.com/v1";
-#[derive(Clone, Debug)]
+
+#[derive(Clone)]
 pub struct Client {
     base_url: String,
+    api_key: String,
     http_client: reqwest::Client,
+}
+
+impl std::fmt::Debug for Client {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Client")
+            .field("base_url", &self.base_url)
+            .field("http_client", &self.http_client)
+            .field("api_key", &"<REDACTED>")
+            .finish()
+    }
 }
 
 impl Client {
@@ -38,25 +50,24 @@ impl Client {
     pub fn from_url(api_key: &str, base_url: &str) -> Self {
         Self {
             base_url: base_url.to_string(),
+            api_key: api_key.to_string(),
             http_client: reqwest::Client::builder()
-                .default_headers({
-                    let mut headers = reqwest::header::HeaderMap::new();
-                    headers.insert(
-                        "Authorization",
-                        format!("Bearer {api_key}")
-                            .parse()
-                            .expect("Bearer token should parse"),
-                    );
-                    headers
-                })
                 .build()
                 .expect("OpenAI reqwest client should build"),
         }
     }
 
+    /// Use your own `reqwest::Client`.
+    /// The required headers will be automatically attached upon trying to make a request.
+    pub fn with_custom_client(mut self, client: reqwest::Client) -> Self {
+        self.http_client = client;
+
+        self
+    }
+
     pub(crate) fn post(&self, path: &str) -> reqwest::RequestBuilder {
         let url = format!("{}/{}", self.base_url, path).replace("//", "/");
-        self.http_client.post(url)
+        self.http_client.post(url).bearer_auth(&self.api_key)
     }
 }
 

--- a/rig-core/src/providers/openrouter/client.rs
+++ b/rig-core/src/providers/openrouter/client.rs
@@ -45,6 +45,14 @@ impl Client {
         }
     }
 
+    /// Use your own `reqwest::Client`.
+    /// The required headers will be automatically attached upon trying to make a request.
+    pub fn with_custom_client(mut self, client: reqwest::Client) -> Self {
+        self.http_client = client;
+
+        self
+    }
+
     pub(crate) fn post(&self, path: &str) -> reqwest::RequestBuilder {
         let url = format!("{}/{}", self.base_url, path).replace("//", "/");
         self.http_client.post(url).bearer_auth(&self.api_key)

--- a/rig-core/src/providers/openrouter/client.rs
+++ b/rig-core/src/providers/openrouter/client.rs
@@ -11,10 +11,21 @@ use super::completion::CompletionModel;
 // ================================================================
 const OPENROUTER_API_BASE_URL: &str = "https://openrouter.ai/api/v1";
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Client {
     base_url: String,
+    api_key: String,
     http_client: reqwest::Client,
+}
+
+impl std::fmt::Debug for Client {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Client")
+            .field("base_url", &self.base_url)
+            .field("http_client", &self.http_client)
+            .field("api_key", &"<REDACTED>")
+            .finish()
+    }
 }
 
 impl Client {
@@ -27,17 +38,8 @@ impl Client {
     pub fn from_url(api_key: &str, base_url: &str) -> Self {
         Self {
             base_url: base_url.to_string(),
+            api_key: api_key.to_string(),
             http_client: reqwest::Client::builder()
-                .default_headers({
-                    let mut headers = reqwest::header::HeaderMap::new();
-                    headers.insert(
-                        "Authorization",
-                        format!("Bearer {api_key}")
-                            .parse()
-                            .expect("Bearer token should parse"),
-                    );
-                    headers
-                })
                 .build()
                 .expect("OpenRouter reqwest client should build"),
         }
@@ -45,7 +47,7 @@ impl Client {
 
     pub(crate) fn post(&self, path: &str) -> reqwest::RequestBuilder {
         let url = format!("{}/{}", self.base_url, path).replace("//", "/");
-        self.http_client.post(url)
+        self.http_client.post(url).bearer_auth(&self.api_key)
     }
 }
 

--- a/rig-core/src/providers/perplexity.rs
+++ b/rig-core/src/providers/perplexity.rs
@@ -31,10 +31,21 @@ use serde_json::{json, Value};
 // ================================================================
 const PERPLEXITY_API_BASE_URL: &str = "https://api.perplexity.ai";
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Client {
     base_url: String,
+    api_key: String,
     http_client: reqwest::Client,
+}
+
+impl std::fmt::Debug for Client {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Client")
+            .field("base_url", &self.base_url)
+            .field("http_client", &self.http_client)
+            .field("api_key", &"<REDACTED>")
+            .finish()
+    }
 }
 
 impl Client {
@@ -45,25 +56,24 @@ impl Client {
     pub fn from_url(api_key: &str, base_url: &str) -> Self {
         Self {
             base_url: base_url.to_string(),
+            api_key: api_key.to_string(),
             http_client: reqwest::Client::builder()
-                .default_headers({
-                    let mut headers = reqwest::header::HeaderMap::new();
-                    headers.insert(
-                        "Authorization",
-                        format!("Bearer {api_key}")
-                            .parse()
-                            .expect("Bearer token should parse"),
-                    );
-                    headers
-                })
                 .build()
                 .expect("Perplexity reqwest client should build"),
         }
     }
 
+    /// Use your own `reqwest::Client`.
+    /// The required headers will be automatically attached upon trying to make a request.
+    pub fn with_custom_client(mut self, client: reqwest::Client) -> Self {
+        self.http_client = client;
+
+        self
+    }
+
     pub fn post(&self, path: &str) -> reqwest::RequestBuilder {
         let url = format!("{}/{}", self.base_url, path).replace("//", "/");
-        self.http_client.post(url)
+        self.http_client.post(url).bearer_auth(&self.api_key)
     }
 
     pub fn agent(&self, model: &str) -> AgentBuilder<CompletionModel> {

--- a/rig-core/src/providers/together/client.rs
+++ b/rig-core/src/providers/together/client.rs
@@ -48,6 +48,14 @@ impl Client {
         }
     }
 
+    /// Use your own `reqwest::Client`.
+    /// The required headers will be automatically attached upon trying to make a request.
+    pub fn with_custom_client(mut self, client: reqwest::Client) -> Self {
+        self.http_client = client;
+
+        self
+    }
+
     pub fn post(&self, path: &str) -> reqwest::RequestBuilder {
         let url = format!("{}/{}", self.base_url, path).replace("//", "/");
 

--- a/rig-core/src/providers/together/client.rs
+++ b/rig-core/src/providers/together/client.rs
@@ -7,10 +7,23 @@ use rig::client::CompletionClient;
 // ================================================================
 const TOGETHER_AI_BASE_URL: &str = "https://api.together.xyz";
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Client {
     base_url: String,
+    default_headers: reqwest::header::HeaderMap,
+    api_key: String,
     http_client: reqwest::Client,
+}
+
+impl std::fmt::Debug for Client {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Client")
+            .field("base_url", &self.base_url)
+            .field("http_client", &self.http_client)
+            .field("default_headers", &self.default_headers)
+            .field("api_key", &"<REDACTED>")
+            .finish()
+    }
 }
 
 impl Client {
@@ -20,23 +33,16 @@ impl Client {
     }
 
     fn from_url(api_key: &str, base_url: &str) -> Self {
+        let mut default_headers = reqwest::header::HeaderMap::new();
+        default_headers.insert(
+            reqwest::header::CONTENT_TYPE,
+            "application/json".parse().unwrap(),
+        );
         Self {
             base_url: base_url.to_string(),
+            api_key: api_key.to_string(),
+            default_headers,
             http_client: reqwest::Client::builder()
-                .default_headers({
-                    let mut headers = reqwest::header::HeaderMap::new();
-                    headers.insert(
-                        reqwest::header::CONTENT_TYPE,
-                        "application/json".parse().unwrap(),
-                    );
-                    headers.insert(
-                        "Authorization",
-                        format!("Bearer {api_key}")
-                            .parse()
-                            .expect("Bearer token should parse"),
-                    );
-                    headers
-                })
                 .build()
                 .expect("Together AI reqwest client should build"),
         }
@@ -46,7 +52,10 @@ impl Client {
         let url = format!("{}/{}", self.base_url, path).replace("//", "/");
 
         tracing::debug!("POST {}", url);
-        self.http_client.post(url)
+        self.http_client
+            .post(url)
+            .bearer_auth(&self.api_key)
+            .headers(self.default_headers.clone())
     }
 }
 

--- a/rig-core/src/providers/xai/client.rs
+++ b/rig-core/src/providers/xai/client.rs
@@ -6,34 +6,42 @@ use crate::client::{impl_conversion_traits, CompletionClient, ProviderClient};
 // ================================================================
 const XAI_BASE_URL: &str = "https://api.x.ai";
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Client {
     base_url: String,
+    api_key: String,
+    default_headers: reqwest::header::HeaderMap,
     http_client: reqwest::Client,
+}
+
+impl std::fmt::Debug for Client {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Client")
+            .field("base_url", &self.base_url)
+            .field("http_client", &self.http_client)
+            .field("default_headers", &self.default_headers)
+            .field("api_key", &"<REDACTED>")
+            .finish()
+    }
 }
 
 impl Client {
     pub fn new(api_key: &str) -> Self {
         Self::from_url(api_key, XAI_BASE_URL)
     }
+
     fn from_url(api_key: &str, base_url: &str) -> Self {
+        let mut default_headers = reqwest::header::HeaderMap::new();
+        default_headers.insert(
+            reqwest::header::CONTENT_TYPE,
+            "application/json".parse().unwrap(),
+        );
+
         Self {
             base_url: base_url.to_string(),
+            api_key: api_key.to_string(),
+            default_headers,
             http_client: reqwest::Client::builder()
-                .default_headers({
-                    let mut headers = reqwest::header::HeaderMap::new();
-                    headers.insert(
-                        reqwest::header::CONTENT_TYPE,
-                        "application/json".parse().unwrap(),
-                    );
-                    headers.insert(
-                        "Authorization",
-                        format!("Bearer {api_key}")
-                            .parse()
-                            .expect("Bearer token should parse"),
-                    );
-                    headers
-                })
                 .build()
                 .expect("xAI reqwest client should build"),
         }
@@ -43,7 +51,10 @@ impl Client {
         let url = format!("{}/{}", self.base_url, path).replace("//", "/");
 
         tracing::debug!("POST {}", url);
-        self.http_client.post(url)
+        self.http_client
+            .post(url)
+            .bearer_auth(&self.api_key)
+            .headers(self.default_headers.clone())
     }
 }
 

--- a/rig-core/src/providers/xai/client.rs
+++ b/rig-core/src/providers/xai/client.rs
@@ -47,6 +47,14 @@ impl Client {
         }
     }
 
+    /// Use your own `reqwest::Client`.
+    /// The required headers will be automatically attached upon trying to make a request.
+    pub fn with_custom_client(mut self, client: reqwest::Client) -> Self {
+        self.http_client = client;
+
+        self
+    }
+
     pub fn post(&self, path: &str) -> reqwest::RequestBuilder {
         let url = format!("{}/{}", self.base_url, path).replace("//", "/");
 


### PR DESCRIPTION
Fixes #467 
Fixes RIG-754

Additionally adds an upgrade to the Debug implementation for every client such that the API key will never be exposed when using Debug. This is a highly important implementation detail as the user should not need to work around this if/when implementing observability systems that additionally cover Rig.