### PR TITLE
Chore: Update rmcp to version 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9705,9 +9705,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b008b927a85d514699ff304be84c5084598596e6cad4a6f5bc67207715fafe5f"
+checksum = "2faf35b7d3c4b7f8c21c45bb014011b32a0ce6444bf6094da04daab01a8c3c34"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -9736,9 +9736,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7465280d5f73f2c5c99017a04af407b2262455a149f255ad22f2b0b29087695c"
+checksum = "ad9720d9d2a943779f1dc3d47fa9072c7eeffaff4e1a82f67eb9f7ea52696091"
 dependencies = [
  "darling 0.21.0",
  "proc-macro2",

--- a/rig-core/Cargo.toml
+++ b/rig-core/Cargo.toml
@@ -36,7 +36,7 @@ async-stream = { workspace = true }
 mime_guess = { workspace = true }
 base64 = { workspace = true }
 as-any = { workspace = true }
-rmcp = { version = "0.3", optional = true, features = ["client"] }
+rmcp = { version = "0.5", optional = true, features = ["client"] }
 url = { workspace = true }
 
 [dev-dependencies]
@@ -52,7 +52,7 @@ mcp-core-macros = { workspace = true }
 
 # Required for `rmcp` example
 hyper-util = { version = "0.1.14", features = ["service", "server"] }
-rmcp = { version = "0.3", features = [
+rmcp = { version = "0.5", features = [
     "client",
     "reqwest",                                  # required for some strange reason
     "transport-streamable-http-client",


### PR DESCRIPTION
Breaking change in rmcp: 

> CallToolResult.content is now Option<Vec<Content>> instead of Vec<Content>


https://github.com/modelcontextprotocol/rust-sdk/commit/fbc7ab70cab26fd4f8897e5f88463cd442e7c59d