### PR TITLE
Update lib.rs: make json_utils public

### DIFF
--- a/rig-core/src/lib.rs
+++ b/rig-core/src/lib.rs
@@ -118,7 +118,7 @@ pub mod extractor;
 #[cfg(feature = "image")]
 #[cfg_attr(docsrs, doc(cfg(feature = "image")))]
 pub mod image_generation;
-pub(crate) mod json_utils;
+pub mod json_utils;
 pub mod loaders;
 pub mod one_or_many;
 pub mod pipeline;


### PR DESCRIPTION
json_utils is very useful to implement your own model provider integration by defining types that implement the CompletionModel and EmbeddingModel traits.