### PR TITLE
refactor: Add #[non_exhaustive] to public enums (#598)

### DIFF
--- a/rig-core/src/agent/prompt_request/mod.rs
+++ b/rig-core/src/agent/prompt_request/mod.rs
@@ -2,13 +2,13 @@ pub(crate) mod streaming;
 
 use std::{future::IntoFuture, marker::PhantomData};
 
-use futures::{FutureExt, StreamExt, future::BoxFuture, stream};
+use futures::{future::BoxFuture, stream, FutureExt, StreamExt};
 
 use crate::{
-    OneOrMany,
     completion::{Completion, CompletionError, CompletionModel, Message, PromptError, Usage},
     message::{AssistantContent, UserContent},
     tool::ToolSetError,
+    OneOrMany,
 };
 
 use super::Agent;
@@ -28,159 +28,161 @@ impl PromptType for Extended {}
 /// attempting to await (which will send the prompt request) can potentially return
 /// [`crate::completion::request::PromptError::MaxDepthError`] if the agent decides to call tools
 /// back to back.
+///
+#[non_exhaustive]
 pub struct PromptRequest<'a, S, M, P>
 where
-    S: PromptType,
-    M: CompletionModel,
-    P: PromptHook<M>,
+	S: PromptType,
+	M: CompletionModel,
+	P: PromptHook<M>,
 {
-    /// The prompt message to send to the model
-    prompt: Message,
-    /// Optional chat history to include with the prompt
-    /// Note: chat history needs to outlive the agent as it might be used with other agents
-    chat_history: Option<&'a mut Vec<Message>>,
-    /// Maximum depth for multi-turn conversations (0 means no multi-turn)
-    max_depth: usize,
-    /// The agent to use for execution
-    agent: &'a Agent<M>,
-    /// Phantom data to track the type of the request
-    state: PhantomData<S>,
-    /// Optional per-request hook for events
-    hook: Option<P>,
+	/// The prompt message to send to the model
+	prompt: Message,
+	/// Optional chat history to include with the prompt
+	/// Note: chat history needs to outlive the agent as it might be used with other agents
+	chat_history: Option<&'a mut Vec<Message>>,
+	/// Maximum depth for multi-turn conversations (0 means no multi-turn)
+	max_depth: usize,
+	/// The agent to use for execution
+	agent: &'a Agent<M>,
+	/// Phantom data to track the type of the request
+	state: PhantomData<S>,
+	/// Optional per-request hook for events
+	hook: Option<P>,
 }
 
 impl<'a, M> PromptRequest<'a, Standard, M, ()>
 where
-    M: CompletionModel,
+	M: CompletionModel,
 {
-    /// Create a new PromptRequest with the given prompt and model
-    pub fn new(agent: &'a Agent<M>, prompt: impl Into<Message>) -> Self {
-        Self {
-            prompt: prompt.into(),
-            chat_history: None,
-            max_depth: 0,
-            agent,
-            state: PhantomData,
-            hook: None,
-        }
-    }
+	/// Create a new PromptRequest with the given prompt and model
+	pub fn new(agent: &'a Agent<M>, prompt: impl Into<Message>) -> Self {
+		Self {
+			prompt: prompt.into(),
+			chat_history: None,
+			max_depth: 0,
+			agent,
+			state: PhantomData,
+			hook: None,
+		}
+	}
 }
 
 impl<'a, S, M, P> PromptRequest<'a, S, M, P>
 where
-    S: PromptType,
-    M: CompletionModel,
-    P: PromptHook<M>,
+	S: PromptType,
+	M: CompletionModel,
+	P: PromptHook<M>,
 {
-    /// Enable returning extended details for responses (includes aggregated token usage)
-    ///
-    /// Note: This changes the type of the response from `.send` to return a `PromptResponse` struct
-    /// instead of a simple `String`. This is useful for tracking token usage across multiple turns
-    /// of conversation.
-    pub fn extended_details(self) -> PromptRequest<'a, Extended, M, P> {
-        PromptRequest {
-            prompt: self.prompt,
-            chat_history: self.chat_history,
-            max_depth: self.max_depth,
-            agent: self.agent,
-            state: PhantomData,
-            hook: self.hook,
-        }
-    }
-    /// Set the maximum depth for multi-turn conversations (ie, the maximum number of turns an LLM can have calling tools before writing a text response).
-    /// If the maximum turn number is exceeded, it will return a [`crate::completion::request::PromptError::MaxDepthError`].
-    pub fn multi_turn(self, depth: usize) -> PromptRequest<'a, S, M, P> {
-        PromptRequest {
-            prompt: self.prompt,
-            chat_history: self.chat_history,
-            max_depth: depth,
-            agent: self.agent,
-            state: PhantomData,
-            hook: self.hook,
-        }
-    }
+	/// Enable returning extended details for responses (includes aggregated token usage)
+	///
+	/// Note: This changes the type of the response from `.send` to return a `PromptResponse` struct
+	/// instead of a simple `String`. This is useful for tracking token usage across multiple turns
+	/// of conversation.
+	pub fn extended_details(self) -> PromptRequest<'a, Extended, M, P> {
+		PromptRequest {
+			prompt: self.prompt,
+			chat_history: self.chat_history,
+			max_depth: self.max_depth,
+			agent: self.agent,
+			state: PhantomData,
+			hook: self.hook,
+		}
+	}
+	/// Set the maximum depth for multi-turn conversations (ie, the maximum number of turns an LLM can have calling tools before writing a text response).
+	/// If the maximum turn number is exceeded, it will return a [`crate::completion::request::PromptError::MaxDepthError`].
+	pub fn multi_turn(self, depth: usize) -> PromptRequest<'a, S, M, P> {
+		PromptRequest {
+			prompt: self.prompt,
+			chat_history: self.chat_history,
+			max_depth: depth,
+			agent: self.agent,
+			state: PhantomData,
+			hook: self.hook,
+		}
+	}
 
-    /// Add chat history to the prompt request
-    pub fn with_history(self, history: &'a mut Vec<Message>) -> PromptRequest<'a, S, M, P> {
-        PromptRequest {
-            prompt: self.prompt,
-            chat_history: Some(history),
-            max_depth: self.max_depth,
-            agent: self.agent,
-            state: PhantomData,
-            hook: self.hook,
-        }
-    }
+	/// Add chat history to the prompt request
+	pub fn with_history(self, history: &'a mut Vec<Message>) -> PromptRequest<'a, S, M, P> {
+		PromptRequest {
+			prompt: self.prompt,
+			chat_history: Some(history),
+			max_depth: self.max_depth,
+			agent: self.agent,
+			state: PhantomData,
+			hook: self.hook,
+		}
+	}
 
-    /// Attach a per-request hook for tool call events
-    pub fn with_hook<P2>(self, hook: P2) -> PromptRequest<'a, S, M, P2>
-    where
-        P2: PromptHook<M>,
-    {
-        PromptRequest {
-            prompt: self.prompt,
-            chat_history: self.chat_history,
-            max_depth: self.max_depth,
-            agent: self.agent,
-            state: PhantomData,
-            hook: Some(hook),
-        }
-    }
+	/// Attach a per-request hook for tool call events
+	pub fn with_hook<P2>(self, hook: P2) -> PromptRequest<'a, S, M, P2>
+	where
+		P2: PromptHook<M>,
+	{
+		PromptRequest {
+			prompt: self.prompt,
+			chat_history: self.chat_history,
+			max_depth: self.max_depth,
+			agent: self.agent,
+			state: PhantomData,
+			hook: Some(hook),
+		}
+	}
 }
 
 // dead code allowed because of functions being left empty to allow for users to not have to implement every single function
 /// Trait for per-request hooks to observe tool call events.
 pub trait PromptHook<M>: Clone + Send + Sync
 where
-    M: CompletionModel,
+	M: CompletionModel,
 {
-    #[allow(unused_variables)]
-    /// Called before the prompt is sent to the model
-    fn on_completion_call(
-        &self,
-        prompt: &Message,
-        history: &[Message],
-    ) -> impl Future<Output = ()> + Send {
-        async {}
-    }
+	#[allow(unused_variables)]
+	/// Called before the prompt is sent to the model
+	fn on_completion_call(
+		&self,
+		prompt: &Message,
+		history: &[Message],
+	) -> impl Future<Output=()> + Send {
+		async {}
+	}
 
-    #[allow(unused_variables)]
-    /// Called after the prompt is sent to the model and a response is received.
-    /// This function is for non-streamed responses. Please refer to `on_stream_completion_response_finish` for streamed responses.
-    fn on_completion_response(
-        &self,
-        prompt: &Message,
-        response: &crate::completion::CompletionResponse<M::Response>,
-    ) -> impl Future<Output = ()> + Send {
-        async {}
-    }
+	#[allow(unused_variables)]
+	/// Called after the prompt is sent to the model and a response is received.
+	/// This function is for non-streamed responses. Please refer to `on_stream_completion_response_finish` for streamed responses.
+	fn on_completion_response(
+		&self,
+		prompt: &Message,
+		response: &crate::completion::CompletionResponse<M::Response>,
+	) -> impl Future<Output=()> + Send {
+		async {}
+	}
 
-    #[allow(unused_variables)]
-    /// Called after the model provider has finished streaming a text response from their completion API to the client.
-    fn on_stream_completion_response_finish(
-        &self,
-        prompt: &Message,
-        response: &<M as CompletionModel>::StreamingResponse,
-    ) -> impl Future<Output = ()> + Send {
-        async {}
-    }
+	#[allow(unused_variables)]
+	/// Called after the model provider has finished streaming a text response from their completion API to the client.
+	fn on_stream_completion_response_finish(
+		&self,
+		prompt: &Message,
+		response: &<M as CompletionModel>::StreamingResponse,
+	) -> impl Future<Output=()> + Send {
+		async {}
+	}
 
-    #[allow(unused_variables)]
-    /// Called before a tool is invoked.
-    fn on_tool_call(&self, tool_name: &str, args: &str) -> impl Future<Output = ()> + Send {
-        async {}
-    }
+	#[allow(unused_variables)]
+	/// Called before a tool is invoked.
+	fn on_tool_call(&self, tool_name: &str, args: &str) -> impl Future<Output=()> + Send {
+		async {}
+	}
 
-    #[allow(unused_variables)]
-    /// Called after a tool is invoked (and a result has been returned).
-    fn on_tool_result(
-        &self,
-        tool_name: &str,
-        args: &str,
-        result: &str,
-    ) -> impl Future<Output = ()> + Send {
-        async {}
-    }
+	#[allow(unused_variables)]
+	/// Called after a tool is invoked (and a result has been returned).
+	fn on_tool_result(
+		&self,
+		tool_name: &str,
+		args: &str,
+		result: &str,
+	) -> impl Future<Output=()> + Send {
+		async {}
+	}
 }
 
 impl<M> PromptHook<M> for () where M: CompletionModel {}
@@ -190,197 +192,197 @@ impl<M> PromptHook<M> for () where M: CompletionModel {}
 ///  directly via the associated type.
 impl<'a, M, P> IntoFuture for PromptRequest<'a, Standard, M, P>
 where
-    M: CompletionModel,
-    P: PromptHook<M> + 'static,
+	M: CompletionModel,
+	P: PromptHook<M> + 'static,
 {
-    type Output = Result<String, PromptError>;
-    type IntoFuture = BoxFuture<'a, Self::Output>; // This future should not outlive the agent
+	type Output = Result<String, PromptError>;
+	type IntoFuture = BoxFuture<'a, Self::Output>; // This future should not outlive the agent
 
-    fn into_future(self) -> Self::IntoFuture {
-        self.send().boxed()
-    }
+	fn into_future(self) -> Self::IntoFuture {
+		self.send().boxed()
+	}
 }
 
 impl<'a, M, P> IntoFuture for PromptRequest<'a, Extended, M, P>
 where
-    M: CompletionModel,
-    P: PromptHook<M> + 'static,
+	M: CompletionModel,
+	P: PromptHook<M> + 'static,
 {
-    type Output = Result<PromptResponse, PromptError>;
-    type IntoFuture = BoxFuture<'a, Self::Output>; // This future should not outlive the agent
+	type Output = Result<PromptResponse, PromptError>;
+	type IntoFuture = BoxFuture<'a, Self::Output>; // This future should not outlive the agent
 
-    fn into_future(self) -> Self::IntoFuture {
-        self.send().boxed()
-    }
+	fn into_future(self) -> Self::IntoFuture {
+		self.send().boxed()
+	}
 }
 
 impl<M, P> PromptRequest<'_, Standard, M, P>
 where
-    M: CompletionModel,
-    P: PromptHook<M>,
+	M: CompletionModel,
+	P: PromptHook<M>,
 {
-    async fn send(self) -> Result<String, PromptError> {
-        self.extended_details().send().await.map(|resp| resp.output)
-    }
+	async fn send(self) -> Result<String, PromptError> {
+		self.extended_details().send().await.map(|resp| resp.output)
+	}
 }
 
 #[derive(Debug, Clone)]
 pub struct PromptResponse {
-    pub output: String,
-    pub total_usage: Usage,
+	pub output: String,
+	pub total_usage: Usage,
 }
 
 impl PromptResponse {
-    pub fn new(output: impl Into<String>, total_usage: Usage) -> Self {
-        Self {
-            output: output.into(),
-            total_usage,
-        }
-    }
+	pub fn new(output: impl Into<String>, total_usage: Usage) -> Self {
+		Self {
+			output: output.into(),
+			total_usage,
+		}
+	}
 }
 
 impl<M, P> PromptRequest<'_, Extended, M, P>
 where
-    M: CompletionModel,
-    P: PromptHook<M>,
+	M: CompletionModel,
+	P: PromptHook<M>,
 {
-    #[tracing::instrument(skip(self), fields(agent_name = self.agent.name()))]
-    async fn send(self) -> Result<PromptResponse, PromptError> {
-        let agent = self.agent;
-        let chat_history = if let Some(history) = self.chat_history {
-            history.push(self.prompt);
-            history
-        } else {
-            &mut vec![self.prompt]
-        };
+	#[tracing::instrument(skip(self), fields(agent_name = self.agent.name()))]
+	async fn send(self) -> Result<PromptResponse, PromptError> {
+		let agent = self.agent;
+		let chat_history = if let Some(history) = self.chat_history {
+			history.push(self.prompt);
+			history
+		} else {
+			&mut vec![self.prompt]
+		};
 
-        let mut current_max_depth = 0;
-        let mut usage = Usage::new();
+		let mut current_max_depth = 0;
+		let mut usage = Usage::new();
 
-        // We need to do at least 2 loops for 1 roundtrip (user expects normal message)
-        let last_prompt = loop {
-            let prompt = chat_history
-                .last()
-                .cloned()
-                .expect("there should always be at least one message in the chat history");
+		// We need to do at least 2 loops for 1 roundtrip (user expects normal message)
+		let last_prompt = loop {
+			let prompt = chat_history
+				.last()
+				.cloned()
+				.expect("there should always be at least one message in the chat history");
 
-            if current_max_depth > self.max_depth + 1 {
-                break prompt;
-            }
+			if current_max_depth > self.max_depth + 1 {
+				break prompt;
+			}
 
-            current_max_depth += 1;
+			current_max_depth += 1;
 
-            if self.max_depth > 1 {
-                tracing::info!(
+			if self.max_depth > 1 {
+				tracing::info!(
                     "Current conversation depth: {}/{}",
                     current_max_depth,
                     self.max_depth
                 );
-            }
+			}
 
-            if let Some(ref hook) = self.hook {
-                hook.on_completion_call(&prompt, &chat_history[..chat_history.len() - 1])
-                    .await;
-            }
+			if let Some(ref hook) = self.hook {
+				hook.on_completion_call(&prompt, &chat_history[..chat_history.len() - 1])
+				    .await;
+			}
 
-            let resp = agent
-                .completion(
-                    prompt.clone(),
-                    chat_history[..chat_history.len() - 1].to_vec(),
-                )
-                .await?
-                .send()
-                .await?;
+			let resp = agent
+				.completion(
+					prompt.clone(),
+					chat_history[..chat_history.len() - 1].to_vec(),
+				)
+				.await?
+				.send()
+				.await?;
 
-            usage += resp.usage;
+			usage += resp.usage;
 
-            if let Some(ref hook) = self.hook {
-                hook.on_completion_response(&prompt, &resp).await;
-            }
+			if let Some(ref hook) = self.hook {
+				hook.on_completion_response(&prompt, &resp).await;
+			}
 
-            let (tool_calls, texts): (Vec<_>, Vec<_>) = resp
-                .choice
-                .iter()
-                .partition(|choice| matches!(choice, AssistantContent::ToolCall(_)));
+			let (tool_calls, texts): (Vec<_>, Vec<_>) = resp
+				.choice
+				.iter()
+				.partition(|choice| matches!(choice, AssistantContent::ToolCall(_)));
 
-            chat_history.push(Message::Assistant {
-                id: None,
-                content: resp.choice.clone(),
-            });
+			chat_history.push(Message::Assistant {
+				id: None,
+				content: resp.choice.clone(),
+			});
 
-            if tool_calls.is_empty() {
-                let merged_texts = texts
-                    .into_iter()
-                    .filter_map(|content| {
-                        if let AssistantContent::Text(text) = content {
-                            Some(text.text.clone())
-                        } else {
-                            None
-                        }
-                    })
-                    .collect::<Vec<_>>()
-                    .join("\n");
+			if tool_calls.is_empty() {
+				let merged_texts = texts
+					.into_iter()
+					.filter_map(|content| {
+						if let AssistantContent::Text(text) = content {
+							Some(text.text.clone())
+						} else {
+							None
+						}
+					})
+					.collect::<Vec<_>>()
+					.join("\n");
 
-                if self.max_depth > 1 {
-                    tracing::info!("Depth reached: {}/{}", current_max_depth, self.max_depth);
-                }
+				if self.max_depth > 1 {
+					tracing::info!("Depth reached: {}/{}", current_max_depth, self.max_depth);
+				}
 
-                // If there are no tool calls, depth is not relevant, we can just return the merged text response.
-                return Ok(PromptResponse::new(merged_texts, usage));
-            }
+				// If there are no tool calls, depth is not relevant, we can just return the merged text response.
+				return Ok(PromptResponse::new(merged_texts, usage));
+			}
 
-            let hook = self.hook.clone();
-            let tool_content = stream::iter(tool_calls)
-                .then(|choice| {
-                    let hook1 = hook.clone();
-                    let hook2 = hook.clone();
-                    async move {
-                        if let AssistantContent::ToolCall(tool_call) = choice {
-                            let tool_name = &tool_call.function.name;
-                            let args = tool_call.function.arguments.to_string();
-                            if let Some(hook) = hook1 {
-                                hook.on_tool_call(tool_name, &args).await;
-                            }
-                            let output = agent.tools.call(tool_name, args.clone()).await?;
-                            if let Some(hook) = hook2 {
-                                hook.on_tool_result(tool_name, &args, &output.to_string())
-                                    .await;
-                            }
-                            if let Some(call_id) = tool_call.call_id.clone() {
-                                Ok(UserContent::tool_result_with_call_id(
-                                    tool_call.id.clone(),
-                                    call_id,
-                                    OneOrMany::one(output.into()),
-                                ))
-                            } else {
-                                Ok(UserContent::tool_result(
-                                    tool_call.id.clone(),
-                                    OneOrMany::one(output.into()),
-                                ))
-                            }
-                        } else {
-                            unreachable!(
-                                "This should never happen as we already filtered for `ToolCall`"
-                            )
-                        }
-                    }
-                })
-                .collect::<Vec<Result<UserContent, ToolSetError>>>()
-                .await
-                .into_iter()
-                .collect::<Result<Vec<_>, _>>()
-                .map_err(|e| CompletionError::RequestError(Box::new(e)))?;
+			let hook = self.hook.clone();
+			let tool_content = stream::iter(tool_calls)
+				.then(|choice| {
+					let hook1 = hook.clone();
+					let hook2 = hook.clone();
+					async move {
+						if let AssistantContent::ToolCall(tool_call) = choice {
+							let tool_name = &tool_call.function.name;
+							let args = tool_call.function.arguments.to_string();
+							if let Some(hook) = hook1 {
+								hook.on_tool_call(tool_name, &args).await;
+							}
+							let output = agent.tools.call(tool_name, args.clone()).await?;
+							if let Some(hook) = hook2 {
+								hook.on_tool_result(tool_name, &args, &output.to_string())
+								    .await;
+							}
+							if let Some(call_id) = tool_call.call_id.clone() {
+								Ok(UserContent::tool_result_with_call_id(
+									tool_call.id.clone(),
+									call_id,
+									OneOrMany::one(output.into()),
+								))
+							} else {
+								Ok(UserContent::tool_result(
+									tool_call.id.clone(),
+									OneOrMany::one(output.into()),
+								))
+							}
+						} else {
+							unreachable!(
+								"This should never happen as we already filtered for `ToolCall`"
+							)
+						}
+					}
+				})
+				.collect::<Vec<Result<UserContent, ToolSetError>>>()
+				.await
+				.into_iter()
+				.collect::<Result<Vec<_>, _>>()
+				.map_err(|e| CompletionError::RequestError(Box::new(e)))?;
 
-            chat_history.push(Message::User {
-                content: OneOrMany::many(tool_content).expect("There is atleast one tool call"),
-            });
-        };
+			chat_history.push(Message::User {
+				content: OneOrMany::many(tool_content).expect("There is atleast one tool call"),
+			});
+		};
 
-        // If we reach here, we never resolved the final tool call. We need to do ... something.
-        Err(PromptError::MaxDepthError {
-            max_depth: self.max_depth,
-            chat_history: chat_history.clone(),
-            prompt: last_prompt,
-        })
-    }
+		// If we reach here, we never resolved the final tool call. We need to do ... something.
+		Err(PromptError::MaxDepthError {
+			max_depth: self.max_depth,
+			chat_history: chat_history.clone(),
+			prompt: last_prompt,
+		})
+	}
 }

--- a/rig-core/src/audio_generation.rs
+++ b/rig-core/src/audio_generation.rs
@@ -7,176 +7,177 @@ use std::sync::Arc;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum AudioGenerationError {
-    /// Http error (e.g.: connection error, timeout, etc.)
-    #[error("HttpError: {0}")]
-    HttpError(#[from] reqwest::Error),
+	/// Http error (e.g.: connection error, timeout, etc.)
+	#[error("HttpError: {0}")]
+	HttpError(#[from] reqwest::Error),
 
-    /// Json error (e.g.: serialization, deserialization)
-    #[error("JsonError: {0}")]
-    JsonError(#[from] serde_json::Error),
+	/// Json error (e.g.: serialization, deserialization)
+	#[error("JsonError: {0}")]
+	JsonError(#[from] serde_json::Error),
 
-    /// Error building the transcription request
-    #[error("RequestError: {0}")]
-    RequestError(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
+	/// Error building the transcription request
+	#[error("RequestError: {0}")]
+	RequestError(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
 
-    /// Error parsing the transcription response
-    #[error("ResponseError: {0}")]
-    ResponseError(String),
+	/// Error parsing the transcription response
+	#[error("ResponseError: {0}")]
+	ResponseError(String),
 
-    /// Error returned by the transcription model provider
-    #[error("ProviderError: {0}")]
-    ProviderError(String),
+	/// Error returned by the transcription model provider
+	#[error("ProviderError: {0}")]
+	ProviderError(String),
 }
 pub trait AudioGeneration<M>
 where
-    M: AudioGenerationModel,
+	M: AudioGenerationModel,
 {
-    /// Generates an audio generation request builder for the given `text` and `voice`.
-    /// This function is meant to be called by the user to further customize the
-    /// request at generation time before sending it.
-    ///
-    /// ❗IMPORTANT: The type that implements this trait might have already
-    /// populated fields in the builder (the exact fields depend on the type).
-    /// For fields that have already been set by the model, calling the corresponding
-    /// method on the builder will overwrite the value set by the model.
-    fn audio_generation(
-        &self,
-        text: &str,
-        voice: &str,
-    ) -> impl std::future::Future<
-        Output = Result<AudioGenerationRequestBuilder<M>, AudioGenerationError>,
-    > + Send;
+	/// Generates an audio generation request builder for the given `text` and `voice`.
+	/// This function is meant to be called by the user to further customize the
+	/// request at generation time before sending it.
+	///
+	/// ❗IMPORTANT: The type that implements this trait might have already
+	/// populated fields in the builder (the exact fields depend on the type).
+	/// For fields that have already been set by the model, calling the corresponding
+	/// method on the builder will overwrite the value set by the model.
+	fn audio_generation(
+		&self,
+		text: &str,
+		voice: &str,
+	) -> impl std::future::Future<
+		Output=Result<AudioGenerationRequestBuilder<M>, AudioGenerationError>,
+	> + Send;
 }
 
 pub struct AudioGenerationResponse<T> {
-    pub audio: Vec<u8>,
-    pub response: T,
+	pub audio: Vec<u8>,
+	pub response: T,
 }
 
 pub trait AudioGenerationModel: Clone + Send + Sync {
-    type Response: Send + Sync;
+	type Response: Send + Sync;
 
-    fn audio_generation(
-        &self,
-        request: AudioGenerationRequest,
-    ) -> impl std::future::Future<
-        Output = Result<AudioGenerationResponse<Self::Response>, AudioGenerationError>,
-    > + Send;
+	fn audio_generation(
+		&self,
+		request: AudioGenerationRequest,
+	) -> impl std::future::Future<
+		Output=Result<AudioGenerationResponse<Self::Response>, AudioGenerationError>,
+	> + Send;
 
-    fn audio_generation_request(&self) -> AudioGenerationRequestBuilder<Self> {
-        AudioGenerationRequestBuilder::new(self.clone())
-    }
+	fn audio_generation_request(&self) -> AudioGenerationRequestBuilder<Self> {
+		AudioGenerationRequestBuilder::new(self.clone())
+	}
 }
 
 pub trait AudioGenerationModelDyn: Send + Sync {
-    fn audio_generation(
-        &self,
-        request: AudioGenerationRequest,
-    ) -> BoxFuture<'_, Result<AudioGenerationResponse<()>, AudioGenerationError>>;
+	fn audio_generation(
+		&self,
+		request: AudioGenerationRequest,
+	) -> BoxFuture<'_, Result<AudioGenerationResponse<()>, AudioGenerationError>>;
 
-    fn audio_generation_request(
-        &self,
-    ) -> AudioGenerationRequestBuilder<AudioGenerationModelHandle<'_>>;
+	fn audio_generation_request(
+		&self,
+	) -> AudioGenerationRequestBuilder<AudioGenerationModelHandle<'_>>;
 }
 
 impl<T> AudioGenerationModelDyn for T
 where
-    T: AudioGenerationModel,
+	T: AudioGenerationModel,
 {
-    fn audio_generation(
-        &self,
-        request: AudioGenerationRequest,
-    ) -> BoxFuture<'_, Result<AudioGenerationResponse<()>, AudioGenerationError>> {
-        Box::pin(async move {
-            let resp = self.audio_generation(request).await;
+	fn audio_generation(
+		&self,
+		request: AudioGenerationRequest,
+	) -> BoxFuture<'_, Result<AudioGenerationResponse<()>, AudioGenerationError>> {
+		Box::pin(async move {
+			let resp = self.audio_generation(request).await;
 
-            resp.map(|r| AudioGenerationResponse {
-                audio: r.audio,
-                response: (),
-            })
-        })
-    }
+			resp.map(|r| AudioGenerationResponse {
+				audio: r.audio,
+				response: (),
+			})
+		})
+	}
 
-    fn audio_generation_request(
-        &self,
-    ) -> AudioGenerationRequestBuilder<AudioGenerationModelHandle<'_>> {
-        AudioGenerationRequestBuilder::new(AudioGenerationModelHandle {
-            inner: Arc::new(self.clone()),
-        })
-    }
+	fn audio_generation_request(
+		&self,
+	) -> AudioGenerationRequestBuilder<AudioGenerationModelHandle<'_>> {
+		AudioGenerationRequestBuilder::new(AudioGenerationModelHandle {
+			inner: Arc::new(self.clone()),
+		})
+	}
 }
 
 #[non_exhaustive]
 pub struct AudioGenerationRequest {
-    pub text: String,
-    pub voice: String,
-    pub speed: f32,
-    pub additional_params: Option<Value>,
+	pub text: String,
+	pub voice: String,
+	pub speed: f32,
+	pub additional_params: Option<Value>,
 }
 
 #[non_exhaustive]
 pub struct AudioGenerationRequestBuilder<M>
 where
-    M: AudioGenerationModel,
+	M: AudioGenerationModel,
 {
-    model: M,
-    text: String,
-    voice: String,
-    speed: f32,
-    additional_params: Option<Value>,
+	model: M,
+	text: String,
+	voice: String,
+	speed: f32,
+	additional_params: Option<Value>,
 }
 
 impl<M> AudioGenerationRequestBuilder<M>
 where
-    M: AudioGenerationModel,
+	M: AudioGenerationModel,
 {
-    pub fn new(model: M) -> Self {
-        Self {
-            model,
-            text: "".to_string(),
-            voice: "".to_string(),
-            speed: 1.0,
-            additional_params: None,
-        }
-    }
+	pub fn new(model: M) -> Self {
+		Self {
+			model,
+			text: "".to_string(),
+			voice: "".to_string(),
+			speed: 1.0,
+			additional_params: None,
+		}
+	}
 
-    /// Sets the text for the audio generation request
-    pub fn text(mut self, text: &str) -> Self {
-        self.text = text.to_string();
-        self
-    }
+	/// Sets the text for the audio generation request
+	pub fn text(mut self, text: &str) -> Self {
+		self.text = text.to_string();
+		self
+	}
 
-    /// The voice of the generated audio
-    pub fn voice(mut self, voice: &str) -> Self {
-        self.voice = voice.to_string();
-        self
-    }
+	/// The voice of the generated audio
+	pub fn voice(mut self, voice: &str) -> Self {
+		self.voice = voice.to_string();
+		self
+	}
 
-    /// The speed of the generated audio
-    pub fn speed(mut self, speed: f32) -> Self {
-        self.speed = speed;
-        self
-    }
+	/// The speed of the generated audio
+	pub fn speed(mut self, speed: f32) -> Self {
+		self.speed = speed;
+		self
+	}
 
-    /// Adds additional parameters to the audio generation request.
-    pub fn additional_params(mut self, params: Value) -> Self {
-        self.additional_params = Some(params);
-        self
-    }
+	/// Adds additional parameters to the audio generation request.
+	pub fn additional_params(mut self, params: Value) -> Self {
+		self.additional_params = Some(params);
+		self
+	}
 
-    pub fn build(self) -> AudioGenerationRequest {
-        AudioGenerationRequest {
-            text: self.text,
-            voice: self.voice,
-            speed: self.speed,
-            additional_params: self.additional_params,
-        }
-    }
+	pub fn build(self) -> AudioGenerationRequest {
+		AudioGenerationRequest {
+			text: self.text,
+			voice: self.voice,
+			speed: self.speed,
+			additional_params: self.additional_params,
+		}
+	}
 
-    pub async fn send(self) -> Result<AudioGenerationResponse<M::Response>, AudioGenerationError> {
-        let model = self.model.clone();
+	pub async fn send(self) -> Result<AudioGenerationResponse<M::Response>, AudioGenerationError> {
+		let model = self.model.clone();
 
-        model.audio_generation(self.build()).await
-    }
+		model.audio_generation(self.build()).await
+	}
 }

--- a/rig-core/src/cli_chatbot.rs
+++ b/rig-core/src/cli_chatbot.rs
@@ -3,7 +3,7 @@ use std::io::{self, Write};
 use futures::StreamExt;
 
 use crate::{
-    agent::{Agent, prompt_request::streaming::MultiTurnStreamItem},
+    agent::{prompt_request::streaming::MultiTurnStreamItem, Agent},
     completion::{Chat, CompletionError, CompletionModel, Message, PromptError},
     streaming::StreamingPrompt,
 };
@@ -18,71 +18,72 @@ pub struct AgentNotSet;
 /// let chatbot = ChatbotBuilder::new().agent(my_agent).show_usage().build();
 ///
 /// chatbot.run().await?;
+#[non_exhaustive]
 pub struct ChatbotBuilder<A> {
-    agent: A,
-    multi_turn_depth: usize,
-    show_usage: bool,
+	agent: A,
+	multi_turn_depth: usize,
+	show_usage: bool,
 }
 
 impl Default for ChatbotBuilder<AgentNotSet> {
-    fn default() -> Self {
-        ChatbotBuilder {
-            agent: AgentNotSet,
-            multi_turn_depth: 0,
-            show_usage: false,
-        }
-    }
+	fn default() -> Self {
+		ChatbotBuilder {
+			agent: AgentNotSet,
+			multi_turn_depth: 0,
+			show_usage: false,
+		}
+	}
 }
 
 impl ChatbotBuilder<AgentNotSet> {
-    pub fn new() -> Self {
-        Default::default()
-    }
+	pub fn new() -> Self {
+		Default::default()
+	}
 
-    /// Sets the agent that will be used to drive the CLI interface
-    pub fn agent<M>(self, agent: Agent<M>) -> ChatbotBuilder<Agent<M>>
-    where
-        M: CompletionModel + 'static,
-    {
-        ChatbotBuilder {
-            agent,
-            multi_turn_depth: self.multi_turn_depth,
-            show_usage: self.show_usage,
-        }
-    }
+	/// Sets the agent that will be used to drive the CLI interface
+	pub fn agent<M>(self, agent: Agent<M>) -> ChatbotBuilder<Agent<M>>
+	where
+		M: CompletionModel + 'static,
+	{
+		ChatbotBuilder {
+			agent,
+			multi_turn_depth: self.multi_turn_depth,
+			show_usage: self.show_usage,
+		}
+	}
 }
 
 impl<A> ChatbotBuilder<A> {
-    /// Sets the `show_usage` flag, so that after a request the number of tokens
-    /// in the input and output will be printed
-    pub fn show_usage(self) -> Self {
-        Self {
-            show_usage: true,
-            ..self
-        }
-    }
+	/// Sets the `show_usage` flag, so that after a request the number of tokens
+	/// in the input and output will be printed
+	pub fn show_usage(self) -> Self {
+		Self {
+			show_usage: true,
+			..self
+		}
+	}
 
-    /// Sets the maximum depth for multi-turn, i.e. toolcalls
-    pub fn multi_turn_depth(self, multi_turn_depth: usize) -> Self {
-        Self {
-            multi_turn_depth,
-            ..self
-        }
-    }
+	/// Sets the maximum depth for multi-turn, i.e. toolcalls
+	pub fn multi_turn_depth(self, multi_turn_depth: usize) -> Self {
+		Self {
+			multi_turn_depth,
+			..self
+		}
+	}
 }
 
 impl<M> ChatbotBuilder<Agent<M>>
 where
-    M: CompletionModel + 'static,
+	M: CompletionModel + 'static,
 {
-    /// Consumes the `ChatbotBuilder`, returning a `Chatbot` which can be run
-    pub fn build(self) -> Chatbot<M> {
-        Chatbot {
-            agent: self.agent,
-            multi_turn_depth: self.multi_turn_depth,
-            show_usage: self.show_usage,
-        }
-    }
+	/// Consumes the `ChatbotBuilder`, returning a `Chatbot` which can be run
+	pub fn build(self) -> Chatbot<M> {
+		Chatbot {
+			agent: self.agent,
+			multi_turn_depth: self.multi_turn_depth,
+			show_usage: self.show_usage,
+		}
+	}
 }
 
 /// A CLI chatbot.
@@ -95,102 +96,102 @@ where
 /// chatbot.run().await?;
 pub struct Chatbot<M>
 where
-    M: CompletionModel + 'static,
+	M: CompletionModel + 'static,
 {
-    agent: Agent<M>,
-    multi_turn_depth: usize,
-    show_usage: bool,
+	agent: Agent<M>,
+	multi_turn_depth: usize,
+	show_usage: bool,
 }
 
 impl<M> Chatbot<M>
 where
-    M: CompletionModel + 'static,
+	M: CompletionModel + 'static,
 {
-    pub async fn run(self) -> Result<(), PromptError> {
-        let stdin = io::stdin();
-        let mut stdout = io::stdout();
-        let mut chat_log = vec![];
+	pub async fn run(self) -> Result<(), PromptError> {
+		let stdin = io::stdin();
+		let mut stdout = io::stdout();
+		let mut chat_log = vec![];
 
-        println!("Welcome to the chatbot! Type 'exit' to quit.");
+		println!("Welcome to the chatbot! Type 'exit' to quit.");
 
-        loop {
-            print!("> ");
-            // Flush stdout to ensure the prompt appears before input
-            stdout.flush().unwrap();
+		loop {
+			print!("> ");
+			// Flush stdout to ensure the prompt appears before input
+			stdout.flush().unwrap();
 
-            let mut input = String::new();
-            match stdin.read_line(&mut input) {
-                Ok(_) => {
-                    // Remove the newline character from the input
-                    let input = input.trim();
+			let mut input = String::new();
+			match stdin.read_line(&mut input) {
+				Ok(_) => {
+					// Remove the newline character from the input
+					let input = input.trim();
 
-                    if input.is_empty() {
-                        continue;
-                    }
+					if input.is_empty() {
+						continue;
+					}
 
-                    // Check for a command to exit
-                    if input == "exit" {
-                        break;
-                    }
+					// Check for a command to exit
+					if input == "exit" {
+						break;
+					}
 
-                    tracing::info!("Prompt:\n{}\n", input);
+					tracing::info!("Prompt:\n{}\n", input);
 
-                    let mut usage = None;
-                    let mut response = String::new();
+					let mut usage = None;
+					let mut response = String::new();
 
-                    println!();
-                    println!("========================== Response ============================");
+					println!();
+					println!("========================== Response ============================");
 
-                    let mut stream_response = self
-                        .agent
-                        .stream_prompt(input)
-                        .with_history(chat_log.clone())
-                        .multi_turn(self.multi_turn_depth)
-                        .await;
+					let mut stream_response = self
+						.agent
+						.stream_prompt(input)
+						.with_history(chat_log.clone())
+						.multi_turn(self.multi_turn_depth)
+						.await;
 
-                    while let Some(chunk) = stream_response.next().await {
-                        match chunk {
-                            Ok(MultiTurnStreamItem::Text(s)) => {
-                                let text = s.text.as_str();
-                                print!("{text}");
-                                response.push_str(text);
-                            }
-                            Ok(MultiTurnStreamItem::FinalResponse(r)) => {
-                                if self.show_usage {
-                                    usage = Some(r.usage());
-                                }
-                            }
+					while let Some(chunk) = stream_response.next().await {
+						match chunk {
+							Ok(MultiTurnStreamItem::Text(s)) => {
+								let text = s.text.as_str();
+								print!("{text}");
+								response.push_str(text);
+							}
+							Ok(MultiTurnStreamItem::FinalResponse(r)) => {
+								if self.show_usage {
+									usage = Some(r.usage());
+								}
+							}
 
-                            Err(e) => {
-                                return Err(PromptError::CompletionError(
-                                    CompletionError::ResponseError(e.to_string()),
-                                ));
-                            }
-                        }
-                    }
+							Err(e) => {
+								return Err(PromptError::CompletionError(
+									CompletionError::ResponseError(e.to_string()),
+								));
+							}
+						}
+					}
 
-                    println!("================================================================");
-                    println!();
+					println!("================================================================");
+					println!();
 
-                    // `with_history` does not push to history, we have handle that
-                    chat_log.push(Message::user(input));
-                    chat_log.push(Message::assistant(response.clone()));
+					// `with_history` does not push to history, we have handle that
+					chat_log.push(Message::user(input));
+					chat_log.push(Message::assistant(response.clone()));
 
-                    if let Some(usage) = usage {
-                        println!(
-                            "Input: {} tokens\nOutput: {} tokens",
-                            usage.input_tokens, usage.output_tokens
-                        )
-                    }
+					if let Some(usage) = usage {
+						println!(
+							"Input: {} tokens\nOutput: {} tokens",
+							usage.input_tokens, usage.output_tokens
+						)
+					}
 
-                    tracing::info!("Response:\n{}\n", response);
-                }
-                Err(error) => println!("Error reading input: {error}"),
-            }
-        }
+					tracing::info!("Response:\n{}\n", response);
+				}
+				Err(error) => println!("Error reading input: {error}"),
+			}
+		}
 
-        Ok(())
-    }
+		Ok(())
+	}
 }
 
 /// Utility function to create a simple REPL CLI chatbot from a type that implements the
@@ -198,40 +199,40 @@ where
 ///
 /// Where the [Chatbot] type takes an agent, this takes any type that implements the [Chat] trait.
 pub async fn cli_chatbot(chatbot: impl Chat) -> Result<(), PromptError> {
-    let stdin = io::stdin();
-    let mut stdout = io::stdout();
-    let mut chat_log = vec![];
+	let stdin = io::stdin();
+	let mut stdout = io::stdout();
+	let mut chat_log = vec![];
 
-    println!("Welcome to the chatbot! Type 'exit' to quit.");
-    loop {
-        print!("> ");
-        // Flush stdout to ensure the prompt appears before input
-        stdout.flush().unwrap();
+	println!("Welcome to the chatbot! Type 'exit' to quit.");
+	loop {
+		print!("> ");
+		// Flush stdout to ensure the prompt appears before input
+		stdout.flush().unwrap();
 
-        let mut input = String::new();
-        match stdin.read_line(&mut input) {
-            Ok(_) => {
-                // Remove the newline character from the input
-                let input = input.trim();
-                // Check for a command to exit
-                if input == "exit" {
-                    break;
-                }
-                tracing::info!("Prompt:\n{}\n", input);
+		let mut input = String::new();
+		match stdin.read_line(&mut input) {
+			Ok(_) => {
+				// Remove the newline character from the input
+				let input = input.trim();
+				// Check for a command to exit
+				if input == "exit" {
+					break;
+				}
+				tracing::info!("Prompt:\n{}\n", input);
 
-                let response = chatbot.chat(input, chat_log.clone()).await?;
-                chat_log.push(Message::user(input));
-                chat_log.push(Message::assistant(response.clone()));
+				let response = chatbot.chat(input, chat_log.clone()).await?;
+				chat_log.push(Message::user(input));
+				chat_log.push(Message::assistant(response.clone()));
 
-                println!("========================== Response ============================");
-                println!("{response}");
-                println!("================================================================\n\n");
+				println!("========================== Response ============================");
+				println!("{response}");
+				println!("================================================================\n\n");
 
-                tracing::info!("Response:\n{}\n", response);
-            }
-            Err(error) => println!("Error reading input: {error}"),
-        }
-    }
+				tracing::info!("Response:\n{}\n", response);
+			}
+			Err(error) => println!("Error reading input: {error}"),
+		}
+	}
 
-    Ok(())
+	Ok(())
 }

--- a/rig-core/src/client/builder.rs
+++ b/rig-core/src/client/builder.rs
@@ -12,15 +12,16 @@ use std::panic::{RefUnwindSafe, UnwindSafe};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ClientBuildError {
-    #[error("factory error: {}", .0)]
-    FactoryError(String),
-    #[error("invalid id string: {}", .0)]
-    InvalidIdString(String),
-    #[error("unsupported feature: {} for {}", .1, .0)]
-    UnsupportedFeature(String, String),
-    #[error("unknown provider")]
-    UnknownProvider,
+	#[error("factory error: {}", .0)]
+	FactoryError(String),
+	#[error("invalid id string: {}", .0)]
+	InvalidIdString(String),
+	#[error("unsupported feature: {} for {}", .1, .0)]
+	UnsupportedFeature(String, String),
+	#[error("unknown provider")]
+	UnknownProvider,
 }
 
 pub type BoxCompletionModel<'a> = Box<dyn CompletionModelDyn + 'a>;
@@ -58,345 +59,345 @@ pub type BoxTranscriptionModel<'a> = Box<dyn TranscriptionModelDyn + 'a>;
 /// }
 /// ```
 pub struct DynClientBuilder {
-    registry: HashMap<String, ClientFactory>,
+	registry: HashMap<String, ClientFactory>,
 }
 
 impl Default for DynClientBuilder {
-    fn default() -> Self {
-        Self::new()
-    }
+	fn default() -> Self {
+		Self::new()
+	}
 }
 
 impl<'a> DynClientBuilder {
-    /// Generate a new instance of `DynClientBuilder`.
-    /// By default, every single possible client that can be registered
-    /// will be registered to the client builder.
-    pub fn new() -> Self {
-        Self {
-            registry: HashMap::new(),
-        }
-        .register_all(vec![
-            ClientFactory::new(
-                DefaultProviders::ANTHROPIC,
-                anthropic::Client::from_env_boxed,
-                anthropic::Client::from_val_boxed,
-            ),
-            ClientFactory::new(
-                DefaultProviders::COHERE,
-                cohere::Client::from_env_boxed,
-                cohere::Client::from_val_boxed,
-            ),
-            ClientFactory::new(
-                DefaultProviders::GEMINI,
-                gemini::Client::from_env_boxed,
-                gemini::Client::from_val_boxed,
-            ),
-            ClientFactory::new(
-                DefaultProviders::HUGGINGFACE,
-                huggingface::Client::from_env_boxed,
-                huggingface::Client::from_val_boxed,
-            ),
-            ClientFactory::new(
-                DefaultProviders::OPENAI,
-                openai::Client::from_env_boxed,
-                openai::Client::from_val_boxed,
-            ),
-            ClientFactory::new(
-                DefaultProviders::OPENROUTER,
-                openrouter::Client::from_env_boxed,
-                openrouter::Client::from_val_boxed,
-            ),
-            ClientFactory::new(
-                DefaultProviders::TOGETHER,
-                together::Client::from_env_boxed,
-                together::Client::from_val_boxed,
-            ),
-            ClientFactory::new(
-                DefaultProviders::XAI,
-                xai::Client::from_env_boxed,
-                xai::Client::from_val_boxed,
-            ),
-            ClientFactory::new(
-                DefaultProviders::AZURE,
-                azure::Client::from_env_boxed,
-                azure::Client::from_val_boxed,
-            ),
-            ClientFactory::new(
-                DefaultProviders::DEEPSEEK,
-                deepseek::Client::from_env_boxed,
-                deepseek::Client::from_val_boxed,
-            ),
-            ClientFactory::new(
-                DefaultProviders::GALADRIEL,
-                galadriel::Client::from_env_boxed,
-                galadriel::Client::from_val_boxed,
-            ),
-            ClientFactory::new(
-                DefaultProviders::GROQ,
-                groq::Client::from_env_boxed,
-                groq::Client::from_val_boxed,
-            ),
-            ClientFactory::new(
-                DefaultProviders::HYPERBOLIC,
-                hyperbolic::Client::from_env_boxed,
-                hyperbolic::Client::from_val_boxed,
-            ),
-            ClientFactory::new(
-                DefaultProviders::MOONSHOT,
-                moonshot::Client::from_env_boxed,
-                moonshot::Client::from_val_boxed,
-            ),
-            ClientFactory::new(
-                DefaultProviders::MIRA,
-                mira::Client::from_env_boxed,
-                mira::Client::from_val_boxed,
-            ),
-            ClientFactory::new(
-                DefaultProviders::MISTRAL,
-                mistral::Client::from_env_boxed,
-                mistral::Client::from_val_boxed,
-            ),
-            ClientFactory::new(
-                DefaultProviders::OLLAMA,
-                ollama::Client::from_env_boxed,
-                ollama::Client::from_val_boxed,
-            ),
-            ClientFactory::new(
-                DefaultProviders::PERPLEXITY,
-                perplexity::Client::from_env_boxed,
-                perplexity::Client::from_val_boxed,
-            ),
-        ])
-    }
+	/// Generate a new instance of `DynClientBuilder`.
+	/// By default, every single possible client that can be registered
+	/// will be registered to the client builder.
+	pub fn new() -> Self {
+		Self {
+			registry: HashMap::new(),
+		}
+			.register_all(vec![
+				ClientFactory::new(
+					DefaultProviders::ANTHROPIC,
+					anthropic::Client::from_env_boxed,
+					anthropic::Client::from_val_boxed,
+				),
+				ClientFactory::new(
+					DefaultProviders::COHERE,
+					cohere::Client::from_env_boxed,
+					cohere::Client::from_val_boxed,
+				),
+				ClientFactory::new(
+					DefaultProviders::GEMINI,
+					gemini::Client::from_env_boxed,
+					gemini::Client::from_val_boxed,
+				),
+				ClientFactory::new(
+					DefaultProviders::HUGGINGFACE,
+					huggingface::Client::from_env_boxed,
+					huggingface::Client::from_val_boxed,
+				),
+				ClientFactory::new(
+					DefaultProviders::OPENAI,
+					openai::Client::from_env_boxed,
+					openai::Client::from_val_boxed,
+				),
+				ClientFactory::new(
+					DefaultProviders::OPENROUTER,
+					openrouter::Client::from_env_boxed,
+					openrouter::Client::from_val_boxed,
+				),
+				ClientFactory::new(
+					DefaultProviders::TOGETHER,
+					together::Client::from_env_boxed,
+					together::Client::from_val_boxed,
+				),
+				ClientFactory::new(
+					DefaultProviders::XAI,
+					xai::Client::from_env_boxed,
+					xai::Client::from_val_boxed,
+				),
+				ClientFactory::new(
+					DefaultProviders::AZURE,
+					azure::Client::from_env_boxed,
+					azure::Client::from_val_boxed,
+				),
+				ClientFactory::new(
+					DefaultProviders::DEEPSEEK,
+					deepseek::Client::from_env_boxed,
+					deepseek::Client::from_val_boxed,
+				),
+				ClientFactory::new(
+					DefaultProviders::GALADRIEL,
+					galadriel::Client::from_env_boxed,
+					galadriel::Client::from_val_boxed,
+				),
+				ClientFactory::new(
+					DefaultProviders::GROQ,
+					groq::Client::from_env_boxed,
+					groq::Client::from_val_boxed,
+				),
+				ClientFactory::new(
+					DefaultProviders::HYPERBOLIC,
+					hyperbolic::Client::from_env_boxed,
+					hyperbolic::Client::from_val_boxed,
+				),
+				ClientFactory::new(
+					DefaultProviders::MOONSHOT,
+					moonshot::Client::from_env_boxed,
+					moonshot::Client::from_val_boxed,
+				),
+				ClientFactory::new(
+					DefaultProviders::MIRA,
+					mira::Client::from_env_boxed,
+					mira::Client::from_val_boxed,
+				),
+				ClientFactory::new(
+					DefaultProviders::MISTRAL,
+					mistral::Client::from_env_boxed,
+					mistral::Client::from_val_boxed,
+				),
+				ClientFactory::new(
+					DefaultProviders::OLLAMA,
+					ollama::Client::from_env_boxed,
+					ollama::Client::from_val_boxed,
+				),
+				ClientFactory::new(
+					DefaultProviders::PERPLEXITY,
+					perplexity::Client::from_env_boxed,
+					perplexity::Client::from_val_boxed,
+				),
+			])
+	}
 
-    /// Generate a new instance of `DynClientBuilder` with no client factories registered.
-    pub fn empty() -> Self {
-        Self {
-            registry: HashMap::new(),
-        }
-    }
+	/// Generate a new instance of `DynClientBuilder` with no client factories registered.
+	pub fn empty() -> Self {
+		Self {
+			registry: HashMap::new(),
+		}
+	}
 
-    /// Register a new ClientFactory
-    pub fn register(mut self, client_factory: ClientFactory) -> Self {
-        self.registry
-            .insert(client_factory.name.clone(), client_factory);
-        self
-    }
+	/// Register a new ClientFactory
+	pub fn register(mut self, client_factory: ClientFactory) -> Self {
+		self.registry
+		    .insert(client_factory.name.clone(), client_factory);
+		self
+	}
 
-    /// Register multiple ClientFactories
-    pub fn register_all(mut self, factories: impl IntoIterator<Item = ClientFactory>) -> Self {
-        for factory in factories {
-            self.registry.insert(factory.name.clone(), factory);
-        }
+	/// Register multiple ClientFactories
+	pub fn register_all(mut self, factories: impl IntoIterator<Item=ClientFactory>) -> Self {
+		for factory in factories {
+			self.registry.insert(factory.name.clone(), factory);
+		}
 
-        self
-    }
+		self
+	}
 
-    /// Returns a (boxed) specific provider based on the given provider.
-    pub fn build(&self, provider: &str) -> Result<Box<dyn ProviderClient>, ClientBuildError> {
-        let factory = self.get_factory(provider)?;
-        factory.build()
-    }
+	/// Returns a (boxed) specific provider based on the given provider.
+	pub fn build(&self, provider: &str) -> Result<Box<dyn ProviderClient>, ClientBuildError> {
+		let factory = self.get_factory(provider)?;
+		factory.build()
+	}
 
-    /// Returns a (boxed) specific provider based on the given provider.
-    pub fn build_val(
-        &self,
-        provider: &str,
-        provider_value: ProviderValue,
-    ) -> Result<Box<dyn ProviderClient>, ClientBuildError> {
-        let factory = self.get_factory(provider)?;
-        factory.build_from_val(provider_value)
-    }
+	/// Returns a (boxed) specific provider based on the given provider.
+	pub fn build_val(
+		&self,
+		provider: &str,
+		provider_value: ProviderValue,
+	) -> Result<Box<dyn ProviderClient>, ClientBuildError> {
+		let factory = self.get_factory(provider)?;
+		factory.build_from_val(provider_value)
+	}
 
-    /// Parses a provider:model string to the provider and the model separately.
-    /// For example, `openai:gpt-4o` will return ("openai", "gpt-4o").
-    pub fn parse(&self, id: &'a str) -> Result<(&'a str, &'a str), ClientBuildError> {
-        let (provider, model) = id
-            .split_once(":")
-            .ok_or(ClientBuildError::InvalidIdString(id.to_string()))?;
+	/// Parses a provider:model string to the provider and the model separately.
+	/// For example, `openai:gpt-4o` will return ("openai", "gpt-4o").
+	pub fn parse(&self, id: &'a str) -> Result<(&'a str, &'a str), ClientBuildError> {
+		let (provider, model) = id
+			.split_once(":")
+			.ok_or(ClientBuildError::InvalidIdString(id.to_string()))?;
 
-        Ok((provider, model))
-    }
+		Ok((provider, model))
+	}
 
-    /// Returns a specific client factory (that exists in the registry).
-    fn get_factory(&self, provider: &str) -> Result<&ClientFactory, ClientBuildError> {
-        self.registry
-            .get(provider)
-            .ok_or(ClientBuildError::UnknownProvider)
-    }
+	/// Returns a specific client factory (that exists in the registry).
+	fn get_factory(&self, provider: &str) -> Result<&ClientFactory, ClientBuildError> {
+		self.registry
+		    .get(provider)
+		    .ok_or(ClientBuildError::UnknownProvider)
+	}
 
-    /// Get a boxed completion model based on the provider and model.
-    pub fn completion(
-        &self,
-        provider: &str,
-        model: &str,
-    ) -> Result<BoxCompletionModel<'a>, ClientBuildError> {
-        let client = self.build(provider)?;
+	/// Get a boxed completion model based on the provider and model.
+	pub fn completion(
+		&self,
+		provider: &str,
+		model: &str,
+	) -> Result<BoxCompletionModel<'a>, ClientBuildError> {
+		let client = self.build(provider)?;
 
-        let completion = client
-            .as_completion()
-            .ok_or(ClientBuildError::UnsupportedFeature(
-                provider.to_string(),
-                "completion".to_owned(),
-            ))?;
+		let completion = client
+			.as_completion()
+			.ok_or(ClientBuildError::UnsupportedFeature(
+				provider.to_string(),
+				"completion".to_owned(),
+			))?;
 
-        Ok(completion.completion_model(model))
-    }
+		Ok(completion.completion_model(model))
+	}
 
-    /// Get a boxed agent based on the provider and model..
-    pub fn agent(
-        &self,
-        provider: &str,
-        model: &str,
-    ) -> Result<BoxAgentBuilder<'a>, ClientBuildError> {
-        let client = self.build(provider)?;
+	/// Get a boxed agent based on the provider and model..
+	pub fn agent(
+		&self,
+		provider: &str,
+		model: &str,
+	) -> Result<BoxAgentBuilder<'a>, ClientBuildError> {
+		let client = self.build(provider)?;
 
-        let client = client
-            .as_completion()
-            .ok_or(ClientBuildError::UnsupportedFeature(
-                provider.to_string(),
-                "completion".to_string(),
-            ))?;
+		let client = client
+			.as_completion()
+			.ok_or(ClientBuildError::UnsupportedFeature(
+				provider.to_string(),
+				"completion".to_string(),
+			))?;
 
-        Ok(client.agent(model))
-    }
+		Ok(client.agent(model))
+	}
 
-    /// Get a boxed agent based on the provider and model, as well as an API key.
-    pub fn agent_with_api_key_val<P>(
-        &self,
-        provider: &str,
-        model: &str,
-        provider_value: P,
-    ) -> Result<BoxAgentBuilder<'a>, ClientBuildError>
-    where
-        P: Into<ProviderValue>,
-    {
-        let client = self.build_val(provider, provider_value.into())?;
+	/// Get a boxed agent based on the provider and model, as well as an API key.
+	pub fn agent_with_api_key_val<P>(
+		&self,
+		provider: &str,
+		model: &str,
+		provider_value: P,
+	) -> Result<BoxAgentBuilder<'a>, ClientBuildError>
+	where
+		P: Into<ProviderValue>,
+	{
+		let client = self.build_val(provider, provider_value.into())?;
 
-        let client = client
-            .as_completion()
-            .ok_or(ClientBuildError::UnsupportedFeature(
-                provider.to_string(),
-                "completion".to_string(),
-            ))?;
+		let client = client
+			.as_completion()
+			.ok_or(ClientBuildError::UnsupportedFeature(
+				provider.to_string(),
+				"completion".to_string(),
+			))?;
 
-        Ok(client.agent(model))
-    }
+		Ok(client.agent(model))
+	}
 
-    /// Get a boxed embedding model based on the provider and model.
-    pub fn embeddings(
-        &self,
-        provider: &str,
-        model: &str,
-    ) -> Result<Box<dyn EmbeddingModelDyn + 'a>, ClientBuildError> {
-        let client = self.build(provider)?;
+	/// Get a boxed embedding model based on the provider and model.
+	pub fn embeddings(
+		&self,
+		provider: &str,
+		model: &str,
+	) -> Result<Box<dyn EmbeddingModelDyn + 'a>, ClientBuildError> {
+		let client = self.build(provider)?;
 
-        let embeddings = client
-            .as_embeddings()
-            .ok_or(ClientBuildError::UnsupportedFeature(
-                provider.to_string(),
-                "embeddings".to_owned(),
-            ))?;
+		let embeddings = client
+			.as_embeddings()
+			.ok_or(ClientBuildError::UnsupportedFeature(
+				provider.to_string(),
+				"embeddings".to_owned(),
+			))?;
 
-        Ok(embeddings.embedding_model(model))
-    }
+		Ok(embeddings.embedding_model(model))
+	}
 
-    /// Get a boxed embedding model based on the provider and model.
-    pub fn embeddings_with_api_key_val<P>(
-        &self,
-        provider: &str,
-        model: &str,
-        provider_value: P,
-    ) -> Result<Box<dyn EmbeddingModelDyn + 'a>, ClientBuildError>
-    where
-        P: Into<ProviderValue>,
-    {
-        let client = self.build_val(provider, provider_value.into())?;
+	/// Get a boxed embedding model based on the provider and model.
+	pub fn embeddings_with_api_key_val<P>(
+		&self,
+		provider: &str,
+		model: &str,
+		provider_value: P,
+	) -> Result<Box<dyn EmbeddingModelDyn + 'a>, ClientBuildError>
+	where
+		P: Into<ProviderValue>,
+	{
+		let client = self.build_val(provider, provider_value.into())?;
 
-        let embeddings = client
-            .as_embeddings()
-            .ok_or(ClientBuildError::UnsupportedFeature(
-                provider.to_string(),
-                "embeddings".to_owned(),
-            ))?;
+		let embeddings = client
+			.as_embeddings()
+			.ok_or(ClientBuildError::UnsupportedFeature(
+				provider.to_string(),
+				"embeddings".to_owned(),
+			))?;
 
-        Ok(embeddings.embedding_model(model))
-    }
+		Ok(embeddings.embedding_model(model))
+	}
 
-    /// Get a boxed transcription model based on the provider and model.
-    pub fn transcription(
-        &self,
-        provider: &str,
-        model: &str,
-    ) -> Result<Box<dyn TranscriptionModelDyn + 'a>, ClientBuildError> {
-        let client = self.build(provider)?;
-        let transcription =
-            client
-                .as_transcription()
-                .ok_or(ClientBuildError::UnsupportedFeature(
-                    provider.to_string(),
-                    "transcription".to_owned(),
-                ))?;
+	/// Get a boxed transcription model based on the provider and model.
+	pub fn transcription(
+		&self,
+		provider: &str,
+		model: &str,
+	) -> Result<Box<dyn TranscriptionModelDyn + 'a>, ClientBuildError> {
+		let client = self.build(provider)?;
+		let transcription =
+			client
+				.as_transcription()
+				.ok_or(ClientBuildError::UnsupportedFeature(
+					provider.to_string(),
+					"transcription".to_owned(),
+				))?;
 
-        Ok(transcription.transcription_model(model))
-    }
+		Ok(transcription.transcription_model(model))
+	}
 
-    /// Get a boxed transcription model based on the provider and model.
-    pub fn transcription_with_api_key_val<P>(
-        &self,
-        provider: &str,
-        model: &str,
-        provider_value: P,
-    ) -> Result<Box<dyn TranscriptionModelDyn + 'a>, ClientBuildError>
-    where
-        P: Into<ProviderValue>,
-    {
-        let client = self.build_val(provider, provider_value.into())?;
-        let transcription =
-            client
-                .as_transcription()
-                .ok_or(ClientBuildError::UnsupportedFeature(
-                    provider.to_string(),
-                    "transcription".to_owned(),
-                ))?;
+	/// Get a boxed transcription model based on the provider and model.
+	pub fn transcription_with_api_key_val<P>(
+		&self,
+		provider: &str,
+		model: &str,
+		provider_value: P,
+	) -> Result<Box<dyn TranscriptionModelDyn + 'a>, ClientBuildError>
+	where
+		P: Into<ProviderValue>,
+	{
+		let client = self.build_val(provider, provider_value.into())?;
+		let transcription =
+			client
+				.as_transcription()
+				.ok_or(ClientBuildError::UnsupportedFeature(
+					provider.to_string(),
+					"transcription".to_owned(),
+				))?;
 
-        Ok(transcription.transcription_model(model))
-    }
+		Ok(transcription.transcription_model(model))
+	}
 
-    /// Get the ID of a provider model based on a `provider:model` ID.
-    pub fn id<'id>(&'a self, id: &'id str) -> Result<ProviderModelId<'a, 'id>, ClientBuildError> {
-        let (provider, model) = self.parse(id)?;
+	/// Get the ID of a provider model based on a `provider:model` ID.
+	pub fn id<'id>(&'a self, id: &'id str) -> Result<ProviderModelId<'a, 'id>, ClientBuildError> {
+		let (provider, model) = self.parse(id)?;
 
-        Ok(ProviderModelId {
-            builder: self,
-            provider,
-            model,
-        })
-    }
+		Ok(ProviderModelId {
+			builder: self,
+			provider,
+			model,
+		})
+	}
 }
 
 pub struct ProviderModelId<'builder, 'id> {
-    builder: &'builder DynClientBuilder,
-    provider: &'id str,
-    model: &'id str,
+	builder: &'builder DynClientBuilder,
+	provider: &'id str,
+	model: &'id str,
 }
 
 impl<'builder> ProviderModelId<'builder, '_> {
-    pub fn completion(self) -> Result<BoxCompletionModel<'builder>, ClientBuildError> {
-        self.builder.completion(self.provider, self.model)
-    }
+	pub fn completion(self) -> Result<BoxCompletionModel<'builder>, ClientBuildError> {
+		self.builder.completion(self.provider, self.model)
+	}
 
-    pub fn agent(self) -> Result<BoxAgentBuilder<'builder>, ClientBuildError> {
-        self.builder.agent(self.provider, self.model)
-    }
+	pub fn agent(self) -> Result<BoxAgentBuilder<'builder>, ClientBuildError> {
+		self.builder.agent(self.provider, self.model)
+	}
 
-    pub fn embedding(self) -> Result<BoxEmbeddingModel<'builder>, ClientBuildError> {
-        self.builder.embeddings(self.provider, self.model)
-    }
+	pub fn embedding(self) -> Result<BoxEmbeddingModel<'builder>, ClientBuildError> {
+		self.builder.embeddings(self.provider, self.model)
+	}
 
-    pub fn transcription(self) -> Result<BoxTranscriptionModel<'builder>, ClientBuildError> {
-        self.builder.transcription(self.provider, self.model)
-    }
+	pub fn transcription(self) -> Result<BoxTranscriptionModel<'builder>, ClientBuildError> {
+		self.builder.transcription(self.provider, self.model)
+	}
 }
 
 #[cfg(feature = "image")]
@@ -407,32 +408,32 @@ mod image {
 
     pub type BoxImageGenerationModel<'a> = Box<dyn ImageGenerationModelDyn + 'a>;
 
-    impl DynClientBuilder {
-        pub fn image_generation<'a>(
-            &self,
-            provider: &str,
-            model: &str,
-        ) -> Result<BoxImageGenerationModel<'a>, ClientBuildError> {
-            let client = self.build(provider)?;
-            let image =
-                client
-                    .as_image_generation()
-                    .ok_or(ClientBuildError::UnsupportedFeature(
-                        provider.to_string(),
-                        "image_generation".to_string(),
-                    ))?;
+	impl DynClientBuilder {
+		pub fn image_generation<'a>(
+			&self,
+			provider: &str,
+			model: &str,
+		) -> Result<BoxImageGenerationModel<'a>, ClientBuildError> {
+			let client = self.build(provider)?;
+			let image =
+				client
+					.as_image_generation()
+					.ok_or(ClientBuildError::UnsupportedFeature(
+						provider.to_string(),
+						"image_generation".to_string(),
+					))?;
 
-            Ok(image.image_generation_model(model))
-        }
-    }
+			Ok(image.image_generation_model(model))
+		}
+	}
 
-    impl<'builder> ProviderModelId<'builder, '_> {
-        pub fn image_generation(
-            self,
-        ) -> Result<Box<dyn ImageGenerationModelDyn + 'builder>, ClientBuildError> {
-            self.builder.image_generation(self.provider, self.model)
-        }
-    }
+	impl<'builder> ProviderModelId<'builder, '_> {
+		pub fn image_generation(
+			self,
+		) -> Result<Box<dyn ImageGenerationModelDyn + 'builder>, ClientBuildError> {
+			self.builder.image_generation(self.provider, self.model)
+		}
+	}
 }
 #[cfg(feature = "image")]
 pub use image::*;
@@ -445,32 +446,32 @@ mod audio {
 
     pub type BoxAudioGenerationModel<'a> = Box<dyn AudioGenerationModelDyn + 'a>;
 
-    impl DynClientBuilder {
-        pub fn audio_generation<'a>(
-            &self,
-            provider: &str,
-            model: &str,
-        ) -> Result<BoxAudioGenerationModel<'a>, ClientBuildError> {
-            let client = self.build(provider)?;
-            let audio =
-                client
-                    .as_audio_generation()
-                    .ok_or(ClientBuildError::UnsupportedFeature(
-                        provider.to_string(),
-                        "audio_generation".to_owned(),
-                    ))?;
+	impl DynClientBuilder {
+		pub fn audio_generation<'a>(
+			&self,
+			provider: &str,
+			model: &str,
+		) -> Result<BoxAudioGenerationModel<'a>, ClientBuildError> {
+			let client = self.build(provider)?;
+			let audio =
+				client
+					.as_audio_generation()
+					.ok_or(ClientBuildError::UnsupportedFeature(
+						provider.to_string(),
+						"audio_generation".to_owned(),
+					))?;
 
-            Ok(audio.audio_generation_model(model))
-        }
-    }
+			Ok(audio.audio_generation_model(model))
+		}
+	}
 
-    impl<'builder> ProviderModelId<'builder, '_> {
-        pub fn audio_generation(
-            self,
-        ) -> Result<Box<dyn AudioGenerationModelDyn + 'builder>, ClientBuildError> {
-            self.builder.audio_generation(self.provider, self.model)
-        }
-    }
+	impl<'builder> ProviderModelId<'builder, '_> {
+		pub fn audio_generation(
+			self,
+		) -> Result<Box<dyn AudioGenerationModelDyn + 'builder>, ClientBuildError> {
+			self.builder.audio_generation(self.provider, self.model)
+		}
+	}
 }
 use crate::agent::AgentBuilder;
 use crate::client::completion::CompletionModelHandle;
@@ -481,59 +482,59 @@ use rig::providers::mistral;
 use super::ProviderValue;
 
 pub struct ClientFactory {
-    pub name: String,
-    pub factory_env: Box<dyn Fn() -> Box<dyn ProviderClient>>,
-    pub factory_val: Box<dyn Fn(ProviderValue) -> Box<dyn ProviderClient>>,
+	pub name: String,
+	pub factory_env: Box<dyn Fn() -> Box<dyn ProviderClient>>,
+	pub factory_val: Box<dyn Fn(ProviderValue) -> Box<dyn ProviderClient>>,
 }
 
 impl UnwindSafe for ClientFactory {}
 impl RefUnwindSafe for ClientFactory {}
 
 impl ClientFactory {
-    pub fn new<F1, F2>(name: &str, func_env: F1, func_val: F2) -> Self
-    where
-        F1: 'static + Fn() -> Box<dyn ProviderClient>,
-        F2: 'static + Fn(ProviderValue) -> Box<dyn ProviderClient>,
-    {
-        Self {
-            name: name.to_string(),
-            factory_env: Box::new(func_env),
-            factory_val: Box::new(func_val),
-        }
-    }
+	pub fn new<F1, F2>(name: &str, func_env: F1, func_val: F2) -> Self
+	where
+		F1: 'static + Fn() -> Box<dyn ProviderClient>,
+		F2: 'static + Fn(ProviderValue) -> Box<dyn ProviderClient>,
+	{
+		Self {
+			name: name.to_string(),
+			factory_env: Box::new(func_env),
+			factory_val: Box::new(func_val),
+		}
+	}
 
-    pub fn build(&self) -> Result<Box<dyn ProviderClient>, ClientBuildError> {
-        std::panic::catch_unwind(|| (self.factory_env)())
-            .map_err(|e| ClientBuildError::FactoryError(format!("{e:?}")))
-    }
+	pub fn build(&self) -> Result<Box<dyn ProviderClient>, ClientBuildError> {
+		std::panic::catch_unwind(|| (self.factory_env)())
+			.map_err(|e| ClientBuildError::FactoryError(format!("{e:?}")))
+	}
 
-    pub fn build_from_val(
-        &self,
-        val: ProviderValue,
-    ) -> Result<Box<dyn ProviderClient>, ClientBuildError> {
-        std::panic::catch_unwind(|| (self.factory_val)(val))
-            .map_err(|e| ClientBuildError::FactoryError(format!("{e:?}")))
-    }
+	pub fn build_from_val(
+		&self,
+		val: ProviderValue,
+	) -> Result<Box<dyn ProviderClient>, ClientBuildError> {
+		std::panic::catch_unwind(|| (self.factory_val)(val))
+			.map_err(|e| ClientBuildError::FactoryError(format!("{e:?}")))
+	}
 }
 
 pub struct DefaultProviders;
 impl DefaultProviders {
-    pub const ANTHROPIC: &'static str = "anthropic";
-    pub const COHERE: &'static str = "cohere";
-    pub const GEMINI: &'static str = "gemini";
-    pub const HUGGINGFACE: &'static str = "huggingface";
-    pub const OPENAI: &'static str = "openai";
-    pub const OPENROUTER: &'static str = "openrouter";
-    pub const TOGETHER: &'static str = "together";
-    pub const XAI: &'static str = "xai";
-    pub const AZURE: &'static str = "azure";
-    pub const DEEPSEEK: &'static str = "deepseek";
-    pub const GALADRIEL: &'static str = "galadriel";
-    pub const GROQ: &'static str = "groq";
-    pub const HYPERBOLIC: &'static str = "hyperbolic";
-    pub const MOONSHOT: &'static str = "moonshot";
-    pub const MIRA: &'static str = "mira";
-    pub const MISTRAL: &'static str = "mistral";
-    pub const OLLAMA: &'static str = "ollama";
-    pub const PERPLEXITY: &'static str = "perplexity";
+	pub const ANTHROPIC: &'static str = "anthropic";
+	pub const COHERE: &'static str = "cohere";
+	pub const GEMINI: &'static str = "gemini";
+	pub const HUGGINGFACE: &'static str = "huggingface";
+	pub const OPENAI: &'static str = "openai";
+	pub const OPENROUTER: &'static str = "openrouter";
+	pub const TOGETHER: &'static str = "together";
+	pub const XAI: &'static str = "xai";
+	pub const AZURE: &'static str = "azure";
+	pub const DEEPSEEK: &'static str = "deepseek";
+	pub const GALADRIEL: &'static str = "galadriel";
+	pub const GROQ: &'static str = "groq";
+	pub const HYPERBOLIC: &'static str = "hyperbolic";
+	pub const MOONSHOT: &'static str = "moonshot";
+	pub const MIRA: &'static str = "mira";
+	pub const MISTRAL: &'static str = "mistral";
+	pub const OLLAMA: &'static str = "ollama";
+	pub const PERPLEXITY: &'static str = "perplexity";
 }

--- a/rig-core/src/client/mod.rs
+++ b/rig-core/src/client/mod.rs
@@ -18,14 +18,14 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum ClientBuilderError {
-    #[error("reqwest error: {0}")]
-    HttpError(
-        #[from]
-        #[source]
-        reqwest::Error,
-    ),
-    #[error("invalid property: {0}")]
-    InvalidProperty(&'static str),
+	#[error("reqwest error: {0}")]
+	HttpError(
+		#[from]
+		#[source]
+		reqwest::Error,
+	),
+	#[error("invalid property: {0}")]
+	InvalidProperty(&'static str),
 }
 
 /// The base ProviderClient trait, facilitates conversion between client types
@@ -34,133 +34,134 @@ pub enum ClientBuilderError {
 /// All conversion traits must be implemented, they are automatically
 /// implemented if the respective client trait is implemented.
 pub trait ProviderClient:
-    AsCompletion + AsTranscription + AsEmbeddings + AsImageGeneration + AsAudioGeneration + Debug
+AsCompletion + AsTranscription + AsEmbeddings + AsImageGeneration + AsAudioGeneration + Debug
 {
-    /// Create a client from the process's environment.
-    /// Panics if an environment is improperly configured.
-    fn from_env() -> Self
-    where
-        Self: Sized;
+	/// Create a client from the process's environment.
+	/// Panics if an environment is improperly configured.
+	fn from_env() -> Self
+	where
+		Self: Sized;
 
-    /// A helper method to box the client.
-    fn boxed(self) -> Box<dyn ProviderClient>
-    where
-        Self: Sized + 'static,
-    {
-        Box::new(self)
-    }
+	/// A helper method to box the client.
+	fn boxed(self) -> Box<dyn ProviderClient>
+	where
+		Self: Sized + 'static,
+	{
+		Box::new(self)
+	}
 
-    /// Create a boxed client from the process's environment.
-    /// Panics if an environment is improperly configured.
-    fn from_env_boxed<'a>() -> Box<dyn ProviderClient + 'a>
-    where
-        Self: Sized,
-        Self: 'a,
-    {
-        Box::new(Self::from_env())
-    }
+	/// Create a boxed client from the process's environment.
+	/// Panics if an environment is improperly configured.
+	fn from_env_boxed<'a>() -> Box<dyn ProviderClient + 'a>
+	where
+		Self: Sized,
+		Self: 'a,
+	{
+		Box::new(Self::from_env())
+	}
 
-    fn from_val(input: ProviderValue) -> Self
-    where
-        Self: Sized;
+	fn from_val(input: ProviderValue) -> Self
+	where
+		Self: Sized;
 
-    /// Create a boxed client from the process's environment.
-    /// Panics if an environment is improperly configured.
-    fn from_val_boxed<'a>(input: ProviderValue) -> Box<dyn ProviderClient + 'a>
-    where
-        Self: Sized,
-        Self: 'a,
-    {
-        Box::new(Self::from_val(input))
-    }
+	/// Create a boxed client from the process's environment.
+	/// Panics if an environment is improperly configured.
+	fn from_val_boxed<'a>(input: ProviderValue) -> Box<dyn ProviderClient + 'a>
+	where
+		Self: Sized,
+		Self: 'a,
+	{
+		Box::new(Self::from_val(input))
+	}
 }
 
 #[derive(Clone)]
+#[non_exhaustive]
 pub enum ProviderValue {
-    Simple(String),
-    ApiKeyWithOptionalKey(String, Option<String>),
-    ApiKeyWithVersionAndHeader(String, String, String),
+	Simple(String),
+	ApiKeyWithOptionalKey(String, Option<String>),
+	ApiKeyWithVersionAndHeader(String, String, String),
 }
 
 impl From<&str> for ProviderValue {
-    fn from(value: &str) -> Self {
-        Self::Simple(value.to_string())
-    }
+	fn from(value: &str) -> Self {
+		Self::Simple(value.to_string())
+	}
 }
 
 impl From<String> for ProviderValue {
-    fn from(value: String) -> Self {
-        Self::Simple(value)
-    }
+	fn from(value: String) -> Self {
+		Self::Simple(value)
+	}
 }
 
 impl<P> From<(P, Option<P>)> for ProviderValue
 where
-    P: AsRef<str>,
+	P: AsRef<str>,
 {
-    fn from((api_key, optional_key): (P, Option<P>)) -> Self {
-        Self::ApiKeyWithOptionalKey(
-            api_key.as_ref().to_string(),
-            optional_key.map(|x| x.as_ref().to_string()),
-        )
-    }
+	fn from((api_key, optional_key): (P, Option<P>)) -> Self {
+		Self::ApiKeyWithOptionalKey(
+			api_key.as_ref().to_string(),
+			optional_key.map(|x| x.as_ref().to_string()),
+		)
+	}
 }
 
 impl<P> From<(P, P, P)> for ProviderValue
 where
-    P: AsRef<str>,
+	P: AsRef<str>,
 {
-    fn from((api_key, version, header): (P, P, P)) -> Self {
-        Self::ApiKeyWithVersionAndHeader(
-            api_key.as_ref().to_string(),
-            version.as_ref().to_string(),
-            header.as_ref().to_string(),
-        )
-    }
+	fn from((api_key, version, header): (P, P, P)) -> Self {
+		Self::ApiKeyWithVersionAndHeader(
+			api_key.as_ref().to_string(),
+			version.as_ref().to_string(),
+			header.as_ref().to_string(),
+		)
+	}
 }
 
 /// Attempt to convert a ProviderClient to a CompletionClient
 pub trait AsCompletion {
-    fn as_completion(&self) -> Option<Box<dyn CompletionClientDyn>> {
-        None
-    }
+	fn as_completion(&self) -> Option<Box<dyn CompletionClientDyn>> {
+		None
+	}
 }
 
 /// Attempt to convert a ProviderClient to a TranscriptionClient
 pub trait AsTranscription {
-    fn as_transcription(&self) -> Option<Box<dyn TranscriptionClientDyn>> {
-        None
-    }
+	fn as_transcription(&self) -> Option<Box<dyn TranscriptionClientDyn>> {
+		None
+	}
 }
 
 /// Attempt to convert a ProviderClient to a EmbeddingsClient
 pub trait AsEmbeddings {
-    fn as_embeddings(&self) -> Option<Box<dyn EmbeddingsClientDyn>> {
-        None
-    }
+	fn as_embeddings(&self) -> Option<Box<dyn EmbeddingsClientDyn>> {
+		None
+	}
 }
 
 /// Attempt to convert a ProviderClient to a AudioGenerationClient
 pub trait AsAudioGeneration {
-    #[cfg(feature = "audio")]
-    fn as_audio_generation(&self) -> Option<Box<dyn AudioGenerationClientDyn>> {
-        None
-    }
+	#[cfg(feature = "audio")]
+	fn as_audio_generation(&self) -> Option<Box<dyn AudioGenerationClientDyn>> {
+		None
+	}
 }
 
 /// Attempt to convert a ProviderClient to a ImageGenerationClient
 pub trait AsImageGeneration {
-    #[cfg(feature = "image")]
-    fn as_image_generation(&self) -> Option<Box<dyn ImageGenerationClientDyn>> {
-        None
-    }
+	#[cfg(feature = "image")]
+	fn as_image_generation(&self) -> Option<Box<dyn ImageGenerationClientDyn>> {
+		None
+	}
 }
 
 /// Attempt to convert a ProviderClient to a VerifyClient
 pub trait AsVerify {
-    fn as_verify(&self) -> Option<Box<dyn VerifyClientDyn>> {
-        None
-    }
+	fn as_verify(&self) -> Option<Box<dyn VerifyClientDyn>> {
+		None
+	}
 }
 
 #[cfg(not(feature = "audio"))]
@@ -250,7 +251,6 @@ pub use crate::client::verify::{VerifyClient, VerifyError};
 
 #[cfg(test)]
 mod tests {
-    use crate::OneOrMany;
     use crate::client::ProviderClient;
     use crate::completion::{Completion, CompletionRequest, ToolDefinition};
     use crate::image_generation::ImageGenerationRequest;
@@ -262,6 +262,7 @@ mod tests {
     use crate::streaming::StreamingCompletion;
     use crate::tool::Tool;
     use crate::transcription::TranscriptionRequest;
+    use crate::OneOrMany;
     use futures::StreamExt;
     use rig::message::Message;
     use rig::providers::{groq, ollama, perplexity};
@@ -273,724 +274,724 @@ mod tests {
     use super::ProviderValue;
 
     struct ClientConfig {
-        name: &'static str,
-        factory_env: Box<dyn Fn() -> Box<dyn ProviderClient>>,
-        // Not sure where we're going to be using this but I've added it for completeness
-        #[allow(dead_code)]
-        factory_val: Box<dyn Fn(ProviderValue) -> Box<dyn ProviderClient>>,
-        env_variable: &'static str,
-        completion_model: Option<&'static str>,
-        embeddings_model: Option<&'static str>,
-        transcription_model: Option<&'static str>,
-        image_generation_model: Option<&'static str>,
-        audio_generation_model: Option<(&'static str, &'static str)>,
-    }
-
-    impl Default for ClientConfig {
-        fn default() -> Self {
-            Self {
-                name: "",
-                factory_env: Box::new(|| panic!("Not implemented")),
-                factory_val: Box::new(|_| panic!("Not implemented")),
-                env_variable: "",
-                completion_model: None,
-                embeddings_model: None,
-                transcription_model: None,
-                image_generation_model: None,
-                audio_generation_model: None,
-            }
-        }
-    }
-
-    impl ClientConfig {
-        fn is_env_var_set(&self) -> bool {
-            self.env_variable.is_empty() || std::env::var(self.env_variable).is_ok()
-        }
-
-        fn factory_env(&self) -> Box<dyn ProviderClient + '_> {
-            self.factory_env.as_ref()()
-        }
-    }
-
-    fn providers() -> Vec<ClientConfig> {
-        vec![
-            ClientConfig {
-                name: "Anthropic",
-                factory_env: Box::new(anthropic::Client::from_env_boxed),
-                factory_val: Box::new(anthropic::Client::from_val_boxed),
-                env_variable: "ANTHROPIC_API_KEY",
-                completion_model: Some(anthropic::CLAUDE_3_5_SONNET),
-                ..Default::default()
-            },
-            ClientConfig {
-                name: "Cohere",
-                factory_env: Box::new(cohere::Client::from_env_boxed),
-                factory_val: Box::new(cohere::Client::from_val_boxed),
-                env_variable: "COHERE_API_KEY",
-                completion_model: Some(cohere::COMMAND_R),
-                embeddings_model: Some(cohere::EMBED_ENGLISH_LIGHT_V2),
-                ..Default::default()
-            },
-            ClientConfig {
-                name: "Gemini",
-                factory_env: Box::new(gemini::Client::from_env_boxed),
-                factory_val: Box::new(gemini::Client::from_val_boxed),
-                env_variable: "GEMINI_API_KEY",
-                completion_model: Some(gemini::completion::GEMINI_2_0_FLASH),
-                embeddings_model: Some(gemini::embedding::EMBEDDING_001),
-                transcription_model: Some(gemini::transcription::GEMINI_2_0_FLASH),
-                ..Default::default()
-            },
-            ClientConfig {
-                name: "Huggingface",
-                factory_env: Box::new(huggingface::Client::from_env_boxed),
-                factory_val: Box::new(huggingface::Client::from_val_boxed),
-                env_variable: "HUGGINGFACE_API_KEY",
-                completion_model: Some(huggingface::PHI_4),
-                transcription_model: Some(huggingface::WHISPER_SMALL),
-                image_generation_model: Some(huggingface::STABLE_DIFFUSION_3),
-                ..Default::default()
-            },
-            ClientConfig {
-                name: "OpenAI",
-                factory_env: Box::new(openai::Client::from_env_boxed),
-                factory_val: Box::new(openai::Client::from_val_boxed),
-                env_variable: "OPENAI_API_KEY",
-                completion_model: Some(openai::GPT_4O),
-                embeddings_model: Some(openai::TEXT_EMBEDDING_ADA_002),
-                transcription_model: Some(openai::WHISPER_1),
-                image_generation_model: Some(openai::DALL_E_2),
-                audio_generation_model: Some((openai::TTS_1, "onyx")),
-            },
-            ClientConfig {
-                name: "OpenRouter",
-                factory_env: Box::new(openrouter::Client::from_env_boxed),
-                factory_val: Box::new(openrouter::Client::from_val_boxed),
-                env_variable: "OPENROUTER_API_KEY",
-                completion_model: Some(openrouter::CLAUDE_3_7_SONNET),
-                ..Default::default()
-            },
-            ClientConfig {
-                name: "Together",
-                factory_env: Box::new(together::Client::from_env_boxed),
-                factory_val: Box::new(together::Client::from_val_boxed),
-                env_variable: "TOGETHER_API_KEY",
-                completion_model: Some(together::ALPACA_7B),
-                embeddings_model: Some(together::BERT_BASE_UNCASED),
-                ..Default::default()
-            },
-            ClientConfig {
-                name: "XAI",
-                factory_env: Box::new(xai::Client::from_env_boxed),
-                factory_val: Box::new(xai::Client::from_val_boxed),
-                env_variable: "XAI_API_KEY",
-                completion_model: Some(xai::GROK_3_MINI),
-                embeddings_model: None,
-                ..Default::default()
-            },
-            ClientConfig {
-                name: "Azure",
-                factory_env: Box::new(azure::Client::from_env_boxed),
-                factory_val: Box::new(azure::Client::from_val_boxed),
-                env_variable: "AZURE_API_KEY",
-                completion_model: Some(azure::GPT_4O),
-                embeddings_model: Some(azure::TEXT_EMBEDDING_ADA_002),
-                transcription_model: Some("whisper-1"),
-                image_generation_model: Some("dalle-2"),
-                audio_generation_model: Some(("tts-1", "onyx")),
-            },
-            ClientConfig {
-                name: "Deepseek",
-                factory_env: Box::new(deepseek::Client::from_env_boxed),
-                factory_val: Box::new(deepseek::Client::from_val_boxed),
-                env_variable: "DEEPSEEK_API_KEY",
-                completion_model: Some(deepseek::DEEPSEEK_CHAT),
-                ..Default::default()
-            },
-            ClientConfig {
-                name: "Galadriel",
-                factory_env: Box::new(galadriel::Client::from_env_boxed),
-                factory_val: Box::new(galadriel::Client::from_val_boxed),
-                env_variable: "GALADRIEL_API_KEY",
-                completion_model: Some(galadriel::GPT_4O),
-                ..Default::default()
-            },
-            ClientConfig {
-                name: "Groq",
-                factory_env: Box::new(groq::Client::from_env_boxed),
-                factory_val: Box::new(groq::Client::from_val_boxed),
-                env_variable: "GROQ_API_KEY",
-                completion_model: Some(groq::MIXTRAL_8X7B_32768),
-                transcription_model: Some(groq::DISTIL_WHISPER_LARGE_V3),
-                ..Default::default()
-            },
-            ClientConfig {
-                name: "Hyperbolic",
-                factory_env: Box::new(hyperbolic::Client::from_env_boxed),
-                factory_val: Box::new(hyperbolic::Client::from_val_boxed),
-                env_variable: "HYPERBOLIC_API_KEY",
-                completion_model: Some(hyperbolic::LLAMA_3_1_8B),
-                image_generation_model: Some(hyperbolic::SD1_5),
-                audio_generation_model: Some(("EN", "EN-US")),
-                ..Default::default()
-            },
-            ClientConfig {
-                name: "Mira",
-                factory_env: Box::new(mira::Client::from_env_boxed),
-                factory_val: Box::new(mira::Client::from_val_boxed),
-                env_variable: "MIRA_API_KEY",
-                completion_model: Some("gpt-4o"),
-                ..Default::default()
-            },
-            ClientConfig {
-                name: "Moonshot",
-                factory_env: Box::new(moonshot::Client::from_env_boxed),
-                factory_val: Box::new(moonshot::Client::from_val_boxed),
-                env_variable: "MOONSHOT_API_KEY",
-                completion_model: Some(moonshot::MOONSHOT_CHAT),
-                ..Default::default()
-            },
-            ClientConfig {
-                name: "Ollama",
-                factory_env: Box::new(ollama::Client::from_env_boxed),
-                factory_val: Box::new(ollama::Client::from_val_boxed),
-                env_variable: "OLLAMA_ENABLED",
-                completion_model: Some("llama3.1:8b"),
-                embeddings_model: Some(ollama::NOMIC_EMBED_TEXT),
-                ..Default::default()
-            },
-            ClientConfig {
-                name: "Perplexity",
-                factory_env: Box::new(perplexity::Client::from_env_boxed),
-                factory_val: Box::new(perplexity::Client::from_val_boxed),
-                env_variable: "PERPLEXITY_API_KEY",
-                completion_model: Some(perplexity::SONAR),
-                ..Default::default()
-            },
-        ]
-    }
-
-    async fn test_completions_client(config: &ClientConfig) {
-        let client = config.factory_env();
-
-        let Some(client) = client.as_completion() else {
-            return;
-        };
-
-        let model = config
-            .completion_model
-            .unwrap_or_else(|| panic!("{} does not have completion_model set", config.name));
-
-        let model = client.completion_model(model);
-
-        let resp = model
-            .completion_request(Message::user("Whats the capital of France?"))
-            .send()
-            .await;
-
-        assert!(
-            resp.is_ok(),
-            "[{}]: Error occurred when prompting, {}",
-            config.name,
-            resp.err().unwrap()
-        );
-
-        let resp = resp.unwrap();
-
-        match resp.choice.first() {
-            AssistantContent::Text(text) => {
-                assert!(text.text.to_lowercase().contains("paris"));
-            }
-            _ => {
-                unreachable!(
-                    "[{}]: First choice wasn't a Text message, {:?}",
-                    config.name,
-                    resp.choice.first()
-                );
-            }
-        }
-    }
-
-    #[tokio::test]
-    #[ignore]
-    async fn test_completions() {
-        for p in providers().into_iter().filter(ClientConfig::is_env_var_set) {
-            test_completions_client(&p).await;
-        }
-    }
-
-    async fn test_tools_client(config: &ClientConfig) {
-        let client = config.factory_env();
-        let model = config
-            .completion_model
-            .unwrap_or_else(|| panic!("{} does not have the model set.", config.name));
-
-        let Some(client) = client.as_completion() else {
-            return;
-        };
-
-        let model = client.agent(model)
-            .preamble("You are a calculator here to help the user perform arithmetic operations. Use the tools provided to answer the user's question.")
-            .max_tokens(1024)
-            .tool(Adder)
-            .tool(Subtract)
-            .build();
-
-        let request = model.completion("Calculate 2 - 5", vec![]).await;
-
-        assert!(
-            request.is_ok(),
-            "[{}]: Error occurred when building prompt, {}",
-            config.name,
-            request.err().unwrap()
-        );
-
-        let resp = request.unwrap().send().await;
-
-        assert!(
-            resp.is_ok(),
-            "[{}]: Error occurred when prompting, {}",
-            config.name,
-            resp.err().unwrap()
-        );
-
-        let resp = resp.unwrap();
-
-        assert!(
-            resp.choice.iter().any(|content| match content {
-                AssistantContent::ToolCall(tc) => {
-                    if tc.function.name != Subtract::NAME {
-                        return false;
-                    }
-
-                    let arguments =
-                        serde_json::from_value::<OperationArgs>((tc.function.arguments).clone())
-                            .expect("Error parsing arguments");
-
-                    arguments.x == 2.0 && arguments.y == 5.0
-                }
-                _ => false,
-            }),
-            "[{}]: Model did not use the Subtract tool.",
-            config.name
-        )
-    }
-
-    #[tokio::test]
-    #[ignore]
-    async fn test_tools() {
-        for p in providers().into_iter().filter(ClientConfig::is_env_var_set) {
-            test_tools_client(&p).await;
-        }
-    }
-
-    async fn test_streaming_client(config: &ClientConfig) {
-        let client = config.factory_env();
-
-        let Some(client) = client.as_completion() else {
-            return;
-        };
-
-        let model = config
-            .completion_model
-            .unwrap_or_else(|| panic!("{} does not have the model set.", config.name));
-
-        let model = client.completion_model(model);
-
-        let resp = model.stream(CompletionRequest {
-            preamble: None,
-            tools: vec![],
-            documents: vec![],
-            temperature: None,
-            max_tokens: None,
-            additional_params: None,
-            chat_history: OneOrMany::one(Message::user("What is the capital of France?")),
-        });
-
-        let mut resp = resp.await.unwrap();
-
-        let mut received_chunk = false;
-
-        while let Some(chunk) = resp.next().await {
-            received_chunk = true;
-            assert!(chunk.is_ok());
-        }
-
-        assert!(
-            received_chunk,
-            "[{}]: Failed to receive a chunk from stream",
-            config.name
-        );
-
-        for choice in resp.choice {
-            match choice {
-                AssistantContent::Text(text) => {
-                    assert!(
-                        text.text.to_lowercase().contains("paris"),
-                        "[{}]: Did not answer with Paris",
-                        config.name
-                    );
-                }
-                AssistantContent::ToolCall(_) => {}
-                AssistantContent::Reasoning(_) => {}
-            }
-        }
-    }
-
-    #[tokio::test]
-    #[ignore]
-    async fn test_streaming() {
-        for provider in providers().into_iter().filter(ClientConfig::is_env_var_set) {
-            test_streaming_client(&provider).await;
-        }
-    }
-
-    async fn test_streaming_tools_client(config: &ClientConfig) {
-        let client = config.factory_env();
-        let model = config
-            .completion_model
-            .unwrap_or_else(|| panic!("{} does not have the model set.", config.name));
-
-        let Some(client) = client.as_completion() else {
-            return;
-        };
-
-        let model = client.agent(model)
-            .preamble("You are a calculator here to help the user perform arithmetic operations. Use the tools provided to answer the user's question.")
-            .max_tokens(1024)
-            .tool(Adder)
-            .tool(Subtract)
-            .build();
-
-        let request = model.stream_completion("Calculate 2 - 5", vec![]).await;
-
-        assert!(
-            request.is_ok(),
-            "[{}]: Error occurred when building prompt, {}",
-            config.name,
-            request.err().unwrap()
-        );
-
-        let resp = request.unwrap().stream().await;
-
-        assert!(
-            resp.is_ok(),
-            "[{}]: Error occurred when prompting, {}",
-            config.name,
-            resp.err().unwrap()
-        );
-
-        let mut resp = resp.unwrap();
-
-        let mut received_chunk = false;
-
-        while let Some(chunk) = resp.next().await {
-            received_chunk = true;
-            assert!(chunk.is_ok());
-        }
-
-        assert!(
-            received_chunk,
-            "[{}]: Failed to receive a chunk from stream",
-            config.name
-        );
-
-        assert!(
-            resp.choice.iter().any(|content| match content {
-                AssistantContent::ToolCall(tc) => {
-                    if tc.function.name != Subtract::NAME {
-                        return false;
-                    }
-
-                    let arguments =
-                        serde_json::from_value::<OperationArgs>((tc.function.arguments).clone())
-                            .expect("Error parsing arguments");
-
-                    arguments.x == 2.0 && arguments.y == 5.0
-                }
-                _ => false,
-            }),
-            "[{}]: Model did not use the Subtract tool.",
-            config.name
-        )
-    }
-
-    #[tokio::test]
-    #[ignore]
-    async fn test_streaming_tools() {
-        for p in providers().into_iter().filter(ClientConfig::is_env_var_set) {
-            test_streaming_tools_client(&p).await;
-        }
-    }
-
-    async fn test_audio_generation_client(config: &ClientConfig) {
-        let client = config.factory_env();
-
-        let Some(client) = client.as_audio_generation() else {
-            return;
-        };
-
-        let (model, voice) = config
-            .audio_generation_model
-            .unwrap_or_else(|| panic!("{} doesn't have the model set", config.name));
-
-        let model = client.audio_generation_model(model);
-
-        let request = model
-            .audio_generation_request()
-            .text("Hello world!")
-            .voice(voice);
-
-        let resp = request.send().await;
-
-        assert!(
-            resp.is_ok(),
-            "[{}]: Error occurred when sending request, {}",
-            config.name,
-            resp.err().unwrap()
-        );
-
-        let resp = resp.unwrap();
-
-        assert!(
-            !resp.audio.is_empty(),
-            "[{}]: Returned audio was empty",
-            config.name
-        );
-    }
-
-    #[tokio::test]
-    #[ignore]
-    async fn test_audio_generation() {
-        for p in providers().into_iter().filter(ClientConfig::is_env_var_set) {
-            test_audio_generation_client(&p).await;
-        }
-    }
-
-    fn assert_feature<F, M>(
-        name: &str,
-        feature_name: &str,
-        model_name: &str,
-        feature: Option<F>,
-        model: Option<M>,
-    ) {
-        assert_eq!(
-            feature.is_some(),
-            model.is_some(),
-            "{} has{} implemented {} but config.{} is {}.",
-            name,
-            if feature.is_some() { "" } else { "n't" },
-            feature_name,
-            model_name,
-            if model.is_some() { "some" } else { "none" }
-        );
-    }
-
-    #[test]
-    #[ignore]
-    pub fn test_polymorphism() {
-        for config in providers().into_iter().filter(ClientConfig::is_env_var_set) {
-            let client = config.factory_env();
-            assert_feature(
-                config.name,
-                "AsCompletion",
-                "completion_model",
-                client.as_completion(),
-                config.completion_model,
-            );
-
-            assert_feature(
-                config.name,
-                "AsEmbeddings",
-                "embeddings_model",
-                client.as_embeddings(),
-                config.embeddings_model,
-            );
-
-            assert_feature(
-                config.name,
-                "AsTranscription",
-                "transcription_model",
-                client.as_transcription(),
-                config.transcription_model,
-            );
-
-            assert_feature(
-                config.name,
-                "AsImageGeneration",
-                "image_generation_model",
-                client.as_image_generation(),
-                config.image_generation_model,
-            );
-
-            assert_feature(
-                config.name,
-                "AsAudioGeneration",
-                "audio_generation_model",
-                client.as_audio_generation(),
-                config.audio_generation_model,
-            )
-        }
-    }
-
-    async fn test_embed_client(config: &ClientConfig) {
-        const TEST: &str = "Hello world.";
-
-        let client = config.factory_env();
-
-        let Some(client) = client.as_embeddings() else {
-            return;
-        };
-
-        let model = config.embeddings_model.unwrap();
-
-        let model = client.embedding_model(model);
-
-        let resp = model.embed_text(TEST).await;
-
-        assert!(
-            resp.is_ok(),
-            "[{}]: Error occurred when sending request, {}",
-            config.name,
-            resp.err().unwrap()
-        );
-
-        let resp = resp.unwrap();
-
-        assert_eq!(resp.document, TEST);
-
-        assert!(
-            !resp.vec.is_empty(),
-            "[{}]: Returned embed was empty",
-            config.name
-        );
-    }
-
-    #[tokio::test]
-    #[ignore]
-    async fn test_embed() {
-        for config in providers().into_iter().filter(ClientConfig::is_env_var_set) {
-            test_embed_client(&config).await;
-        }
-    }
-
-    async fn test_image_generation_client(config: &ClientConfig) {
-        let client = config.factory_env();
-        let Some(client) = client.as_image_generation() else {
-            return;
-        };
-
-        let model = config.image_generation_model.unwrap();
-
-        let model = client.image_generation_model(model);
-
-        let resp = model
-            .image_generation(ImageGenerationRequest {
-                prompt: "A castle sitting on a large hill.".to_string(),
-                width: 256,
-                height: 256,
-                additional_params: None,
-            })
-            .await;
-
-        assert!(
-            resp.is_ok(),
-            "[{}]: Error occurred when sending request, {}",
-            config.name,
-            resp.err().unwrap()
-        );
-
-        let resp = resp.unwrap();
-
-        assert!(
-            !resp.image.is_empty(),
-            "[{}]: Generated image was empty",
-            config.name
-        );
-    }
-
-    #[tokio::test]
-    #[ignore]
-    async fn test_image_generation() {
-        for config in providers().into_iter().filter(ClientConfig::is_env_var_set) {
-            test_image_generation_client(&config).await;
-        }
-    }
-
-    async fn test_transcription_client(config: &ClientConfig, data: Vec<u8>) {
-        let client = config.factory_env();
-        let Some(client) = client.as_transcription() else {
-            return;
-        };
-
-        let model = config.image_generation_model.unwrap();
-
-        let model = client.transcription_model(model);
-
-        let resp = model
-            .transcription(TranscriptionRequest {
-                data,
-                filename: "audio.mp3".to_string(),
-                language: "en".to_string(),
-                prompt: None,
-                temperature: None,
-                additional_params: None,
-            })
-            .await;
-
-        assert!(
-            resp.is_ok(),
-            "[{}]: Error occurred when sending request, {}",
-            config.name,
-            resp.err().unwrap()
-        );
-
-        let resp = resp.unwrap();
-
-        assert!(
-            !resp.text.is_empty(),
-            "[{}]: Returned transcription was empty",
-            config.name
-        );
-    }
-
-    #[tokio::test]
-    #[ignore]
-    async fn test_transcription() {
-        let mut file = File::open("examples/audio/en-us-natural-speech.mp3").unwrap();
-
-        let mut data = Vec::new();
-        let _ = file.read(&mut data);
-
-        for config in providers().into_iter().filter(ClientConfig::is_env_var_set) {
-            test_transcription_client(&config, data.clone()).await;
-        }
-    }
-
-    #[derive(Deserialize)]
-    struct OperationArgs {
-        x: f32,
-        y: f32,
-    }
-
-    #[derive(Debug, thiserror::Error)]
-    #[error("Math error")]
-    struct MathError;
-
-    #[derive(Deserialize, Serialize)]
-    struct Adder;
-    impl Tool for Adder {
-        const NAME: &'static str = "add";
-
-        type Error = MathError;
-        type Args = OperationArgs;
-        type Output = f32;
-
-        async fn definition(&self, _prompt: String) -> ToolDefinition {
-            ToolDefinition {
-                name: "add".to_string(),
-                description: "Add x and y together".to_string(),
-                parameters: json!({
+		name: &'static str,
+		factory_env: Box<dyn Fn() -> Box<dyn ProviderClient>>,
+		// Not sure where we're going to be using this but I've added it for completeness
+		#[allow(dead_code)]
+		factory_val: Box<dyn Fn(ProviderValue) -> Box<dyn ProviderClient>>,
+		env_variable: &'static str,
+		completion_model: Option<&'static str>,
+		embeddings_model: Option<&'static str>,
+		transcription_model: Option<&'static str>,
+		image_generation_model: Option<&'static str>,
+		audio_generation_model: Option<(&'static str, &'static str)>,
+	}
+
+	impl Default for ClientConfig {
+		fn default() -> Self {
+			Self {
+				name: "",
+				factory_env: Box::new(|| panic!("Not implemented")),
+				factory_val: Box::new(|_| panic!("Not implemented")),
+				env_variable: "",
+				completion_model: None,
+				embeddings_model: None,
+				transcription_model: None,
+				image_generation_model: None,
+				audio_generation_model: None,
+			}
+		}
+	}
+
+	impl ClientConfig {
+		fn is_env_var_set(&self) -> bool {
+			self.env_variable.is_empty() || std::env::var(self.env_variable).is_ok()
+		}
+
+		fn factory_env(&self) -> Box<dyn ProviderClient + '_> {
+			self.factory_env.as_ref()()
+		}
+	}
+
+	fn providers() -> Vec<ClientConfig> {
+		vec![
+			ClientConfig {
+				name: "Anthropic",
+				factory_env: Box::new(anthropic::Client::from_env_boxed),
+				factory_val: Box::new(anthropic::Client::from_val_boxed),
+				env_variable: "ANTHROPIC_API_KEY",
+				completion_model: Some(anthropic::CLAUDE_3_5_SONNET),
+				..Default::default()
+			},
+			ClientConfig {
+				name: "Cohere",
+				factory_env: Box::new(cohere::Client::from_env_boxed),
+				factory_val: Box::new(cohere::Client::from_val_boxed),
+				env_variable: "COHERE_API_KEY",
+				completion_model: Some(cohere::COMMAND_R),
+				embeddings_model: Some(cohere::EMBED_ENGLISH_LIGHT_V2),
+				..Default::default()
+			},
+			ClientConfig {
+				name: "Gemini",
+				factory_env: Box::new(gemini::Client::from_env_boxed),
+				factory_val: Box::new(gemini::Client::from_val_boxed),
+				env_variable: "GEMINI_API_KEY",
+				completion_model: Some(gemini::completion::GEMINI_2_0_FLASH),
+				embeddings_model: Some(gemini::embedding::EMBEDDING_001),
+				transcription_model: Some(gemini::transcription::GEMINI_2_0_FLASH),
+				..Default::default()
+			},
+			ClientConfig {
+				name: "Huggingface",
+				factory_env: Box::new(huggingface::Client::from_env_boxed),
+				factory_val: Box::new(huggingface::Client::from_val_boxed),
+				env_variable: "HUGGINGFACE_API_KEY",
+				completion_model: Some(huggingface::PHI_4),
+				transcription_model: Some(huggingface::WHISPER_SMALL),
+				image_generation_model: Some(huggingface::STABLE_DIFFUSION_3),
+				..Default::default()
+			},
+			ClientConfig {
+				name: "OpenAI",
+				factory_env: Box::new(openai::Client::from_env_boxed),
+				factory_val: Box::new(openai::Client::from_val_boxed),
+				env_variable: "OPENAI_API_KEY",
+				completion_model: Some(openai::GPT_4O),
+				embeddings_model: Some(openai::TEXT_EMBEDDING_ADA_002),
+				transcription_model: Some(openai::WHISPER_1),
+				image_generation_model: Some(openai::DALL_E_2),
+				audio_generation_model: Some((openai::TTS_1, "onyx")),
+			},
+			ClientConfig {
+				name: "OpenRouter",
+				factory_env: Box::new(openrouter::Client::from_env_boxed),
+				factory_val: Box::new(openrouter::Client::from_val_boxed),
+				env_variable: "OPENROUTER_API_KEY",
+				completion_model: Some(openrouter::CLAUDE_3_7_SONNET),
+				..Default::default()
+			},
+			ClientConfig {
+				name: "Together",
+				factory_env: Box::new(together::Client::from_env_boxed),
+				factory_val: Box::new(together::Client::from_val_boxed),
+				env_variable: "TOGETHER_API_KEY",
+				completion_model: Some(together::ALPACA_7B),
+				embeddings_model: Some(together::BERT_BASE_UNCASED),
+				..Default::default()
+			},
+			ClientConfig {
+				name: "XAI",
+				factory_env: Box::new(xai::Client::from_env_boxed),
+				factory_val: Box::new(xai::Client::from_val_boxed),
+				env_variable: "XAI_API_KEY",
+				completion_model: Some(xai::GROK_3_MINI),
+				embeddings_model: None,
+				..Default::default()
+			},
+			ClientConfig {
+				name: "Azure",
+				factory_env: Box::new(azure::Client::from_env_boxed),
+				factory_val: Box::new(azure::Client::from_val_boxed),
+				env_variable: "AZURE_API_KEY",
+				completion_model: Some(azure::GPT_4O),
+				embeddings_model: Some(azure::TEXT_EMBEDDING_ADA_002),
+				transcription_model: Some("whisper-1"),
+				image_generation_model: Some("dalle-2"),
+				audio_generation_model: Some(("tts-1", "onyx")),
+			},
+			ClientConfig {
+				name: "Deepseek",
+				factory_env: Box::new(deepseek::Client::from_env_boxed),
+				factory_val: Box::new(deepseek::Client::from_val_boxed),
+				env_variable: "DEEPSEEK_API_KEY",
+				completion_model: Some(deepseek::DEEPSEEK_CHAT),
+				..Default::default()
+			},
+			ClientConfig {
+				name: "Galadriel",
+				factory_env: Box::new(galadriel::Client::from_env_boxed),
+				factory_val: Box::new(galadriel::Client::from_val_boxed),
+				env_variable: "GALADRIEL_API_KEY",
+				completion_model: Some(galadriel::GPT_4O),
+				..Default::default()
+			},
+			ClientConfig {
+				name: "Groq",
+				factory_env: Box::new(groq::Client::from_env_boxed),
+				factory_val: Box::new(groq::Client::from_val_boxed),
+				env_variable: "GROQ_API_KEY",
+				completion_model: Some(groq::MIXTRAL_8X7B_32768),
+				transcription_model: Some(groq::DISTIL_WHISPER_LARGE_V3),
+				..Default::default()
+			},
+			ClientConfig {
+				name: "Hyperbolic",
+				factory_env: Box::new(hyperbolic::Client::from_env_boxed),
+				factory_val: Box::new(hyperbolic::Client::from_val_boxed),
+				env_variable: "HYPERBOLIC_API_KEY",
+				completion_model: Some(hyperbolic::LLAMA_3_1_8B),
+				image_generation_model: Some(hyperbolic::SD1_5),
+				audio_generation_model: Some(("EN", "EN-US")),
+				..Default::default()
+			},
+			ClientConfig {
+				name: "Mira",
+				factory_env: Box::new(mira::Client::from_env_boxed),
+				factory_val: Box::new(mira::Client::from_val_boxed),
+				env_variable: "MIRA_API_KEY",
+				completion_model: Some("gpt-4o"),
+				..Default::default()
+			},
+			ClientConfig {
+				name: "Moonshot",
+				factory_env: Box::new(moonshot::Client::from_env_boxed),
+				factory_val: Box::new(moonshot::Client::from_val_boxed),
+				env_variable: "MOONSHOT_API_KEY",
+				completion_model: Some(moonshot::MOONSHOT_CHAT),
+				..Default::default()
+			},
+			ClientConfig {
+				name: "Ollama",
+				factory_env: Box::new(ollama::Client::from_env_boxed),
+				factory_val: Box::new(ollama::Client::from_val_boxed),
+				env_variable: "OLLAMA_ENABLED",
+				completion_model: Some("llama3.1:8b"),
+				embeddings_model: Some(ollama::NOMIC_EMBED_TEXT),
+				..Default::default()
+			},
+			ClientConfig {
+				name: "Perplexity",
+				factory_env: Box::new(perplexity::Client::from_env_boxed),
+				factory_val: Box::new(perplexity::Client::from_val_boxed),
+				env_variable: "PERPLEXITY_API_KEY",
+				completion_model: Some(perplexity::SONAR),
+				..Default::default()
+			},
+		]
+	}
+
+	async fn test_completions_client(config: &ClientConfig) {
+		let client = config.factory_env();
+
+		let Some(client) = client.as_completion() else {
+			return;
+		};
+
+		let model = config
+			.completion_model
+			.unwrap_or_else(|| panic!("{} does not have completion_model set", config.name));
+
+		let model = client.completion_model(model);
+
+		let resp = model
+			.completion_request(Message::user("Whats the capital of France?"))
+			.send()
+			.await;
+
+		assert!(
+			resp.is_ok(),
+			"[{}]: Error occurred when prompting, {}",
+			config.name,
+			resp.err().unwrap()
+		);
+
+		let resp = resp.unwrap();
+
+		match resp.choice.first() {
+			AssistantContent::Text(text) => {
+				assert!(text.text.to_lowercase().contains("paris"));
+			}
+			_ => {
+				unreachable!(
+					"[{}]: First choice wasn't a Text message, {:?}",
+					config.name,
+					resp.choice.first()
+				);
+			}
+		}
+	}
+
+	#[tokio::test]
+	#[ignore]
+	async fn test_completions() {
+		for p in providers().into_iter().filter(ClientConfig::is_env_var_set) {
+			test_completions_client(&p).await;
+		}
+	}
+
+	async fn test_tools_client(config: &ClientConfig) {
+		let client = config.factory_env();
+		let model = config
+			.completion_model
+			.unwrap_or_else(|| panic!("{} does not have the model set.", config.name));
+
+		let Some(client) = client.as_completion() else {
+			return;
+		};
+
+		let model = client.agent(model)
+		                  .preamble("You are a calculator here to help the user perform arithmetic operations. Use the tools provided to answer the user's question.")
+		                  .max_tokens(1024)
+		                  .tool(Adder)
+		                  .tool(Subtract)
+		                  .build();
+
+		let request = model.completion("Calculate 2 - 5", vec![]).await;
+
+		assert!(
+			request.is_ok(),
+			"[{}]: Error occurred when building prompt, {}",
+			config.name,
+			request.err().unwrap()
+		);
+
+		let resp = request.unwrap().send().await;
+
+		assert!(
+			resp.is_ok(),
+			"[{}]: Error occurred when prompting, {}",
+			config.name,
+			resp.err().unwrap()
+		);
+
+		let resp = resp.unwrap();
+
+		assert!(
+			resp.choice.iter().any(|content| match content {
+				AssistantContent::ToolCall(tc) => {
+					if tc.function.name != Subtract::NAME {
+						return false;
+					}
+
+					let arguments =
+						serde_json::from_value::<OperationArgs>((tc.function.arguments).clone())
+							.expect("Error parsing arguments");
+
+					arguments.x == 2.0 && arguments.y == 5.0
+				}
+				_ => false,
+			}),
+			"[{}]: Model did not use the Subtract tool.",
+			config.name
+		)
+	}
+
+	#[tokio::test]
+	#[ignore]
+	async fn test_tools() {
+		for p in providers().into_iter().filter(ClientConfig::is_env_var_set) {
+			test_tools_client(&p).await;
+		}
+	}
+
+	async fn test_streaming_client(config: &ClientConfig) {
+		let client = config.factory_env();
+
+		let Some(client) = client.as_completion() else {
+			return;
+		};
+
+		let model = config
+			.completion_model
+			.unwrap_or_else(|| panic!("{} does not have the model set.", config.name));
+
+		let model = client.completion_model(model);
+
+		let resp = model.stream(CompletionRequest {
+			preamble: None,
+			tools: vec![],
+			documents: vec![],
+			temperature: None,
+			max_tokens: None,
+			additional_params: None,
+			chat_history: OneOrMany::one(Message::user("What is the capital of France?")),
+		});
+
+		let mut resp = resp.await.unwrap();
+
+		let mut received_chunk = false;
+
+		while let Some(chunk) = resp.next().await {
+			received_chunk = true;
+			assert!(chunk.is_ok());
+		}
+
+		assert!(
+			received_chunk,
+			"[{}]: Failed to receive a chunk from stream",
+			config.name
+		);
+
+		for choice in resp.choice {
+			match choice {
+				AssistantContent::Text(text) => {
+					assert!(
+						text.text.to_lowercase().contains("paris"),
+						"[{}]: Did not answer with Paris",
+						config.name
+					);
+				}
+				AssistantContent::ToolCall(_) => {}
+				AssistantContent::Reasoning(_) => {}
+			}
+		}
+	}
+
+	#[tokio::test]
+	#[ignore]
+	async fn test_streaming() {
+		for provider in providers().into_iter().filter(ClientConfig::is_env_var_set) {
+			test_streaming_client(&provider).await;
+		}
+	}
+
+	async fn test_streaming_tools_client(config: &ClientConfig) {
+		let client = config.factory_env();
+		let model = config
+			.completion_model
+			.unwrap_or_else(|| panic!("{} does not have the model set.", config.name));
+
+		let Some(client) = client.as_completion() else {
+			return;
+		};
+
+		let model = client.agent(model)
+		                  .preamble("You are a calculator here to help the user perform arithmetic operations. Use the tools provided to answer the user's question.")
+		                  .max_tokens(1024)
+		                  .tool(Adder)
+		                  .tool(Subtract)
+		                  .build();
+
+		let request = model.stream_completion("Calculate 2 - 5", vec![]).await;
+
+		assert!(
+			request.is_ok(),
+			"[{}]: Error occurred when building prompt, {}",
+			config.name,
+			request.err().unwrap()
+		);
+
+		let resp = request.unwrap().stream().await;
+
+		assert!(
+			resp.is_ok(),
+			"[{}]: Error occurred when prompting, {}",
+			config.name,
+			resp.err().unwrap()
+		);
+
+		let mut resp = resp.unwrap();
+
+		let mut received_chunk = false;
+
+		while let Some(chunk) = resp.next().await {
+			received_chunk = true;
+			assert!(chunk.is_ok());
+		}
+
+		assert!(
+			received_chunk,
+			"[{}]: Failed to receive a chunk from stream",
+			config.name
+		);
+
+		assert!(
+			resp.choice.iter().any(|content| match content {
+				AssistantContent::ToolCall(tc) => {
+					if tc.function.name != Subtract::NAME {
+						return false;
+					}
+
+					let arguments =
+						serde_json::from_value::<OperationArgs>((tc.function.arguments).clone())
+							.expect("Error parsing arguments");
+
+					arguments.x == 2.0 && arguments.y == 5.0
+				}
+				_ => false,
+			}),
+			"[{}]: Model did not use the Subtract tool.",
+			config.name
+		)
+	}
+
+	#[tokio::test]
+	#[ignore]
+	async fn test_streaming_tools() {
+		for p in providers().into_iter().filter(ClientConfig::is_env_var_set) {
+			test_streaming_tools_client(&p).await;
+		}
+	}
+
+	async fn test_audio_generation_client(config: &ClientConfig) {
+		let client = config.factory_env();
+
+		let Some(client) = client.as_audio_generation() else {
+			return;
+		};
+
+		let (model, voice) = config
+			.audio_generation_model
+			.unwrap_or_else(|| panic!("{} doesn't have the model set", config.name));
+
+		let model = client.audio_generation_model(model);
+
+		let request = model
+			.audio_generation_request()
+			.text("Hello world!")
+			.voice(voice);
+
+		let resp = request.send().await;
+
+		assert!(
+			resp.is_ok(),
+			"[{}]: Error occurred when sending request, {}",
+			config.name,
+			resp.err().unwrap()
+		);
+
+		let resp = resp.unwrap();
+
+		assert!(
+			!resp.audio.is_empty(),
+			"[{}]: Returned audio was empty",
+			config.name
+		);
+	}
+
+	#[tokio::test]
+	#[ignore]
+	async fn test_audio_generation() {
+		for p in providers().into_iter().filter(ClientConfig::is_env_var_set) {
+			test_audio_generation_client(&p).await;
+		}
+	}
+
+	fn assert_feature<F, M>(
+		name: &str,
+		feature_name: &str,
+		model_name: &str,
+		feature: Option<F>,
+		model: Option<M>,
+	) {
+		assert_eq!(
+			feature.is_some(),
+			model.is_some(),
+			"{} has{} implemented {} but config.{} is {}.",
+			name,
+			if feature.is_some() { "" } else { "n't" },
+			feature_name,
+			model_name,
+			if model.is_some() { "some" } else { "none" }
+		);
+	}
+
+	#[test]
+	#[ignore]
+	pub fn test_polymorphism() {
+		for config in providers().into_iter().filter(ClientConfig::is_env_var_set) {
+			let client = config.factory_env();
+			assert_feature(
+				config.name,
+				"AsCompletion",
+				"completion_model",
+				client.as_completion(),
+				config.completion_model,
+			);
+
+			assert_feature(
+				config.name,
+				"AsEmbeddings",
+				"embeddings_model",
+				client.as_embeddings(),
+				config.embeddings_model,
+			);
+
+			assert_feature(
+				config.name,
+				"AsTranscription",
+				"transcription_model",
+				client.as_transcription(),
+				config.transcription_model,
+			);
+
+			assert_feature(
+				config.name,
+				"AsImageGeneration",
+				"image_generation_model",
+				client.as_image_generation(),
+				config.image_generation_model,
+			);
+
+			assert_feature(
+				config.name,
+				"AsAudioGeneration",
+				"audio_generation_model",
+				client.as_audio_generation(),
+				config.audio_generation_model,
+			)
+		}
+	}
+
+	async fn test_embed_client(config: &ClientConfig) {
+		const TEST: &str = "Hello world.";
+
+		let client = config.factory_env();
+
+		let Some(client) = client.as_embeddings() else {
+			return;
+		};
+
+		let model = config.embeddings_model.unwrap();
+
+		let model = client.embedding_model(model);
+
+		let resp = model.embed_text(TEST).await;
+
+		assert!(
+			resp.is_ok(),
+			"[{}]: Error occurred when sending request, {}",
+			config.name,
+			resp.err().unwrap()
+		);
+
+		let resp = resp.unwrap();
+
+		assert_eq!(resp.document, TEST);
+
+		assert!(
+			!resp.vec.is_empty(),
+			"[{}]: Returned embed was empty",
+			config.name
+		);
+	}
+
+	#[tokio::test]
+	#[ignore]
+	async fn test_embed() {
+		for config in providers().into_iter().filter(ClientConfig::is_env_var_set) {
+			test_embed_client(&config).await;
+		}
+	}
+
+	async fn test_image_generation_client(config: &ClientConfig) {
+		let client = config.factory_env();
+		let Some(client) = client.as_image_generation() else {
+			return;
+		};
+
+		let model = config.image_generation_model.unwrap();
+
+		let model = client.image_generation_model(model);
+
+		let resp = model
+			.image_generation(ImageGenerationRequest {
+				prompt: "A castle sitting on a large hill.".to_string(),
+				width: 256,
+				height: 256,
+				additional_params: None,
+			})
+			.await;
+
+		assert!(
+			resp.is_ok(),
+			"[{}]: Error occurred when sending request, {}",
+			config.name,
+			resp.err().unwrap()
+		);
+
+		let resp = resp.unwrap();
+
+		assert!(
+			!resp.image.is_empty(),
+			"[{}]: Generated image was empty",
+			config.name
+		);
+	}
+
+	#[tokio::test]
+	#[ignore]
+	async fn test_image_generation() {
+		for config in providers().into_iter().filter(ClientConfig::is_env_var_set) {
+			test_image_generation_client(&config).await;
+		}
+	}
+
+	async fn test_transcription_client(config: &ClientConfig, data: Vec<u8>) {
+		let client = config.factory_env();
+		let Some(client) = client.as_transcription() else {
+			return;
+		};
+
+		let model = config.image_generation_model.unwrap();
+
+		let model = client.transcription_model(model);
+
+		let resp = model
+			.transcription(TranscriptionRequest {
+				data,
+				filename: "audio.mp3".to_string(),
+				language: "en".to_string(),
+				prompt: None,
+				temperature: None,
+				additional_params: None,
+			})
+			.await;
+
+		assert!(
+			resp.is_ok(),
+			"[{}]: Error occurred when sending request, {}",
+			config.name,
+			resp.err().unwrap()
+		);
+
+		let resp = resp.unwrap();
+
+		assert!(
+			!resp.text.is_empty(),
+			"[{}]: Returned transcription was empty",
+			config.name
+		);
+	}
+
+	#[tokio::test]
+	#[ignore]
+	async fn test_transcription() {
+		let mut file = File::open("examples/audio/en-us-natural-speech.mp3").unwrap();
+
+		let mut data = Vec::new();
+		let _ = file.read(&mut data);
+
+		for config in providers().into_iter().filter(ClientConfig::is_env_var_set) {
+			test_transcription_client(&config, data.clone()).await;
+		}
+	}
+
+	#[derive(Deserialize)]
+	struct OperationArgs {
+		x: f32,
+		y: f32,
+	}
+
+	#[derive(Debug, thiserror::Error)]
+	#[error("Math error")]
+	struct MathError;
+
+	#[derive(Deserialize, Serialize)]
+	struct Adder;
+	impl Tool for Adder {
+		const NAME: &'static str = "add";
+
+		type Error = MathError;
+		type Args = OperationArgs;
+		type Output = f32;
+
+		async fn definition(&self, _prompt: String) -> ToolDefinition {
+			ToolDefinition {
+				name: "add".to_string(),
+				description: "Add x and y together".to_string(),
+				parameters: json!({
                     "type": "object",
                     "properties": {
                         "x": {
@@ -1003,27 +1004,27 @@ mod tests {
                         }
                     }
                 }),
-            }
-        }
+			}
+		}
 
-        async fn call(&self, args: Self::Args) -> anyhow::Result<Self::Output, Self::Error> {
-            println!("[tool-call] Adding {} and {}", args.x, args.y);
-            let result = args.x + args.y;
-            Ok(result)
-        }
-    }
+		async fn call(&self, args: Self::Args) -> anyhow::Result<Self::Output, Self::Error> {
+			println!("[tool-call] Adding {} and {}", args.x, args.y);
+			let result = args.x + args.y;
+			Ok(result)
+		}
+	}
 
-    #[derive(Deserialize, Serialize)]
-    struct Subtract;
-    impl Tool for Subtract {
-        const NAME: &'static str = "subtract";
+	#[derive(Deserialize, Serialize)]
+	struct Subtract;
+	impl Tool for Subtract {
+		const NAME: &'static str = "subtract";
 
-        type Error = MathError;
-        type Args = OperationArgs;
-        type Output = f32;
+		type Error = MathError;
+		type Args = OperationArgs;
+		type Output = f32;
 
-        async fn definition(&self, _prompt: String) -> ToolDefinition {
-            serde_json::from_value(json!({
+		async fn definition(&self, _prompt: String) -> ToolDefinition {
+			serde_json::from_value(json!({
                 "name": "subtract",
                 "description": "Subtract y from x (i.e.: x - y)",
                 "parameters": {
@@ -1040,13 +1041,13 @@ mod tests {
                     }
                 }
             }))
-            .expect("Tool Definition")
-        }
+				.expect("Tool Definition")
+		}
 
-        async fn call(&self, args: Self::Args) -> anyhow::Result<Self::Output, Self::Error> {
-            println!("[tool-call] Subtracting {} from {}", args.y, args.x);
-            let result = args.x - args.y;
-            Ok(result)
-        }
-    }
+		async fn call(&self, args: Self::Args) -> anyhow::Result<Self::Output, Self::Error> {
+			println!("[tool-call] Subtracting {} from {}", args.y, args.x);
+			let result = args.x - args.y;
+			Ok(result)
+		}
+	}
 }

--- a/rig-core/src/client/verify.rs
+++ b/rig-core/src/client/verify.rs
@@ -3,45 +3,46 @@ use futures::future::BoxFuture;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum VerifyError {
-    #[error("invalid authentication")]
-    InvalidAuthentication,
-    #[error("provider error: {0}")]
-    ProviderError(String),
-    #[error("http error: {0}")]
-    HttpError(
-        #[from]
-        #[source]
-        reqwest::Error,
-    ),
+	#[error("invalid authentication")]
+	InvalidAuthentication,
+	#[error("provider error: {0}")]
+	ProviderError(String),
+	#[error("http error: {0}")]
+	HttpError(
+		#[from]
+		#[source]
+		reqwest::Error,
+	),
 }
 
 /// A provider client that can verify the configuration.
 /// Clone is required for conversions between client types.
 pub trait VerifyClient: ProviderClient + Clone {
-    /// Verify the configuration.
-    fn verify(&self) -> impl Future<Output = Result<(), VerifyError>> + Send;
+	/// Verify the configuration.
+	fn verify(&self) -> impl Future<Output=Result<(), VerifyError>> + Send;
 }
 
 pub trait VerifyClientDyn: ProviderClient {
-    /// Verify the configuration.
-    fn verify(&self) -> BoxFuture<'_, Result<(), VerifyError>>;
+	/// Verify the configuration.
+	fn verify(&self) -> BoxFuture<'_, Result<(), VerifyError>>;
 }
 
 impl<T> VerifyClientDyn for T
 where
-    T: VerifyClient,
+	T: VerifyClient,
 {
-    fn verify(&self) -> BoxFuture<'_, Result<(), VerifyError>> {
-        Box::pin(self.verify())
-    }
+	fn verify(&self) -> BoxFuture<'_, Result<(), VerifyError>> {
+		Box::pin(self.verify())
+	}
 }
 
 impl<T> AsVerify for T
 where
-    T: VerifyClientDyn + Clone + 'static,
+	T: VerifyClientDyn + Clone + 'static,
 {
-    fn as_verify(&self) -> Option<Box<dyn VerifyClientDyn>> {
-        Some(Box::new(self.clone()))
-    }
+	fn as_verify(&self) -> Option<Box<dyn VerifyClientDyn>> {
+		Some(Box::new(self.clone()))
+	}
 }

--- a/rig-core/src/completion/message.rs
+++ b/rig-core/src/completion/message.rs
@@ -16,9 +16,9 @@ use super::CompletionError;
 /// when trying to use `TryFrom<T>`, you would normally run into the orphan rule as Vec is
 /// technically considered a foreign type (it's owned by stdlib).
 pub trait ConvertMessage: Sized + Send + Sync {
-    type Error: std::error::Error + Send;
+	type Error: std::error::Error + Send;
 
-    fn convert_from_message(message: Message) -> Result<Vec<Self>, Self::Error>;
+	fn convert_from_message(message: Message) -> Result<Vec<Self>, Self::Error>;
 }
 
 /// A message represents a run of input (user) and output (assistant).
@@ -34,14 +34,14 @@ pub trait ConvertMessage: Sized + Send + Sync {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(tag = "role", rename_all = "lowercase")]
 pub enum Message {
-    /// User message containing one or more content types defined by `UserContent`.
-    User { content: OneOrMany<UserContent> },
+	/// User message containing one or more content types defined by `UserContent`.
+	User { content: OneOrMany<UserContent> },
 
-    /// Assistant message containing one or more content types defined by `AssistantContent`.
-    Assistant {
-        id: Option<String>,
-        content: OneOrMany<AssistantContent>,
-    },
+	/// Assistant message containing one or more content types defined by `AssistantContent`.
+	Assistant {
+		id: Option<String>,
+		content: OneOrMany<AssistantContent>,
+	},
 }
 
 /// Describes the content of a message, which can be text, a tool result, an image, audio, or
@@ -50,86 +50,89 @@ pub enum Message {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum UserContent {
-    Text(Text),
-    ToolResult(ToolResult),
-    Image(Image),
-    Audio(Audio),
-    Video(Video),
-    Document(Document),
+	Text(Text),
+	ToolResult(ToolResult),
+	Image(Image),
+	Audio(Audio),
+	Video(Video),
+	Document(Document),
 }
 
 /// Describes responses from a provider which is either text or a tool call.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(untagged)]
 pub enum AssistantContent {
-    Text(Text),
-    ToolCall(ToolCall),
-    Reasoning(Reasoning),
+	Text(Text),
+	ToolCall(ToolCall),
+	Reasoning(Reasoning),
 }
-
+#[non_exhaustive]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct Reasoning {
-    pub id: Option<String>,
-    pub reasoning: Vec<String>,
+	pub id: Option<String>,
+	pub reasoning: Vec<String>,
 }
 
 impl Reasoning {
-    /// Create a new reasoning item from a single item
-    pub fn new(input: &str) -> Self {
-        Self {
-            id: None,
-            reasoning: vec![input.to_string()],
-        }
-    }
+	/// Create a new reasoning item from a single item
+	pub fn new(input: &str) -> Self {
+		Self {
+			id: None,
+			reasoning: vec![input.to_string()],
+		}
+	}
 
-    pub fn multi(input: Vec<String>) -> Self {
-        Self {
-            id: None,
-            reasoning: input,
-        }
-    }
+	pub fn multi(input: Vec<String>) -> Self {
+		Self {
+			id: None,
+			reasoning: input,
+		}
+	}
 
-    pub fn optional_id(mut self, id: Option<String>) -> Self {
-        self.id = id;
-        self
-    }
+	pub fn optional_id(mut self, id: Option<String>) -> Self {
+		self.id = id;
+		self
+	}
 
-    pub fn with_id(mut self, id: String) -> Self {
-        self.id = Some(id);
-        self
-    }
+	pub fn with_id(mut self, id: String) -> Self {
+		self.id = Some(id);
+		self
+	}
 }
 
 /// Tool result content containing information about a tool call and it's resulting content.
+// to add #[non_exhaustive] we will need to add a builder/new method
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct ToolResult {
-    pub id: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub call_id: Option<String>,
-    pub content: OneOrMany<ToolResultContent>,
+	pub id: String,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub call_id: Option<String>,
+	pub content: OneOrMany<ToolResultContent>,
 }
 
 /// Describes the content of a tool result, which can be text or an image.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum ToolResultContent {
-    Text(Text),
-    Image(Image),
+	Text(Text),
+	Image(Image),
 }
 
 /// Describes a tool call with an id and function to call, generally produced by a provider.
+// to add #[non_exhaustive] we will need to add a builder/new method
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct ToolCall {
-    pub id: String,
-    pub call_id: Option<String>,
-    pub function: ToolFunction,
+	pub id: String,
+	pub call_id: Option<String>,
+	pub function: ToolFunction,
 }
 
 /// Describes a tool function to call with a name and arguments, generally produced by a provider.
+// to add #[non_exhaustive] we will need to add a builder/new method
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct ToolFunction {
-    pub name: String,
-    pub arguments: serde_json::Value,
+	pub name: String,
+	pub arguments: serde_json::Value,
 }
 
 // ================================================================
@@ -137,104 +140,111 @@ pub struct ToolFunction {
 // ================================================================
 
 /// Basic text content.
+// to add #[non_exhaustive] we will need to add a builder/new method
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct Text {
-    pub text: String,
+	pub text: String,
 }
 
 impl Text {
-    pub fn text(&self) -> &str {
-        &self.text
-    }
+	pub fn text(&self) -> &str {
+		&self.text
+	}
 }
 
 impl std::fmt::Display for Text {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Self { text } = self;
-        write!(f, "{text}")
-    }
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		let Self { text } = self;
+		write!(f, "{text}")
+	}
 }
 
 /// Image content containing image data and metadata about it.
+// to add #[non_exhaustive] we will need to add a builder/new method
 #[derive(Default, Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct Image {
-    pub data: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub format: Option<ContentFormat>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub media_type: Option<ImageMediaType>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub detail: Option<ImageDetail>,
-    #[serde(flatten, skip_serializing_if = "Option::is_none")]
-    pub additional_params: Option<serde_json::Value>,
+	pub data: String,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub format: Option<ContentFormat>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub media_type: Option<ImageMediaType>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub detail: Option<ImageDetail>,
+	#[serde(flatten, skip_serializing_if = "Option::is_none")]
+	pub additional_params: Option<serde_json::Value>,
 }
 
 /// Audio content containing audio data and metadata about it.
 #[derive(Default, Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct Audio {
-    pub data: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub format: Option<ContentFormat>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub media_type: Option<AudioMediaType>,
-    #[serde(flatten, skip_serializing_if = "Option::is_none")]
-    pub additional_params: Option<serde_json::Value>,
+	pub data: String,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub format: Option<ContentFormat>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub media_type: Option<AudioMediaType>,
+	#[serde(flatten, skip_serializing_if = "Option::is_none")]
+	pub additional_params: Option<serde_json::Value>,
 }
 
 /// Video content containing video data and metadata about it.
+// to add #[non_exhaustive] we will need to add a builder/new method
 #[derive(Default, Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct Video {
-    pub data: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub format: Option<ContentFormat>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub media_type: Option<VideoMediaType>,
-    #[serde(flatten, skip_serializing_if = "Option::is_none")]
-    pub additional_params: Option<serde_json::Value>,
+	pub data: String,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub format: Option<ContentFormat>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub media_type: Option<VideoMediaType>,
+	#[serde(flatten, skip_serializing_if = "Option::is_none")]
+	pub additional_params: Option<serde_json::Value>,
 }
 
 /// Document content containing document data and metadata about it.
+// to add #[non_exhaustive] we will need to add a builder/new method
 #[derive(Default, Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct Document {
-    pub data: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub format: Option<ContentFormat>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub media_type: Option<DocumentMediaType>,
-    #[serde(flatten, skip_serializing_if = "Option::is_none")]
-    pub additional_params: Option<serde_json::Value>,
+	pub data: String,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub format: Option<ContentFormat>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub media_type: Option<DocumentMediaType>,
+	#[serde(flatten, skip_serializing_if = "Option::is_none")]
+	pub additional_params: Option<serde_json::Value>,
 }
 
 /// Describes the format of the content, which can be base64 or string.
 #[derive(Default, Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum ContentFormat {
-    #[default]
-    Base64,
-    String,
+	#[default]
+	Base64,
+	String,
 }
 
 /// Helper enum that tracks the media type of the content.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[non_exhaustive]
 pub enum MediaType {
-    Image(ImageMediaType),
-    Audio(AudioMediaType),
-    Document(DocumentMediaType),
-    Video(VideoMediaType),
+	Image(ImageMediaType),
+	Audio(AudioMediaType),
+	Document(DocumentMediaType),
+	Video(VideoMediaType),
 }
 
 /// Describes the image media type of the content. Not every provider supports every media type.
 /// Convertible to and from MIME type strings.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum ImageMediaType {
-    JPEG,
-    PNG,
-    GIF,
-    WEBP,
-    HEIC,
-    HEIF,
-    SVG,
+	JPEG,
+	PNG,
+	GIF,
+	WEBP,
+	HEIC,
+	HEIF,
+	SVG,
 }
 
 /// Describes the document media type of the content. Not every provider supports every media type.
@@ -242,50 +252,54 @@ pub enum ImageMediaType {
 /// Convertible to and from MIME type strings.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum DocumentMediaType {
-    PDF,
-    TXT,
-    RTF,
-    HTML,
-    CSS,
-    MARKDOWN,
-    CSV,
-    XML,
-    Javascript,
-    Python,
+	PDF,
+	TXT,
+	RTF,
+	HTML,
+	CSS,
+	MARKDOWN,
+	CSV,
+	XML,
+	Javascript,
+	Python,
 }
 
 /// Describes the audio media type of the content. Not every provider supports every media type.
 /// Convertible to and from MIME type strings.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum AudioMediaType {
-    WAV,
-    MP3,
-    AIFF,
-    AAC,
-    OGG,
-    FLAC,
+	WAV,
+	MP3,
+	AIFF,
+	AAC,
+	OGG,
+	FLAC,
 }
 
 /// Describes the video media type of the content. Not every provider supports every media type.
 /// Convertible to and from MIME type strings.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum VideoMediaType {
-    AVI,
-    MP4,
-    MPEG,
+	AVI,
+	MP4,
+	MPEG,
 }
 
 /// Describes the detail of the image content, which can be low, high, or auto (open-ai specific).
 #[derive(Default, Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum ImageDetail {
-    Low,
-    High,
-    #[default]
-    Auto,
+	Low,
+	High,
+	#[default]
+	Auto,
 }
 
 // ================================================================
@@ -293,353 +307,353 @@ pub enum ImageDetail {
 // ================================================================
 
 impl Message {
-    /// This helper method is primarily used to extract the first string prompt from a `Message`.
-    /// Since `Message` might have more than just text content, we need to find the first text.
-    pub(crate) fn rag_text(&self) -> Option<String> {
-        match self {
-            Message::User { content } => {
-                for item in content.iter() {
-                    if let UserContent::Text(Text { text }) = item {
-                        return Some(text.clone());
-                    }
-                }
-                None
-            }
-            _ => None,
-        }
-    }
+	/// This helper method is primarily used to extract the first string prompt from a `Message`.
+	/// Since `Message` might have more than just text content, we need to find the first text.
+	pub(crate) fn rag_text(&self) -> Option<String> {
+		match self {
+			Message::User { content } => {
+				for item in content.iter() {
+					if let UserContent::Text(Text { text }) = item {
+						return Some(text.clone());
+					}
+				}
+				None
+			}
+			_ => None,
+		}
+	}
 
-    /// Helper constructor to make creating user messages easier.
-    pub fn user(text: impl Into<String>) -> Self {
-        Message::User {
-            content: OneOrMany::one(UserContent::text(text)),
-        }
-    }
+	/// Helper constructor to make creating user messages easier.
+	pub fn user(text: impl Into<String>) -> Self {
+		Message::User {
+			content: OneOrMany::one(UserContent::text(text)),
+		}
+	}
 
-    /// Helper constructor to make creating assistant messages easier.
-    pub fn assistant(text: impl Into<String>) -> Self {
-        Message::Assistant {
-            id: None,
-            content: OneOrMany::one(AssistantContent::text(text)),
-        }
-    }
+	/// Helper constructor to make creating assistant messages easier.
+	pub fn assistant(text: impl Into<String>) -> Self {
+		Message::Assistant {
+			id: None,
+			content: OneOrMany::one(AssistantContent::text(text)),
+		}
+	}
 
-    /// Helper constructor to make creating assistant messages easier.
-    pub fn assistant_with_id(id: String, text: impl Into<String>) -> Self {
-        Message::Assistant {
-            id: Some(id),
-            content: OneOrMany::one(AssistantContent::text(text)),
-        }
-    }
+	/// Helper constructor to make creating assistant messages easier.
+	pub fn assistant_with_id(id: String, text: impl Into<String>) -> Self {
+		Message::Assistant {
+			id: Some(id),
+			content: OneOrMany::one(AssistantContent::text(text)),
+		}
+	}
 
-    /// Helper constructor to make creating tool result messages easier.
-    pub fn tool_result(id: impl Into<String>, content: impl Into<String>) -> Self {
-        Message::User {
-            content: OneOrMany::one(UserContent::ToolResult(ToolResult {
-                id: id.into(),
-                call_id: None,
-                content: OneOrMany::one(ToolResultContent::text(content)),
-            })),
-        }
-    }
+	/// Helper constructor to make creating tool result messages easier.
+	pub fn tool_result(id: impl Into<String>, content: impl Into<String>) -> Self {
+		Message::User {
+			content: OneOrMany::one(UserContent::ToolResult(ToolResult {
+				id: id.into(),
+				call_id: None,
+				content: OneOrMany::one(ToolResultContent::text(content)),
+			})),
+		}
+	}
 
-    pub fn tool_result_with_call_id(
-        id: impl Into<String>,
-        call_id: Option<String>,
-        content: impl Into<String>,
-    ) -> Self {
-        Message::User {
-            content: OneOrMany::one(UserContent::ToolResult(ToolResult {
-                id: id.into(),
-                call_id,
-                content: OneOrMany::one(ToolResultContent::text(content)),
-            })),
-        }
-    }
+	pub fn tool_result_with_call_id(
+		id: impl Into<String>,
+		call_id: Option<String>,
+		content: impl Into<String>,
+	) -> Self {
+		Message::User {
+			content: OneOrMany::one(UserContent::ToolResult(ToolResult {
+				id: id.into(),
+				call_id,
+				content: OneOrMany::one(ToolResultContent::text(content)),
+			})),
+		}
+	}
 }
 
 impl UserContent {
-    /// Helper constructor to make creating user text content easier.
-    pub fn text(text: impl Into<String>) -> Self {
-        UserContent::Text(text.into().into())
-    }
+	/// Helper constructor to make creating user text content easier.
+	pub fn text(text: impl Into<String>) -> Self {
+		UserContent::Text(text.into().into())
+	}
 
-    /// Helper constructor to make creating user image content easier.
-    pub fn image(
-        data: impl Into<String>,
-        format: Option<ContentFormat>,
-        media_type: Option<ImageMediaType>,
-        detail: Option<ImageDetail>,
-    ) -> Self {
-        UserContent::Image(Image {
-            data: data.into(),
-            format,
-            media_type,
-            detail,
-            additional_params: None,
-        })
-    }
+	/// Helper constructor to make creating user image content easier.
+	pub fn image(
+		data: impl Into<String>,
+		format: Option<ContentFormat>,
+		media_type: Option<ImageMediaType>,
+		detail: Option<ImageDetail>,
+	) -> Self {
+		UserContent::Image(Image {
+			data: data.into(),
+			format,
+			media_type,
+			detail,
+			additional_params: None,
+		})
+	}
 
-    /// Helper constructor to make creating user audio content easier.
-    pub fn audio(
-        data: impl Into<String>,
-        format: Option<ContentFormat>,
-        media_type: Option<AudioMediaType>,
-    ) -> Self {
-        UserContent::Audio(Audio {
-            data: data.into(),
-            format,
-            media_type,
-            additional_params: None,
-        })
-    }
+	/// Helper constructor to make creating user audio content easier.
+	pub fn audio(
+		data: impl Into<String>,
+		format: Option<ContentFormat>,
+		media_type: Option<AudioMediaType>,
+	) -> Self {
+		UserContent::Audio(Audio {
+			data: data.into(),
+			format,
+			media_type,
+			additional_params: None,
+		})
+	}
 
-    /// Helper constructor to make creating user document content easier.
-    pub fn document(
-        data: impl Into<String>,
-        format: Option<ContentFormat>,
-        media_type: Option<DocumentMediaType>,
-    ) -> Self {
-        UserContent::Document(Document {
-            data: data.into(),
-            format,
-            media_type,
-            additional_params: None,
-        })
-    }
+	/// Helper constructor to make creating user document content easier.
+	pub fn document(
+		data: impl Into<String>,
+		format: Option<ContentFormat>,
+		media_type: Option<DocumentMediaType>,
+	) -> Self {
+		UserContent::Document(Document {
+			data: data.into(),
+			format,
+			media_type,
+			additional_params: None,
+		})
+	}
 
-    /// Helper constructor to make creating user tool result content easier.
-    pub fn tool_result(id: impl Into<String>, content: OneOrMany<ToolResultContent>) -> Self {
-        UserContent::ToolResult(ToolResult {
-            id: id.into(),
-            call_id: None,
-            content,
-        })
-    }
+	/// Helper constructor to make creating user tool result content easier.
+	pub fn tool_result(id: impl Into<String>, content: OneOrMany<ToolResultContent>) -> Self {
+		UserContent::ToolResult(ToolResult {
+			id: id.into(),
+			call_id: None,
+			content,
+		})
+	}
 
-    /// Helper constructor to make creating user tool result content easier.
-    pub fn tool_result_with_call_id(
-        id: impl Into<String>,
-        call_id: String,
-        content: OneOrMany<ToolResultContent>,
-    ) -> Self {
-        UserContent::ToolResult(ToolResult {
-            id: id.into(),
-            call_id: Some(call_id),
-            content,
-        })
-    }
+	/// Helper constructor to make creating user tool result content easier.
+	pub fn tool_result_with_call_id(
+		id: impl Into<String>,
+		call_id: String,
+		content: OneOrMany<ToolResultContent>,
+	) -> Self {
+		UserContent::ToolResult(ToolResult {
+			id: id.into(),
+			call_id: Some(call_id),
+			content,
+		})
+	}
 }
 
 impl AssistantContent {
-    /// Helper constructor to make creating assistant text content easier.
-    pub fn text(text: impl Into<String>) -> Self {
-        AssistantContent::Text(text.into().into())
-    }
+	/// Helper constructor to make creating assistant text content easier.
+	pub fn text(text: impl Into<String>) -> Self {
+		AssistantContent::Text(text.into().into())
+	}
 
-    /// Helper constructor to make creating assistant tool call content easier.
-    pub fn tool_call(
-        id: impl Into<String>,
-        name: impl Into<String>,
-        arguments: serde_json::Value,
-    ) -> Self {
-        AssistantContent::ToolCall(ToolCall {
-            id: id.into(),
-            call_id: None,
-            function: ToolFunction {
-                name: name.into(),
-                arguments,
-            },
-        })
-    }
+	/// Helper constructor to make creating assistant tool call content easier.
+	pub fn tool_call(
+		id: impl Into<String>,
+		name: impl Into<String>,
+		arguments: serde_json::Value,
+	) -> Self {
+		AssistantContent::ToolCall(ToolCall {
+			id: id.into(),
+			call_id: None,
+			function: ToolFunction {
+				name: name.into(),
+				arguments,
+			},
+		})
+	}
 
-    pub fn tool_call_with_call_id(
-        id: impl Into<String>,
-        call_id: String,
-        name: impl Into<String>,
-        arguments: serde_json::Value,
-    ) -> Self {
-        AssistantContent::ToolCall(ToolCall {
-            id: id.into(),
-            call_id: Some(call_id),
-            function: ToolFunction {
-                name: name.into(),
-                arguments,
-            },
-        })
-    }
+	pub fn tool_call_with_call_id(
+		id: impl Into<String>,
+		call_id: String,
+		name: impl Into<String>,
+		arguments: serde_json::Value,
+	) -> Self {
+		AssistantContent::ToolCall(ToolCall {
+			id: id.into(),
+			call_id: Some(call_id),
+			function: ToolFunction {
+				name: name.into(),
+				arguments,
+			},
+		})
+	}
 }
 
 impl ToolResultContent {
-    /// Helper constructor to make creating tool result text content easier.
-    pub fn text(text: impl Into<String>) -> Self {
-        ToolResultContent::Text(text.into().into())
-    }
+	/// Helper constructor to make creating tool result text content easier.
+	pub fn text(text: impl Into<String>) -> Self {
+		ToolResultContent::Text(text.into().into())
+	}
 
-    /// Helper constructor to make creating tool result image content easier.
-    pub fn image(
-        data: impl Into<String>,
-        format: Option<ContentFormat>,
-        media_type: Option<ImageMediaType>,
-        detail: Option<ImageDetail>,
-    ) -> Self {
-        ToolResultContent::Image(Image {
-            data: data.into(),
-            format,
-            media_type,
-            detail,
-            additional_params: None,
-        })
-    }
+	/// Helper constructor to make creating tool result image content easier.
+	pub fn image(
+		data: impl Into<String>,
+		format: Option<ContentFormat>,
+		media_type: Option<ImageMediaType>,
+		detail: Option<ImageDetail>,
+	) -> Self {
+		ToolResultContent::Image(Image {
+			data: data.into(),
+			format,
+			media_type,
+			detail,
+			additional_params: None,
+		})
+	}
 }
 
 /// Trait for converting between MIME types and media types.
 pub trait MimeType {
-    fn from_mime_type(mime_type: &str) -> Option<Self>
-    where
-        Self: Sized;
-    fn to_mime_type(&self) -> &'static str;
+	fn from_mime_type(mime_type: &str) -> Option<Self>
+	where
+		Self: Sized;
+	fn to_mime_type(&self) -> &'static str;
 }
 
 impl MimeType for MediaType {
-    fn from_mime_type(mime_type: &str) -> Option<Self> {
-        ImageMediaType::from_mime_type(mime_type)
-            .map(MediaType::Image)
-            .or_else(|| {
-                DocumentMediaType::from_mime_type(mime_type)
-                    .map(MediaType::Document)
-                    .or_else(|| AudioMediaType::from_mime_type(mime_type).map(MediaType::Audio))
-            })
-    }
+	fn from_mime_type(mime_type: &str) -> Option<Self> {
+		ImageMediaType::from_mime_type(mime_type)
+			.map(MediaType::Image)
+			.or_else(|| {
+				DocumentMediaType::from_mime_type(mime_type)
+					.map(MediaType::Document)
+					.or_else(|| AudioMediaType::from_mime_type(mime_type).map(MediaType::Audio))
+			})
+	}
 
-    fn to_mime_type(&self) -> &'static str {
-        match self {
-            MediaType::Image(media_type) => media_type.to_mime_type(),
-            MediaType::Audio(media_type) => media_type.to_mime_type(),
-            MediaType::Document(media_type) => media_type.to_mime_type(),
-            MediaType::Video(media_type) => media_type.to_mime_type(),
-        }
-    }
+	fn to_mime_type(&self) -> &'static str {
+		match self {
+			MediaType::Image(media_type) => media_type.to_mime_type(),
+			MediaType::Audio(media_type) => media_type.to_mime_type(),
+			MediaType::Document(media_type) => media_type.to_mime_type(),
+			MediaType::Video(media_type) => media_type.to_mime_type(),
+		}
+	}
 }
 
 impl MimeType for ImageMediaType {
-    fn from_mime_type(mime_type: &str) -> Option<Self> {
-        match mime_type {
-            "image/jpeg" => Some(ImageMediaType::JPEG),
-            "image/png" => Some(ImageMediaType::PNG),
-            "image/gif" => Some(ImageMediaType::GIF),
-            "image/webp" => Some(ImageMediaType::WEBP),
-            "image/heic" => Some(ImageMediaType::HEIC),
-            "image/heif" => Some(ImageMediaType::HEIF),
-            "image/svg+xml" => Some(ImageMediaType::SVG),
-            _ => None,
-        }
-    }
+	fn from_mime_type(mime_type: &str) -> Option<Self> {
+		match mime_type {
+			"image/jpeg" => Some(ImageMediaType::JPEG),
+			"image/png" => Some(ImageMediaType::PNG),
+			"image/gif" => Some(ImageMediaType::GIF),
+			"image/webp" => Some(ImageMediaType::WEBP),
+			"image/heic" => Some(ImageMediaType::HEIC),
+			"image/heif" => Some(ImageMediaType::HEIF),
+			"image/svg+xml" => Some(ImageMediaType::SVG),
+			_ => None,
+		}
+	}
 
-    fn to_mime_type(&self) -> &'static str {
-        match self {
-            ImageMediaType::JPEG => "image/jpeg",
-            ImageMediaType::PNG => "image/png",
-            ImageMediaType::GIF => "image/gif",
-            ImageMediaType::WEBP => "image/webp",
-            ImageMediaType::HEIC => "image/heic",
-            ImageMediaType::HEIF => "image/heif",
-            ImageMediaType::SVG => "image/svg+xml",
-        }
-    }
+	fn to_mime_type(&self) -> &'static str {
+		match self {
+			ImageMediaType::JPEG => "image/jpeg",
+			ImageMediaType::PNG => "image/png",
+			ImageMediaType::GIF => "image/gif",
+			ImageMediaType::WEBP => "image/webp",
+			ImageMediaType::HEIC => "image/heic",
+			ImageMediaType::HEIF => "image/heif",
+			ImageMediaType::SVG => "image/svg+xml",
+		}
+	}
 }
 
 impl MimeType for DocumentMediaType {
-    fn from_mime_type(mime_type: &str) -> Option<Self> {
-        match mime_type {
-            "application/pdf" => Some(DocumentMediaType::PDF),
-            "text/plain" => Some(DocumentMediaType::TXT),
-            "text/rtf" => Some(DocumentMediaType::RTF),
-            "text/html" => Some(DocumentMediaType::HTML),
-            "text/css" => Some(DocumentMediaType::CSS),
-            "text/md" | "text/markdown" => Some(DocumentMediaType::MARKDOWN),
-            "text/csv" => Some(DocumentMediaType::CSV),
-            "text/xml" => Some(DocumentMediaType::XML),
-            "application/x-javascript" | "text/x-javascript" => Some(DocumentMediaType::Javascript),
-            "application/x-python" | "text/x-python" => Some(DocumentMediaType::Python),
-            _ => None,
-        }
-    }
+	fn from_mime_type(mime_type: &str) -> Option<Self> {
+		match mime_type {
+			"application/pdf" => Some(DocumentMediaType::PDF),
+			"text/plain" => Some(DocumentMediaType::TXT),
+			"text/rtf" => Some(DocumentMediaType::RTF),
+			"text/html" => Some(DocumentMediaType::HTML),
+			"text/css" => Some(DocumentMediaType::CSS),
+			"text/md" | "text/markdown" => Some(DocumentMediaType::MARKDOWN),
+			"text/csv" => Some(DocumentMediaType::CSV),
+			"text/xml" => Some(DocumentMediaType::XML),
+			"application/x-javascript" | "text/x-javascript" => Some(DocumentMediaType::Javascript),
+			"application/x-python" | "text/x-python" => Some(DocumentMediaType::Python),
+			_ => None,
+		}
+	}
 
-    fn to_mime_type(&self) -> &'static str {
-        match self {
-            DocumentMediaType::PDF => "application/pdf",
-            DocumentMediaType::TXT => "text/plain",
-            DocumentMediaType::RTF => "text/rtf",
-            DocumentMediaType::HTML => "text/html",
-            DocumentMediaType::CSS => "text/css",
-            DocumentMediaType::MARKDOWN => "text/markdown",
-            DocumentMediaType::CSV => "text/csv",
-            DocumentMediaType::XML => "text/xml",
-            DocumentMediaType::Javascript => "application/x-javascript",
-            DocumentMediaType::Python => "application/x-python",
-        }
-    }
+	fn to_mime_type(&self) -> &'static str {
+		match self {
+			DocumentMediaType::PDF => "application/pdf",
+			DocumentMediaType::TXT => "text/plain",
+			DocumentMediaType::RTF => "text/rtf",
+			DocumentMediaType::HTML => "text/html",
+			DocumentMediaType::CSS => "text/css",
+			DocumentMediaType::MARKDOWN => "text/markdown",
+			DocumentMediaType::CSV => "text/csv",
+			DocumentMediaType::XML => "text/xml",
+			DocumentMediaType::Javascript => "application/x-javascript",
+			DocumentMediaType::Python => "application/x-python",
+		}
+	}
 }
 
 impl MimeType for AudioMediaType {
-    fn from_mime_type(mime_type: &str) -> Option<Self> {
-        match mime_type {
-            "audio/wav" => Some(AudioMediaType::WAV),
-            "audio/mp3" => Some(AudioMediaType::MP3),
-            "audio/aiff" => Some(AudioMediaType::AIFF),
-            "audio/aac" => Some(AudioMediaType::AAC),
-            "audio/ogg" => Some(AudioMediaType::OGG),
-            "audio/flac" => Some(AudioMediaType::FLAC),
-            _ => None,
-        }
-    }
+	fn from_mime_type(mime_type: &str) -> Option<Self> {
+		match mime_type {
+			"audio/wav" => Some(AudioMediaType::WAV),
+			"audio/mp3" => Some(AudioMediaType::MP3),
+			"audio/aiff" => Some(AudioMediaType::AIFF),
+			"audio/aac" => Some(AudioMediaType::AAC),
+			"audio/ogg" => Some(AudioMediaType::OGG),
+			"audio/flac" => Some(AudioMediaType::FLAC),
+			_ => None,
+		}
+	}
 
-    fn to_mime_type(&self) -> &'static str {
-        match self {
-            AudioMediaType::WAV => "audio/wav",
-            AudioMediaType::MP3 => "audio/mp3",
-            AudioMediaType::AIFF => "audio/aiff",
-            AudioMediaType::AAC => "audio/aac",
-            AudioMediaType::OGG => "audio/ogg",
-            AudioMediaType::FLAC => "audio/flac",
-        }
-    }
+	fn to_mime_type(&self) -> &'static str {
+		match self {
+			AudioMediaType::WAV => "audio/wav",
+			AudioMediaType::MP3 => "audio/mp3",
+			AudioMediaType::AIFF => "audio/aiff",
+			AudioMediaType::AAC => "audio/aac",
+			AudioMediaType::OGG => "audio/ogg",
+			AudioMediaType::FLAC => "audio/flac",
+		}
+	}
 }
 
 impl MimeType for VideoMediaType {
-    fn from_mime_type(mime_type: &str) -> Option<Self>
-    where
-        Self: Sized,
-    {
-        match mime_type {
-            "video/avi" => Some(VideoMediaType::AVI),
-            "video/mp4" => Some(VideoMediaType::MP4),
-            "video/mpeg" => Some(VideoMediaType::MPEG),
-            &_ => None,
-        }
-    }
+	fn from_mime_type(mime_type: &str) -> Option<Self>
+	where
+		Self: Sized,
+	{
+		match mime_type {
+			"video/avi" => Some(VideoMediaType::AVI),
+			"video/mp4" => Some(VideoMediaType::MP4),
+			"video/mpeg" => Some(VideoMediaType::MPEG),
+			&_ => None,
+		}
+	}
 
-    fn to_mime_type(&self) -> &'static str {
-        match self {
-            VideoMediaType::AVI => "video/avi",
-            VideoMediaType::MP4 => "video/mp4",
-            VideoMediaType::MPEG => "video/mpeg",
-        }
-    }
+	fn to_mime_type(&self) -> &'static str {
+		match self {
+			VideoMediaType::AVI => "video/avi",
+			VideoMediaType::MP4 => "video/mp4",
+			VideoMediaType::MPEG => "video/mpeg",
+		}
+	}
 }
 
 impl std::str::FromStr for ImageDetail {
-    type Err = ();
+	type Err = ();
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "low" => Ok(ImageDetail::Low),
-            "high" => Ok(ImageDetail::High),
-            "auto" => Ok(ImageDetail::Auto),
-            _ => Err(()),
-        }
-    }
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		match s.to_lowercase().as_str() {
+			"low" => Ok(ImageDetail::Low),
+			"high" => Ok(ImageDetail::High),
+			"auto" => Ok(ImageDetail::Auto),
+			_ => Err(()),
+		}
+	}
 }
 
 // ================================================================
@@ -647,161 +661,161 @@ impl std::str::FromStr for ImageDetail {
 // ================================================================
 
 impl From<String> for Text {
-    fn from(text: String) -> Self {
-        Text { text }
-    }
+	fn from(text: String) -> Self {
+		Text { text }
+	}
 }
 
 impl From<&String> for Text {
-    fn from(text: &String) -> Self {
-        text.to_owned().into()
-    }
+	fn from(text: &String) -> Self {
+		text.to_owned().into()
+	}
 }
 
 impl From<&str> for Text {
-    fn from(text: &str) -> Self {
-        text.to_owned().into()
-    }
+	fn from(text: &str) -> Self {
+		text.to_owned().into()
+	}
 }
 
 impl FromStr for Text {
-    type Err = Infallible;
+	type Err = Infallible;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(s.into())
-    }
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		Ok(s.into())
+	}
 }
 
 impl From<String> for Message {
-    fn from(text: String) -> Self {
-        Message::User {
-            content: OneOrMany::one(UserContent::Text(text.into())),
-        }
-    }
+	fn from(text: String) -> Self {
+		Message::User {
+			content: OneOrMany::one(UserContent::Text(text.into())),
+		}
+	}
 }
 
 impl From<&str> for Message {
-    fn from(text: &str) -> Self {
-        Message::User {
-            content: OneOrMany::one(UserContent::Text(text.into())),
-        }
-    }
+	fn from(text: &str) -> Self {
+		Message::User {
+			content: OneOrMany::one(UserContent::Text(text.into())),
+		}
+	}
 }
 
 impl From<&String> for Message {
-    fn from(text: &String) -> Self {
-        Message::User {
-            content: OneOrMany::one(UserContent::Text(text.into())),
-        }
-    }
+	fn from(text: &String) -> Self {
+		Message::User {
+			content: OneOrMany::one(UserContent::Text(text.into())),
+		}
+	}
 }
 
 impl From<Text> for Message {
-    fn from(text: Text) -> Self {
-        Message::User {
-            content: OneOrMany::one(UserContent::Text(text)),
-        }
-    }
+	fn from(text: Text) -> Self {
+		Message::User {
+			content: OneOrMany::one(UserContent::Text(text)),
+		}
+	}
 }
 
 impl From<Image> for Message {
-    fn from(image: Image) -> Self {
-        Message::User {
-            content: OneOrMany::one(UserContent::Image(image)),
-        }
-    }
+	fn from(image: Image) -> Self {
+		Message::User {
+			content: OneOrMany::one(UserContent::Image(image)),
+		}
+	}
 }
 
 impl From<Audio> for Message {
-    fn from(audio: Audio) -> Self {
-        Message::User {
-            content: OneOrMany::one(UserContent::Audio(audio)),
-        }
-    }
+	fn from(audio: Audio) -> Self {
+		Message::User {
+			content: OneOrMany::one(UserContent::Audio(audio)),
+		}
+	}
 }
 
 impl From<Document> for Message {
-    fn from(document: Document) -> Self {
-        Message::User {
-            content: OneOrMany::one(UserContent::Document(document)),
-        }
-    }
+	fn from(document: Document) -> Self {
+		Message::User {
+			content: OneOrMany::one(UserContent::Document(document)),
+		}
+	}
 }
 
 impl From<String> for ToolResultContent {
-    fn from(text: String) -> Self {
-        ToolResultContent::text(text)
-    }
+	fn from(text: String) -> Self {
+		ToolResultContent::text(text)
+	}
 }
 
 impl From<String> for AssistantContent {
-    fn from(text: String) -> Self {
-        AssistantContent::text(text)
-    }
+	fn from(text: String) -> Self {
+		AssistantContent::text(text)
+	}
 }
 
 impl From<String> for UserContent {
-    fn from(text: String) -> Self {
-        UserContent::text(text)
-    }
+	fn from(text: String) -> Self {
+		UserContent::text(text)
+	}
 }
 
 impl From<AssistantContent> for Message {
-    fn from(content: AssistantContent) -> Self {
-        Message::Assistant {
-            id: None,
-            content: OneOrMany::one(content),
-        }
-    }
+	fn from(content: AssistantContent) -> Self {
+		Message::Assistant {
+			id: None,
+			content: OneOrMany::one(content),
+		}
+	}
 }
 
 impl From<UserContent> for Message {
-    fn from(content: UserContent) -> Self {
-        Message::User {
-            content: OneOrMany::one(content),
-        }
-    }
+	fn from(content: UserContent) -> Self {
+		Message::User {
+			content: OneOrMany::one(content),
+		}
+	}
 }
 
 impl From<OneOrMany<AssistantContent>> for Message {
-    fn from(content: OneOrMany<AssistantContent>) -> Self {
-        Message::Assistant { id: None, content }
-    }
+	fn from(content: OneOrMany<AssistantContent>) -> Self {
+		Message::Assistant { id: None, content }
+	}
 }
 
 impl From<OneOrMany<UserContent>> for Message {
-    fn from(content: OneOrMany<UserContent>) -> Self {
-        Message::User { content }
-    }
+	fn from(content: OneOrMany<UserContent>) -> Self {
+		Message::User { content }
+	}
 }
 
 impl From<ToolCall> for Message {
-    fn from(tool_call: ToolCall) -> Self {
-        Message::Assistant {
-            id: None,
-            content: OneOrMany::one(AssistantContent::ToolCall(tool_call)),
-        }
-    }
+	fn from(tool_call: ToolCall) -> Self {
+		Message::Assistant {
+			id: None,
+			content: OneOrMany::one(AssistantContent::ToolCall(tool_call)),
+		}
+	}
 }
 
 impl From<ToolResult> for Message {
-    fn from(tool_result: ToolResult) -> Self {
-        Message::User {
-            content: OneOrMany::one(UserContent::ToolResult(tool_result)),
-        }
-    }
+	fn from(tool_result: ToolResult) -> Self {
+		Message::User {
+			content: OneOrMany::one(UserContent::ToolResult(tool_result)),
+		}
+	}
 }
 
 impl From<ToolResultContent> for Message {
-    fn from(tool_result_content: ToolResultContent) -> Self {
-        Message::User {
-            content: OneOrMany::one(UserContent::ToolResult(ToolResult {
-                id: String::new(),
-                call_id: None,
-                content: OneOrMany::one(tool_result_content),
-            })),
-        }
-    }
+	fn from(tool_result_content: ToolResultContent) -> Self {
+		Message::User {
+			content: OneOrMany::one(UserContent::ToolResult(ToolResult {
+				id: String::new(),
+				call_id: None,
+				content: OneOrMany::one(tool_result_content),
+			})),
+		}
+	}
 }
 
 // ================================================================
@@ -810,13 +824,14 @@ impl From<ToolResultContent> for Message {
 
 /// Error type to represent issues with converting messages to and from specific provider messages.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum MessageError {
-    #[error("Message conversion error: {0}")]
-    ConversionError(String),
+	#[error("Message conversion error: {0}")]
+	ConversionError(String),
 }
 
 impl From<MessageError> for CompletionError {
-    fn from(error: MessageError) -> Self {
-        CompletionError::RequestError(error.into())
-    }
+	fn from(error: MessageError) -> Self {
+		CompletionError::RequestError(error.into())
+	}
 }

--- a/rig-core/src/embeddings/embedding.rs
+++ b/rig-core/src/embeddings/embedding.rs
@@ -10,136 +10,137 @@ use futures::future::BoxFuture;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum EmbeddingError {
-    /// Http error (e.g.: connection error, timeout, etc.)
-    #[error("HttpError: {0}")]
-    HttpError(#[from] reqwest::Error),
+	/// Http error (e.g.: connection error, timeout, etc.)
+	#[error("HttpError: {0}")]
+	HttpError(#[from] reqwest::Error),
 
-    /// Json error (e.g.: serialization, deserialization)
-    #[error("JsonError: {0}")]
-    JsonError(#[from] serde_json::Error),
+	/// Json error (e.g.: serialization, deserialization)
+	#[error("JsonError: {0}")]
+	JsonError(#[from] serde_json::Error),
 
-    #[error("UrlError: {0}")]
-    UrlError(#[from] url::ParseError),
+	#[error("UrlError: {0}")]
+	UrlError(#[from] url::ParseError),
 
-    /// Error processing the document for embedding
-    #[error("DocumentError: {0}")]
-    DocumentError(Box<dyn std::error::Error + Send + Sync + 'static>),
+	/// Error processing the document for embedding
+	#[error("DocumentError: {0}")]
+	DocumentError(Box<dyn std::error::Error + Send + Sync + 'static>),
 
-    /// Error parsing the completion response
-    #[error("ResponseError: {0}")]
-    ResponseError(String),
+	/// Error parsing the completion response
+	#[error("ResponseError: {0}")]
+	ResponseError(String),
 
-    /// Error returned by the embedding model provider
-    #[error("ProviderError: {0}")]
-    ProviderError(String),
+	/// Error returned by the embedding model provider
+	#[error("ProviderError: {0}")]
+	ProviderError(String),
 }
 
 /// Trait for embedding models that can generate embeddings for documents.
 pub trait EmbeddingModel: Clone + Sync + Send {
-    /// The maximum number of documents that can be embedded in a single request.
-    const MAX_DOCUMENTS: usize;
+	/// The maximum number of documents that can be embedded in a single request.
+	const MAX_DOCUMENTS: usize;
 
-    /// The number of dimensions in the embedding vector.
-    fn ndims(&self) -> usize;
+	/// The number of dimensions in the embedding vector.
+	fn ndims(&self) -> usize;
 
-    /// Embed multiple text documents in a single request
-    fn embed_texts(
-        &self,
-        texts: impl IntoIterator<Item = String> + Send,
-    ) -> impl std::future::Future<Output = Result<Vec<Embedding>, EmbeddingError>> + Send;
+	/// Embed multiple text documents in a single request
+	fn embed_texts(
+		&self,
+		texts: impl IntoIterator<Item=String> + Send,
+	) -> impl std::future::Future<Output=Result<Vec<Embedding>, EmbeddingError>> + Send;
 
-    /// Embed a single text document.
-    fn embed_text(
-        &self,
-        text: &str,
-    ) -> impl std::future::Future<Output = Result<Embedding, EmbeddingError>> + Send {
-        async {
-            Ok(self
-                .embed_texts(vec![text.to_string()])
-                .await?
-                .pop()
-                .expect("There should be at least one embedding"))
-        }
-    }
+	/// Embed a single text document.
+	fn embed_text(
+		&self,
+		text: &str,
+	) -> impl std::future::Future<Output=Result<Embedding, EmbeddingError>> + Send {
+		async {
+			Ok(self
+				.embed_texts(vec![text.to_string()])
+				.await?
+				.pop()
+				.expect("There should be at least one embedding"))
+		}
+	}
 }
 
 pub trait EmbeddingModelDyn: Sync + Send {
-    fn max_documents(&self) -> usize;
-    fn ndims(&self) -> usize;
-    fn embed_text<'a>(&'a self, text: &'a str) -> BoxFuture<'a, Result<Embedding, EmbeddingError>>;
-    fn embed_texts(
-        &self,
-        texts: Vec<String>,
-    ) -> BoxFuture<'_, Result<Vec<Embedding>, EmbeddingError>>;
+	fn max_documents(&self) -> usize;
+	fn ndims(&self) -> usize;
+	fn embed_text<'a>(&'a self, text: &'a str) -> BoxFuture<'a, Result<Embedding, EmbeddingError>>;
+	fn embed_texts(
+		&self,
+		texts: Vec<String>,
+	) -> BoxFuture<'_, Result<Vec<Embedding>, EmbeddingError>>;
 }
 
 impl<T> EmbeddingModelDyn for T
 where
-    T: EmbeddingModel,
+	T: EmbeddingModel,
 {
-    fn max_documents(&self) -> usize {
-        T::MAX_DOCUMENTS
-    }
+	fn max_documents(&self) -> usize {
+		T::MAX_DOCUMENTS
+	}
 
-    fn ndims(&self) -> usize {
-        self.ndims()
-    }
+	fn ndims(&self) -> usize {
+		self.ndims()
+	}
 
-    fn embed_text<'a>(&'a self, text: &'a str) -> BoxFuture<'a, Result<Embedding, EmbeddingError>> {
-        Box::pin(self.embed_text(text))
-    }
+	fn embed_text<'a>(&'a self, text: &'a str) -> BoxFuture<'a, Result<Embedding, EmbeddingError>> {
+		Box::pin(self.embed_text(text))
+	}
 
-    fn embed_texts(
-        &self,
-        texts: Vec<String>,
-    ) -> BoxFuture<'_, Result<Vec<Embedding>, EmbeddingError>> {
-        Box::pin(self.embed_texts(texts.into_iter().collect::<Vec<_>>()))
-    }
+	fn embed_texts(
+		&self,
+		texts: Vec<String>,
+	) -> BoxFuture<'_, Result<Vec<Embedding>, EmbeddingError>> {
+		Box::pin(self.embed_texts(texts.into_iter().collect::<Vec<_>>()))
+	}
 }
 
 /// Trait for embedding models that can generate embeddings for images.
 pub trait ImageEmbeddingModel: Clone + Sync + Send {
-    /// The maximum number of images that can be embedded in a single request.
-    const MAX_DOCUMENTS: usize;
+	/// The maximum number of images that can be embedded in a single request.
+	const MAX_DOCUMENTS: usize;
 
-    /// The number of dimensions in the embedding vector.
-    fn ndims(&self) -> usize;
+	/// The number of dimensions in the embedding vector.
+	fn ndims(&self) -> usize;
 
-    /// Embed multiple images in a single request from bytes.
-    fn embed_images(
-        &self,
-        images: impl IntoIterator<Item = Vec<u8>> + Send,
-    ) -> impl std::future::Future<Output = Result<Vec<Embedding>, EmbeddingError>> + Send;
+	/// Embed multiple images in a single request from bytes.
+	fn embed_images(
+		&self,
+		images: impl IntoIterator<Item=Vec<u8>> + Send,
+	) -> impl std::future::Future<Output=Result<Vec<Embedding>, EmbeddingError>> + Send;
 
-    /// Embed a single image from bytes.
-    fn embed_image<'a>(
-        &'a self,
-        bytes: &'a [u8],
-    ) -> impl std::future::Future<Output = Result<Embedding, EmbeddingError>> + Send {
-        async move {
-            Ok(self
-                .embed_images(vec![bytes.to_owned()])
-                .await?
-                .pop()
-                .expect("There should be at least one embedding"))
-        }
-    }
+	/// Embed a single image from bytes.
+	fn embed_image<'a>(
+		&'a self,
+		bytes: &'a [u8],
+	) -> impl std::future::Future<Output=Result<Embedding, EmbeddingError>> + Send {
+		async move {
+			Ok(self
+				.embed_images(vec![bytes.to_owned()])
+				.await?
+				.pop()
+				.expect("There should be at least one embedding"))
+		}
+	}
 }
 
 /// Struct that holds a single document and its embedding.
 #[derive(Clone, Default, Deserialize, Serialize, Debug)]
 pub struct Embedding {
-    /// The document that was embedded. Used for debugging.
-    pub document: String,
-    /// The embedding vector
-    pub vec: Vec<f64>,
+	/// The document that was embedded. Used for debugging.
+	pub document: String,
+	/// The embedding vector
+	pub vec: Vec<f64>,
 }
 
 impl PartialEq for Embedding {
-    fn eq(&self, other: &Self) -> bool {
-        self.document == other.document
-    }
+	fn eq(&self, other: &Self) -> bool {
+		self.document == other.document
+	}
 }
 
 impl Eq for Embedding {}

--- a/rig-core/src/image_generation.rs
+++ b/rig-core/src/image_generation.rs
@@ -7,114 +7,115 @@ use std::sync::Arc;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ImageGenerationError {
-    /// Http error (e.g.: connection error, timeout, etc.)
-    #[error("HttpError: {0}")]
-    HttpError(#[from] reqwest::Error),
+	/// Http error (e.g.: connection error, timeout, etc.)
+	#[error("HttpError: {0}")]
+	HttpError(#[from] reqwest::Error),
 
-    /// Json error (e.g.: serialization, deserialization)
-    #[error("JsonError: {0}")]
-    JsonError(#[from] serde_json::Error),
+	/// Json error (e.g.: serialization, deserialization)
+	#[error("JsonError: {0}")]
+	JsonError(#[from] serde_json::Error),
 
-    /// Error building the transcription request
-    #[error("RequestError: {0}")]
-    RequestError(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
+	/// Error building the transcription request
+	#[error("RequestError: {0}")]
+	RequestError(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
 
-    /// Error parsing the transcription response
-    #[error("ResponseError: {0}")]
-    ResponseError(String),
+	/// Error parsing the transcription response
+	#[error("ResponseError: {0}")]
+	ResponseError(String),
 
-    /// Error returned by the transcription model provider
-    #[error("ProviderError: {0}")]
-    ProviderError(String),
+	/// Error returned by the transcription model provider
+	#[error("ProviderError: {0}")]
+	ProviderError(String),
 }
 pub trait ImageGeneration<M>
 where
-    M: ImageGenerationModel,
+	M: ImageGenerationModel,
 {
-    /// Generates a transcription request builder for the given `file`.
-    /// This function is meant to be called by the user to further customize the
-    /// request at transcription time before sending it.
-    ///
-    /// ❗IMPORTANT: The type that implements this trait might have already
-    /// populated fields in the builder (the exact fields depend on the type).
-    /// For fields that have already been set by the model, calling the corresponding
-    /// method on the builder will overwrite the value set by the model.
-    fn image_generation(
-        &self,
-        prompt: &str,
-        size: &(u32, u32),
-    ) -> impl std::future::Future<
-        Output = Result<ImageGenerationRequestBuilder<M>, ImageGenerationError>,
-    > + Send;
+	/// Generates a transcription request builder for the given `file`.
+	/// This function is meant to be called by the user to further customize the
+	/// request at transcription time before sending it.
+	///
+	/// ❗IMPORTANT: The type that implements this trait might have already
+	/// populated fields in the builder (the exact fields depend on the type).
+	/// For fields that have already been set by the model, calling the corresponding
+	/// method on the builder will overwrite the value set by the model.
+	fn image_generation(
+		&self,
+		prompt: &str,
+		size: &(u32, u32),
+	) -> impl std::future::Future<
+		Output=Result<ImageGenerationRequestBuilder<M>, ImageGenerationError>,
+	> + Send;
 }
 
 /// A unified response for a model image generation, returning both the image and the raw response.
 #[derive(Debug)]
 pub struct ImageGenerationResponse<T> {
-    pub image: Vec<u8>,
-    pub response: T,
+	pub image: Vec<u8>,
+	pub response: T,
 }
 
 pub trait ImageGenerationModel: Clone + Send + Sync {
-    type Response: Send + Sync;
+	type Response: Send + Sync;
 
-    fn image_generation(
-        &self,
-        request: ImageGenerationRequest,
-    ) -> impl std::future::Future<
-        Output = Result<ImageGenerationResponse<Self::Response>, ImageGenerationError>,
-    > + Send;
+	fn image_generation(
+		&self,
+		request: ImageGenerationRequest,
+	) -> impl std::future::Future<
+		Output=Result<ImageGenerationResponse<Self::Response>, ImageGenerationError>,
+	> + Send;
 
-    fn image_generation_request(&self) -> ImageGenerationRequestBuilder<Self> {
-        ImageGenerationRequestBuilder::new(self.clone())
-    }
+	fn image_generation_request(&self) -> ImageGenerationRequestBuilder<Self> {
+		ImageGenerationRequestBuilder::new(self.clone())
+	}
 }
 
 pub trait ImageGenerationModelDyn: Send + Sync {
-    fn image_generation(
-        &self,
-        request: ImageGenerationRequest,
-    ) -> BoxFuture<'_, Result<ImageGenerationResponse<()>, ImageGenerationError>>;
+	fn image_generation(
+		&self,
+		request: ImageGenerationRequest,
+	) -> BoxFuture<'_, Result<ImageGenerationResponse<()>, ImageGenerationError>>;
 
-    fn image_generation_request(
-        &self,
-    ) -> ImageGenerationRequestBuilder<ImageGenerationModelHandle<'_>>;
+	fn image_generation_request(
+		&self,
+	) -> ImageGenerationRequestBuilder<ImageGenerationModelHandle<'_>>;
 }
 
 impl<T> ImageGenerationModelDyn for T
 where
-    T: ImageGenerationModel,
+	T: ImageGenerationModel,
 {
-    fn image_generation(
-        &self,
-        request: ImageGenerationRequest,
-    ) -> BoxFuture<'_, Result<ImageGenerationResponse<()>, ImageGenerationError>> {
-        Box::pin(async {
-            let resp = self.image_generation(request).await;
-            resp.map(|r| ImageGenerationResponse {
-                image: r.image,
-                response: (),
-            })
-        })
-    }
+	fn image_generation(
+		&self,
+		request: ImageGenerationRequest,
+	) -> BoxFuture<'_, Result<ImageGenerationResponse<()>, ImageGenerationError>> {
+		Box::pin(async {
+			let resp = self.image_generation(request).await;
+			resp.map(|r| ImageGenerationResponse {
+				image: r.image,
+				response: (),
+			})
+		})
+	}
 
-    fn image_generation_request(
-        &self,
-    ) -> ImageGenerationRequestBuilder<ImageGenerationModelHandle<'_>> {
-        ImageGenerationRequestBuilder::new(ImageGenerationModelHandle {
-            inner: Arc::new(self.clone()),
-        })
-    }
+	fn image_generation_request(
+		&self,
+	) -> ImageGenerationRequestBuilder<ImageGenerationModelHandle<'_>> {
+		ImageGenerationRequestBuilder::new(ImageGenerationModelHandle {
+			inner: Arc::new(self.clone()),
+		})
+	}
 }
 
 /// An image generation request.
 #[non_exhaustive]
 pub struct ImageGenerationRequest {
-    pub prompt: String,
-    pub width: u32,
-    pub height: u32,
-    pub additional_params: Option<Value>,
+	pub prompt: String,
+	pub width: u32,
+	pub height: u32,
+	pub additional_params: Option<Value>,
 }
 
 /// A builder for `ImageGenerationRequest`.
@@ -122,65 +123,65 @@ pub struct ImageGenerationRequest {
 #[non_exhaustive]
 pub struct ImageGenerationRequestBuilder<M>
 where
-    M: ImageGenerationModel,
+	M: ImageGenerationModel,
 {
-    model: M,
-    prompt: String,
-    width: u32,
-    height: u32,
-    additional_params: Option<Value>,
+	model: M,
+	prompt: String,
+	width: u32,
+	height: u32,
+	additional_params: Option<Value>,
 }
 
 impl<M> ImageGenerationRequestBuilder<M>
 where
-    M: ImageGenerationModel,
+	M: ImageGenerationModel,
 {
-    pub fn new(model: M) -> Self {
-        Self {
-            model,
-            prompt: "".to_string(),
-            height: 256,
-            width: 256,
-            additional_params: None,
-        }
-    }
+	pub fn new(model: M) -> Self {
+		Self {
+			model,
+			prompt: "".to_string(),
+			height: 256,
+			width: 256,
+			additional_params: None,
+		}
+	}
 
-    /// Sets the prompt for the image generation request
-    pub fn prompt(mut self, prompt: &str) -> Self {
-        self.prompt = prompt.to_string();
-        self
-    }
+	/// Sets the prompt for the image generation request
+	pub fn prompt(mut self, prompt: &str) -> Self {
+		self.prompt = prompt.to_string();
+		self
+	}
 
-    /// The width of the generated image
-    pub fn width(mut self, width: u32) -> Self {
-        self.width = width;
-        self
-    }
+	/// The width of the generated image
+	pub fn width(mut self, width: u32) -> Self {
+		self.width = width;
+		self
+	}
 
-    /// The height of the generated image
-    pub fn height(mut self, height: u32) -> Self {
-        self.height = height;
-        self
-    }
+	/// The height of the generated image
+	pub fn height(mut self, height: u32) -> Self {
+		self.height = height;
+		self
+	}
 
-    /// Adds additional parameters to the image generation request.
-    pub fn additional_params(mut self, params: Value) -> Self {
-        self.additional_params = Some(params);
-        self
-    }
+	/// Adds additional parameters to the image generation request.
+	pub fn additional_params(mut self, params: Value) -> Self {
+		self.additional_params = Some(params);
+		self
+	}
 
-    pub fn build(self) -> ImageGenerationRequest {
-        ImageGenerationRequest {
-            prompt: self.prompt,
-            width: self.width,
-            height: self.height,
-            additional_params: self.additional_params,
-        }
-    }
+	pub fn build(self) -> ImageGenerationRequest {
+		ImageGenerationRequest {
+			prompt: self.prompt,
+			width: self.width,
+			height: self.height,
+			additional_params: self.additional_params,
+		}
+	}
 
-    pub async fn send(self) -> Result<ImageGenerationResponse<M::Response>, ImageGenerationError> {
-        let model = self.model.clone();
+	pub async fn send(self) -> Result<ImageGenerationResponse<M::Response>, ImageGenerationError> {
+		let model = self.model.clone();
 
-        model.image_generation(self.build()).await
-    }
+		model.image_generation(self.build()).await
+	}
 }

--- a/rig-core/src/loaders/epub/errors.rs
+++ b/rig-core/src/loaders/epub/errors.rs
@@ -5,13 +5,14 @@ use epub::doc::DocError;
 use crate::loaders::file::FileLoaderError;
 
 #[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
 pub enum EpubLoaderError {
-    #[error("IO error: {0}")]
-    EpubError(#[from] DocError),
+	#[error("IO error: {0}")]
+	EpubError(#[from] DocError),
 
-    #[error("File loader error: {0}")]
-    FileLoaderError(#[from] FileLoaderError),
+	#[error("File loader error: {0}")]
+	FileLoaderError(#[from] FileLoaderError),
 
-    #[error("Text processor error: {0}")]
-    TextProcessorError(#[from] Box<dyn Error>),
+	#[error("Text processor error: {0}")]
+	TextProcessorError(#[from] Box<dyn Error>),
 }

--- a/rig-core/src/loaders/file.rs
+++ b/rig-core/src/loaders/file.rs
@@ -4,73 +4,74 @@ use glob::glob;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum FileLoaderError {
-    #[error("Invalid glob pattern: {0}")]
-    InvalidGlobPattern(String),
+	#[error("Invalid glob pattern: {0}")]
+	InvalidGlobPattern(String),
 
-    #[error("IO error: {0}")]
-    IoError(#[from] std::io::Error),
+	#[error("IO error: {0}")]
+	IoError(#[from] std::io::Error),
 
-    #[error("Pattern error: {0}")]
-    PatternError(#[from] glob::PatternError),
+	#[error("Pattern error: {0}")]
+	PatternError(#[from] glob::PatternError),
 
-    #[error("Glob error: {0}")]
-    GlobError(#[from] glob::GlobError),
+	#[error("Glob error: {0}")]
+	GlobError(#[from] glob::GlobError),
 
-    #[error("String conversion error: {0}")]
-    StringUtf8Error(#[from] FromUtf8Error),
+	#[error("String conversion error: {0}")]
+	StringUtf8Error(#[from] FromUtf8Error),
 }
 
 // ================================================================
 // Implementing Readable trait for reading file contents
 // ================================================================
 pub(crate) trait Readable {
-    fn read(self) -> Result<String, FileLoaderError>;
-    fn read_with_path(self) -> Result<(PathBuf, String), FileLoaderError>;
+	fn read(self) -> Result<String, FileLoaderError>;
+	fn read_with_path(self) -> Result<(PathBuf, String), FileLoaderError>;
 }
 
 impl<'a> FileLoader<'a, PathBuf> {
-    pub fn read(self) -> FileLoader<'a, Result<String, FileLoaderError>> {
-        FileLoader {
-            iterator: Box::new(self.iterator.map(|res| res.read())),
-        }
-    }
-    pub fn read_with_path(self) -> FileLoader<'a, Result<(PathBuf, String), FileLoaderError>> {
-        FileLoader {
-            iterator: Box::new(self.iterator.map(|res| res.read_with_path())),
-        }
-    }
+	pub fn read(self) -> FileLoader<'a, Result<String, FileLoaderError>> {
+		FileLoader {
+			iterator: Box::new(self.iterator.map(|res| res.read())),
+		}
+	}
+	pub fn read_with_path(self) -> FileLoader<'a, Result<(PathBuf, String), FileLoaderError>> {
+		FileLoader {
+			iterator: Box::new(self.iterator.map(|res| res.read_with_path())),
+		}
+	}
 }
 
 impl Readable for PathBuf {
-    fn read(self) -> Result<String, FileLoaderError> {
-        fs::read_to_string(self).map_err(FileLoaderError::IoError)
-    }
-    fn read_with_path(self) -> Result<(PathBuf, String), FileLoaderError> {
-        let contents = fs::read_to_string(&self);
-        Ok((self, contents?))
-    }
+	fn read(self) -> Result<String, FileLoaderError> {
+		fs::read_to_string(self).map_err(FileLoaderError::IoError)
+	}
+	fn read_with_path(self) -> Result<(PathBuf, String), FileLoaderError> {
+		let contents = fs::read_to_string(&self);
+		Ok((self, contents?))
+	}
 }
 
 impl Readable for Vec<u8> {
-    fn read(self) -> Result<String, FileLoaderError> {
-        Ok(String::from_utf8(self)?)
-    }
+	fn read(self) -> Result<String, FileLoaderError> {
+		Ok(String::from_utf8(self)?)
+	}
 
-    fn read_with_path(self) -> Result<(PathBuf, String), FileLoaderError> {
-        let res = String::from_utf8(self)?;
+	fn read_with_path(self) -> Result<(PathBuf, String), FileLoaderError> {
+		let res = String::from_utf8(self)?;
 
-        Ok((PathBuf::from("<memory>"), res))
-    }
+		Ok((PathBuf::from("<memory>"), res))
+	}
 }
 
 impl<T: Readable> Readable for Result<T, FileLoaderError> {
-    fn read(self) -> Result<String, FileLoaderError> {
-        self.map(|t| t.read())?
-    }
-    fn read_with_path(self) -> Result<(PathBuf, String), FileLoaderError> {
-        self.map(|t| t.read_with_path())?
-    }
+	fn read(self) -> Result<String, FileLoaderError> {
+		self.map(|t| t.read())?
+	}
+	fn read_with_path(self) -> Result<(PathBuf, String), FileLoaderError> {
+		self.map(|t| t.read_with_path())?
+	}
 }
 
 // ================================================================
@@ -111,146 +112,146 @@ impl<T: Readable> Readable for Result<T, FileLoaderError> {
 /// [FileLoader] uses strict typing between the iterator methods to ensure that transitions between
 ///   different implementations of the loaders and it's methods are handled properly by the compiler.
 pub struct FileLoader<'a, T> {
-    iterator: Box<dyn Iterator<Item = T> + 'a>,
+	iterator: Box<dyn Iterator<Item=T> + 'a>,
 }
 
 impl<'a> FileLoader<'a, Result<PathBuf, FileLoaderError>> {
-    /// Reads the contents of the files within the iterator returned by [FileLoader::with_glob] or
-    ///  [FileLoader::with_dir].
-    ///
-    /// # Example
-    /// Read files in directory "files/*.txt" and print the content for each file
-    ///
-    /// ```rust
-    /// let content = FileLoader::with_glob(...)?.read();
-    /// for result in content {
-    ///     match result {
-    ///         Ok(content) => println!("{}", content),
-    ///         Err(e) => eprintln!("Error reading file: {}", e),
-    ///     }
-    /// }
-    /// ```
-    pub fn read(self) -> FileLoader<'a, Result<String, FileLoaderError>> {
-        FileLoader {
-            iterator: Box::new(self.iterator.map(|res| res.read())),
-        }
-    }
-    /// Reads the contents of the files within the iterator returned by [FileLoader::with_glob] or
-    ///  [FileLoader::with_dir] and returns the path along with the content.
-    ///
-    /// # Example
-    /// Read files in directory "files/*.txt" and print the content for corresponding path for each
-    ///  file.
-    ///
-    /// ```rust
-    /// let content = FileLoader::with_glob("files/*.txt")?.read();
-    /// for (path, result) in content {
-    ///     match result {
-    ///         Ok((path, content)) => println!("{:?} {}", path, content),
-    ///         Err(e) => eprintln!("Error reading file: {}", e),
-    ///     }
-    /// }
-    /// ```
-    pub fn read_with_path(self) -> FileLoader<'a, Result<(PathBuf, String), FileLoaderError>> {
-        FileLoader {
-            iterator: Box::new(self.iterator.map(|res| res.read_with_path())),
-        }
-    }
+	/// Reads the contents of the files within the iterator returned by [FileLoader::with_glob] or
+	///  [FileLoader::with_dir].
+	///
+	/// # Example
+	/// Read files in directory "files/*.txt" and print the content for each file
+	///
+	/// ```rust
+	/// let content = FileLoader::with_glob(...)?.read();
+	/// for result in content {
+	///     match result {
+	///         Ok(content) => println!("{}", content),
+	///         Err(e) => eprintln!("Error reading file: {}", e),
+	///     }
+	/// }
+	/// ```
+	pub fn read(self) -> FileLoader<'a, Result<String, FileLoaderError>> {
+		FileLoader {
+			iterator: Box::new(self.iterator.map(|res| res.read())),
+		}
+	}
+	/// Reads the contents of the files within the iterator returned by [FileLoader::with_glob] or
+	///  [FileLoader::with_dir] and returns the path along with the content.
+	///
+	/// # Example
+	/// Read files in directory "files/*.txt" and print the content for corresponding path for each
+	///  file.
+	///
+	/// ```rust
+	/// let content = FileLoader::with_glob("files/*.txt")?.read();
+	/// for (path, result) in content {
+	///     match result {
+	///         Ok((path, content)) => println!("{:?} {}", path, content),
+	///         Err(e) => eprintln!("Error reading file: {}", e),
+	///     }
+	/// }
+	/// ```
+	pub fn read_with_path(self) -> FileLoader<'a, Result<(PathBuf, String), FileLoaderError>> {
+		FileLoader {
+			iterator: Box::new(self.iterator.map(|res| res.read_with_path())),
+		}
+	}
 }
 
 impl<'a, T> FileLoader<'a, Result<T, FileLoaderError>>
 where
-    T: 'a,
+	T: 'a,
 {
-    /// Ignores errors in the iterator, returning only successful results. This can be used on any
-    ///  [FileLoader] state of iterator whose items are results.
-    ///
-    /// # Example
-    /// Read files in directory "files/*.txt" and ignore errors from unreadable files.
-    ///
-    /// ```rust
-    /// let content = FileLoader::with_glob("files/*.txt")?.read().ignore_errors();
-    /// for result in content {
-    ///     println!("{}", content)
-    /// }
-    /// ```
-    pub fn ignore_errors(self) -> FileLoader<'a, T> {
-        FileLoader {
-            iterator: Box::new(self.iterator.filter_map(|res| res.ok())),
-        }
-    }
+	/// Ignores errors in the iterator, returning only successful results. This can be used on any
+	///  [FileLoader] state of iterator whose items are results.
+	///
+	/// # Example
+	/// Read files in directory "files/*.txt" and ignore errors from unreadable files.
+	///
+	/// ```rust
+	/// let content = FileLoader::with_glob("files/*.txt")?.read().ignore_errors();
+	/// for result in content {
+	///     println!("{}", content)
+	/// }
+	/// ```
+	pub fn ignore_errors(self) -> FileLoader<'a, T> {
+		FileLoader {
+			iterator: Box::new(self.iterator.filter_map(|res| res.ok())),
+		}
+	}
 }
 
 impl FileLoader<'_, Result<PathBuf, FileLoaderError>> {
-    /// Creates a new [FileLoader] using a glob pattern to match files.
-    ///
-    /// # Example
-    /// Create a [FileLoader] for all `.txt` files that match the glob "files/*.txt".
-    ///
-    /// ```rust
-    /// let loader = FileLoader::with_glob("files/*.txt")?;
-    /// ```
-    pub fn with_glob(
-        pattern: &str,
-    ) -> Result<FileLoader<'_, Result<PathBuf, FileLoaderError>>, FileLoaderError> {
-        let paths = glob(pattern)?;
-        Ok(FileLoader {
-            iterator: Box::new(
-                paths
-                    .into_iter()
-                    .map(|path| path.map_err(FileLoaderError::GlobError)),
-            ),
-        })
-    }
+	/// Creates a new [FileLoader] using a glob pattern to match files.
+	///
+	/// # Example
+	/// Create a [FileLoader] for all `.txt` files that match the glob "files/*.txt".
+	///
+	/// ```rust
+	/// let loader = FileLoader::with_glob("files/*.txt")?;
+	/// ```
+	pub fn with_glob(
+		pattern: &str,
+	) -> Result<FileLoader<'_, Result<PathBuf, FileLoaderError>>, FileLoaderError> {
+		let paths = glob(pattern)?;
+		Ok(FileLoader {
+			iterator: Box::new(
+				paths
+					.into_iter()
+					.map(|path| path.map_err(FileLoaderError::GlobError)),
+			),
+		})
+	}
 
-    /// Creates a new [FileLoader] on all files within a directory.
-    ///
-    /// # Example
-    /// Create a [FileLoader] for all files that are in the directory "files" (ignores subdirectories).
-    ///
-    /// ```rust
-    /// let loader = FileLoader::with_dir("files")?;
-    /// ```
-    pub fn with_dir(
-        directory: &str,
-    ) -> Result<FileLoader<'_, Result<PathBuf, FileLoaderError>>, FileLoaderError> {
-        Ok(FileLoader {
-            iterator: Box::new(fs::read_dir(directory)?.filter_map(|entry| {
-                let path = entry.ok()?.path();
-                if path.is_file() { Some(Ok(path)) } else { None }
-            })),
-        })
-    }
+	/// Creates a new [FileLoader] on all files within a directory.
+	///
+	/// # Example
+	/// Create a [FileLoader] for all files that are in the directory "files" (ignores subdirectories).
+	///
+	/// ```rust
+	/// let loader = FileLoader::with_dir("files")?;
+	/// ```
+	pub fn with_dir(
+		directory: &str,
+	) -> Result<FileLoader<'_, Result<PathBuf, FileLoaderError>>, FileLoaderError> {
+		Ok(FileLoader {
+			iterator: Box::new(fs::read_dir(directory)?.filter_map(|entry| {
+				let path = entry.ok()?.path();
+				if path.is_file() { Some(Ok(path)) } else { None }
+			})),
+		})
+	}
 }
 
 impl<'a> FileLoader<'a, Vec<u8>> {
-    /// Ingest a  as a byte array.
-    pub fn from_bytes(bytes: Vec<u8>) -> FileLoader<'a, Vec<u8>> {
-        FileLoader {
-            iterator: Box::new(vec![bytes].into_iter()),
-        }
-    }
+	/// Ingest a  as a byte array.
+	pub fn from_bytes(bytes: Vec<u8>) -> FileLoader<'a, Vec<u8>> {
+		FileLoader {
+			iterator: Box::new(vec![bytes].into_iter()),
+		}
+	}
 
-    /// Ingest multiple byte arrays.
-    pub fn from_bytes_multi(bytes_vec: Vec<Vec<u8>>) -> FileLoader<'a, Vec<u8>> {
-        FileLoader {
-            iterator: Box::new(bytes_vec.into_iter()),
-        }
-    }
+	/// Ingest multiple byte arrays.
+	pub fn from_bytes_multi(bytes_vec: Vec<Vec<u8>>) -> FileLoader<'a, Vec<u8>> {
+		FileLoader {
+			iterator: Box::new(bytes_vec.into_iter()),
+		}
+	}
 
-    /// Use this once you've created the loader to load the document in.
-    pub fn read(self) -> FileLoader<'a, Result<String, FileLoaderError>> {
-        FileLoader {
-            iterator: Box::new(self.iterator.map(|res| res.read())),
-        }
-    }
+	/// Use this once you've created the loader to load the document in.
+	pub fn read(self) -> FileLoader<'a, Result<String, FileLoaderError>> {
+		FileLoader {
+			iterator: Box::new(self.iterator.map(|res| res.read())),
+		}
+	}
 
-    /// Use this once you've created the reader to load the document in (and get the path).
-    pub fn read_with_path(self) -> FileLoader<'a, Result<(PathBuf, String), FileLoaderError>> {
-        FileLoader {
-            iterator: Box::new(self.iterator.map(|res| res.read_with_path())),
-        }
-    }
+	/// Use this once you've created the reader to load the document in (and get the path).
+	pub fn read_with_path(self) -> FileLoader<'a, Result<(PathBuf, String), FileLoaderError>> {
+		FileLoader {
+			iterator: Box::new(self.iterator.map(|res| res.read_with_path())),
+		}
+	}
 }
 
 // ================================================================
@@ -258,26 +259,26 @@ impl<'a> FileLoader<'a, Vec<u8>> {
 // ================================================================
 
 pub struct IntoIter<'a, T> {
-    iterator: Box<dyn Iterator<Item = T> + 'a>,
+	iterator: Box<dyn Iterator<Item=T> + 'a>,
 }
 
 impl<'a, T> IntoIterator for FileLoader<'a, T> {
-    type Item = T;
-    type IntoIter = IntoIter<'a, T>;
+	type Item = T;
+	type IntoIter = IntoIter<'a, T>;
 
-    fn into_iter(self) -> Self::IntoIter {
-        IntoIter {
-            iterator: self.iterator,
-        }
-    }
+	fn into_iter(self) -> Self::IntoIter {
+		IntoIter {
+			iterator: self.iterator,
+		}
+	}
 }
 
 impl<T> Iterator for IntoIter<'_, T> {
-    type Item = T;
+	type Item = T;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        self.iterator.next()
-    }
+	fn next(&mut self) -> Option<Self::Item> {
+		self.iterator.next()
+	}
 }
 
 #[cfg(test)]
@@ -287,62 +288,62 @@ mod tests {
     use super::FileLoader;
 
     #[test]
-    fn test_file_loader() {
-        let temp = assert_fs::TempDir::new().expect("Failed to create temp dir");
-        let foo_file = temp.child("foo.txt");
-        let bar_file = temp.child("bar.txt");
+	fn test_file_loader() {
+		let temp = assert_fs::TempDir::new().expect("Failed to create temp dir");
+		let foo_file = temp.child("foo.txt");
+		let bar_file = temp.child("bar.txt");
 
-        foo_file.touch().expect("Failed to create foo.txt");
-        bar_file.touch().expect("Failed to create bar.txt");
+		foo_file.touch().expect("Failed to create foo.txt");
+		bar_file.touch().expect("Failed to create bar.txt");
 
-        foo_file.write_str("foo").expect("Failed to write to foo");
-        bar_file.write_str("bar").expect("Failed to write to bar");
+		foo_file.write_str("foo").expect("Failed to write to foo");
+		bar_file.write_str("bar").expect("Failed to write to bar");
 
-        let glob = temp.path().to_string_lossy().to_string() + "/*.txt";
+		let glob = temp.path().to_string_lossy().to_string() + "/*.txt";
 
-        let loader = FileLoader::with_glob(&glob).unwrap();
-        let mut actual = loader
-            .ignore_errors()
-            .read()
-            .ignore_errors()
-            .into_iter()
-            .collect::<Vec<_>>();
-        let mut expected = vec!["foo".to_string(), "bar".to_string()];
+		let loader = FileLoader::with_glob(&glob).unwrap();
+		let mut actual = loader
+			.ignore_errors()
+			.read()
+			.ignore_errors()
+			.into_iter()
+			.collect::<Vec<_>>();
+		let mut expected = vec!["foo".to_string(), "bar".to_string()];
 
-        actual.sort();
-        expected.sort();
+		actual.sort();
+		expected.sort();
 
-        assert!(!actual.is_empty());
-        assert!(expected == actual)
-    }
+		assert!(!actual.is_empty());
+		assert!(expected == actual)
+	}
 
-    #[test]
-    fn test_file_loader_bytes() {
-        let temp = assert_fs::TempDir::new().expect("Failed to create temp dir");
-        let foo_file = temp.child("foo.txt");
-        let bar_file = temp.child("bar.txt");
+	#[test]
+	fn test_file_loader_bytes() {
+		let temp = assert_fs::TempDir::new().expect("Failed to create temp dir");
+		let foo_file = temp.child("foo.txt");
+		let bar_file = temp.child("bar.txt");
 
-        foo_file.touch().expect("Failed to create foo.txt");
-        bar_file.touch().expect("Failed to create bar.txt");
+		foo_file.touch().expect("Failed to create foo.txt");
+		bar_file.touch().expect("Failed to create bar.txt");
 
-        foo_file.write_str("foo").expect("Failed to write to foo");
-        bar_file.write_str("bar").expect("Failed to write to bar");
+		foo_file.write_str("foo").expect("Failed to write to foo");
+		bar_file.write_str("bar").expect("Failed to write to bar");
 
-        let foo_bytes = std::fs::read(foo_file.path()).unwrap();
-        let bar_bytes = std::fs::read(bar_file.path()).unwrap();
+		let foo_bytes = std::fs::read(foo_file.path()).unwrap();
+		let bar_bytes = std::fs::read(bar_file.path()).unwrap();
 
-        let loader = FileLoader::from_bytes_multi(vec![foo_bytes, bar_bytes]);
-        let mut actual = loader
-            .read()
-            .ignore_errors()
-            .into_iter()
-            .collect::<Vec<_>>();
-        let mut expected = vec!["foo".to_string(), "bar".to_string()];
+		let loader = FileLoader::from_bytes_multi(vec![foo_bytes, bar_bytes]);
+		let mut actual = loader
+			.read()
+			.ignore_errors()
+			.into_iter()
+			.collect::<Vec<_>>();
+		let mut expected = vec!["foo".to_string(), "bar".to_string()];
 
-        actual.sort();
-        expected.sort();
+		actual.sort();
+		expected.sort();
 
-        assert!(!actual.is_empty());
-        assert!(expected == actual)
-    }
+		assert!(!actual.is_empty());
+		assert!(expected == actual)
+	}
 }

--- a/rig-core/src/loaders/pdf.rs
+++ b/rig-core/src/loaders/pdf.rs
@@ -7,15 +7,16 @@ use thiserror::Error;
 use super::file::FileLoaderError;
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum PdfLoaderError {
-    #[error("{0}")]
-    FileLoaderError(#[from] FileLoaderError),
+	#[error("{0}")]
+	FileLoaderError(#[from] FileLoaderError),
 
-    #[error("UTF-8 conversion error: {0}")]
-    FromUtf8Error(#[from] std::string::FromUtf8Error),
+	#[error("UTF-8 conversion error: {0}")]
+	FromUtf8Error(#[from] std::string::FromUtf8Error),
 
-    #[error("IO error: {0}")]
-    PdfError(#[from] LopdfError),
+	#[error("IO error: {0}")]
+	PdfError(#[from] LopdfError),
 }
 
 // ================================================================
@@ -23,41 +24,41 @@ pub enum PdfLoaderError {
 // ================================================================
 
 pub(crate) trait Loadable {
-    fn load(self) -> Result<Document, PdfLoaderError>;
-    fn load_with_path(self) -> Result<(PathBuf, Document), PdfLoaderError>;
+	fn load(self) -> Result<Document, PdfLoaderError>;
+	fn load_with_path(self) -> Result<(PathBuf, Document), PdfLoaderError>;
 }
 
 impl Loadable for PathBuf {
-    fn load(self) -> Result<Document, PdfLoaderError> {
-        Document::load(self).map_err(PdfLoaderError::PdfError)
-    }
-    fn load_with_path(self) -> Result<(PathBuf, Document), PdfLoaderError> {
-        let contents = Document::load(&self);
-        Ok((self, contents?))
-    }
+	fn load(self) -> Result<Document, PdfLoaderError> {
+		Document::load(self).map_err(PdfLoaderError::PdfError)
+	}
+	fn load_with_path(self) -> Result<(PathBuf, Document), PdfLoaderError> {
+		let contents = Document::load(&self);
+		Ok((self, contents?))
+	}
 }
 
 impl<T> Loadable for Result<T, PdfLoaderError>
 where
-    T: Loadable,
+	T: Loadable,
 {
-    fn load(self) -> Result<Document, PdfLoaderError> {
-        self.map(|t| t.load())?
-    }
-    fn load_with_path(self) -> Result<(PathBuf, Document), PdfLoaderError> {
-        self.map(|t| t.load_with_path())?
-    }
+	fn load(self) -> Result<Document, PdfLoaderError> {
+		self.map(|t| t.load())?
+	}
+	fn load_with_path(self) -> Result<(PathBuf, Document), PdfLoaderError> {
+		self.map(|t| t.load_with_path())?
+	}
 }
 
 impl Loadable for Vec<u8> {
-    fn load(self) -> Result<Document, PdfLoaderError> {
-        Document::load_mem(&self).map_err(PdfLoaderError::PdfError)
-    }
+	fn load(self) -> Result<Document, PdfLoaderError> {
+		Document::load_mem(&self).map_err(PdfLoaderError::PdfError)
+	}
 
-    fn load_with_path(self) -> Result<(PathBuf, Document), PdfLoaderError> {
-        let doc = Document::load_mem(&self).map_err(PdfLoaderError::PdfError)?;
-        Ok((PathBuf::from("<memory>"), doc))
-    }
+	fn load_with_path(self) -> Result<(PathBuf, Document), PdfLoaderError> {
+		let doc = Document::load_mem(&self).map_err(PdfLoaderError::PdfError)?;
+		Ok((PathBuf::from("<memory>"), doc))
+	}
 }
 
 // ================================================================
@@ -100,329 +101,329 @@ impl Loadable for Vec<u8> {
 ///  between different implementations of the loaders and it's methods are handled properly by
 ///  the compiler.
 pub struct PdfFileLoader<'a, T> {
-    iterator: Box<dyn Iterator<Item = T> + 'a>,
+	iterator: Box<dyn Iterator<Item=T> + 'a>,
 }
 
 impl<'a> PdfFileLoader<'a, Result<PathBuf, PdfLoaderError>> {
-    /// Loads the contents of the pdfs within the iterator returned by [PdfFileLoader::with_glob]
-    ///  or [PdfFileLoader::with_dir]. Loaded PDF documents are raw PDF instances that can be
-    ///  further processed (by page, etc).
-    ///
-    /// # Example
-    /// Load pdfs in directory "tests/data/*.pdf" and return the loaded documents
-    ///
-    /// ```rust
-    /// let content = PdfFileLoader::with_glob("tests/data/*.pdf")?.load().into_iter();
-    /// for result in content {
-    ///     match result {
-    ///         Ok((path, doc)) => println!("{:?} {}", path, doc),
-    ///         Err(e) => eprintln!("Error reading pdf: {}", e),
-    ///     }
-    /// }
-    /// ```
-    pub fn load(self) -> PdfFileLoader<'a, Result<Document, PdfLoaderError>> {
-        PdfFileLoader {
-            iterator: Box::new(self.iterator.map(|res| res.load())),
-        }
-    }
+	/// Loads the contents of the pdfs within the iterator returned by [PdfFileLoader::with_glob]
+	///  or [PdfFileLoader::with_dir]. Loaded PDF documents are raw PDF instances that can be
+	///  further processed (by page, etc).
+	///
+	/// # Example
+	/// Load pdfs in directory "tests/data/*.pdf" and return the loaded documents
+	///
+	/// ```rust
+	/// let content = PdfFileLoader::with_glob("tests/data/*.pdf")?.load().into_iter();
+	/// for result in content {
+	///     match result {
+	///         Ok((path, doc)) => println!("{:?} {}", path, doc),
+	///         Err(e) => eprintln!("Error reading pdf: {}", e),
+	///     }
+	/// }
+	/// ```
+	pub fn load(self) -> PdfFileLoader<'a, Result<Document, PdfLoaderError>> {
+		PdfFileLoader {
+			iterator: Box::new(self.iterator.map(|res| res.load())),
+		}
+	}
 
-    /// Loads the contents of the pdfs within the iterator returned by [PdfFileLoader::with_glob]
-    ///  or [PdfFileLoader::with_dir]. Loaded PDF documents are raw PDF instances with their path
-    ///  that can be further processed.
-    ///
-    /// # Example
-    /// Load pdfs in directory "tests/data/*.pdf" and return the loaded documents
-    ///
-    /// ```rust
-    /// let content = PdfFileLoader::with_glob("tests/data/*.pdf")?.load_with_path().into_iter();
-    /// for result in content {
-    ///     match result {
-    ///         Ok((path, doc)) => println!("{:?} {}", path, doc),
-    ///         Err(e) => eprintln!("Error reading pdf: {}", e),
-    ///     }
-    /// }
-    /// ```
-    pub fn load_with_path(self) -> PdfFileLoader<'a, Result<(PathBuf, Document), PdfLoaderError>> {
-        PdfFileLoader {
-            iterator: Box::new(self.iterator.map(|res| res.load_with_path())),
-        }
-    }
+	/// Loads the contents of the pdfs within the iterator returned by [PdfFileLoader::with_glob]
+	///  or [PdfFileLoader::with_dir]. Loaded PDF documents are raw PDF instances with their path
+	///  that can be further processed.
+	///
+	/// # Example
+	/// Load pdfs in directory "tests/data/*.pdf" and return the loaded documents
+	///
+	/// ```rust
+	/// let content = PdfFileLoader::with_glob("tests/data/*.pdf")?.load_with_path().into_iter();
+	/// for result in content {
+	///     match result {
+	///         Ok((path, doc)) => println!("{:?} {}", path, doc),
+	///         Err(e) => eprintln!("Error reading pdf: {}", e),
+	///     }
+	/// }
+	/// ```
+	pub fn load_with_path(self) -> PdfFileLoader<'a, Result<(PathBuf, Document), PdfLoaderError>> {
+		PdfFileLoader {
+			iterator: Box::new(self.iterator.map(|res| res.load_with_path())),
+		}
+	}
 }
 
 impl<'a> PdfFileLoader<'a, Result<PathBuf, PdfLoaderError>> {
-    /// Directly reads the contents of the pdfs within the iterator returned by
-    ///  [PdfFileLoader::with_glob] or [PdfFileLoader::with_dir].
-    ///
-    /// # Example
-    /// Read pdfs in directory "tests/data/*.pdf" and return the contents of the documents.
-    ///
-    /// ```rust
-    /// let content = PdfFileLoader::with_glob("tests/data/*.pdf")?.read_with_path().into_iter();
-    /// for result in content {
-    ///     match result {
-    ///         Ok((path, content)) => println!("{}", content),
-    ///         Err(e) => eprintln!("Error reading pdf: {}", e),
-    ///     }
-    /// }
-    /// ```
-    pub fn read(self) -> PdfFileLoader<'a, Result<String, PdfLoaderError>> {
-        PdfFileLoader {
-            iterator: Box::new(self.iterator.map(|res| {
-                let doc = res.load()?;
-                Ok(doc
-                    .page_iter()
-                    .enumerate()
-                    .map(|(page_no, _)| {
-                        doc.extract_text(&[page_no as u32 + 1])
-                            .map_err(PdfLoaderError::PdfError)
-                    })
-                    .collect::<Result<Vec<String>, PdfLoaderError>>()?
-                    .into_iter()
-                    .collect::<String>())
-            })),
-        }
-    }
+	/// Directly reads the contents of the pdfs within the iterator returned by
+	///  [PdfFileLoader::with_glob] or [PdfFileLoader::with_dir].
+	///
+	/// # Example
+	/// Read pdfs in directory "tests/data/*.pdf" and return the contents of the documents.
+	///
+	/// ```rust
+	/// let content = PdfFileLoader::with_glob("tests/data/*.pdf")?.read_with_path().into_iter();
+	/// for result in content {
+	///     match result {
+	///         Ok((path, content)) => println!("{}", content),
+	///         Err(e) => eprintln!("Error reading pdf: {}", e),
+	///     }
+	/// }
+	/// ```
+	pub fn read(self) -> PdfFileLoader<'a, Result<String, PdfLoaderError>> {
+		PdfFileLoader {
+			iterator: Box::new(self.iterator.map(|res| {
+				let doc = res.load()?;
+				Ok(doc
+					.page_iter()
+					.enumerate()
+					.map(|(page_no, _)| {
+						doc.extract_text(&[page_no as u32 + 1])
+						   .map_err(PdfLoaderError::PdfError)
+					})
+					.collect::<Result<Vec<String>, PdfLoaderError>>()?
+					.into_iter()
+					.collect::<String>())
+			})),
+		}
+	}
 
-    /// Directly reads the contents of the pdfs within the iterator returned by
-    ///  [PdfFileLoader::with_glob] or [PdfFileLoader::with_dir] and returns the path along with
-    ///  the content.
-    ///
-    /// # Example
-    /// Read pdfs in directory "tests/data/*.pdf" and return the content and paths of the documents.
-    ///
-    /// ```rust
-    /// let content = PdfFileLoader::with_glob("tests/data/*.pdf")?.read_with_path().into_iter();
-    /// for result in content {
-    ///     match result {
-    ///         Ok((path, content)) => println!("{:?} {}", path, content),
-    ///         Err(e) => eprintln!("Error reading pdf: {}", e),
-    ///     }
-    /// }
-    /// ```
-    pub fn read_with_path(self) -> PdfFileLoader<'a, Result<(PathBuf, String), PdfLoaderError>> {
-        PdfFileLoader {
-            iterator: Box::new(self.iterator.map(|res| {
-                let (path, doc) = res.load_with_path()?;
-                println!(
-                    "Loaded {:?} PDF: {:?}",
-                    path,
-                    doc.page_iter().collect::<Vec<_>>()
-                );
-                let content = doc
-                    .page_iter()
-                    .enumerate()
-                    .map(|(page_no, _)| {
-                        doc.extract_text(&[page_no as u32 + 1])
-                            .map_err(PdfLoaderError::PdfError)
-                    })
-                    .collect::<Result<Vec<String>, PdfLoaderError>>()?
-                    .into_iter()
-                    .collect::<String>();
+	/// Directly reads the contents of the pdfs within the iterator returned by
+	///  [PdfFileLoader::with_glob] or [PdfFileLoader::with_dir] and returns the path along with
+	///  the content.
+	///
+	/// # Example
+	/// Read pdfs in directory "tests/data/*.pdf" and return the content and paths of the documents.
+	///
+	/// ```rust
+	/// let content = PdfFileLoader::with_glob("tests/data/*.pdf")?.read_with_path().into_iter();
+	/// for result in content {
+	///     match result {
+	///         Ok((path, content)) => println!("{:?} {}", path, content),
+	///         Err(e) => eprintln!("Error reading pdf: {}", e),
+	///     }
+	/// }
+	/// ```
+	pub fn read_with_path(self) -> PdfFileLoader<'a, Result<(PathBuf, String), PdfLoaderError>> {
+		PdfFileLoader {
+			iterator: Box::new(self.iterator.map(|res| {
+				let (path, doc) = res.load_with_path()?;
+				println!(
+					"Loaded {:?} PDF: {:?}",
+					path,
+					doc.page_iter().collect::<Vec<_>>()
+				);
+				let content = doc
+					.page_iter()
+					.enumerate()
+					.map(|(page_no, _)| {
+						doc.extract_text(&[page_no as u32 + 1])
+						   .map_err(PdfLoaderError::PdfError)
+					})
+					.collect::<Result<Vec<String>, PdfLoaderError>>()?
+					.into_iter()
+					.collect::<String>();
 
-                Ok((path, content))
-            })),
-        }
-    }
+				Ok((path, content))
+			})),
+		}
+	}
 }
 
 impl<'a> PdfFileLoader<'a, Document> {
-    /// Chunks the pages of a loaded document by page, flattened as a single vector.
-    ///
-    /// # Example
-    /// Load pdfs in directory "tests/data/*.pdf" and chunk all document into it's pages.
-    ///
-    /// ```rust
-    /// let content = PdfFileLoader::with_glob("tests/data/*.pdf")?.load().by_page().into_iter();
-    /// for result in content {
-    ///     match result {
-    ///         Ok(page) => println!("{}", page),
-    ///         Err(e) => eprintln!("Error reading pdf: {}", e),
-    ///     }
-    /// }
-    /// ```
-    pub fn by_page(self) -> PdfFileLoader<'a, Result<String, PdfLoaderError>> {
-        PdfFileLoader {
-            iterator: Box::new(self.iterator.flat_map(|doc| {
-                doc.page_iter()
-                    .enumerate()
-                    .map(|(page_no, _)| {
-                        doc.extract_text(&[page_no as u32 + 1])
-                            .map_err(PdfLoaderError::PdfError)
-                    })
-                    .collect::<Vec<_>>()
-            })),
-        }
-    }
+	/// Chunks the pages of a loaded document by page, flattened as a single vector.
+	///
+	/// # Example
+	/// Load pdfs in directory "tests/data/*.pdf" and chunk all document into it's pages.
+	///
+	/// ```rust
+	/// let content = PdfFileLoader::with_glob("tests/data/*.pdf")?.load().by_page().into_iter();
+	/// for result in content {
+	///     match result {
+	///         Ok(page) => println!("{}", page),
+	///         Err(e) => eprintln!("Error reading pdf: {}", e),
+	///     }
+	/// }
+	/// ```
+	pub fn by_page(self) -> PdfFileLoader<'a, Result<String, PdfLoaderError>> {
+		PdfFileLoader {
+			iterator: Box::new(self.iterator.flat_map(|doc| {
+				doc.page_iter()
+				   .enumerate()
+				   .map(|(page_no, _)| {
+					   doc.extract_text(&[page_no as u32 + 1])
+					      .map_err(PdfLoaderError::PdfError)
+				   })
+				   .collect::<Vec<_>>()
+			})),
+		}
+	}
 }
 
 type ByPage = (PathBuf, Vec<(usize, Result<String, PdfLoaderError>)>);
 impl<'a> PdfFileLoader<'a, (PathBuf, Document)> {
-    /// Chunks the pages of a loaded document by page, processed as a vector of documents by path
-    ///  which each document container an inner vector of pages by page number.
-    ///
-    /// # Example
-    /// Read pdfs in directory "tests/data/*.pdf" and chunk all documents by path by it's pages.
-    ///
-    /// ```rust
-    /// let content = PdfFileLoader::with_glob("tests/data/*.pdf")?
-    ///     .load_with_path()
-    ///     .by_page()
-    ///     .into_iter();
-    ///
-    /// for result in content {
-    ///     match result {
-    ///         Ok(documents) => {
-    ///             for doc in documents {
-    ///                 match doc {
-    ///                     Ok((pageno, content)) => println!("Page {}: {}", pageno, content),
-    ///                     Err(e) => eprintln!("Error reading page: {}", e),
-    ///                }
-    ///             }
-    ///         },
-    ///         Err(e) => eprintln!("Error reading pdf: {}", e),
-    ///     }
-    /// }
-    /// ```
-    pub fn by_page(self) -> PdfFileLoader<'a, ByPage> {
-        PdfFileLoader {
-            iterator: Box::new(self.iterator.map(|(path, doc)| {
-                (
-                    path,
-                    doc.page_iter()
-                        .enumerate()
-                        .map(|(page_no, _)| {
-                            (
-                                page_no,
-                                doc.extract_text(&[page_no as u32 + 1])
-                                    .map_err(PdfLoaderError::PdfError),
-                            )
-                        })
-                        .collect::<Vec<_>>(),
-                )
-            })),
-        }
-    }
+	/// Chunks the pages of a loaded document by page, processed as a vector of documents by path
+	///  which each document container an inner vector of pages by page number.
+	///
+	/// # Example
+	/// Read pdfs in directory "tests/data/*.pdf" and chunk all documents by path by it's pages.
+	///
+	/// ```rust
+	/// let content = PdfFileLoader::with_glob("tests/data/*.pdf")?
+	///     .load_with_path()
+	///     .by_page()
+	///     .into_iter();
+	///
+	/// for result in content {
+	///     match result {
+	///         Ok(documents) => {
+	///             for doc in documents {
+	///                 match doc {
+	///                     Ok((pageno, content)) => println!("Page {}: {}", pageno, content),
+	///                     Err(e) => eprintln!("Error reading page: {}", e),
+	///                }
+	///             }
+	///         },
+	///         Err(e) => eprintln!("Error reading pdf: {}", e),
+	///     }
+	/// }
+	/// ```
+	pub fn by_page(self) -> PdfFileLoader<'a, ByPage> {
+		PdfFileLoader {
+			iterator: Box::new(self.iterator.map(|(path, doc)| {
+				(
+					path,
+					doc.page_iter()
+					   .enumerate()
+					   .map(|(page_no, _)| {
+						   (
+							   page_no,
+							   doc.extract_text(&[page_no as u32 + 1])
+							      .map_err(PdfLoaderError::PdfError),
+						   )
+					   })
+					   .collect::<Vec<_>>(),
+				)
+			})),
+		}
+	}
 }
 
 impl<'a> PdfFileLoader<'a, ByPage> {
-    /// Ignores errors in the iterator, returning only successful results. This can be used on any
-    ///  [PdfFileLoader] state of iterator whose items are results.
-    ///
-    /// # Example
-    /// Read files in directory "tests/data/*.pdf" and ignore errors from unreadable files.
-    ///
-    /// ```rust
-    /// let content = FileLoader::with_glob("tests/data/*.pdf")?.read().ignore_errors().into_iter();
-    /// for result in content {
-    ///     println!("{}", content)
-    /// }
-    /// ```
-    pub fn ignore_errors(self) -> PdfFileLoader<'a, (PathBuf, Vec<(usize, String)>)> {
-        PdfFileLoader {
-            iterator: Box::new(self.iterator.map(|(path, pages)| {
-                let pages = pages
-                    .into_iter()
-                    .filter_map(|(page_no, res)| res.ok().map(|content| (page_no, content)))
-                    .collect::<Vec<_>>();
-                (path, pages)
-            })),
-        }
-    }
+	/// Ignores errors in the iterator, returning only successful results. This can be used on any
+	///  [PdfFileLoader] state of iterator whose items are results.
+	///
+	/// # Example
+	/// Read files in directory "tests/data/*.pdf" and ignore errors from unreadable files.
+	///
+	/// ```rust
+	/// let content = FileLoader::with_glob("tests/data/*.pdf")?.read().ignore_errors().into_iter();
+	/// for result in content {
+	///     println!("{}", content)
+	/// }
+	/// ```
+	pub fn ignore_errors(self) -> PdfFileLoader<'a, (PathBuf, Vec<(usize, String)>)> {
+		PdfFileLoader {
+			iterator: Box::new(self.iterator.map(|(path, pages)| {
+				let pages = pages
+					.into_iter()
+					.filter_map(|(page_no, res)| res.ok().map(|content| (page_no, content)))
+					.collect::<Vec<_>>();
+				(path, pages)
+			})),
+		}
+	}
 }
 
 impl<'a, T> PdfFileLoader<'a, Result<T, PdfLoaderError>>
 where
-    T: 'a,
+	T: 'a,
 {
-    /// Ignores errors in the iterator, returning only successful results. This can be used on any
-    ///  [PdfFileLoader] state of iterator whose items are results.
-    ///
-    /// # Example
-    /// Read files in directory "tests/data/*.pdf" and ignore errors from unreadable files.
-    ///
-    /// ```rust
-    /// let content = FileLoader::with_glob("tests/data/*.pdf")?.read().ignore_errors().into_iter();
-    /// for result in content {
-    ///     println!("{}", content)
-    /// }
-    /// ```
-    pub fn ignore_errors(self) -> PdfFileLoader<'a, T> {
-        PdfFileLoader {
-            iterator: Box::new(self.iterator.filter_map(|res| res.ok())),
-        }
-    }
+	/// Ignores errors in the iterator, returning only successful results. This can be used on any
+	///  [PdfFileLoader] state of iterator whose items are results.
+	///
+	/// # Example
+	/// Read files in directory "tests/data/*.pdf" and ignore errors from unreadable files.
+	///
+	/// ```rust
+	/// let content = FileLoader::with_glob("tests/data/*.pdf")?.read().ignore_errors().into_iter();
+	/// for result in content {
+	///     println!("{}", content)
+	/// }
+	/// ```
+	pub fn ignore_errors(self) -> PdfFileLoader<'a, T> {
+		PdfFileLoader {
+			iterator: Box::new(self.iterator.filter_map(|res| res.ok())),
+		}
+	}
 }
 
 impl PdfFileLoader<'_, Result<PathBuf, FileLoaderError>> {
-    /// Creates a new [PdfFileLoader] using a glob pattern to match files.
-    ///
-    /// # Example
-    /// Create a [PdfFileLoader] for all `.pdf` files that match the glob "tests/data/*.pdf".
-    ///
-    /// ```rust
-    /// let loader = FileLoader::with_glob("tests/data/*.txt")?;
-    /// ```
-    pub fn with_glob(
-        pattern: &str,
-    ) -> Result<PdfFileLoader<'_, Result<PathBuf, PdfLoaderError>>, PdfLoaderError> {
-        let paths = glob(pattern).map_err(FileLoaderError::PatternError)?;
-        Ok(PdfFileLoader {
-            iterator: Box::new(paths.into_iter().map(|path| {
-                path.map_err(FileLoaderError::GlobError)
-                    .map_err(PdfLoaderError::FileLoaderError)
-            })),
-        })
-    }
+	/// Creates a new [PdfFileLoader] using a glob pattern to match files.
+	///
+	/// # Example
+	/// Create a [PdfFileLoader] for all `.pdf` files that match the glob "tests/data/*.pdf".
+	///
+	/// ```rust
+	/// let loader = FileLoader::with_glob("tests/data/*.txt")?;
+	/// ```
+	pub fn with_glob(
+		pattern: &str,
+	) -> Result<PdfFileLoader<'_, Result<PathBuf, PdfLoaderError>>, PdfLoaderError> {
+		let paths = glob(pattern).map_err(FileLoaderError::PatternError)?;
+		Ok(PdfFileLoader {
+			iterator: Box::new(paths.into_iter().map(|path| {
+				path.map_err(FileLoaderError::GlobError)
+				    .map_err(PdfLoaderError::FileLoaderError)
+			})),
+		})
+	}
 
-    /// Creates a new [PdfFileLoader] on all files within a directory.
-    ///
-    /// # Example
-    /// Create a [PdfFileLoader] for all files that are in the directory "files".
-    ///
-    /// ```rust
-    /// let loader = PdfFileLoader::with_dir("files")?;
-    /// ```
-    pub fn with_dir(
-        directory: &str,
-    ) -> Result<PdfFileLoader<'_, Result<PathBuf, PdfLoaderError>>, PdfLoaderError> {
-        Ok(PdfFileLoader {
-            iterator: Box::new(
-                fs::read_dir(directory)
-                    .map_err(FileLoaderError::IoError)?
-                    .map(|entry| Ok(entry.map_err(FileLoaderError::IoError)?.path())),
-            ),
-        })
-    }
+	/// Creates a new [PdfFileLoader] on all files within a directory.
+	///
+	/// # Example
+	/// Create a [PdfFileLoader] for all files that are in the directory "files".
+	///
+	/// ```rust
+	/// let loader = PdfFileLoader::with_dir("files")?;
+	/// ```
+	pub fn with_dir(
+		directory: &str,
+	) -> Result<PdfFileLoader<'_, Result<PathBuf, PdfLoaderError>>, PdfLoaderError> {
+		Ok(PdfFileLoader {
+			iterator: Box::new(
+				fs::read_dir(directory)
+					.map_err(FileLoaderError::IoError)?
+					.map(|entry| Ok(entry.map_err(FileLoaderError::IoError)?.path())),
+			),
+		})
+	}
 }
 
 impl<'a> PdfFileLoader<'a, Vec<u8>> {
-    /// Ingest a PDF as a byte array.
-    pub fn from_bytes(bytes: Vec<u8>) -> PdfFileLoader<'a, Vec<u8>> {
-        PdfFileLoader {
-            iterator: Box::new(vec![bytes].into_iter()),
-        }
-    }
+	/// Ingest a PDF as a byte array.
+	pub fn from_bytes(bytes: Vec<u8>) -> PdfFileLoader<'a, Vec<u8>> {
+		PdfFileLoader {
+			iterator: Box::new(vec![bytes].into_iter()),
+		}
+	}
 
-    /// Ingest multiple byte arrays.
-    pub fn from_bytes_multi(bytes_vec: Vec<Vec<u8>>) -> PdfFileLoader<'a, Vec<u8>> {
-        PdfFileLoader {
-            iterator: Box::new(bytes_vec.into_iter()),
-        }
-    }
+	/// Ingest multiple byte arrays.
+	pub fn from_bytes_multi(bytes_vec: Vec<Vec<u8>>) -> PdfFileLoader<'a, Vec<u8>> {
+		PdfFileLoader {
+			iterator: Box::new(bytes_vec.into_iter()),
+		}
+	}
 
-    /// Use this once you've created the loader to load the document in.
-    pub fn load(self) -> PdfFileLoader<'a, Result<Document, PdfLoaderError>> {
-        PdfFileLoader {
-            iterator: Box::new(self.iterator.map(|res| res.load())),
-        }
-    }
+	/// Use this once you've created the loader to load the document in.
+	pub fn load(self) -> PdfFileLoader<'a, Result<Document, PdfLoaderError>> {
+		PdfFileLoader {
+			iterator: Box::new(self.iterator.map(|res| res.load())),
+		}
+	}
 
-    /// Use this once you've created the loader to load the document in (and get the path).
-    pub fn load_with_path(self) -> PdfFileLoader<'a, Result<(PathBuf, Document), PdfLoaderError>> {
-        PdfFileLoader {
-            iterator: Box::new(self.iterator.map(|res| res.load_with_path())),
-        }
-    }
+	/// Use this once you've created the loader to load the document in (and get the path).
+	pub fn load_with_path(self) -> PdfFileLoader<'a, Result<(PathBuf, Document), PdfLoaderError>> {
+		PdfFileLoader {
+			iterator: Box::new(self.iterator.map(|res| res.load_with_path())),
+		}
+	}
 }
 
 // ================================================================
@@ -430,26 +431,26 @@ impl<'a> PdfFileLoader<'a, Vec<u8>> {
 // ================================================================
 
 pub struct IntoIter<'a, T> {
-    iterator: Box<dyn Iterator<Item = T> + 'a>,
+	iterator: Box<dyn Iterator<Item=T> + 'a>,
 }
 
 impl<'a, T> IntoIterator for PdfFileLoader<'a, T> {
-    type Item = T;
-    type IntoIter = IntoIter<'a, T>;
+	type Item = T;
+	type IntoIter = IntoIter<'a, T>;
 
-    fn into_iter(self) -> Self::IntoIter {
-        IntoIter {
-            iterator: self.iterator,
-        }
-    }
+	fn into_iter(self) -> Self::IntoIter {
+		IntoIter {
+			iterator: self.iterator,
+		}
+	}
 }
 
 impl<T> Iterator for IntoIter<'_, T> {
-    type Item = T;
+	type Item = T;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        self.iterator.next()
-    }
+	fn next(&mut self) -> Option<Self::Item> {
+		self.iterator.next()
+	}
 }
 
 #[cfg(test)]
@@ -459,88 +460,88 @@ mod tests {
     use super::PdfFileLoader;
 
     #[test]
-    fn test_pdf_loader() {
-        let loader = PdfFileLoader::with_glob("tests/data/*.pdf").unwrap();
-        let actual = loader
-            .load_with_path()
-            .ignore_errors()
-            .by_page()
-            .ignore_errors()
-            .into_iter()
-            .collect::<Vec<_>>();
+	fn test_pdf_loader() {
+		let loader = PdfFileLoader::with_glob("tests/data/*.pdf").unwrap();
+		let actual = loader
+			.load_with_path()
+			.ignore_errors()
+			.by_page()
+			.ignore_errors()
+			.into_iter()
+			.collect::<Vec<_>>();
 
-        let mut actual = actual
-            .into_iter()
-            .map(|result| {
-                let (path, pages) = result;
-                pages.iter().for_each(|(page_no, content)| {
-                    println!("{path:?} Page {page_no}: {content:?}");
-                });
-                (path, pages)
-            })
-            .collect::<Vec<_>>();
+		let mut actual = actual
+			.into_iter()
+			.map(|result| {
+				let (path, pages) = result;
+				pages.iter().for_each(|(page_no, content)| {
+					println!("{path:?} Page {page_no}: {content:?}");
+				});
+				(path, pages)
+			})
+			.collect::<Vec<_>>();
 
-        let mut expected = vec![
-            (
-                PathBuf::from("tests/data/dummy.pdf"),
-                vec![(0, "Test\nPDF\nDocument\n".to_string())],
-            ),
-            (
-                PathBuf::from("tests/data/pages.pdf"),
-                vec![
-                    (0, "Page\n1\n".to_string()),
-                    (1, "Page\n2\n".to_string()),
-                    (2, "Page\n3\n".to_string()),
-                ],
-            ),
-        ];
+		let mut expected = vec![
+			(
+				PathBuf::from("tests/data/dummy.pdf"),
+				vec![(0, "Test\nPDF\nDocument\n".to_string())],
+			),
+			(
+				PathBuf::from("tests/data/pages.pdf"),
+				vec![
+					(0, "Page\n1\n".to_string()),
+					(1, "Page\n2\n".to_string()),
+					(2, "Page\n3\n".to_string()),
+				],
+			),
+		];
 
-        actual.sort();
-        expected.sort();
+		actual.sort();
+		expected.sort();
 
-        assert!(!actual.is_empty());
-        assert!(expected == actual)
-    }
+		assert!(!actual.is_empty());
+		assert!(expected == actual)
+	}
 
-    #[test]
-    fn test_pdf_loader_bytes() {
-        // this should never fail!
-        let bytes = std::fs::read("tests/data/dummy.pdf").unwrap();
+	#[test]
+	fn test_pdf_loader_bytes() {
+		// this should never fail!
+		let bytes = std::fs::read("tests/data/dummy.pdf").unwrap();
 
-        let loader = PdfFileLoader::from_bytes(bytes);
+		let loader = PdfFileLoader::from_bytes(bytes);
 
-        let actual = loader
-            .load()
-            .ignore_errors()
-            .by_page()
-            .ignore_errors()
-            .into_iter()
-            .collect::<Vec<_>>();
+		let actual = loader
+			.load()
+			.ignore_errors()
+			.by_page()
+			.ignore_errors()
+			.into_iter()
+			.collect::<Vec<_>>();
 
-        assert_eq!(actual.len(), 1);
-        assert_eq!(actual, vec!["Test\nPDF\nDocument\n".to_string()]);
+		assert_eq!(actual.len(), 1);
+		assert_eq!(actual, vec!["Test\nPDF\nDocument\n".to_string()]);
 
-        // this should never fail!
-        let bytes = std::fs::read("tests/data/pages.pdf").unwrap();
+		// this should never fail!
+		let bytes = std::fs::read("tests/data/pages.pdf").unwrap();
 
-        let loader = PdfFileLoader::from_bytes(bytes);
+		let loader = PdfFileLoader::from_bytes(bytes);
 
-        let actual = loader
-            .load()
-            .ignore_errors()
-            .by_page()
-            .ignore_errors()
-            .into_iter()
-            .collect::<Vec<_>>();
+		let actual = loader
+			.load()
+			.ignore_errors()
+			.by_page()
+			.ignore_errors()
+			.into_iter()
+			.collect::<Vec<_>>();
 
-        assert_eq!(actual.len(), 3);
-        assert_eq!(
-            actual,
-            vec![
-                "Page\n1\n".to_string(),
-                "Page\n2\n".to_string(),
-                "Page\n3\n".to_string(),
-            ]
-        );
-    }
+		assert_eq!(actual.len(), 3);
+		assert_eq!(
+			actual,
+			vec![
+				"Page\n1\n".to_string(),
+				"Page\n2\n".to_string(),
+				"Page\n3\n".to_string(),
+			]
+		);
+	}
 }

--- a/rig-core/src/pipeline/mod.rs
+++ b/rig-core/src/pipeline/mod.rs
@@ -97,207 +97,208 @@ pub mod conditional;
 
 use std::future::Future;
 
-pub use op::{Op, map, passthrough, then};
+pub use op::{map, passthrough, then, Op};
 pub use try_op::TryOp;
 
 use crate::{completion, extractor::Extractor, vector_store};
 
 pub struct PipelineBuilder<E> {
-    _error: std::marker::PhantomData<E>,
+	_error: std::marker::PhantomData<E>,
 }
 
 impl<E> PipelineBuilder<E> {
-    /// Add a function to the current pipeline
-    ///
-    /// # Example
-    /// ```rust
-    /// use rig::pipeline::{self, Op};
-    ///
-    /// let pipeline = pipeline::new()
-    ///    .map(|(x, y)| x + y)
-    ///    .map(|z| format!("Result: {z}!"));
-    ///
-    /// let result = pipeline.call((1, 2)).await;
-    /// assert_eq!(result, "Result: 3!");
-    /// ```
-    pub fn map<F, Input, Output>(self, f: F) -> op::Map<F, Input>
-    where
-        F: Fn(Input) -> Output + Send + Sync,
-        Input: Send + Sync,
-        Output: Send + Sync,
-        Self: Sized,
-    {
-        op::Map::new(f)
-    }
+	/// Add a function to the current pipeline
+	///
+	/// # Example
+	/// ```rust
+	/// use rig::pipeline::{self, Op};
+	///
+	/// let pipeline = pipeline::new()
+	///    .map(|(x, y)| x + y)
+	///    .map(|z| format!("Result: {z}!"));
+	///
+	/// let result = pipeline.call((1, 2)).await;
+	/// assert_eq!(result, "Result: 3!");
+	/// ```
+	pub fn map<F, Input, Output>(self, f: F) -> op::Map<F, Input>
+	where
+		F: Fn(Input) -> Output + Send + Sync,
+		Input: Send + Sync,
+		Output: Send + Sync,
+		Self: Sized,
+	{
+		op::Map::new(f)
+	}
 
-    /// Same as `map` but for asynchronous functions
-    ///
-    /// # Example
-    /// ```rust
-    /// use rig::pipeline::{self, Op};
-    ///
-    /// let pipeline = pipeline::new()
-    ///     .then(|email: String| async move {
-    ///         email.split('@').next().unwrap().to_string()
-    ///     })
-    ///     .then(|username: String| async move {
-    ///         format!("Hello, {}!", username)
-    ///     });
-    ///
-    /// let result = pipeline.call("bob@gmail.com".to_string()).await;
-    /// assert_eq!(result, "Hello, bob!");
-    /// ```
-    pub fn then<F, Input, Fut>(self, f: F) -> op::Then<F, Input>
-    where
-        F: Fn(Input) -> Fut + Send + Sync,
-        Input: Send + Sync,
-        Fut: Future + Send + Sync,
-        Fut::Output: Send + Sync,
-        Self: Sized,
-    {
-        op::Then::new(f)
-    }
+	/// Same as `map` but for asynchronous functions
+	///
+	/// # Example
+	/// ```rust
+	/// use rig::pipeline::{self, Op};
+	///
+	/// let pipeline = pipeline::new()
+	///     .then(|email: String| async move {
+	///         email.split('@').next().unwrap().to_string()
+	///     })
+	///     .then(|username: String| async move {
+	///         format!("Hello, {}!", username)
+	///     });
+	///
+	/// let result = pipeline.call("bob@gmail.com".to_string()).await;
+	/// assert_eq!(result, "Hello, bob!");
+	/// ```
+	pub fn then<F, Input, Fut>(self, f: F) -> op::Then<F, Input>
+	where
+		F: Fn(Input) -> Fut + Send + Sync,
+		Input: Send + Sync,
+		Fut: Future + Send + Sync,
+		Fut::Output: Send + Sync,
+		Self: Sized,
+	{
+		op::Then::new(f)
+	}
 
-    /// Add an arbitrary operation to the current pipeline.
-    ///
-    /// # Example
-    /// ```rust
-    /// use rig::pipeline::{self, Op};
-    ///
-    /// struct MyOp;
-    ///
-    /// impl Op for MyOp {
-    ///     type Input = i32;
-    ///     type Output = i32;
-    ///
-    ///     async fn call(&self, input: Self::Input) -> Self::Output {
-    ///         input + 1
-    ///     }
-    /// }
-    ///
-    /// let pipeline = pipeline::new()
-    ///    .chain(MyOp);
-    ///
-    /// let result = pipeline.call(1).await;
-    /// assert_eq!(result, 2);
-    /// ```
-    pub fn chain<T>(self, op: T) -> T
-    where
-        T: Op,
-        Self: Sized,
-    {
-        op
-    }
+	/// Add an arbitrary operation to the current pipeline.
+	///
+	/// # Example
+	/// ```rust
+	/// use rig::pipeline::{self, Op};
+	///
+	/// struct MyOp;
+	///
+	/// impl Op for MyOp {
+	///     type Input = i32;
+	///     type Output = i32;
+	///
+	///     async fn call(&self, input: Self::Input) -> Self::Output {
+	///         input + 1
+	///     }
+	/// }
+	///
+	/// let pipeline = pipeline::new()
+	///    .chain(MyOp);
+	///
+	/// let result = pipeline.call(1).await;
+	/// assert_eq!(result, 2);
+	/// ```
+	pub fn chain<T>(self, op: T) -> T
+	where
+		T: Op,
+		Self: Sized,
+	{
+		op
+	}
 
-    /// Chain a lookup operation to the current chain. The lookup operation expects the
-    /// current chain to output a query string. The lookup operation will use the query to
-    /// retrieve the top `n` documents from the index and return them with the query string.
-    ///
-    /// # Example
-    /// ```rust
-    /// use rig::pipeline::{self, Op};
-    ///
-    /// let pipeline = pipeline::new()
-    ///     .lookup(index, 2)
-    ///     .pipeline(|(query, docs): (_, Vec<String>)| async move {
-    ///         format!("User query: {}\n\nTop documents:\n{}", query, docs.join("\n"))
-    ///     });
-    ///
-    /// let result = pipeline.call("What is a flurbo?".to_string()).await;
-    /// ```
-    pub fn lookup<I, Input, Output>(self, index: I, n: usize) -> agent_ops::Lookup<I, Input, Output>
-    where
-        I: vector_store::VectorStoreIndex,
-        Output: Send + Sync + for<'a> serde::Deserialize<'a>,
-        Input: Into<String> + Send + Sync,
-        // E: From<vector_store::VectorStoreError> + Send + Sync,
-        Self: Sized,
-    {
-        agent_ops::Lookup::new(index, n)
-    }
+	/// Chain a lookup operation to the current chain. The lookup operation expects the
+	/// current chain to output a query string. The lookup operation will use the query to
+	/// retrieve the top `n` documents from the index and return them with the query string.
+	///
+	/// # Example
+	/// ```rust
+	/// use rig::pipeline::{self, Op};
+	///
+	/// let pipeline = pipeline::new()
+	///     .lookup(index, 2)
+	///     .pipeline(|(query, docs): (_, Vec<String>)| async move {
+	///         format!("User query: {}\n\nTop documents:\n{}", query, docs.join("\n"))
+	///     });
+	///
+	/// let result = pipeline.call("What is a flurbo?".to_string()).await;
+	/// ```
+	pub fn lookup<I, Input, Output>(self, index: I, n: usize) -> agent_ops::Lookup<I, Input, Output>
+	where
+		I: vector_store::VectorStoreIndex,
+		Output: Send + Sync + for<'a> serde::Deserialize<'a>,
+		Input: Into<String> + Send + Sync,
+	// E: From<vector_store::VectorStoreError> + Send + Sync,
+		Self: Sized,
+	{
+		agent_ops::Lookup::new(index, n)
+	}
 
-    /// Add a prompt operation to the current pipeline/op. The prompt operation expects the
-    /// current pipeline to output a string. The prompt operation will use the string to prompt
-    /// the given `agent`, which must implements the [Prompt](completion::Prompt) trait and return
-    /// the response.
-    ///
-    /// # Example
-    /// ```rust
-    /// use rig::pipeline::{self, Op};
-    ///
-    /// let agent = &openai_client.agent("gpt-4").build();
-    ///
-    /// let pipeline = pipeline::new()
-    ///    .map(|name| format!("Find funny nicknames for the following name: {name}!"))
-    ///    .prompt(agent);
-    ///
-    /// let result = pipeline.call("Alice".to_string()).await;
-    /// ```
-    pub fn prompt<P, Input>(self, agent: P) -> agent_ops::Prompt<P, Input>
-    where
-        P: completion::Prompt,
-        Input: Into<String> + Send + Sync,
-        // E: From<completion::PromptError> + Send + Sync,
-        Self: Sized,
-    {
-        agent_ops::Prompt::new(agent)
-    }
+	/// Add a prompt operation to the current pipeline/op. The prompt operation expects the
+	/// current pipeline to output a string. The prompt operation will use the string to prompt
+	/// the given `agent`, which must implements the [Prompt](completion::Prompt) trait and return
+	/// the response.
+	///
+	/// # Example
+	/// ```rust
+	/// use rig::pipeline::{self, Op};
+	///
+	/// let agent = &openai_client.agent("gpt-4").build();
+	///
+	/// let pipeline = pipeline::new()
+	///    .map(|name| format!("Find funny nicknames for the following name: {name}!"))
+	///    .prompt(agent);
+	///
+	/// let result = pipeline.call("Alice".to_string()).await;
+	/// ```
+	pub fn prompt<P, Input>(self, agent: P) -> agent_ops::Prompt<P, Input>
+	where
+		P: completion::Prompt,
+		Input: Into<String> + Send + Sync,
+	// E: From<completion::PromptError> + Send + Sync,
+		Self: Sized,
+	{
+		agent_ops::Prompt::new(agent)
+	}
 
-    /// Add an extract operation to the current pipeline/op. The extract operation expects the
-    /// current pipeline to output a string. The extract operation will use the given `extractor`
-    /// to extract information from the string in the form of the type `T` and return it.
-    ///
-    /// # Example
-    /// ```rust
-    /// use rig::pipeline::{self, Op};
-    ///
-    /// #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
-    /// struct Sentiment {
-    ///     /// The sentiment score of the text (0.0 = negative, 1.0 = positive)
-    ///     score: f64,
-    /// }
-    ///
-    /// let extractor = &openai_client.extractor::<Sentiment>("gpt-4").build();
-    ///
-    /// let pipeline = pipeline::new()
-    ///     .map(|text| format!("Analyze the sentiment of the following text: {text}!"))
-    ///     .extract(extractor);
-    ///
-    /// let result: Sentiment = pipeline.call("I love ice cream!".to_string()).await?;
-    /// assert!(result.score > 0.5);
-    /// ```
-    pub fn extract<M, Input, Output>(
-        self,
-        extractor: Extractor<M, Output>,
-    ) -> agent_ops::Extract<M, Input, Output>
-    where
-        M: completion::CompletionModel,
-        Output: schemars::JsonSchema + for<'a> serde::Deserialize<'a> + Send + Sync,
-        Input: Into<String> + Send + Sync,
-    {
-        agent_ops::Extract::new(extractor)
-    }
+	/// Add an extract operation to the current pipeline/op. The extract operation expects the
+	/// current pipeline to output a string. The extract operation will use the given `extractor`
+	/// to extract information from the string in the form of the type `T` and return it.
+	///
+	/// # Example
+	/// ```rust
+	/// use rig::pipeline::{self, Op};
+	///
+	/// #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+	/// struct Sentiment {
+	///     /// The sentiment score of the text (0.0 = negative, 1.0 = positive)
+	///     score: f64,
+	/// }
+	///
+	/// let extractor = &openai_client.extractor::<Sentiment>("gpt-4").build();
+	///
+	/// let pipeline = pipeline::new()
+	///     .map(|text| format!("Analyze the sentiment of the following text: {text}!"))
+	///     .extract(extractor);
+	///
+	/// let result: Sentiment = pipeline.call("I love ice cream!".to_string()).await?;
+	/// assert!(result.score > 0.5);
+	/// ```
+	pub fn extract<M, Input, Output>(
+		self,
+		extractor: Extractor<M, Output>,
+	) -> agent_ops::Extract<M, Input, Output>
+	where
+		M: completion::CompletionModel,
+		Output: schemars::JsonSchema + for<'a> serde::Deserialize<'a> + Send + Sync,
+		Input: Into<String> + Send + Sync,
+	{
+		agent_ops::Extract::new(extractor)
+	}
 }
 
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum ChainError {
-    #[error("Failed to prompt agent: {0}")]
-    PromptError(#[from] completion::PromptError),
+	#[error("Failed to prompt agent: {0}")]
+	PromptError(#[from] completion::PromptError),
 
-    #[error("Failed to lookup documents: {0}")]
-    LookupError(#[from] vector_store::VectorStoreError),
+	#[error("Failed to lookup documents: {0}")]
+	LookupError(#[from] vector_store::VectorStoreError),
 }
 
 pub fn new() -> PipelineBuilder<ChainError> {
-    PipelineBuilder {
-        _error: std::marker::PhantomData,
-    }
+	PipelineBuilder {
+		_error: std::marker::PhantomData,
+	}
 }
 
 pub fn with_error<E>() -> PipelineBuilder<E> {
-    PipelineBuilder {
-        _error: std::marker::PhantomData,
-    }
+	PipelineBuilder {
+		_error: std::marker::PhantomData,
+	}
 }
 
 #[cfg(test)]
@@ -307,76 +308,76 @@ mod tests {
     use parallel::parallel;
 
     #[tokio::test]
-    async fn test_prompt_pipeline() {
-        let model = MockModel;
+	async fn test_prompt_pipeline() {
+		let model = MockModel;
 
-        let chain = super::new()
-            .map(|input| format!("User query: {input}"))
-            .prompt(model);
+		let chain = super::new()
+			.map(|input| format!("User query: {input}"))
+			.prompt(model);
 
-        let result = chain
-            .call("What is a flurbo?")
-            .await
-            .expect("Failed to run chain");
+		let result = chain
+			.call("What is a flurbo?")
+			.await
+			.expect("Failed to run chain");
 
-        assert_eq!(result, "Mock response: User query: What is a flurbo?");
-    }
+		assert_eq!(result, "Mock response: User query: What is a flurbo?");
+	}
 
-    #[tokio::test]
-    async fn test_prompt_pipeline_error() {
-        let model = MockModel;
+	#[tokio::test]
+	async fn test_prompt_pipeline_error() {
+		let model = MockModel;
 
-        let chain = super::with_error::<()>()
-            .map(|input| format!("User query: {input}"))
-            .prompt(model);
+		let chain = super::with_error::<()>()
+			.map(|input| format!("User query: {input}"))
+			.prompt(model);
 
-        let result = chain
-            .try_call("What is a flurbo?")
-            .await
-            .expect("Failed to run chain");
+		let result = chain
+			.try_call("What is a flurbo?")
+			.await
+			.expect("Failed to run chain");
 
-        assert_eq!(result, "Mock response: User query: What is a flurbo?");
-    }
+		assert_eq!(result, "Mock response: User query: What is a flurbo?");
+	}
 
-    #[tokio::test]
-    async fn test_lookup_pipeline() {
-        let index = MockIndex;
+	#[tokio::test]
+	async fn test_lookup_pipeline() {
+		let index = MockIndex;
 
-        let chain = super::new()
-            .lookup::<_, _, Foo>(index, 1)
-            .map_ok(|docs| format!("Top documents:\n{}", docs[0].2.foo));
+		let chain = super::new()
+			.lookup::<_, _, Foo>(index, 1)
+			.map_ok(|docs| format!("Top documents:\n{}", docs[0].2.foo));
 
-        let result = chain
-            .try_call("What is a flurbo?")
-            .await
-            .expect("Failed to run chain");
+		let result = chain
+			.try_call("What is a flurbo?")
+			.await
+			.expect("Failed to run chain");
 
-        assert_eq!(result, "Top documents:\nbar");
-    }
+		assert_eq!(result, "Top documents:\nbar");
+	}
 
-    #[tokio::test]
-    async fn test_rag_pipeline() {
-        let index = MockIndex;
+	#[tokio::test]
+	async fn test_rag_pipeline() {
+		let index = MockIndex;
 
-        let chain = super::new()
-            .chain(parallel!(
+		let chain = super::new()
+			.chain(parallel!(
                 passthrough(),
                 agent_ops::lookup::<_, _, Foo>(index, 1),
             ))
-            .map(|(query, maybe_docs)| match maybe_docs {
-                Ok(docs) => format!("User query: {}\n\nTop documents:\n{}", query, docs[0].2.foo),
-                Err(err) => format!("Error: {err}"),
-            })
-            .prompt(MockModel);
+			.map(|(query, maybe_docs)| match maybe_docs {
+				Ok(docs) => format!("User query: {}\n\nTop documents:\n{}", query, docs[0].2.foo),
+				Err(err) => format!("Error: {err}"),
+			})
+			.prompt(MockModel);
 
-        let result = chain
-            .call("What is a flurbo?")
-            .await
-            .expect("Failed to run chain");
+		let result = chain
+			.call("What is a flurbo?")
+			.await
+			.expect("Failed to run chain");
 
-        assert_eq!(
-            result,
-            "Mock response: User query: What is a flurbo?\n\nTop documents:\nbar"
-        );
-    }
+		assert_eq!(
+			result,
+			"Mock response: User query: What is a flurbo?\n\nTop documents:\nbar"
+		);
+	}
 }

--- a/rig-core/src/streaming.rs
+++ b/rig-core/src/streaming.rs
@@ -8,14 +8,14 @@
 //! - [StreamingCompletion]: Defines a low-level streaming LLM completion interface
 //!
 
-use crate::OneOrMany;
-use crate::agent::Agent;
 use crate::agent::prompt_request::streaming::StreamingPromptRequest;
+use crate::agent::Agent;
 use crate::completion::{
-    CompletionError, CompletionModel, CompletionRequestBuilder, CompletionResponse, GetTokenUsage,
-    Message, Usage,
+	CompletionError, CompletionModel, CompletionRequestBuilder, CompletionResponse, GetTokenUsage,
+	Message, Usage,
 };
 use crate::message::{AssistantContent, Reasoning, Text, ToolCall, ToolFunction};
+use crate::OneOrMany;
 use futures::stream::{AbortHandle, Abortable};
 use futures::{Stream, StreamExt};
 use serde::{Deserialize, Serialize};
@@ -27,416 +27,418 @@ use std::task::{Context, Poll};
 use tokio::sync::watch;
 
 /// Control for pausing and resuming a streaming response
+#[non_exhaustive]
 pub struct PauseControl {
-    pub(crate) paused_tx: watch::Sender<bool>,
-    pub(crate) paused_rx: watch::Receiver<bool>,
+	pub(crate) paused_tx: watch::Sender<bool>,
+	pub(crate) paused_rx: watch::Receiver<bool>,
 }
 
 impl PauseControl {
-    pub fn new() -> Self {
-        let (paused_tx, paused_rx) = watch::channel(false);
-        Self {
-            paused_tx,
-            paused_rx,
-        }
-    }
+	pub fn new() -> Self {
+		let (paused_tx, paused_rx) = watch::channel(false);
+		Self {
+			paused_tx,
+			paused_rx,
+		}
+	}
 
-    pub fn pause(&self) {
-        self.paused_tx.send(true).unwrap();
-    }
+	pub fn pause(&self) {
+		self.paused_tx.send(true).unwrap();
+	}
 
-    pub fn resume(&self) {
-        self.paused_tx.send(false).unwrap();
-    }
+	pub fn resume(&self) {
+		self.paused_tx.send(false).unwrap();
+	}
 
-    pub fn is_paused(&self) -> bool {
-        *self.paused_rx.borrow()
-    }
+	pub fn is_paused(&self) -> bool {
+		*self.paused_rx.borrow()
+	}
 }
 
 impl Default for PauseControl {
-    fn default() -> Self {
-        Self::new()
-    }
+	fn default() -> Self {
+		Self::new()
+	}
 }
 
 /// Enum representing a streaming chunk from the model
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum RawStreamingChoice<R>
 where
-    R: Clone,
+	R: Clone,
 {
-    /// A text chunk from a message response
-    Message(String),
+	/// A text chunk from a message response
+	Message(String),
 
-    /// A tool call response chunk
-    ToolCall {
-        id: String,
-        call_id: Option<String>,
-        name: String,
-        arguments: serde_json::Value,
-    },
-    /// A reasoning chunk
-    Reasoning {
-        id: Option<String>,
-        reasoning: String,
-    },
+	/// A tool call response chunk
+	ToolCall {
+		id: String,
+		call_id: Option<String>,
+		name: String,
+		arguments: serde_json::Value,
+	},
+	/// A reasoning chunk
+	Reasoning {
+		id: Option<String>,
+		reasoning: String,
+	},
 
-    /// The final response object, must be yielded if you want the
-    /// `response` field to be populated on the `StreamingCompletionResponse`
-    FinalResponse(R),
+	/// The final response object, must be yielded if you want the
+	/// `response` field to be populated on the `StreamingCompletionResponse`
+	FinalResponse(R),
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 pub type StreamingResult<R> =
-    Pin<Box<dyn Stream<Item = Result<RawStreamingChoice<R>, CompletionError>> + Send>>;
+Pin<Box<dyn Stream<Item=Result<RawStreamingChoice<R>, CompletionError>> + Send>>;
 
 #[cfg(target_arch = "wasm32")]
 pub type StreamingResult<R> =
-    Pin<Box<dyn Stream<Item = Result<RawStreamingChoice<R>, CompletionError>>>>;
+Pin<Box<dyn Stream<Item=Result<RawStreamingChoice<R>, CompletionError>>>>;
 
 /// The response from a streaming completion request;
 /// message and response are populated at the end of the
 /// `inner` stream.
 pub struct StreamingCompletionResponse<R>
 where
-    R: Clone + Unpin + GetTokenUsage,
+	R: Clone + Unpin + GetTokenUsage,
 {
-    pub(crate) inner: Abortable<StreamingResult<R>>,
-    pub(crate) abort_handle: AbortHandle,
-    pub(crate) pause_control: PauseControl,
-    text: String,
-    reasoning: String,
-    tool_calls: Vec<ToolCall>,
-    /// The final aggregated message from the stream
-    /// contains all text and tool calls generated
-    pub choice: OneOrMany<AssistantContent>,
-    /// The final response from the stream, may be `None`
-    /// if the provider didn't yield it during the stream
-    pub response: Option<R>,
-    pub final_response_yielded: AtomicBool,
+	pub(crate) inner: Abortable<StreamingResult<R>>,
+	pub(crate) abort_handle: AbortHandle,
+	pub(crate) pause_control: PauseControl,
+	text: String,
+	reasoning: String,
+	tool_calls: Vec<ToolCall>,
+	/// The final aggregated message from the stream
+	/// contains all text and tool calls generated
+	pub choice: OneOrMany<AssistantContent>,
+	/// The final response from the stream, may be `None`
+	/// if the provider didn't yield it during the stream
+	pub response: Option<R>,
+	pub final_response_yielded: AtomicBool,
 }
 
 impl<R> StreamingCompletionResponse<R>
 where
-    R: Clone + Unpin + GetTokenUsage,
+	R: Clone + Unpin + GetTokenUsage,
 {
-    pub fn stream(inner: StreamingResult<R>) -> StreamingCompletionResponse<R> {
-        let (abort_handle, abort_registration) = AbortHandle::new_pair();
-        let abortable_stream = Abortable::new(inner, abort_registration);
-        let pause_control = PauseControl::new();
-        Self {
-            inner: abortable_stream,
-            abort_handle,
-            pause_control,
-            reasoning: String::new(),
-            text: "".to_string(),
-            tool_calls: vec![],
-            choice: OneOrMany::one(AssistantContent::text("")),
-            response: None,
-            final_response_yielded: AtomicBool::new(false),
-        }
-    }
+	pub fn stream(inner: StreamingResult<R>) -> StreamingCompletionResponse<R> {
+		let (abort_handle, abort_registration) = AbortHandle::new_pair();
+		let abortable_stream = Abortable::new(inner, abort_registration);
+		let pause_control = PauseControl::new();
+		Self {
+			inner: abortable_stream,
+			abort_handle,
+			pause_control,
+			reasoning: String::new(),
+			text: "".to_string(),
+			tool_calls: vec![],
+			choice: OneOrMany::one(AssistantContent::text("")),
+			response: None,
+			final_response_yielded: AtomicBool::new(false),
+		}
+	}
 
-    pub fn cancel(&self) {
-        self.abort_handle.abort();
-    }
+	pub fn cancel(&self) {
+		self.abort_handle.abort();
+	}
 
-    pub fn pause(&self) {
-        self.pause_control.pause();
-    }
+	pub fn pause(&self) {
+		self.pause_control.pause();
+	}
 
-    pub fn resume(&self) {
-        self.pause_control.resume();
-    }
+	pub fn resume(&self) {
+		self.pause_control.resume();
+	}
 
-    pub fn is_paused(&self) -> bool {
-        self.pause_control.is_paused()
-    }
+	pub fn is_paused(&self) -> bool {
+		self.pause_control.is_paused()
+	}
 }
 
 impl<R> From<StreamingCompletionResponse<R>> for CompletionResponse<Option<R>>
 where
-    R: Clone + Unpin + GetTokenUsage,
+	R: Clone + Unpin + GetTokenUsage,
 {
-    fn from(value: StreamingCompletionResponse<R>) -> CompletionResponse<Option<R>> {
-        CompletionResponse {
-            choice: value.choice,
-            usage: Usage::new(), // Usage is not tracked in streaming responses
-            raw_response: value.response,
-        }
-    }
+	fn from(value: StreamingCompletionResponse<R>) -> CompletionResponse<Option<R>> {
+		CompletionResponse {
+			choice: value.choice,
+			usage: Usage::new(), // Usage is not tracked in streaming responses
+			raw_response: value.response,
+		}
+	}
 }
 
 impl<R> Stream for StreamingCompletionResponse<R>
 where
-    R: Clone + Unpin + GetTokenUsage,
+	R: Clone + Unpin + GetTokenUsage,
 {
-    type Item = Result<StreamedAssistantContent<R>, CompletionError>;
+	type Item = Result<StreamedAssistantContent<R>, CompletionError>;
 
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let stream = self.get_mut();
+	fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+		let stream = self.get_mut();
 
-        if stream.is_paused() {
-            cx.waker().wake_by_ref();
-            return Poll::Pending;
-        }
+		if stream.is_paused() {
+			cx.waker().wake_by_ref();
+			return Poll::Pending;
+		}
 
-        match Pin::new(&mut stream.inner).poll_next(cx) {
-            Poll::Pending => Poll::Pending,
-            Poll::Ready(None) => {
-                // This is run at the end of the inner stream to collect all tokens into
-                // a single unified `Message`.
-                let mut choice = vec![];
+		match Pin::new(&mut stream.inner).poll_next(cx) {
+			Poll::Pending => Poll::Pending,
+			Poll::Ready(None) => {
+				// This is run at the end of the inner stream to collect all tokens into
+				// a single unified `Message`.
+				let mut choice = vec![];
 
-                stream.tool_calls.iter().for_each(|tc| {
-                    choice.push(AssistantContent::ToolCall(tc.clone()));
-                });
+				stream.tool_calls.iter().for_each(|tc| {
+					choice.push(AssistantContent::ToolCall(tc.clone()));
+				});
 
-                // This is required to ensure there's always at least one item in the content
-                if choice.is_empty() || !stream.text.is_empty() {
-                    choice.insert(0, AssistantContent::text(stream.text.clone()));
-                }
+				// This is required to ensure there's always at least one item in the content
+				if choice.is_empty() || !stream.text.is_empty() {
+					choice.insert(0, AssistantContent::text(stream.text.clone()));
+				}
 
-                stream.choice = OneOrMany::many(choice)
-                    .expect("There should be at least one assistant message");
+				stream.choice = OneOrMany::many(choice)
+					.expect("There should be at least one assistant message");
 
-                Poll::Ready(None)
-            }
-            Poll::Ready(Some(Err(err))) => {
-                if matches!(err, CompletionError::ProviderError(ref e) if e.to_string().contains("aborted"))
-                {
-                    return Poll::Ready(None); // Treat cancellation as stream termination
-                }
-                Poll::Ready(Some(Err(err)))
-            }
-            Poll::Ready(Some(Ok(choice))) => match choice {
-                RawStreamingChoice::Message(text) => {
-                    // Forward the streaming tokens to the outer stream
-                    // and concat the text together
-                    stream.text = format!("{}{}", stream.text, text.clone());
-                    Poll::Ready(Some(Ok(StreamedAssistantContent::text(&text))))
-                }
-                RawStreamingChoice::Reasoning { id, reasoning } => {
-                    // Forward the streaming tokens to the outer stream
-                    // and concat the text together
-                    stream.reasoning = format!("{}{}", stream.reasoning, reasoning.clone());
-                    Poll::Ready(Some(Ok(StreamedAssistantContent::Reasoning(Reasoning {
-                        id,
-                        reasoning: vec![stream.reasoning.clone()],
-                    }))))
-                }
-                RawStreamingChoice::ToolCall {
-                    id,
-                    name,
-                    arguments,
-                    call_id,
-                } => {
-                    // Keep track of each tool call to aggregate the final message later
-                    // and pass it to the outer stream
-                    stream.tool_calls.push(ToolCall {
-                        id: id.clone(),
-                        call_id: call_id.clone(),
-                        function: ToolFunction {
-                            name: name.clone(),
-                            arguments: arguments.clone(),
-                        },
-                    });
-                    if let Some(call_id) = call_id {
-                        Poll::Ready(Some(Ok(StreamedAssistantContent::tool_call_with_call_id(
-                            id, call_id, name, arguments,
-                        ))))
-                    } else {
-                        Poll::Ready(Some(Ok(StreamedAssistantContent::tool_call(
-                            id, name, arguments,
-                        ))))
-                    }
-                }
-                RawStreamingChoice::FinalResponse(response) => {
-                    if stream
-                        .final_response_yielded
-                        .load(std::sync::atomic::Ordering::SeqCst)
-                    {
-                        stream.poll_next_unpin(cx)
-                    } else {
-                        // Set the final response field and return the next item in the stream
-                        stream.response = Some(response.clone());
-                        stream
-                            .final_response_yielded
-                            .store(true, std::sync::atomic::Ordering::SeqCst);
-                        let final_response = StreamedAssistantContent::final_response(response);
-                        Poll::Ready(Some(Ok(final_response)))
-                    }
-                }
-            },
-        }
-    }
+				Poll::Ready(None)
+			}
+			Poll::Ready(Some(Err(err))) => {
+				if matches!(err, CompletionError::ProviderError(ref e) if e.to_string().contains("aborted"))
+				{
+					return Poll::Ready(None); // Treat cancellation as stream termination
+				}
+				Poll::Ready(Some(Err(err)))
+			}
+			Poll::Ready(Some(Ok(choice))) => match choice {
+				RawStreamingChoice::Message(text) => {
+					// Forward the streaming tokens to the outer stream
+					// and concat the text together
+					stream.text = format!("{}{}", stream.text, text.clone());
+					Poll::Ready(Some(Ok(StreamedAssistantContent::text(&text))))
+				}
+				RawStreamingChoice::Reasoning { id, reasoning } => {
+					// Forward the streaming tokens to the outer stream
+					// and concat the text together
+					stream.reasoning = format!("{}{}", stream.reasoning, reasoning.clone());
+					Poll::Ready(Some(Ok(StreamedAssistantContent::Reasoning(Reasoning {
+						id,
+						reasoning: vec![stream.reasoning.clone()],
+					}))))
+				}
+				RawStreamingChoice::ToolCall {
+					id,
+					name,
+					arguments,
+					call_id,
+				} => {
+					// Keep track of each tool call to aggregate the final message later
+					// and pass it to the outer stream
+					stream.tool_calls.push(ToolCall {
+						id: id.clone(),
+						call_id: call_id.clone(),
+						function: ToolFunction {
+							name: name.clone(),
+							arguments: arguments.clone(),
+						},
+					});
+					if let Some(call_id) = call_id {
+						Poll::Ready(Some(Ok(StreamedAssistantContent::tool_call_with_call_id(
+							id, call_id, name, arguments,
+						))))
+					} else {
+						Poll::Ready(Some(Ok(StreamedAssistantContent::tool_call(
+							id, name, arguments,
+						))))
+					}
+				}
+				RawStreamingChoice::FinalResponse(response) => {
+					if stream
+						.final_response_yielded
+						.load(std::sync::atomic::Ordering::SeqCst)
+					{
+						stream.poll_next_unpin(cx)
+					} else {
+						// Set the final response field and return the next item in the stream
+						stream.response = Some(response.clone());
+						stream
+							.final_response_yielded
+							.store(true, std::sync::atomic::Ordering::SeqCst);
+						let final_response = StreamedAssistantContent::final_response(response);
+						Poll::Ready(Some(Ok(final_response)))
+					}
+				}
+			},
+		}
+	}
 }
 
 /// Trait for high-level streaming prompt interface
 pub trait StreamingPrompt<M, R>
 where
-    M: CompletionModel + 'static,
-    <M as CompletionModel>::StreamingResponse: Send,
-    R: Clone + Unpin + GetTokenUsage,
+	M: CompletionModel + 'static,
+	<M as CompletionModel>::StreamingResponse: Send,
+	R: Clone + Unpin + GetTokenUsage,
 {
-    /// Stream a simple prompt to the model
-    fn stream_prompt(&self, prompt: impl Into<Message> + Send) -> StreamingPromptRequest<M, ()>;
+	/// Stream a simple prompt to the model
+	fn stream_prompt(&self, prompt: impl Into<Message> + Send) -> StreamingPromptRequest<M, ()>;
 }
 
 /// Trait for high-level streaming chat interface
 pub trait StreamingChat<M, R>: Send + Sync
 where
-    M: CompletionModel + 'static,
-    <M as CompletionModel>::StreamingResponse: Send,
-    R: Clone + Unpin + GetTokenUsage,
+	M: CompletionModel + 'static,
+	<M as CompletionModel>::StreamingResponse: Send,
+	R: Clone + Unpin + GetTokenUsage,
 {
-    /// Stream a chat with history to the model
-    fn stream_chat(
-        &self,
-        prompt: impl Into<Message> + Send,
-        chat_history: Vec<Message>,
-    ) -> StreamingPromptRequest<M, ()>;
+	/// Stream a chat with history to the model
+	fn stream_chat(
+		&self,
+		prompt: impl Into<Message> + Send,
+		chat_history: Vec<Message>,
+	) -> StreamingPromptRequest<M, ()>;
 }
 
 /// Trait for low-level streaming completion interface
 pub trait StreamingCompletion<M: CompletionModel> {
-    /// Generate a streaming completion from a request
-    fn stream_completion(
-        &self,
-        prompt: impl Into<Message> + Send,
-        chat_history: Vec<Message>,
-    ) -> impl Future<Output = Result<CompletionRequestBuilder<M>, CompletionError>>;
+	/// Generate a streaming completion from a request
+	fn stream_completion(
+		&self,
+		prompt: impl Into<Message> + Send,
+		chat_history: Vec<Message>,
+	) -> impl Future<Output=Result<CompletionRequestBuilder<M>, CompletionError>>;
 }
 
 pub(crate) struct StreamingResultDyn<R: Clone + Unpin> {
-    pub(crate) inner: StreamingResult<R>,
+	pub(crate) inner: StreamingResult<R>,
 }
 
 impl<R: Clone + Unpin> Stream for StreamingResultDyn<R> {
-    type Item = Result<RawStreamingChoice<()>, CompletionError>;
+	type Item = Result<RawStreamingChoice<()>, CompletionError>;
 
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let stream = self.get_mut();
+	fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+		let stream = self.get_mut();
 
-        match stream.inner.as_mut().poll_next(cx) {
-            Poll::Pending => Poll::Pending,
-            Poll::Ready(None) => Poll::Ready(None),
-            Poll::Ready(Some(Err(err))) => Poll::Ready(Some(Err(err))),
-            Poll::Ready(Some(Ok(chunk))) => match chunk {
-                RawStreamingChoice::FinalResponse(_) => {
-                    Poll::Ready(Some(Ok(RawStreamingChoice::FinalResponse(()))))
-                }
-                RawStreamingChoice::Message(m) => {
-                    Poll::Ready(Some(Ok(RawStreamingChoice::Message(m))))
-                }
-                RawStreamingChoice::Reasoning { id, reasoning } => {
-                    Poll::Ready(Some(Ok(RawStreamingChoice::Reasoning { id, reasoning })))
-                }
-                RawStreamingChoice::ToolCall {
-                    id,
-                    name,
-                    arguments,
-                    call_id,
-                } => Poll::Ready(Some(Ok(RawStreamingChoice::ToolCall {
-                    id,
-                    name,
-                    arguments,
-                    call_id,
-                }))),
-            },
-        }
-    }
+		match stream.inner.as_mut().poll_next(cx) {
+			Poll::Pending => Poll::Pending,
+			Poll::Ready(None) => Poll::Ready(None),
+			Poll::Ready(Some(Err(err))) => Poll::Ready(Some(Err(err))),
+			Poll::Ready(Some(Ok(chunk))) => match chunk {
+				RawStreamingChoice::FinalResponse(_) => {
+					Poll::Ready(Some(Ok(RawStreamingChoice::FinalResponse(()))))
+				}
+				RawStreamingChoice::Message(m) => {
+					Poll::Ready(Some(Ok(RawStreamingChoice::Message(m))))
+				}
+				RawStreamingChoice::Reasoning { id, reasoning } => {
+					Poll::Ready(Some(Ok(RawStreamingChoice::Reasoning { id, reasoning })))
+				}
+				RawStreamingChoice::ToolCall {
+					id,
+					name,
+					arguments,
+					call_id,
+				} => Poll::Ready(Some(Ok(RawStreamingChoice::ToolCall {
+					id,
+					name,
+					arguments,
+					call_id,
+				}))),
+			},
+		}
+	}
 }
 
 /// helper function to stream a completion request to stdout
 pub async fn stream_to_stdout<M>(
-    agent: &Agent<M>,
-    stream: &mut StreamingCompletionResponse<M::StreamingResponse>,
+	agent: &Agent<M>,
+	stream: &mut StreamingCompletionResponse<M::StreamingResponse>,
 ) -> Result<(), std::io::Error>
 where
-    M: CompletionModel,
+	M: CompletionModel,
 {
-    let mut is_reasoning = false;
-    print!("Response: ");
-    while let Some(chunk) = stream.next().await {
-        match chunk {
-            Ok(StreamedAssistantContent::Text(text)) => {
-                if is_reasoning {
-                    is_reasoning = false;
-                    println!("\n---\n");
-                }
-                print!("{}", text.text);
-                std::io::Write::flush(&mut std::io::stdout())?;
-            }
-            Ok(StreamedAssistantContent::ToolCall(tool_call)) => {
-                let res = agent
-                    .tools
-                    .call(
-                        &tool_call.function.name,
-                        tool_call.function.arguments.to_string(),
-                    )
-                    .await
-                    .map_err(|e| std::io::Error::other(e.to_string()))?;
-                println!("\nResult: {res}");
-            }
-            Ok(StreamedAssistantContent::Final(res)) => {
-                let json_res = serde_json::to_string_pretty(&res).unwrap();
-                println!();
-                tracing::info!("Final result: {json_res}");
-            }
-            Ok(StreamedAssistantContent::Reasoning(Reasoning { reasoning, .. })) => {
-                if !is_reasoning {
-                    is_reasoning = true;
-                    println!();
-                    println!("Thinking: ");
-                }
-                let reasoning = reasoning.into_iter().collect::<Vec<String>>().join("");
+	let mut is_reasoning = false;
+	print!("Response: ");
+	while let Some(chunk) = stream.next().await {
+		match chunk {
+			Ok(StreamedAssistantContent::Text(text)) => {
+				if is_reasoning {
+					is_reasoning = false;
+					println!("\n---\n");
+				}
+				print!("{}", text.text);
+				std::io::Write::flush(&mut std::io::stdout())?;
+			}
+			Ok(StreamedAssistantContent::ToolCall(tool_call)) => {
+				let res = agent
+					.tools
+					.call(
+						&tool_call.function.name,
+						tool_call.function.arguments.to_string(),
+					)
+					.await
+					.map_err(|e| std::io::Error::other(e.to_string()))?;
+				println!("\nResult: {res}");
+			}
+			Ok(StreamedAssistantContent::Final(res)) => {
+				let json_res = serde_json::to_string_pretty(&res).unwrap();
+				println!();
+				tracing::info!("Final result: {json_res}");
+			}
+			Ok(StreamedAssistantContent::Reasoning(Reasoning { reasoning, .. })) => {
+				if !is_reasoning {
+					is_reasoning = true;
+					println!();
+					println!("Thinking: ");
+				}
+				let reasoning = reasoning.into_iter().collect::<Vec<String>>().join("");
 
-                print!("{reasoning}");
-                std::io::Write::flush(&mut std::io::stdout())?;
-            }
-            Err(e) => {
-                if e.to_string().contains("aborted") {
-                    println!("\nStream cancelled.");
-                    break;
-                }
-                eprintln!("Error: {e}");
-                break;
-            }
-        }
-    }
+				print!("{reasoning}");
+				std::io::Write::flush(&mut std::io::stdout())?;
+			}
+			Err(e) => {
+				if e.to_string().contains("aborted") {
+					println!("\nStream cancelled.");
+					break;
+				}
+				eprintln!("Error: {e}");
+				break;
+			}
+		}
+	}
 
-    println!(); // New line after streaming completes
+	println!(); // New line after streaming completes
 
-    Ok(())
+	Ok(())
 }
 
 // Test module
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+	use std::time::Duration;
 
-    use super::*;
-    use async_stream::stream;
-    use tokio::time::sleep;
+	use super::*;
+	use async_stream::stream;
+	use tokio::time::sleep;
 
-    #[derive(Debug, Clone)]
-    pub struct MockResponse {
-        #[allow(dead_code)]
-        token_count: u32,
-    }
+	#[derive(Debug, Clone)]
+	pub struct MockResponse {
+		#[allow(dead_code)]
+		token_count: u32,
+	}
 
-    impl GetTokenUsage for MockResponse {
-        fn token_usage(&self) -> Option<crate::completion::Usage> {
-            let mut usage = Usage::new();
-            usage.total_tokens = 15;
-            Some(usage)
-        }
-    }
+	impl GetTokenUsage for MockResponse {
+		fn token_usage(&self) -> Option<crate::completion::Usage> {
+			let mut usage = Usage::new();
+			usage.total_tokens = 15;
+			Some(usage)
+		}
+	}
 
-    fn create_mock_stream() -> StreamingCompletionResponse<MockResponse> {
-        let stream = stream! {
+	fn create_mock_stream() -> StreamingCompletionResponse<MockResponse> {
+		let stream = stream! {
             yield Ok(RawStreamingChoice::Message("hello 1".to_string()));
             sleep(Duration::from_millis(100)).await;
             yield Ok(RawStreamingChoice::Message("hello 2".to_string()));
@@ -446,127 +448,128 @@ mod tests {
             yield Ok(RawStreamingChoice::FinalResponse(MockResponse { token_count: 15 }));
         };
 
-        #[cfg(not(target_arch = "wasm32"))]
-        let pinned_stream: StreamingResult<MockResponse> = Box::pin(stream);
-        #[cfg(target_arch = "wasm32")]
-        let pinned_stream: StreamingResult<MockResponse> = Box::pin(stream);
+		#[cfg(not(target_arch = "wasm32"))]
+		let pinned_stream: StreamingResult<MockResponse> = Box::pin(stream);
+		#[cfg(target_arch = "wasm32")]
+		let pinned_stream: StreamingResult<MockResponse> = Box::pin(stream);
 
-        StreamingCompletionResponse::stream(pinned_stream)
-    }
+		StreamingCompletionResponse::stream(pinned_stream)
+	}
 
-    #[tokio::test]
-    async fn test_stream_cancellation() {
-        let mut stream = create_mock_stream();
+	#[tokio::test]
+	async fn test_stream_cancellation() {
+		let mut stream = create_mock_stream();
 
-        println!("Response: ");
-        let mut chunk_count = 0;
-        while let Some(chunk) = stream.next().await {
-            match chunk {
-                Ok(StreamedAssistantContent::Text(text)) => {
-                    print!("{}", text.text);
-                    std::io::Write::flush(&mut std::io::stdout()).unwrap();
-                    chunk_count += 1;
-                }
-                Ok(StreamedAssistantContent::ToolCall(tc)) => {
-                    println!("\nTool Call: {tc:?}");
-                    chunk_count += 1;
-                }
-                Ok(StreamedAssistantContent::Final(res)) => {
-                    println!("\nFinal response: {res:?}");
-                }
-                Ok(StreamedAssistantContent::Reasoning(Reasoning { reasoning, .. })) => {
-                    let reasoning = reasoning.into_iter().collect::<Vec<String>>().join("");
-                    print!("{reasoning}");
-                    std::io::Write::flush(&mut std::io::stdout()).unwrap();
-                }
-                Err(e) => {
-                    eprintln!("Error: {e:?}");
-                    break;
-                }
-            }
+		println!("Response: ");
+		let mut chunk_count = 0;
+		while let Some(chunk) = stream.next().await {
+			match chunk {
+				Ok(StreamedAssistantContent::Text(text)) => {
+					print!("{}", text.text);
+					std::io::Write::flush(&mut std::io::stdout()).unwrap();
+					chunk_count += 1;
+				}
+				Ok(StreamedAssistantContent::ToolCall(tc)) => {
+					println!("\nTool Call: {tc:?}");
+					chunk_count += 1;
+				}
+				Ok(StreamedAssistantContent::Final(res)) => {
+					println!("\nFinal response: {res:?}");
+				}
+				Ok(StreamedAssistantContent::Reasoning(Reasoning { reasoning, .. })) => {
+					let reasoning = reasoning.into_iter().collect::<Vec<String>>().join("");
+					print!("{reasoning}");
+					std::io::Write::flush(&mut std::io::stdout()).unwrap();
+				}
+				Err(e) => {
+					eprintln!("Error: {e:?}");
+					break;
+				}
+			}
 
-            if chunk_count >= 2 {
-                println!("\nCancelling stream...");
-                stream.cancel();
-                println!("Stream cancelled.");
-                break;
-            }
-        }
+			if chunk_count >= 2 {
+				println!("\nCancelling stream...");
+				stream.cancel();
+				println!("Stream cancelled.");
+				break;
+			}
+		}
 
-        let next_chunk = stream.next().await;
-        assert!(
-            next_chunk.is_none(),
-            "Expected no further chunks after cancellation, got {next_chunk:?}"
-        );
-    }
+		let next_chunk = stream.next().await;
+		assert!(
+			next_chunk.is_none(),
+			"Expected no further chunks after cancellation, got {next_chunk:?}"
+		);
+	}
 
-    #[tokio::test]
-    async fn test_stream_pause_resume() {
-        let stream = create_mock_stream();
+	#[tokio::test]
+	async fn test_stream_pause_resume() {
+		let stream = create_mock_stream();
 
-        // Test pause
-        stream.pause();
-        assert!(stream.is_paused());
+		// Test pause
+		stream.pause();
+		assert!(stream.is_paused());
 
-        // Test resume
-        stream.resume();
-        assert!(!stream.is_paused());
-    }
+		// Test resume
+		stream.resume();
+		assert!(!stream.is_paused());
+	}
 }
 
 /// Describes responses from a streamed provider response which is either text, a tool call or a final usage response.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum StreamedAssistantContent<R> {
-    Text(Text),
-    ToolCall(ToolCall),
-    Reasoning(Reasoning),
-    Final(R),
+	Text(Text),
+	ToolCall(ToolCall),
+	Reasoning(Reasoning),
+	Final(R),
 }
 
 impl<R> StreamedAssistantContent<R>
 where
-    R: Clone + Unpin,
+	R: Clone + Unpin,
 {
-    pub fn text(text: &str) -> Self {
-        Self::Text(Text {
-            text: text.to_string(),
-        })
-    }
+	pub fn text(text: &str) -> Self {
+		Self::Text(Text {
+			text: text.to_string(),
+		})
+	}
 
-    /// Helper constructor to make creating assistant tool call content easier.
-    pub fn tool_call(
-        id: impl Into<String>,
-        name: impl Into<String>,
-        arguments: serde_json::Value,
-    ) -> Self {
-        Self::ToolCall(ToolCall {
-            id: id.into(),
-            call_id: None,
-            function: ToolFunction {
-                name: name.into(),
-                arguments,
-            },
-        })
-    }
+	/// Helper constructor to make creating assistant tool call content easier.
+	pub fn tool_call(
+		id: impl Into<String>,
+		name: impl Into<String>,
+		arguments: serde_json::Value,
+	) -> Self {
+		Self::ToolCall(ToolCall {
+			id: id.into(),
+			call_id: None,
+			function: ToolFunction {
+				name: name.into(),
+				arguments,
+			},
+		})
+	}
 
-    pub fn tool_call_with_call_id(
-        id: impl Into<String>,
-        call_id: String,
-        name: impl Into<String>,
-        arguments: serde_json::Value,
-    ) -> Self {
-        Self::ToolCall(ToolCall {
-            id: id.into(),
-            call_id: Some(call_id),
-            function: ToolFunction {
-                name: name.into(),
-                arguments,
-            },
-        })
-    }
+	pub fn tool_call_with_call_id(
+		id: impl Into<String>,
+		call_id: String,
+		name: impl Into<String>,
+		arguments: serde_json::Value,
+	) -> Self {
+		Self::ToolCall(ToolCall {
+			id: id.into(),
+			call_id: Some(call_id),
+			function: ToolFunction {
+				name: name.into(),
+				arguments,
+			},
+		})
+	}
 
-    pub fn final_response(res: R) -> Self {
-        Self::Final(res)
-    }
+	pub fn final_response(res: R) -> Self {
+		Self::Final(res)
+	}
 }

--- a/rig-core/src/tool.rs
+++ b/rig-core/src/tool.rs
@@ -15,18 +15,19 @@ use futures::Future;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    completion::{self, ToolDefinition},
-    embeddings::{embed::EmbedError, tool::ToolSchema},
+	completion::{self, ToolDefinition},
+	embeddings::{embed::EmbedError, tool::ToolSchema},
 };
 
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum ToolError {
-    /// Error returned by the tool
-    #[error("ToolCallError: {0}")]
-    ToolCallError(#[from] Box<dyn std::error::Error + Send + Sync>),
+	/// Error returned by the tool
+	#[error("ToolCallError: {0}")]
+	ToolCallError(#[from] Box<dyn std::error::Error + Send + Sync>),
 
-    #[error("JsonError: {0}")]
-    JsonError(#[from] serde_json::Error),
+	#[error("JsonError: {0}")]
+	JsonError(#[from] serde_json::Error),
 }
 
 /// Trait that represents a simple LLM tool
@@ -85,498 +86,500 @@ pub enum ToolError {
 /// }
 /// ```
 pub trait Tool: Sized + Send + Sync {
-    /// The name of the tool. This name should be unique.
-    const NAME: &'static str;
+	/// The name of the tool. This name should be unique.
+	const NAME: &'static str;
 
-    /// The error type of the tool.
-    type Error: std::error::Error + Send + Sync + 'static;
-    /// The arguments type of the tool.
-    type Args: for<'a> Deserialize<'a> + Send + Sync;
-    /// The output type of the tool.
-    type Output: Serialize;
+	/// The error type of the tool.
+	type Error: std::error::Error + Send + Sync + 'static;
+	/// The arguments type of the tool.
+	type Args: for<'a> Deserialize<'a> + Send + Sync;
+	/// The output type of the tool.
+	type Output: Serialize;
 
-    /// A method returning the name of the tool.
-    fn name(&self) -> String {
-        Self::NAME.to_string()
-    }
+	/// A method returning the name of the tool.
+	fn name(&self) -> String {
+		Self::NAME.to_string()
+	}
 
-    /// A method returning the tool definition. The user prompt can be used to
-    /// tailor the definition to the specific use case.
-    fn definition(&self, _prompt: String) -> impl Future<Output = ToolDefinition> + Send + Sync;
+	/// A method returning the tool definition. The user prompt can be used to
+	/// tailor the definition to the specific use case.
+	fn definition(&self, _prompt: String) -> impl Future<Output=ToolDefinition> + Send + Sync;
 
-    /// The tool execution method.
-    /// Both the arguments and return value are a String since these values are meant to
-    /// be the output and input of LLM models (respectively)
-    fn call(
-        &self,
-        args: Self::Args,
-    ) -> impl Future<Output = Result<Self::Output, Self::Error>> + Send;
+	/// The tool execution method.
+	/// Both the arguments and return value are a String since these values are meant to
+	/// be the output and input of LLM models (respectively)
+	fn call(
+		&self,
+		args: Self::Args,
+	) -> impl Future<Output=Result<Self::Output, Self::Error>> + Send;
 }
 
 /// Trait that represents an LLM tool that can be stored in a vector store and RAGged
 pub trait ToolEmbedding: Tool {
-    type InitError: std::error::Error + Send + Sync + 'static;
+	type InitError: std::error::Error + Send + Sync + 'static;
 
-    /// Type of the tool' context. This context will be saved and loaded from the
-    /// vector store when ragging the tool.
-    /// This context can be used to store the tool's static configuration and local
-    /// context.
-    type Context: for<'a> Deserialize<'a> + Serialize;
+	/// Type of the tool' context. This context will be saved and loaded from the
+	/// vector store when ragging the tool.
+	/// This context can be used to store the tool's static configuration and local
+	/// context.
+	type Context: for<'a> Deserialize<'a> + Serialize;
 
-    /// Type of the tool's state. This state will be passed to the tool when initializing it.
-    /// This state can be used to pass runtime arguments to the tool such as clients,
-    /// API keys and other configuration.
-    type State: Send;
+	/// Type of the tool's state. This state will be passed to the tool when initializing it.
+	/// This state can be used to pass runtime arguments to the tool such as clients,
+	/// API keys and other configuration.
+	type State: Send;
 
-    /// A method returning the documents that will be used as embeddings for the tool.
-    /// This allows for a tool to be retrieved from multiple embedding "directions".
-    /// If the tool will not be RAGged, this method should return an empty vector.
-    fn embedding_docs(&self) -> Vec<String>;
+	/// A method returning the documents that will be used as embeddings for the tool.
+	/// This allows for a tool to be retrieved from multiple embedding "directions".
+	/// If the tool will not be RAGged, this method should return an empty vector.
+	fn embedding_docs(&self) -> Vec<String>;
 
-    /// A method returning the context of the tool.
-    fn context(&self) -> Self::Context;
+	/// A method returning the context of the tool.
+	fn context(&self) -> Self::Context;
 
-    /// A method to initialize the tool from the context, and a state.
-    fn init(state: Self::State, context: Self::Context) -> Result<Self, Self::InitError>;
+	/// A method to initialize the tool from the context, and a state.
+	fn init(state: Self::State, context: Self::Context) -> Result<Self, Self::InitError>;
 }
 
 /// Wrapper trait to allow for dynamic dispatch of simple tools
 pub trait ToolDyn: Send + Sync {
-    fn name(&self) -> String;
+	fn name(&self) -> String;
 
-    fn definition(
-        &self,
-        prompt: String,
-    ) -> Pin<Box<dyn Future<Output = ToolDefinition> + Send + Sync + '_>>;
+	fn definition(
+		&self,
+		prompt: String,
+	) -> Pin<Box<dyn Future<Output=ToolDefinition> + Send + Sync + '_>>;
 
-    fn call(
-        &self,
-        args: String,
-    ) -> Pin<Box<dyn Future<Output = Result<String, ToolError>> + Send + '_>>;
+	fn call(
+		&self,
+		args: String,
+	) -> Pin<Box<dyn Future<Output=Result<String, ToolError>> + Send + '_>>;
 }
 
 impl<T: Tool> ToolDyn for T {
-    fn name(&self) -> String {
-        self.name()
-    }
+	fn name(&self) -> String {
+		self.name()
+	}
 
-    fn definition(
-        &self,
-        prompt: String,
-    ) -> Pin<Box<dyn Future<Output = ToolDefinition> + Send + Sync + '_>> {
-        Box::pin(<Self as Tool>::definition(self, prompt))
-    }
+	fn definition(
+		&self,
+		prompt: String,
+	) -> Pin<Box<dyn Future<Output=ToolDefinition> + Send + Sync + '_>> {
+		Box::pin(<Self as Tool>::definition(self, prompt))
+	}
 
-    fn call(
-        &self,
-        args: String,
-    ) -> Pin<Box<dyn Future<Output = Result<String, ToolError>> + Send + '_>> {
-        Box::pin(async move {
-            match serde_json::from_str(&args) {
-                Ok(args) => <Self as Tool>::call(self, args)
-                    .await
-                    .map_err(|e| ToolError::ToolCallError(Box::new(e)))
-                    .and_then(|output| {
-                        serde_json::to_string(&output).map_err(ToolError::JsonError)
-                    }),
-                Err(e) => Err(ToolError::JsonError(e)),
-            }
-        })
-    }
+	fn call(
+		&self,
+		args: String,
+	) -> Pin<Box<dyn Future<Output=Result<String, ToolError>> + Send + '_>> {
+		Box::pin(async move {
+			match serde_json::from_str(&args) {
+				Ok(args) => <Self as Tool>::call(self, args)
+					.await
+					.map_err(|e| ToolError::ToolCallError(Box::new(e)))
+					.and_then(|output| {
+						serde_json::to_string(&output).map_err(ToolError::JsonError)
+					}),
+				Err(e) => Err(ToolError::JsonError(e)),
+			}
+		})
+	}
 }
 
 #[cfg(feature = "rmcp")]
 #[cfg_attr(docsrs, doc(cfg(feature = "rmcp")))]
 pub mod rmcp {
-    use crate::completion::ToolDefinition;
-    use crate::tool::ToolDyn;
-    use crate::tool::ToolError;
-    use rmcp::model::RawContent;
-    use std::borrow::Cow;
-    use std::pin::Pin;
+	use crate::completion::ToolDefinition;
+	use crate::tool::ToolDyn;
+	use crate::tool::ToolError;
+	use rmcp::model::RawContent;
+	use std::borrow::Cow;
+	use std::pin::Pin;
 
-    pub struct McpTool {
-        definition: rmcp::model::Tool,
-        client: rmcp::service::ServerSink,
-    }
+	pub struct McpTool {
+		definition: rmcp::model::Tool,
+		client: rmcp::service::ServerSink,
+	}
 
-    impl McpTool {
-        pub fn from_mcp_server(
-            definition: rmcp::model::Tool,
-            client: rmcp::service::ServerSink,
-        ) -> Self {
-            Self { definition, client }
-        }
-    }
+	impl McpTool {
+		pub fn from_mcp_server(
+			definition: rmcp::model::Tool,
+			client: rmcp::service::ServerSink,
+		) -> Self {
+			Self { definition, client }
+		}
+	}
 
-    impl From<&rmcp::model::Tool> for ToolDefinition {
-        fn from(val: &rmcp::model::Tool) -> Self {
-            Self {
-                name: val.name.to_string(),
-                description: val.description.clone().unwrap_or(Cow::from("")).to_string(),
-                parameters: val.schema_as_json_value(),
-            }
-        }
-    }
+	impl From<&rmcp::model::Tool> for ToolDefinition {
+		fn from(val: &rmcp::model::Tool) -> Self {
+			Self {
+				name: val.name.to_string(),
+				description: val.description.clone().unwrap_or(Cow::from("")).to_string(),
+				parameters: val.schema_as_json_value(),
+			}
+		}
+	}
 
-    impl From<rmcp::model::Tool> for ToolDefinition {
-        fn from(val: rmcp::model::Tool) -> Self {
-            Self {
-                name: val.name.to_string(),
-                description: val.description.clone().unwrap_or(Cow::from("")).to_string(),
-                parameters: val.schema_as_json_value(),
-            }
-        }
-    }
+	impl From<rmcp::model::Tool> for ToolDefinition {
+		fn from(val: rmcp::model::Tool) -> Self {
+			Self {
+				name: val.name.to_string(),
+				description: val.description.clone().unwrap_or(Cow::from("")).to_string(),
+				parameters: val.schema_as_json_value(),
+			}
+		}
+	}
 
-    #[derive(Debug, thiserror::Error)]
-    #[error("MCP tool error: {0}")]
-    pub struct McpToolError(String);
+	#[derive(Debug, thiserror::Error)]
+	#[error("MCP tool error: {0}")]
+	pub struct McpToolError(String);
 
-    impl From<McpToolError> for ToolError {
-        fn from(e: McpToolError) -> Self {
-            ToolError::ToolCallError(Box::new(e))
-        }
-    }
+	impl From<McpToolError> for ToolError {
+		fn from(e: McpToolError) -> Self {
+			ToolError::ToolCallError(Box::new(e))
+		}
+	}
 
-    impl ToolDyn for McpTool {
-        fn name(&self) -> String {
-            self.definition.name.to_string()
-        }
+	impl ToolDyn for McpTool {
+		fn name(&self) -> String {
+			self.definition.name.to_string()
+		}
 
-        fn definition(
-            &self,
-            _prompt: String,
-        ) -> Pin<Box<dyn Future<Output = ToolDefinition> + Send + Sync + '_>> {
-            Box::pin(async move {
-                ToolDefinition {
-                    name: self.definition.name.to_string(),
-                    description: self
-                        .definition
-                        .description
-                        .clone()
-                        .unwrap_or(Cow::from(""))
-                        .to_string(),
-                    parameters: serde_json::to_value(&self.definition.input_schema)
-                        .unwrap_or_default(),
-                }
-            })
-        }
+		fn definition(
+			&self,
+			_prompt: String,
+		) -> Pin<Box<dyn Future<Output=ToolDefinition> + Send + Sync + '_>> {
+			Box::pin(async move {
+				ToolDefinition {
+					name: self.definition.name.to_string(),
+					description: self
+						.definition
+						.description
+						.clone()
+						.unwrap_or(Cow::from(""))
+						.to_string(),
+					parameters: serde_json::to_value(&self.definition.input_schema)
+						.unwrap_or_default(),
+				}
+			})
+		}
 
-        fn call(
-            &self,
-            args: String,
-        ) -> Pin<Box<dyn Future<Output = Result<String, ToolError>> + Send + '_>> {
-            let name = self.definition.name.clone();
-            let arguments = serde_json::from_str(&args).unwrap_or_default();
+		fn call(
+			&self,
+			args: String,
+		) -> Pin<Box<dyn Future<Output=Result<String, ToolError>> + Send + '_>> {
+			let name = self.definition.name.clone();
+			let arguments = serde_json::from_str(&args).unwrap_or_default();
 
-            Box::pin(async move {
-                let result = self
-                    .client
-                    .call_tool(rmcp::model::CallToolRequestParam { name, arguments })
-                    .await
-                    .map_err(|e| McpToolError(format!("Tool returned an error: {e}")))?;
+			Box::pin(async move {
+				let result = self
+					.client
+					.call_tool(rmcp::model::CallToolRequestParam { name, arguments })
+					.await
+					.map_err(|e| McpToolError(format!("Tool returned an error: {e}")))?;
 
-                if let Some(true) = result.is_error {
-                    let error_msg = result
-                        .content
-                        .as_deref()
-                        .and_then(|errors| errors.first())
-                        .and_then(|error| error.as_text())
-                        .map(|raw| raw.text.as_str())
-                        .unwrap_or("No error message returned");
-                    return Err(McpToolError(error_msg.to_string()).into());
-                };
+				if let Some(true) = result.is_error {
+					let error_msg = result
+						.content
+						.as_deref()
+						.and_then(|errors| errors.first())
+						.and_then(|error| error.as_text())
+						.map(|raw| raw.text.as_str())
+						.unwrap_or("No error message returned");
+					return Err(McpToolError(error_msg.to_string()).into());
+				};
 
-                Ok(result
-                    .content
-                    .into_iter()
-                    .flatten()
-                    .map(|c| match c.raw {
-                        rmcp::model::RawContent::Text(raw) => raw.text,
-                        rmcp::model::RawContent::Image(raw) => {
-                            format!("data:{};base64,{}", raw.mime_type, raw.data)
-                        }
-                        rmcp::model::RawContent::Resource(raw) => match raw.resource {
-                            rmcp::model::ResourceContents::TextResourceContents {
-                                uri,
-                                mime_type,
-                                text,
-                            } => {
-                                format!(
-                                    "{mime_type}{uri}:{text}",
-                                    mime_type = mime_type
-                                        .map(|m| format!("data:{m};"))
-                                        .unwrap_or_default(),
-                                )
-                            }
-                            rmcp::model::ResourceContents::BlobResourceContents {
-                                uri,
-                                mime_type,
-                                blob,
-                            } => format!(
-                                "{mime_type}{uri}:{blob}",
-                                mime_type = mime_type
-                                    .map(|m| format!("data:{m};"))
-                                    .unwrap_or_default(),
-                            ),
-                        },
-                        RawContent::Audio(_) => {
-                            unimplemented!("Support for audio results from an MCP tool is currently unimplemented. Come back later!")
-                        }
-                    })
-                    .collect::<String>())
-            })
-        }
-    }
+				Ok(result
+					.content
+					.into_iter()
+					.flatten()
+					.map(|c| match c.raw {
+						rmcp::model::RawContent::Text(raw) => raw.text,
+						rmcp::model::RawContent::Image(raw) => {
+							format!("data:{};base64,{}", raw.mime_type, raw.data)
+						}
+						rmcp::model::RawContent::Resource(raw) => match raw.resource {
+							rmcp::model::ResourceContents::TextResourceContents {
+								uri,
+								mime_type,
+								text,
+							} => {
+								format!(
+									"{mime_type}{uri}:{text}",
+									mime_type = mime_type
+										.map(|m| format!("data:{m};"))
+										.unwrap_or_default(),
+								)
+							}
+							rmcp::model::ResourceContents::BlobResourceContents {
+								uri,
+								mime_type,
+								blob,
+							} => format!(
+								"{mime_type}{uri}:{blob}",
+								mime_type = mime_type
+									.map(|m| format!("data:{m};"))
+									.unwrap_or_default(),
+							),
+						},
+						RawContent::Audio(_) => {
+							unimplemented!("Support for audio results from an MCP tool is currently unimplemented. Come back later!")
+						}
+					})
+					.collect::<String>())
+			})
+		}
+	}
 }
 
 /// Wrapper trait to allow for dynamic dispatch of raggable tools
 pub trait ToolEmbeddingDyn: ToolDyn {
-    fn context(&self) -> serde_json::Result<serde_json::Value>;
+	fn context(&self) -> serde_json::Result<serde_json::Value>;
 
-    fn embedding_docs(&self) -> Vec<String>;
+	fn embedding_docs(&self) -> Vec<String>;
 }
 
 impl<T> ToolEmbeddingDyn for T
 where
-    T: ToolEmbedding,
+	T: ToolEmbedding,
 {
-    fn context(&self) -> serde_json::Result<serde_json::Value> {
-        serde_json::to_value(self.context())
-    }
+	fn context(&self) -> serde_json::Result<serde_json::Value> {
+		serde_json::to_value(self.context())
+	}
 
-    fn embedding_docs(&self) -> Vec<String> {
-        self.embedding_docs()
-    }
+	fn embedding_docs(&self) -> Vec<String> {
+		self.embedding_docs()
+	}
 }
 
 pub(crate) enum ToolType {
-    Simple(Box<dyn ToolDyn>),
-    Embedding(Box<dyn ToolEmbeddingDyn>),
+	Simple(Box<dyn ToolDyn>),
+	Embedding(Box<dyn ToolEmbeddingDyn>),
 }
 
 impl ToolType {
-    pub fn name(&self) -> String {
-        match self {
-            ToolType::Simple(tool) => tool.name(),
-            ToolType::Embedding(tool) => tool.name(),
-        }
-    }
+	pub fn name(&self) -> String {
+		match self {
+			ToolType::Simple(tool) => tool.name(),
+			ToolType::Embedding(tool) => tool.name(),
+		}
+	}
 
-    pub async fn definition(&self, prompt: String) -> ToolDefinition {
-        match self {
-            ToolType::Simple(tool) => tool.definition(prompt).await,
-            ToolType::Embedding(tool) => tool.definition(prompt).await,
-        }
-    }
+	pub async fn definition(&self, prompt: String) -> ToolDefinition {
+		match self {
+			ToolType::Simple(tool) => tool.definition(prompt).await,
+			ToolType::Embedding(tool) => tool.definition(prompt).await,
+		}
+	}
 
-    pub async fn call(&self, args: String) -> Result<String, ToolError> {
-        match self {
-            ToolType::Simple(tool) => tool.call(args).await,
-            ToolType::Embedding(tool) => tool.call(args).await,
-        }
-    }
+	pub async fn call(&self, args: String) -> Result<String, ToolError> {
+		match self {
+			ToolType::Simple(tool) => tool.call(args).await,
+			ToolType::Embedding(tool) => tool.call(args).await,
+		}
+	}
 }
 
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum ToolSetError {
-    /// Error returned by the tool
-    #[error("ToolCallError: {0}")]
-    ToolCallError(#[from] ToolError),
+	/// Error returned by the tool
+	#[error("ToolCallError: {0}")]
+	ToolCallError(#[from] ToolError),
 
-    #[error("ToolNotFoundError: {0}")]
-    ToolNotFoundError(String),
+	#[error("ToolNotFoundError: {0}")]
+	ToolNotFoundError(String),
 
-    // TODO: Revisit this
-    #[error("JsonError: {0}")]
-    JsonError(#[from] serde_json::Error),
+	// TODO: Revisit this
+	#[error("JsonError: {0}")]
+	JsonError(#[from] serde_json::Error),
 }
 
 /// A struct that holds a set of tools
 #[derive(Default)]
 pub struct ToolSet {
-    pub(crate) tools: HashMap<String, ToolType>,
+	pub(crate) tools: HashMap<String, ToolType>,
 }
 
 impl ToolSet {
-    /// Create a new ToolSet from a list of tools
-    pub fn from_tools(tools: Vec<impl ToolDyn + 'static>) -> Self {
-        let mut toolset = Self::default();
-        tools.into_iter().for_each(|tool| {
-            toolset.add_tool(tool);
-        });
-        toolset
-    }
+	/// Create a new ToolSet from a list of tools
+	pub fn from_tools(tools: Vec<impl ToolDyn + 'static>) -> Self {
+		let mut toolset = Self::default();
+		tools.into_iter().for_each(|tool| {
+			toolset.add_tool(tool);
+		});
+		toolset
+	}
 
-    /// Create a toolset builder
-    pub fn builder() -> ToolSetBuilder {
-        ToolSetBuilder::default()
-    }
+	/// Create a toolset builder
+	pub fn builder() -> ToolSetBuilder {
+		ToolSetBuilder::default()
+	}
 
-    /// Check if the toolset contains a tool with the given name
-    pub fn contains(&self, toolname: &str) -> bool {
-        self.tools.contains_key(toolname)
-    }
+	/// Check if the toolset contains a tool with the given name
+	pub fn contains(&self, toolname: &str) -> bool {
+		self.tools.contains_key(toolname)
+	}
 
-    /// Add a tool to the toolset
-    pub fn add_tool(&mut self, tool: impl ToolDyn + 'static) {
-        self.tools
-            .insert(tool.name(), ToolType::Simple(Box::new(tool)));
-    }
+	/// Add a tool to the toolset
+	pub fn add_tool(&mut self, tool: impl ToolDyn + 'static) {
+		self.tools
+		    .insert(tool.name(), ToolType::Simple(Box::new(tool)));
+	}
 
-    pub fn delete_tool(&mut self, tool_name: &str) {
-        let _ = self.tools.remove(tool_name);
-    }
+	pub fn delete_tool(&mut self, tool_name: &str) {
+		let _ = self.tools.remove(tool_name);
+	}
 
-    /// Merge another toolset into this one
-    pub fn add_tools(&mut self, toolset: ToolSet) {
-        self.tools.extend(toolset.tools);
-    }
+	/// Merge another toolset into this one
+	pub fn add_tools(&mut self, toolset: ToolSet) {
+		self.tools.extend(toolset.tools);
+	}
 
-    pub(crate) fn get(&self, toolname: &str) -> Option<&ToolType> {
-        self.tools.get(toolname)
-    }
+	pub(crate) fn get(&self, toolname: &str) -> Option<&ToolType> {
+		self.tools.get(toolname)
+	}
 
-    pub async fn get_tool_definitions(&self) -> Result<Vec<ToolDefinition>, ToolSetError> {
-        let mut defs = Vec::new();
-        for tool in self.tools.values() {
-            let def = tool.definition(String::new()).await;
-            defs.push(def);
-        }
-        Ok(defs)
-    }
+	pub async fn get_tool_definitions(&self) -> Result<Vec<ToolDefinition>, ToolSetError> {
+		let mut defs = Vec::new();
+		for tool in self.tools.values() {
+			let def = tool.definition(String::new()).await;
+			defs.push(def);
+		}
+		Ok(defs)
+	}
 
-    /// Call a tool with the given name and arguments
-    pub async fn call(&self, toolname: &str, args: String) -> Result<String, ToolSetError> {
-        if let Some(tool) = self.tools.get(toolname) {
-            tracing::info!(target: "rig",
+	/// Call a tool with the given name and arguments
+	pub async fn call(&self, toolname: &str, args: String) -> Result<String, ToolSetError> {
+		if let Some(tool) = self.tools.get(toolname) {
+			tracing::info!(target: "rig",
                 "Calling tool {toolname} with args:\n{}",
                 serde_json::to_string_pretty(&args).unwrap()
             );
-            Ok(tool.call(args).await?)
-        } else {
-            Err(ToolSetError::ToolNotFoundError(toolname.to_string()))
-        }
-    }
+			Ok(tool.call(args).await?)
+		} else {
+			Err(ToolSetError::ToolNotFoundError(toolname.to_string()))
+		}
+	}
 
-    /// Get the documents of all the tools in the toolset
-    pub async fn documents(&self) -> Result<Vec<completion::Document>, ToolSetError> {
-        let mut docs = Vec::new();
-        for tool in self.tools.values() {
-            match tool {
-                ToolType::Simple(tool) => {
-                    docs.push(completion::Document {
-                        id: tool.name(),
-                        text: format!(
-                            "\
+	/// Get the documents of all the tools in the toolset
+	pub async fn documents(&self) -> Result<Vec<completion::Document>, ToolSetError> {
+		let mut docs = Vec::new();
+		for tool in self.tools.values() {
+			match tool {
+				ToolType::Simple(tool) => {
+					docs.push(completion::Document {
+						id: tool.name(),
+						text: format!(
+							"\
                             Tool: {}\n\
                             Definition: \n\
                             {}\
                         ",
-                            tool.name(),
-                            serde_json::to_string_pretty(&tool.definition("".to_string()).await)?
-                        ),
-                        additional_props: HashMap::new(),
-                    });
-                }
-                ToolType::Embedding(tool) => {
-                    docs.push(completion::Document {
-                        id: tool.name(),
-                        text: format!(
-                            "\
+							tool.name(),
+							serde_json::to_string_pretty(&tool.definition("".to_string()).await)?
+						),
+						additional_props: HashMap::new(),
+					});
+				}
+				ToolType::Embedding(tool) => {
+					docs.push(completion::Document {
+						id: tool.name(),
+						text: format!(
+							"\
                             Tool: {}\n\
                             Definition: \n\
                             {}\
                         ",
-                            tool.name(),
-                            serde_json::to_string_pretty(&tool.definition("".to_string()).await)?
-                        ),
-                        additional_props: HashMap::new(),
-                    });
-                }
-            }
-        }
-        Ok(docs)
-    }
+							tool.name(),
+							serde_json::to_string_pretty(&tool.definition("".to_string()).await)?
+						),
+						additional_props: HashMap::new(),
+					});
+				}
+			}
+		}
+		Ok(docs)
+	}
 
-    /// Convert tools in self to objects of type ToolSchema.
-    /// This is necessary because when adding tools to the EmbeddingBuilder because all
-    /// documents added to the builder must all be of the same type.
-    pub fn schemas(&self) -> Result<Vec<ToolSchema>, EmbedError> {
-        self.tools
-            .values()
-            .filter_map(|tool_type| {
-                if let ToolType::Embedding(tool) = tool_type {
-                    Some(ToolSchema::try_from(&**tool))
-                } else {
-                    None
-                }
-            })
-            .collect::<Result<Vec<_>, _>>()
-    }
+	/// Convert tools in self to objects of type ToolSchema.
+	/// This is necessary because when adding tools to the EmbeddingBuilder because all
+	/// documents added to the builder must all be of the same type.
+	pub fn schemas(&self) -> Result<Vec<ToolSchema>, EmbedError> {
+		self.tools
+		    .values()
+		    .filter_map(|tool_type| {
+			    if let ToolType::Embedding(tool) = tool_type {
+				    Some(ToolSchema::try_from(&**tool))
+			    } else {
+				    None
+			    }
+		    })
+		    .collect::<Result<Vec<_>, _>>()
+	}
 }
 
 #[derive(Default)]
+#[non_exhaustive]
 pub struct ToolSetBuilder {
-    tools: Vec<ToolType>,
+	tools: Vec<ToolType>,
 }
 
 impl ToolSetBuilder {
-    pub fn static_tool(mut self, tool: impl ToolDyn + 'static) -> Self {
-        self.tools.push(ToolType::Simple(Box::new(tool)));
-        self
-    }
+	pub fn static_tool(mut self, tool: impl ToolDyn + 'static) -> Self {
+		self.tools.push(ToolType::Simple(Box::new(tool)));
+		self
+	}
 
-    pub fn dynamic_tool(mut self, tool: impl ToolEmbeddingDyn + 'static) -> Self {
-        self.tools.push(ToolType::Embedding(Box::new(tool)));
-        self
-    }
+	pub fn dynamic_tool(mut self, tool: impl ToolEmbeddingDyn + 'static) -> Self {
+		self.tools.push(ToolType::Embedding(Box::new(tool)));
+		self
+	}
 
-    pub fn build(self) -> ToolSet {
-        ToolSet {
-            tools: self
-                .tools
-                .into_iter()
-                .map(|tool| (tool.name(), tool))
-                .collect(),
-        }
-    }
+	pub fn build(self) -> ToolSet {
+		ToolSet {
+			tools: self
+				.tools
+				.into_iter()
+				.map(|tool| (tool.name(), tool))
+				.collect(),
+		}
+	}
 }
 
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
+	use serde_json::json;
 
-    use super::*;
+	use super::*;
 
-    fn get_test_toolset() -> ToolSet {
-        let mut toolset = ToolSet::default();
+	fn get_test_toolset() -> ToolSet {
+		let mut toolset = ToolSet::default();
 
-        #[derive(Deserialize)]
-        struct OperationArgs {
-            x: i32,
-            y: i32,
-        }
+		#[derive(Deserialize)]
+		struct OperationArgs {
+			x: i32,
+			y: i32,
+		}
 
-        #[derive(Debug, thiserror::Error)]
-        #[error("Math error")]
-        struct MathError;
+		#[derive(Debug, thiserror::Error)]
+		#[error("Math error")]
+		struct MathError;
 
-        #[derive(Deserialize, Serialize)]
-        struct Adder;
+		#[derive(Deserialize, Serialize)]
+		struct Adder;
 
-        impl Tool for Adder {
-            const NAME: &'static str = "add";
-            type Error = MathError;
-            type Args = OperationArgs;
-            type Output = i32;
+		impl Tool for Adder {
+			const NAME: &'static str = "add";
+			type Error = MathError;
+			type Args = OperationArgs;
+			type Output = i32;
 
-            async fn definition(&self, _prompt: String) -> ToolDefinition {
-                ToolDefinition {
-                    name: "add".to_string(),
-                    description: "Add x and y together".to_string(),
-                    parameters: json!({
+			async fn definition(&self, _prompt: String) -> ToolDefinition {
+				ToolDefinition {
+					name: "add".to_string(),
+					description: "Add x and y together".to_string(),
+					parameters: json!({
                         "type": "object",
                         "properties": {
                             "x": {
@@ -590,26 +593,26 @@ mod tests {
                         },
                         "required": ["x", "y"]
                     }),
-                }
-            }
+				}
+			}
 
-            async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
-                let result = args.x + args.y;
-                Ok(result)
-            }
-        }
+			async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+				let result = args.x + args.y;
+				Ok(result)
+			}
+		}
 
-        #[derive(Deserialize, Serialize)]
-        struct Subtract;
+		#[derive(Deserialize, Serialize)]
+		struct Subtract;
 
-        impl Tool for Subtract {
-            const NAME: &'static str = "subtract";
-            type Error = MathError;
-            type Args = OperationArgs;
-            type Output = i32;
+		impl Tool for Subtract {
+			const NAME: &'static str = "subtract";
+			type Error = MathError;
+			type Args = OperationArgs;
+			type Output = i32;
 
-            async fn definition(&self, _prompt: String) -> ToolDefinition {
-                serde_json::from_value(json!({
+			async fn definition(&self, _prompt: String) -> ToolDefinition {
+				serde_json::from_value(json!({
                     "name": "subtract",
                     "description": "Subtract y from x (i.e.: x - y)",
                     "parameters": {
@@ -627,33 +630,33 @@ mod tests {
                         "required": ["x", "y"]
                     }
                 }))
-                .expect("Tool Definition")
-            }
+					.expect("Tool Definition")
+			}
 
-            async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
-                let result = args.x - args.y;
-                Ok(result)
-            }
-        }
+			async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+				let result = args.x - args.y;
+				Ok(result)
+			}
+		}
 
-        toolset.add_tool(Adder);
-        toolset.add_tool(Subtract);
-        toolset
-    }
+		toolset.add_tool(Adder);
+		toolset.add_tool(Subtract);
+		toolset
+	}
 
-    #[tokio::test]
-    async fn test_get_tool_definitions() {
-        let toolset = get_test_toolset();
-        let tools = toolset.get_tool_definitions().await.unwrap();
-        assert_eq!(tools.len(), 2);
-    }
+	#[tokio::test]
+	async fn test_get_tool_definitions() {
+		let toolset = get_test_toolset();
+		let tools = toolset.get_tool_definitions().await.unwrap();
+		assert_eq!(tools.len(), 2);
+	}
 
-    #[test]
-    fn test_tool_deletion() {
-        let mut toolset = get_test_toolset();
-        assert_eq!(toolset.tools.len(), 2);
-        toolset.delete_tool("add");
-        assert!(!toolset.contains("add"));
-        assert_eq!(toolset.tools.len(), 1);
-    }
+	#[test]
+	fn test_tool_deletion() {
+		let mut toolset = get_test_toolset();
+		assert_eq!(toolset.tools.len(), 2);
+		toolset.delete_tool("add");
+		assert!(!toolset.contains("add"));
+		assert_eq!(toolset.tools.len(), 1);
+	}
 }

--- a/rig-core/src/transcription.rs
+++ b/rig-core/src/transcription.rs
@@ -11,126 +11,129 @@ use thiserror::Error;
 
 // Errors
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum TranscriptionError {
-    /// Http error (e.g.: connection error, timeout, etc.)
-    #[error("HttpError: {0}")]
-    HttpError(#[from] reqwest::Error),
+	/// Http error (e.g.: connection error, timeout, etc.)
+	#[error("HttpError: {0}")]
+	HttpError(#[from] reqwest::Error),
 
-    /// Json error (e.g.: serialization, deserialization)
-    #[error("JsonError: {0}")]
-    JsonError(#[from] serde_json::Error),
+	/// Json error (e.g.: serialization, deserialization)
+	#[error("JsonError: {0}")]
+	JsonError(#[from] serde_json::Error),
 
-    /// Error building the transcription request
-    #[error("RequestError: {0}")]
-    RequestError(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
+	/// Error building the transcription request
+	#[error("RequestError: {0}")]
+	RequestError(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
 
-    /// Error parsing the transcription response
-    #[error("ResponseError: {0}")]
-    ResponseError(String),
+	/// Error parsing the transcription response
+	#[error("ResponseError: {0}")]
+	ResponseError(String),
 
-    /// Error returned by the transcription model provider
-    #[error("ProviderError: {0}")]
-    ProviderError(String),
+	/// Error returned by the transcription model provider
+	#[error("ProviderError: {0}")]
+	ProviderError(String),
 }
 
 /// Trait defining a low-level LLM transcription interface
 pub trait Transcription<M>
 where
-    M: TranscriptionModel,
+	M: TranscriptionModel,
 {
-    /// Generates a transcription request builder for the given `file`.
-    /// This function is meant to be called by the user to further customize the
-    /// request at transcription time before sending it.
-    ///
-    /// ❗IMPORTANT: The type that implements this trait might have already
-    /// populated fields in the builder (the exact fields depend on the type).
-    /// For fields that have already been set by the model, calling the corresponding
-    /// method on the builder will overwrite the value set by the model.
-    fn transcription(
-        &self,
-        filename: &str,
-        data: &[u8],
-    ) -> impl std::future::Future<
-        Output = Result<TranscriptionRequestBuilder<M>, TranscriptionError>,
-    > + Send;
+	/// Generates a transcription request builder for the given `file`.
+	/// This function is meant to be called by the user to further customize the
+	/// request at transcription time before sending it.
+	///
+	/// ❗IMPORTANT: The type that implements this trait might have already
+	/// populated fields in the builder (the exact fields depend on the type).
+	/// For fields that have already been set by the model, calling the corresponding
+	/// method on the builder will overwrite the value set by the model.
+	fn transcription(
+		&self,
+		filename: &str,
+		data: &[u8],
+	) -> impl std::future::Future<
+		Output=Result<TranscriptionRequestBuilder<M>, TranscriptionError>,
+	> + Send;
 }
 
 /// General transcription response struct that contains the transcription text
 /// and the raw response.
+// to add #[non_exhaustive] we will need to add a builder/new method
 pub struct TranscriptionResponse<T> {
-    pub text: String,
-    pub response: T,
+	pub text: String,
+	pub response: T,
 }
 
 /// Trait defining a transcription model that can be used to generate transcription requests.
 /// This trait is meant to be implemented by the user to define a custom transcription model,
 /// either from a third-party provider (e.g: OpenAI) or a local model.
 pub trait TranscriptionModel: Clone + Send + Sync {
-    /// The raw response type returned by the underlying model.
-    type Response: Sync + Send;
+	/// The raw response type returned by the underlying model.
+	type Response: Sync + Send;
 
-    /// Generates a completion response for the given transcription model
-    fn transcription(
-        &self,
-        request: TranscriptionRequest,
-    ) -> impl std::future::Future<
-        Output = Result<TranscriptionResponse<Self::Response>, TranscriptionError>,
-    > + Send;
+	/// Generates a completion response for the given transcription model
+	fn transcription(
+		&self,
+		request: TranscriptionRequest,
+	) -> impl std::future::Future<
+		Output=Result<TranscriptionResponse<Self::Response>, TranscriptionError>,
+	> + Send;
 
-    /// Generates a transcription request builder for the given `file`
-    fn transcription_request(&self) -> TranscriptionRequestBuilder<Self> {
-        TranscriptionRequestBuilder::new(self.clone())
-    }
+	/// Generates a transcription request builder for the given `file`
+	fn transcription_request(&self) -> TranscriptionRequestBuilder<Self> {
+		TranscriptionRequestBuilder::new(self.clone())
+	}
 }
 
 pub trait TranscriptionModelDyn: Send + Sync {
-    fn transcription(
-        &self,
-        request: TranscriptionRequest,
-    ) -> BoxFuture<'_, Result<TranscriptionResponse<()>, TranscriptionError>>;
+	fn transcription(
+		&self,
+		request: TranscriptionRequest,
+	) -> BoxFuture<'_, Result<TranscriptionResponse<()>, TranscriptionError>>;
 
-    fn transcription_request(&self) -> TranscriptionRequestBuilder<TranscriptionModelHandle<'_>>;
+	fn transcription_request(&self) -> TranscriptionRequestBuilder<TranscriptionModelHandle<'_>>;
 }
 
 impl<T> TranscriptionModelDyn for T
 where
-    T: TranscriptionModel,
+	T: TranscriptionModel,
 {
-    fn transcription(
-        &self,
-        request: TranscriptionRequest,
-    ) -> BoxFuture<'_, Result<TranscriptionResponse<()>, TranscriptionError>> {
-        Box::pin(async move {
-            let resp = self.transcription(request).await?;
+	fn transcription(
+		&self,
+		request: TranscriptionRequest,
+	) -> BoxFuture<'_, Result<TranscriptionResponse<()>, TranscriptionError>> {
+		Box::pin(async move {
+			let resp = self.transcription(request).await?;
 
-            Ok(TranscriptionResponse {
-                text: resp.text,
-                response: (),
-            })
-        })
-    }
+			Ok(TranscriptionResponse {
+				text: resp.text,
+				response: (),
+			})
+		})
+	}
 
-    fn transcription_request(&self) -> TranscriptionRequestBuilder<TranscriptionModelHandle<'_>> {
-        TranscriptionRequestBuilder::new(TranscriptionModelHandle {
-            inner: Arc::new(self.clone()),
-        })
-    }
+	fn transcription_request(&self) -> TranscriptionRequestBuilder<TranscriptionModelHandle<'_>> {
+		TranscriptionRequestBuilder::new(TranscriptionModelHandle {
+			inner: Arc::new(self.clone()),
+		})
+	}
 }
 
 /// Struct representing a general transcription request that can be sent to a transcription model provider.
+#[non_exhaustive]
 pub struct TranscriptionRequest {
-    /// The file data to be sent to the transcription model provider
-    pub data: Vec<u8>,
-    /// The file name to be used in the request
-    pub filename: String,
-    /// The language used in the response from the transcription model provider
-    pub language: String,
-    /// The prompt to be sent to the transcription model provider
-    pub prompt: Option<String>,
-    /// The temperature sent to the transcription model provider
-    pub temperature: Option<f64>,
-    /// Additional parameters to be sent to the transcription model provider
-    pub additional_params: Option<serde_json::Value>,
+	/// The file data to be sent to the transcription model provider
+	pub data: Vec<u8>,
+	/// The file name to be used in the request
+	pub filename: String,
+	/// The language used in the response from the transcription model provider
+	pub language: String,
+	/// The prompt to be sent to the transcription model provider
+	pub prompt: Option<String>,
+	/// The temperature sent to the transcription model provider
+	pub temperature: Option<f64>,
+	/// Additional parameters to be sent to the transcription model provider
+	pub additional_params: Option<serde_json::Value>,
 }
 
 /// Builder struct for a transcription request
@@ -175,122 +178,123 @@ pub struct TranscriptionRequest {
 ///
 /// Note: It is usually unnecessary to create a completion request builder directly.
 /// Instead, use the [TranscriptionModel::transcription_request] method.
+#[non_exhaustive]
 pub struct TranscriptionRequestBuilder<M>
 where
-    M: TranscriptionModel,
+	M: TranscriptionModel,
 {
-    model: M,
-    data: Vec<u8>,
-    filename: Option<String>,
-    language: String,
-    prompt: Option<String>,
-    temperature: Option<f64>,
-    additional_params: Option<serde_json::Value>,
+	model: M,
+	data: Vec<u8>,
+	filename: Option<String>,
+	language: String,
+	prompt: Option<String>,
+	temperature: Option<f64>,
+	additional_params: Option<serde_json::Value>,
 }
 
 impl<M> TranscriptionRequestBuilder<M>
 where
-    M: TranscriptionModel,
+	M: TranscriptionModel,
 {
-    pub fn new(model: M) -> Self {
-        TranscriptionRequestBuilder {
-            model,
-            data: vec![],
-            filename: None,
-            language: "en".to_string(),
-            prompt: None,
-            temperature: None,
-            additional_params: None,
-        }
-    }
+	pub fn new(model: M) -> Self {
+		TranscriptionRequestBuilder {
+			model,
+			data: vec![],
+			filename: None,
+			language: "en".to_string(),
+			prompt: None,
+			temperature: None,
+			additional_params: None,
+		}
+	}
 
-    pub fn filename(mut self, filename: Option<String>) -> Self {
-        self.filename = filename;
-        self
-    }
+	pub fn filename(mut self, filename: Option<String>) -> Self {
+		self.filename = filename;
+		self
+	}
 
-    /// Sets the data for the request
-    pub fn data(mut self, data: Vec<u8>) -> Self {
-        self.data = data;
-        self
-    }
+	/// Sets the data for the request
+	pub fn data(mut self, data: Vec<u8>) -> Self {
+		self.data = data;
+		self
+	}
 
-    /// Load the specified file into data
-    pub fn load_file<P>(self, path: P) -> Self
-    where
-        P: AsRef<Path>,
-    {
-        let path = path.as_ref();
-        let data = fs::read(path).expect("Failed to load audio file, file did not exist");
+	/// Load the specified file into data
+	pub fn load_file<P>(self, path: P) -> Self
+	where
+		P: AsRef<Path>,
+	{
+		let path = path.as_ref();
+		let data = fs::read(path).expect("Failed to load audio file, file did not exist");
 
-        self.filename(Some(
-            path.file_name()
-                .expect("Path was not a file")
-                .to_str()
-                .expect("Failed to convert filename to ascii")
-                .to_string(),
-        ))
-        .data(data)
-    }
+		self.filename(Some(
+			path.file_name()
+			    .expect("Path was not a file")
+			    .to_str()
+			    .expect("Failed to convert filename to ascii")
+			    .to_string(),
+		))
+		    .data(data)
+	}
 
-    /// Sets the output language for the transcription request
-    pub fn language(mut self, language: String) -> Self {
-        self.language = language;
-        self
-    }
+	/// Sets the output language for the transcription request
+	pub fn language(mut self, language: String) -> Self {
+		self.language = language;
+		self
+	}
 
-    /// Sets the prompt to be sent in the transcription request
-    pub fn prompt(mut self, prompt: String) -> Self {
-        self.prompt = Some(prompt);
-        self
-    }
+	/// Sets the prompt to be sent in the transcription request
+	pub fn prompt(mut self, prompt: String) -> Self {
+		self.prompt = Some(prompt);
+		self
+	}
 
-    /// Set the temperature to be sent in the transcription request
-    pub fn temperature(mut self, temperature: f64) -> Self {
-        self.temperature = Some(temperature);
-        self
-    }
+	/// Set the temperature to be sent in the transcription request
+	pub fn temperature(mut self, temperature: f64) -> Self {
+		self.temperature = Some(temperature);
+		self
+	}
 
-    /// Adds additional parameters to the transcription request.
-    pub fn additional_params(mut self, additional_params: serde_json::Value) -> Self {
-        match self.additional_params {
-            Some(params) => {
-                self.additional_params = Some(json_utils::merge(params, additional_params));
-            }
-            None => {
-                self.additional_params = Some(additional_params);
-            }
-        }
-        self
-    }
+	/// Adds additional parameters to the transcription request.
+	pub fn additional_params(mut self, additional_params: serde_json::Value) -> Self {
+		match self.additional_params {
+			Some(params) => {
+				self.additional_params = Some(json_utils::merge(params, additional_params));
+			}
+			None => {
+				self.additional_params = Some(additional_params);
+			}
+		}
+		self
+	}
 
-    /// Sets the additional parameters for the transcription request.
-    pub fn additional_params_opt(mut self, additional_params: Option<serde_json::Value>) -> Self {
-        self.additional_params = additional_params;
-        self
-    }
+	/// Sets the additional parameters for the transcription request.
+	pub fn additional_params_opt(mut self, additional_params: Option<serde_json::Value>) -> Self {
+		self.additional_params = additional_params;
+		self
+	}
 
-    /// Builds the transcription request
-    /// Panics if data is empty.
-    pub fn build(self) -> TranscriptionRequest {
-        if self.data.is_empty() {
-            panic!("Data cannot be empty!")
-        }
+	/// Builds the transcription request
+	/// Panics if data is empty.
+	pub fn build(self) -> TranscriptionRequest {
+		if self.data.is_empty() {
+			panic!("Data cannot be empty!")
+		}
 
-        TranscriptionRequest {
-            data: self.data,
-            filename: self.filename.unwrap_or("file".to_string()),
-            language: self.language,
-            prompt: self.prompt,
-            temperature: self.temperature,
-            additional_params: self.additional_params,
-        }
-    }
+		TranscriptionRequest {
+			data: self.data,
+			filename: self.filename.unwrap_or("file".to_string()),
+			language: self.language,
+			prompt: self.prompt,
+			temperature: self.temperature,
+			additional_params: self.additional_params,
+		}
+	}
 
-    /// Sends the transcription request to the transcription model provider and returns the transcription response
-    pub async fn send(self) -> Result<TranscriptionResponse<M::Response>, TranscriptionError> {
-        let model = self.model.clone();
+	/// Sends the transcription request to the transcription model provider and returns the transcription response
+	pub async fn send(self) -> Result<TranscriptionResponse<M::Response>, TranscriptionError> {
+		let model = self.model.clone();
 
-        model.transcription(self.build()).await
-    }
+		model.transcription(self.build()).await
+	}
 }

--- a/rig-core/src/vector_store/in_memory_store.rs
+++ b/rig-core/src/vector_store/in_memory_store.rs
@@ -7,93 +7,94 @@ use std::{
 use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
 
-use super::{VectorStoreError, VectorStoreIndex, request::VectorSearchRequest};
+use super::{request::VectorSearchRequest, VectorStoreError, VectorStoreIndex};
 use crate::{
+    embeddings::{distance::VectorDistance, Embedding, EmbeddingModel},
     OneOrMany,
-    embeddings::{Embedding, EmbeddingModel, distance::VectorDistance},
 };
 
 /// [InMemoryVectorStore] is a simple in-memory vector store that stores embeddings
 /// in-memory using a HashMap.
+#[non_exhaustive]
 #[derive(Clone, Default)]
 pub struct InMemoryVectorStore<D: Serialize> {
-    /// The embeddings are stored in a HashMap.
-    /// Hashmap key is the document id.
-    /// Hashmap value is a tuple of the serializable document and its corresponding embeddings.
-    embeddings: HashMap<String, (D, OneOrMany<Embedding>)>,
+	/// The embeddings are stored in a HashMap.
+	/// Hashmap key is the document id.
+	/// Hashmap value is a tuple of the serializable document and its corresponding embeddings.
+	embeddings: HashMap<String, (D, OneOrMany<Embedding>)>,
 }
 
 impl<D: Serialize + Eq> InMemoryVectorStore<D> {
-    /// Create a new [InMemoryVectorStore] from documents and their corresponding embeddings.
-    /// Ids are automatically generated have will have the form `"doc{n}"` where `n`
-    /// is the index of the document.
-    pub fn from_documents(documents: impl IntoIterator<Item = (D, OneOrMany<Embedding>)>) -> Self {
-        let mut store = HashMap::new();
-        documents
-            .into_iter()
-            .enumerate()
-            .for_each(|(i, (doc, embeddings))| {
-                store.insert(format!("doc{i}"), (doc, embeddings));
-            });
+	/// Create a new [InMemoryVectorStore] from documents and their corresponding embeddings.
+	/// Ids are automatically generated have will have the form `"doc{n}"` where `n`
+	/// is the index of the document.
+	pub fn from_documents(documents: impl IntoIterator<Item=(D, OneOrMany<Embedding>)>) -> Self {
+		let mut store = HashMap::new();
+		documents
+			.into_iter()
+			.enumerate()
+			.for_each(|(i, (doc, embeddings))| {
+				store.insert(format!("doc{i}"), (doc, embeddings));
+			});
 
-        Self { embeddings: store }
-    }
+		Self { embeddings: store }
+	}
 
-    /// Create a new [InMemoryVectorStore] from documents and their corresponding embeddings with ids.
-    pub fn from_documents_with_ids(
-        documents: impl IntoIterator<Item = (impl ToString, D, OneOrMany<Embedding>)>,
-    ) -> Self {
-        let mut store = HashMap::new();
-        documents.into_iter().for_each(|(i, doc, embeddings)| {
-            store.insert(i.to_string(), (doc, embeddings));
-        });
+	/// Create a new [InMemoryVectorStore] from documents and their corresponding embeddings with ids.
+	pub fn from_documents_with_ids(
+		documents: impl IntoIterator<Item=(impl ToString, D, OneOrMany<Embedding>)>,
+	) -> Self {
+		let mut store = HashMap::new();
+		documents.into_iter().for_each(|(i, doc, embeddings)| {
+			store.insert(i.to_string(), (doc, embeddings));
+		});
 
-        Self { embeddings: store }
-    }
+		Self { embeddings: store }
+	}
 
-    /// Create a new [InMemoryVectorStore] from documents and their corresponding embeddings.
-    /// Document ids are generated using the provided function.
-    pub fn from_documents_with_id_f(
-        documents: impl IntoIterator<Item = (D, OneOrMany<Embedding>)>,
-        f: fn(&D) -> String,
-    ) -> Self {
-        let mut store = HashMap::new();
-        documents.into_iter().for_each(|(doc, embeddings)| {
-            store.insert(f(&doc), (doc, embeddings));
-        });
+	/// Create a new [InMemoryVectorStore] from documents and their corresponding embeddings.
+	/// Document ids are generated using the provided function.
+	pub fn from_documents_with_id_f(
+		documents: impl IntoIterator<Item=(D, OneOrMany<Embedding>)>,
+		f: fn(&D) -> String,
+	) -> Self {
+		let mut store = HashMap::new();
+		documents.into_iter().for_each(|(doc, embeddings)| {
+			store.insert(f(&doc), (doc, embeddings));
+		});
 
-        Self { embeddings: store }
-    }
+		Self { embeddings: store }
+	}
 
-    /// Implement vector search on [InMemoryVectorStore].
-    /// To be used by implementations of [VectorStoreIndex::top_n] and [VectorStoreIndex::top_n_ids] methods.
-    fn vector_search(&self, prompt_embedding: &Embedding, n: usize) -> EmbeddingRanking<'_, D> {
-        // Sort documents by best embedding distance
-        let mut docs = BinaryHeap::new();
+	/// Implement vector search on [InMemoryVectorStore].
+	/// To be used by implementations of [VectorStoreIndex::top_n] and [VectorStoreIndex::top_n_ids] methods.
+	fn vector_search(&self, prompt_embedding: &Embedding, n: usize) -> EmbeddingRanking<'_, D> {
+		// Sort documents by best embedding distance
+		let mut docs = BinaryHeap::new();
 
-        for (id, (doc, embeddings)) in self.embeddings.iter() {
-            // Get the best context for the document given the prompt
-            if let Some((distance, embed_doc)) = embeddings
-                .iter()
-                .map(|embedding| {
-                    (
-                        OrderedFloat(embedding.cosine_similarity(prompt_embedding, false)),
-                        &embedding.document,
-                    )
-                })
-                .max_by(|a, b| a.0.cmp(&b.0))
-            {
-                docs.push(Reverse(RankingItem(distance, id, doc, embed_doc)));
-            };
+		for (id, (doc, embeddings)) in self.embeddings.iter() {
+			// Get the best context for the document given the prompt
+			if let Some((distance, embed_doc)) = embeddings
+				.iter()
+				.map(|embedding| {
+					(
+						OrderedFloat(embedding.cosine_similarity(prompt_embedding, false)),
+						&embedding.document,
+					)
+				})
+				.max_by(|a, b| a.0.cmp(&b.0))
+			{
+				docs.push(Reverse(RankingItem(distance, id, doc, embed_doc)));
+			};
 
-            // If the heap size exceeds n, pop the least old element.
-            if docs.len() > n {
-                docs.pop();
-            }
-        }
+			// If the heap size exceeds n, pop the least old element.
+			if docs.len() > n {
+				docs.pop();
+			}
+		}
 
-        // Log selected tools with their distances
-        tracing::info!(target: "rig",
+		// Log selected tools with their distances
+		tracing::info!(target: "rig",
             "Selected documents: {}",
             docs.iter()
                 .map(|Reverse(RankingItem(distance, id, _, _))| format!("{id} ({distance})"))
@@ -101,60 +102,60 @@ impl<D: Serialize + Eq> InMemoryVectorStore<D> {
                 .join(", ")
         );
 
-        docs
-    }
+		docs
+	}
 
-    /// Add documents and their corresponding embeddings to the store.
-    /// Ids are automatically generated have will have the form `"doc{n}"` where `n`
-    /// is the index of the document.
-    pub fn add_documents(
-        &mut self,
-        documents: impl IntoIterator<Item = (D, OneOrMany<Embedding>)>,
-    ) {
-        let current_index = self.embeddings.len();
-        documents
-            .into_iter()
-            .enumerate()
-            .for_each(|(index, (doc, embeddings))| {
-                self.embeddings
-                    .insert(format!("doc{}", index + current_index), (doc, embeddings));
-            });
-    }
+	/// Add documents and their corresponding embeddings to the store.
+	/// Ids are automatically generated have will have the form `"doc{n}"` where `n`
+	/// is the index of the document.
+	pub fn add_documents(
+		&mut self,
+		documents: impl IntoIterator<Item=(D, OneOrMany<Embedding>)>,
+	) {
+		let current_index = self.embeddings.len();
+		documents
+			.into_iter()
+			.enumerate()
+			.for_each(|(index, (doc, embeddings))| {
+				self.embeddings
+				    .insert(format!("doc{}", index + current_index), (doc, embeddings));
+			});
+	}
 
-    /// Add documents and their corresponding embeddings to the store with ids.
-    pub fn add_documents_with_ids(
-        &mut self,
-        documents: impl IntoIterator<Item = (impl ToString, D, OneOrMany<Embedding>)>,
-    ) {
-        documents.into_iter().for_each(|(id, doc, embeddings)| {
-            self.embeddings.insert(id.to_string(), (doc, embeddings));
-        });
-    }
+	/// Add documents and their corresponding embeddings to the store with ids.
+	pub fn add_documents_with_ids(
+		&mut self,
+		documents: impl IntoIterator<Item=(impl ToString, D, OneOrMany<Embedding>)>,
+	) {
+		documents.into_iter().for_each(|(id, doc, embeddings)| {
+			self.embeddings.insert(id.to_string(), (doc, embeddings));
+		});
+	}
 
-    /// Add documents and their corresponding embeddings to the store.
-    /// Document ids are generated using the provided function.
-    pub fn add_documents_with_id_f(
-        &mut self,
-        documents: Vec<(D, OneOrMany<Embedding>)>,
-        f: fn(&D) -> String,
-    ) {
-        for (doc, embeddings) in documents {
-            let id = f(&doc);
-            self.embeddings.insert(id, (doc, embeddings));
-        }
-    }
+	/// Add documents and their corresponding embeddings to the store.
+	/// Document ids are generated using the provided function.
+	pub fn add_documents_with_id_f(
+		&mut self,
+		documents: Vec<(D, OneOrMany<Embedding>)>,
+		f: fn(&D) -> String,
+	) {
+		for (doc, embeddings) in documents {
+			let id = f(&doc);
+			self.embeddings.insert(id, (doc, embeddings));
+		}
+	}
 
-    /// Get the document by its id and deserialize it into the given type.
-    pub fn get_document<T: for<'a> Deserialize<'a>>(
-        &self,
-        id: &str,
-    ) -> Result<Option<T>, VectorStoreError> {
-        Ok(self
-            .embeddings
-            .get(id)
-            .map(|(doc, _)| serde_json::from_str(&serde_json::to_string(doc)?))
-            .transpose()?)
-    }
+	/// Get the document by its id and deserialize it into the given type.
+	pub fn get_document<T: for<'a> Deserialize<'a>>(
+		&self,
+		id: &str,
+	) -> Result<Option<T>, VectorStoreError> {
+		Ok(self
+			.embeddings
+			.get(id)
+			.map(|(doc, _)| serde_json::from_str(&serde_json::to_string(doc)?))
+			.transpose()?)
+	}
 }
 
 /// RankingItem(distance, document_id, serializable document, embeddings document)
@@ -162,346 +163,346 @@ impl<D: Serialize + Eq> InMemoryVectorStore<D> {
 struct RankingItem<'a, D: Serialize>(OrderedFloat<f64>, &'a String, &'a D, &'a String);
 
 impl<D: Serialize + Eq> Ord for RankingItem<'_, D> {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.0.cmp(&other.0)
-    }
+	fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+		self.0.cmp(&other.0)
+	}
 }
 
 impl<D: Serialize + Eq> PartialOrd for RankingItem<'_, D> {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
+	fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+		Some(self.cmp(other))
+	}
 }
 
 type EmbeddingRanking<'a, D> = BinaryHeap<Reverse<RankingItem<'a, D>>>;
 
 impl<D: Serialize> InMemoryVectorStore<D> {
-    pub fn index<M: EmbeddingModel>(self, model: M) -> InMemoryVectorIndex<M, D> {
-        InMemoryVectorIndex::new(model, self)
-    }
+	pub fn index<M: EmbeddingModel>(self, model: M) -> InMemoryVectorIndex<M, D> {
+		InMemoryVectorIndex::new(model, self)
+	}
 
-    pub fn iter(&self) -> impl Iterator<Item = (&String, &(D, OneOrMany<Embedding>))> {
-        self.embeddings.iter()
-    }
+	pub fn iter(&self) -> impl Iterator<Item=(&String, &(D, OneOrMany<Embedding>))> {
+		self.embeddings.iter()
+	}
 
-    pub fn len(&self) -> usize {
-        self.embeddings.len()
-    }
+	pub fn len(&self) -> usize {
+		self.embeddings.len()
+	}
 
-    pub fn is_empty(&self) -> bool {
-        self.embeddings.is_empty()
-    }
+	pub fn is_empty(&self) -> bool {
+		self.embeddings.is_empty()
+	}
 }
-
+#[non_exhaustive]
 pub struct InMemoryVectorIndex<M: EmbeddingModel, D: Serialize> {
-    model: M,
-    pub store: InMemoryVectorStore<D>,
+	model: M,
+	pub store: InMemoryVectorStore<D>,
 }
 
 impl<M: EmbeddingModel, D: Serialize> InMemoryVectorIndex<M, D> {
-    pub fn new(model: M, store: InMemoryVectorStore<D>) -> Self {
-        Self { model, store }
-    }
+	pub fn new(model: M, store: InMemoryVectorStore<D>) -> Self {
+		Self { model, store }
+	}
 
-    pub fn iter(&self) -> impl Iterator<Item = (&String, &(D, OneOrMany<Embedding>))> {
-        self.store.iter()
-    }
+	pub fn iter(&self) -> impl Iterator<Item=(&String, &(D, OneOrMany<Embedding>))> {
+		self.store.iter()
+	}
 
-    pub fn len(&self) -> usize {
-        self.store.len()
-    }
+	pub fn len(&self) -> usize {
+		self.store.len()
+	}
 
-    pub fn is_empty(&self) -> bool {
-        self.store.is_empty()
-    }
+	pub fn is_empty(&self) -> bool {
+		self.store.is_empty()
+	}
 }
 
 impl<M: EmbeddingModel + Sync, D: Serialize + Sync + Send + Eq> VectorStoreIndex
-    for InMemoryVectorIndex<M, D>
+for InMemoryVectorIndex<M, D>
 {
-    async fn top_n<T: for<'a> Deserialize<'a>>(
-        &self,
-        req: VectorSearchRequest,
-    ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {
-        let prompt_embedding = &self.model.embed_text(req.query()).await?;
+	async fn top_n<T: for<'a> Deserialize<'a>>(
+		&self,
+		req: VectorSearchRequest,
+	) -> Result<Vec<(f64, String, T)>, VectorStoreError> {
+		let prompt_embedding = &self.model.embed_text(req.query()).await?;
 
-        let docs = self
-            .store
-            .vector_search(prompt_embedding, req.samples() as usize);
+		let docs = self
+			.store
+			.vector_search(prompt_embedding, req.samples() as usize);
 
-        // Return n best
-        docs.into_iter()
-            // The distance should always be between 0 and 1, so distance should be fine to use as an absolute value
-            .map(|Reverse(RankingItem(distance, id, doc, _))| {
-                Ok((
-                    distance.0,
-                    id.clone(),
-                    serde_json::from_str(
-                        &serde_json::to_string(doc).map_err(VectorStoreError::JsonError)?,
-                    )
-                    .map_err(VectorStoreError::JsonError)?,
-                ))
-            })
-            .collect::<Result<Vec<_>, _>>()
-    }
+		// Return n best
+		docs.into_iter()
+			// The distance should always be between 0 and 1, so distance should be fine to use as an absolute value
+			.map(|Reverse(RankingItem(distance, id, doc, _))| {
+				Ok((
+					distance.0,
+					id.clone(),
+					serde_json::from_str(
+						&serde_json::to_string(doc).map_err(VectorStoreError::JsonError)?,
+					)
+						.map_err(VectorStoreError::JsonError)?,
+				))
+			})
+		    .collect::<Result<Vec<_>, _>>()
+	}
 
-    async fn top_n_ids(
-        &self,
-        req: VectorSearchRequest,
-    ) -> Result<Vec<(f64, String)>, VectorStoreError> {
-        let prompt_embedding = &self.model.embed_text(req.query()).await?;
+	async fn top_n_ids(
+		&self,
+		req: VectorSearchRequest,
+	) -> Result<Vec<(f64, String)>, VectorStoreError> {
+		let prompt_embedding = &self.model.embed_text(req.query()).await?;
 
-        let docs = self
-            .store
-            .vector_search(prompt_embedding, req.samples() as usize);
+		let docs = self
+			.store
+			.vector_search(prompt_embedding, req.samples() as usize);
 
-        docs.into_iter()
-            .map(|Reverse(RankingItem(distance, id, _, _))| Ok((distance.0, id.clone())))
-            .collect::<Result<Vec<_>, _>>()
-    }
+		docs.into_iter()
+		    .map(|Reverse(RankingItem(distance, id, _, _))| Ok((distance.0, id.clone())))
+		    .collect::<Result<Vec<_>, _>>()
+	}
 }
 
 #[cfg(test)]
 mod tests {
     use std::cmp::Reverse;
 
-    use crate::{OneOrMany, embeddings::embedding::Embedding};
+    use crate::{embeddings::embedding::Embedding, OneOrMany};
 
     use super::{InMemoryVectorStore, RankingItem};
 
     #[test]
-    fn test_auto_ids() {
-        let mut vector_store = InMemoryVectorStore::from_documents(vec![
-            (
-                "glarb-garb",
-                OneOrMany::one(Embedding {
-                    document: "glarb-garb".to_string(),
-                    vec: vec![0.1, 0.1, 0.5],
-                }),
-            ),
-            (
-                "marble-marble",
-                OneOrMany::one(Embedding {
-                    document: "marble-marble".to_string(),
-                    vec: vec![0.7, -0.3, 0.0],
-                }),
-            ),
-            (
-                "flumb-flumb",
-                OneOrMany::one(Embedding {
-                    document: "flumb-flumb".to_string(),
-                    vec: vec![0.3, 0.7, 0.1],
-                }),
-            ),
-        ]);
+	fn test_auto_ids() {
+		let mut vector_store = InMemoryVectorStore::from_documents(vec![
+			(
+				"glarb-garb",
+				OneOrMany::one(Embedding {
+					document: "glarb-garb".to_string(),
+					vec: vec![0.1, 0.1, 0.5],
+				}),
+			),
+			(
+				"marble-marble",
+				OneOrMany::one(Embedding {
+					document: "marble-marble".to_string(),
+					vec: vec![0.7, -0.3, 0.0],
+				}),
+			),
+			(
+				"flumb-flumb",
+				OneOrMany::one(Embedding {
+					document: "flumb-flumb".to_string(),
+					vec: vec![0.3, 0.7, 0.1],
+				}),
+			),
+		]);
 
-        vector_store.add_documents(vec![
-            (
-                "brotato",
-                OneOrMany::one(Embedding {
-                    document: "brotato".to_string(),
-                    vec: vec![0.3, 0.7, 0.1],
-                }),
-            ),
-            (
-                "ping-pong",
-                OneOrMany::one(Embedding {
-                    document: "ping-pong".to_string(),
-                    vec: vec![0.7, -0.3, 0.0],
-                }),
-            ),
-        ]);
+		vector_store.add_documents(vec![
+			(
+				"brotato",
+				OneOrMany::one(Embedding {
+					document: "brotato".to_string(),
+					vec: vec![0.3, 0.7, 0.1],
+				}),
+			),
+			(
+				"ping-pong",
+				OneOrMany::one(Embedding {
+					document: "ping-pong".to_string(),
+					vec: vec![0.7, -0.3, 0.0],
+				}),
+			),
+		]);
 
-        let mut store = vector_store.embeddings.into_iter().collect::<Vec<_>>();
-        store.sort_by_key(|(id, _)| id.clone());
+		let mut store = vector_store.embeddings.into_iter().collect::<Vec<_>>();
+		store.sort_by_key(|(id, _)| id.clone());
 
-        assert_eq!(
-            store,
-            vec![
-                (
-                    "doc0".to_string(),
-                    (
-                        "glarb-garb",
-                        OneOrMany::one(Embedding {
-                            document: "glarb-garb".to_string(),
-                            vec: vec![0.1, 0.1, 0.5],
-                        })
-                    )
-                ),
-                (
-                    "doc1".to_string(),
-                    (
-                        "marble-marble",
-                        OneOrMany::one(Embedding {
-                            document: "marble-marble".to_string(),
-                            vec: vec![0.7, -0.3, 0.0],
-                        })
-                    )
-                ),
-                (
-                    "doc2".to_string(),
-                    (
-                        "flumb-flumb",
-                        OneOrMany::one(Embedding {
-                            document: "flumb-flumb".to_string(),
-                            vec: vec![0.3, 0.7, 0.1],
-                        })
-                    )
-                ),
-                (
-                    "doc3".to_string(),
-                    (
-                        "brotato",
-                        OneOrMany::one(Embedding {
-                            document: "brotato".to_string(),
-                            vec: vec![0.3, 0.7, 0.1],
-                        })
-                    )
-                ),
-                (
-                    "doc4".to_string(),
-                    (
-                        "ping-pong",
-                        OneOrMany::one(Embedding {
-                            document: "ping-pong".to_string(),
-                            vec: vec![0.7, -0.3, 0.0],
-                        })
-                    )
-                )
-            ]
-        );
-    }
+		assert_eq!(
+			store,
+			vec![
+				(
+					"doc0".to_string(),
+					(
+						"glarb-garb",
+						OneOrMany::one(Embedding {
+							document: "glarb-garb".to_string(),
+							vec: vec![0.1, 0.1, 0.5],
+						})
+					)
+				),
+				(
+					"doc1".to_string(),
+					(
+						"marble-marble",
+						OneOrMany::one(Embedding {
+							document: "marble-marble".to_string(),
+							vec: vec![0.7, -0.3, 0.0],
+						})
+					)
+				),
+				(
+					"doc2".to_string(),
+					(
+						"flumb-flumb",
+						OneOrMany::one(Embedding {
+							document: "flumb-flumb".to_string(),
+							vec: vec![0.3, 0.7, 0.1],
+						})
+					)
+				),
+				(
+					"doc3".to_string(),
+					(
+						"brotato",
+						OneOrMany::one(Embedding {
+							document: "brotato".to_string(),
+							vec: vec![0.3, 0.7, 0.1],
+						})
+					)
+				),
+				(
+					"doc4".to_string(),
+					(
+						"ping-pong",
+						OneOrMany::one(Embedding {
+							document: "ping-pong".to_string(),
+							vec: vec![0.7, -0.3, 0.0],
+						})
+					)
+				)
+			]
+		);
+	}
 
-    #[test]
-    fn test_single_embedding() {
-        let vector_store = InMemoryVectorStore::from_documents_with_ids(vec![
-            (
-                "doc1",
-                "glarb-garb",
-                OneOrMany::one(Embedding {
-                    document: "glarb-garb".to_string(),
-                    vec: vec![0.1, 0.1, 0.5],
-                }),
-            ),
-            (
-                "doc2",
-                "marble-marble",
-                OneOrMany::one(Embedding {
-                    document: "marble-marble".to_string(),
-                    vec: vec![0.7, -0.3, 0.0],
-                }),
-            ),
-            (
-                "doc3",
-                "flumb-flumb",
-                OneOrMany::one(Embedding {
-                    document: "flumb-flumb".to_string(),
-                    vec: vec![0.3, 0.7, 0.1],
-                }),
-            ),
-        ]);
+	#[test]
+	fn test_single_embedding() {
+		let vector_store = InMemoryVectorStore::from_documents_with_ids(vec![
+			(
+				"doc1",
+				"glarb-garb",
+				OneOrMany::one(Embedding {
+					document: "glarb-garb".to_string(),
+					vec: vec![0.1, 0.1, 0.5],
+				}),
+			),
+			(
+				"doc2",
+				"marble-marble",
+				OneOrMany::one(Embedding {
+					document: "marble-marble".to_string(),
+					vec: vec![0.7, -0.3, 0.0],
+				}),
+			),
+			(
+				"doc3",
+				"flumb-flumb",
+				OneOrMany::one(Embedding {
+					document: "flumb-flumb".to_string(),
+					vec: vec![0.3, 0.7, 0.1],
+				}),
+			),
+		]);
 
-        let ranking = vector_store.vector_search(
-            &Embedding {
-                document: "glarby-glarble".to_string(),
-                vec: vec![0.0, 0.1, 0.6],
-            },
-            1,
-        );
+		let ranking = vector_store.vector_search(
+			&Embedding {
+				document: "glarby-glarble".to_string(),
+				vec: vec![0.0, 0.1, 0.6],
+			},
+			1,
+		);
 
-        assert_eq!(
-            ranking
-                .into_iter()
-                .map(|Reverse(RankingItem(distance, id, doc, _))| {
-                    (
-                        distance.0,
-                        id.clone(),
-                        serde_json::from_str(&serde_json::to_string(doc).unwrap()).unwrap(),
-                    )
-                })
-                .collect::<Vec<(_, _, String)>>(),
-            vec![(
-                0.9807965956109156,
-                "doc1".to_string(),
-                "glarb-garb".to_string()
-            )]
-        )
-    }
+		assert_eq!(
+			ranking
+				.into_iter()
+				.map(|Reverse(RankingItem(distance, id, doc, _))| {
+					(
+						distance.0,
+						id.clone(),
+						serde_json::from_str(&serde_json::to_string(doc).unwrap()).unwrap(),
+					)
+				})
+				.collect::<Vec<(_, _, String)>>(),
+			vec![(
+				0.9807965956109156,
+				"doc1".to_string(),
+				"glarb-garb".to_string()
+			)]
+		)
+	}
 
-    #[test]
-    fn test_multiple_embeddings() {
-        let vector_store = InMemoryVectorStore::from_documents_with_ids(vec![
-            (
-                "doc1",
-                "glarb-garb",
-                OneOrMany::many(vec![
-                    Embedding {
-                        document: "glarb-garb".to_string(),
-                        vec: vec![0.1, 0.1, 0.5],
-                    },
-                    Embedding {
-                        document: "don't-choose-me".to_string(),
-                        vec: vec![-0.5, 0.9, 0.1],
-                    },
-                ])
-                .unwrap(),
-            ),
-            (
-                "doc2",
-                "marble-marble",
-                OneOrMany::many(vec![
-                    Embedding {
-                        document: "marble-marble".to_string(),
-                        vec: vec![0.7, -0.3, 0.0],
-                    },
-                    Embedding {
-                        document: "sandwich".to_string(),
-                        vec: vec![0.5, 0.5, -0.7],
-                    },
-                ])
-                .unwrap(),
-            ),
-            (
-                "doc3",
-                "flumb-flumb",
-                OneOrMany::many(vec![
-                    Embedding {
-                        document: "flumb-flumb".to_string(),
-                        vec: vec![0.3, 0.7, 0.1],
-                    },
-                    Embedding {
-                        document: "banana".to_string(),
-                        vec: vec![0.1, -0.5, -0.5],
-                    },
-                ])
-                .unwrap(),
-            ),
-        ]);
+	#[test]
+	fn test_multiple_embeddings() {
+		let vector_store = InMemoryVectorStore::from_documents_with_ids(vec![
+			(
+				"doc1",
+				"glarb-garb",
+				OneOrMany::many(vec![
+					Embedding {
+						document: "glarb-garb".to_string(),
+						vec: vec![0.1, 0.1, 0.5],
+					},
+					Embedding {
+						document: "don't-choose-me".to_string(),
+						vec: vec![-0.5, 0.9, 0.1],
+					},
+				])
+					.unwrap(),
+			),
+			(
+				"doc2",
+				"marble-marble",
+				OneOrMany::many(vec![
+					Embedding {
+						document: "marble-marble".to_string(),
+						vec: vec![0.7, -0.3, 0.0],
+					},
+					Embedding {
+						document: "sandwich".to_string(),
+						vec: vec![0.5, 0.5, -0.7],
+					},
+				])
+					.unwrap(),
+			),
+			(
+				"doc3",
+				"flumb-flumb",
+				OneOrMany::many(vec![
+					Embedding {
+						document: "flumb-flumb".to_string(),
+						vec: vec![0.3, 0.7, 0.1],
+					},
+					Embedding {
+						document: "banana".to_string(),
+						vec: vec![0.1, -0.5, -0.5],
+					},
+				])
+					.unwrap(),
+			),
+		]);
 
-        let ranking = vector_store.vector_search(
-            &Embedding {
-                document: "glarby-glarble".to_string(),
-                vec: vec![0.0, 0.1, 0.6],
-            },
-            1,
-        );
+		let ranking = vector_store.vector_search(
+			&Embedding {
+				document: "glarby-glarble".to_string(),
+				vec: vec![0.0, 0.1, 0.6],
+			},
+			1,
+		);
 
-        assert_eq!(
-            ranking
-                .into_iter()
-                .map(|Reverse(RankingItem(distance, id, doc, _))| {
-                    (
-                        distance.0,
-                        id.clone(),
-                        serde_json::from_str(&serde_json::to_string(doc).unwrap()).unwrap(),
-                    )
-                })
-                .collect::<Vec<(_, _, String)>>(),
-            vec![(
-                0.9807965956109156,
-                "doc1".to_string(),
-                "glarb-garb".to_string()
-            )]
-        )
-    }
+		assert_eq!(
+			ranking
+				.into_iter()
+				.map(|Reverse(RankingItem(distance, id, doc, _))| {
+					(
+						distance.0,
+						id.clone(),
+						serde_json::from_str(&serde_json::to_string(doc).unwrap()).unwrap(),
+					)
+				})
+				.collect::<Vec<(_, _, String)>>(),
+			vec![(
+				0.9807965956109156,
+				"doc1".to_string(),
+				"glarb-garb".to_string()
+			)]
+		)
+	}
 }

--- a/rig-core/src/vector_store/mod.rs
+++ b/rig-core/src/vector_store/mod.rs
@@ -6,115 +6,116 @@ use serde::Serialize;
 use serde_json::Value;
 
 use crate::embeddings::EmbeddingError;
-use crate::{Embed, OneOrMany, embeddings::Embedding};
+use crate::{embeddings::Embedding, Embed, OneOrMany};
 
 pub mod in_memory_store;
 pub mod request;
 
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum VectorStoreError {
-    #[error("Embedding error: {0}")]
-    EmbeddingError(#[from] EmbeddingError),
+	#[error("Embedding error: {0}")]
+	EmbeddingError(#[from] EmbeddingError),
 
-    /// Json error (e.g.: serialization, deserialization, etc.)
-    #[error("Json error: {0}")]
-    JsonError(#[from] serde_json::Error),
+	/// Json error (e.g.: serialization, deserialization, etc.)
+	#[error("Json error: {0}")]
+	JsonError(#[from] serde_json::Error),
 
-    #[error("Datastore error: {0}")]
-    DatastoreError(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
+	#[error("Datastore error: {0}")]
+	DatastoreError(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
 
-    #[error("Missing Id: {0}")]
-    MissingIdError(String),
+	#[error("Missing Id: {0}")]
+	MissingIdError(String),
 
-    #[error("HTTP request error: {0}")]
-    ReqwestError(#[from] reqwest::Error),
+	#[error("HTTP request error: {0}")]
+	ReqwestError(#[from] reqwest::Error),
 
-    #[error("External call to API returned an error. Error code: {0} Message: {1}")]
-    ExternalAPIError(StatusCode, String),
+	#[error("External call to API returned an error. Error code: {0} Message: {1}")]
+	ExternalAPIError(StatusCode, String),
 
-    #[error("Error while building VectorSearchRequest: {0}")]
-    BuilderError(String),
+	#[error("Error while building VectorSearchRequest: {0}")]
+	BuilderError(String),
 }
 
 /// Trait for inserting documents into a vector store.
 pub trait InsertDocuments: Send + Sync {
-    /// Insert documents into the vector store.
-    ///
-    fn insert_documents<Doc: Serialize + Embed + Send>(
-        &self,
-        documents: Vec<(Doc, OneOrMany<Embedding>)>,
-    ) -> impl std::future::Future<Output = Result<(), VectorStoreError>> + Send;
+	/// Insert documents into the vector store.
+	///
+	fn insert_documents<Doc: Serialize + Embed + Send>(
+		&self,
+		documents: Vec<(Doc, OneOrMany<Embedding>)>,
+	) -> impl std::future::Future<Output=Result<(), VectorStoreError>> + Send;
 }
 
 /// Trait for vector store indexes
 pub trait VectorStoreIndex: Send + Sync {
-    /// Get the top n documents based on the distance to the given query.
-    /// The result is a list of tuples of the form (score, id, document)
-    fn top_n<T: for<'a> Deserialize<'a> + Send>(
-        &self,
-        req: VectorSearchRequest,
-    ) -> impl std::future::Future<Output = Result<Vec<(f64, String, T)>, VectorStoreError>> + Send;
+	/// Get the top n documents based on the distance to the given query.
+	/// The result is a list of tuples of the form (score, id, document)
+	fn top_n<T: for<'a> Deserialize<'a> + Send>(
+		&self,
+		req: VectorSearchRequest,
+	) -> impl std::future::Future<Output=Result<Vec<(f64, String, T)>, VectorStoreError>> + Send;
 
-    /// Same as `top_n` but returns the document ids only.
-    fn top_n_ids(
-        &self,
-        req: VectorSearchRequest,
-    ) -> impl std::future::Future<Output = Result<Vec<(f64, String)>, VectorStoreError>> + Send;
+	/// Same as `top_n` but returns the document ids only.
+	fn top_n_ids(
+		&self,
+		req: VectorSearchRequest,
+	) -> impl std::future::Future<Output=Result<Vec<(f64, String)>, VectorStoreError>> + Send;
 }
 
 pub type TopNResults = Result<Vec<(f64, String, Value)>, VectorStoreError>;
 
 pub trait VectorStoreIndexDyn: Send + Sync {
-    fn top_n<'a>(&'a self, req: VectorSearchRequest) -> BoxFuture<'a, TopNResults>;
+	fn top_n<'a>(&'a self, req: VectorSearchRequest) -> BoxFuture<'a, TopNResults>;
 
-    fn top_n_ids<'a>(
-        &'a self,
-        req: VectorSearchRequest,
-    ) -> BoxFuture<'a, Result<Vec<(f64, String)>, VectorStoreError>>;
+	fn top_n_ids<'a>(
+		&'a self,
+		req: VectorSearchRequest,
+	) -> BoxFuture<'a, Result<Vec<(f64, String)>, VectorStoreError>>;
 }
 
 impl<I: VectorStoreIndex> VectorStoreIndexDyn for I {
-    fn top_n<'a>(
-        &'a self,
-        req: VectorSearchRequest,
-    ) -> BoxFuture<'a, Result<Vec<(f64, String, Value)>, VectorStoreError>> {
-        Box::pin(async move {
-            Ok(self
-                .top_n::<serde_json::Value>(req)
-                .await?
-                .into_iter()
-                .map(|(score, id, doc)| (score, id, prune_document(doc).unwrap_or_default()))
-                .collect::<Vec<_>>())
-        })
-    }
+	fn top_n<'a>(
+		&'a self,
+		req: VectorSearchRequest,
+	) -> BoxFuture<'a, Result<Vec<(f64, String, Value)>, VectorStoreError>> {
+		Box::pin(async move {
+			Ok(self
+				.top_n::<serde_json::Value>(req)
+				.await?
+				.into_iter()
+				.map(|(score, id, doc)| (score, id, prune_document(doc).unwrap_or_default()))
+				.collect::<Vec<_>>())
+		})
+	}
 
-    fn top_n_ids<'a>(
-        &'a self,
-        req: VectorSearchRequest,
-    ) -> BoxFuture<'a, Result<Vec<(f64, String)>, VectorStoreError>> {
-        Box::pin(self.top_n_ids(req))
-    }
+	fn top_n_ids<'a>(
+		&'a self,
+		req: VectorSearchRequest,
+	) -> BoxFuture<'a, Result<Vec<(f64, String)>, VectorStoreError>> {
+		Box::pin(self.top_n_ids(req))
+	}
 }
 
 fn prune_document(document: serde_json::Value) -> Option<serde_json::Value> {
-    match document {
-        Value::Object(mut map) => {
-            let new_map = map
-                .iter_mut()
-                .filter_map(|(key, value)| {
-                    prune_document(value.take()).map(|value| (key.clone(), value))
-                })
-                .collect::<serde_json::Map<_, _>>();
+	match document {
+		Value::Object(mut map) => {
+			let new_map = map
+				.iter_mut()
+				.filter_map(|(key, value)| {
+					prune_document(value.take()).map(|value| (key.clone(), value))
+				})
+				.collect::<serde_json::Map<_, _>>();
 
-            Some(Value::Object(new_map))
-        }
-        Value::Array(vec) if vec.len() > 400 => None,
-        Value::Array(vec) => Some(Value::Array(
-            vec.into_iter().filter_map(prune_document).collect(),
-        )),
-        Value::Number(num) => Some(Value::Number(num)),
-        Value::String(s) => Some(Value::String(s)),
-        Value::Bool(b) => Some(Value::Bool(b)),
-        Value::Null => Some(Value::Null),
-    }
+			Some(Value::Object(new_map))
+		}
+		Value::Array(vec) if vec.len() > 400 => None,
+		Value::Array(vec) => Some(Value::Array(
+			vec.into_iter().filter_map(prune_document).collect(),
+		)),
+		Value::Number(num) => Some(Value::Number(num)),
+		Value::String(s) => Some(Value::String(s)),
+		Value::Bool(b) => Some(Value::Bool(b)),
+		Value::Null => Some(Value::Null),
+	}
 }

--- a/rig-core/src/vector_store/request.rs
+++ b/rig-core/src/vector_store/request.rs
@@ -3,105 +3,107 @@ use serde::{Deserialize, Serialize};
 use super::VectorStoreError;
 
 /// A vector search request - used in the [`super::VectorStoreIndex`] trait.
+#[non_exhaustive]
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct VectorSearchRequest {
-    /// The query to be embedded and used in similarity search.
-    query: String,
-    /// The maximum number of samples that may be returned. If adding a similarity search threshold, you may receive less than the inputted number if there aren't enough results that satisfy the threshold.
-    samples: u64,
-    /// Similarity search threshold. If present, any result with a distance less than this may be omitted from the final result.
-    threshold: Option<f64>,
-    /// Any additional parameters that are required by the vector store.
-    additional_params: Option<serde_json::Value>,
+	/// The query to be embedded and used in similarity search.
+	query: String,
+	/// The maximum number of samples that may be returned. If adding a similarity search threshold, you may receive less than the inputted number if there aren't enough results that satisfy the threshold.
+	samples: u64,
+	/// Similarity search threshold. If present, any result with a distance less than this may be omitted from the final result.
+	threshold: Option<f64>,
+	/// Any additional parameters that are required by the vector store.
+	additional_params: Option<serde_json::Value>,
 }
 
 impl VectorSearchRequest {
-    /// Creates a [`VectorSearchRequestBuilder`] which you can use to instantiate this struct.
-    pub fn builder() -> VectorSearchRequestBuilder {
-        VectorSearchRequestBuilder::default()
-    }
+	/// Creates a [`VectorSearchRequestBuilder`] which you can use to instantiate this struct.
+	pub fn builder() -> VectorSearchRequestBuilder {
+		VectorSearchRequestBuilder::default()
+	}
 
-    /// The query to be embedded and used in similarity search.
-    pub fn query(&self) -> &str {
-        &self.query
-    }
+	/// The query to be embedded and used in similarity search.
+	pub fn query(&self) -> &str {
+		&self.query
+	}
 
-    /// The maximum number of samples that may be returned. If adding a similarity search threshold, you may receive less than the inputted number if there aren't enough results that satisfy the threshold.
-    pub fn samples(&self) -> u64 {
-        self.samples
-    }
+	/// The maximum number of samples that may be returned. If adding a similarity search threshold, you may receive less than the inputted number if there aren't enough results that satisfy the threshold.
+	pub fn samples(&self) -> u64 {
+		self.samples
+	}
 
-    pub fn threshold(&self) -> Option<f64> {
-        self.threshold
-    }
+	pub fn threshold(&self) -> Option<f64> {
+		self.threshold
+	}
 }
 
 /// The builder struct to instantiate [`VectorSearchRequest`].
+#[non_exhaustive]
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
 pub struct VectorSearchRequestBuilder {
-    query: Option<String>,
-    samples: Option<u64>,
-    threshold: Option<f64>,
-    additional_params: Option<serde_json::Value>,
+	query: Option<String>,
+	samples: Option<u64>,
+	threshold: Option<f64>,
+	additional_params: Option<serde_json::Value>,
 }
 
 impl VectorSearchRequestBuilder {
-    /// Set the query (that will then be embedded )
-    pub fn query<T>(mut self, query: T) -> Self
-    where
-        T: Into<String>,
-    {
-        self.query = Some(query.into());
-        self
-    }
+	/// Set the query (that will then be embedded )
+	pub fn query<T>(mut self, query: T) -> Self
+	where
+		T: Into<String>,
+	{
+		self.query = Some(query.into());
+		self
+	}
 
-    pub fn samples(mut self, samples: u64) -> Self {
-        self.samples = Some(samples);
-        self
-    }
+	pub fn samples(mut self, samples: u64) -> Self {
+		self.samples = Some(samples);
+		self
+	}
 
-    pub fn threshold(mut self, threshold: f64) -> Self {
-        self.threshold = Some(threshold);
-        self
-    }
+	pub fn threshold(mut self, threshold: f64) -> Self {
+		self.threshold = Some(threshold);
+		self
+	}
 
-    pub fn additional_params(
-        mut self,
-        params: serde_json::Value,
-    ) -> Result<Self, VectorStoreError> {
-        self.additional_params = Some(params);
-        Ok(self)
-    }
+	pub fn additional_params(
+		mut self,
+		params: serde_json::Value,
+	) -> Result<Self, VectorStoreError> {
+		self.additional_params = Some(params);
+		Ok(self)
+	}
 
-    pub fn build(self) -> Result<VectorSearchRequest, VectorStoreError> {
-        let Some(query) = self.query else {
-            return Err(VectorStoreError::BuilderError(
-                "`query` is a required variable for building a vector search request".into(),
-            ));
-        };
+	pub fn build(self) -> Result<VectorSearchRequest, VectorStoreError> {
+		let Some(query) = self.query else {
+			return Err(VectorStoreError::BuilderError(
+				"`query` is a required variable for building a vector search request".into(),
+			));
+		};
 
-        let Some(samples) = self.samples else {
-            return Err(VectorStoreError::BuilderError(
-                "`samples` is a required variable for building a vector search request".into(),
-            ));
-        };
+		let Some(samples) = self.samples else {
+			return Err(VectorStoreError::BuilderError(
+				"`samples` is a required variable for building a vector search request".into(),
+			));
+		};
 
-        let additional_params = if let Some(params) = self.additional_params {
-            if !params.is_object() {
-                return Err(VectorStoreError::BuilderError(
-                    "Expected JSON object for additional params, got something else".into(),
-                ));
-            }
-            Some(params)
-        } else {
-            None
-        };
+		let additional_params = if let Some(params) = self.additional_params {
+			if !params.is_object() {
+				return Err(VectorStoreError::BuilderError(
+					"Expected JSON object for additional params, got something else".into(),
+				));
+			}
+			Some(params)
+		} else {
+			None
+		};
 
-        Ok(VectorSearchRequest {
-            query,
-            samples,
-            threshold: self.threshold,
-            additional_params,
-        })
-    }
+		Ok(VectorSearchRequest {
+			query,
+			samples,
+			threshold: self.threshold,
+			additional_params,
+		})
+	}
 }


### PR DESCRIPTION
in [rig-core](https://github.com/0xPlaygrounds/rig/tree/main/rig-core) excluding ( `/providers`), I add `#[non_exhaustive` to all pub enum. Additionally, I added `#[non_exhaustive]` to pub structs in the condition that there is an initiator, such as `build ()`  or  `new()` , or a similar initiator. For public structs without initiator methods, I hesitate to add `new()` or `build()` function just add the following comment: `// to add #[non_exhaustive] we will need to add a builder/new method
` 