### PR TITLE
refactor: change log level to debug for input/output

### DIFF
--- a/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/rig-core/src/providers/openai/responses_api/mod.rs
@@ -891,13 +891,13 @@ impl completion::CompletionModel for ResponsesCompletionModel {
         let request = self.create_completion_request(completion_request)?;
         let request = serde_json::to_value(request)?;
 
-        tracing::info!("Input: {}", serde_json::to_string_pretty(&request)?);
+        tracing::debug!("OpenAI input: {}", serde_json::to_string_pretty(&request)?);
 
         let response = self.client.post("/responses").json(&request).send().await?;
 
         if response.status().is_success() {
             let t = response.text().await?;
-            tracing::info!(target: "rig", "OpenAI response: {}", t);
+            tracing::debug!(target: "rig", "OpenAI response: {}", t);
 
             let response = serde_json::from_str::<Self::Response>(&t)?;
             response.try_into()


### PR DESCRIPTION
Changes the log level to `debug` for input/output so that end user logs do not get clogged with huge documents.