### PR TITLE
feat(rig-904): Rework CLI chatbot integration

### DIFF
--- a/rig-core/examples/agent_with_echochambers.rs
+++ b/rig-core/examples/agent_with_echochambers.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use reqwest::header::{CONTENT_TYPE, HeaderMap, HeaderValue};
 use rig::prelude::*;
 use rig::{
-    cli_chatbot::cli_chatbot,
+    cli_chatbot::ChatbotBuilder,
     completion::ToolDefinition,
     providers::openai::{Client, GPT_4O},
     tool::Tool,
@@ -360,7 +360,14 @@ async fn main() -> Result<(), anyhow::Error> {
         .tool(GetMetricsHistory)
         .build();
 
-    // Start the CLI chatbot
-    cli_chatbot(echochambers_agent).await?;
+    // Build a CLI chatbot from the agent, with multi-turn enabled
+    let chatbot = ChatbotBuilder::new()
+        .agent(echochambers_agent)
+        .multi_turn_depth(10)
+        .build();
+
+    // Run the agent
+    chatbot.run().await?;
+
     Ok(())
 }

--- a/rig-core/examples/calculator_chatbot.rs
+++ b/rig-core/examples/calculator_chatbot.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use rig::prelude::*;
 use rig::{
-    cli_chatbot::cli_chatbot,
+    cli_chatbot::ChatbotBuilder,
     completion::ToolDefinition,
     embeddings::EmbeddingsBuilder,
     providers::openai::{Client, TEXT_EMBEDDING_ADA_002},
@@ -269,8 +269,10 @@ async fn main() -> Result<(), anyhow::Error> {
         .dynamic_tools(4, index, toolset)
         .build();
 
-    // Prompt the agent and print the response
-    cli_chatbot(calculator_rag).await?;
+    // Create a CLI chatbot from the agent
+    let chatbot = ChatbotBuilder::new().agent(calculator_rag).build();
+
+    chatbot.run().await?;
 
     Ok(())
 }

--- a/rig-core/examples/multi_agent.rs
+++ b/rig-core/examples/multi_agent.rs
@@ -1,68 +1,99 @@
+use anyhow::Result;
 use rig::prelude::*;
 use rig::{
     agent::{Agent, AgentBuilder},
-    cli_chatbot::cli_chatbot,
-    completion::{Chat, CompletionModel, PromptError},
-    message::Message,
+    cli_chatbot::ChatbotBuilder,
+    completion::{Chat, CompletionModel, PromptError, ToolDefinition},
     providers::openai::Client as OpenAIClient,
+    tool::Tool,
 };
+use serde::Deserialize;
+use serde_json::json;
 
-/// Represents a multi agent application that consists of two components:
-/// an agent specialized in translating prompt into english and a simple GPT-4 model.
-/// When prompted, the application will use the translator agent to translate the
-/// prompt in english, before answering it with GPT-4. The answer in english is returned.
-struct EnglishTranslator<M: CompletionModel> {
-    translator_agent: Agent<M>,
-    gpt4: Agent<M>,
+// Define a wrapper around an agent so that it can be provided to another agent
+// as a tool
+struct TranslatorTool<M: CompletionModel>(Agent<M>);
+
+// The input that will be sent to the translator agent from the main agent
+#[derive(Deserialize)]
+struct TranslatorArgs {
+    prompt: String,
 }
 
-impl<M: CompletionModel> EnglishTranslator<M> {
-    fn new(model: M) -> Self {
-        Self {
-            // Create the translator agent
-            translator_agent: AgentBuilder::new(model.clone())
-                .preamble("\
-                    You are a translator assistant that will translate any input text into english. \
-                    If the text is already in english, simply respond with the original text but fix any mistakes (grammar, syntax, etc.). \
-                ")
-                .build(),
+impl<M: CompletionModel> Tool for TranslatorTool<M> {
+    const NAME: &'static str = "translator";
 
-            // Create the GPT4 model
-            gpt4: AgentBuilder::new(model).build()
+    type Args = TranslatorArgs;
+    type Error = PromptError;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        serde_json::from_value(json!({
+            "name": Self::NAME,
+            "description": "Translate any text to English. If already in English, fix grammar and syntax issues.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "prompt": {
+                        "type": "string",
+                        "description": "The text to translate to English"
+                    },
+                },
+                "required": ["prompt"]
+            }
+        }))
+        .expect("Tool Definition")
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        match self.0.chat(&args.prompt, vec![]).await {
+            Ok(response) => {
+                println!("Translated prompt: {response}");
+                Ok(response)
+            }
+            Err(e) => Err(e),
         }
     }
 }
 
-impl<M: CompletionModel> Chat for EnglishTranslator<M> {
-    #[allow(refining_impl_trait)]
-    async fn chat(
-        &self,
-        prompt: impl Into<Message> + Send,
-        chat_history: Vec<Message>,
-    ) -> Result<String, PromptError> {
-        // Translate the prompt using the translator agent
-        let translated_prompt = self
-            .translator_agent
-            .chat(prompt, chat_history.clone())
-            .await?;
-        println!("Translated prompt: {translated_prompt}");
-        // Answer the prompt using gpt4
-        self.gpt4
-            .chat(translated_prompt.as_str(), chat_history)
-            .await
-    }
-}
-
+/// A multi agent application that consists of two components:
+/// an agent specialized in translating prompt into english and a simple GPT-4 model.
+/// When provided with a prompt in a language besides english, the application will use
+/// the translator agent to translate the prompt in english, before answering it with GPT-4.
+/// The answer in english is returned.
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     // Create OpenAI client
     let openai_client = OpenAIClient::from_env();
     let model = openai_client.completion_model("gpt-4");
 
-    // Create model
-    let translator = EnglishTranslator::new(model);
+    let translator_agent = AgentBuilder::new(model.clone())
+                .preamble(
+                    "You are a translator assistant that will translate any input text into english. \
+                    If the text is already in english, simply respond with the original text but fix any mistakes (grammar, syntax, etc.)."
+                )
+                .build();
 
-    // Spin up a chatbot using the agent
-    cli_chatbot(translator).await?;
+    let translator_tool = TranslatorTool(translator_agent);
+
+    let multi_agent_system = AgentBuilder::new(model)
+        .preamble(&format!(
+            "You are a helpful assistant that can work with text in any language. \
+            When you receive input that is not in English, or contains grammatical errors \
+            use the {} tool first to ensure proper English, then provide your response. \
+            Always show both the translated text and your final response.",
+            translator_tool.name()
+        ))
+        .tool(translator_tool)
+        .build();
+
+    // Spin up a CLI chatbot using the multi-agent system
+    let chatbot = ChatbotBuilder::new()
+        .agent(multi_agent_system)
+        .multi_turn_depth(1)
+        .build();
+
+    chatbot.run().await?;
+
     Ok(())
 }

--- a/rig-core/examples/pdf_agent.rs
+++ b/rig-core/examples/pdf_agent.rs
@@ -95,7 +95,7 @@ async fn main() -> Result<()> {
     println!("Starting CLI chatbot...");
 
     // Start interactive CLI
-    rig::cli_chatbot::cli_chatbot(rag_agent).await?;
+    rig::cli_chatbot::cli_chatbot(rag_agent, 10).await?;
 
     Ok(())
 }

--- a/rig-core/examples/pdf_agent.rs
+++ b/rig-core/examples/pdf_agent.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use rig::cli_chatbot::ChatbotBuilder;
 use rig::prelude::*;
 use rig::{
     Embed, embeddings::EmbeddingsBuilder, loaders::PdfFileLoader, providers::openai,
@@ -95,7 +96,12 @@ async fn main() -> Result<()> {
     println!("Starting CLI chatbot...");
 
     // Start interactive CLI
-    rig::cli_chatbot::cli_chatbot(rag_agent, 10).await?;
+    let chatbot = ChatbotBuilder::new()
+        .agent(rag_agent)
+        .multi_turn_depth(10)
+        .build();
+
+    chatbot.run().await?;
 
     Ok(())
 }

--- a/rig-core/src/cli_chatbot.rs
+++ b/rig-core/src/cli_chatbot.rs
@@ -1,44 +1,193 @@
 use std::io::{self, Write};
 
-use crate::completion::{Chat, Message, PromptError};
+use futures::StreamExt;
 
-/// Utility function to create a simple REPL CLI chatbot from a type that implements the
-/// `Chat` trait.
-pub async fn cli_chatbot(chatbot: impl Chat) -> Result<(), PromptError> {
-    let stdin = io::stdin();
-    let mut stdout = io::stdout();
-    let mut chat_log = vec![];
+use crate::{
+    agent::{Agent, prompt_request::streaming::MultiTurnStreamItem},
+    completion::{CompletionError, CompletionModel, Message, PromptError},
+    streaming::StreamingPrompt,
+};
 
-    println!("Welcome to the chatbot! Type 'exit' to quit.");
-    loop {
-        print!("> ");
-        // Flush stdout to ensure the prompt appears before input
-        stdout.flush().unwrap();
+/// Type-state representing an empty `agent` field in `ChatbotBuilder`
+pub struct AgentNotSet;
 
-        let mut input = String::new();
-        match stdin.read_line(&mut input) {
-            Ok(_) => {
-                // Remove the newline character from the input
-                let input = input.trim();
-                // Check for a command to exit
-                if input == "exit" {
-                    break;
-                }
-                tracing::info!("Prompt:\n{}\n", input);
+/// Builder pattern for CLI chatbots
+///
+/// # Example
+/// ```rust
+/// let chatbot = ChatbotBuilder::new().agent(my_agent).show_usage().build();
+///
+/// chatbot.run().await?;
+pub struct ChatbotBuilder<A> {
+    agent: A,
+    multi_turn_depth: usize,
+    show_usage: bool,
+}
 
-                let response = chatbot.chat(input, chat_log.clone()).await?;
-                chat_log.push(Message::user(input));
-                chat_log.push(Message::assistant(response.clone()));
+impl Default for ChatbotBuilder<AgentNotSet> {
+    fn default() -> Self {
+        ChatbotBuilder {
+            agent: AgentNotSet,
+            multi_turn_depth: 0,
+            show_usage: false,
+        }
+    }
+}
 
-                println!("========================== Response ============================");
-                println!("{response}");
-                println!("================================================================\n\n");
+impl ChatbotBuilder<AgentNotSet> {
+    pub fn new() -> Self {
+        Default::default()
+    }
 
-                tracing::info!("Response:\n{}\n", response);
-            }
-            Err(error) => println!("Error reading input: {error}"),
+    /// Sets the agent that will be used to drive the CLI interface
+    pub fn agent<M>(self, agent: Agent<M>) -> ChatbotBuilder<Agent<M>>
+    where
+        M: CompletionModel + 'static,
+    {
+        ChatbotBuilder {
+            agent,
+            multi_turn_depth: self.multi_turn_depth,
+            show_usage: self.show_usage,
+        }
+    }
+}
+
+impl<A> ChatbotBuilder<A> {
+    /// Sets the `show_usage` flag, so that after a request the number of tokens
+    /// in the input and output will be printed
+    pub fn show_usage(self) -> Self {
+        Self {
+            show_usage: true,
+            ..self
         }
     }
 
-    Ok(())
+    /// Sets the maximum depth for multi-turn, i.e. toolcalls
+    pub fn multi_turn_depth(self, multi_turn_depth: usize) -> Self {
+        Self {
+            multi_turn_depth,
+            ..self
+        }
+    }
+}
+
+impl<M> ChatbotBuilder<Agent<M>>
+where
+    M: CompletionModel + 'static,
+{
+    /// Consumes the `ChatbotBuilder`, returning a `Chatbot` which can be run
+    pub fn build(self) -> Chatbot<M> {
+        Chatbot {
+            agent: self.agent,
+            multi_turn_depth: self.multi_turn_depth,
+            show_usage: self.show_usage,
+        }
+    }
+}
+
+/// A CLI chatbot
+///
+/// # Example
+/// ```rust
+/// let chatbot = ChatbotBuilder::new().agent(my_agent).show_usage().build();
+///
+/// chatbot.run().await?;
+pub struct Chatbot<M>
+where
+    M: CompletionModel + 'static,
+{
+    agent: Agent<M>,
+    multi_turn_depth: usize,
+    show_usage: bool,
+}
+
+impl<M> Chatbot<M>
+where
+    M: CompletionModel + 'static,
+{
+    pub async fn run(self) -> Result<(), PromptError> {
+        let stdin = io::stdin();
+        let mut stdout = io::stdout();
+        let mut chat_log = vec![];
+
+        println!("Welcome to the chatbot! Type 'exit' to quit.");
+
+        loop {
+            print!("> ");
+            // Flush stdout to ensure the prompt appears before input
+            stdout.flush().unwrap();
+
+            let mut input = String::new();
+            match stdin.read_line(&mut input) {
+                Ok(_) => {
+                    // Remove the newline character from the input
+                    let input = input.trim();
+
+                    if input.is_empty() {
+                        continue;
+                    }
+
+                    // Check for a command to exit
+                    if input == "exit" {
+                        break;
+                    }
+
+                    tracing::info!("Prompt:\n{}\n", input);
+
+                    let mut usage = None;
+                    let mut response = String::new();
+
+                    println!();
+                    println!("========================== Response ============================");
+
+                    let mut stream_response = self
+                        .agent
+                        .stream_prompt(input)
+                        .with_history(chat_log.clone())
+                        .multi_turn(self.multi_turn_depth)
+                        .await;
+
+                    while let Some(chunk) = stream_response.next().await {
+                        match chunk {
+                            Ok(MultiTurnStreamItem::Text(s)) => {
+                                let text = s.text.as_str();
+                                print!("{text}");
+                                response.push_str(text);
+                            }
+                            Ok(MultiTurnStreamItem::FinalResponse(r)) => {
+                                if self.show_usage {
+                                    usage = Some(r.usage());
+                                }
+                            }
+
+                            Err(e) => {
+                                return Err(PromptError::CompletionError(
+                                    CompletionError::ResponseError(e.to_string()),
+                                ));
+                            }
+                        }
+                    }
+
+                    println!("================================================================");
+                    println!();
+
+                    // `with_history` does not push to history, we have handle that
+                    chat_log.push(Message::user(input));
+                    chat_log.push(Message::assistant(response.clone()));
+
+                    if let Some(usage) = usage {
+                        println!(
+                            "Input: {} tokens\nOutput: {} tokens",
+                            usage.input_tokens, usage.output_tokens
+                        )
+                    }
+
+                    tracing::info!("Response:\n{}\n", response);
+                }
+                Err(error) => println!("Error reading input: {error}"),
+            }
+        }
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
Fixes #742 

## Changes 
- Replaced the `cli_chatbot` function with `Chatbot` and `ChatbotBuilder`
- Type-safe builder using the "type-state" pattern, where the `build` method is not available until the agent has been set
- Added configuration options for multi-turn depth and displaying token usage
- Added streaming requests, with response chunks printed as they are received
- Refactored examples using `cli_chatbot`

## API
```rust
let chatbot = ChatbotBuilder::new()
  .agent(my_agent)
  .multi_turn_depth(1)
  .show_usage()
  .build();

chatbot.run().await?;
```

## Notes
- I wasn't able to match the API @joshua-mo-143 suggested exactly (`Chatbot::builder`) due to inference issues with the generic parameter in `Agent<M>`. 
- The multi-agent example had to be refactored significantly to match the new API. It now composes agents by providing one as a tool to the other, as opposed to the previous approach where both are placed in a struct implementing `Chat`. I'm not 100% that this still aligns with the original intention.
