### PR TITLE
feat: Add agent name

### DIFF
--- a/rig-core/src/agent/builder.rs
+++ b/rig-core/src/agent/builder.rs
@@ -36,6 +36,8 @@ use super::Agent;
 ///     .build();
 /// ```
 pub struct AgentBuilder<M: CompletionModel> {
+    /// Name of the agent used for logging and debugging
+    name: Option<String>,
     /// Completion model (e.g.: OpenAI's gpt-3.5-turbo-1106, Cohere's command-r)
     model: M,
     /// System prompt
@@ -61,6 +63,7 @@ pub struct AgentBuilder<M: CompletionModel> {
 impl<M: CompletionModel> AgentBuilder<M> {
     pub fn new(model: M) -> Self {
         Self {
+            name: None,
             model,
             preamble: None,
             static_context: vec![],
@@ -72,6 +75,12 @@ impl<M: CompletionModel> AgentBuilder<M> {
             dynamic_tools: vec![],
             tools: ToolSet::default(),
         }
+    }
+
+    /// Set the name of the agent
+    pub fn name(mut self, name: &str) -> Self {
+        self.name = Some(name.into());
+        self
     }
 
     /// Set the system prompt
@@ -176,6 +185,7 @@ impl<M: CompletionModel> AgentBuilder<M> {
     /// Build the agent
     pub fn build(self) -> Agent<M> {
         Agent {
+            name: self.name,
             model: self.model,
             preamble: self.preamble.unwrap_or_default(),
             static_context: self.static_context,

--- a/rig-core/src/agent/prompt_request.rs
+++ b/rig-core/src/agent/prompt_request.rs
@@ -136,6 +136,7 @@ impl PromptResponse {
 }
 
 impl<M: CompletionModel> PromptRequest<'_, Extended, M> {
+    #[tracing::instrument(skip(self), fields(agent_name = self.agent.name()))]
     async fn send(self) -> Result<PromptResponse, PromptError> {
         let agent = self.agent;
         let chat_history = if let Some(history) = self.chat_history {


### PR DESCRIPTION
Added also some instrumentation

```
2025-07-29T16:01:40.239264Z  INFO send{agent_name="Unnamed Agent"}: rig::agent::prompt_request: Current conversation depth: 1/20
2025-07-29T16:01:40.327220Z  INFO send{agent_name="Unnamed Agent"}:completion{agent_name="Unnamed Agent"}: rig: Selected documents: get_ticket_by_priority (0.3910402831735857)
2025-07-29T16:01:42.670064Z  INFO send{agent_name="Unnamed Agent"}: rig: Calling tool get_ticket_by_priority with args:
"{\"limit\":2,\"priority\":\"medium\"}"
2025-07-29T16:01:42.686429Z  INFO send{agent_name="Unnamed Agent"}: rig::agent::prompt_request: Current conversation depth: 2/20
2025-07-29T16:01:42.700915Z  INFO send{agent_name="Unnamed Agent"}:completion{agent_name="Unnamed Agent"}: rig: Selected documents: get_ticket_by_priority (0.3910402831735857)
2025-07-29T16:01:57.581055Z  INFO send{agent_name="Unnamed Agent"}: rig::agent::prompt_request: Depth reached: 2/20
```