### PR TITLE
feat: Read the OPENAI_BASE_URL env variable when constructing an OpenAI client from_env

### DIFF
--- a/rig-core/examples/agent.rs
+++ b/rig-core/examples/agent.rs
@@ -1,14 +1,11 @@
 use rig::prelude::*;
-use std::env;
 
 use rig::{completion::Prompt, providers};
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     // Create OpenAI client
-    let client = providers::openai::Client::new(
-        &env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set"),
-    );
+    let client = providers::openai::Client::from_env();
 
     // Create agent with a single context prompt
     let comedian_agent = client

--- a/rig-core/examples/agent_autonomous.rs
+++ b/rig-core/examples/agent_autonomous.rs
@@ -3,8 +3,6 @@ use rig::providers::openai::client::Client;
 
 use schemars::JsonSchema;
 
-use std::env;
-
 #[derive(Debug, serde::Deserialize, JsonSchema, serde::Serialize)]
 struct Counter {
     /// The score of the document
@@ -14,8 +12,7 @@ struct Counter {
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     // Create OpenAI client
-    let openai_api_key = env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set");
-    let openai_client = Client::new(&openai_api_key);
+    let openai_client = Client::from_env();
     let agent = openai_client.extractor::<Counter>("gpt-4")
         .preamble("
             Your role is to add a random number between 1 and 64 (using only integers) to the previous number.

--- a/rig-core/examples/agent_evaluator_optimizer.rs
+++ b/rig-core/examples/agent_evaluator_optimizer.rs
@@ -1,5 +1,4 @@
 use rig::prelude::*;
-use std::env;
 
 use rig::completion::Prompt;
 
@@ -27,8 +26,7 @@ All operations should be O(1).
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     // Create OpenAI client
-    let openai_api_key = env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set");
-    let openai_client = Client::new(&openai_api_key);
+    let openai_client = Client::from_env();
 
     let generator_agent = openai_client
         .agent("gpt-4")

--- a/rig-core/examples/agent_orchestrator.rs
+++ b/rig-core/examples/agent_orchestrator.rs
@@ -1,7 +1,6 @@
 use rig::prelude::*;
 use rig::providers::openai::client::Client;
 use schemars::JsonSchema;
-use std::env;
 
 #[derive(serde::Deserialize, JsonSchema, serde::Serialize, Debug)]
 struct Specification {
@@ -24,8 +23,7 @@ struct TaskResults {
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     // Create OpenAI client
-    let openai_api_key = env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set");
-    let openai_client = Client::new(&openai_api_key);
+    let openai_client = Client::from_env();
 
     // Note that you can also create your own semantic router for this
     // that uses a vector store under the hood

--- a/rig-core/examples/agent_parallelization.rs
+++ b/rig-core/examples/agent_parallelization.rs
@@ -1,5 +1,4 @@
 use rig::prelude::*;
-use std::env;
 
 use rig::pipeline::agent_ops::extract;
 
@@ -20,8 +19,7 @@ struct DocumentScore {
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     // Create OpenAI client
-    let openai_api_key = env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set");
-    let openai_client = Client::new(&openai_api_key);
+    let openai_client = Client::from_env();
 
     let manipulation_agent = openai_client
         .extractor::<DocumentScore>("gpt-4")

--- a/rig-core/examples/agent_prompt_chaining.rs
+++ b/rig-core/examples/agent_prompt_chaining.rs
@@ -1,12 +1,10 @@
 use rig::pipeline::{self, Op};
 use rig::prelude::*;
 use rig::providers::openai::client::Client;
-use std::env;
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     // Create OpenAI client
-    let openai_api_key = env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set");
-    let openai_client = Client::new(&openai_api_key);
+    let openai_client = Client::from_env();
 
     let rng_agent = openai_client.agent("gpt-4")
         .preamble("

--- a/rig-core/examples/agent_routing.rs
+++ b/rig-core/examples/agent_routing.rs
@@ -1,13 +1,11 @@
 use rig::pipeline::{self, Op, TryOp};
 use rig::prelude::*;
 use rig::providers::openai::client::Client;
-use std::env;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     // Create OpenAI client
-    let openai_api_key = env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set");
-    let openai_client = Client::new(&openai_api_key);
+    let openai_client = Client::from_env();
 
     // Note that you can also create your own semantic router for this
     // that uses a vector store under the hood

--- a/rig-core/examples/agent_with_echochambers.rs
+++ b/rig-core/examples/agent_with_echochambers.rs
@@ -303,12 +303,11 @@ impl Tool for GetMetricsHistory {
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     // Get API keys from environment
-    let openai_api_key = env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set");
     let echochambers_api_key =
         env::var("ECHOCHAMBERS_API_KEY").expect("ECHOCHAMBERS_API_KEY not set");
 
     // Create OpenAI client
-    let openai_client = Client::new(&openai_api_key);
+    let openai_client = Client::from_env();
 
     // Create agent with all tools
     let echochambers_agent = openai_client

--- a/rig-core/examples/agent_with_loaders.rs
+++ b/rig-core/examples/agent_with_loaders.rs
@@ -5,12 +5,10 @@ use rig::{
     loaders::FileLoader,
     providers::openai::{self, GPT_4O},
 };
-use std::env;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    let openai_client =
-        openai::Client::new(&env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set"));
+    let openai_client = openai::Client::from_env();
     let model = openai_client.completion_model(GPT_4O);
 
     // Load in all the rust examples

--- a/rig-core/examples/calculator_chatbot.rs
+++ b/rig-core/examples/calculator_chatbot.rs
@@ -11,7 +11,6 @@ use rig::{
 
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::env;
 
 #[derive(Deserialize)]
 struct OperationArgs {
@@ -231,8 +230,7 @@ impl ToolEmbedding for Divide {
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     // Create OpenAI client
-    let openai_api_key = env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set");
-    let openai_client = Client::new(&openai_api_key);
+    let openai_client = Client::from_env();
 
     // Create dynamic tools embeddings
     let toolset = ToolSet::builder()

--- a/rig-core/examples/chain.rs
+++ b/rig-core/examples/chain.rs
@@ -1,5 +1,4 @@
 use rig::prelude::*;
-use std::env;
 
 use rig::{
     embeddings::EmbeddingsBuilder,
@@ -13,8 +12,7 @@ use rig::{
 async fn main() -> Result<(), anyhow::Error> {
     tracing_subscriber::fmt().init();
     // Create OpenAI client
-    let openai_api_key = env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set");
-    let openai_client = Client::new(&openai_api_key);
+    let openai_client = Client::from_env();
     let embedding_model = openai_client.embedding_model(TEXT_EMBEDDING_ADA_002);
 
     // Create embeddings for our documents

--- a/rig-core/examples/debate.rs
+++ b/rig-core/examples/debate.rs
@@ -19,8 +19,7 @@ impl Debater {
             .with_max_level(tracing::Level::INFO)
             .with_target(false)
             .init();
-        let openai_client =
-            openai::Client::new(&env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set"));
+        let openai_client = openai::Client::from_env();
         let cohere_client =
             cohere::Client::new(&env::var("COHERE_API_KEY").expect("COHERE_API_KEY not set"));
         Self {

--- a/rig-core/examples/multi_agent.rs
+++ b/rig-core/examples/multi_agent.rs
@@ -6,7 +6,6 @@ use rig::{
     message::Message,
     providers::openai::Client as OpenAIClient,
 };
-use std::env;
 
 /// Represents a multi agent application that consists of two components:
 /// an agent specialized in translating prompt into english and a simple GPT-4 model.
@@ -57,8 +56,7 @@ impl<M: CompletionModel> Chat for EnglishTranslator<M> {
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     // Create OpenAI client
-    let openai_api_key = env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set");
-    let openai_client = OpenAIClient::new(&openai_api_key);
+    let openai_client = OpenAIClient::from_env();
     let model = openai_client.completion_model("gpt-4");
 
     // Create model

--- a/rig-core/examples/openai_agent_completions_api.rs
+++ b/rig-core/examples/openai_agent_completions_api.rs
@@ -3,16 +3,13 @@
 
 use rig::completion::Prompt;
 use rig::prelude::*;
-use std::env;
 
 use rig::providers;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     // Create OpenAI client
-    let agent = providers::openai::Client::new(
-        &env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set"),
-    )
+    let agent = providers::openai::Client::from_env()
     .completion_model("gpt-4o")
     .completions_api()
     .into_agent_builder()

--- a/rig-core/examples/openai_agent_completions_api.rs
+++ b/rig-core/examples/openai_agent_completions_api.rs
@@ -10,11 +10,11 @@ use rig::providers;
 async fn main() -> Result<(), anyhow::Error> {
     // Create OpenAI client
     let agent = providers::openai::Client::from_env()
-    .completion_model("gpt-4o")
-    .completions_api()
-    .into_agent_builder()
-    .preamble("You are a helpful assistant")
-    .build();
+        .completion_model("gpt-4o")
+        .completions_api()
+        .into_agent_builder()
+        .preamble("You are a helpful assistant")
+        .build();
 
     let res = agent.prompt("Hello world!").await.unwrap();
 

--- a/rig-core/examples/rag.rs
+++ b/rig-core/examples/rag.rs
@@ -5,7 +5,7 @@ use rig::{
     providers::openai::TEXT_EMBEDDING_ADA_002, vector_store::in_memory_store::InMemoryVectorStore,
 };
 use serde::Serialize;
-use std::{env, vec};
+use std::vec;
 
 // Data to be RAGged.
 // A vector search needs to be performed on the `definitions` field, so we derive the `Embed` trait for `WordDefinition`
@@ -27,8 +27,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .init();
 
     // Create OpenAI client
-    let openai_api_key = env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set");
-    let openai_client = Client::new(&openai_api_key);
+    let openai_client = Client::from_env();
     let embedding_model = openai_client.embedding_model(TEXT_EMBEDDING_ADA_002);
 
     // Generate embeddings for the definitions of all the documents using the specified embedding model.

--- a/rig-core/examples/rag_dynamic_tools.rs
+++ b/rig-core/examples/rag_dynamic_tools.rs
@@ -9,7 +9,6 @@ use rig::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::env;
 
 #[derive(Deserialize)]
 struct OperationArgs {
@@ -130,8 +129,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .init();
 
     // Create OpenAI client
-    let openai_api_key = env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set");
-    let openai_client = Client::new(&openai_api_key);
+    let openai_client = Client::from_env();
     let embedding_model = openai_client.embedding_model(TEXT_EMBEDDING_ADA_002);
     let toolset = ToolSet::builder()
         .dynamic_tool(Add)

--- a/rig-core/examples/rag_dynamic_tools_multi_turn.rs
+++ b/rig-core/examples/rag_dynamic_tools_multi_turn.rs
@@ -9,7 +9,6 @@ use rig::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::env;
 
 #[derive(Deserialize)]
 struct OperationArgs {
@@ -141,8 +140,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .init();
 
     // Create OpenAI client
-    let openai_api_key = env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set");
-    let openai_client = Client::new(&openai_api_key);
+    let openai_client = Client::from_env();
 
     let embedding_model = openai_client.embedding_model(TEXT_EMBEDDING_ADA_002);
 

--- a/rig-core/examples/vector_search.rs
+++ b/rig-core/examples/vector_search.rs
@@ -8,7 +8,6 @@ use rig::{
     vector_store::{VectorStoreIndex, in_memory_store::InMemoryVectorStore},
 };
 use serde::{Deserialize, Serialize};
-use std::env;
 
 // Shape of data that needs to be RAG'ed.
 // The definition field will be used to generate embeddings.
@@ -23,8 +22,7 @@ struct WordDefinition {
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     // Create OpenAI client
-    let openai_api_key = env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set");
-    let openai_client = Client::new(&openai_api_key);
+    let openai_client = Client::from_env();
     let embedding_model = openai_client.embedding_model(TEXT_EMBEDDING_ADA_002);
     let embeddings = EmbeddingsBuilder::new(embedding_model.clone())
         .documents(vec![

--- a/rig-core/src/providers/openai/client.rs
+++ b/rig-core/src/providers/openai/client.rs
@@ -116,8 +116,13 @@ impl ProviderClient for Client {
     /// Create a new OpenAI client from the `OPENAI_API_KEY` environment variable.
     /// Panics if the environment variable is not set.
     fn from_env() -> Self {
+        let base_url: Option<String> = std::env::var("OPENAI_BASE_URL").ok();
         let api_key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set");
-        Self::new(&api_key)
+
+        match base_url {
+            Some(url) => Self::builder(&api_key).base_url(&url).build().unwrap(),
+            None => Self::new(&api_key),
+        }
     }
 
     fn from_val(input: crate::client::ProviderValue) -> Self {


### PR DESCRIPTION
Allow constructing an OpenAI client with a custom base url from the environment variable OPENAI_BASE_URL, similar to the Python client.

This PR also migrates all the examples which were previously directly reading the environment to instead use the `openai::client::from_env` constructor.

Tested by building. I'm not able to run the examples E2E due to #658 , but the behavior appears to be correct for some that I spot-checked.