### PR TITLE
feat(rig-823): impl size hint for OneOrMany types

### DIFF
--- a/rig-core/src/one_or_many.rs
+++ b/rig-core/src/one_or_many.rs
@@ -462,6 +462,29 @@ mod test {
     }
 
     #[test]
+    fn test_size_hint() {
+        let foo = "bar".to_string();
+        let one_or_many = OneOrMany::one(foo);
+        let size_hint = one_or_many.iter().size_hint();
+        assert_eq!(size_hint.0, 1);
+        assert_eq!(size_hint.1, Some(1));
+
+        let vec = vec!["foo".to_string(), "bar".to_string(), "baz".to_string()];
+        let mut one_or_many = OneOrMany::many(vec).expect("this should never fail");
+        let size_hint = one_or_many.iter().size_hint();
+        assert_eq!(size_hint.0, 1);
+        assert_eq!(size_hint.1, Some(3));
+
+        let size_hint = one_or_many.clone().into_iter().size_hint();
+        assert_eq!(size_hint.0, 1);
+        assert_eq!(size_hint.1, Some(3));
+
+        let size_hint = one_or_many.iter_mut().size_hint();
+        assert_eq!(size_hint.0, 1);
+        assert_eq!(size_hint.1, Some(3));
+    }
+
+    #[test]
     fn test_one_or_many_into_iter_single() {
         let one_or_many = OneOrMany::one("hello".to_string());
 

--- a/rig-core/src/one_or_many.rs
+++ b/rig-core/src/one_or_many.rs
@@ -167,6 +167,16 @@ impl<'a, T> Iterator for Iter<'a, T> {
             self.rest.next()
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let first = if self.first.is_some() { 1 } else { 0 };
+        let max = self.rest.size_hint().1.unwrap_or(0) + first;
+        if max > 0 {
+            (1, Some(max))
+        } else {
+            (0, Some(0))
+        }
+    }
 }
 
 /// Struct returned by call to `OneOrMany::into_iter()`.
@@ -200,6 +210,16 @@ impl<T: Clone> Iterator for IntoIter<T> {
             _ => self.rest.next(),
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let first = if self.first.is_some() { 1 } else { 0 };
+        let max = self.rest.size_hint().1.unwrap_or(0) + first;
+        if max > 0 {
+            (1, Some(max))
+        } else {
+            (0, Some(0))
+        }
+    }
 }
 
 /// Struct returned by call to `OneOrMany::iter_mut()`.
@@ -219,6 +239,16 @@ impl<'a, T> Iterator for IterMut<'a, T> {
             Some(first)
         } else {
             self.rest.next()
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let first = if self.first.is_some() { 1 } else { 0 };
+        let max = self.rest.size_hint().1.unwrap_or(0) + first;
+        if max > 0 {
+            (1, Some(max))
+        } else {
+            (0, Some(0))
         }
     }
 }


### PR DESCRIPTION
Fixes #605 
Fixes RIG-823

cc @Sytten - I believe this seems to work? I pretty much just copy and pasted your implementation in and it seems to be fine (and have added tests to prove it). Theoretically speaking there should always be at least one item, but seeing as I would much rather not voluntarily panic unless there is a need to do so, I've just returned the `(0, Some(0))` instead.