### PR TITLE
fix(rig-820): ensure call ID is properly propagated

### DIFF
--- a/rig-core/Cargo.toml
+++ b/rig-core/Cargo.toml
@@ -42,7 +42,7 @@ as-any = { workspace = true }
 anyhow = { workspace = true }
 assert_fs = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-tracing-subscriber = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tokio-test = { workspace = true }
 serde_path_to_error = { workspace = true }
 base64 = { workspace = true }

--- a/rig-core/examples/multi_turn_streaming.rs
+++ b/rig-core/examples/multi_turn_streaming.rs
@@ -109,7 +109,7 @@ where
                         let tool_call_msg = AssistantContent::ToolCall(tool_call.clone());
 
                         tool_calls.push(tool_call_msg);
-                        tool_results.push((tool_call.id, tool_result));
+                        tool_results.push((tool_call.id, tool_call.call_id, tool_result));
 
                         did_call_tool = true;
                         // break;
@@ -130,13 +130,25 @@ where
             }
 
             // Add tool results to chat history
-            for (id, tool_result) in tool_results {
-                chat_history.push(Message::User {
-                    content: OneOrMany::one(UserContent::tool_result(
-                        id,
-                        OneOrMany::one(ToolResultContent::text(tool_result)),
-                    )),
-                });
+            for (id, call_id, tool_result) in tool_results {
+                if let Some(call_id) = call_id {
+                    chat_history.push(Message::User {
+                        content: OneOrMany::one(UserContent::tool_result_with_call_id(
+                            id,
+                            call_id,
+                            OneOrMany::one(ToolResultContent::text(tool_result)),
+                        )),
+                    });
+                } else {
+                    chat_history.push(Message::User {
+                        content: OneOrMany::one(UserContent::tool_result(
+                            id,
+                            OneOrMany::one(ToolResultContent::text(tool_result)),
+                        )),
+                    });
+
+                }
+
             }
 
             // Set the current prompt to the last message in the chat history

--- a/rig-core/examples/multi_turn_streaming.rs
+++ b/rig-core/examples/multi_turn_streaming.rs
@@ -9,8 +9,9 @@ use rig::{
     streaming::StreamingCompletion,
     tool::{Tool, ToolSetError},
 };
+use schemars::{JsonSchema, schema_for};
 use serde::{Deserialize, Serialize};
-use serde_json::json;
+
 use std::pin::Pin;
 use thiserror::Error;
 
@@ -184,7 +185,7 @@ async fn custom_stream_to_stdout(stream: &mut StreamingResult) -> Result<(), std
     Ok(())
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, JsonSchema)]
 struct OperationArgs {
     x: i32,
     y: i32,
@@ -204,24 +205,12 @@ impl Tool for Add {
     type Output = i32;
 
     async fn definition(&self, _prompt: String) -> ToolDefinition {
-        serde_json::from_value(json!({
-            "name": "add",
-            "description": "Add x and y together",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The first number to add"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The second number to add"
-                    }
-                }
-            }
-        }))
-        .expect("Tool Definition")
+        ToolDefinition {
+            name: "add".to_string(),
+            description: "Add x and y together".to_string(),
+            parameters: serde_json::to_value(schema_for!(OperationArgs))
+                .expect("converting JSON schema to JSON value should never fail"),
+        }
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -240,24 +229,12 @@ impl Tool for Subtract {
     type Output = i32;
 
     async fn definition(&self, _prompt: String) -> ToolDefinition {
-        serde_json::from_value(json!({
-            "name": "subtract",
-            "description": "Subtract y from x (i.e.: x - y)",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The number to subtract from"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The number to subtract"
-                    }
-                }
-            }
-        }))
-        .expect("Tool Definition")
+        ToolDefinition {
+            name: "subtract".to_string(),
+            description: "Subtract y from x (i.e.: x - y)".to_string(),
+            parameters: serde_json::to_value(schema_for!(OperationArgs))
+                .expect("converting JSON schema to JSON value should never fail"),
+        }
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -275,24 +252,12 @@ impl Tool for Multiply {
     type Output = i32;
 
     async fn definition(&self, _prompt: String) -> ToolDefinition {
-        serde_json::from_value(json!({
-            "name": "multiply",
-            "description": "Compute the product of x and y (i.e.: x * y)",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The first factor in the product"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The second factor in the product"
-                    }
-                }
-            }
-        }))
-        .expect("Tool Definition")
+        ToolDefinition {
+            name: "multiply".to_string(),
+            description: "Compute the product of x and y (i.e.: x * y)".to_string(),
+            parameters: serde_json::to_value(schema_for!(OperationArgs))
+                .expect("converting JSON schema to JSON value should never fail"),
+        }
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -310,24 +275,13 @@ impl Tool for Divide {
     type Output = i32;
 
     async fn definition(&self, _prompt: String) -> ToolDefinition {
-        serde_json::from_value(json!({
-            "name": "divide",
-            "description": "Compute the Quotient of x and y (i.e.: x / y). Useful for ratios.",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The Dividend of the division. The number being divided"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The Divisor of the division. The number by which the dividend is being divided"
-                    }
-                }
-            }
-        }))
-        .expect("Tool Definition")
+        ToolDefinition {
+            name: "divide".to_string(),
+            description: "Compute the Quotient of x and y (i.e.: x / y). Useful for ratios."
+                .to_string(),
+            parameters: serde_json::to_value(schema_for!(OperationArgs))
+                .expect("converting JSON schema to JSON value should never fail"),
+        }
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -178,6 +178,8 @@ impl ResponsesCompletionModel {
         let mut request = self.create_completion_request(completion_request)?;
         request.stream = Some(true);
 
+        tracing::debug!("Input: {}", serde_json::to_string_pretty(&request)?);
+
         let builder = self.client.post("/responses").json(&request);
         send_compatible_streaming_request(builder).await
     }
@@ -269,6 +271,7 @@ pub async fn send_compatible_streaming_request(
                                         yield Ok(streaming::RawStreamingChoice::Message(message.clone()))
                                 }
                                 StreamingItemDoneOutput {  item: Output::FunctionCall(func), .. } => {
+                                    tracing::warn!("Function call received: {func:?}");
                                     tool_calls.push(streaming::RawStreamingChoice::ToolCall { id: func.id.clone(), call_id: Some(func.call_id.clone()), name: func.name.clone(), arguments: func.arguments.clone() });
                                 }
                             }

--- a/rig-core/src/streaming.rs
+++ b/rig-core/src/streaming.rs
@@ -144,13 +144,19 @@ impl<R: Clone + Unpin> Stream for StreamingCompletionResponse<R> {
                     // and pass it to the outer stream
                     stream.tool_calls.push(ToolCall {
                         id: id.clone(),
-                        call_id,
+                        call_id: call_id.clone(),
                         function: ToolFunction {
                             name: name.clone(),
                             arguments: arguments.clone(),
                         },
                     });
-                    Poll::Ready(Some(Ok(AssistantContent::tool_call(id, name, arguments))))
+                    if let Some(call_id) = call_id {
+                        Poll::Ready(Some(Ok(AssistantContent::tool_call_with_call_id(
+                            id, call_id, name, arguments,
+                        ))))
+                    } else {
+                        Poll::Ready(Some(Ok(AssistantContent::tool_call(id, name, arguments))))
+                    }
                 }
                 RawStreamingChoice::FinalResponse(response) => {
                     // Set the final response field and return the next item in the stream


### PR DESCRIPTION
Fixes #600 
Fixes RIG-820

We weren't setting the call ID in the streaming function, so inevitably nothing was passed in which caused OpenAI to freak out.

edit: There were some additional changes that were required to be made, so the PR title will be amended to reflect this.