### PR TITLE
Make clippy happy on all targets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,7 @@ jobs:
       - name: Run clippy action
         uses: clechasseur/rs-clippy-check@v3
         with:
-          args: --all-features
+          args: --all-features --all-targets
 
   test:
     name: stable / test

--- a/rig-bedrock/examples/agent_with_bedrock.rs
+++ b/rig-bedrock/examples/agent_with_bedrock.rs
@@ -106,7 +106,7 @@ async fn loaders() -> Result<(), anyhow::Error> {
     // Create an agent with multiple context documents
     let agent = examples
         .fold(AgentBuilder::new(model), |builder, (path, content)| {
-            builder.context(format!("Rust Example {:?}:\n{}", path, content).as_str())
+            builder.context(format!("Rust Example {path:?}:\n{content}").as_str())
         })
         .preamble("Answer the question")
         .build();

--- a/rig-bedrock/src/types/assistant_content.rs
+++ b/rig-bedrock/src/types/assistant_content.rs
@@ -134,7 +134,7 @@ mod tests {
                 .unwrap();
         let completion: Result<completion::CompletionResponse<AwsConverseOutput>, _> =
             AwsConverseOutput(converse_output).try_into();
-        assert_eq!(completion.is_ok(), true);
+        assert!(completion.is_ok());
         let completion = completion.unwrap();
         assert_eq!(
             completion.choice,
@@ -146,7 +146,7 @@ mod tests {
     fn aws_content_block_to_assistant_content() {
         let content_block = aws_bedrock::ContentBlock::Text("text".into());
         let rig_assistant_content: Result<RigAssistantContent, _> = content_block.try_into();
-        assert_eq!(rig_assistant_content.is_ok(), true);
+        assert!(rig_assistant_content.is_ok());
         assert_eq!(
             rig_assistant_content.unwrap().0,
             AssistantContent::Text("text".into())

--- a/rig-bedrock/src/types/document.rs
+++ b/rig-bedrock/src/types/document.rs
@@ -37,7 +37,7 @@ impl TryFrom<RigDocument> for aws_bedrock::DocumentBlock {
         let document_source = aws_bedrock::DocumentSource::Bytes(data);
 
         let random_string = Uuid::new_v4().simple().to_string();
-        let document_name = format!("document-{}", random_string);
+        let document_name = format!("document-{random_string}");
         let result = aws_bedrock::DocumentBlock::builder()
             .source(document_source)
             .name(document_name)
@@ -92,7 +92,7 @@ mod tests {
             media_type: Some(DocumentMediaType::PDF),
         });
         let aws_document: Result<aws_bedrock::DocumentBlock, _> = rig_document.clone().try_into();
-        assert_eq!(aws_document.is_ok(), true);
+        assert!(aws_document.is_ok());
         let aws_document = aws_document.unwrap();
         assert_eq!(aws_document.format, aws_bedrock::DocumentFormat::Pdf);
         let document_data = rig_document.0.data.as_bytes().to_vec();
@@ -156,7 +156,7 @@ mod tests {
             .build()
             .unwrap();
         let rig_document: Result<RigDocument, _> = aws_document.clone().try_into();
-        assert_eq!(rig_document.is_ok(), true);
+        assert!(rig_document.is_ok());
         let rig_document = rig_document.unwrap().0;
         assert_eq!(rig_document.media_type.unwrap(), DocumentMediaType::PDF)
     }
@@ -172,7 +172,7 @@ mod tests {
             .build()
             .unwrap();
         let rig_document: Result<RigDocument, _> = aws_document.clone().try_into();
-        assert_eq!(rig_document.is_ok(), false);
+        assert!(!rig_document.is_ok());
         assert_eq!(
             rig_document.err().unwrap().to_string(),
             CompletionError::ProviderError("Unsupported media type xlsx".into()).to_string()

--- a/rig-bedrock/src/types/document.rs
+++ b/rig-bedrock/src/types/document.rs
@@ -172,7 +172,7 @@ mod tests {
             .build()
             .unwrap();
         let rig_document: Result<RigDocument, _> = aws_document.clone().try_into();
-        assert!(!rig_document.is_ok());
+        assert!(rig_document.is_err());
         assert_eq!(
             rig_document.err().unwrap().to_string(),
             CompletionError::ProviderError("Unsupported media type xlsx".into()).to_string()

--- a/rig-bedrock/src/types/image.rs
+++ b/rig-bedrock/src/types/image.rs
@@ -55,8 +55,7 @@ impl TryFrom<aws_bedrock::ImageBlock> for RigImage {
             aws_bedrock::ImageFormat::Png => Ok(ImageMediaType::PNG),
             aws_bedrock::ImageFormat::Webp => Ok(ImageMediaType::WEBP),
             e => Err(CompletionError::ProviderError(format!(
-                "Unsupported format {}",
-                e
+                "Unsupported format {e}"
             ))),
         }?;
 
@@ -98,7 +97,7 @@ mod tests {
             detail: None,
         });
         let aws_image: Result<aws_bedrock::ImageBlock, _> = rig_image.clone().try_into();
-        assert_eq!(aws_image.is_ok(), true);
+        assert!(aws_image.is_ok());
         let aws_image = aws_image.unwrap();
         assert_eq!(aws_image.format, aws_bedrock::ImageFormat::Jpeg);
         let img_data = BASE64_STANDARD.decode(rig_image.0.data).unwrap();

--- a/rig-bedrock/src/types/json.rs
+++ b/rig-bedrock/src/types/json.rs
@@ -112,7 +112,7 @@ mod tests {
 
         let value: Value = serde_json::from_str(json).unwrap();
         let document: AwsDocument = value.into();
-        println!("{:?}", document);
+        println!("{document:?}");
     }
 
     #[test]
@@ -177,6 +177,6 @@ mod tests {
         ])));
 
         let json: Value = document.into();
-        println!("{:?}", json);
+        println!("{json:?}");
     }
 }

--- a/rig-bedrock/src/types/media_types.rs
+++ b/rig-bedrock/src/types/media_types.rs
@@ -35,8 +35,7 @@ impl TryFrom<DocumentFormat> for RigDocumentMediaType {
             DocumentFormat::Pdf => Ok(RigDocumentMediaType(DocumentMediaType::PDF)),
             DocumentFormat::Txt => Ok(RigDocumentMediaType(DocumentMediaType::TXT)),
             e => Err(CompletionError::ProviderError(format!(
-                "Unsupported media type {}",
-                e
+                "Unsupported media type {e}"
             ))),
         }
     }

--- a/rig-bedrock/src/types/message.rs
+++ b/rig-bedrock/src/types/message.rs
@@ -100,7 +100,7 @@ mod tests {
             content: OneOrMany::one(UserContent::Text("text".into())),
         };
         let aws_message: Result<aws_bedrock::Message, _> = RigMessage(message).try_into();
-        assert_eq!(aws_message.is_ok(), true);
+        assert!(aws_message.is_ok());
         let aws_message = aws_message.unwrap();
         assert_eq!(aws_message.role, aws_bedrock::ConversationRole::User);
         assert_eq!(

--- a/rig-bedrock/src/types/tool.rs
+++ b/rig-bedrock/src/types/tool.rs
@@ -66,7 +66,7 @@ mod tests {
     fn rig_tool_text_to_aws_tool() {
         let tool = RigToolResultContent(ToolResultContent::Text(Text { text: "42".into() }));
         let aws_tool: Result<aws_bedrock::ToolResultContentBlock, _> = tool.try_into();
-        assert_eq!(aws_tool.is_ok(), true);
+        assert!(aws_tool.is_ok());
         assert_eq!(
             String::from(aws_tool.unwrap().as_text().unwrap()),
             String::from("42")
@@ -83,20 +83,20 @@ mod tests {
         };
         let tool = RigToolResultContent(ToolResultContent::Image(image));
         let aws_tool: Result<aws_bedrock::ToolResultContentBlock, _> = tool.try_into();
-        assert_eq!(aws_tool.is_ok(), true);
-        assert_eq!(aws_tool.unwrap().is_image(), true)
+        assert!(aws_tool.is_ok());
+        assert!(aws_tool.unwrap().is_image())
     }
 
     #[test]
     fn aws_tool_to_rig_tool() {
         let aws_tool = aws_bedrock::ToolResultContentBlock::Text("txt".into());
         let tool: Result<RigToolResultContent, _> = aws_tool.try_into();
-        assert_eq!(tool.is_ok(), true);
+        assert!(tool.is_ok());
         let tool = match tool.unwrap().0 {
             ToolResultContent::Text(text) => Ok(text),
             _ => Err("tool doesn't contain text"),
         };
-        assert_eq!(tool.is_ok(), true);
+        assert!(tool.is_ok());
         assert_eq!(tool.unwrap().text, String::from("txt"))
     }
 
@@ -112,7 +112,7 @@ mod tests {
             .unwrap();
         let aws_tool = aws_bedrock::ToolResultContentBlock::Document(aws_document);
         let tool: Result<RigToolResultContent, _> = aws_tool.try_into();
-        assert_eq!(tool.is_ok(), false);
+        assert!(!tool.is_ok());
         assert_eq!(
             tool.err().unwrap().to_string(),
             CompletionError::ProviderError(

--- a/rig-bedrock/src/types/tool.rs
+++ b/rig-bedrock/src/types/tool.rs
@@ -112,7 +112,7 @@ mod tests {
             .unwrap();
         let aws_tool = aws_bedrock::ToolResultContentBlock::Document(aws_document);
         let tool: Result<RigToolResultContent, _> = aws_tool.try_into();
-        assert!(!tool.is_ok());
+        assert!(tool.is_err());
         assert_eq!(
             tool.err().unwrap().to_string(),
             CompletionError::ProviderError(

--- a/rig-bedrock/src/types/user_content.rs
+++ b/rig-bedrock/src/types/user_content.rs
@@ -149,7 +149,7 @@ mod tests {
             ),
         );
         let user_content: Result<RigUserContent, _> = cb.try_into();
-        assert!(!user_content.is_ok());
+        assert!(user_content.is_err());
         assert_eq!(
             user_content.err().unwrap().to_string(),
             CompletionError::ProviderError(

--- a/rig-bedrock/src/types/user_content.rs
+++ b/rig-bedrock/src/types/user_content.rs
@@ -105,12 +105,12 @@ mod tests {
     fn aws_content_block_to_user_content() {
         let cb = aws_bedrock::ContentBlock::Text("42".into());
         let user_content: Result<RigUserContent, _> = cb.try_into();
-        assert_eq!(user_content.is_ok(), true);
+        assert!(user_content.is_ok());
         let content = match user_content.unwrap().0 {
             rig::message::UserContent::Text(text) => Ok(text),
             _ => Err("Invalid content type"),
         };
-        assert_eq!(content.is_ok(), true);
+        assert!(content.is_ok());
         assert_eq!(content.unwrap().text, "42")
     }
 
@@ -124,12 +124,12 @@ mod tests {
                 .unwrap(),
         );
         let user_content: Result<RigUserContent, _> = cb.try_into();
-        assert_eq!(user_content.is_ok(), true);
+        assert!(user_content.is_ok());
         let content = match user_content.unwrap().0 {
             rig::message::UserContent::ToolResult(tool_result) => Ok(tool_result),
             _ => Err("Invalid content type"),
         };
-        assert_eq!(content.is_ok(), true);
+        assert!(content.is_ok());
         let content = content.unwrap();
         assert_eq!(content.id, "123");
         assert_eq!(
@@ -149,7 +149,7 @@ mod tests {
             ),
         );
         let user_content: Result<RigUserContent, _> = cb.try_into();
-        assert_eq!(user_content.is_ok(), false);
+        assert!(!user_content.is_ok());
         assert_eq!(
             user_content.err().unwrap().to_string(),
             CompletionError::ProviderError(
@@ -163,7 +163,7 @@ mod tests {
     fn user_content_to_aws_content_block() {
         let uc = RigUserContent(UserContent::Text("txt".into()));
         let aws_content_blocks: Result<Vec<aws_bedrock::ContentBlock>, _> = uc.try_into();
-        assert_eq!(aws_content_blocks.is_ok(), true);
+        assert!(aws_content_blocks.is_ok());
         let aws_content_blocks = aws_content_blocks.unwrap();
         assert_eq!(
             aws_content_blocks,

--- a/rig-core/examples/agent.rs
+++ b/rig-core/examples/agent.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let response = comedian_agent.prompt("Entertain me!").await?;
 
-    println!("{}", response);
+    println!("{response}");
 
     Ok(())
 }

--- a/rig-core/examples/agent_with_cohere.rs
+++ b/rig-core/examples/agent_with_cohere.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .build();
 
     let answer = agent.prompt("Tell me a joke").await?;
-    println!("Answer: {}", answer);
+    println!("Answer: {answer}");
 
     // Create agent with a single context prompt and two tools
     let calculator_agent = client

--- a/rig-core/examples/agent_with_context.rs
+++ b/rig-core/examples/agent_with_context.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), anyhow::Error> {
     // Prompt the agent and print the response
     let response = agent.prompt("What does \"glarb-glarb\" mean?").await?;
 
-    println!("{}", response);
+    println!("{response}");
 
     Ok(())
 }

--- a/rig-core/examples/agent_with_deepseek.rs
+++ b/rig-core/examples/agent_with_deepseek.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .build();
     let answer = agent.prompt("Tell me a joke").await?;
 
-    println!("Answer: {}", answer);
+    println!("Answer: {answer}");
 
     // Create agent with a single context prompt and two tools
     let calculator_agent = client

--- a/rig-core/examples/agent_with_echochambers.rs
+++ b/rig-core/examples/agent_with_echochambers.rs
@@ -118,7 +118,7 @@ impl Tool for SendMessage {
                 .text()
                 .await
                 .map_err(|e| EchoChamberError(e.to_string()))?;
-            return Err(EchoChamberError(format!("API error: {}", error_text)));
+            return Err(EchoChamberError(format!("API error: {error_text}")));
         }
 
         let data = response
@@ -162,7 +162,7 @@ impl Tool for GetHistory {
         let client = reqwest::Client::new();
         let mut url = format!("https://echochambers.ai/api/rooms/{}/history", args.room_id);
         if let Some(limit) = args.limit {
-            url = format!("{}?limit={}", url, limit);
+            url = format!("{url}?limit={limit}");
         }
         let response = client
             .get(&url)

--- a/rig-core/examples/agent_with_galadriel.rs
+++ b/rig-core/examples/agent_with_galadriel.rs
@@ -19,6 +19,6 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Prompt the agent and print the response
     let response = comedian_agent.prompt("Entertain me!").await?;
-    println!("{}", response);
+    println!("{response}");
     Ok(())
 }

--- a/rig-core/examples/agent_with_grok.rs
+++ b/rig-core/examples/agent_with_grok.rs
@@ -44,7 +44,7 @@ async fn basic() -> Result<(), anyhow::Error> {
         .build();
     // Prompt the agent and print the response
     let response = comedian_agent.prompt("Entertain me!").await?;
-    println!("{}", response);
+    println!("{response}");
     Ok(())
 }
 
@@ -83,7 +83,7 @@ async fn loaders() -> Result<(), anyhow::Error> {
     // Create an agent with multiple context documents
     let agent = examples
         .fold(AgentBuilder::new(model), |builder, (path, content)| {
-            builder.context(format!("Rust Example {:?}:\n{}", path, content).as_str())
+            builder.context(format!("Rust Example {path:?}:\n{content}").as_str())
         })
         .build();
 
@@ -92,7 +92,7 @@ async fn loaders() -> Result<(), anyhow::Error> {
         .prompt("Which rust example is best suited for the operation 1 + 2")
         .await?;
 
-    println!("{}", response);
+    println!("{response}");
 
     Ok(())
 }
@@ -109,7 +109,7 @@ async fn context() -> Result<(), anyhow::Error> {
 
     // Prompt the agent and print the response
     let response = agent.prompt("What does \"glarb-glarb\" mean?").await?;
-    println!("{}", response);
+    println!("{response}");
     Ok(())
 }
 #[derive(Deserialize)]

--- a/rig-core/examples/agent_with_groq.rs
+++ b/rig-core/examples/agent_with_groq.rs
@@ -19,6 +19,6 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Prompt the agent and print the response
     let response = comedian_agent.prompt("Entertain me!").await?;
-    println!("{}", response);
+    println!("{response}");
     Ok(())
 }

--- a/rig-core/examples/agent_with_huggingface.rs
+++ b/rig-core/examples/agent_with_huggingface.rs
@@ -8,30 +8,22 @@ use rig::{
     providers,
     tool::Tool,
 };
-
 use serde::{Deserialize, Serialize};
-
 use serde_json::json;
 
 /// Runs 4 agents based on deepseek R1 (derived from the other examples)
-
 #[tokio::main]
-
 async fn main() -> Result<(), anyhow::Error> {
     println!("Running basic agent with deepseek R1");
-
     basic().await?;
 
     println!("\nRunning deepseek R1 agent with tools");
-
     tools().await?;
 
     println!("\nRunning deepseek R1 agent with loaders");
-
     loaders().await?;
 
     println!("\nRunning deepseek R1 agent with context");
-
     context().await?;
 
     println!("\n\nAll agents ran successfully");
@@ -41,26 +33,19 @@ async fn main() -> Result<(), anyhow::Error> {
 
 fn client() -> providers::huggingface::Client {
     let api_key = &env::var("HUGGINGFACE_API_KEY").expect("HUGGINGFACE_API_KEY not set");
-
     providers::huggingface::ClientBuilder::new(api_key).build()
 }
 
 /// Create a partial huggingface agent (deepseek R1)
-
 fn partial_agent() -> AgentBuilder<providers::huggingface::completion::CompletionModel> {
     let client = client();
-
     client.agent("deepseek-ai/DeepSeek-R1-Distill-Qwen-32B")
 }
 
 /// Create an huggingface agent (deepseek R1) with a preamble
-
 /// Based upon the `agent` example
-
 ///
-
 /// This example creates a comedian agent with a preamble
-
 async fn basic() -> Result<(), anyhow::Error> {
     let comedian_agent = partial_agent()
         .preamble("You are a comedian here to entertain the user using humour and jokes.")
@@ -76,32 +61,20 @@ async fn basic() -> Result<(), anyhow::Error> {
 }
 
 /// Create an huggingface agent (deepseek R1) with tools
-
 /// Based upon the `tools` example
-
 ///
-
 /// This example creates a calculator agent with two tools: add and subtract
-
 async fn tools() -> Result<(), anyhow::Error> {
     // Create agent with a single context prompt and two tools
-
     let calculator_agent = partial_agent()
-
         .preamble("You are a calculator here to help the user perform arithmetic operations. Use the tools provided to answer the user's question.")
-
         .max_tokens(1024)
-
         .tool(Adder)
-
         .tool(Subtract)
-
         .build();
 
     // Prompt the agent and print the response
-
     println!("Calculate 2 - 5");
-
     println!(
         "Calculator Agent: {}",
         calculator_agent.prompt("Calculate 2 - 5").await?
@@ -111,20 +84,14 @@ async fn tools() -> Result<(), anyhow::Error> {
 }
 
 /// Create an huggingface agent (deepseek R1) with loaders
-
 /// Based upon the `loaders` example
-
 ///
-
-/// This example loads in all the rust examples from the rig-core crate and uses them as\\
-
-///  context for the agent
-
+/// This example loads in all the rust examples from the rig-core crate and uses them as
+/// context for the agent
 async fn loaders() -> Result<(), anyhow::Error> {
     let model = client().completion_model("deepseek-ai/DeepSeek-R1-Distill-Qwen-32B");
 
     // Load in all the rust examples
-
     let examples = FileLoader::with_glob("rig-core/examples/*.rs")?
         .read_with_path()
         .ignore_errors()
@@ -132,7 +99,6 @@ async fn loaders() -> Result<(), anyhow::Error> {
         .step_by(2);
 
     // Create an agent with multiple context documents
-
     let agent = examples
         .fold(AgentBuilder::new(model), |builder, (path, content)| {
             builder.context(format!("Rust Example {path:?}:\n{content}").as_str())
@@ -140,7 +106,6 @@ async fn loaders() -> Result<(), anyhow::Error> {
         .build();
 
     // Prompt the agent and print the response
-
     let response = agent
         .prompt("Which rust example is best suited for the operation 1 + 2")
         .await?;
@@ -154,146 +119,95 @@ async fn context() -> Result<(), anyhow::Error> {
     let model = client().completion_model("deepseek-ai/DeepSeek-R1-Distill-Qwen-32B");
 
     // Create an agent with multiple context documents
-
     let agent = AgentBuilder::new(model)
-
         .context("Definition of a *flurbo*: A flurbo is a green alien that lives on cold planets")
-
         .context("Definition of a *glarb-glarb*: A glarb-glarb is an ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.")
-
         .context("Definition of a *linglingdong*: A term used by inhabitants of the far side of the moon to describe humans.")
-
         .build();
 
     // Prompt the agent and print the response
-
     let response = agent.prompt("What does \"glarb-glarb\" mean?").await?;
-
     println!("{response}");
 
     Ok(())
 }
 
 #[derive(Deserialize)]
-
 struct OperationArgs {
     x: i32,
-
     y: i32,
 }
 
 #[derive(Debug, thiserror::Error)]
 #[error("Math error")]
-
 struct MathError;
 
 #[derive(Deserialize, Serialize)]
-
 struct Adder;
 
 impl Tool for Adder {
     const NAME: &'static str = "add";
-
     type Error = MathError;
-
     type Args = OperationArgs;
-
     type Output = i32;
 
     async fn definition(&self, _prompt: String) -> ToolDefinition {
         ToolDefinition {
             name: "add".to_string(),
-
             description: "Add x and y together".to_string(),
-
             parameters: json!({
-
                 "type": "object",
-
                 "properties": {
-
                     "x": {
-
                         "type": "number",
-
                         "description": "The first number to add"
-
                     },
-
                     "y": {
-
                         "type": "number",
-
                         "description": "The second number to add"
-
                     }
-
                 }
-
             }),
         }
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
         let result = args.x + args.y;
-
         Ok(result)
     }
 }
 
 #[derive(Deserialize, Serialize)]
-
 struct Subtract;
-
 impl Tool for Subtract {
     const NAME: &'static str = "subtract";
-
     type Error = MathError;
-
     type Args = OperationArgs;
-
     type Output = i32;
 
     async fn definition(&self, _prompt: String) -> ToolDefinition {
         serde_json::from_value(json!({
-
             "name": "subtract",
-
             "description": "Subtract y from x (i.e.: x - y)",
-
             "parameters": {
-
                 "type": "object",
-
                 "properties": {
-
                     "x": {
-
                         "type": "number",
-
                         "description": "The number to subtract from"
-
                     },
-
                     "y": {
-
                         "type": "number",
-
                         "description": "The number to subtract"
-
                     }
-
                 }
-
             }
-
         }))
         .expect("Tool Definition")
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
         let result = args.x - args.y;
-
         Ok(result)
     }
 }

--- a/rig-core/examples/agent_with_huggingface.rs
+++ b/rig-core/examples/agent_with_huggingface.rs
@@ -70,7 +70,7 @@ async fn basic() -> Result<(), anyhow::Error> {
 
     let response = comedian_agent.prompt("Entertain me!").await?;
 
-    println!("{}", response);
+    println!("{response}");
 
     Ok(())
 }
@@ -135,7 +135,7 @@ async fn loaders() -> Result<(), anyhow::Error> {
 
     let agent = examples
         .fold(AgentBuilder::new(model), |builder, (path, content)| {
-            builder.context(format!("Rust Example {:?}:\n{}", path, content).as_str())
+            builder.context(format!("Rust Example {path:?}:\n{content}").as_str())
         })
         .build();
 
@@ -145,7 +145,7 @@ async fn loaders() -> Result<(), anyhow::Error> {
         .prompt("Which rust example is best suited for the operation 1 + 2")
         .await?;
 
-    println!("{}", response);
+    println!("{response}");
 
     Ok(())
 }
@@ -169,7 +169,7 @@ async fn context() -> Result<(), anyhow::Error> {
 
     let response = agent.prompt("What does \"glarb-glarb\" mean?").await?;
 
-    println!("{}", response);
+    println!("{response}");
 
     Ok(())
 }

--- a/rig-core/examples/agent_with_hyperbolic.rs
+++ b/rig-core/examples/agent_with_hyperbolic.rs
@@ -17,6 +17,6 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Prompt the agent and print the response
     let response = comedian_agent.prompt("Entertain me!").await?;
-    println!("{}", response);
+    println!("{response}");
     Ok(())
 }

--- a/rig-core/examples/agent_with_loaders.rs
+++ b/rig-core/examples/agent_with_loaders.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), anyhow::Error> {
     // Create an agent with multiple context documents
     let agent = examples
         .fold(AgentBuilder::new(model), |builder, (path, content)| {
-            builder.context(format!("Rust Example {:?}:\n{}", path, content).as_str())
+            builder.context(format!("Rust Example {path:?}:\n{content}").as_str())
         })
         .build();
 
@@ -30,6 +30,6 @@ async fn main() -> Result<(), anyhow::Error> {
     let response = agent
         .prompt("Which rust example is best suited for the operation 1 + 2")
         .await?;
-    println!("{}", response);
+    println!("{response}");
     Ok(())
 }

--- a/rig-core/examples/agent_with_mira.rs
+++ b/rig-core/examples/agent_with_mira.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<(), anyhow::Error> {
             println!("Successfully connected to Mira API!");
             println!("Available models:");
             for model in models {
-                println!("- {}", model);
+                println!("- {model}");
             }
             println!("\nProceeding with chat completion...\n");
         }
@@ -45,7 +45,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Send a message and get response
     let response = agent.prompt("What are the 7 wonders of the world?").await?;
-    println!("Basic Agent Response: {}", response);
+    println!("Basic Agent Response: {response}");
 
     // Create a calculator agent with tools
     let calculator_agent = client

--- a/rig-core/examples/agent_with_moonshot.rs
+++ b/rig-core/examples/agent_with_moonshot.rs
@@ -29,7 +29,7 @@ async fn basic_moonshot() -> Result<(), anyhow::Error> {
 
     // Prompt the agent and print the response
     let response = comedian_agent.prompt("Entertain me!").await?;
-    println!("{}", response);
+    println!("{response}");
     Ok(())
 }
 
@@ -43,6 +43,6 @@ async fn context_moonshot() -> Result<(), anyhow::Error> {
 
     // Prompt the agent and print the response
     let response = agent.prompt("What does \"glarb-glarb\" mean?").await?;
-    println!("{}", response);
+    println!("{response}");
     Ok(())
 }

--- a/rig-core/examples/agent_with_ollama.rs
+++ b/rig-core/examples/agent_with_ollama.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<(), anyhow::Error> {
     // Prompt the agent and print the response
     let response = comedian_agent.prompt("Entertain me!").await?;
 
-    println!("{}", response);
+    println!("{response}");
 
     Ok(())
 }

--- a/rig-core/examples/agent_with_openrouter.rs
+++ b/rig-core/examples/agent_with_openrouter.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<(), anyhow::Error> {
     // Prompt the agent and print the response
     let response = comedian_agent.prompt("Entertain me!").await?;
 
-    println!("{}", response);
+    println!("{response}");
 
     Ok(())
 }

--- a/rig-core/examples/agent_with_together.rs
+++ b/rig-core/examples/agent_with_together.rs
@@ -32,7 +32,7 @@ async fn basic() -> Result<(), anyhow::Error> {
         .build();
     // Prompt the agent and print the response
     let response = agent.prompt("Entertain me!").await?;
-    println!("{}", response);
+    println!("{response}");
     Ok(())
 }
 
@@ -77,7 +77,7 @@ async fn context() -> Result<(), anyhow::Error> {
 
     // Prompt the agent and print the response
     let response = agent.prompt("What does \"glarb-glarb\" mean?").await?;
-    println!("{}", response);
+    println!("{response}");
     Ok(())
 }
 
@@ -121,7 +121,7 @@ impl Tool for Adder {
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
-        println!("The args: {:?}", args);
+        println!("The args: {args:?}");
         let result = args.x + args.y;
         Ok(result)
     }

--- a/rig-core/examples/anthropic_agent.rs
+++ b/rig-core/examples/anthropic_agent.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .prompt("When and where and what type is the next solar eclipse?")
         .await?;
 
-    println!("{}", response);
+    println!("{response}");
 
     Ok(())
 }

--- a/rig-core/examples/chain.rs
+++ b/rig-core/examples/chain.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<(), anyhow::Error> {
         // while simultaneously applying a passthrough operation. The latter will allow
         // us to forward the initial prompt to the next operation in the chain.
         .chain(parallel!(
-            passthrough(),
+            passthrough::<&str>(),
             lookup::<_, _, String>(index, 1), // Required to specify document type
         ))
         // Chain a "map" operation to the current chain, which will combine the user
@@ -58,8 +58,8 @@ async fn main() -> Result<(), anyhow::Error> {
                 prompt,
             ),
             Err(err) => {
-                println!("Error: {}! Prompting without additional context", err);
-                format!("{prompt}")
+                println!("Error: {err}! Prompting without additional context");
+                prompt.to_string()
             }
         })
         // Chain a "prompt" operation which will prompt out agent with the final prompt
@@ -67,6 +67,6 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Prompt the agent and print the response
     let response = chain.call("What does \"glarb-glarb\" mean?").await?;
-    println!("{:?}", response);
+    println!("{response}");
     Ok(())
 }

--- a/rig-core/examples/debate.rs
+++ b/rig-core/examples/debate.rs
@@ -47,14 +47,14 @@ impl Debater {
                 .prompt(prompt_a.as_str())
                 .with_history(&mut history_a)
                 .await?;
-            println!("GPT-4:\n{}", resp_a);
+            println!("GPT-4:\n{resp_a}");
             println!("================================================================");
             let resp_b = self
                 .coral
                 .prompt(resp_a.as_str())
                 .with_history(&mut history_b)
                 .await?;
-            println!("Coral:\n{}", resp_b);
+            println!("Coral:\n{resp_b}");
             println!("================================================================");
             last_resp_b = Some(resp_b)
         }

--- a/rig-core/examples/gemini_agent.rs
+++ b/rig-core/examples/gemini_agent.rs
@@ -37,7 +37,7 @@ async fn main() -> Result<(), anyhow::Error> {
     tracing::info!("Response: {:?}", response);
 
     match response {
-        Ok(response) => println!("{}", response),
+        Ok(response) => println!("{response}"),
         Err(e) => {
             tracing::error!("Error: {:?}", e);
             return Err(e.into());

--- a/rig-core/examples/gemini_embeddings.rs
+++ b/rig-core/examples/gemini_embeddings.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .await
         .expect("Failed to embed documents");
 
-    println!("{:?}", embeddings);
+    println!("{embeddings:?}");
 
     Ok(())
 }

--- a/rig-core/examples/huggingface_subproviders.rs
+++ b/rig-core/examples/huggingface_subproviders.rs
@@ -54,7 +54,7 @@ async fn tools(model: &str, sub_provider: SubProvider) -> Result<(), anyhow::Err
         .tool(Subtract)
         .build();
     // Prompt the agent and print the response
-    println!("Asking {} on {:?} to Calculate 2 - 5", model, sub_provider);
+    println!("Asking {model} on {sub_provider:?} to Calculate 2 - 5");
     println!(
         "Calculator Agent: {}",
         calculator_agent.prompt("Calculate 2 - 5").await?

--- a/rig-core/examples/image.rs
+++ b/rig-core/examples/image.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<(), anyhow::Error> {
     // Prompt the agent and print the response
     let response = agent.prompt(image).await?;
 
-    println!("{}", response);
+    println!("{response}");
 
     Ok(())
 }

--- a/rig-core/examples/image_ollama.rs
+++ b/rig-core/examples/image_ollama.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<(), anyhow::Error> {
     // Prompt the agent and print the response
     let response = agent.prompt(image).await?;
 
-    println!("{}", response);
+    println!("{response}");
 
     Ok(())
 }

--- a/rig-core/examples/loaders.rs
+++ b/rig-core/examples/loaders.rs
@@ -6,9 +6,9 @@ async fn main() -> Result<(), anyhow::Error> {
         .read()
         .into_iter()
         .for_each(|result| match result {
-            Ok(content) => println!("{}", content),
+            Ok(content) => println!("{content}"),
 
-            Err(e) => eprintln!("Error reading file: {}", e),
+            Err(e) => eprintln!("Error reading file: {e}"),
         });
 
     Ok(())

--- a/rig-core/examples/mcp_tool.rs
+++ b/rig-core/examples/mcp_tool.rs
@@ -75,7 +75,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .tools
         .into_iter()
         .fold(agent_builder, |builder, tool| {
-            builder.mcp_tool(tool, mcp_client.clone().into())
+            builder.mcp_tool(tool, mcp_client.clone())
         });
     let agent = agent_builder.build();
 

--- a/rig-core/examples/mistral_embeddings.rs
+++ b/rig-core/examples/mistral_embeddings.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let results = index.top_n::<Greetings>("Hello, World", 1).await?;
 
-    println!("{:?}", results);
+    println!("{results:?}");
 
     Ok(())
 }

--- a/rig-core/examples/multi_agent.rs
+++ b/rig-core/examples/multi_agent.rs
@@ -46,7 +46,7 @@ impl<M: CompletionModel> Chat for EnglishTranslator<M> {
             .translator_agent
             .chat(prompt, chat_history.clone())
             .await?;
-        println!("Translated prompt: {}", translated_prompt);
+        println!("Translated prompt: {translated_prompt}");
         // Answer the prompt using gpt4
         self.gpt4
             .chat(translated_prompt.as_str(), chat_history)

--- a/rig-core/examples/multi_turn_agent.rs
+++ b/rig-core/examples/multi_turn_agent.rs
@@ -40,7 +40,7 @@ async fn main() -> anyhow::Result<()> {
         .multi_turn(20)
         .await?;
 
-    println!("\n\nOpenAI Calculator Agent: {}", result);
+    println!("\n\nOpenAI Calculator Agent: {result}");
 
     // Prompt the agent again and print the response
     let result = agent
@@ -48,7 +48,7 @@ async fn main() -> anyhow::Result<()> {
         .multi_turn(20)
         .await?;
 
-    println!("\n\nOpenAI Calculator Agent: {}", result);
+    println!("\n\nOpenAI Calculator Agent: {result}");
 
     Ok(())
 }

--- a/rig-core/examples/multi_turn_streaming.rs
+++ b/rig-core/examples/multi_turn_streaming.rs
@@ -17,11 +17,11 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 enum StreamingError {
     #[error("CompletionError: {0}")]
-    CompletionError(#[from] CompletionError),
+    Completion(#[from] CompletionError),
     #[error("PromptError: {0}")]
-    PromptError(#[from] PromptError),
+    Prompt(#[from] PromptError),
     #[error("ToolSetError: {0}")]
-    ToolError(#[from] ToolSetError),
+    Tool(#[from] ToolSetError),
 }
 
 type StreamingResult = Pin<Box<dyn Stream<Item = Result<Text, StreamingError>> + Send>>;

--- a/rig-core/examples/multi_turn_streaming.rs
+++ b/rig-core/examples/multi_turn_streaming.rs
@@ -158,11 +158,11 @@ async fn custom_stream_to_stdout(stream: &mut StreamingResult) -> Result<(), std
     while let Some(content) = stream.next().await {
         match content {
             Ok(Text { text }) => {
-                print!("{}", text);
+                print!("{text}");
                 std::io::Write::flush(&mut std::io::stdout())?;
             }
             Err(err) => {
-                eprintln!("Error: {}", err);
+                eprintln!("Error: {err}");
             }
         }
     }

--- a/rig-core/examples/pdf_agent.rs
+++ b/rig-core/examples/pdf_agent.rs
@@ -22,7 +22,7 @@ fn load_pdf(path: PathBuf) -> Result<Vec<String>> {
         .filter_map(|result| {
             result
                 .map_err(|e| {
-                    eprintln!("Error reading PDF content: {}", e);
+                    eprintln!("Error reading PDF content: {e}");
                     e
                 })
                 .ok()
@@ -69,7 +69,7 @@ async fn main() -> Result<()> {
     // Add chunks from pdf documents
     for (i, chunk) in pdf_chunks.into_iter().enumerate() {
         builder = builder.document(Document {
-            id: format!("pdf_document_{}", i),
+            id: format!("pdf_document_{i}"),
             content: chunk,
         })?;
     }

--- a/rig-core/examples/perplexity_agent.rs
+++ b/rig-core/examples/perplexity_agent.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .prompt("When and where and what type is the next solar eclipse?")
         .await?;
 
-    println!("{}", response);
+    println!("{response}");
 
     Ok(())
 }

--- a/rig-core/examples/rag.rs
+++ b/rig-core/examples/rag.rs
@@ -78,7 +78,7 @@ async fn main() -> Result<(), anyhow::Error> {
     // Prompt the agent and print the response
     let response = rag_agent.prompt("What does \"glarb-glarb\" mean?").await?;
 
-    println!("{}", response);
+    println!("{response}");
 
     Ok(())
 }

--- a/rig-core/examples/rag_dynamic_tools.rs
+++ b/rig-core/examples/rag_dynamic_tools.rs
@@ -161,7 +161,7 @@ async fn main() -> Result<(), anyhow::Error> {
     // Prompt the agent and print the response
     let response = calculator_rag.prompt("Calculate 3 - 7").await?;
 
-    println!("{}", response);
+    println!("{response}");
 
     Ok(())
 }

--- a/rig-core/examples/rag_dynamic_tools_multi_turn.rs
+++ b/rig-core/examples/rag_dynamic_tools_multi_turn.rs
@@ -181,7 +181,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .multi_turn(10)
         .await?;
 
-    println!("{}", response);
+    println!("{response}");
 
     Ok(())
 }

--- a/rig-core/examples/rag_ollama.rs
+++ b/rig-core/examples/rag_ollama.rs
@@ -75,7 +75,7 @@ async fn main() -> Result<(), anyhow::Error> {
     // Prompt the agent and print the response
     let response = rag_agent.prompt("What does \"glarb-glarb\" mean?").await?;
 
-    println!("{}", response);
+    println!("{response}");
 
     Ok(())
 }

--- a/rig-core/examples/reasoning_loop.rs
+++ b/rig-core/examples/reasoning_loop.rs
@@ -98,7 +98,7 @@ async fn main() -> anyhow::Result<()> {
         .prompt("Calculate ((15 + 25) * (100 - 50)) / (200 / (10 + 10))")
         .await?;
 
-    println!("\n\nReasoning Agent Chat History: {}", result);
+    println!("\n\nReasoning Agent Chat History: {result}");
 
     Ok(())
 }

--- a/rig-core/examples/sentiment_classifier.rs
+++ b/rig-core/examples/sentiment_classifier.rs
@@ -32,5 +32,5 @@ async fn main() {
         .await
         .expect("Failed to extract sentiment");
 
-    println!("GPT-4: {:?}", sentiment);
+    println!("GPT-4: {sentiment:?}");
 }

--- a/rig-core/examples/together_embeddings.rs
+++ b/rig-core/examples/together_embeddings.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .await
         .expect("Failed to embed documents");
 
-    println!("{:?}", embeddings);
+    println!("{embeddings:?}");
 
     Ok(())
 }

--- a/rig-core/examples/vector_search.rs
+++ b/rig-core/examples/vector_search.rs
@@ -68,7 +68,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .map(|(score, id, doc)| (score, id, doc.word))
         .collect::<Vec<_>>();
 
-    println!("Results: {:?}", results);
+    println!("Results: {results:?}");
 
     let id_results = index
         .top_n_ids("I need to buy something in a fictional universe. What type of money can I use for this?", 1)
@@ -76,7 +76,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .into_iter()
         .collect::<Vec<_>>();
 
-    println!("ID results: {:?}", id_results);
+    println!("ID results: {id_results:?}");
 
     Ok(())
 }

--- a/rig-core/examples/vector_search_cohere.rs
+++ b/rig-core/examples/vector_search_cohere.rs
@@ -70,7 +70,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .map(|(score, id, doc)| (score, id, doc.word))
         .collect::<Vec<_>>();
 
-    println!("Results: {:?}", results);
+    println!("Results: {results:?}");
 
     Ok(())
 }

--- a/rig-core/examples/vector_search_ollama.rs
+++ b/rig-core/examples/vector_search_ollama.rs
@@ -68,7 +68,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .map(|(score, id, doc)| (score, id, doc.word))
         .collect::<Vec<_>>();
 
-    println!("Results: {:?}", results);
+    println!("Results: {results:?}");
 
     let id_results = index
         .top_n_ids("I need to buy something in a fictional universe. What type of money can I use for this?", 1)
@@ -76,7 +76,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .into_iter()
         .collect::<Vec<_>>();
 
-    println!("ID results: {:?}", id_results);
+    println!("ID results: {id_results:?}");
 
     Ok(())
 }

--- a/rig-core/examples/voyageai_embeddings.rs
+++ b/rig-core/examples/voyageai_embeddings.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .await
         .expect("Failed to embed documents");
 
-    println!("{:?}", embeddings);
+    println!("{embeddings:?}");
 
     Ok(())
 }

--- a/rig-core/rig-core-derive/examples/rig_tool/async_tool.rs
+++ b/rig-core/rig-core-derive/examples/rig_tool/async_tool.rs
@@ -4,7 +4,6 @@ use rig::providers;
 use rig::tool::Tool;
 use rig_derive::rig_tool;
 use std::time::Duration;
-use tracing_subscriber;
 
 // Example demonstrating async tool usage
 #[rig_tool(
@@ -48,7 +47,7 @@ async fn main() {
         "Process the text 'concurrent calls' with a delay of 200ms",
         "Process the text 'error handling' with a delay of 'not a number'",
     ] {
-        println!("User: {}", prompt);
+        println!("User: {prompt}");
         println!("Agent: {}", async_agent.prompt(prompt).await.unwrap());
     }
 }

--- a/rig-core/rig-core-derive/examples/rig_tool/full.rs
+++ b/rig-core/rig-core-derive/examples/rig_tool/full.rs
@@ -3,7 +3,6 @@ use rig::completion::Prompt;
 use rig::providers;
 use rig::tool::Tool;
 use rig_derive::rig_tool;
-use tracing_subscriber;
 
 // Example with full attributes including parameter descriptions
 #[rig_tool(
@@ -20,7 +19,7 @@ fn string_processor(text: String, operation: String) -> Result<String, rig::tool
         "reverse" => text.chars().rev().collect(),
         _ => {
             return Err(rig::tool::ToolError::ToolCallError(
-                format!("Unknown operation: {}", operation).into(),
+                format!("Unknown operation: {operation}").into(),
             ))
         }
     };
@@ -53,7 +52,7 @@ async fn main() {
         "Convert 'hello world' to uppercase and repeat it 3 times",
         "Perform an invalid operation on 'hello world'",
     ] {
-        println!("User: {}", prompt);
+        println!("User: {prompt}");
         println!("Agent: {}", string_agent.prompt(prompt).await.unwrap());
     }
 }

--- a/rig-core/rig-core-derive/examples/rig_tool/simple.rs
+++ b/rig-core/rig-core-derive/examples/rig_tool/simple.rs
@@ -2,7 +2,6 @@ use rig::client::{CompletionClient, ProviderClient};
 use rig::completion::Prompt;
 use rig::providers;
 use rig_derive::rig_tool;
-use tracing_subscriber;
 
 // Simple example with no attributes
 #[rig_tool]
@@ -66,7 +65,7 @@ async fn main() {
         "What is 10 + 20?",
         "Add 100 and 200",
     ] {
-        println!("User: {}", prompt);
+        println!("User: {prompt}");
         println!("Agent: {}", calculator_agent.prompt(prompt).await.unwrap());
     }
 }

--- a/rig-core/rig-core-derive/examples/rig_tool/with_description.rs
+++ b/rig-core/rig-core-derive/examples/rig_tool/with_description.rs
@@ -3,7 +3,6 @@ use rig::completion::Prompt;
 use rig::providers;
 use rig::tool::Tool;
 use rig_derive::rig_tool;
-use tracing_subscriber;
 
 // Example with description attribute
 #[rig_tool(description = "Perform basic arithmetic operations")]
@@ -22,7 +21,7 @@ fn calculator(x: i32, y: i32, operation: String) -> Result<i32, rig::tool::ToolE
             }
         }
         _ => Err(rig::tool::ToolError::ToolCallError(
-            format!("Unknown operation: {}", operation).into(),
+            format!("Unknown operation: {operation}").into(),
         )),
     }
 }
@@ -52,7 +51,7 @@ async fn main() {
         "Divide 20 by 5",
         "What is 10 / 0?",
     ] {
-        println!("User: {}", prompt);
+        println!("User: {prompt}");
         println!("Agent: {}", calculator_agent.prompt(prompt).await.unwrap());
     }
 }

--- a/rig-core/rig-core-derive/src/custom.rs
+++ b/rig-core/rig-core-derive/src/custom.rs
@@ -66,7 +66,7 @@ impl CustomAttributeParser for syn::Attribute {
                 let path = meta.path.to_token_stream().to_string().replace(' ', "");
                 Err(syn::Error::new_spanned(
                     meta.path,
-                    format_args!("unknown embedding field attribute `{}`", path),
+                    format_args!("unknown embedding field attribute `{path}`"),
                 ))
             }
         })?;
@@ -91,7 +91,7 @@ impl CustomAttributeParser for syn::Attribute {
                 if !suffix.is_empty() {
                     return Err(syn::Error::new_spanned(
                         lit_str,
-                        format!("unexpected suffix `{}` on string literal", suffix),
+                        format!("unexpected suffix `{suffix}` on string literal"),
                     ));
                 }
                 lit_str.clone()
@@ -99,8 +99,7 @@ impl CustomAttributeParser for syn::Attribute {
                 return Err(syn::Error::new_spanned(
                     value,
                     format!(
-                        "expected {} attribute to be a string: `{} = \"...\"`",
-                        EMBED_WITH, EMBED_WITH
+                        "expected {EMBED_WITH} attribute to be a string: `{EMBED_WITH} = \"...\"`"
                     ),
                 ));
             };

--- a/rig-core/rig-core-derive/src/lib.rs
+++ b/rig-core/rig-core-derive/src/lib.rs
@@ -215,7 +215,7 @@ pub fn rig_tool(args: TokenStream, input: TokenStream) -> TokenStream {
                                 // Convert the error type to a string for comparison
                                 let error_str = quote!(#error).to_string().replace(" ", "");
                                 if !error_str.contains("rig::tool::ToolError") {
-                                    panic!("Expected rig::tool::ToolError as second type parameter but found {}", error_str);
+                                    panic!("Expected rig::tool::ToolError as second type parameter but found {error_str}");
                                 }
 
                                 quote!(#output)
@@ -259,7 +259,7 @@ pub fn rig_tool(args: TokenStream, input: TokenStream) -> TokenStream {
                 let param_name = &param_ident.ident;
                 let param_name_str = param_name.to_string();
                 let ty = &pat_type.ty;
-                let default_parameter_description = format!("Parameter {}", param_name_str);
+                let default_parameter_description = format!("Parameter {param_name_str}");
                 let description = args
                     .param_descriptions
                     .get(&param_name_str)

--- a/rig-core/rig-core-derive/tests/calculator.rs
+++ b/rig-core/rig-core-derive/tests/calculator.rs
@@ -24,7 +24,7 @@ async fn calculator(x: i32, y: i32, operation: String) -> Result<i32, rig::tool:
             }
         }
         _ => Err(rig::tool::ToolError::ToolCallError(
-            format!("Unknown operation: {}", operation).into(),
+            format!("Unknown operation: {operation}").into(),
         )),
     }
 }
@@ -52,7 +52,7 @@ fn sync_calculator(x: i32, y: i32, operation: String) -> Result<i32, rig::tool::
             }
         }
         _ => Err(rig::tool::ToolError::ToolCallError(
-            format!("Unknown operation: {}", operation).into(),
+            format!("Unknown operation: {operation}").into(),
         )),
     }
 }
@@ -60,11 +60,11 @@ fn sync_calculator(x: i32, y: i32, operation: String) -> Result<i32, rig::tool::
 #[tokio::test]
 async fn test_calculator_tool() {
     // Create an instance of our tool
-    let calculator = Calculator::default();
+    let calculator = Calculator;
 
     // Test tool information
     let definition = calculator.definition(String::default()).await;
-    println!("{:?}", definition);
+    println!("{definition:?}");
     assert_eq!(calculator.name(), "calculator");
     assert_eq!(
         definition.description,
@@ -131,7 +131,7 @@ async fn test_calculator_tool() {
     assert!(matches!(err, rig::tool::ToolError::ToolCallError(_)));
 
     // Test sync calculator
-    let sync_calculator = SyncCalculator::default();
+    let sync_calculator = SyncCalculator;
     let result = sync_calculator
         .call(SyncCalculatorParameters {
             x: 5,

--- a/rig-core/src/client/builder.rs
+++ b/rig-core/src/client/builder.rs
@@ -366,7 +366,7 @@ impl ClientFactory {
 
     pub fn build(&self) -> Result<Box<dyn ProviderClient>, ClientBuildError> {
         std::panic::catch_unwind(|| (self.factory)())
-            .map_err(|e| ClientBuildError::FactoryError(format!("{:?}", e)))
+            .map_err(|e| ClientBuildError::FactoryError(format!("{e:?}")))
     }
 }
 

--- a/rig-core/src/client/mod.rs
+++ b/rig-core/src/client/mod.rs
@@ -374,10 +374,9 @@ mod tests {
             return;
         };
 
-        let model = config.completion_model.expect(&format!(
-            "{} does not have completion_model set",
-            config.name
-        ));
+        let model = config
+            .completion_model
+            .unwrap_or_else(|| panic!("{} does not have completion_model set", config.name));
 
         let model = client.completion_model(model);
 
@@ -400,8 +399,7 @@ mod tests {
                 assert!(text.text.to_lowercase().contains("paris"));
             }
             _ => {
-                assert!(
-                    false,
+                unreachable!(
                     "[{}]: First choice wasn't a Text message, {:?}",
                     config.name,
                     resp.choice.first()
@@ -422,7 +420,7 @@ mod tests {
         let client = config.factory();
         let model = config
             .completion_model
-            .expect(&format!("{} does not have the model set.", config.name));
+            .unwrap_or_else(|| panic!("{} does not have the model set.", config.name));
 
         let Some(client) = client.as_completion() else {
             return;
@@ -492,7 +490,7 @@ mod tests {
 
         let model = config
             .completion_model
-            .expect(&format!("{} does not have the model set.", config.name));
+            .unwrap_or_else(|| panic!("{} does not have the model set.", config.name));
 
         let model = client.completion_model(model);
 
@@ -547,7 +545,7 @@ mod tests {
         let client = config.factory();
         let model = config
             .completion_model
-            .expect(&format!("{} does not have the model set.", config.name));
+            .unwrap_or_else(|| panic!("{} does not have the model set.", config.name));
 
         let Some(client) = client.as_completion() else {
             return;
@@ -630,7 +628,7 @@ mod tests {
 
         let (model, voice) = config
             .audio_generation_model
-            .expect(&format!("{} doesn't have the model set", config.name));
+            .unwrap_or_else(|| panic!("{} doesn't have the model set", config.name));
 
         let model = client.audio_generation_model(model);
 
@@ -651,7 +649,7 @@ mod tests {
         let resp = resp.unwrap();
 
         assert!(
-            resp.audio.len() > 0,
+            !resp.audio.is_empty(),
             "[{}]: Returned audio was empty",
             config.name
         );
@@ -732,7 +730,7 @@ mod tests {
     }
 
     async fn test_embed_client(config: &ClientConfig) {
-        const TEST: &'static str = "Hello world.";
+        const TEST: &str = "Hello world.";
 
         let client = config.factory();
 

--- a/rig-core/src/completion/request.rs
+++ b/rig-core/src/completion/request.rs
@@ -583,7 +583,7 @@ mod tests {
         };
 
         let expected = "<file id: 123>\nThis is a test document.\n</file>\n";
-        assert_eq!(format!("{}", doc), expected);
+        assert_eq!(format!("{doc}"), expected);
     }
 
     #[test]
@@ -604,7 +604,7 @@ mod tests {
             "This is a test document.\n",
             "</file>\n"
         );
-        assert_eq!(format!("{}", doc), expected);
+        assert_eq!(format!("{doc}"), expected);
     }
 
     #[test]

--- a/rig-core/src/embeddings/builder.rs
+++ b/rig-core/src/embeddings/builder.rs
@@ -366,7 +366,7 @@ mod tests {
             .unwrap();
 
         result.sort_by(|(fake_definition_1, _), (fake_definition_2, _)| {
-            fake_definition_1.cmp(&fake_definition_2)
+            fake_definition_1.cmp(fake_definition_2)
         });
 
         assert_eq!(result.len(), 2);

--- a/rig-core/src/loaders/epub/loader.rs
+++ b/rig-core/src/loaders/epub/loader.rs
@@ -484,7 +484,7 @@ mod tests {
         assert_eq!(chapters.len(), 3);
 
         for chapter in chapters {
-            assert!(matches!(chapter.1, Ok(_)));
+            assert!(chapter.1.is_ok());
         }
     }
 

--- a/rig-core/src/loaders/pdf.rs
+++ b/rig-core/src/loaders/pdf.rs
@@ -468,7 +468,7 @@ mod tests {
             .map(|result| {
                 let (path, pages) = result;
                 pages.iter().for_each(|(page_no, content)| {
-                    println!("{:?} Page {}: {:?}", path, page_no, content);
+                    println!("{path:?} Page {page_no}: {content:?}");
                 });
                 (path, pages)
             })

--- a/rig-core/src/pipeline/agent_ops.rs
+++ b/rig-core/src/pipeline/agent_ops.rs
@@ -172,7 +172,7 @@ pub mod tests {
                 },
                 _ => unreachable!(),
             };
-            Ok(format!("Mock response: {}", prompt))
+            Ok(format!("Mock response: {prompt}"))
         }
     }
 

--- a/rig-core/src/pipeline/mod.rs
+++ b/rig-core/src/pipeline/mod.rs
@@ -311,7 +311,7 @@ mod tests {
         let model = MockModel;
 
         let chain = super::new()
-            .map(|input| format!("User query: {}", input))
+            .map(|input| format!("User query: {input}"))
             .prompt(model);
 
         let result = chain
@@ -327,7 +327,7 @@ mod tests {
         let model = MockModel;
 
         let chain = super::with_error::<()>()
-            .map(|input| format!("User query: {}", input))
+            .map(|input| format!("User query: {input}"))
             .prompt(model);
 
         let result = chain
@@ -365,7 +365,7 @@ mod tests {
             ))
             .map(|(query, maybe_docs)| match maybe_docs {
                 Ok(docs) => format!("User query: {}\n\nTop documents:\n{}", query, docs[0].2.foo),
-                Err(err) => format!("Error: {}", err),
+                Err(err) => format!("Error: {err}"),
             })
             .prompt(MockModel);
 

--- a/rig-core/src/pipeline/parallel.rs
+++ b/rig-core/src/pipeline/parallel.rs
@@ -297,7 +297,7 @@ mod tests {
     async fn test_parallel_nested() {
         let op1 = map(|x: i32| x + 1);
         let op2 = map(|x: i32| x * 3);
-        let op3 = map(|x: i32| format!("{} is the number!", x));
+        let op3 = map(|x: i32| format!("{x} is the number!"));
         let op4 = map(|x: i32| x - 1);
 
         let pipeline = Parallel::new(Parallel::new(Parallel::new(op1, op2), op3), op4);
@@ -310,7 +310,7 @@ mod tests {
     async fn test_parallel_nested_rev() {
         let op1 = map(|x: i32| x + 1);
         let op2 = map(|x: i32| x * 3);
-        let op3 = map(|x: i32| format!("{} is the number!", x));
+        let op3 = map(|x: i32| format!("{x} is the number!"));
         let op4 = map(|x: i32| x == 1);
 
         let pipeline = Parallel::new(op1, Parallel::new(op2, Parallel::new(op3, op4)));
@@ -340,7 +340,7 @@ mod tests {
                 Parallel::new(
                     map(|x: i32| x * 3),
                     Parallel::new(
-                        map(|x: i32| format!("{} is the number!", x)),
+                        map(|x: i32| format!("{x} is the number!")),
                         map(|x: i32| x == 1),
                     ),
                 ),
@@ -371,7 +371,7 @@ mod tests {
         let pipeline = parallel!(
             passthrough(),
             op2,
-            map(|x: i32| format!("{} is the number!", x)),
+            map(|x: i32| format!("{x} is the number!")),
             map(|x: i32| x == 1)
         );
 
@@ -387,7 +387,7 @@ mod tests {
                 Parallel::new(
                     map(|x: i32| Ok::<_, String>(x * 3)),
                     Parallel::new(
-                        map(|x: i32| Err::<i32, _>(format!("{} is the number!", x))),
+                        map(|x: i32| Err::<i32, _>(format!("{x} is the number!"))),
                         map(|x: i32| Ok::<_, String>(x == 1)),
                     ),
                 ),
@@ -406,7 +406,7 @@ mod tests {
         let pipeline = try_parallel!(
             map(|x: i32| Ok::<_, String>(x)),
             op2,
-            map(|x: i32| Ok::<_, String>(format!("{} is the number!", x))),
+            map(|x: i32| Ok::<_, String>(format!("{x} is the number!"))),
             map(|x: i32| Ok::<_, String>(x == 1))
         );
 
@@ -421,7 +421,7 @@ mod tests {
         let pipeline = try_parallel!(
             map(|x: i32| Ok::<_, String>(x)),
             op2,
-            map(|x: i32| Err::<i32, _>(format!("{} is the number!", x))),
+            map(|x: i32| Err::<i32, _>(format!("{x} is the number!"))),
             map(|x: i32| Ok::<_, String>(x == 1))
         );
 

--- a/rig-core/src/pipeline/try_op.rs
+++ b/rig-core/src/pipeline/try_op.rs
@@ -410,7 +410,7 @@ mod tests {
     #[tokio::test]
     async fn test_map_err_constructor() {
         let op1 = map(|x: i32| if x % 2 == 0 { Ok(x) } else { Err("x is odd") });
-        let op2 = then(|err: &str| async move { format!("Error: {}", err) });
+        let op2 = then(|err: &str| async move { format!("Error: {err}") });
         let op3 = map(|err: String| err.len());
 
         let pipeline = MapErr::new(MapErr::new(op1, op2), op3);
@@ -422,7 +422,7 @@ mod tests {
     #[tokio::test]
     async fn test_map_err_chain() {
         let pipeline = map(|x: i32| if x % 2 == 0 { Ok(x) } else { Err("x is odd") })
-            .map_err(|err| format!("Error: {}", err))
+            .map_err(|err| format!("Error: {err}"))
             .map_err(|err| err.len());
 
         let result = pipeline.try_call(1).await;
@@ -454,7 +454,7 @@ mod tests {
     #[tokio::test]
     async fn test_or_else_constructor() {
         let op1 = map(|x: i32| if x % 2 == 0 { Ok(x) } else { Err("x is odd") });
-        let op2 = then(|err: &str| async move { Err(format!("Error: {}", err)) });
+        let op2 = then(|err: &str| async move { Err(format!("Error: {err}")) });
         let op3 = map(|err: String| Ok::<i32, String>(err.len() as i32));
 
         let pipeline = OrElse::new(OrElse::new(op1, op2), op3);
@@ -466,7 +466,7 @@ mod tests {
     #[tokio::test]
     async fn test_or_else_chain() {
         let pipeline = map(|x: i32| if x % 2 == 0 { Ok(x) } else { Err("x is odd") })
-            .or_else(|err| async move { Err(format!("Error: {}", err)) })
+            .or_else(|err| async move { Err(format!("Error: {err}")) })
             .or_else(|err| async move { Ok::<i32, String>(err.len() as i32) });
 
         let result = pipeline.try_call(1).await.unwrap();

--- a/rig-core/src/providers/anthropic/completion.rs
+++ b/rig-core/src/providers/anthropic/completion.rs
@@ -759,81 +759,79 @@ mod tests {
             }
         );
 
-        match assistant_message2 {
-            Message { role, content } => {
-                assert_eq!(role, Role::Assistant);
-                assert_eq!(content.len(), 2);
+        let Message { role, content } = assistant_message2;
+        {
+            assert_eq!(role, Role::Assistant);
+            assert_eq!(content.len(), 2);
 
-                let mut iter = content.into_iter();
+            let mut iter = content.into_iter();
 
-                match iter.next().unwrap() {
-                    Content::Text { text } => {
-                        assert_eq!(text, "\n\nHello there, how may I assist you today?");
-                    }
-                    _ => panic!("Expected text content"),
+            match iter.next().unwrap() {
+                Content::Text { text } => {
+                    assert_eq!(text, "\n\nHello there, how may I assist you today?");
                 }
-
-                match iter.next().unwrap() {
-                    Content::ToolUse { id, name, input } => {
-                        assert_eq!(id, "toolu_01A09q90qw90lq917835lq9");
-                        assert_eq!(name, "get_weather");
-                        assert_eq!(input, json!({"location": "San Francisco, CA"}));
-                    }
-                    _ => panic!("Expected tool use content"),
-                }
-
-                assert_eq!(iter.next(), None);
+                _ => panic!("Expected text content"),
             }
+
+            match iter.next().unwrap() {
+                Content::ToolUse { id, name, input } => {
+                    assert_eq!(id, "toolu_01A09q90qw90lq917835lq9");
+                    assert_eq!(name, "get_weather");
+                    assert_eq!(input, json!({"location": "San Francisco, CA"}));
+                }
+                _ => panic!("Expected tool use content"),
+            }
+
+            assert_eq!(iter.next(), None);
         }
 
-        match user_message {
-            Message { role, content } => {
-                assert_eq!(role, Role::User);
-                assert_eq!(content.len(), 3);
+        let Message { role, content } = user_message;
+        {
+            assert_eq!(role, Role::User);
+            assert_eq!(content.len(), 3);
 
-                let mut iter = content.into_iter();
+            let mut iter = content.into_iter();
 
-                match iter.next().unwrap() {
-                    Content::Image { source } => {
-                        assert_eq!(
-                            source,
-                            ImageSource {
-                                data: "/9j/4AAQSkZJRg...".to_owned(),
-                                media_type: ImageFormat::JPEG,
-                                r#type: SourceType::BASE64,
-                            }
-                        );
-                    }
-                    _ => panic!("Expected image content"),
+            match iter.next().unwrap() {
+                Content::Image { source } => {
+                    assert_eq!(
+                        source,
+                        ImageSource {
+                            data: "/9j/4AAQSkZJRg...".to_owned(),
+                            media_type: ImageFormat::JPEG,
+                            r#type: SourceType::BASE64,
+                        }
+                    );
                 }
-
-                match iter.next().unwrap() {
-                    Content::Text { text } => {
-                        assert_eq!(text, "What is in this image?");
-                    }
-                    _ => panic!("Expected text content"),
-                }
-
-                match iter.next().unwrap() {
-                    Content::ToolResult {
-                        tool_use_id,
-                        content,
-                        is_error,
-                    } => {
-                        assert_eq!(tool_use_id, "toolu_01A09q90qw90lq917835lq9");
-                        assert_eq!(
-                            content.first(),
-                            ToolResultContent::Text {
-                                text: "15 degrees".to_owned()
-                            }
-                        );
-                        assert_eq!(is_error, None);
-                    }
-                    _ => panic!("Expected tool result content"),
-                }
-
-                assert_eq!(iter.next(), None);
+                _ => panic!("Expected image content"),
             }
+
+            match iter.next().unwrap() {
+                Content::Text { text } => {
+                    assert_eq!(text, "What is in this image?");
+                }
+                _ => panic!("Expected text content"),
+            }
+
+            match iter.next().unwrap() {
+                Content::ToolResult {
+                                            tool_use_id,
+                                            content,
+                                            is_error,
+                                        } => {
+                    assert_eq!(tool_use_id, "toolu_01A09q90qw90lq917835lq9");
+                    assert_eq!(
+                                    content.first(),
+                                    ToolResultContent::Text {
+                                        text: "15 degrees".to_owned()
+                                    }
+                                );
+                    assert_eq!(is_error, None);
+                }
+                _ => panic!("Expected tool result content"),
+            }
+
+            assert_eq!(iter.next(), None);
         }
     }
 

--- a/rig-core/src/providers/anthropic/completion.rs
+++ b/rig-core/src/providers/anthropic/completion.rs
@@ -750,17 +750,14 @@ mod tests {
             })
         };
 
-        match assistant_message {
-            Message { role, content } => {
-                assert_eq!(role, Role::Assistant);
-                assert_eq!(
-                    content.first(),
-                    Content::Text {
-                        text: "\n\nHello there, how may I assist you today?".to_owned()
-                    }
-                );
+        let Message { role, content } = assistant_message;
+        assert_eq!(role, Role::Assistant);
+        assert_eq!(
+            content.first(),
+            Content::Text {
+                text: "\n\nHello there, how may I assist you today?".to_owned()
             }
-        }
+        );
 
         match assistant_message2 {
             Message { role, content } => {

--- a/rig-core/src/providers/anthropic/completion.rs
+++ b/rig-core/src/providers/anthropic/completion.rs
@@ -815,17 +815,17 @@ mod tests {
 
             match iter.next().unwrap() {
                 Content::ToolResult {
-                                            tool_use_id,
-                                            content,
-                                            is_error,
-                                        } => {
+                    tool_use_id,
+                    content,
+                    is_error,
+                } => {
                     assert_eq!(tool_use_id, "toolu_01A09q90qw90lq917835lq9");
                     assert_eq!(
-                                    content.first(),
-                                    ToolResultContent::Text {
-                                        text: "15 degrees".to_owned()
-                                    }
-                                );
+                        content.first(),
+                        ToolResultContent::Text {
+                            text: "15 degrees".to_owned()
+                        }
+                    );
                     assert_eq!(is_error, None);
                 }
                 _ => panic!("Expected tool result content"),

--- a/rig-core/src/providers/huggingface/client.rs
+++ b/rig-core/src/providers/huggingface/client.rs
@@ -58,10 +58,9 @@ impl SubProvider {
     #[cfg(feature = "image")]
     pub fn image_generation_endpoint(&self, model: &str) -> Result<String, ImageGenerationError> {
         match self {
-            SubProvider::HFInference => Ok(format!("/{}", model)),
+            SubProvider::HFInference => Ok(format!("/{model}")),
             _ => Err(ImageGenerationError::ProviderError(format!(
-                "image generation endpoint is not supported yet for {}",
-                self
+                "image generation endpoint is not supported yet for {self}"
             ))),
         }
     }

--- a/rig-core/src/providers/mira.rs
+++ b/rig-core/src/providers/mira.rs
@@ -632,7 +632,7 @@ mod tests {
         };
 
         // Convert to Mira format
-        let mira_value: serde_json::Value = original_message.clone().try_into().unwrap();
+        let mira_value: serde_json::Value = original_message.clone().into();
 
         // Convert back to our Message type
         let converted_message: Message = mira_value.try_into().unwrap();

--- a/rig-core/src/providers/mira.rs
+++ b/rig-core/src/providers/mira.rs
@@ -637,10 +637,7 @@ mod tests {
         // Convert back to our Message type
         let converted_message: Message = mira_value.try_into().unwrap();
 
-        // Convert back to original format
-        let final_message: message::Message = converted_message.try_into().unwrap();
-
-        assert_eq!(original_message, final_message);
+        assert_eq!(original_message, converted_message);
     }
 
     #[test]

--- a/rig-core/src/tool.rs
+++ b/rig-core/src/tool.rs
@@ -275,7 +275,7 @@ where
                 .client
                 .call_tool(&name, Some(args))
                 .await
-                .map_err(|e| McpToolError(format!("Tool returned an error: {}", e)))?;
+                .map_err(|e| McpToolError(format!("Tool returned an error: {e}")))?;
 
             if result.is_error.unwrap_or(false) {
                 if let Some(error) = result.content.first() {
@@ -314,7 +314,7 @@ where
                             embedded_resource
                                 .resource
                                 .mime_type
-                                .map(|m| format!("data:{};", m))
+                                .map(|m| format!("data:{m};"))
                                 .unwrap_or_default(),
                             embedded_resource.resource.uri
                         )

--- a/rig-eternalai/examples/agent_with_eternalai.rs
+++ b/rig-eternalai/examples/agent_with_eternalai.rs
@@ -39,7 +39,7 @@ async fn basic_eternalai() -> Result<(), anyhow::Error> {
 
     // Prompt the agent and print the response
     let response = comedian_agent.prompt("Entertain me!").await?;
-    println!("{}", response);
+    println!("{response}");
 
     Ok(())
 }
@@ -61,7 +61,7 @@ async fn context_eternalai() -> Result<(), anyhow::Error> {
     // Prompt the agent and print the response
     let response = agent.prompt("What does \"glarb-glarb\" mean?").await?;
 
-    println!("{}", response);
+    println!("{response}");
 
     Ok(())
 }

--- a/rig-eternalai/src/eternalai_system_prompt_manager_toolset.rs
+++ b/rig-eternalai/src/eternalai_system_prompt_manager_toolset.rs
@@ -44,17 +44,17 @@ pub async fn get_on_chain_system_prompt(
         "#
     );
     let provider =
-        Provider::<Http>::try_from(rpc_url).map_err(|e| format!("Failed to parse url: {}", e))?;
+        Provider::<Http>::try_from(rpc_url).map_err(|e| format!("Failed to parse url: {e}"))?;
     let client = Arc::new(provider);
     let contract_address: Address = contract_addr
         .parse()
-        .map_err(|e| format!("invalid contract address: {}", e))?;
+        .map_err(|e| format!("invalid contract address: {e}"))?;
     let contract = SystemPromptManagementContract::new(contract_address, client);
     let system_prompts: Vec<Bytes> = contract
         .get_agent_system_prompt(U256::from(agent_id))
         .call()
         .await
-        .map_err(|e| format!("invalid agent system prompt: {}", e))?;
+        .map_err(|e| format!("invalid agent system prompt: {e}"))?;
 
     let decoded_strings: Vec<String> = system_prompts
         .iter()

--- a/rig-eternalai/src/providers/eternalai.rs
+++ b/rig-eternalai/src/providers/eternalai.rs
@@ -54,7 +54,7 @@ impl Client {
                     let mut headers = reqwest::header::HeaderMap::new();
                     headers.insert(
                         "Authorization",
-                        format!("Bearer {}", api_key)
+                        format!("Bearer {api_key}")
                             .parse()
                             .expect("Bearer token should parse"),
                     );

--- a/rig-fastembed/examples/vector_search.rs
+++ b/rig-fastembed/examples/vector_search.rs
@@ -67,7 +67,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .map(|(score, id, doc)| (score, id, doc.word))
         .collect::<Vec<_>>();
 
-    println!("Results: {:?}", results);
+    println!("Results: {results:?}");
 
     let id_results = index
         .top_n_ids("I need to buy something in a fictional universe. What type of money can I use for this?", 1)
@@ -75,7 +75,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .into_iter()
         .collect::<Vec<_>>();
 
-    println!("ID results: {:?}", id_results);
+    println!("ID results: {id_results:?}");
 
     Ok(())
 }

--- a/rig-fastembed/examples/vector_search_local.rs
+++ b/rig-fastembed/examples/vector_search_local.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Set up model directory
     let model_dir = Path::new("./models/Qdrant--all-MiniLM-L6-v2-onnx/snapshots");
-    println!("Loading model from: {:?}", model_dir);
+    println!("Loading model from: {model_dir:?}");
 
     // Load model files
     let onnx_file =
@@ -51,7 +51,7 @@ async fn main() -> Result<(), anyhow::Error> {
         UserDefinedEmbeddingModel::new(onnx_file, tokenizer_files).with_pooling(Pooling::Mean);
 
     let embedding_model =
-        EmbeddingModel::new_from_user_defined(user_defined_model, 384, &test_model_info);
+        EmbeddingModel::new_from_user_defined(user_defined_model, 384, test_model_info);
 
     // Create documents
     let documents = vec![
@@ -99,7 +99,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .map(|(score, id, doc)| (score, id, doc.word))
         .collect::<Vec<_>>();
 
-    println!("Results: {:?}", results);
+    println!("Results: {results:?}");
 
     Ok(())
 }

--- a/rig-lancedb/examples/vector_search_local_ann.rs
+++ b/rig-lancedb/examples/vector_search_local_ann.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .documents(
             (0..256)
                 .map(|i| Word {
-                    id: format!("doc{}", i),
+                    id: format!("doc{i}"),
                     definition: "Definition of *flumbuzzle (noun)*: A sudden, inexplicable urge to rearrange or reorganize small objects, such as desk items or books, for no apparent reason.".to_string()
                 })
         )?
@@ -78,7 +78,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .top_n::<Word>("My boss says I zindle too much, what does that mean?", 1)
         .await?;
 
-    println!("Results: {:?}", results);
+    println!("Results: {results:?}");
 
     Ok(())
 }

--- a/rig-lancedb/examples/vector_search_local_enn.rs
+++ b/rig-lancedb/examples/vector_search_local_enn.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .top_n_ids("My boss says I zindle too much, what does that mean?", 1)
         .await?;
 
-    println!("Results: {:?}", results);
+    println!("Results: {results:?}");
 
     Ok(())
 }

--- a/rig-lancedb/examples/vector_search_s3_ann.rs
+++ b/rig-lancedb/examples/vector_search_s3_ann.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .documents(
             (0..256)
                 .map(|i| Word {
-                    id: format!("doc{}", i),
+                    id: format!("doc{i}"),
                     definition: "Definition of *flumbuzzle (noun)*: A sudden, inexplicable urge to rearrange or reorganize small objects, such as desk items or books, for no apparent reason.".to_string()
                 })
         )?
@@ -90,7 +90,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .top_n::<Word>("I'm always looking for my phone, I always seem to forget it in the most counterintuitive places. What's the word for this feeling?", 1)
         .await?;
 
-    println!("Results: {:?}", results);
+    println!("Results: {results:?}");
 
     Ok(())
 }

--- a/rig-lancedb/tests/integration_tests.rs
+++ b/rig-lancedb/tests/integration_tests.rs
@@ -121,7 +121,7 @@ async fn vector_search_test() {
         .documents(
             (0..256)
                 .map(|i| Word {
-                    id: format!("doc{}", i),
+                    id: format!("doc{i}"),
                     definition: "Definition of *flumbuzzle (noun)*: A sudden, inexplicable urge to rearrange or reorganize small objects, such as desk items or books, for no apparent reason.".to_string()
                 })
         ).unwrap()

--- a/rig-milvus/examples/vector_search_milvus.rs
+++ b/rig-milvus/examples/vector_search_milvus.rs
@@ -74,7 +74,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     println!("#{} results for query: {}", results.len(), query);
     for (distance, _id, doc) in results.iter() {
-        println!("Result distance {} for word: {}", distance, doc);
+        println!("Result distance {distance} for word: {doc}");
 
         // expected output
         // Result distance 0.693218142100547 for word: glarb-glarb

--- a/rig-mongodb/examples/vector_search_mongodb.rs
+++ b/rig-mongodb/examples/vector_search_mongodb.rs
@@ -103,7 +103,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     match collection.insert_many(mongo_documents).await {
         Ok(_) => println!("Documents added successfully"),
-        Err(e) => println!("Error adding documents: {:?}", e),
+        Err(e) => println!("Error adding documents: {e:?}"),
     };
 
     // Create a vector index on our vector store.
@@ -115,7 +115,7 @@ async fn main() -> Result<(), anyhow::Error> {
     // Query the index
     let results = index.top_n::<Word>("What is a linglingdong?", 1).await?;
 
-    println!("Results: {:?}", results);
+    println!("Results: {results:?}");
 
     let id_results = index
         .top_n_ids("What is a linglingdong?", 1)
@@ -123,7 +123,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .into_iter()
         .collect::<Vec<_>>();
 
-    println!("ID results: {:?}", id_results);
+    println!("ID results: {id_results:?}");
 
     Ok(())
 }

--- a/rig-mongodb/src/lib.rs
+++ b/rig-mongodb/src/lib.rs
@@ -260,7 +260,7 @@ impl<M: EmbeddingModel + Sync + Send, C: Sync + Send> VectorStoreIndex
         tracing::info!(target: "rig",
             "Selected documents: {}",
             results.iter()
-                .map(|(distance, id, _)| format!("{} ({})", id, distance))
+                .map(|(distance, id, _)| format!("{id} ({distance})"))
                 .collect::<Vec<String>>()
                 .join(", ")
         );
@@ -303,7 +303,7 @@ impl<M: EmbeddingModel + Sync + Send, C: Sync + Send> VectorStoreIndex
         tracing::info!(target: "rig",
             "Selected documents: {}",
             results.iter()
-                .map(|(distance, id)| format!("{} ({})", id, distance))
+                .map(|(distance, id)| format!("{id} ({distance})"))
                 .collect::<Vec<String>>()
                 .join(", ")
         );

--- a/rig-mongodb/tests/integration_tests.rs
+++ b/rig-mongodb/tests/integration_tests.rs
@@ -205,12 +205,9 @@ async fn create_search_index(collection: &Collection<bson::Document>) {
                             .ok()
                             .map(|i| {
                                 // Check both name and status
-                                let name_matches = i
-                                    .get_str("name")
-                                    .ok() == Some(VECTOR_SEARCH_INDEX_NAME);
-                                let status_ready = i
-                                    .get_str("status")
-                                    .ok() == Some("READY");
+                                let name_matches =
+                                    i.get_str("name").ok() == Some(VECTOR_SEARCH_INDEX_NAME);
+                                let status_ready = i.get_str("status").ok() == Some("READY");
                                 name_matches && status_ready
                             })
                             .unwrap_or(false)
@@ -231,9 +228,7 @@ async fn create_search_index(collection: &Collection<bson::Document>) {
         }
     }
 
-    panic!(
-        "Failed to create search index after {max_attempts} attempts"
-    );
+    panic!("Failed to create search index after {max_attempts} attempts");
 }
 
 async fn bootstrap_collection(host: String, port: u16) -> Collection<bson::Document> {

--- a/rig-mongodb/tests/integration_tests.rs
+++ b/rig-mongodb/tests/integration_tests.rs
@@ -203,17 +203,15 @@ async fn create_search_index(collection: &Collection<bson::Document>) {
                     if indexes.iter().any(|idx| {
                         idx.as_ref()
                             .ok()
-                            .and_then(|i| {
+                            .map(|i| {
                                 // Check both name and status
                                 let name_matches = i
                                     .get_str("name")
-                                    .ok()
-                                    .map_or(false, |name| name == VECTOR_SEARCH_INDEX_NAME);
+                                    .ok() == Some(VECTOR_SEARCH_INDEX_NAME);
                                 let status_ready = i
                                     .get_str("status")
-                                    .ok()
-                                    .map_or(false, |status| status == "READY");
-                                Some(name_matches && status_ready)
+                                    .ok() == Some("READY");
+                                name_matches && status_ready
                             })
                             .unwrap_or(false)
                     }) {
@@ -234,8 +232,7 @@ async fn create_search_index(collection: &Collection<bson::Document>) {
     }
 
     panic!(
-        "Failed to create search index after {} attempts",
-        max_attempts
+        "Failed to create search index after {max_attempts} attempts"
     );
 }
 

--- a/rig-neo4j/examples/vector_search_movies_add_embeddings.rs
+++ b/rig-neo4j/examples/vector_search_movies_add_embeddings.rs
@@ -65,7 +65,7 @@ async fn main() -> Result<(), anyhow::Error> {
             movies_batch.push(Movie {
                 title: title.to_string(),
                 plot: plot.to_string(),
-                to_encode: Some(format!("Title: {}\nPlot: {}", title, plot)),
+                to_encode: Some(format!("Title: {title}\nPlot: {plot}")),
             });
         }
 
@@ -95,9 +95,8 @@ async fn main() -> Result<(), anyhow::Error> {
         let size: i64 = row.get("embeddingSize")?;
         println!(
             "Embeddings generated and attached to nodes.\n\
-             Movie nodes with embeddings: {}.\n\
-             Embedding size: {}.",
-            count, size
+             Movie nodes with embeddings: {count}.\n\
+             Embedding size: {size}."
         );
     }
 
@@ -137,10 +136,9 @@ async fn main() -> Result<(), anyhow::Error> {
         .top_n_ids("What is a linglingdong?", 1)
         .await?
         .into_iter()
-        .map(|(score, id)| (score, id))
         .collect::<Vec<_>>();
 
-    println!("ID results: {:?}", id_results);
+    println!("ID results: {id_results:?}");
 
     Ok(())
 }
@@ -155,14 +153,14 @@ async fn import_batch(graph: &Graph, nodes: &[Movie], batch_n: i32) -> Result<()
     graph.run(
         Query::new(format!(
             "CALL genai.vector.encodeBatch($to_encode_list, 'OpenAI', {{ token: $token }}) YIELD index, vector
-             MATCH (m:{} {{title: $movies[index].title, plot: $movies[index].plot}})
-             CALL db.create.setNodeVectorProperty(m, 'embedding', vector)", NODE_LABEL).to_string()
+             MATCH (m:{NODE_LABEL} {{title: $movies[index].title, plot: $movies[index].plot}})
+             CALL db.create.setNodeVectorProperty(m, 'embedding', vector)").to_string()
         )
         .param("movies", nodes.to_bolt_type())
         .param("to_encode_list", to_encode_list)
         .param("token", openai_api_key)
     ).await?;
 
-    println!("Processed batch {}", batch_n);
+    println!("Processed batch {batch_n}");
     Ok(())
 }

--- a/rig-neo4j/examples/vector_search_movies_consume.rs
+++ b/rig-neo4j/examples/vector_search_movies_consume.rs
@@ -95,10 +95,9 @@ async fn main() -> Result<(), anyhow::Error> {
         .top_n_ids("A movie where the bad guy wins", 1)
         .await?
         .into_iter()
-        .map(|(score, id)| (score, id))
         .collect::<Vec<_>>();
 
-    println!("ID results: {:?}", id_results);
+    println!("ID results: {id_results:?}");
 
     Ok(())
 }

--- a/rig-neo4j/examples/vector_search_simple.rs
+++ b/rig-neo4j/examples/vector_search_simple.rs
@@ -109,7 +109,7 @@ async fn main() -> Result<(), anyhow::Error> {
         std::thread::sleep(std::time::Duration::from_secs(5));
     }
 
-    println!("Index exists: {:?}", index_exists);
+    println!("Index exists: {index_exists:?}");
 
     // Create a vector index on our vector store
     // IMPORTANT: Reuse the same model that was used to generate the embeddings
@@ -134,16 +134,15 @@ async fn main() -> Result<(), anyhow::Error> {
         .map(|(score, id, doc)| (score, id, doc.document))
         .collect::<Vec<_>>();
 
-    println!("Results: {:?}", results);
+    println!("Results: {results:?}");
 
     let id_results = index
         .top_n_ids("What is a linglingdong?", 1)
         .await?
         .into_iter()
-        .map(|(score, id)| (score, id))
         .collect::<Vec<_>>();
 
-    println!("ID results: {:?}", id_results);
+    println!("ID results: {id_results:?}");
 
     Ok(())
 }

--- a/rig-neo4j/src/lib.rs
+++ b/rig-neo4j/src/lib.rs
@@ -255,8 +255,7 @@ impl Neo4jClient {
                 std::io::Error::new(
                     std::io::ErrorKind::NotFound,
                     format!(
-                        "Index `{}` not found in database. Available indexes: {:?}",
-                        index_name, indexes
+                        "Index `{index_name}` not found in database. Available indexes: {indexes:?}"
                     ),
                 ),
             )));

--- a/rig-neo4j/src/vector_index.rs
+++ b/rig-neo4j/src/vector_index.rs
@@ -90,7 +90,7 @@ impl FromStr for VectorSimilarityFunction {
             "cosine" => Ok(VectorSimilarityFunction::Cosine),
             "euclidean" => Ok(VectorSimilarityFunction::Euclidean),
             _ => Err(VectorStoreError::JsonError(serde_json::Error::custom(
-                format!("Invalid similarity function: {}", s),
+                format!("Invalid similarity function: {s}"),
             ))),
         }
     }
@@ -133,7 +133,7 @@ impl<M: EmbeddingModel> Neo4jVectorIndex<M> {
         n: usize,
     ) -> Query {
         let where_clause = match &self.search_params.post_vector_search_filter {
-            Some(filter) => format!("WHERE {}", filter),
+            Some(filter) => format!("WHERE {filter}"),
             None => "".to_string(),
         };
 

--- a/rig-neo4j/tests/integration_tests.rs
+++ b/rig-neo4j/tests/integration_tests.rs
@@ -181,7 +181,7 @@ async fn vector_search_test() {
         std::thread::sleep(std::time::Duration::from_secs(5));
     }
 
-    println!("Index exists: {:?}", index_exists);
+    println!("Index exists: {index_exists:?}");
 
     // Create a vector index on our vector store
     // IMPORTANT: Reuse the same model that was used to generate the embeddings

--- a/rig-postgres/examples/vector_search_postgres.rs
+++ b/rig-postgres/examples/vector_search_postgres.rs
@@ -91,7 +91,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     println!("#{} results for query: {}", results.len(), query);
     for (distance, _id, doc) in results.iter() {
-        println!("Result distance {} for word: {}", distance, doc);
+        println!("Result distance {distance} for word: {doc}");
 
         // expected output (even if we have 2 entries on glarb-glarb the index only gives closest match)
         // Result distance 0.2988549857990437 for word: glarb-glarb

--- a/rig-postgres/tests/integration_tests.rs
+++ b/rig-postgres/tests/integration_tests.rs
@@ -30,7 +30,7 @@ async fn vector_search_test() {
         .await
         .expect("Error getting docker port");
 
-    println!("Container started on host:port {}:{}", host, port);
+    println!("Container started on host:port {host}:{port}");
 
     // connect to Postgres
     let pg_pool = connect_to_postgres(host, port).await;
@@ -105,8 +105,7 @@ async fn vector_search_test() {
 
     let (distance, full_query_id, doc) = results[0].clone();
     println!(
-        "Distance: {}, id: {}, document: {:?}",
-        distance, full_query_id, doc
+        "Distance: {distance}, id: {full_query_id}, document: {doc:?}"
     );
 
     assert_eq!(doc.name, "glarb-glarb");
@@ -125,7 +124,7 @@ async fn vector_search_test() {
     );
 
     let (distance, id) = results[0].clone();
-    println!("Distance: {}, id: {}", distance, id);
+    println!("Distance: {distance}, id: {id}");
 
     assert_eq!(id, full_query_id);
 }
@@ -151,8 +150,7 @@ async fn connect_to_postgres(host: String, port: u16) -> PgPool {
         .max_connections(50)
         .idle_timeout(std::time::Duration::from_secs(5))
         .connect(&format!(
-            "postgres://postgres:postgres@{}:{}/rig",
-            host, port
+            "postgres://postgres:postgres@{host}:{port}/rig"
         ))
         .await
         .expect("Failed to create postgres pool")

--- a/rig-postgres/tests/integration_tests.rs
+++ b/rig-postgres/tests/integration_tests.rs
@@ -104,9 +104,7 @@ async fn vector_search_test() {
     );
 
     let (distance, full_query_id, doc) = results[0].clone();
-    println!(
-        "Distance: {distance}, id: {full_query_id}, document: {doc:?}"
-    );
+    println!("Distance: {distance}, id: {full_query_id}, document: {doc:?}");
 
     assert_eq!(doc.name, "glarb-glarb");
 
@@ -149,9 +147,7 @@ async fn connect_to_postgres(host: String, port: u16) -> PgPool {
     PgPoolOptions::new()
         .max_connections(50)
         .idle_timeout(std::time::Duration::from_secs(5))
-        .connect(&format!(
-            "postgres://postgres:postgres@{host}:{port}/rig"
-        ))
+        .connect(&format!("postgres://postgres:postgres@{host}:{port}/rig"))
         .await
         .expect("Failed to create postgres pool")
 }

--- a/rig-qdrant/examples/qdrant_vector_search.rs
+++ b/rig-qdrant/examples/qdrant_vector_search.rs
@@ -82,7 +82,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .top_n::<Word>("What is a linglingdong?", 1)
         .await?;
 
-    println!("Results: {:?}", results);
+    println!("Results: {results:?}");
 
     Ok(())
 }

--- a/rig-sqlite/examples/vector_search_sqlite.rs
+++ b/rig-sqlite/examples/vector_search_sqlite.rs
@@ -102,10 +102,9 @@ async fn main() -> Result<(), anyhow::Error> {
         .top_n::<Document>("What is a linglingdong?", 1)
         .await?
         .into_iter()
-        .map(|(score, id, doc)| (score, id, doc))
         .collect::<Vec<_>>();
 
-    println!("Results: {:?}", results);
+    println!("Results: {results:?}");
 
     let id_results = index
         .top_n_ids("What is a linglingdong?", 1)
@@ -113,7 +112,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .into_iter()
         .collect::<Vec<_>>();
 
-    println!("ID results: {:?}", id_results);
+    println!("ID results: {id_results:?}");
 
     Ok(())
 }

--- a/rig-sqlite/examples/vector_search_sqlite.rs
+++ b/rig-sqlite/examples/vector_search_sqlite.rs
@@ -6,7 +6,7 @@ use rig::{
     Embed,
 };
 use rig_sqlite::{Column, ColumnValue, SqliteVectorStore, SqliteVectorStoreTable};
-use rusqlite::ffi::sqlite3_auto_extension;
+use rusqlite::ffi::{sqlite3, sqlite3_api_routines, sqlite3_auto_extension};
 use serde::Deserialize;
 use sqlite_vec::sqlite3_vec_init;
 use std::env;
@@ -43,6 +43,9 @@ impl SqliteVectorStoreTable for Document {
     }
 }
 
+type SqliteExtensionFn =
+    unsafe extern "C" fn(*mut sqlite3, *mut *mut i8, *const sqlite3_api_routines) -> i32;
+
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     tracing_subscriber::fmt()
@@ -59,7 +62,9 @@ async fn main() -> Result<(), anyhow::Error> {
     // Initialize the `sqlite-vec`extension
     // See: https://alexgarcia.xyz/sqlite-vec/rust.html
     unsafe {
-        sqlite3_auto_extension(Some(std::mem::transmute(sqlite3_vec_init as *const ())));
+        sqlite3_auto_extension(Some(std::mem::transmute::<*const (), SqliteExtensionFn>(
+            sqlite3_vec_init as *const (),
+        )));
     }
 
     // Initialize SQLite connection

--- a/rig-sqlite/src/lib.rs
+++ b/rig-sqlite/src/lib.rs
@@ -97,7 +97,7 @@ impl<E: EmbeddingModel + 'static, T: SqliteVectorStoreTable + 'static> SqliteVec
         let schema = T::schema();
 
         // Build the table schema
-        let mut create_table = format!("CREATE TABLE IF NOT EXISTS {} (", table_name);
+        let mut create_table = format!("CREATE TABLE IF NOT EXISTS {table_name} (");
 
         // Add columns
         let mut first = true;
@@ -140,8 +140,7 @@ impl<E: EmbeddingModel + 'static, T: SqliteVectorStoreTable + 'static> SqliteVec
 
             // Create embeddings table
             conn.execute_batch(&format!(
-                "CREATE VIRTUAL TABLE IF NOT EXISTS {}_embeddings USING vec0(embedding float[{}])",
-                table_name, dims
+                "CREATE VIRTUAL TABLE IF NOT EXISTS {table_name}_embeddings USING vec0(embedding float[{dims}])"
             ))?;
 
             conn.execute_batch("COMMIT")?;
@@ -176,7 +175,7 @@ impl<E: EmbeddingModel + 'static, T: SqliteVectorStoreTable + 'static> SqliteVec
             let columns = values.iter().map(|(col, _)| *col).collect::<Vec<_>>();
 
             let placeholders = (1..=values.len())
-                .map(|i| format!("?{}", i))
+                .map(|i| format!("?{i}"))
                 .collect::<Vec<_>>();
 
             let insert_sql = format!(
@@ -193,8 +192,7 @@ impl<E: EmbeddingModel + 'static, T: SqliteVectorStoreTable + 'static> SqliteVec
             last_id = txn.last_insert_rowid();
 
             let embeddings_sql = format!(
-                "INSERT INTO {}_embeddings (rowid, embedding) VALUES (?1, ?2)",
-                table_name
+                "INSERT INTO {table_name}_embeddings (rowid, embedding) VALUES (?1, ?2)"
             );
 
             let mut stmt = txn.prepare(&embeddings_sql)?;
@@ -353,12 +351,11 @@ impl<E: EmbeddingModel + std::marker::Sync, T: SqliteVectorStoreTable> VectorSto
                 // Build SELECT statement with all columns
                 let select_cols = column_names.join(", ");
                 let mut stmt = conn.prepare(&format!(
-                    "SELECT d.{}, e.distance 
-                    FROM {}_embeddings e
-                    JOIN {} d ON e.rowid = d.rowid
+                    "SELECT d.{select_cols}, e.distance 
+                    FROM {table_name}_embeddings e
+                    JOIN {table_name} d ON e.rowid = d.rowid
                     WHERE e.embedding MATCH ?1 AND k = ?2
-                    ORDER BY e.distance",
-                    select_cols, table_name, table_name
+                    ORDER BY e.distance"
                 ))?;
 
                 let rows = stmt
@@ -414,11 +411,10 @@ impl<E: EmbeddingModel + std::marker::Sync, T: SqliteVectorStoreTable> VectorSto
             .call(move |conn| {
                 let mut stmt = conn.prepare(&format!(
                     "SELECT d.id, e.distance 
-                     FROM {0}_embeddings e
-                     JOIN {0} d ON e.rowid = d.rowid
+                     FROM {table_name}_embeddings e
+                     JOIN {table_name} d ON e.rowid = d.rowid
                      WHERE e.embedding MATCH ?1 AND k = ?2
-                     ORDER BY e.distance",
-                    table_name
+                     ORDER BY e.distance"
                 ))?;
 
                 let results = stmt

--- a/rig-sqlite/src/lib.rs
+++ b/rig-sqlite/src/lib.rs
@@ -191,9 +191,8 @@ impl<E: EmbeddingModel + 'static, T: SqliteVectorStoreTable + 'static> SqliteVec
             )?;
             last_id = txn.last_insert_rowid();
 
-            let embeddings_sql = format!(
-                "INSERT INTO {table_name}_embeddings (rowid, embedding) VALUES (?1, ?2)"
-            );
+            let embeddings_sql =
+                format!("INSERT INTO {table_name}_embeddings (rowid, embedding) VALUES (?1, ?2)");
 
             let mut stmt = txn.prepare(&embeddings_sql)?;
             for (i, embedding) in embeddings.iter().enumerate() {

--- a/rig-sqlite/tests/integration_test.rs
+++ b/rig-sqlite/tests/integration_test.rs
@@ -8,7 +8,7 @@ use rig::{
     Embed, OneOrMany,
 };
 use rig_sqlite::{Column, ColumnValue, SqliteVectorStore, SqliteVectorStoreTable};
-use rusqlite::ffi::sqlite3_auto_extension;
+use rusqlite::ffi::{sqlite3, sqlite3_api_routines, sqlite3_auto_extension};
 use sqlite_vec::sqlite3_vec_init;
 use tokio_rusqlite::Connection;
 
@@ -43,12 +43,17 @@ impl SqliteVectorStoreTable for Word {
     }
 }
 
+type SqliteExtensionFn =
+    unsafe extern "C" fn(*mut sqlite3, *mut *mut i8, *const sqlite3_api_routines) -> i32;
+
 #[tokio::test]
 async fn vector_search_test() {
     // Initialize the `sqlite-vec`extension
     // See: https://alexgarcia.xyz/sqlite-vec/rust.html
     unsafe {
-        sqlite3_auto_extension(Some(std::mem::transmute(sqlite3_vec_init as *const ())));
+        sqlite3_auto_extension(Some(std::mem::transmute::<*const (), SqliteExtensionFn>(
+            sqlite3_vec_init as *const (),
+        )));
     }
 
     // Initialize SQLite connection

--- a/rig-surrealdb/examples/vector_search_surreal.rs
+++ b/rig-surrealdb/examples/vector_search_surreal.rs
@@ -65,7 +65,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     println!("#{} results for query: {}", results.len(), query);
     for (distance, _id, doc) in results.iter() {
-        println!("Result distance {} for word: {}", distance, doc);
+        println!("Result distance {distance} for word: {doc}");
 
         // expected output
         // Result distance 0.693218142100547 for word: glarb-glarb


### PR DESCRIPTION
- There are some changes in clippy on the latest Rust stable
  - Most of the time it is simple `cargo clippy --fix`
- agent_with_huggingface.rs has some weird line spacing -> fixed it.
- Add `--all-targets` to run clippy on all targets, including tests and examples