### PR TITLE
Consistent visibility modifiers in OpenAI

### DIFF
--- a/rig-core/src/providers/openai/completion/mod.rs
+++ b/rig-core/src/providers/openai/completion/mod.rs
@@ -148,14 +148,14 @@ impl Message {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct AudioAssistant {
-    id: String,
+    pub id: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct SystemContent {
     #[serde(default)]
-    r#type: SystemContentType,
-    text: String,
+    pub r#type: SystemContentType,
+    pub text: String,
 }
 
 #[derive(Default, Debug, Serialize, Deserialize, PartialEq, Clone)]


### PR DESCRIPTION
Some OpenAI completion types are inconsistently private, I need them public so that I can convert them into [OpenAPI generated types](https://github.com/Coral-Protocol/coral-rs/blob/261228cff76e5083dbd6f6fe670bbae23c9cf1a0/src/api.rs#L248)