### PR TITLE
refactor(rig-861): make Agent<M> non-exhaustive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9368,6 +9368,7 @@ dependencies = [
  "tokio-test",
  "tracing",
  "tracing-subscriber",
+ "url",
  "worker",
 ]
 

--- a/rig-core/src/agent/completion.rs
+++ b/rig-core/src/agent/completion.rs
@@ -33,6 +33,7 @@ const UNKNOWN_AGENT_NAME: &str = "Unnamed Agent";
 ///     .await
 ///     .expect("Failed to prompt the agent");
 /// ```
+#[non_exhaustive]
 pub struct Agent<M: CompletionModel> {
     /// Name of the agent used for logging and debugging
     pub name: Option<String>,


### PR DESCRIPTION
Fixes #669 

We're making `Agent<M>` non exhaustive to try and prevent extra breaking changes in future.