### PR TITLE
fix(rig-811): fix ollama multiple tool results handling

### DIFF
--- a/rig-core/src/providers/ollama.rs
+++ b/rig-core/src/providers/ollama.rs
@@ -41,7 +41,6 @@
 use crate::client::{CompletionClient, EmbeddingsClient, ProviderClient};
 use crate::completion::Usage;
 use crate::json_utils::merge_inplace;
-use crate::message::MessageError;
 use crate::streaming::RawStreamingChoice;
 use crate::{
     Embed, OneOrMany,
@@ -56,7 +55,6 @@ use futures::StreamExt;
 use reqwest;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use std::convert::Infallible;
 use std::{convert::TryFrom, str::FromStr};
 // ---------- Main Client ----------
 
@@ -385,7 +383,10 @@ impl CompletionModel {
             partial_history
                 .into_iter()
                 .map(|msg| msg.try_into())
-                .collect::<Result<Vec<Message>, _>>()?,
+                .collect::<Result<Vec<Vec<Message>>, _>>()?
+                .into_iter()
+                .flatten()
+                .collect::<Vec<Message>>(),
         );
 
         // Convert internal prompt into a provider Message
@@ -636,8 +637,9 @@ pub enum Message {
     },
     #[serde(rename = "tool")]
     ToolResult {
+        #[serde(rename = "tool_name")]
         name: String,
-        content: OneOrMany<ToolResultContent>,
+        content: String,
     },
 }
 
@@ -646,75 +648,91 @@ pub enum Message {
 /// -----------------------------
 /// Conversion from an internal Rig message (crate::message::Message) to a provider Message.
 /// (Only User and Assistant variants are supported.)
-impl TryFrom<crate::message::Message> for Message {
+impl TryFrom<crate::message::Message> for Vec<Message> {
     type Error = crate::message::MessageError;
     fn try_from(internal_msg: crate::message::Message) -> Result<Self, Self::Error> {
         use crate::message::Message as InternalMessage;
         match internal_msg {
             InternalMessage::User { content, .. } => {
-                let mut texts = Vec::new();
-                let mut images = Vec::new();
-                for uc in content.into_iter() {
-                    match uc {
-                        crate::message::UserContent::Text(t) => texts.push(t.text),
-                        crate::message::UserContent::Image(img) => images.push(img.data),
-                        crate::message::UserContent::ToolResult(result) => {
-                            let content = result
-                                .content
-                                .into_iter()
-                                .map(ToolResultContent::try_from)
-                                .collect::<Result<Vec<ToolResultContent>, MessageError>>()?;
+                let (tool_results, other_content): (Vec<_>, Vec<_>) = content
+                    .into_iter()
+                    .partition(|content| matches!(content, crate::message::UserContent::ToolResult(_)));
 
-                            let content = OneOrMany::many(content).map_err(|x| {
-                                MessageError::ConversionError(format!(
-                                    "Couldn't make a OneOrMany from a list of tool results: {x}"
-                                ))
-                            })?;
-
-                            return Ok(Message::ToolResult {
-                                name: result.id,
+                if !tool_results.is_empty() {
+                    tool_results
+                        .into_iter()
+                        .map(|content| match content {
+                            crate::message::UserContent::ToolResult(crate::message::ToolResult {
+                                id,
                                 content,
-                            });
-                        }
-                        _ => {} // Audio variant removed since Ollama API does not support it.
-                    }
-                }
-                let content_str = texts.join(" ");
-                let images_opt = if images.is_empty() {
-                    None
+                                ..
+                            }) => {
+                                // Ollama expects a single string for tool results, so we concatenate
+                                let content_string = content
+                                    .into_iter()
+                                    .map(|content| match content {
+                                        crate::message::ToolResultContent::Text(text) => text.text,
+                                        _ => "[Non-text content]".to_string(),
+                                    })
+                                    .collect::<Vec<_>>()
+                                    .join("\n");
+
+                                Ok::<_, crate::message::MessageError>(Message::ToolResult {
+                                    name: id,
+                                    content: content_string,
+                                })
+                            }
+                            _ => unreachable!(),
+                        })
+                        .collect::<Result<Vec<_>, _>>()
                 } else {
-                    Some(images)
-                };
-                Ok(Message::User {
-                    content: content_str,
-                    images: images_opt,
-                    name: None,
-                })
+                    // Ollama requires separate text content and images array
+                    let (texts, images) = other_content.into_iter().fold(
+                        (Vec::new(), Vec::new()),
+                        |(mut texts, mut images), content| {
+                            match content {
+                                crate::message::UserContent::Text(crate::message::Text { text }) => {
+                                    texts.push(text)
+                                }
+                                crate::message::UserContent::Image(crate::message::Image { data, .. }) => {
+                                    images.push(data)
+                                }
+                                _ => {} // Audio/Document not supported by Ollama
+                            }
+                            (texts, images)
+                        },
+                    );
+                    
+                    Ok(vec![Message::User {
+                        content: texts.join(" "),
+                        images: if images.is_empty() { None } else { Some(images) },
+                        name: None,
+                    }])
+                }
             }
             InternalMessage::Assistant { content, .. } => {
-                let mut texts = Vec::new();
-                let mut tool_calls = Vec::new();
-                for ac in content.into_iter() {
-                    match ac {
-                        crate::message::AssistantContent::Text(t) => texts.push(t.text),
-                        crate::message::AssistantContent::ToolCall(tc) => {
-                            tool_calls.push(ToolCall {
-                                r#type: ToolType::Function, // Assuming internal tool call provides these fields
-                                function: Function {
-                                    name: tc.function.name,
-                                    arguments: tc.function.arguments,
-                                },
-                            });
+                let (text_content, tool_calls) = content.into_iter().fold(
+                    (Vec::new(), Vec::new()),
+                    |(mut texts, mut tools), content| {
+                        match content {
+                            crate::message::AssistantContent::Text(text) => texts.push(text.text),
+                            crate::message::AssistantContent::ToolCall(tool_call) => tools.push(tool_call),
                         }
-                    }
-                }
-                let content_str = texts.join(" ");
-                Ok(Message::Assistant {
-                    content: content_str,
+                        (texts, tools)
+                    },
+                );
+
+                // `OneOrMany` ensures at least one `AssistantContent::Text` or `ToolCall` exists,
+                //  so either `content` or `tool_calls` will have some content.
+                Ok(vec![Message::Assistant {
+                    content: text_content.join(" "),
                     images: None,
                     name: None,
-                    tool_calls,
-                })
+                    tool_calls: tool_calls
+                        .into_iter()
+                        .map(|tool_call| tool_call.into())
+                        .collect::<Vec<_>>(),
+                }])
             }
         }
     }
@@ -762,7 +780,7 @@ impl From<Message> for crate::completion::Message {
             Message::ToolResult { name, content } => crate::completion::Message::User {
                 content: OneOrMany::one(message::UserContent::tool_result(
                     name,
-                    OneOrMany::one(message::ToolResultContent::Text(Text { text: content })),
+                    OneOrMany::one(message::ToolResultContent::text(content)),
                 )),
             },
         }
@@ -782,35 +800,15 @@ impl Message {
 
 // ---------- Additional Message Types ----------
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
-pub struct ToolResultContent {
-    text: String,
-}
-
-impl TryFrom<crate::message::ToolResultContent> for ToolResultContent {
-    type Error = MessageError;
-    fn try_from(value: crate::message::ToolResultContent) -> Result<Self, Self::Error> {
-        let crate::message::ToolResultContent::Text(Text { text }) = value else {
-            return Err(MessageError::ConversionError(
-                "Non-text tool results not supported".into(),
-            ));
-        };
-
-        Ok(Self { text })
-    }
-}
-
-impl FromStr for ToolResultContent {
-    type Err = Infallible;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(s.to_owned().into())
-    }
-}
-
-impl From<String> for ToolResultContent {
-    fn from(s: String) -> Self {
-        ToolResultContent { text: s }
+impl From<crate::message::ToolCall> for ToolCall {
+    fn from(tool_call: crate::message::ToolCall) -> Self {
+        Self {
+            r#type: ToolType::Function,
+            function: Function {
+                name: tool_call.function.name,
+                arguments: tool_call.function.arguments,
+            },
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #811
- Fix ToolResult struct to match Ollama API spec (tool_name field, string content)
- Align code structure with OpenAI provider for consistency
- Each tool result now sent as separate message as per Ollama docs

Ollama related docs https://github.com/ollama/ollama/blob/4261a3b0b264430489921a1b4a16a6267711d595/docs/api.md?plain=1#L902

Follow-up pr for https://github.com/0xPlaygrounds/rig/pull/581
