### PR TITLE
fix: Allow CompletionModel Chat to call functions

### DIFF
--- a/rig-core/src/agent/completion.rs
+++ b/rig-core/src/agent/completion.rs
@@ -226,6 +226,7 @@ impl<M: CompletionModel> Chat for Agent<M> {
     ) -> Result<String, PromptError> {
         let mut cloned_history = chat_history.clone();
         PromptRequest::new(self, prompt)
+            .multi_turn(1)
             .with_history(&mut cloned_history)
             .await
     }


### PR DESCRIPTION
When running the calculator_chatbot example, I observed it would persistently fail with MaxDepthError, like

```
> What is the quotient of 7 and 3?
Error: MaxDepthError: (reached limit: 0)
```

Indicating it was given a max depth of 0, and thus could never work.

This patch gives a multi_turn of 1 which allows basic usage. I'm open for discussion of whether this should be propagated as a decision to the Agent, but I don't see a clean way to do that, and I gather this is primarily example code anyway.