### PR TITLE
polishing docs: error fixes for clarity

### DIFF
--- a/rig-core/src/vector_store/in_memory_store.rs
+++ b/rig-core/src/vector_store/in_memory_store.rs
@@ -39,7 +39,7 @@ impl<D: Serialize + Eq> InMemoryVectorStore<D> {
         Self { embeddings: store }
     }
 
-    /// Create a new [InMemoryVectorStore] from documents and and their corresponding embeddings with ids.
+    /// Create a new [InMemoryVectorStore] from documents and their corresponding embeddings with ids.
     pub fn from_documents_with_ids(
         documents: impl IntoIterator<Item = (impl ToString, D, OneOrMany<Embedding>)>,
     ) -> Self {


### PR DESCRIPTION
Spotted and fixed a few wording hiccups:


`and and` - fix duplicate
