### PR TITLE
feat: add ScyllaDB vector store implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8284,6 +8284,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_pcg"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b48ac3f7ffaab7fac4d2376632268aa5f89abdb55f7ebf8f4d11fffccb2320f7"
+dependencies = [
+ "rand_core 0.9.3",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8895,6 +8904,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rig-scylladb"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "futures",
+ "httpmock",
+ "rig-core",
+ "scylla",
+ "serde",
+ "serde_json",
+ "testcontainers",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid 1.17.0",
+]
+
+[[package]]
 name = "rig-sqlite"
 version = "0.1.11"
 dependencies = [
@@ -9460,6 +9488,63 @@ checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring 0.17.14",
  "untrusted 0.9.0",
+]
+
+[[package]]
+name = "scylla"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f4d5b7fe3cb3e140d374238f5f916eb810053562287a01d66ac685e305c166f"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "dashmap 5.5.3",
+ "futures",
+ "hashbrown 0.14.5",
+ "itertools 0.14.0",
+ "rand 0.9.0",
+ "rand_pcg",
+ "scylla-cql",
+ "smallvec",
+ "socket2",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+ "uuid 1.17.0",
+]
+
+[[package]]
+name = "scylla-cql"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507db4914c625c86d32c5c00ed1add75eaf966a2d4ba9772b601b2563701df58"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "chrono",
+ "itertools 0.14.0",
+ "lz4_flex",
+ "scylla-macros",
+ "snap",
+ "stable_deref_trait",
+ "thiserror 2.0.12",
+ "tokio",
+ "uuid 1.17.0",
+ "yoke",
+]
+
+[[package]]
+name = "scylla-macros"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8efb4b519ab70556c8d3adfd4f192c635d0c7c72d4f125d2b79713742c98f39d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "rig-postgres",
     "rig-qdrant",
     "rig-core/rig-core-derive",
+    "rig-scylladb",
     "rig-sqlite",
     "rig-surrealdb",
     "rig-eternalai",

--- a/rig-scylladb/Cargo.toml
+++ b/rig-scylladb/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "rig-scylladb"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+readme = "README.md"
+description = "ScyllaDB vector store index integration for Rig. High-performance NoSQL database with vector search capabilities."
+repository = "https://github.com/0xPlaygrounds/rig"
+
+[dependencies]
+rig-core = { path = "../rig-core", version = "0.13.0", features = ["derive"] }
+serde_json = "1.0.128"
+serde = { version = "1.0.210", features = ["derive"] }
+scylla = "1.2.0"
+uuid = { version = "1.13.1", features = ["v4", "serde"] }
+chrono = { version = "0.4", features = ["serde"] }
+futures = "0.3.30"
+tracing = "0.1.40"
+
+[dev-dependencies]
+tokio = { version = "1.40.0", features = ["rt-multi-thread"] }
+anyhow = "1.0.89"
+testcontainers = "0.23.1"
+tracing-subscriber = "0.3"
+httpmock = "0.7.0"
+serde_json = "1.0"
+
+[[example]]
+name = "scylladb_vector_search"
+required-features = ["rig-core/derive"]
+
+[[test]]
+name = "integration_tests"
+required-features = ["rig-core/derive"] 

--- a/rig-scylladb/LICENSE
+++ b/rig-scylladb/LICENSE
@@ -1,0 +1,7 @@
+Copyright (c) 2024, Playgrounds Analytics Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 

--- a/rig-scylladb/README.md
+++ b/rig-scylladb/README.md
@@ -1,0 +1,68 @@
+# Rig-ScyllaDB
+
+Vector store implementation for [ScyllaDB](https://www.scylladb.com/). This integration provides vector storage and similarity search using ScyllaDB as the backend.
+
+## Installation
+
+Add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+rig-scylladb = { git = "https://github.com/0xPlaygrounds/rig", package = "rig-scylladb" }
+rig-core = "0.4.0"
+```
+
+You can also run `cargo add rig-scylladb rig-core` to add the most recent versions of the dependencies to your project.
+
+## Usage
+
+```rust
+use rig::{providers::openai, vector_store::VectorStoreIndex, Embed};
+use rig_scylladb::{ScyllaDbVectorStore, create_session};
+
+#[derive(Embed, serde::Deserialize, serde::Serialize, Debug)]
+struct Document {
+    id: String,
+    #[embed]
+    text: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Create ScyllaDB session
+    let session = create_session("127.0.0.1:9042").await?;
+    
+    // Create OpenAI client and embedding model
+    let openai_client = openai::Client::from_env();
+    let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_ADA_002);
+    
+    // Create vector store
+    let vector_store = ScyllaDbVectorStore::new(
+        model,
+        session,
+        "vector_db",    // keyspace
+        "documents",    // table
+        1536,          // embedding dimensions
+    ).await?;
+    
+    // Query the store
+    let results = vector_store
+        .top_n::<Document>("search query", 5)
+        .await?;
+    
+    for (score, id, doc) in results {
+        println!("Score: {}, ID: {}, Document: {:?}", score, id, doc);
+    }
+    
+    Ok(())
+}
+```
+
+See the [`/examples`](./examples) folder for usage examples.
+
+## Notes
+
+- Uses application-level cosine similarity search (similar to SQLite and SurrealDB implementations)
+- Suitable for small to medium datasets (< 100k vectors)
+- Provides ScyllaDB's operational benefits: high availability, horizontal scaling, low latency
+- Future-ready for ScyllaDB's native vector search capabilities 

--- a/rig-scylladb/examples/scylladb_vector_search.rs
+++ b/rig-scylladb/examples/scylladb_vector_search.rs
@@ -1,0 +1,146 @@
+use rig::{
+    client::EmbeddingsClient,
+    embeddings::EmbeddingsBuilder,
+    providers::openai::{Client, TEXT_EMBEDDING_ADA_002},
+    vector_store::VectorStoreIndex,
+    Embed,
+};
+use rig_scylladb::{create_session, ScyllaDbVectorStore};
+use serde::{Deserialize, Serialize};
+use std::env;
+
+#[derive(Embed, Clone, Debug, Deserialize, Serialize)]
+struct Word {
+    id: String,
+    #[embed]
+    definition: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    // Initialize tracing for logging
+    tracing_subscriber::fmt::init();
+
+    // Create ScyllaDB session
+    // In production, you would use your ScyllaDB cluster endpoints
+    let session = create_session("127.0.0.1:9042")
+        .await
+        .expect("Failed to create ScyllaDB session");
+
+    // Create OpenAI client and embedding model
+    let openai_api_key = env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set");
+    let openai_client = Client::new(&openai_api_key);
+    let model = openai_client.embedding_model(TEXT_EMBEDDING_ADA_002);
+
+    // Create ScyllaDB vector store
+    let vector_store = ScyllaDbVectorStore::new(
+        model.clone(),
+        session,
+        "word_definitions", // keyspace
+        "words",           // table
+        1536,             // dimensions for text-embedding-ada-002
+    )
+    .await
+    .expect("Failed to create ScyllaDB vector store");
+
+    // Create sample word definitions
+    let words = vec![
+        Word {
+            id: "doc0".to_string(),
+            definition: "A large language model trained by OpenAI".to_string(),
+        },
+        Word {
+            id: "doc1".to_string(),
+            definition: "A high-performance NoSQL database compatible with Cassandra".to_string(),
+        },
+        Word {
+            id: "doc2".to_string(),
+            definition: "A systems programming language focused on safety and performance".to_string(),
+        },
+        Word {
+            id: "doc3".to_string(),
+            definition: "A vector database for storing and querying high-dimensional data".to_string(),
+        },
+        Word {
+            id: "doc4".to_string(),
+            definition: "An asynchronous runtime for Rust programming language".to_string(),
+        },
+    ];
+
+    // Generate embeddings for the documents
+    let embeddings = EmbeddingsBuilder::new(model.clone())
+        .documents(words.clone())?
+        .build()
+        .await?;
+
+    println!("Inserting {} word definitions into ScyllaDB...", words.len());
+
+    // Insert documents with their embeddings
+    let documents_with_embeddings = embeddings
+        .iter()
+        .map(|(document, embedding)| (document.clone(), embedding.clone()))
+        .collect::<Vec<_>>();
+
+    vector_store
+        .insert_documents(documents_with_embeddings)
+        .await
+        .expect("Failed to insert documents");
+
+    println!("Documents inserted successfully!");
+
+    // Test similarity search
+    let query = "What is Rust programming language?";
+    println!("\nSearching for: '{}'", query);
+
+    let results = vector_store
+        .top_n::<Word>(query, 3)
+        .await
+        .expect("Failed to search vectors");
+
+    println!("\nTop 3 similar definitions:");
+    for (i, (score, id, word)) in results.iter().enumerate() {
+        println!(
+            "{}. Score: {:.4}, ID: {}, Definition: {}",
+            i + 1,
+            score,
+            id,
+            word.definition
+        );
+    }
+
+    // Test ID-only search
+    println!("\nSearching for IDs only...");
+    let id_results = vector_store
+        .top_n_ids(query, 2)
+        .await
+        .expect("Failed to search vector IDs");
+
+    println!("Top 2 similar document IDs:");
+    for (i, (score, id)) in id_results.iter().enumerate() {
+        println!("{}. Score: {:.4}, ID: {}", i + 1, score, id);
+    }
+
+    // Test with different query
+    let database_query = "distributed database system";
+    println!("\nSearching for: '{}'", database_query);
+
+    let db_results = vector_store
+        .top_n::<Word>(database_query, 2)
+        .await
+        .expect("Failed to search vectors");
+
+    println!("Top 2 similar definitions:");
+    for (i, (score, id, word)) in db_results.iter().enumerate() {
+        println!(
+            "{}. Score: {:.4}, ID: {}, Definition: {}",
+            i + 1,
+            score,
+            id,
+            word.definition
+        );
+    }
+
+    println!("\n✅ ScyllaDB vector search example completed successfully!");
+
+    Ok(())
+} 

--- a/rig-scylladb/src/lib.rs
+++ b/rig-scylladb/src/lib.rs
@@ -1,0 +1,312 @@
+use rig::{
+    embeddings::{Embedding, EmbeddingModel},
+    vector_store::{VectorStoreError, VectorStoreIndex},
+    Embed, OneOrMany,
+};
+use scylla::{
+    client::{session::Session, session_builder::SessionBuilder, Compression},
+    statement::prepared::PreparedStatement,
+};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use uuid::Uuid;
+
+/// Represents a vector store implementation using ScyllaDB as the backend.
+/// 
+/// ScyllaDB is a high-performance NoSQL database that's compatible with Apache Cassandra
+/// and provides excellent performance for vector storage and similarity search operations.
+pub struct ScyllaDbVectorStore<M: EmbeddingModel> {
+    /// Model used to generate embeddings for the vector store
+    model: M,
+    /// Session instance for ScyllaDB communication
+    session: Arc<Session>,
+    /// Keyspace and table name for vector storage
+    keyspace: String,
+    table: String,
+    /// The number of dimensions for vectors
+    dimensions: usize,
+    /// Prepared statements for optimized queries
+    insert_stmt: PreparedStatement,
+    search_stmt: PreparedStatement,
+    get_by_id_stmt: PreparedStatement,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct VectorRecord {
+    id: Uuid,
+    vector: Vec<f32>,
+    metadata: String, // JSON serialized metadata
+    created_at: i64, // Unix timestamp
+}
+
+impl<M: EmbeddingModel> ScyllaDbVectorStore<M> {
+    /// Creates a new instance of `ScyllaDbVectorStore`.
+    ///
+    /// # Arguments
+    /// * `model` - Embedding model instance
+    /// * `session` - ScyllaDB session
+    /// * `keyspace` - Keyspace name (will be created if it doesn't exist)
+    /// * `table` - Table name for storing vectors
+    /// * `dimensions` - Number of dimensions for the vectors
+    pub async fn new(
+        model: M,
+        session: Session,
+        keyspace: &str,
+        table: &str,
+        dimensions: usize,
+    ) -> Result<Self, VectorStoreError> {
+        let session = Arc::new(session);
+        
+        // Create keyspace if it doesn't exist
+        let create_keyspace_cql = format!(
+            "CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{
+                'class': 'SimpleStrategy',
+                'replication_factor': 1
+            }}",
+            keyspace
+        );
+        session.query_unpaged(create_keyspace_cql, &[]).await
+            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+
+        // Create table for storing vectors
+        // Note: Once ScyllaDB vector search is fully available, we'll use VECTOR type
+        // For now, we use a list of floats and implement similarity search in application code
+        let create_table_cql = format!(
+            "CREATE TABLE IF NOT EXISTS {}.{} (
+                id UUID PRIMARY KEY,
+                vector LIST<FLOAT>,
+                metadata TEXT,
+                created_at BIGINT
+            )",
+            keyspace, table
+        );
+        session.query_unpaged(create_table_cql, &[]).await
+            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+
+        // Prepare statements for better performance
+        let insert_stmt = session
+            .prepare(format!(
+                "INSERT INTO {}.{} (id, vector, metadata, created_at) VALUES (?, ?, ?, ?)",
+                keyspace, table
+            ))
+            .await
+            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+
+        let search_stmt = session
+            .prepare(format!("SELECT id, vector, metadata, created_at FROM {}.{}", keyspace, table))
+            .await
+            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+
+        let get_by_id_stmt = session
+            .prepare(format!(
+                "SELECT id, vector, metadata, created_at FROM {}.{} WHERE id = ?",
+                keyspace, table
+            ))
+            .await
+            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+
+        Ok(Self {
+            model,
+            session,
+            keyspace: keyspace.to_string(),
+            table: table.to_string(),
+            dimensions,
+            insert_stmt,
+            search_stmt,
+            get_by_id_stmt,
+        })
+    }
+
+    /// Get the session reference
+    pub fn session(&self) -> &Arc<Session> {
+        &self.session
+    }
+
+    /// Get the keyspace name
+    pub fn keyspace(&self) -> &str {
+        &self.keyspace
+    }
+
+    /// Get the table name
+    pub fn table(&self) -> &str {
+        &self.table
+    }
+
+    /// Get a document by its ID
+    pub async fn get_by_id<T: for<'a> Deserialize<'a> + Send>(
+        &self,
+        id: &str,
+    ) -> Result<Option<T>, VectorStoreError> {
+        let uuid = Uuid::parse_str(id)
+            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+        
+        let result = self.session
+            .execute_unpaged(&self.get_by_id_stmt, (uuid,))
+            .await
+            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+
+        let rows_result = result
+            .into_rows_result()
+            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+
+        if let Some(first_row) = rows_result.rows::<(Uuid, Vec<f32>, String, i64)>()
+            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?
+            .next() {
+            let (_, _, metadata, _) = first_row
+                .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+
+            let payload: T = serde_json::from_str(&metadata)?;
+            return Ok(Some(payload));
+        }
+        
+        Ok(None)
+    }
+
+    /// Insert documents with their embeddings into the vector store
+    pub async fn insert_documents<Doc: Serialize + Embed + Send>(
+        &self,
+        documents: Vec<(Doc, OneOrMany<Embedding>)>,
+    ) -> Result<(), VectorStoreError> {
+        for (document, embeddings) in documents {
+            let metadata = serde_json::to_string(&document)?;
+            let now = chrono::Utc::now().timestamp();
+
+            for embedding in embeddings.into_iter() {
+                let vector: Vec<f32> = embedding.vec.into_iter().map(|x| x as f32).collect();
+                
+                if vector.len() != self.dimensions {
+                    return Err(VectorStoreError::DatastoreError(
+                        format!(
+                            "Vector dimension mismatch: expected {}, got {}",
+                            self.dimensions,
+                            vector.len()
+                        ).into()
+                    ));
+                }
+
+                let id = Uuid::new_v4();
+                
+                self.session
+                    .execute_unpaged(&self.insert_stmt, (id, vector, &metadata, now))
+                    .await
+                    .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Calculate cosine similarity between two vectors
+    fn cosine_similarity(vec1: &[f32], vec2: &[f32]) -> f32 {
+        let dot_product: f32 = vec1.iter().zip(vec2.iter()).map(|(a, b)| a * b).sum();
+        let norm1: f32 = vec1.iter().map(|x| x * x).sum::<f32>().sqrt();
+        let norm2: f32 = vec2.iter().map(|x| x * x).sum::<f32>().sqrt();
+        
+        if norm1 == 0.0 || norm2 == 0.0 {
+            0.0
+        } else {
+            dot_product / (norm1 * norm2)
+        }
+    }
+
+    /// Generate query vector from text
+    async fn generate_query_vector(&self, query: &str) -> Result<Vec<f32>, VectorStoreError> {
+        let embedding = self.model.embed_text(query).await?;
+        Ok(embedding.vec.iter().map(|&x| x as f32).collect())
+    }
+}
+
+impl<M: EmbeddingModel + std::marker::Sync + Send> VectorStoreIndex for ScyllaDbVectorStore<M> {
+    /// Search for the top `n` nearest neighbors to the given query.
+    /// Returns a vector of tuples containing the score, ID, and payload of the nearest neighbors.
+    ///
+    /// Note: This implementation performs a brute-force search since ScyllaDB's native vector
+    /// search is still in development. Once available, this will be optimized to use native
+    /// vector search capabilities with ANN (Approximate Nearest Neighbor) algorithms.
+    async fn top_n<T: for<'a> Deserialize<'a> + Send>(
+        &self,
+        query: &str,
+        n: usize,
+    ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {
+        let query_vector = self.generate_query_vector(query).await?;
+        
+        // Fetch all vectors (this will be optimized once ScyllaDB vector search is available)
+        let results = self.session
+            .execute_unpaged(&self.search_stmt, &[])
+            .await
+            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+
+        let rows_result = results
+            .into_rows_result()
+            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+
+        let mut candidates = Vec::new();
+        
+        for row_result in rows_result.rows::<(Uuid, Vec<f32>, String, i64)>()
+            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))? {
+            let (id, vector, metadata, _) = row_result
+                .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+            
+            let similarity = Self::cosine_similarity(&query_vector, &vector);
+            let score = similarity as f64;
+            
+            let payload: T = serde_json::from_str(&metadata)?;
+            
+            candidates.push((score, id.to_string(), payload));
+        }
+        
+        // Sort by similarity score (descending) and take top n
+        candidates.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap());
+        candidates.truncate(n);
+        
+        Ok(candidates)
+    }
+
+    /// Search for the top `n` nearest neighbors to the given query.
+    /// Returns a vector of tuples containing the score and ID of the nearest neighbors.
+    async fn top_n_ids(
+        &self,
+        query: &str,
+        n: usize,
+    ) -> Result<Vec<(f64, String)>, VectorStoreError> {
+        let query_vector = self.generate_query_vector(query).await?;
+        
+        let results = self.session
+            .execute_unpaged(&self.search_stmt, &[])
+            .await
+            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+
+        let rows_result = results
+            .into_rows_result()
+            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+
+        let mut candidates = Vec::new();
+        
+        for row_result in rows_result.rows::<(Uuid, Vec<f32>, String, i64)>()
+            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))? {
+            let (id, vector, _, _) = row_result
+                .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+            
+            let similarity = Self::cosine_similarity(&query_vector, &vector);
+            let score = similarity as f64;
+            
+            candidates.push((score, id.to_string()));
+        }
+        
+        // Sort by similarity score (descending) and take top n
+        candidates.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap());
+        candidates.truncate(n);
+        
+        Ok(candidates)
+    }
+}
+
+/// Convenience function to create a ScyllaDB session
+pub async fn create_session(uri: &str) -> Result<Session, VectorStoreError> {
+    SessionBuilder::new()
+        .known_node(uri)
+        .compression(Some(Compression::Lz4))
+        .build()
+        .await
+        .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))
+} 

--- a/rig-scylladb/tests/integration_tests.rs
+++ b/rig-scylladb/tests/integration_tests.rs
@@ -1,0 +1,357 @@
+use rig::client::EmbeddingsClient;
+use rig::{embeddings::EmbeddingsBuilder, vector_store::VectorStoreIndex, Embed};
+use rig_scylladb::{create_session, ScyllaDbVectorStore};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use testcontainers::{
+    core::{IntoContainerPort, WaitFor},
+    runners::AsyncRunner,
+    GenericImage,
+};
+
+const SCYLLA_PORT: u16 = 9042;
+
+fn create_embedding_vector(index: usize) -> Vec<f64> {
+    let mut vec = vec![0.0; 1536];
+    if index < 1536 {
+        vec[index] = 1.0;
+    }
+    vec
+}
+
+#[derive(Embed, Clone, Serialize, Deserialize, Debug, PartialEq)]
+struct Word {
+    id: String,
+    #[embed]
+    definition: String,
+}
+
+#[tokio::test]
+#[ignore = "requires Docker and ScyllaDB container"]
+async fn vector_search_test() {
+    let container = start_container().await;
+
+    let host = container.get_host().await.unwrap().to_string();
+    let port = container
+        .get_host_port_ipv4(SCYLLA_PORT)
+        .await
+        .expect("Error getting docker port");
+
+    println!("Container started on host:port {}:{}", host, port);
+
+    // Wait for ScyllaDB to be ready and retry connection
+    println!("🔌 Attempting to connect to ScyllaDB at {}:{}...", host, port);
+    let session = {
+        let mut retries = 0;
+        loop {
+            tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+            
+            match create_session(&format!("{}:{}", host, port)).await {
+                Ok(session) => {
+                    println!("✅ Successfully connected to ScyllaDB!");
+                    break session;
+                },
+                Err(e) => {
+                    retries += 1;
+                    if retries >= 15 {
+                        panic!("Failed to connect to ScyllaDB after {} retries: {:?}", retries, e);
+                    }
+                    println!("🔄 Connection attempt {} failed, retrying in 5 seconds... (attempt {}/15): {}", retries, retries, e);
+                }
+            }
+        }
+    };
+
+    println!("Connected to ScyllaDB");
+
+    // Init fake openai service
+    let openai_mock = create_openai_mock_service().await;
+    let openai_client = rig::providers::openai::Client::from_url("TEST", &openai_mock.base_url());
+
+    let model = openai_client.embedding_model(rig::providers::openai::TEXT_EMBEDDING_ADA_002);
+
+    // Create test documents with mocked embeddings
+    let words = vec![
+        Word {
+            id: "doc0".to_string(),
+            definition: "Definition of a *flurbo*: A flurbo is a green alien that lives on cold planets".to_string(),
+        },
+        Word {
+            id: "doc1".to_string(),
+            definition: "Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
+        },
+        Word {
+            id: "doc2".to_string(),
+            definition: "Definition of a *linglingdong*: A term used by inhabitants of the far side of the moon to describe humans.".to_string(),
+        }
+    ];
+
+    let documents = EmbeddingsBuilder::new(model.clone())
+        .documents(words)
+        .unwrap()
+        .build()
+        .await
+        .expect("Failed to create embeddings");
+
+    // Create ScyllaDB vector store
+    let vector_store = ScyllaDbVectorStore::new(
+        model.clone(),
+        session,
+        "test_keyspace",
+        "test_words",
+        1536, // dimensions for text-embedding-ada-002
+    )
+    .await
+    .expect("Failed to create ScyllaDB vector store");
+
+    // Insert documents into vector store
+    vector_store
+        .insert_documents(documents)
+        .await
+        .expect("Failed to insert documents");
+
+    println!("Documents inserted successfully");
+
+    // Test vector search
+    let results = vector_store
+        .top_n::<Word>("What is a glarb?", 1)
+        .await
+        .expect("Failed to search for document");
+
+    assert_eq!(
+        results.len(),
+        1,
+        "Expected one result, got {}",
+        results.len()
+    );
+
+    let (distance, id, doc) = results[0].clone();
+    println!(
+        "Distance: {}, id: {}, document: {:?}",
+        distance, id, doc
+    );
+
+    assert_eq!(doc.id, "doc1");
+    assert!(doc.definition.contains("glarb-glarb"));
+
+    // Test top_n_ids
+    let id_results = vector_store
+        .top_n_ids("What is a glarb?", 1)
+        .await
+        .expect("Failed to search for document ids");
+
+    assert_eq!(
+        id_results.len(),
+        1,
+        "Expected one (id) result, got {}",
+        id_results.len()
+    );
+
+    let (id_distance, result_id) = id_results[0].clone();
+    println!("Distance: {}, id: {}", id_distance, result_id);
+
+    assert_eq!(result_id, id);
+
+    // Test with different query
+    let results2 = vector_store
+        .top_n::<Word>("What is a linglingdong?", 1)
+        .await
+        .expect("Failed to search for linglingdong");
+
+    assert_eq!(results2.len(), 1);
+    let (_, _, doc2) = &results2[0];
+    assert_eq!(doc2.id, "doc2");
+    assert!(doc2.definition.contains("linglingdong"));
+
+    println!("✅ ScyllaDB integration test completed successfully!");
+}
+
+async fn start_container() -> testcontainers::ContainerAsync<GenericImage> {
+    use std::time::Duration;
+    use testcontainers::ImageExt;
+    
+    println!("🚀 Starting ScyllaDB container (this may take 2-5 minutes)...");
+    
+    // Setup a local ScyllaDB container for testing. NOTE: docker service must be running.
+    // ScyllaDB takes a long time to start, so we:
+    // 1. Use a smaller/faster image configuration  
+    // 2. Use developer mode for faster startup
+    // 3. Set a generous timeout
+    // 4. Use multiple wait strategies for better reliability
+    let container = GenericImage::new("scylladb/scylla", "5.4") // Use older, more stable version
+        .with_wait_for(WaitFor::seconds(60)) // Wait 60 seconds then check port
+        .with_exposed_port(SCYLLA_PORT.tcp())
+        .with_env_var("SCYLLA_ARGS", "--smp 1 --memory 512M --overprovisioned 1 --skip-wait-for-gossip-to-settle 0 --developer-mode 1")
+        .with_startup_timeout(Duration::from_secs(300)) // 5 minutes timeout
+        .start()
+        .await
+        .expect("Failed to start ScyllaDB container");
+        
+    println!("✅ ScyllaDB container started successfully!");
+    container
+}
+
+async fn create_openai_mock_service() -> httpmock::MockServer {
+    let server = httpmock::MockServer::start();
+
+    // Mock for multiple documents (integration test)
+    server.mock(|when, then| {
+        when.method(httpmock::Method::POST)
+            .path("/embeddings")
+            .header("Authorization", "Bearer TEST")
+            .json_body(json!({
+                "input": [
+                    "Definition of a *flurbo*: A flurbo is a green alien that lives on cold planets",
+                    "Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.",
+                    "Definition of a *linglingdong*: A term used by inhabitants of the far side of the moon to describe humans."
+                ],
+                "model": "text-embedding-ada-002",
+            }));
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "object": "list",
+                "data": [
+                  {
+                    "object": "embedding",
+                    "embedding": create_embedding_vector(0),
+                    "index": 0
+                  },
+                  {
+                    "object": "embedding", 
+                    "embedding": create_embedding_vector(1),
+                    "index": 1
+                  },
+                  {
+                    "object": "embedding",
+                    "embedding": create_embedding_vector(2),
+                    "index": 2
+                  }
+                ],
+                "model": "text-embedding-ada-002",
+                "usage": {
+                  "prompt_tokens": 8,
+                  "total_tokens": 8
+                }
+            }));
+    });
+
+    // Mock for single document (unit test)
+    server.mock(|when, then| {
+        when.method(httpmock::Method::POST)
+            .path("/embeddings")
+            .header("Authorization", "Bearer TEST")
+            .json_body(json!({
+                "input": ["Test definition"],
+                "model": "text-embedding-ada-002",
+            }));
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "object": "list",
+                "data": [
+                  {
+                    "object": "embedding",
+                    "embedding": create_embedding_vector(0),
+                    "index": 0
+                  }
+                ],
+                "model": "text-embedding-ada-002",
+                "usage": {
+                  "prompt_tokens": 8,
+                  "total_tokens": 8
+                }
+            }));
+    });
+
+    // Mock for search queries
+    server.mock(|when, then| {
+        when.method(httpmock::Method::POST)
+            .path("/embeddings")
+            .header("Authorization", "Bearer TEST")
+            .json_body(json!({
+                "input": ["What is a glarb?"],
+                "model": "text-embedding-ada-002",
+            }));
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "object": "list",
+                "data": [
+                  {
+                    "object": "embedding",
+                    "embedding": create_embedding_vector(1), // Match doc1
+                    "index": 0
+                  }
+                ],
+                "model": "text-embedding-ada-002",
+                "usage": {
+                  "prompt_tokens": 8,
+                  "total_tokens": 8
+                }
+            }));
+    });
+
+    server.mock(|when, then| {
+        when.method(httpmock::Method::POST)
+            .path("/embeddings")
+            .header("Authorization", "Bearer TEST")
+            .json_body(json!({
+                "input": ["What is a linglingdong?"],
+                "model": "text-embedding-ada-002",
+            }));
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "object": "list",
+                "data": [
+                  {
+                    "object": "embedding",
+                    "embedding": create_embedding_vector(2), // Match doc2
+                    "index": 0
+                  }
+                ],
+                "model": "text-embedding-ada-002",
+                "usage": {
+                  "prompt_tokens": 8,
+                  "total_tokens": 8
+                }
+            }));
+    });
+
+    server
+}
+
+#[tokio::test]
+async fn test_mock_server_setup() {
+    // Test that our mock server setup works without requiring ScyllaDB
+    let server = create_openai_mock_service().await;
+    let openai_client = rig::providers::openai::Client::from_url("TEST", &server.base_url());
+    let model = openai_client.embedding_model(rig::providers::openai::TEXT_EMBEDDING_ADA_002);
+    
+    // Test that we can create embeddings with the mock
+    let words = vec![
+        Word {
+            id: "test1".to_string(),
+            definition: "Test definition".to_string(),
+        }
+    ];
+    
+    let result = EmbeddingsBuilder::new(model)
+        .documents(words)
+        .unwrap()
+        .build()
+        .await;
+    
+    match &result {
+        Ok(embeddings) => {
+            assert_eq!(embeddings.len(), 1);
+        }
+        Err(e) => {
+            println!("Error creating embeddings: {:?}", e);
+            panic!("Failed to create embeddings: {:?}", e);
+        }
+    }
+    
+    println!("✅ Mock server test passed!");
+} 


### PR DESCRIPTION
## Summary
Adds a new ScyllaDB vector store implementation to the Rig ecosystem.

Fixes #531

## Implementation Details
- New `rig-scylladb` crate following existing vector store patterns
- Application-level cosine similarity search (similar to SQLite/SurrealDB implementations)
- Full `VectorStoreIndex` trait implementation