### PR TITLE
fix(rig-824): ToolResultContent should be serde-tagged

### DIFF
--- a/rig-core/src/completion/message.rs
+++ b/rig-core/src/completion/message.rs
@@ -71,6 +71,7 @@ pub struct ToolResult {
 
 /// Describes the content of a tool result, which can be text or an image.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[serde(tag = "type", rename_all = "lowercase")]
 pub enum ToolResultContent {
     Text(Text),
     Image(Image),


### PR DESCRIPTION
Fixes #608 
Fixes RIG-824