### PR TITLE
fix: issue with gemini when there are not tools

### DIFF
--- a/rig-core/src/providers/gemini/completion.rs
+++ b/rig-core/src/providers/gemini/completion.rs
@@ -141,6 +141,12 @@ pub(crate) fn create_request_body(
         role: Some(Role::Model),
     });
 
+    let tools = if completion_request.tools.is_empty() {
+        None
+    } else {
+        Some(Tool::try_from(completion_request.tools)?)
+    };
+
     let request = GenerateContentRequest {
         contents: full_history
             .into_iter()
@@ -151,7 +157,7 @@ pub(crate) fn create_request_body(
             .collect::<Result<Vec<_>, _>>()?,
         generation_config: Some(generation_config),
         safety_settings: None,
-        tools: Some(Tool::try_from(completion_request.tools)?),
+        tools,
         tool_config: None,
         system_instruction,
     };


### PR DESCRIPTION
Fixes:

```
CompletionError: ProviderError: Cannot create OneOrMany with an empty vector.
```

for a agent created with gemini and no tools:

```rust
       // client is a gemini completion client
        let agent = client
            .agent(provider.model())
            .preamble(&metadata.preamble)
            .build();
```