### PR TITLE
Add verify client

### DIFF
--- a/rig-bedrock/src/client.rs
+++ b/rig-bedrock/src/client.rs
@@ -103,6 +103,14 @@ impl ImageGenerationClient for Client {
         ImageGenerationModel::new(self.clone(), model)
     }
 }
+
+impl VerifyClient for Client {
+    async fn verify(&self) -> Result<(), VerifyError> {
+        // No API endpoint to verify the API key
+        Ok(())
+    }
+}
+
 impl_conversion_traits!(
     AsTranscription,
     AsAudioGeneration for Client

--- a/rig-core/src/client/mod.rs
+++ b/rig-core/src/client/mod.rs
@@ -8,6 +8,7 @@ pub mod completion;
 pub mod embeddings;
 pub mod image_generation;
 pub mod transcription;
+pub mod verify;
 
 #[cfg(feature = "derive")]
 pub use rig_derive::ProviderClient;
@@ -155,6 +156,13 @@ pub trait AsImageGeneration {
     }
 }
 
+/// Attempt to convert a ProviderClient to a VerifyClient
+pub trait AsVerify {
+    fn as_verify(&self) -> Option<Box<dyn VerifyClientDyn>> {
+        None
+    }
+}
+
 #[cfg(not(feature = "audio"))]
 impl<T: ProviderClient> AsAudioGeneration for T {}
 
@@ -229,6 +237,7 @@ use crate::client::embeddings::EmbeddingsClientDyn;
 #[cfg(feature = "image")]
 use crate::client::image_generation::ImageGenerationClientDyn;
 use crate::client::transcription::TranscriptionClientDyn;
+use crate::client::verify::VerifyClientDyn;
 
 #[cfg(feature = "audio")]
 pub use crate::client::audio_generation::AudioGenerationClient;
@@ -237,6 +246,7 @@ pub use crate::client::embeddings::EmbeddingsClient;
 #[cfg(feature = "image")]
 pub use crate::client::image_generation::ImageGenerationClient;
 pub use crate::client::transcription::TranscriptionClient;
+pub use crate::client::verify::{VerifyClient, VerifyError};
 
 #[cfg(test)]
 mod tests {

--- a/rig-core/src/client/verify.rs
+++ b/rig-core/src/client/verify.rs
@@ -1,0 +1,41 @@
+use crate::client::{AsVerify, ProviderClient};
+use futures::future::BoxFuture;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum VerifyError {
+    #[error("invalid authentication")]
+    InvalidAuthentication,
+    #[error("provider error: {0}")]
+    ProviderError(String),
+    #[error("http error: {0}")]
+    HttpError(
+        #[from]
+        #[source]
+        reqwest::Error,
+    ),
+}
+
+/// A provider client that can verify the configuration.
+/// Clone is required for conversions between client types.
+pub trait VerifyClient: ProviderClient + Clone {
+    /// Verify the configuration.
+    fn verify(&self) -> impl Future<Output = Result<(), VerifyError>> + Send;
+}
+
+pub trait VerifyClientDyn: ProviderClient {
+    /// Verify the configuration.
+    fn verify(&self) -> BoxFuture<'_, Result<(), VerifyError>>;
+}
+
+impl<T: VerifyClient> VerifyClientDyn for T {
+    fn verify(&self) -> BoxFuture<'_, Result<(), VerifyError>> {
+        Box::pin(self.verify())
+    }
+}
+
+impl<T: VerifyClientDyn + Clone + 'static> AsVerify for T {
+    fn as_verify(&self) -> Option<Box<dyn VerifyClientDyn>> {
+        Some(Box::new(self.clone()))
+    }
+}

--- a/rig-core/src/prelude.rs
+++ b/rig-core/src/prelude.rs
@@ -14,3 +14,5 @@ pub use crate::client::image_generation::ImageGenerationClient;
 
 #[cfg(feature = "audio")]
 pub use crate::client::audio_generation::AudioGenerationClient;
+
+pub use crate::client::{VerifyClient, VerifyError};

--- a/rig-core/src/providers/anthropic/client.rs
+++ b/rig-core/src/providers/anthropic/client.rs
@@ -1,7 +1,8 @@
 //! Anthropic client api implementation
 use super::completion::{ANTHROPIC_VERSION_LATEST, CompletionModel};
 use crate::client::{
-    ClientBuilderError, CompletionClient, ProviderClient, ProviderValue, impl_conversion_traits,
+    ClientBuilderError, CompletionClient, ProviderClient, ProviderValue, VerifyClient, VerifyError,
+    impl_conversion_traits,
 };
 
 // ================================================================
@@ -156,6 +157,14 @@ impl Client {
             .header("X-Api-Key", &self.api_key)
             .headers(self.default_headers.clone())
     }
+
+    pub(crate) fn get(&self, path: &str) -> reqwest::RequestBuilder {
+        let url = format!("{}/{}", self.base_url, path).replace("//", "/");
+        self.http_client
+            .get(url)
+            .header("X-Api-Key", &self.api_key)
+            .headers(self.default_headers.clone())
+    }
 }
 
 impl ProviderClient for Client {
@@ -178,6 +187,28 @@ impl CompletionClient for Client {
     type CompletionModel = CompletionModel;
     fn completion_model(&self, model: &str) -> CompletionModel {
         CompletionModel::new(self.clone(), model)
+    }
+}
+
+impl VerifyClient for Client {
+    async fn verify(&self) -> Result<(), VerifyError> {
+        let response = self.get("/v1/models").send().await?;
+        match response.status() {
+            reqwest::StatusCode::OK => Ok(()),
+            reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN => {
+                Err(VerifyError::InvalidAuthentication)
+            }
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR => {
+                Err(VerifyError::ProviderError(response.text().await?))
+            }
+            status if status.as_u16() == 529 => {
+                Err(VerifyError::ProviderError(response.text().await?))
+            }
+            _ => {
+                response.error_for_status()?;
+                Ok(())
+            }
+        }
     }
 }
 

--- a/rig-core/src/providers/anthropic/client.rs
+++ b/rig-core/src/providers/anthropic/client.rs
@@ -191,6 +191,7 @@ impl CompletionClient for Client {
 }
 
 impl VerifyClient for Client {
+    #[cfg_attr(feature = "worker", worker::send)]
     async fn verify(&self) -> Result<(), VerifyError> {
         let response = self.get("/v1/models").send().await?;
         match response.status() {

--- a/rig-core/src/providers/azure.rs
+++ b/rig-core/src/providers/azure.rs
@@ -852,6 +852,7 @@ mod audio_generation {
 }
 
 impl VerifyClient for Client {
+    #[cfg_attr(feature = "worker", worker::send)]
     async fn verify(&self) -> Result<(), VerifyError> {
         // There is currently no way to verify the Azure OpenAI API key or token without
         // consuming tokens

--- a/rig-core/src/providers/azure.rs
+++ b/rig-core/src/providers/azure.rs
@@ -776,7 +776,10 @@ mod image_generation {
 // Azure OpenAI Audio Generation API
 // ================================================================
 
-use crate::client::{CompletionClient, EmbeddingsClient, ProviderClient, TranscriptionClient};
+use crate::client::{
+    CompletionClient, EmbeddingsClient, ProviderClient, TranscriptionClient, VerifyClient,
+    VerifyError,
+};
 #[cfg(feature = "audio")]
 pub use audio_generation::*;
 
@@ -845,6 +848,14 @@ mod audio_generation {
                 model: model.to_string(),
             }
         }
+    }
+}
+
+impl VerifyClient for Client {
+    async fn verify(&self) -> Result<(), VerifyError> {
+        // There is currently no way to verify the Azure OpenAI API key or token without
+        // consuming tokens
+        Ok(())
     }
 }
 

--- a/rig-core/src/providers/cohere/client.rs
+++ b/rig-core/src/providers/cohere/client.rs
@@ -1,4 +1,8 @@
-use crate::{Embed, embeddings::EmbeddingsBuilder};
+use crate::{
+    Embed,
+    client::{VerifyClient, VerifyError},
+    embeddings::EmbeddingsBuilder,
+};
 
 use super::{CompletionModel, EmbeddingModel};
 use crate::client::{
@@ -110,6 +114,11 @@ impl Client {
         self.http_client.post(url).bearer_auth(&self.api_key)
     }
 
+    pub(crate) fn get(&self, path: &str) -> reqwest::RequestBuilder {
+        let url = format!("{}/{}", self.base_url, path).replace("//", "/");
+        self.http_client.get(url).bearer_auth(&self.api_key)
+    }
+
     pub fn embeddings<D: Embed>(
         &self,
         model: &str,
@@ -181,6 +190,23 @@ impl EmbeddingsClient for Client {
 
     fn embeddings<D: Embed>(&self, model: &str) -> EmbeddingsBuilder<Self::EmbeddingModel, D> {
         self.embeddings(model, "search_document")
+    }
+}
+
+impl VerifyClient for Client {
+    async fn verify(&self) -> Result<(), VerifyError> {
+        let response = self.get("/v1/models").send().await?;
+        match response.status() {
+            reqwest::StatusCode::OK => Ok(()),
+            reqwest::StatusCode::UNAUTHORIZED => Err(VerifyError::InvalidAuthentication),
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR => {
+                Err(VerifyError::ProviderError(response.text().await?))
+            }
+            _ => {
+                response.error_for_status()?;
+                Ok(())
+            }
+        }
     }
 }
 

--- a/rig-core/src/providers/cohere/client.rs
+++ b/rig-core/src/providers/cohere/client.rs
@@ -194,6 +194,7 @@ impl EmbeddingsClient for Client {
 }
 
 impl VerifyClient for Client {
+    #[cfg_attr(feature = "worker", worker::send)]
     async fn verify(&self) -> Result<(), VerifyError> {
         let response = self.get("/v1/models").send().await?;
         match response.status() {

--- a/rig-core/src/providers/deepseek.rs
+++ b/rig-core/src/providers/deepseek.rs
@@ -155,6 +155,7 @@ impl CompletionClient for Client {
 }
 
 impl VerifyClient for Client {
+    #[cfg_attr(feature = "worker", worker::send)]
     async fn verify(&self) -> Result<(), VerifyError> {
         let response = self.get("/user/balance").send().await?;
         match response.status() {

--- a/rig-core/src/providers/deepseek.rs
+++ b/rig-core/src/providers/deepseek.rs
@@ -12,7 +12,9 @@
 use futures::StreamExt;
 use std::collections::HashMap;
 
-use crate::client::{ClientBuilderError, CompletionClient, ProviderClient};
+use crate::client::{
+    ClientBuilderError, CompletionClient, ProviderClient, VerifyClient, VerifyError,
+};
 use crate::completion::GetTokenUsage;
 use crate::json_utils::merge;
 use crate::message::Document;
@@ -118,6 +120,11 @@ impl Client {
         let url = format!("{}/{}", self.base_url, path).replace("//", "/");
         self.http_client.post(url).bearer_auth(&self.api_key)
     }
+
+    pub(crate) fn get(&self, path: &str) -> reqwest::RequestBuilder {
+        let url = format!("{}/{}", self.base_url, path).replace("//", "/");
+        self.http_client.get(url).bearer_auth(&self.api_key)
+    }
 }
 
 impl ProviderClient for Client {
@@ -143,6 +150,24 @@ impl CompletionClient for Client {
         CompletionModel {
             client: self.clone(),
             model: model_name.to_string(),
+        }
+    }
+}
+
+impl VerifyClient for Client {
+    async fn verify(&self) -> Result<(), VerifyError> {
+        let response = self.get("/user/balance").send().await?;
+        match response.status() {
+            reqwest::StatusCode::OK => Ok(()),
+            reqwest::StatusCode::UNAUTHORIZED => Err(VerifyError::InvalidAuthentication),
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR
+            | reqwest::StatusCode::SERVICE_UNAVAILABLE => {
+                Err(VerifyError::ProviderError(response.text().await?))
+            }
+            _ => {
+                response.error_for_status()?;
+                Ok(())
+            }
         }
     }
 }

--- a/rig-core/src/providers/galadriel.rs
+++ b/rig-core/src/providers/galadriel.rs
@@ -181,6 +181,7 @@ impl CompletionClient for Client {
 }
 
 impl VerifyClient for Client {
+    #[cfg_attr(feature = "worker", worker::send)]
     async fn verify(&self) -> Result<(), VerifyError> {
         // Could not find an API endpoint to verify the API key
         Ok(())

--- a/rig-core/src/providers/galadriel.rs
+++ b/rig-core/src/providers/galadriel.rs
@@ -11,7 +11,9 @@
 //! let gpt4o = client.completion_model(galadriel::GPT_4O);
 //! ```
 use super::openai;
-use crate::client::{ClientBuilderError, CompletionClient, ProviderClient};
+use crate::client::{
+    ClientBuilderError, CompletionClient, ProviderClient, VerifyClient, VerifyError,
+};
 use crate::json_utils::merge;
 use crate::message::MessageError;
 use crate::providers::openai::send_compatible_streaming_request;
@@ -175,6 +177,13 @@ impl CompletionClient for Client {
     /// ```
     fn completion_model(&self, model: &str) -> CompletionModel {
         CompletionModel::new(self.clone(), model)
+    }
+}
+
+impl VerifyClient for Client {
+    async fn verify(&self) -> Result<(), VerifyError> {
+        // Could not find an API endpoint to verify the API key
+        Ok(())
     }
 }
 

--- a/rig-core/src/providers/gemini/client.rs
+++ b/rig-core/src/providers/gemini/client.rs
@@ -234,6 +234,7 @@ impl TranscriptionClient for Client {
 }
 
 impl VerifyClient for Client {
+    #[cfg_attr(feature = "worker", worker::send)]
     async fn verify(&self) -> Result<(), VerifyError> {
         let response = self.get("/v1beta/models").send().await?;
         match response.status() {

--- a/rig-core/src/providers/gemini/client.rs
+++ b/rig-core/src/providers/gemini/client.rs
@@ -3,7 +3,7 @@ use super::{
 };
 use crate::client::{
     ClientBuilderError, CompletionClient, EmbeddingsClient, ProviderClient, TranscriptionClient,
-    impl_conversion_traits,
+    VerifyClient, VerifyError, impl_conversion_traits,
 };
 use crate::{
     Embed,
@@ -115,6 +115,16 @@ impl Client {
             .headers(self.default_headers.clone())
     }
 
+    pub(crate) fn get(&self, path: &str) -> reqwest::RequestBuilder {
+        // API key gets inserted as query param - no need to add bearer auth or headers
+        let url = format!("{}/{}?key={}", self.base_url, path, self.api_key).replace("//", "/");
+
+        tracing::debug!("GET {}/{}?key={}", self.base_url, path, "****");
+        self.http_client
+            .get(url)
+            .headers(self.default_headers.clone())
+    }
+
     pub(crate) fn post_sse(&self, path: &str) -> reqwest::RequestBuilder {
         let url =
             format!("{}/{}?alt=sse&key={}", self.base_url, path, self.api_key).replace("//", "/");
@@ -220,6 +230,24 @@ impl TranscriptionClient for Client {
     /// [Gemini API Reference](https://ai.google.dev/api/generate-content#generationconfig)
     fn transcription_model(&self, model: &str) -> TranscriptionModel {
         TranscriptionModel::new(self.clone(), model)
+    }
+}
+
+impl VerifyClient for Client {
+    async fn verify(&self) -> Result<(), VerifyError> {
+        let response = self.get("/v1beta/models").send().await?;
+        match response.status() {
+            reqwest::StatusCode::OK => Ok(()),
+            reqwest::StatusCode::FORBIDDEN => Err(VerifyError::InvalidAuthentication),
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR
+            | reqwest::StatusCode::SERVICE_UNAVAILABLE => {
+                Err(VerifyError::ProviderError(response.text().await?))
+            }
+            _ => {
+                response.error_for_status()?;
+                Ok(())
+            }
+        }
     }
 }
 

--- a/rig-core/src/providers/groq.rs
+++ b/rig-core/src/providers/groq.rs
@@ -11,7 +11,9 @@
 use std::collections::HashMap;
 
 use super::openai::{CompletionResponse, StreamingToolCall, TranscriptionResponse, Usage};
-use crate::client::{ClientBuilderError, CompletionClient, TranscriptionClient};
+use crate::client::{
+    ClientBuilderError, CompletionClient, TranscriptionClient, VerifyClient, VerifyError,
+};
 use crate::completion::GetTokenUsage;
 use crate::json_utils::merge;
 use futures::StreamExt;
@@ -123,6 +125,11 @@ impl Client {
         let url = format!("{}/{}", self.base_url, path).replace("//", "/");
         self.http_client.post(url).bearer_auth(&self.api_key)
     }
+
+    pub(crate) fn get(&self, path: &str) -> reqwest::RequestBuilder {
+        let url = format!("{}/{}", self.base_url, path).replace("//", "/");
+        self.http_client.get(url).bearer_auth(&self.api_key)
+    }
 }
 
 impl ProviderClient for Client {
@@ -176,6 +183,25 @@ impl TranscriptionClient for Client {
     /// ```
     fn transcription_model(&self, model: &str) -> TranscriptionModel {
         TranscriptionModel::new(self.clone(), model)
+    }
+}
+
+impl VerifyClient for Client {
+    async fn verify(&self) -> Result<(), VerifyError> {
+        let response = self.get("/models").send().await?;
+        match response.status() {
+            reqwest::StatusCode::OK => Ok(()),
+            reqwest::StatusCode::UNAUTHORIZED => Err(VerifyError::InvalidAuthentication),
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR
+            | reqwest::StatusCode::SERVICE_UNAVAILABLE
+            | reqwest::StatusCode::BAD_GATEWAY => {
+                Err(VerifyError::ProviderError(response.text().await?))
+            }
+            _ => {
+                response.error_for_status()?;
+                Ok(())
+            }
+        }
     }
 }
 

--- a/rig-core/src/providers/groq.rs
+++ b/rig-core/src/providers/groq.rs
@@ -187,6 +187,7 @@ impl TranscriptionClient for Client {
 }
 
 impl VerifyClient for Client {
+    #[cfg_attr(feature = "worker", worker::send)]
     async fn verify(&self) -> Result<(), VerifyError> {
         let response = self.get("/models").send().await?;
         match response.status() {

--- a/rig-core/src/providers/huggingface/client.rs
+++ b/rig-core/src/providers/huggingface/client.rs
@@ -1,7 +1,10 @@
 use super::completion::CompletionModel;
 #[cfg(feature = "image")]
 use crate::client::ImageGenerationClient;
-use crate::client::{ClientBuilderError, CompletionClient, ProviderClient, TranscriptionClient};
+use crate::client::{
+    ClientBuilderError, CompletionClient, ProviderClient, TranscriptionClient, VerifyClient,
+    VerifyError,
+};
 #[cfg(feature = "image")]
 use crate::image_generation::ImageGenerationError;
 #[cfg(feature = "image")]
@@ -214,6 +217,14 @@ impl Client {
             .bearer_auth(&self.api_key)
             .headers(self.default_headers.clone())
     }
+
+    pub(crate) fn get(&self, path: &str) -> reqwest::RequestBuilder {
+        let url = format!("{}/{}", self.base_url, path).replace("//", "/");
+        self.http_client
+            .get(url)
+            .bearer_auth(&self.api_key)
+            .headers(self.default_headers.clone())
+    }
 }
 
 impl ProviderClient for Client {
@@ -288,6 +299,23 @@ impl ImageGenerationClient for Client {
     /// ```
     fn image_generation_model(&self, model: &str) -> ImageGenerationModel {
         ImageGenerationModel::new(self.clone(), model)
+    }
+}
+
+impl VerifyClient for Client {
+    async fn verify(&self) -> Result<(), VerifyError> {
+        let response = self.get("/api/whoami-v2").send().await?;
+        match response.status() {
+            reqwest::StatusCode::OK => Ok(()),
+            reqwest::StatusCode::UNAUTHORIZED => Err(VerifyError::InvalidAuthentication),
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR => {
+                Err(VerifyError::ProviderError(response.text().await?))
+            }
+            _ => {
+                response.error_for_status()?;
+                Ok(())
+            }
+        }
     }
 }
 

--- a/rig-core/src/providers/huggingface/client.rs
+++ b/rig-core/src/providers/huggingface/client.rs
@@ -303,6 +303,7 @@ impl ImageGenerationClient for Client {
 }
 
 impl VerifyClient for Client {
+    #[cfg_attr(feature = "worker", worker::send)]
     async fn verify(&self) -> Result<(), VerifyError> {
         let response = self.get("/api/whoami-v2").send().await?;
         match response.status() {

--- a/rig-core/src/providers/hyperbolic.rs
+++ b/rig-core/src/providers/hyperbolic.rs
@@ -10,7 +10,9 @@
 //! ```
 use super::openai::{AssistantContent, send_compatible_streaming_request};
 
-use crate::client::{ClientBuilderError, CompletionClient, ProviderClient};
+use crate::client::{
+    ClientBuilderError, CompletionClient, ProviderClient, VerifyClient, VerifyError,
+};
 use crate::json_utils::merge_inplace;
 use crate::message;
 use crate::streaming::StreamingCompletionResponse;
@@ -29,7 +31,7 @@ use serde_json::{Value, json};
 // ================================================================
 // Main Hyperbolic Client
 // ================================================================
-const HYPERBOLIC_API_BASE_URL: &str = "https://api.hyperbolic.xyz/v1";
+const HYPERBOLIC_API_BASE_URL: &str = "https://api.hyperbolic.xyz";
 
 pub struct ClientBuilder<'a> {
     api_key: &'a str,
@@ -117,6 +119,11 @@ impl Client {
         let url = format!("{}/{}", self.base_url, path).replace("//", "/");
         self.http_client.post(url).bearer_auth(&self.api_key)
     }
+
+    pub(crate) fn get(&self, path: &str) -> reqwest::RequestBuilder {
+        let url = format!("{}/{}", self.base_url, path).replace("//", "/");
+        self.http_client.get(url).bearer_auth(&self.api_key)
+    }
 }
 
 impl ProviderClient for Client {
@@ -151,6 +158,23 @@ impl CompletionClient for Client {
     /// ```
     fn completion_model(&self, model: &str) -> CompletionModel {
         CompletionModel::new(self.clone(), model)
+    }
+}
+
+impl VerifyClient for Client {
+    async fn verify(&self) -> Result<(), VerifyError> {
+        let response = self.get("/users/me").send().await?;
+        match response.status() {
+            reqwest::StatusCode::OK => Ok(()),
+            reqwest::StatusCode::UNAUTHORIZED => Err(VerifyError::InvalidAuthentication),
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR => {
+                Err(VerifyError::ProviderError(response.text().await?))
+            }
+            _ => {
+                response.error_for_status()?;
+                Ok(())
+            }
+        }
     }
 }
 
@@ -388,7 +412,7 @@ impl completion::CompletionModel for CompletionModel {
 
         let response = self
             .client
-            .post("/chat/completions")
+            .post("/v1/chat/completions")
             .json(&request)
             .send()
             .await?;
@@ -422,7 +446,7 @@ impl completion::CompletionModel for CompletionModel {
             json!({"stream": true, "stream_options": {"include_usage": true}}),
         );
 
-        let builder = self.client.post("/chat/completions").json(&request);
+        let builder = self.client.post("/v1/chat/completions").json(&request);
 
         send_compatible_streaming_request(builder).await
     }
@@ -525,7 +549,7 @@ mod image_generation {
 
             let response = self
                 .client
-                .post("/image/generation")
+                .post("/v1/image/generation")
                 .json(&request)
                 .send()
                 .await?;
@@ -640,7 +664,7 @@ mod audio_generation {
 
             let response = self
                 .client
-                .post("/audio/generation")
+                .post("/v1/audio/generation")
                 .json(&request)
                 .send()
                 .await?;

--- a/rig-core/src/providers/hyperbolic.rs
+++ b/rig-core/src/providers/hyperbolic.rs
@@ -162,6 +162,7 @@ impl CompletionClient for Client {
 }
 
 impl VerifyClient for Client {
+    #[cfg_attr(feature = "worker", worker::send)]
     async fn verify(&self) -> Result<(), VerifyError> {
         let response = self.get("/users/me").send().await?;
         match response.status() {

--- a/rig-core/src/providers/mira.rs
+++ b/rig-core/src/providers/mira.rs
@@ -7,7 +7,9 @@
 //! let client = mira::Client::new("YOUR_API_KEY");
 //!
 //! ```
-use crate::client::{ClientBuilderError, CompletionClient, ProviderClient};
+use crate::client::{
+    ClientBuilderError, CompletionClient, ProviderClient, VerifyClient, VerifyError,
+};
 use crate::json_utils::merge;
 use crate::providers::openai;
 use crate::providers::openai::send_compatible_streaming_request;
@@ -206,15 +208,7 @@ impl Client {
 
     /// List available models
     pub async fn list_models(&self) -> Result<Vec<String>, MiraError> {
-        let url = format!("{}/v1/models", self.base_url);
-
-        let response = self
-            .http_client
-            .get(&url)
-            .bearer_auth(&self.api_key)
-            .headers(self.headers.clone())
-            .send()
-            .await?;
+        let response = self.get("/v1/models").send().await?;
 
         let status = response.status();
 
@@ -233,6 +227,22 @@ impl Client {
         })?;
 
         Ok(models.data.into_iter().map(|model| model.id).collect())
+    }
+
+    pub(crate) fn post(&self, path: &str) -> reqwest::RequestBuilder {
+        let url = format!("{}/{}", self.base_url, path).replace("//", "/");
+        self.http_client
+            .post(url)
+            .bearer_auth(&self.api_key)
+            .headers(self.headers.clone())
+    }
+
+    pub(crate) fn get(&self, path: &str) -> reqwest::RequestBuilder {
+        let url = format!("{}/{}", self.base_url, path).replace("//", "/");
+        self.http_client
+            .get(url)
+            .bearer_auth(&self.api_key)
+            .headers(self.headers.clone())
     }
 }
 
@@ -257,6 +267,23 @@ impl CompletionClient for Client {
     /// Create a completion model with the given name.
     fn completion_model(&self, model: &str) -> CompletionModel {
         CompletionModel::new(self.to_owned(), model)
+    }
+}
+
+impl VerifyClient for Client {
+    async fn verify(&self) -> Result<(), VerifyError> {
+        let response = self.get("/user-credits").send().await?;
+        match response.status() {
+            reqwest::StatusCode::OK => Ok(()),
+            reqwest::StatusCode::UNAUTHORIZED => Err(VerifyError::InvalidAuthentication),
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR => {
+                Err(VerifyError::ProviderError(response.text().await?))
+            }
+            _ => {
+                response.error_for_status()?;
+                Ok(())
+            }
+        }
     }
 }
 
@@ -380,10 +407,7 @@ impl completion::CompletionModel for CompletionModel {
 
         let response = self
             .client
-            .http_client
-            .post(format!("{}/v1/chat/completions", self.client.base_url))
-            .bearer_auth(&self.client.api_key)
-            .headers(self.client.headers.clone())
+            .post("/v1/chat/completions")
             .json(&mira_request)
             .send()
             .await
@@ -414,12 +438,7 @@ impl completion::CompletionModel for CompletionModel {
 
         request = merge(request, json!({"stream": true}));
 
-        let builder = self
-            .client
-            .http_client
-            .post(format!("{}/v1/chat/completions", self.client.base_url))
-            .headers(self.client.headers.clone())
-            .json(&request);
+        let builder = self.client.post("/v1/chat/completions").json(&request);
 
         send_compatible_streaming_request(builder).await
     }

--- a/rig-core/src/providers/mira.rs
+++ b/rig-core/src/providers/mira.rs
@@ -271,6 +271,7 @@ impl CompletionClient for Client {
 }
 
 impl VerifyClient for Client {
+    #[cfg_attr(feature = "worker", worker::send)]
     async fn verify(&self) -> Result<(), VerifyError> {
         let response = self.get("/user-credits").send().await?;
         match response.status() {

--- a/rig-core/src/providers/mistral/client.rs
+++ b/rig-core/src/providers/mistral/client.rs
@@ -172,6 +172,7 @@ impl EmbeddingsClient for Client {
 }
 
 impl VerifyClient for Client {
+    #[cfg_attr(feature = "worker", worker::send)]
     async fn verify(&self) -> Result<(), VerifyError> {
         let response = self.get("/models").send().await?;
         match response.status() {

--- a/rig-core/src/providers/mistral/client.rs
+++ b/rig-core/src/providers/mistral/client.rs
@@ -4,7 +4,10 @@ use super::{
     CompletionModel,
     embedding::{EmbeddingModel, MISTRAL_EMBED},
 };
-use crate::client::{ClientBuilderError, CompletionClient, EmbeddingsClient, ProviderClient};
+use crate::client::{
+    ClientBuilderError, CompletionClient, EmbeddingsClient, ProviderClient, VerifyClient,
+    VerifyError,
+};
 use crate::impl_conversion_traits;
 
 const MISTRAL_API_BASE_URL: &str = "https://api.mistral.ai";
@@ -95,6 +98,11 @@ impl Client {
         let url = format!("{}/{}", self.base_url, path).replace("//", "/");
         self.http_client.post(url).bearer_auth(&self.api_key)
     }
+
+    pub(crate) fn get(&self, path: &str) -> reqwest::RequestBuilder {
+        let url = format!("{}/{}", self.base_url, path).replace("//", "/");
+        self.http_client.get(url).bearer_auth(&self.api_key)
+    }
 }
 
 impl ProviderClient for Client {
@@ -160,6 +168,23 @@ impl EmbeddingsClient for Client {
 
     fn embedding_model_with_ndims(&self, model: &str, ndims: usize) -> Self::EmbeddingModel {
         EmbeddingModel::new(self.clone(), model, ndims)
+    }
+}
+
+impl VerifyClient for Client {
+    async fn verify(&self) -> Result<(), VerifyError> {
+        let response = self.get("/models").send().await?;
+        match response.status() {
+            reqwest::StatusCode::OK => Ok(()),
+            reqwest::StatusCode::UNAUTHORIZED => Err(VerifyError::InvalidAuthentication),
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR => {
+                Err(VerifyError::ProviderError(response.text().await?))
+            }
+            _ => {
+                response.error_for_status()?;
+                Ok(())
+            }
+        }
     }
 }
 

--- a/rig-core/src/providers/moonshot.rs
+++ b/rig-core/src/providers/moonshot.rs
@@ -8,7 +8,9 @@
 //!
 //! let moonshot_model = client.completion_model(moonshot::MOONSHOT_CHAT);
 //! ```
-use crate::client::{ClientBuilderError, CompletionClient, ProviderClient};
+use crate::client::{
+    ClientBuilderError, CompletionClient, ProviderClient, VerifyClient, VerifyError,
+};
 use crate::json_utils::merge;
 use crate::providers::openai::send_compatible_streaming_request;
 use crate::streaming::StreamingCompletionResponse;
@@ -112,6 +114,11 @@ impl Client {
         let url = format!("{}/{}", self.base_url, path).replace("//", "/");
         self.http_client.post(url).bearer_auth(&self.api_key)
     }
+
+    pub(crate) fn get(&self, path: &str) -> reqwest::RequestBuilder {
+        let url = format!("{}/{}", self.base_url, path).replace("//", "/");
+        self.http_client.get(url).bearer_auth(&self.api_key)
+    }
 }
 
 impl ProviderClient for Client {
@@ -146,6 +153,23 @@ impl CompletionClient for Client {
     /// ```
     fn completion_model(&self, model: &str) -> CompletionModel {
         CompletionModel::new(self.clone(), model)
+    }
+}
+
+impl VerifyClient for Client {
+    async fn verify(&self) -> Result<(), VerifyError> {
+        let response = self.get("/models").send().await?;
+        match response.status() {
+            reqwest::StatusCode::OK => Ok(()),
+            reqwest::StatusCode::UNAUTHORIZED => Err(VerifyError::InvalidAuthentication),
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR => {
+                Err(VerifyError::ProviderError(response.text().await?))
+            }
+            _ => {
+                response.error_for_status()?;
+                Ok(())
+            }
+        }
     }
 }
 

--- a/rig-core/src/providers/moonshot.rs
+++ b/rig-core/src/providers/moonshot.rs
@@ -157,6 +157,7 @@ impl CompletionClient for Client {
 }
 
 impl VerifyClient for Client {
+    #[cfg_attr(feature = "worker", worker::send)]
     async fn verify(&self) -> Result<(), VerifyError> {
         let response = self.get("/models").send().await?;
         match response.status() {

--- a/rig-core/src/providers/ollama.rs
+++ b/rig-core/src/providers/ollama.rs
@@ -189,6 +189,7 @@ impl EmbeddingsClient for Client {
 }
 
 impl VerifyClient for Client {
+    #[cfg_attr(feature = "worker", worker::send)]
     async fn verify(&self) -> Result<(), VerifyError> {
         let response = self
             .get("api/tags")

--- a/rig-core/src/providers/openai/client.rs
+++ b/rig-core/src/providers/openai/client.rs
@@ -230,6 +230,7 @@ impl AudioGenerationClient for Client {
 }
 
 impl VerifyClient for Client {
+    #[cfg_attr(feature = "worker", worker::send)]
     async fn verify(&self) -> Result<(), VerifyError> {
         let response = self.get("/models").send().await?;
         match response.status() {

--- a/rig-core/src/providers/openai/client.rs
+++ b/rig-core/src/providers/openai/client.rs
@@ -10,6 +10,7 @@ use super::transcription::TranscriptionModel;
 
 use crate::client::{
     ClientBuilderError, CompletionClient, EmbeddingsClient, ProviderClient, TranscriptionClient,
+    VerifyClient, VerifyError,
 };
 
 #[cfg(feature = "audio")]
@@ -109,6 +110,11 @@ impl Client {
     pub(crate) fn post(&self, path: &str) -> reqwest::RequestBuilder {
         let url = format!("{}/{}", self.base_url, path).replace("//", "/");
         self.http_client.post(url).bearer_auth(&self.api_key)
+    }
+
+    pub(crate) fn get(&self, path: &str) -> reqwest::RequestBuilder {
+        let url = format!("{}/{}", self.base_url, path).replace("//", "/");
+        self.http_client.get(url).bearer_auth(&self.api_key)
     }
 }
 
@@ -220,6 +226,23 @@ impl AudioGenerationClient for Client {
     /// ```
     fn audio_generation_model(&self, model: &str) -> Self::AudioGenerationModel {
         AudioGenerationModel::new(self.clone(), model)
+    }
+}
+
+impl VerifyClient for Client {
+    async fn verify(&self) -> Result<(), VerifyError> {
+        let response = self.get("/models").send().await?;
+        match response.status() {
+            reqwest::StatusCode::OK => Ok(()),
+            reqwest::StatusCode::UNAUTHORIZED => Err(VerifyError::InvalidAuthentication),
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR => {
+                Err(VerifyError::ProviderError(response.text().await?))
+            }
+            _ => {
+                response.error_for_status()?;
+                Ok(())
+            }
+        }
     }
 }
 

--- a/rig-core/src/providers/openrouter/client.rs
+++ b/rig-core/src/providers/openrouter/client.rs
@@ -1,5 +1,5 @@
 use crate::{
-    client::{ClientBuilderError, CompletionClient, ProviderClient},
+    client::{ClientBuilderError, CompletionClient, ProviderClient, VerifyClient, VerifyError},
     impl_conversion_traits,
 };
 use serde::{Deserialize, Serialize};
@@ -97,6 +97,11 @@ impl Client {
         let url = format!("{}/{}", self.base_url, path).replace("//", "/");
         self.http_client.post(url).bearer_auth(&self.api_key)
     }
+
+    pub(crate) fn get(&self, path: &str) -> reqwest::RequestBuilder {
+        let url = format!("{}/{}", self.base_url, path).replace("//", "/");
+        self.http_client.get(url).bearer_auth(&self.api_key)
+    }
 }
 
 impl ProviderClient for Client {
@@ -131,6 +136,23 @@ impl CompletionClient for Client {
     /// ```
     fn completion_model(&self, model: &str) -> CompletionModel {
         CompletionModel::new(self.clone(), model)
+    }
+}
+
+impl VerifyClient for Client {
+    async fn verify(&self) -> Result<(), VerifyError> {
+        let response = self.get("/key").send().await?;
+        match response.status() {
+            reqwest::StatusCode::OK => Ok(()),
+            reqwest::StatusCode::UNAUTHORIZED => Err(VerifyError::InvalidAuthentication),
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR => {
+                Err(VerifyError::ProviderError(response.text().await?))
+            }
+            _ => {
+                response.error_for_status()?;
+                Ok(())
+            }
+        }
     }
 }
 

--- a/rig-core/src/providers/openrouter/client.rs
+++ b/rig-core/src/providers/openrouter/client.rs
@@ -140,6 +140,7 @@ impl CompletionClient for Client {
 }
 
 impl VerifyClient for Client {
+    #[cfg_attr(feature = "worker", worker::send)]
     async fn verify(&self) -> Result<(), VerifyError> {
         let response = self.get("/key").send().await?;
         match response.status() {

--- a/rig-core/src/providers/perplexity.rs
+++ b/rig-core/src/providers/perplexity.rs
@@ -156,6 +156,7 @@ impl CompletionClient for Client {
 }
 
 impl VerifyClient for Client {
+    #[cfg_attr(feature = "worker", worker::send)]
     async fn verify(&self) -> Result<(), VerifyError> {
         // No API endpoint to verify the API key
         Ok(())

--- a/rig-core/src/providers/perplexity.rs
+++ b/rig-core/src/providers/perplexity.rs
@@ -11,6 +11,7 @@
 use crate::{
     OneOrMany,
     agent::AgentBuilder,
+    client::{VerifyClient, VerifyError},
     completion::{self, CompletionError, MessageError, message},
     extractor::ExtractorBuilder,
     impl_conversion_traits, json_utils,
@@ -151,6 +152,13 @@ impl CompletionClient for Client {
 
     fn completion_model(&self, model: &str) -> CompletionModel {
         CompletionModel::new(self.clone(), model)
+    }
+}
+
+impl VerifyClient for Client {
+    async fn verify(&self) -> Result<(), VerifyError> {
+        // No API endpoint to verify the API key
+        Ok(())
     }
 }
 

--- a/rig-core/src/providers/together/client.rs
+++ b/rig-core/src/providers/together/client.rs
@@ -1,5 +1,8 @@
 use super::{M2_BERT_80M_8K_RETRIEVAL, completion::CompletionModel, embedding::EmbeddingModel};
-use crate::client::{ClientBuilderError, EmbeddingsClient, ProviderClient, impl_conversion_traits};
+use crate::client::{
+    ClientBuilderError, EmbeddingsClient, ProviderClient, VerifyClient, VerifyError,
+    impl_conversion_traits,
+};
 use rig::client::CompletionClient;
 
 // ================================================================
@@ -106,6 +109,16 @@ impl Client {
             .bearer_auth(&self.api_key)
             .headers(self.default_headers.clone())
     }
+
+    pub(crate) fn get(&self, path: &str) -> reqwest::RequestBuilder {
+        let url = format!("{}/{}", self.base_url, path).replace("//", "/");
+
+        tracing::debug!("GET {}", url);
+        self.http_client
+            .get(url)
+            .bearer_auth(&self.api_key)
+            .headers(self.default_headers.clone())
+    }
 }
 
 impl ProviderClient for Client {
@@ -171,6 +184,23 @@ impl EmbeddingsClient for Client {
     /// ```
     fn embedding_model_with_ndims(&self, model: &str, ndims: usize) -> EmbeddingModel {
         EmbeddingModel::new(self.clone(), model, ndims)
+    }
+}
+
+impl VerifyClient for Client {
+    async fn verify(&self) -> Result<(), VerifyError> {
+        let response = self.get("/models").send().await?;
+        match response.status() {
+            reqwest::StatusCode::OK => Ok(()),
+            reqwest::StatusCode::UNAUTHORIZED => Err(VerifyError::InvalidAuthentication),
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR | reqwest::StatusCode::GATEWAY_TIMEOUT => {
+                Err(VerifyError::ProviderError(response.text().await?))
+            }
+            _ => {
+                response.error_for_status()?;
+                Ok(())
+            }
+        }
     }
 }
 

--- a/rig-core/src/providers/together/client.rs
+++ b/rig-core/src/providers/together/client.rs
@@ -188,6 +188,7 @@ impl EmbeddingsClient for Client {
 }
 
 impl VerifyClient for Client {
+    #[cfg_attr(feature = "worker", worker::send)]
     async fn verify(&self) -> Result<(), VerifyError> {
         let response = self.get("/models").send().await?;
         match response.status() {

--- a/rig-core/src/providers/voyageai.rs
+++ b/rig-core/src/providers/voyageai.rs
@@ -1,4 +1,6 @@
-use crate::client::{ClientBuilderError, EmbeddingsClient, ProviderClient};
+use crate::client::{
+    ClientBuilderError, EmbeddingsClient, ProviderClient, VerifyClient, VerifyError,
+};
 use crate::embeddings::EmbeddingError;
 use crate::{embeddings, impl_conversion_traits};
 use serde::Deserialize;
@@ -94,6 +96,13 @@ impl Client {
     pub(crate) fn post(&self, path: &str) -> reqwest::RequestBuilder {
         let url = format!("{}/{}", self.base_url, path).replace("//", "/");
         self.http_client.post(url).bearer_auth(&self.api_key)
+    }
+}
+
+impl VerifyClient for Client {
+    async fn verify(&self) -> Result<(), VerifyError> {
+        // No API endpoint to verify the API key
+        Ok(())
     }
 }
 

--- a/rig-core/src/providers/voyageai.rs
+++ b/rig-core/src/providers/voyageai.rs
@@ -100,6 +100,7 @@ impl Client {
 }
 
 impl VerifyClient for Client {
+    #[cfg_attr(feature = "worker", worker::send)]
     async fn verify(&self) -> Result<(), VerifyError> {
         // No API endpoint to verify the API key
         Ok(())

--- a/rig-core/src/providers/xai/client.rs
+++ b/rig-core/src/providers/xai/client.rs
@@ -1,5 +1,8 @@
 use super::completion::CompletionModel;
-use crate::client::{ClientBuilderError, CompletionClient, ProviderClient, impl_conversion_traits};
+use crate::client::{
+    ClientBuilderError, CompletionClient, ProviderClient, VerifyClient, VerifyError,
+    impl_conversion_traits,
+};
 
 // ================================================================
 // xAI Client
@@ -106,6 +109,16 @@ impl Client {
             .bearer_auth(&self.api_key)
             .headers(self.default_headers.clone())
     }
+
+    pub(crate) fn get(&self, path: &str) -> reqwest::RequestBuilder {
+        let url = format!("{}/{}", self.base_url, path).replace("//", "/");
+
+        tracing::debug!("GET {}", url);
+        self.http_client
+            .get(url)
+            .bearer_auth(&self.api_key)
+            .headers(self.default_headers.clone())
+    }
 }
 
 impl ProviderClient for Client {
@@ -130,6 +143,25 @@ impl CompletionClient for Client {
     /// Create a completion model with the given name.
     fn completion_model(&self, model: &str) -> CompletionModel {
         CompletionModel::new(self.clone(), model)
+    }
+}
+
+impl VerifyClient for Client {
+    async fn verify(&self) -> Result<(), VerifyError> {
+        let response = self.get("/v1/api-key").send().await?;
+        match response.status() {
+            reqwest::StatusCode::OK => Ok(()),
+            reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN => {
+                Err(VerifyError::InvalidAuthentication)
+            }
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR => {
+                Err(VerifyError::ProviderError(response.text().await?))
+            }
+            _ => {
+                response.error_for_status()?;
+                Ok(())
+            }
+        }
     }
 }
 

--- a/rig-core/src/providers/xai/client.rs
+++ b/rig-core/src/providers/xai/client.rs
@@ -147,6 +147,7 @@ impl CompletionClient for Client {
 }
 
 impl VerifyClient for Client {
+    #[cfg_attr(feature = "worker", worker::send)]
     async fn verify(&self) -> Result<(), VerifyError> {
         let response = self.get("/v1/api-key").send().await?;
         match response.status() {


### PR DESCRIPTION
Allow user to verify if a client is valid without consuming tokens.

The way I built this:
1. Try to use a key verification api if available
2. Fallback to models api
3. Otherwise always return Ok