### PR TITLE
chore: optional candidates token count

### DIFF
--- a/rig-core/src/providers/gemini/completion.rs
+++ b/rig-core/src/providers/gemini/completion.rs
@@ -280,7 +280,7 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse<Generat
             .as_ref()
             .map(|usage| completion::Usage {
                 input_tokens: usage.prompt_token_count as u64,
-                output_tokens: usage.candidates_token_count as u64,
+                output_tokens: usage.candidates_token_count.unwrap_or(0) as u64,
                 total_tokens: usage.total_token_count as u64,
             })
             .unwrap_or_default();
@@ -849,7 +849,8 @@ pub mod gemini_api_types {
         pub prompt_token_count: i32,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub cached_content_token_count: Option<i32>,
-        pub candidates_token_count: i32,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub candidates_token_count: Option<i32>,
         pub total_token_count: i32,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub thoughts_token_count: Option<i32>,
@@ -865,7 +866,10 @@ pub mod gemini_api_types {
                     Some(count) => count.to_string(),
                     None => "n/a".to_string(),
                 },
-                self.candidates_token_count,
+                match self.candidates_token_count {
+                    Some(count) => count.to_string(),
+                    None => "n/a".to_string(),
+                },
                 self.total_token_count
             )
         }


### PR DESCRIPTION
Should fix #788 

not sure which is the source of truth, but here it is optional:

https://github.com/googleapis/python-genai/blob/842974434824c1d77a14ceec13a9591b5d86db3c/google/genai/types.py#L5339

And I get this error with the current main implementation when using gemma: `gemma-3-27b-it`

```
2025-09-08T20:57:06.984165Z  INFO Response: Err(CompletionError(HttpError(reqwest::Error { kind: Decode, source: Error("missing field `candidatesTokenCount`", line: 25, column: 3) })))
2025-09-08T20:57:06.984217Z ERROR Error: CompletionError(HttpError(reqwest::Error { kind: Decode, source: Error("missing field `candidatesTokenCount`", line: 25, column: 3) }))
2025-09-08T20:57:06.984302Z  INFO return=Err(CompletionError: HttpError: error decoding response body

Caused by:
    0: HttpError: error decoding response body
    1: error decoding response body
    2: missing field `candidatesTokenCount` at line 25 column 3)
Error: CompletionError: HttpError: error decoding response body

```