### PR TITLE
feat(rig-core): add fn cli_chatbot() back

### DIFF
--- a/justfile
+++ b/justfile
@@ -27,4 +27,4 @@ bwf:
 # Runs a command that compiles the docs then opens it as if it were the official docs on Docs.rs
 # Requires nightly toolchain
 doc:
-    RUSTDOCFLAGS="--cfg docsrs" cargo +nightly -p rig-core doc --all-features --open
+    RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --package rig-core --all-features --open


### PR DESCRIPTION
Adds `rig::cli_chatbot::cli_chatbot` back in.

The reason why we're adding this back in is that it appears that there are several users who are attempting to use it that still need it. Until we can think of a better solution to this, I think it is pretty obvious that we should just keep it in until we can definitively think of something better.