### PR TITLE
feat: add `.extended_details` to `PromptRequest`

### DIFF
--- a/rig-bedrock/src/types/assistant_content.rs
+++ b/rig-bedrock/src/types/assistant_content.rs
@@ -42,6 +42,16 @@ impl TryFrom<AwsConverseOutput> for completion::CompletionResponse<AwsConverseOu
             )),
         }?;
 
+        let usage = value
+            .0
+            .usage()
+            .map(|usage| completion::Usage {
+                prompt_tokens: usage.input_tokens as u64,
+                completion_tokens: usage.output_tokens as u64,
+                total_tokens: usage.total_tokens as u64,
+            })
+            .unwrap_or_default();
+
         if let Some(tool_use) = choice.iter().find_map(|content| match content {
             AssistantContent::ToolCall(tool_call) => Some(tool_call.to_owned()),
             _ => None,
@@ -55,12 +65,14 @@ impl TryFrom<AwsConverseOutput> for completion::CompletionResponse<AwsConverseOu
                         arguments: tool_use.function.arguments,
                     },
                 })),
+                usage,
                 raw_response: value,
             });
         }
 
         Ok(completion::CompletionResponse {
             choice,
+            usage,
             raw_response: value,
         })
     }

--- a/rig-bedrock/src/types/assistant_content.rs
+++ b/rig-bedrock/src/types/assistant_content.rs
@@ -46,8 +46,8 @@ impl TryFrom<AwsConverseOutput> for completion::CompletionResponse<AwsConverseOu
             .0
             .usage()
             .map(|usage| completion::Usage {
-                prompt_tokens: usage.input_tokens as u64,
-                completion_tokens: usage.output_tokens as u64,
+                input_tokens: usage.input_tokens as u64,
+                output_tokens: usage.output_tokens as u64,
                 total_tokens: usage.total_tokens as u64,
             })
             .unwrap_or_default();

--- a/rig-core/examples/multi_turn_agent.rs
+++ b/rig-core/examples/multi_turn_agent.rs
@@ -135,6 +135,7 @@ impl Tool for Subtract {
     }
 }
 
+#[derive(Deserialize, Serialize)]
 struct Multiply;
 
 impl Tool for Multiply {
@@ -170,6 +171,7 @@ impl Tool for Multiply {
     }
 }
 
+#[derive(Deserialize, Serialize)]
 struct Divide;
 
 impl Tool for Divide {

--- a/rig-core/examples/multi_turn_agent_extended.rs
+++ b/rig-core/examples/multi_turn_agent_extended.rs
@@ -41,7 +41,7 @@ async fn main() -> anyhow::Result<()> {
         .extended_details()
         .await?;
 
-    println!("\n\nOpenAI Calculator Agent: {:?}", result);
+    println!("\n\nOpenAI Calculator Agent: {result:?}");
 
     // Prompt the agent again and print the response
     let result = agent
@@ -50,7 +50,7 @@ async fn main() -> anyhow::Result<()> {
         .extended_details()
         .await?;
 
-    println!("\n\nOpenAI Calculator Agent: {:?}", result);
+    println!("\n\nOpenAI Calculator Agent: {result:?}");
 
     Ok(())
 }

--- a/rig-core/examples/multi_turn_agent_extended.rs
+++ b/rig-core/examples/multi_turn_agent_extended.rs
@@ -137,6 +137,7 @@ impl Tool for Subtract {
     }
 }
 
+#[derive(Deserialize, Serialize)]
 struct Multiply;
 
 impl Tool for Multiply {
@@ -172,6 +173,7 @@ impl Tool for Multiply {
     }
 }
 
+#[derive(Deserialize, Serialize)]
 struct Divide;
 
 impl Tool for Divide {

--- a/rig-core/examples/multi_turn_agent_extended.rs
+++ b/rig-core/examples/multi_turn_agent_extended.rs
@@ -1,0 +1,208 @@
+use rig::prelude::*;
+use rig::{
+    completion::{Prompt, ToolDefinition},
+    providers::anthropic,
+    tool::Tool,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG)
+        .with_target(false)
+        .init();
+
+    // Create OpenAI client
+    let openai_client = anthropic::Client::from_env();
+
+    // Create RAG agent with a single context prompt and a dynamic tool source
+    let agent = openai_client
+        .agent(anthropic::CLAUDE_3_5_SONNET)
+        .preamble(
+            "You are an assistant here to help the user select which tool is most appropriate to perform arithmetic operations.
+            Follow these instructions closely.
+            1. Consider the user's request carefully and identify the core elements of the request.
+            2. Select which tool among those made available to you is appropriate given the context.
+            3. This is very important: never perform the operation yourself.
+            "
+        )
+        .tool(Add)
+        .tool(Subtract)
+        .tool(Multiply)
+        .tool(Divide)
+        .build();
+
+    // Prompt the agent and print the response
+    let result = agent
+        .prompt("Calculate 5 - 2 = ?. Describe the result to me.")
+        .multi_turn(20)
+        .extended_details()
+        .await?;
+
+    println!("\n\nOpenAI Calculator Agent: {:?}", result);
+
+    // Prompt the agent again and print the response
+    let result = agent
+        .prompt("Calculate (3 + 5) / 9  = ?. Describe the result to me.")
+        .multi_turn(20)
+        .extended_details()
+        .await?;
+
+    println!("\n\nOpenAI Calculator Agent: {:?}", result);
+
+    Ok(())
+}
+
+#[derive(Deserialize)]
+struct OperationArgs {
+    x: i32,
+    y: i32,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("Math error")]
+struct MathError;
+
+#[derive(Deserialize, Serialize)]
+struct Add;
+
+impl Tool for Add {
+    const NAME: &'static str = "add";
+    type Error = MathError;
+    type Args = OperationArgs;
+    type Output = i32;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        serde_json::from_value(json!({
+            "name": "add",
+            "description": "Add x and y together",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "x": {
+                        "type": "number",
+                        "description": "The first number to add"
+                    },
+                    "y": {
+                        "type": "number",
+                        "description": "The second number to add"
+                    }
+                }
+            }
+        }))
+        .expect("Tool Definition")
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        let result = args.x + args.y;
+        Ok(result)
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+struct Subtract;
+
+impl Tool for Subtract {
+    const NAME: &'static str = "subtract";
+    type Error = MathError;
+    type Args = OperationArgs;
+    type Output = i32;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        serde_json::from_value(json!({
+            "name": "subtract",
+            "description": "Subtract y from x (i.e.: x - y)",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "x": {
+                        "type": "number",
+                        "description": "The number to subtract from"
+                    },
+                    "y": {
+                        "type": "number",
+                        "description": "The number to subtract"
+                    }
+                }
+            }
+        }))
+        .expect("Tool Definition")
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        let result = args.x - args.y;
+        Ok(result)
+    }
+}
+
+struct Multiply;
+
+impl Tool for Multiply {
+    const NAME: &'static str = "multiply";
+    type Error = MathError;
+    type Args = OperationArgs;
+    type Output = i32;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        serde_json::from_value(json!({
+            "name": "multiply",
+            "description": "Compute the product of x and y (i.e.: x * y)",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "x": {
+                        "type": "number",
+                        "description": "The first factor in the product"
+                    },
+                    "y": {
+                        "type": "number",
+                        "description": "The second factor in the product"
+                    }
+                }
+            }
+        }))
+        .expect("Tool Definition")
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        let result = args.x * args.y;
+        Ok(result)
+    }
+}
+
+struct Divide;
+
+impl Tool for Divide {
+    const NAME: &'static str = "divide";
+    type Error = MathError;
+    type Args = OperationArgs;
+    type Output = i32;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        serde_json::from_value(json!({
+            "name": "divide",
+            "description": "Compute the Quotient of x and y (i.e.: x / y). Useful for ratios.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "x": {
+                        "type": "number",
+                        "description": "The Dividend of the division. The number being divided"
+                    },
+                    "y": {
+                        "type": "number",
+                        "description": "The Divisor of the division. The number by which the dividend is being divided"
+                    }
+                }
+            }
+        }))
+        .expect("Tool Definition")
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        let result = args.x / args.y;
+        Ok(result)
+    }
+}

--- a/rig-core/src/agent/completion.rs
+++ b/rig-core/src/agent/completion.rs
@@ -1,4 +1,4 @@
-use super::prompt_request::PromptRequest;
+use super::prompt_request::{self, PromptRequest};
 use crate::{
     completion::{
         Chat, Completion, CompletionError, CompletionModel, CompletionRequestBuilder, Document,
@@ -189,14 +189,20 @@ impl<M: CompletionModel> Completion<M> for Agent<M> {
 
 #[allow(refining_impl_trait)]
 impl<M: CompletionModel> Prompt for Agent<M> {
-    fn prompt(&self, prompt: impl Into<Message> + Send) -> PromptRequest<M> {
+    fn prompt(
+        &self,
+        prompt: impl Into<Message> + Send,
+    ) -> PromptRequest<prompt_request::Standard, M> {
         PromptRequest::new(self, prompt)
     }
 }
 
 #[allow(refining_impl_trait)]
 impl<M: CompletionModel> Prompt for &Agent<M> {
-    fn prompt(&self, prompt: impl Into<Message> + Send) -> PromptRequest<M> {
+    fn prompt(
+        &self,
+        prompt: impl Into<Message> + Send,
+    ) -> PromptRequest<prompt_request::Standard, M> {
         PromptRequest::new(*self, prompt)
     }
 }

--- a/rig-core/src/agent/prompt_request.rs
+++ b/rig-core/src/agent/prompt_request.rs
@@ -20,10 +20,12 @@ impl PromptType for Extended {}
 
 /// A builder for creating prompt requests with customizable options.
 /// Uses generics to track which options have been set during the build process.
-/// 
-/// If you're using tools, you will want to ensure you use `.multi_turn()` to add more turns as by
-/// default it is 0 (meaning no tool usage). Otherwise, attempting to await (which will send the
-/// prompt request) returns [`crate::completion::request::PromptError::MaxDepthError`].
+///
+/// If you expect to continously call tools, you will want to ensure you use the `.multi_turn()`
+/// argument to add more turns as by default, it is 0 (meaning only 1 tool round-trip). Otherwise,
+/// attempting to await (which will send the prompt request) can potentially return
+/// [`crate::completion::request::PromptError::MaxDepthError`] if the agent decides to call tools
+/// back to back.
 pub struct PromptRequest<'a, S: PromptType, M: CompletionModel> {
     /// The prompt message to send to the model
     prompt: Message,
@@ -50,6 +52,11 @@ impl<'a, M: CompletionModel> PromptRequest<'a, Standard, M> {
         }
     }
 
+    /// Enable returning extended details for responses (includes aggregated token usage)
+    /// 
+    /// Note: This changes the type of the response from `.send` to return a `PromptResponse` struct
+    /// instead of a simple `String`. This is useful for tracking token usage across multiple turns
+    /// of conversation.
     pub fn extended_details(self) -> PromptRequest<'a, Extended, M> {
         PromptRequest {
             prompt: self.prompt,
@@ -61,16 +68,10 @@ impl<'a, M: CompletionModel> PromptRequest<'a, Standard, M> {
     }
 }
 
-<<<<<<< HEAD
-impl<'a, M: CompletionModel> PromptRequest<'a, M> {
+impl<'a, S: PromptType, M: CompletionModel> PromptRequest<'a, S, M> {
     /// Set the maximum depth for multi-turn conversations (ie, the maximum number of turns an LLM can have calling tools before writing a text response).
     /// If the maximum turn number is exceeded, it will return a [`crate::completion::request::PromptError::MaxDepthError`].
-    pub fn multi_turn(self, depth: usize) -> PromptRequest<'a, M> {
-=======
-impl<'a, S: PromptType, M: CompletionModel> PromptRequest<'a, S, M> {
-    /// Set the maximum depth for multi-turn conversations
     pub fn multi_turn(self, depth: usize) -> PromptRequest<'a, S, M> {
->>>>>>> 5ef0bd2 (feat: add `.extended_details` to `PromptRequest`)
         PromptRequest {
             prompt: self.prompt,
             chat_history: self.chat_history,
@@ -80,13 +81,8 @@ impl<'a, S: PromptType, M: CompletionModel> PromptRequest<'a, S, M> {
         }
     }
 
-<<<<<<< HEAD
-    /// Add chat history to the prompt request.
-    pub fn with_history(self, history: &'a mut Vec<Message>) -> PromptRequest<'a, M> {
-=======
     /// Add chat history to the prompt request
     pub fn with_history(self, history: &'a mut Vec<Message>) -> PromptRequest<'a, S, M> {
->>>>>>> 5ef0bd2 (feat: add `.extended_details` to `PromptRequest`)
         PromptRequest {
             prompt: self.prompt,
             chat_history: Some(history),

--- a/rig-core/src/agent/prompt_request.rs
+++ b/rig-core/src/agent/prompt_request.rs
@@ -53,7 +53,7 @@ impl<'a, M: CompletionModel> PromptRequest<'a, Standard, M> {
     }
 
     /// Enable returning extended details for responses (includes aggregated token usage)
-    /// 
+    ///
     /// Note: This changes the type of the response from `.send` to return a `PromptResponse` struct
     /// instead of a simple `String`. This is useful for tracking token usage across multiple turns
     /// of conversation.

--- a/rig-core/src/agent/prompt_request.rs
+++ b/rig-core/src/agent/prompt_request.rs
@@ -1,21 +1,30 @@
-use std::future::IntoFuture;
+use std::{future::IntoFuture, marker::PhantomData};
 
 use futures::{FutureExt, StreamExt, future::BoxFuture, stream};
 
 use crate::{
     OneOrMany,
-    completion::{Completion, CompletionError, CompletionModel, Message, PromptError},
+    completion::{Completion, CompletionError, CompletionModel, Message, PromptError, Usage},
     message::{AssistantContent, UserContent},
     tool::ToolSetError,
 };
 
 use super::Agent;
 
+pub trait PromptType {}
+pub struct Standard;
+pub struct Extended;
+
+impl PromptType for Standard {}
+impl PromptType for Extended {}
+
 /// A builder for creating prompt requests with customizable options.
 /// Uses generics to track which options have been set during the build process.
-/// If you're using tools, you will want to ensure you use `.multi_turn()` to add more turns as by default it is 0 (meaning no tool usage).
-/// Otherwise, attempting to await (which will send the prompt request) returns [`crate::completion::request::PromptError::MaxDepthError`].
-pub struct PromptRequest<'a, M: CompletionModel> {
+/// 
+/// If you're using tools, you will want to ensure you use `.multi_turn()` to add more turns as by
+/// default it is 0 (meaning no tool usage). Otherwise, attempting to await (which will send the
+/// prompt request) returns [`crate::completion::request::PromptError::MaxDepthError`].
+pub struct PromptRequest<'a, S: PromptType, M: CompletionModel> {
     /// The prompt message to send to the model
     prompt: Message,
     /// Optional chat history to include with the prompt
@@ -25,9 +34,11 @@ pub struct PromptRequest<'a, M: CompletionModel> {
     max_depth: usize,
     /// The agent to use for execution
     agent: &'a Agent<M>,
+    /// Phantom data to track the type of the request
+    state: PhantomData<S>,
 }
 
-impl<'a, M: CompletionModel> PromptRequest<'a, M> {
+impl<'a, M: CompletionModel> PromptRequest<'a, Standard, M> {
     /// Create a new PromptRequest with the given prompt and model
     pub fn new(agent: &'a Agent<M>, prompt: impl Into<Message>) -> Self {
         Self {
@@ -35,29 +46,53 @@ impl<'a, M: CompletionModel> PromptRequest<'a, M> {
             chat_history: None,
             max_depth: 0,
             agent,
+            state: PhantomData,
+        }
+    }
+
+    pub fn extended_details(self) -> PromptRequest<'a, Extended, M> {
+        PromptRequest {
+            prompt: self.prompt,
+            chat_history: self.chat_history,
+            max_depth: self.max_depth,
+            agent: self.agent,
+            state: PhantomData,
         }
     }
 }
 
+<<<<<<< HEAD
 impl<'a, M: CompletionModel> PromptRequest<'a, M> {
     /// Set the maximum depth for multi-turn conversations (ie, the maximum number of turns an LLM can have calling tools before writing a text response).
     /// If the maximum turn number is exceeded, it will return a [`crate::completion::request::PromptError::MaxDepthError`].
     pub fn multi_turn(self, depth: usize) -> PromptRequest<'a, M> {
+=======
+impl<'a, S: PromptType, M: CompletionModel> PromptRequest<'a, S, M> {
+    /// Set the maximum depth for multi-turn conversations
+    pub fn multi_turn(self, depth: usize) -> PromptRequest<'a, S, M> {
+>>>>>>> 5ef0bd2 (feat: add `.extended_details` to `PromptRequest`)
         PromptRequest {
             prompt: self.prompt,
             chat_history: self.chat_history,
             max_depth: depth,
             agent: self.agent,
+            state: PhantomData,
         }
     }
 
+<<<<<<< HEAD
     /// Add chat history to the prompt request.
     pub fn with_history(self, history: &'a mut Vec<Message>) -> PromptRequest<'a, M> {
+=======
+    /// Add chat history to the prompt request
+    pub fn with_history(self, history: &'a mut Vec<Message>) -> PromptRequest<'a, S, M> {
+>>>>>>> 5ef0bd2 (feat: add `.extended_details` to `PromptRequest`)
         PromptRequest {
             prompt: self.prompt,
             chat_history: Some(history),
             max_depth: self.max_depth,
             agent: self.agent,
+            state: PhantomData,
         }
     }
 }
@@ -65,7 +100,7 @@ impl<'a, M: CompletionModel> PromptRequest<'a, M> {
 /// Due to: [RFC 2515](https://github.com/rust-lang/rust/issues/63063), we have to use a `BoxFuture`
 ///  for the `IntoFuture` implementation. In the future, we should be able to use `impl Future<...>`
 ///  directly via the associated type.
-impl<'a, M: CompletionModel> IntoFuture for PromptRequest<'a, M> {
+impl<'a, M: CompletionModel> IntoFuture for PromptRequest<'a, Standard, M> {
     type Output = Result<String, PromptError>;
     type IntoFuture = BoxFuture<'a, Self::Output>; // This future should not outlive the agent
 
@@ -74,8 +109,38 @@ impl<'a, M: CompletionModel> IntoFuture for PromptRequest<'a, M> {
     }
 }
 
-impl<M: CompletionModel> PromptRequest<'_, M> {
+impl<'a, M: CompletionModel> IntoFuture for PromptRequest<'a, Extended, M> {
+    type Output = Result<PromptResponse, PromptError>;
+    type IntoFuture = BoxFuture<'a, Self::Output>; // This future should not outlive the agent
+
+    fn into_future(self) -> Self::IntoFuture {
+        self.send().boxed()
+    }
+}
+
+impl<M: CompletionModel> PromptRequest<'_, Standard, M> {
     async fn send(self) -> Result<String, PromptError> {
+        self.extended_details().send().await.map(|resp| resp.output)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PromptResponse {
+    pub output: String,
+    pub total_usage: Usage,
+}
+
+impl PromptResponse {
+    pub fn new(output: impl Into<String>, total_usage: Usage) -> Self {
+        Self {
+            output: output.into(),
+            total_usage,
+        }
+    }
+}
+
+impl<M: CompletionModel> PromptRequest<'_, Extended, M> {
+    async fn send(self) -> Result<PromptResponse, PromptError> {
         let agent = self.agent;
         let chat_history = if let Some(history) = self.chat_history {
             history.push(self.prompt);
@@ -85,6 +150,8 @@ impl<M: CompletionModel> PromptRequest<'_, M> {
         };
 
         let mut current_max_depth = 0;
+        let mut usage = Usage::new();
+
         // We need to do atleast 2 loops for 1 roundtrip (user expects normal message)
         let last_prompt = loop {
             let prompt = chat_history
@@ -111,6 +178,8 @@ impl<M: CompletionModel> PromptRequest<'_, M> {
                 .await?
                 .send()
                 .await?;
+
+            usage += resp.usage;
 
             let (tool_calls, texts): (Vec<_>, Vec<_>) = resp
                 .choice
@@ -139,8 +208,8 @@ impl<M: CompletionModel> PromptRequest<'_, M> {
                     tracing::info!("Depth reached: {}/{}", current_max_depth, self.max_depth);
                 }
 
-                // If there are no tool calls, depth is not relevant, we can just return the merged text.
-                return Ok(merged_texts);
+                // If there are no tool calls, depth is not relevant, we can just return the merged text response.
+                return Ok(PromptResponse::new(merged_texts, usage));
             }
 
             let tool_content = stream::iter(tool_calls)

--- a/rig-core/src/completion/request.rs
+++ b/rig-core/src/completion/request.rs
@@ -235,8 +235,8 @@ pub struct CompletionResponse<T> {
 /// If tokens used are `0`, then the provider failed to supply token usage metrics.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct Usage {
-    pub prompt_tokens: u64,
-    pub completion_tokens: u64,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
     // We store this separately as some providers may only report one number
     pub total_tokens: u64,
 }
@@ -244,8 +244,8 @@ pub struct Usage {
 impl Usage {
     pub fn new() -> Self {
         Self {
-            prompt_tokens: 0,
-            completion_tokens: 0,
+            input_tokens: 0,
+            output_tokens: 0,
             total_tokens: 0,
         }
     }
@@ -262,8 +262,8 @@ impl Add for Usage {
 
     fn add(self, other: Self) -> Self::Output {
         Self {
-            prompt_tokens: self.prompt_tokens + other.prompt_tokens,
-            completion_tokens: self.completion_tokens + other.completion_tokens,
+            input_tokens: self.input_tokens + other.input_tokens,
+            output_tokens: self.output_tokens + other.output_tokens,
             total_tokens: self.total_tokens + other.total_tokens,
         }
     }
@@ -271,8 +271,8 @@ impl Add for Usage {
 
 impl AddAssign for Usage {
     fn add_assign(&mut self, other: Self) {
-        self.prompt_tokens += other.prompt_tokens;
-        self.completion_tokens += other.completion_tokens;
+        self.input_tokens += other.input_tokens;
+        self.output_tokens += other.output_tokens;
         self.total_tokens += other.total_tokens;
     }
 }

--- a/rig-core/src/completion/request.rs
+++ b/rig-core/src/completion/request.rs
@@ -75,6 +75,7 @@ use crate::{
 use futures::future::BoxFuture;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::ops::{Add, AddAssign};
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -224,8 +225,56 @@ pub struct CompletionResponse<T> {
     /// The completion choice (represented by one or more assistant message content)
     /// returned by the completion model provider
     pub choice: OneOrMany<AssistantContent>,
+    /// Tokens used during prompting and responding
+    pub usage: Usage,
     /// The raw response returned by the completion model provider
     pub raw_response: T,
+}
+
+/// Struct representing the token usage for a completion request.
+/// If tokens used are `0`, then the provider failed to supply token usage metrics.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct Usage {
+    pub prompt_tokens: u64,
+    pub completion_tokens: u64,
+    // We store this separately as some providers may only report one number
+    pub total_tokens: u64,
+}
+
+impl Usage {
+    pub fn new() -> Self {
+        Self {
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            total_tokens: 0,
+        }
+    }
+}
+
+impl Default for Usage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Add for Usage {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self::Output {
+        Self {
+            prompt_tokens: self.prompt_tokens + other.prompt_tokens,
+            completion_tokens: self.completion_tokens + other.completion_tokens,
+            total_tokens: self.total_tokens + other.total_tokens,
+        }
+    }
+}
+
+impl AddAssign for Usage {
+    fn add_assign(&mut self, other: Self) {
+        self.prompt_tokens += other.prompt_tokens;
+        self.completion_tokens += other.completion_tokens;
+        self.total_tokens += other.total_tokens;
+    }
 }
 
 /// Trait defining a completion model that can be used to generate completion responses.
@@ -288,6 +337,7 @@ where
                 .await
                 .map(|resp| CompletionResponse {
                     choice: resp.choice,
+                    usage: resp.usage,
                     raw_response: (),
                 })
         })

--- a/rig-core/src/providers/anthropic/completion.rs
+++ b/rig-core/src/providers/anthropic/completion.rs
@@ -119,8 +119,15 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             )
         })?;
 
+        let usage = completion::Usage {
+            prompt_tokens: response.usage.input_tokens as u64,
+            completion_tokens: response.usage.output_tokens as u64,
+            total_tokens: (response.usage.input_tokens + response.usage.output_tokens) as u64,
+        };
+
         Ok(completion::CompletionResponse {
             choice,
+            usage,
             raw_response: response,
         })
     }

--- a/rig-core/src/providers/anthropic/completion.rs
+++ b/rig-core/src/providers/anthropic/completion.rs
@@ -120,8 +120,8 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
         })?;
 
         let usage = completion::Usage {
-            prompt_tokens: response.usage.input_tokens,
-            completion_tokens: response.usage.output_tokens,
+            input_tokens: response.usage.input_tokens,
+            output_tokens: response.usage.output_tokens,
             total_tokens: response.usage.input_tokens + response.usage.output_tokens,
         };
 

--- a/rig-core/src/providers/anthropic/completion.rs
+++ b/rig-core/src/providers/anthropic/completion.rs
@@ -120,9 +120,9 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
         })?;
 
         let usage = completion::Usage {
-            prompt_tokens: response.usage.input_tokens as u64,
-            completion_tokens: response.usage.output_tokens as u64,
-            total_tokens: (response.usage.input_tokens + response.usage.output_tokens) as u64,
+            prompt_tokens: response.usage.input_tokens,
+            completion_tokens: response.usage.output_tokens,
+            total_tokens: response.usage.input_tokens + response.usage.output_tokens,
         };
 
         Ok(completion::CompletionResponse {

--- a/rig-core/src/providers/cohere/completion.rs
+++ b/rig-core/src/providers/cohere/completion.rs
@@ -114,8 +114,8 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                 let output_tokens = tokens.output_tokens.unwrap_or(0.0);
 
                 completion::Usage {
-                    prompt_tokens: input_tokens as u64,
-                    completion_tokens: output_tokens as u64,
+                    input_tokens: input_tokens as u64,
+                    output_tokens: output_tokens as u64,
                     total_tokens: (input_tokens + output_tokens) as u64,
                 }
             })

--- a/rig-core/src/providers/cohere/completion.rs
+++ b/rig-core/src/providers/cohere/completion.rs
@@ -105,8 +105,25 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             })?
         };
 
+        let usage = response
+            .usage
+            .as_ref()
+            .and_then(|usage| usage.tokens.as_ref())
+            .map(|tokens| {
+            let input_tokens = tokens.input_tokens.unwrap_or(0.0);
+            let output_tokens = tokens.output_tokens.unwrap_or(0.0);
+
+            completion::Usage {
+                prompt_tokens: input_tokens as u64,
+                completion_tokens: output_tokens as u64,
+                total_tokens: (input_tokens + output_tokens) as u64,
+            }
+            })
+            .unwrap_or_default();
+
         Ok(completion::CompletionResponse {
             choice: OneOrMany::many(model_response).expect("There is atleast one content"),
+            usage,
             raw_response: response,
         })
     }

--- a/rig-core/src/providers/cohere/completion.rs
+++ b/rig-core/src/providers/cohere/completion.rs
@@ -110,14 +110,14 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             .as_ref()
             .and_then(|usage| usage.tokens.as_ref())
             .map(|tokens| {
-            let input_tokens = tokens.input_tokens.unwrap_or(0.0);
-            let output_tokens = tokens.output_tokens.unwrap_or(0.0);
+                let input_tokens = tokens.input_tokens.unwrap_or(0.0);
+                let output_tokens = tokens.output_tokens.unwrap_or(0.0);
 
-            completion::Usage {
-                prompt_tokens: input_tokens as u64,
-                completion_tokens: output_tokens as u64,
-                total_tokens: (input_tokens + output_tokens) as u64,
-            }
+                completion::Usage {
+                    prompt_tokens: input_tokens as u64,
+                    completion_tokens: output_tokens as u64,
+                    total_tokens: (input_tokens + output_tokens) as u64,
+                }
             })
             .unwrap_or_default();
 

--- a/rig-core/src/providers/deepseek.rs
+++ b/rig-core/src/providers/deepseek.rs
@@ -405,8 +405,8 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
         })?;
 
         let usage = completion::Usage {
-            prompt_tokens: response.usage.prompt_tokens as u64,
-            completion_tokens: response.usage.completion_tokens as u64,
+            input_tokens: response.usage.prompt_tokens as u64,
+            output_tokens: response.usage.completion_tokens as u64,
             total_tokens: response.usage.total_tokens as u64,
         };
 

--- a/rig-core/src/providers/deepseek.rs
+++ b/rig-core/src/providers/deepseek.rs
@@ -568,12 +568,21 @@ mod tests {
 
     #[test]
     fn test_deserialize_deepseek_response() {
-        let data = r#"{"choices":[{
-            "finish_reason": "stop",
-            "index": 0,
-            "logprobs": null,
-            "message":{"role":"assistant","content":"Hello, world!"}
-            }]}"#;
+        let data = r#"{
+            "choices":[{
+                "finish_reason": "stop",
+                "index": 0,
+                "logprobs": null,
+                "message":{"role":"assistant","content":"Hello, world!"}
+            }],
+            "usage": {
+                "completion_tokens": 0,
+                "prompt_tokens": 0,
+                "prompt_cache_hit_tokens": 0,
+                "prompt_cache_miss_tokens": 0,
+                "total_tokens": 0
+            }
+        }"#;
 
         let jd = &mut serde_json::Deserializer::from_str(data);
         let result: Result<CompletionResponse, _> = serde_path_to_error::deserialize(jd);

--- a/rig-core/src/providers/galadriel.rs
+++ b/rig-core/src/providers/galadriel.rs
@@ -248,9 +248,19 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                 "Response contained no message or tool call (empty)".to_owned(),
             )
         })?;
+        let usage = response
+            .usage
+            .as_ref()
+            .map(|usage| completion::Usage {
+                prompt_tokens: usage.prompt_tokens as u64,
+                completion_tokens: (usage.total_tokens - usage.prompt_tokens) as u64,
+                total_tokens: usage.total_tokens as u64,
+            })
+            .unwrap_or_default();
 
         Ok(completion::CompletionResponse {
             choice,
+            usage,
             raw_response: response,
         })
     }

--- a/rig-core/src/providers/galadriel.rs
+++ b/rig-core/src/providers/galadriel.rs
@@ -252,8 +252,8 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             .usage
             .as_ref()
             .map(|usage| completion::Usage {
-                prompt_tokens: usage.prompt_tokens as u64,
-                completion_tokens: (usage.total_tokens - usage.prompt_tokens) as u64,
+                input_tokens: usage.prompt_tokens as u64,
+                output_tokens: (usage.total_tokens - usage.prompt_tokens) as u64,
                 total_tokens: usage.total_tokens as u64,
             })
             .unwrap_or_default();

--- a/rig-core/src/providers/gemini/completion.rs
+++ b/rig-core/src/providers/gemini/completion.rs
@@ -255,8 +255,19 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse<Generat
             )
         })?;
 
+        let usage = response
+            .usage_metadata
+            .as_ref()
+            .map(|usage| completion::Usage {
+                prompt_tokens: usage.prompt_token_count as u64,
+                completion_tokens: usage.candidates_token_count as u64,
+                total_tokens: usage.total_token_count as u64,
+            })
+            .unwrap_or_default();
+
         Ok(completion::CompletionResponse {
             choice,
+            usage,
             raw_response: response,
         })
     }

--- a/rig-core/src/providers/gemini/completion.rs
+++ b/rig-core/src/providers/gemini/completion.rs
@@ -259,8 +259,8 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse<Generat
             .usage_metadata
             .as_ref()
             .map(|usage| completion::Usage {
-                prompt_tokens: usage.prompt_token_count as u64,
-                completion_tokens: usage.candidates_token_count as u64,
+                input_tokens: usage.prompt_token_count as u64,
+                output_tokens: usage.candidates_token_count as u64,
                 total_tokens: usage.total_token_count as u64,
             })
             .unwrap_or_default();

--- a/rig-core/src/providers/huggingface/completion.rs
+++ b/rig-core/src/providers/huggingface/completion.rs
@@ -475,8 +475,8 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
         })?;
 
         let usage = completion::Usage {
-            prompt_tokens: response.usage.prompt_tokens as u64,
-            completion_tokens: response.usage.completion_tokens as u64,
+            input_tokens: response.usage.prompt_tokens as u64,
+            output_tokens: response.usage.completion_tokens as u64,
             total_tokens: response.usage.total_tokens as u64,
         };
 

--- a/rig-core/src/providers/huggingface/completion.rs
+++ b/rig-core/src/providers/huggingface/completion.rs
@@ -474,8 +474,15 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             )
         })?;
 
+        let usage = completion::Usage {
+            prompt_tokens: response.usage.prompt_tokens as u64,
+            completion_tokens: response.usage.completion_tokens as u64,
+            total_tokens: response.usage.total_tokens as u64,
+        };
+
         Ok(completion::CompletionResponse {
             choice,
+            usage,
             raw_response: response,
         })
     }

--- a/rig-core/src/providers/hyperbolic.rs
+++ b/rig-core/src/providers/hyperbolic.rs
@@ -244,8 +244,19 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             )
         })?;
 
+        let usage = response
+            .usage
+            .as_ref()
+            .map(|usage| completion::Usage {
+                prompt_tokens: usage.prompt_tokens as u64,
+                completion_tokens: (usage.total_tokens - usage.prompt_tokens) as u64,
+                total_tokens: usage.total_tokens as u64,
+            })
+            .unwrap_or_default();
+
         Ok(completion::CompletionResponse {
             choice,
+            usage,
             raw_response: response,
         })
     }

--- a/rig-core/src/providers/hyperbolic.rs
+++ b/rig-core/src/providers/hyperbolic.rs
@@ -248,8 +248,8 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             .usage
             .as_ref()
             .map(|usage| completion::Usage {
-                prompt_tokens: usage.prompt_tokens as u64,
-                completion_tokens: (usage.total_tokens - usage.prompt_tokens) as u64,
+                input_tokens: usage.prompt_tokens as u64,
+                output_tokens: (usage.total_tokens - usage.prompt_tokens) as u64,
                 total_tokens: usage.total_tokens as u64,
             })
             .unwrap_or_default();

--- a/rig-core/src/providers/mira.rs
+++ b/rig-core/src/providers/mira.rs
@@ -403,8 +403,8 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                 let usage = usage
                     .as_ref()
                     .map(|usage| completion::Usage {
-                        prompt_tokens: usage.prompt_tokens as u64,
-                        completion_tokens: (usage.total_tokens - usage.prompt_tokens) as u64,
+                        input_tokens: usage.prompt_tokens as u64,
+                        output_tokens: (usage.total_tokens - usage.prompt_tokens) as u64,
                         total_tokens: usage.total_tokens as u64,
                     })
                     .unwrap_or_default();

--- a/rig-core/src/providers/mistral/completion.rs
+++ b/rig-core/src/providers/mistral/completion.rs
@@ -380,8 +380,8 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             .usage
             .as_ref()
             .map(|usage| completion::Usage {
-                prompt_tokens: usage.prompt_tokens as u64,
-                completion_tokens: (usage.total_tokens - usage.prompt_tokens) as u64,
+                input_tokens: usage.prompt_tokens as u64,
+                output_tokens: (usage.total_tokens - usage.prompt_tokens) as u64,
                 total_tokens: usage.total_tokens as u64,
             })
             .unwrap_or_default();

--- a/rig-core/src/providers/mistral/completion.rs
+++ b/rig-core/src/providers/mistral/completion.rs
@@ -376,8 +376,19 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             )
         })?;
 
+        let usage = response
+            .usage
+            .as_ref()
+            .map(|usage| completion::Usage {
+                prompt_tokens: usage.prompt_tokens as u64,
+                completion_tokens: (usage.total_tokens - usage.prompt_tokens) as u64,
+                total_tokens: usage.total_tokens as u64,
+            })
+            .unwrap_or_default();
+
         Ok(completion::CompletionResponse {
             choice,
+            usage,
             raw_response: response,
         })
     }

--- a/rig-core/src/providers/ollama.rs
+++ b/rig-core/src/providers/ollama.rs
@@ -39,6 +39,7 @@
 //! let extractor = client.extractor::<serde_json::Value>("llama3.2");
 //! ```
 use crate::client::{CompletionClient, EmbeddingsClient, ProviderClient};
+use crate::completion::Usage;
 use crate::json_utils::merge_inplace;
 use crate::message::MessageError;
 use crate::streaming::RawStreamingChoice;
@@ -300,6 +301,9 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                 let choice = OneOrMany::many(assistant_contents).map_err(|_| {
                     CompletionError::ResponseError("No content provided".to_owned())
                 })?;
+                let prompt_tokens = resp.prompt_eval_count.unwrap_or(0);
+                let completion_tokens = resp.eval_count.unwrap_or(0);
+
                 let raw_response = CompletionResponse {
                     model: resp.model,
                     created_at: resp.created_at,
@@ -318,8 +322,14 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                         tool_calls,
                     },
                 };
+
                 Ok(completion::CompletionResponse {
                     choice,
+                    usage: Usage {
+                        prompt_tokens,
+                        completion_tokens,
+                        total_tokens: prompt_tokens + completion_tokens,
+                    },
                     raw_response,
                 })
             }

--- a/rig-core/src/providers/ollama.rs
+++ b/rig-core/src/providers/ollama.rs
@@ -326,8 +326,8 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                 Ok(completion::CompletionResponse {
                     choice,
                     usage: Usage {
-                        prompt_tokens,
-                        completion_tokens,
+                        input_tokens: prompt_tokens,
+                        output_tokens: completion_tokens,
                         total_tokens: prompt_tokens + completion_tokens,
                     },
                     raw_response,

--- a/rig-core/src/providers/openai/completion/mod.rs
+++ b/rig-core/src/providers/openai/completion/mod.rs
@@ -607,8 +607,19 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             )
         })?;
 
+        let usage = response
+            .usage
+            .as_ref()
+            .map(|usage| completion::Usage {
+                prompt_tokens: usage.prompt_tokens as u64,
+                completion_tokens: (usage.total_tokens - usage.prompt_tokens) as u64,
+                total_tokens: usage.total_tokens as u64,
+            })
+            .unwrap_or_default();
+
         Ok(completion::CompletionResponse {
             choice,
+            usage,
             raw_response: response,
         })
     }

--- a/rig-core/src/providers/openai/completion/mod.rs
+++ b/rig-core/src/providers/openai/completion/mod.rs
@@ -611,8 +611,8 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             .usage
             .as_ref()
             .map(|usage| completion::Usage {
-                prompt_tokens: usage.prompt_tokens as u64,
-                completion_tokens: (usage.total_tokens - usage.prompt_tokens) as u64,
+                input_tokens: usage.prompt_tokens as u64,
+                output_tokens: (usage.total_tokens - usage.prompt_tokens) as u64,
                 total_tokens: usage.total_tokens as u64,
             })
             .unwrap_or_default();

--- a/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/rig-core/src/providers/openai/responses_api/mod.rs
@@ -871,8 +871,8 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             .usage
             .as_ref()
             .map(|usage| completion::Usage {
-                prompt_tokens: usage.input_tokens,
-                completion_tokens: usage.output_tokens,
+                input_tokens: usage.input_tokens,
+                output_tokens: usage.output_tokens,
                 total_tokens: usage.total_tokens,
             })
             .unwrap_or_default();

--- a/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/rig-core/src/providers/openai/responses_api/mod.rs
@@ -867,8 +867,19 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             )
         })?;
 
+        let usage = response
+            .usage
+            .as_ref()
+            .map(|usage| completion::Usage {
+                prompt_tokens: usage.input_tokens,
+                completion_tokens: usage.output_tokens,
+                total_tokens: usage.total_tokens,
+            })
+            .unwrap_or_default();
+
         Ok(completion::CompletionResponse {
             choice,
+            usage,
             raw_response: response,
         })
     }

--- a/rig-core/src/providers/openrouter/completion.rs
+++ b/rig-core/src/providers/openrouter/completion.rs
@@ -95,8 +95,19 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             )
         })?;
 
+        let usage = response
+            .usage
+            .as_ref()
+            .map(|usage| completion::Usage {
+                prompt_tokens: usage.prompt_tokens as u64,
+                completion_tokens: (usage.total_tokens - usage.prompt_tokens) as u64,
+                total_tokens: usage.total_tokens as u64,
+            })
+            .unwrap_or_default();
+
         Ok(completion::CompletionResponse {
             choice,
+            usage,
             raw_response: response,
         })
     }

--- a/rig-core/src/providers/openrouter/completion.rs
+++ b/rig-core/src/providers/openrouter/completion.rs
@@ -99,8 +99,8 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             .usage
             .as_ref()
             .map(|usage| completion::Usage {
-                prompt_tokens: usage.prompt_tokens as u64,
-                completion_tokens: (usage.total_tokens - usage.prompt_tokens) as u64,
+                input_tokens: usage.prompt_tokens as u64,
+                output_tokens: (usage.total_tokens - usage.prompt_tokens) as u64,
                 total_tokens: usage.total_tokens as u64,
             })
             .unwrap_or_default();

--- a/rig-core/src/providers/perplexity.rs
+++ b/rig-core/src/providers/perplexity.rs
@@ -203,6 +203,11 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                 content,
             } => Ok(completion::CompletionResponse {
                 choice: OneOrMany::one(content.clone().into()),
+                usage: completion::Usage {
+                    prompt_tokens: response.usage.prompt_tokens as u64,
+                    completion_tokens: response.usage.completion_tokens as u64,
+                    total_tokens: response.usage.total_tokens as u64,
+                },
                 raw_response: response,
             }),
             _ => Err(CompletionError::ResponseError(

--- a/rig-core/src/providers/perplexity.rs
+++ b/rig-core/src/providers/perplexity.rs
@@ -204,8 +204,8 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             } => Ok(completion::CompletionResponse {
                 choice: OneOrMany::one(content.clone().into()),
                 usage: completion::Usage {
-                    prompt_tokens: response.usage.prompt_tokens as u64,
-                    completion_tokens: response.usage.completion_tokens as u64,
+                    input_tokens: response.usage.prompt_tokens as u64,
+                    output_tokens: response.usage.completion_tokens as u64,
                     total_tokens: response.usage.total_tokens as u64,
                 },
                 raw_response: response,

--- a/rig-core/src/providers/xai/completion.rs
+++ b/rig-core/src/providers/xai/completion.rs
@@ -196,8 +196,15 @@ pub mod xai_api_types {
                 )
             })?;
 
+            let usage = completion::Usage {
+                prompt_tokens: response.usage.prompt_tokens as u64,
+                completion_tokens: response.usage.completion_tokens as u64,
+                total_tokens: response.usage.total_tokens as u64,
+            };
+
             Ok(completion::CompletionResponse {
                 choice,
+                usage,
                 raw_response: response,
             })
         }

--- a/rig-core/src/providers/xai/completion.rs
+++ b/rig-core/src/providers/xai/completion.rs
@@ -197,8 +197,8 @@ pub mod xai_api_types {
             })?;
 
             let usage = completion::Usage {
-                prompt_tokens: response.usage.prompt_tokens as u64,
-                completion_tokens: response.usage.completion_tokens as u64,
+                input_tokens: response.usage.prompt_tokens as u64,
+                output_tokens: response.usage.completion_tokens as u64,
                 total_tokens: response.usage.total_tokens as u64,
             };
 

--- a/rig-core/src/streaming.rs
+++ b/rig-core/src/streaming.rs
@@ -11,7 +11,7 @@
 use crate::OneOrMany;
 use crate::agent::Agent;
 use crate::completion::{
-    CompletionError, CompletionModel, CompletionRequestBuilder, CompletionResponse, Message,
+    CompletionError, CompletionModel, CompletionRequestBuilder, CompletionResponse, Message, Usage,
 };
 use crate::message::{AssistantContent, ToolCall, ToolFunction};
 use futures::stream::{AbortHandle, Abortable};
@@ -87,6 +87,7 @@ impl<R: Clone + Unpin> From<StreamingCompletionResponse<R>> for CompletionRespon
     fn from(value: StreamingCompletionResponse<R>) -> CompletionResponse<Option<R>> {
         CompletionResponse {
             choice: value.choice,
+            usage: Usage::new(), // Usage is not tracked in streaming responses
             raw_response: value.response,
         }
     }

--- a/rig-eternalai/src/providers/eternalai.rs
+++ b/rig-eternalai/src/providers/eternalai.rs
@@ -409,8 +409,8 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             .usage
             .as_ref()
             .map(|usage| completion::Usage {
-                prompt_tokens: usage.prompt_tokens as u64,
-                completion_tokens: (usage.total_tokens - usage.prompt_tokens) as u64,
+                input_tokens: usage.prompt_tokens as u64,
+                output_tokens: (usage.total_tokens - usage.prompt_tokens) as u64,
                 total_tokens: usage.total_tokens as u64,
             })
             .unwrap_or_default();

--- a/rig-eternalai/src/providers/eternalai.rs
+++ b/rig-eternalai/src/providers/eternalai.rs
@@ -405,9 +405,19 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                 "Response contained no message or tool call (empty)".to_owned(),
             )
         })?;
+        let usage = response
+            .usage
+            .as_ref()
+            .map(|usage| completion::Usage {
+                prompt_tokens: usage.prompt_tokens as u64,
+                completion_tokens: (usage.total_tokens - usage.prompt_tokens) as u64,
+                total_tokens: usage.total_tokens as u64,
+            })
+            .unwrap_or_default();
 
         Ok(completion::CompletionResponse {
             choice,
+            usage,
             raw_response: response,
         })
     }


### PR DESCRIPTION
Fixes #433

Leverages typestate back on `PromptRequest` since the `.send` needs to return a struct instead of a string. otherwise, this allows you to easily encapsulate aggregated token usage with multi-turn usage.

## Testing
`cargo run --example multi_turn_agent_extended`