### PR TITLE
Accept plain-text tool result

### DIFF
--- a/rig-core/src/providers/gemini/completion.rs
+++ b/rig-core/src/providers/gemini/completion.rs
@@ -300,7 +300,7 @@ pub mod gemini_api_types {
     use crate::{
         OneOrMany,
         completion::CompletionError,
-        message::{self, MessageError, MimeType as _, Reasoning, Text},
+        message::{self, MimeType as _, Reasoning, Text},
         one_or_many::string_or_one_or_many,
         providers::gemini::gemini_api_types::{CodeExecutionResult, ExecutableCode},
     };
@@ -535,8 +535,14 @@ pub mod gemini_api_types {
                         }
                     };
                     // Convert to JSON since this value may be a valid JSON value
-                    let result: serde_json::Value = serde_json::from_str(&content)
-                        .map_err(|x| MessageError::ConversionError(x.to_string()))?;
+                    let result: serde_json::Value =
+                        serde_json::from_str(&content).unwrap_or_else(|error| {
+                            tracing::trace!(
+                                ?error,
+                                "Tool result is not a valid JSON, treat it as normal string"
+                            );
+                            json!(content)
+                        });
                     Ok(Part {
                         thought: Some(false),
                         thought_signature: None,


### PR DESCRIPTION
Some tools, like Context7, may return tool result as plain-text instead of json and thus serde_json::from_str will fail. In that case, we treat the value as the original string instead of throwing the conversion error.