### PR TITLE
feat: Stream cancellation using AbortHandle

### DIFF
--- a/rig-core/src/completion/request.rs
+++ b/rig-core/src/completion/request.rs
@@ -294,7 +294,9 @@ where
             let resp = self.stream(request).await?;
             let inner = resp.inner;
 
-            let stream = Box::pin(streaming::StreamingResultDyn { inner });
+            let stream = Box::pin(streaming::StreamingResultDyn {
+                inner: Box::pin(inner),
+            });
 
             Ok(StreamingCompletionResponse::stream(stream))
         })


### PR DESCRIPTION
fixes #491 


new stream api: 
`stream.cancel()` cancels the ongoing stream.

