### PR TITLE
feat(ollama): add support for OLLAMA_API_BASE_URL environment var

### DIFF
--- a/rig-core/src/providers/ollama.rs
+++ b/rig-core/src/providers/ollama.rs
@@ -104,7 +104,8 @@ impl ProviderClient for Client {
     where
         Self: Sized,
     {
-        Client::default()
+        let api_base = std::env::var("OLLAMA_API_BASE_URL").expect("OLLAMA_API_BASE_URL not set");
+        Self::from_url(&api_base)
     }
 }
 


### PR DESCRIPTION
This allows configuring the ollama url via the OLLAMA_API_BASE_URL environment variable.