### PR TITLE
feat(rig-799): add support for official rust sdk for mcp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9155,6 +9155,7 @@ dependencies = [
  "rayon",
  "reqwest 0.12.20",
  "rig-derive",
+ "rmcp",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -9457,6 +9458,40 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rmcp"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37f2048a81a7ff7e8ef6bc5abced70c3d9114c8f03d85d7aaaafd9fd04f12e9e"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "paste",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72398e694b9f6dbb5de960cf158c8699e6a1854cb5bbaac7de0646b2005763c4"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -9841,6 +9876,7 @@ version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "schemars_derive",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,14 +1467,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.4.5",
  "bytes",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
@@ -1485,6 +1485,40 @@ dependencies = [
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
+dependencies = [
+ "axum-core 0.5.2",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1505,6 +1539,26 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -6914,6 +6968,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9141,11 +9201,13 @@ dependencies = [
  "as-any",
  "assert_fs",
  "async-stream",
+ "axum 0.8.4",
  "base64 0.22.1",
  "bytes",
  "epub",
  "futures",
  "glob",
+ "hyper-util",
  "lopdf",
  "mcp-core",
  "mcp-core-macros",
@@ -9467,19 +9529,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37f2048a81a7ff7e8ef6bc5abced70c3d9114c8f03d85d7aaaafd9fd04f12e9e"
 dependencies = [
  "base64 0.22.1",
+ "bytes",
  "chrono",
  "futures",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
  "paste",
  "pin-project-lite",
+ "rand 0.9.1",
+ "reqwest 0.12.20",
  "rmcp-macros",
  "schemars 0.8.22",
  "serde",
  "serde_json",
+ "sse-stream",
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tower-service",
  "tracing",
+ "uuid 1.17.0",
 ]
 
 [[package]]
@@ -10755,6 +10826,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sse-stream"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11837,7 +11921,7 @@ checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.7.9",
  "base64 0.22.1",
  "bytes",
  "flate2",
@@ -11896,6 +11980,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -13070,7 +13155,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "js-sys",
- "matchit",
+ "matchit 0.7.3",
  "pin-project",
  "serde",
  "serde-wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,7 +775,7 @@ checksum = "fd45deb3dbe5da5cdb8d6a670a7736d735ba65b455328440f236dfb113727a3d"
 dependencies = [
  "Inflector",
  "async-graphql-parser",
- "darling",
+ "darling 0.20.11",
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
@@ -2783,8 +2783,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a79c4acb1fd5fa3d9304be4c76e031c54d2e92d172a393e24b19a14fe8532fe9"
+dependencies = [
+ "darling_core 0.21.0",
+ "darling_macro 0.21.0",
 ]
 
 [[package]]
@@ -2802,12 +2812,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74875de90daf30eb59609910b84d4d368103aaec4c924824c6799b28f77d6a1d"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79f8e61677d5df9167cd85265f8e5f64b215cdea3fb55eebc3e622e44c7a146"
+dependencies = [
+ "darling_core 0.21.0",
  "quote",
  "syn 2.0.104",
 ]
@@ -3561,7 +3596,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -9563,9 +9598,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37f2048a81a7ff7e8ef6bc5abced70c3d9114c8f03d85d7aaaafd9fd04f12e9e"
+checksum = "b008b927a85d514699ff304be84c5084598596e6cad4a6f5bc67207715fafe5f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -9579,7 +9614,7 @@ dependencies = [
  "rand 0.9.1",
  "reqwest 0.12.20",
  "rmcp-macros",
- "schemars 0.8.22",
+ "schemars 1.0.4",
  "serde",
  "serde_json",
  "sse-stream",
@@ -9594,11 +9629,11 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72398e694b9f6dbb5de960cf158c8699e6a1854cb5bbaac7de0646b2005763c4"
+checksum = "7465280d5f73f2c5c99017a04af407b2262455a149f255ad22f2b0b29087695c"
 dependencies = [
- "darling",
+ "darling 0.21.0",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -9987,9 +10022,8 @@ version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
- "chrono",
  "dyn-clone",
- "schemars_derive",
+ "schemars_derive 0.8.22",
  "serde",
  "serde_json",
 ]
@@ -10007,10 +10041,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive 1.0.4",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d020396d1d138dc19f1165df7545479dcd58d93810dc5d646a16e55abefa80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10115,7 +10175,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8efb4b519ab70556c8d3adfd4f192c635d0c7c72d4f125d2b79713742c98f39d"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -10354,7 +10414,7 @@ version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81679d9ed988d5e9a5e6531dc3f2c28efbd639cbd1dfb628df08edea6004da77"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.104",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9477,6 +9477,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tracing",
 ]

--- a/rig-core/Cargo.toml
+++ b/rig-core/Cargo.toml
@@ -50,6 +50,18 @@ base64 = { workspace = true }
 mcp-core = { workspace = true, features = ["sse"] }
 mcp-core-macros = { workspace = true }
 
+# Required for `rmcp` example
+hyper-util = { version = "0.1.14", features = ["service", "server"] }
+rmcp = { version = "0.2.1", features = [
+    "client",
+    "reqwest",                                  # required for some strange reason
+    "transport-streamable-http-client",
+    "transport-streamable-http-server-session",
+    "transport-streamable-http-server",
+    "transport-worker",
+] }
+axum = "0.8.4"
+
 
 [features]
 default = ["reqwest/default"]
@@ -131,3 +143,7 @@ required-features = ["derive"]
 [[example]]
 name = "voyageai_embeddings"
 required-features = ["derive"]
+
+[[example]]
+name = "rmcp"
+required-features = ["rmcp"]

--- a/rig-core/Cargo.toml
+++ b/rig-core/Cargo.toml
@@ -36,7 +36,7 @@ async-stream = { workspace = true }
 mime_guess = { workspace = true }
 base64 = { workspace = true }
 as-any = { workspace = true }
-rmcp = { version = "0.2.1", optional = true }
+rmcp = { version = "0.2.1", optional = true, features = ["client"] }
 
 
 [dev-dependencies]

--- a/rig-core/Cargo.toml
+++ b/rig-core/Cargo.toml
@@ -36,6 +36,7 @@ async-stream = { workspace = true }
 mime_guess = { workspace = true }
 base64 = { workspace = true }
 as-any = { workspace = true }
+rmcp = { version = "0.2.1", optional = true }
 
 
 [dev-dependencies]
@@ -61,6 +62,7 @@ epub = ["dep:epub", "dep:quick-xml"]
 rayon = ["dep:rayon"]
 worker = ["dep:worker"]
 mcp = ["dep:mcp-core"]
+rmcp = ["dep:rmcp"]
 socks = ["reqwest/socks"]
 # Replace "default-tls" with "rustls-tls" in "reqwest/default"
 reqwest-rustls = [

--- a/rig-core/Cargo.toml
+++ b/rig-core/Cargo.toml
@@ -36,8 +36,7 @@ async-stream = { workspace = true }
 mime_guess = { workspace = true }
 base64 = { workspace = true }
 as-any = { workspace = true }
-rmcp = { version = "0.2.1", optional = true, features = ["client"] }
-
+rmcp = { version = "0.3", optional = true, features = ["client"] }
 
 [dev-dependencies]
 anyhow = { workspace = true }
@@ -52,7 +51,7 @@ mcp-core-macros = { workspace = true }
 
 # Required for `rmcp` example
 hyper-util = { version = "0.1.14", features = ["service", "server"] }
-rmcp = { version = "0.2.1", features = [
+rmcp = { version = "0.3", features = [
     "client",
     "reqwest",                                  # required for some strange reason
     "transport-streamable-http-client",

--- a/rig-core/examples/rmcp.rs
+++ b/rig-core/examples/rmcp.rs
@@ -9,7 +9,7 @@ use rig::{
     providers::openai,
 };
 use rmcp::{
-    Error as McpError, RoleServer, ServerHandler,
+    RoleServer, ServerHandler,
     handler::server::{router::tool::ToolRouter, tool::Parameters},
     model::*,
     schemars,
@@ -61,7 +61,7 @@ impl Counter {
     }
 
     // #[tool(description = "Increment the counter by 1")]
-    // async fn increment(&self) -> Result<CallToolResult, McpError> {
+    // async fn increment(&self) -> Result<CallToolResult, ErrorData> {
     //     let mut counter = self.counter.lock().await;
     //     *counter += 1;
     //     Ok(CallToolResult::success(vec![Content::text(
@@ -70,7 +70,7 @@ impl Counter {
     // }
 
     // #[tool(description = "Decrement the counter by 1")]
-    // async fn decrement(&self) -> Result<CallToolResult, McpError> {
+    // async fn decrement(&self) -> Result<CallToolResult, ErrorData> {
     //     let mut counter = self.counter.lock().await;
     //     *counter -= 1;
     //     Ok(CallToolResult::success(vec![Content::text(
@@ -79,7 +79,7 @@ impl Counter {
     // }
 
     // #[tool(description = "Get the current counter value")]
-    // async fn get_value(&self) -> Result<CallToolResult, McpError> {
+    // async fn get_value(&self) -> Result<CallToolResult, ErrorData> {
     //     let counter = self.counter.lock().await;
     //     Ok(CallToolResult::success(vec![Content::text(
     //         counter.to_string(),
@@ -87,12 +87,12 @@ impl Counter {
     // }
 
     // #[tool(description = "Say hello to the client")]
-    // fn say_hello(&self) -> Result<CallToolResult, McpError> {
+    // fn say_hello(&self) -> Result<CallToolResult, ErrorData> {
     //     Ok(CallToolResult::success(vec![Content::text("hello")]))
     // }
 
     // #[tool(description = "Repeat what you say")]
-    // fn echo(&self, Parameters(object): Parameters<JsonObject>) -> Result<CallToolResult, McpError> {
+    // fn echo(&self, Parameters(object): Parameters<JsonObject>) -> Result<CallToolResult, ErrorData> {
     //     Ok(CallToolResult::success(vec![Content::text(
     //         serde_json::Value::Object(object).to_string(),
     //     )]))
@@ -102,7 +102,7 @@ impl Counter {
     fn sum(
         &self,
         Parameters(StructRequest { a, b }): Parameters<StructRequest>,
-    ) -> Result<CallToolResult, McpError> {
+    ) -> Result<CallToolResult, ErrorData> {
         Ok(CallToolResult::success(vec![Content::text(
             (a + b).to_string(),
         )]))
@@ -126,7 +126,7 @@ impl ServerHandler for Counter {
         &self,
         _request: Option<PaginatedRequestParam>,
         _: RequestContext<RoleServer>,
-    ) -> Result<ListResourcesResult, McpError> {
+    ) -> Result<ListResourcesResult, ErrorData> {
         Ok(ListResourcesResult {
             resources: vec![
                 self._create_resource_text("str:////Users/to/some/path/", "cwd"),
@@ -140,7 +140,7 @@ impl ServerHandler for Counter {
         &self,
         ReadResourceRequestParam { uri }: ReadResourceRequestParam,
         _: RequestContext<RoleServer>,
-    ) -> Result<ReadResourceResult, McpError> {
+    ) -> Result<ReadResourceResult, ErrorData> {
         match uri.as_str() {
             "str:////Users/to/some/path/" => {
                 let cwd = "/Users/to/some/path/";
@@ -154,7 +154,7 @@ impl ServerHandler for Counter {
                     contents: vec![ResourceContents::text(memo, uri)],
                 })
             }
-            _ => Err(McpError::resource_not_found(
+            _ => Err(ErrorData::resource_not_found(
                 "resource_not_found",
                 Some(json!({
                     "uri": uri
@@ -167,7 +167,7 @@ impl ServerHandler for Counter {
         &self,
         _request: Option<PaginatedRequestParam>,
         _: RequestContext<RoleServer>,
-    ) -> Result<ListResourceTemplatesResult, McpError> {
+    ) -> Result<ListResourceTemplatesResult, ErrorData> {
         Ok(ListResourceTemplatesResult {
             next_cursor: None,
             resource_templates: Vec::new(),
@@ -178,7 +178,7 @@ impl ServerHandler for Counter {
         &self,
         _request: InitializeRequestParam,
         context: RequestContext<RoleServer>,
-    ) -> Result<InitializeResult, McpError> {
+    ) -> Result<InitializeResult, ErrorData> {
         if let Some(http_request_part) = context.extensions.get::<axum::http::request::Parts>() {
             let initialize_headers = &http_request_part.headers;
             let initialize_uri = &http_request_part.uri;

--- a/rig-core/examples/rmcp.rs
+++ b/rig-core/examples/rmcp.rs
@@ -1,0 +1,270 @@
+use std::sync::Arc;
+
+use rmcp::ServiceExt;
+
+use rig::{
+    client::{CompletionClient, ProviderClient},
+    completion::{Prompt, ToolDefinition},
+    providers::openai,
+    tool::ToolSet,
+    tool::rmcp::McpTool,
+};
+use rmcp::{
+    Error as McpError, RoleServer, ServerHandler,
+    handler::server::{router::tool::ToolRouter, tool::Parameters},
+    model::*,
+    schemars,
+    service::RequestContext,
+    tool, tool_handler, tool_router,
+};
+use serde_json::json;
+use tokio::sync::Mutex;
+
+use hyper_util::{
+    rt::{TokioExecutor, TokioIo},
+    server::conn::auto::Builder,
+    service::TowerToHyperService,
+};
+use rmcp::transport::streamable_http_server::{
+    StreamableHttpService, session::local::LocalSessionManager,
+};
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct StructRequest {
+    pub a: i32,
+    pub b: i32,
+}
+
+#[derive(Clone)]
+pub struct Counter {
+    counter: Arc<Mutex<i32>>,
+    tool_router: ToolRouter<Counter>,
+}
+
+#[tool_router]
+impl Counter {
+    #[allow(dead_code)]
+    pub fn new() -> Self {
+        Self {
+            counter: Arc::new(Mutex::new(0)),
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    fn _create_resource_text(&self, uri: &str, name: &str) -> Resource {
+        RawResource::new(uri, name.to_string()).no_annotation()
+    }
+
+    // #[tool(description = "Increment the counter by 1")]
+    // async fn increment(&self) -> Result<CallToolResult, McpError> {
+    //     let mut counter = self.counter.lock().await;
+    //     *counter += 1;
+    //     Ok(CallToolResult::success(vec![Content::text(
+    //         counter.to_string(),
+    //     )]))
+    // }
+
+    // #[tool(description = "Decrement the counter by 1")]
+    // async fn decrement(&self) -> Result<CallToolResult, McpError> {
+    //     let mut counter = self.counter.lock().await;
+    //     *counter -= 1;
+    //     Ok(CallToolResult::success(vec![Content::text(
+    //         counter.to_string(),
+    //     )]))
+    // }
+
+    // #[tool(description = "Get the current counter value")]
+    // async fn get_value(&self) -> Result<CallToolResult, McpError> {
+    //     let counter = self.counter.lock().await;
+    //     Ok(CallToolResult::success(vec![Content::text(
+    //         counter.to_string(),
+    //     )]))
+    // }
+
+    // #[tool(description = "Say hello to the client")]
+    // fn say_hello(&self) -> Result<CallToolResult, McpError> {
+    //     Ok(CallToolResult::success(vec![Content::text("hello")]))
+    // }
+
+    // #[tool(description = "Repeat what you say")]
+    // fn echo(&self, Parameters(object): Parameters<JsonObject>) -> Result<CallToolResult, McpError> {
+    //     Ok(CallToolResult::success(vec![Content::text(
+    //         serde_json::Value::Object(object).to_string(),
+    //     )]))
+    // }
+
+    #[tool(description = "Calculate the sum of two numbers")]
+    fn sum(
+        &self,
+        Parameters(StructRequest { a, b }): Parameters<StructRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(CallToolResult::success(vec![Content::text(
+            (a + b).to_string(),
+        )]))
+    }
+}
+#[tool_handler]
+impl ServerHandler for Counter {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            protocol_version: ProtocolVersion::V_2024_11_05,
+            capabilities: ServerCapabilities::builder()
+                .enable_resources()
+                .enable_tools()
+                .build(),
+            server_info: Implementation::from_build_env(),
+            instructions: Some("This server provides a counter tool that can increment and decrement values. The counter starts at 0 and can be modified using the 'increment' and 'decrement' tools. Use 'get_value' to check the current count.".to_string()),
+        }
+    }
+
+    async fn list_resources(
+        &self,
+        _request: Option<PaginatedRequestParam>,
+        _: RequestContext<RoleServer>,
+    ) -> Result<ListResourcesResult, McpError> {
+        Ok(ListResourcesResult {
+            resources: vec![
+                self._create_resource_text("str:////Users/to/some/path/", "cwd"),
+                self._create_resource_text("memo://insights", "memo-name"),
+            ],
+            next_cursor: None,
+        })
+    }
+
+    async fn read_resource(
+        &self,
+        ReadResourceRequestParam { uri }: ReadResourceRequestParam,
+        _: RequestContext<RoleServer>,
+    ) -> Result<ReadResourceResult, McpError> {
+        match uri.as_str() {
+            "str:////Users/to/some/path/" => {
+                let cwd = "/Users/to/some/path/";
+                Ok(ReadResourceResult {
+                    contents: vec![ResourceContents::text(cwd, uri)],
+                })
+            }
+            "memo://insights" => {
+                let memo = "Business Intelligence Memo\n\nAnalysis has revealed 5 key insights ...";
+                Ok(ReadResourceResult {
+                    contents: vec![ResourceContents::text(memo, uri)],
+                })
+            }
+            _ => Err(McpError::resource_not_found(
+                "resource_not_found",
+                Some(json!({
+                    "uri": uri
+                })),
+            )),
+        }
+    }
+
+    async fn list_resource_templates(
+        &self,
+        _request: Option<PaginatedRequestParam>,
+        _: RequestContext<RoleServer>,
+    ) -> Result<ListResourceTemplatesResult, McpError> {
+        Ok(ListResourceTemplatesResult {
+            next_cursor: None,
+            resource_templates: Vec::new(),
+        })
+    }
+
+    async fn initialize(
+        &self,
+        _request: InitializeRequestParam,
+        context: RequestContext<RoleServer>,
+    ) -> Result<InitializeResult, McpError> {
+        if let Some(http_request_part) = context.extensions.get::<axum::http::request::Parts>() {
+            let initialize_headers = &http_request_part.headers;
+            let initialize_uri = &http_request_part.uri;
+            tracing::info!(?initialize_headers, %initialize_uri, "initialize from http server");
+        }
+        Ok(self.get_info())
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let service = TowerToHyperService::new(StreamableHttpService::new(
+        || Ok(Counter::new()),
+        LocalSessionManager::default().into(),
+        Default::default(),
+    ));
+    let listener = tokio::net::TcpListener::bind("localhost:8080").await?;
+
+    tokio::spawn({
+        let service = service.clone();
+        async move {
+            loop {
+                tokio::select! {
+                    _ = tokio::signal::ctrl_c() => {
+                        println!("Received Ctrl+C, shutting down");
+                        break;
+                    }
+                    accept = listener.accept() => {
+                        match accept {
+                            Ok((stream, _addr)) => {
+                                let io = TokioIo::new(stream);
+                                let service = service.clone();
+
+                                tokio::spawn(async move {
+                                    if let Err(e) = Builder::new(TokioExecutor::default())
+                                        .serve_connection(io, service)
+                                        .await
+                                    {
+                                        eprintln!("Connection error: {:?}", e);
+                                    }
+                                });
+                            }
+                            Err(e) => {
+                                eprintln!("Accept error: {:?}", e);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    let transport =
+        rmcp::transport::StreamableHttpClientTransport::from_uri("http://localhost:8080");
+
+    let client_info = ClientInfo {
+        protocol_version: Default::default(),
+        capabilities: ClientCapabilities::default(),
+        client_info: Implementation {
+            name: "rig-core".to_string(),
+            version: "0.13.0".to_string(),
+        },
+    };
+
+    let client = client_info.serve(transport).await.inspect_err(|e| {
+        tracing::error!("client error: {:?}", e);
+    })?;
+
+    // Initialize
+    let server_info = client.peer_info();
+    tracing::info!("Connected to server: {server_info:#?}");
+
+    // List tools
+    let tools: Vec<Tool> = client.list_tools(Default::default()).await?.tools;
+
+    // takes the `OPENAI_API_KEY` as an env var on usage
+    let openai_client = openai::Client::from_env();
+    let mut agent = openai_client
+        .agent("gpt-4o")
+        .preamble("You are a helpful assistant who has access to a number of tools from an MCP server designed to be used for incrementing and decrementing a counter.");
+
+    let agent = tools
+        .into_iter()
+        .fold(agent, |agent, tool| agent.rmcp_tool(tool, client.clone()))
+        .build();
+
+    let res = agent.prompt("What is 2+5?").multi_turn(2).await.unwrap();
+
+    println!("GPT-4o: {res}");
+
+    Ok(())
+}

--- a/rig-core/examples/rmcp.rs
+++ b/rig-core/examples/rmcp.rs
@@ -1,13 +1,12 @@
+//! An example of how you can use `rmcp` with Rig to create an MCP friendly agent.
 use std::sync::Arc;
 
 use rmcp::ServiceExt;
 
 use rig::{
     client::{CompletionClient, ProviderClient},
-    completion::{Prompt, ToolDefinition},
+    completion::Prompt,
     providers::openai,
-    tool::ToolSet,
-    tool::rmcp::McpTool,
 };
 use rmcp::{
     Error as McpError, RoleServer, ServerHandler,
@@ -37,8 +36,14 @@ pub struct StructRequest {
 
 #[derive(Clone)]
 pub struct Counter {
-    counter: Arc<Mutex<i32>>,
+    pub counter: Arc<Mutex<i32>>,
     tool_router: ToolRouter<Counter>,
+}
+
+impl Default for Counter {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[tool_router]
@@ -214,12 +219,12 @@ async fn main() -> anyhow::Result<()> {
                                         .serve_connection(io, service)
                                         .await
                                     {
-                                        eprintln!("Connection error: {:?}", e);
+                                        eprintln!("Connection error: {e:?}");
                                     }
                                 });
                             }
                             Err(e) => {
-                                eprintln!("Accept error: {:?}", e);
+                                eprintln!("Accept error: {e:?}");
                             }
                         }
                     }
@@ -253,7 +258,7 @@ async fn main() -> anyhow::Result<()> {
 
     // takes the `OPENAI_API_KEY` as an env var on usage
     let openai_client = openai::Client::from_env();
-    let mut agent = openai_client
+    let agent = openai_client
         .agent("gpt-4o")
         .preamble("You are a helpful assistant who has access to a number of tools from an MCP server designed to be used for incrementing and decrementing a counter.");
 

--- a/rig-core/src/agent/builder.rs
+++ b/rig-core/src/agent/builder.rs
@@ -7,7 +7,10 @@ use crate::{
 };
 
 #[cfg(feature = "mcp")]
-use crate::tool::McpTool;
+use crate::tool::mcp::McpTool;
+
+#[cfg(feature = "rmcp")]
+use crate::tool::rmcp::McpTool as RmcpTool;
 
 use super::Agent;
 
@@ -115,6 +118,15 @@ impl<M: CompletionModel> AgentBuilder<M> {
         let toolname = tool.name.clone();
         self.tools.add_tool(McpTool::from_mcp_server(tool, client));
         self.static_tools.push(toolname);
+        self
+    }
+
+    // Add an MCP tool (from `rmcp`) to the agent
+    #[cfg(feature = "rmcp")]
+    pub fn rmcp_tool(mut self, tool: rmcp::model::Tool, client: rmcp::service::ServerSink) -> Self {
+        let toolname = tool.name.clone();
+        self.tools.add_tool(RmcpTool::from_mcp_server(tool, client));
+        self.static_tools.push(toolname.to_string());
         self
     }
 

--- a/rig-core/src/providers/openai/completion.rs
+++ b/rig-core/src/providers/openai/completion.rs
@@ -697,6 +697,11 @@ impl completion::CompletionModel for CompletionModel {
     ) -> Result<completion::CompletionResponse<CompletionResponse>, CompletionError> {
         let request = self.create_completion_request(completion_request)?;
 
+        tracing::debug!(
+            "OpenAI request: {request}",
+            request = serde_json::to_string_pretty(&request).unwrap()
+        );
+
         let response = self
             .client
             .post("/chat/completions")

--- a/rig-core/src/tool.rs
+++ b/rig-core/src/tool.rs
@@ -326,6 +326,144 @@ where
     }
 }
 
+#[cfg(feature = "rmcp")]
+pub struct McpTool {
+    definition: rmcp::model::Tool,
+    client: rmcp::service::ServerSink,
+}
+
+#[cfg(feature = "rmcp")]
+impl McpTool {
+    pub fn from_mcp_server(
+        definition: rmcp::model::Tool,
+        client: rmcp::service::ServerSink,
+    ) -> Self {
+        Self { definition, client }
+    }
+}
+
+#[cfg(feature = "rmcp")]
+impl From<&rmcp::model::Tool> for ToolDefinition {
+    fn from(val: &rmcp::model::Tool) -> Self {
+        Self {
+            name: val.name.to_string(),
+            description: val.description.to_string(),
+            parameters: val.schema_as_json_value(),
+        }
+    }
+}
+
+#[cfg(feature = "rmcp")]
+impl From<rmcp::model::Tool> for ToolDefinition {
+    fn from(val: rmcp::model::Tool) -> Self {
+        Self {
+            name: val.name.to_string(),
+            description: val.description.to_string(),
+            parameters: val.schema_as_json_value(),
+        }
+    }
+}
+
+#[cfg(feature = "rmcp")]
+#[derive(Debug, thiserror::Error)]
+#[error("MCP tool error: {0}")]
+pub struct McpToolError(String);
+
+#[cfg(feature = "rmcp")]
+impl From<McpToolError> for ToolError {
+    fn from(e: McpToolError) -> Self {
+        ToolError::ToolCallError(Box::new(e))
+    }
+}
+
+#[cfg(feature = "rmcp")]
+impl ToolDyn for McpTool {
+    fn name(&self) -> String {
+        self.definition.name.to_string()
+    }
+
+    fn definition(
+        &self,
+        _prompt: String,
+    ) -> Pin<Box<dyn Future<Output = ToolDefinition> + Send + Sync + '_>> {
+        Box::pin(async move {
+            ToolDefinition {
+                name: self.definition.name.to_string(),
+                description: self.definition.description.to_string(),
+                parameters: serde_json::to_value(&self.definition.input_schema).unwrap_or_default(),
+            }
+        })
+    }
+
+    fn call(
+        &self,
+        args: String,
+    ) -> Pin<Box<dyn Future<Output = Result<String, ToolError>> + Send + Sync + '_>> {
+        let name = self.definition.name.clone();
+        let arguments = serde_json::from_str(&args).unwrap_or_default();
+
+        Box::pin(async move {
+            let result = self
+                .client
+                .call_tool(rmcp::model::CallToolRequestParam { name, arguments })
+                .await
+                .map_err(|e| McpToolError(format!("Tool returned an error: {}", e)))?;
+
+            if result.is_error.unwrap_or(false) {
+                if let Some(error) = result.content.first() {
+                    if let Some(raw) = error.as_text() {
+                        return Err(McpToolError(raw.text.clone()).into());
+                    } else {
+                        return Err(McpToolError("Unsuppported error type".to_string()).into());
+                    }
+                } else {
+                    return Err(McpToolError("No error message returned".to_string()).into());
+                }
+            };
+
+            Ok(result
+                .content
+                .into_iter()
+                .map(|c| match c.raw {
+                    rmcp::model::RawContent::Text(raw) => raw.text,
+                    rmcp::model::RawContent::Image(raw) => {
+                        format!("data:{};base64,{}", raw.mime_type, raw.data)
+                    }
+                    rmcp::model::RawContent::Resource(raw) => match raw.resource {
+                        rmcp::model::ResourceContents::TextResourceContents {
+                            uri,
+                            mime_type,
+                            text,
+                        } => {
+                            format!(
+                                "{}{}:{}",
+                                mime_type
+                                    .map(|m| format!("data:{};", m))
+                                    .unwrap_or_default(),
+                                uri,
+                                text
+                            )
+                        }
+                        rmcp::model::ResourceContents::BlobResourceContents {
+                            uri,
+                            mime_type,
+                            blob,
+                        } => format!(
+                            "{}{}:{}",
+                            mime_type
+                                .map(|m| format!("data:{};", m))
+                                .unwrap_or_default(),
+                            uri,
+                            blob
+                        ),
+                    },
+                })
+                .collect::<Vec<_>>()
+                .join(""))
+        })
+    }
+}
+
 /// Wrapper trait to allow for dynamic dispatch of raggable tools
 pub trait ToolEmbeddingDyn: ToolDyn {
     fn context(&self) -> serde_json::Result<serde_json::Value>;


### PR DESCRIPTION
Fixes #551
Fixes RIG-799

Supercedes #422 due to internal business requirements and therefore some urgency may be required for keeping on top of CI. Credits to @byeblack for the initial submitted code.

The current MCP items have been put into a new `mcp` module within the tools file and the new items from `rmcp` have been added into an `rmcp` module. This prevents module conflicts and should allow for an easy transition between the two. The release after next, we should put a deprecation warning on the original `mcp` module to let people know we will be deprecating it.