### PR TITLE
fix: deepseek streaming endpoint

### DIFF
--- a/rig-core/src/providers/deepseek.rs
+++ b/rig-core/src/providers/deepseek.rs
@@ -594,7 +594,7 @@ impl completion::CompletionModel for CompletionModel {
             json!({"stream": true, "stream_options": {"include_usage": true}}),
         );
 
-        let builder = self.client.post("/v1/chat/completions").json(&request);
+        let builder = self.client.post("/chat/completions").json(&request);
         send_compatible_streaming_request(builder).await
     }
 }


### PR DESCRIPTION
Hello, I should have opened an issue first about the DeepSeek streaming URL. I believe the DeepSeek endpoint should be consistent with the OpenAI endpoint, so this PR removes the `v1` prefix.