### PR TITLE
refactor(cohere): use `reqwest-eventsource`, some code cleanup

### DIFF
--- a/rig-core/src/providers/cohere/streaming.rs
+++ b/rig-core/src/providers/cohere/streaming.rs
@@ -5,8 +5,8 @@ use crate::streaming::RawStreamingChoice;
 use crate::{json_utils, streaming};
 use async_stream::stream;
 use futures::StreamExt;
+use reqwest_eventsource::{Event, RequestBuilderExt};
 use serde::{Deserialize, Serialize};
-use serde_json::json;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "kebab-case", tag = "type")]
@@ -91,119 +91,109 @@ impl CompletionModel {
     ) -> Result<streaming::StreamingCompletionResponse<StreamingCompletionResponse>, CompletionError>
     {
         let request = self.create_completion_request(request)?;
-        let request = json_utils::merge(request, json!({"stream": true}));
+        let request = json_utils::merge(request, serde_json::json!({"stream": true}));
 
         tracing::debug!(
             "Cohere request: {}",
             serde_json::to_string_pretty(&request)?
         );
 
-        let response = self.client.post("/v2/chat").json(&request).send().await?;
-
-        if !response.status().is_success() {
-            return Err(CompletionError::ProviderError(format!(
-                "{}: {}",
-                response.status(),
-                response.text().await?
-            )));
-        }
+        let mut event_source = self
+            .client
+            .post("/v2/chat")
+            .json(&request)
+            .eventsource()
+            .map_err(|e| CompletionError::ProviderError(e.to_string()))?;
 
         let stream = Box::pin(stream! {
-            let mut stream = response.bytes_stream();
             let mut current_tool_call: Option<(String, String, String)> = None;
 
-            while let Some(chunk_result) = stream.next().await {
-               let chunk = match chunk_result {
-                    Ok(c) => c,
-                    Err(e) => {
-                        yield Err(CompletionError::from(e));
-                        break;
-                    }
-                };
-
-               let text = match String::from_utf8(chunk.to_vec()) {
-                    Ok(t) => t,
-                    Err(e) => {
-                        yield Err(CompletionError::ResponseError(e.to_string()));
-                        break;
-                    }
-               };
-
-                for line in text.lines() {
-
-                    let Some(line) = line.strip_prefix("data: ") else {
+            while let Some(event_result) = event_source.next().await {
+                match event_result {
+                    Ok(Event::Open) => {
+                        tracing::trace!("SSE connection opened");
                         continue;
-                    };
+                    }
 
-                    let event = {
-                       let result = serde_json::from_str::<StreamingEvent>(line);
+                    Ok(Event::Message(message)) => {
+                        let data_str = message.data.trim();
+                        if data_str.is_empty() || data_str == "[DONE]" {
+                            continue;
+                        }
 
-                       let Ok(event) = result else {
-                           continue;
-                       };
+                        let event: StreamingEvent = match serde_json::from_str(data_str) {
+                            Ok(ev) => ev,
+                            Err(_) => {
+                                tracing::debug!("Couldn't parse SSE payload as StreamingEvent");
+                                continue;
+                            }
+                        };
 
-                        event
-                    };
+                        match event {
+                            StreamingEvent::ContentDelta { delta: Some(delta) } => {
+                                let Some(message) = &delta.message else { continue; };
+                                let Some(content) = &message.content else { continue; };
+                                let Some(text) = &content.text else { continue; };
 
-                    match event {
-                        StreamingEvent::ContentDelta { delta: Some(delta) } => {
-                            let Some(message) = &delta.message else { continue; };
-                            let Some(content) = &message.content else { continue; };
-                            let Some(text) = &content.text else { continue; };
+                                yield Ok(RawStreamingChoice::Message(text.clone()));
+                            },
 
-                            yield Ok(RawStreamingChoice::Message(text.clone()));
-                        },
-                        StreamingEvent::MessageEnd {delta: Some(delta)} => {
-                            yield Ok(RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
-                                usage: delta.usage.clone()
-                            }));
-                        },
-                        StreamingEvent::ToolCallStart { delta: Some(delta)} => {
-                            // Skip the delta if there's any missing information,
-                            // though this *should* all be present
-                            let Some(message) = &delta.message else { continue; };
-                            let Some(tool_calls) = &message.tool_calls else { continue; };
-                            let Some(id) = tool_calls.id.clone() else { continue; };
-                            let Some(function) = &tool_calls.function else { continue; };
-                            let Some(name) = function.name.clone() else { continue; };
-                            let Some(arguments) = function.arguments.clone() else { continue; };
+                            StreamingEvent::MessageEnd { delta: Some(delta) } => {
+                                yield Ok(RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
+                                    usage: delta.usage.clone()
+                                }));
+                            },
 
-                            current_tool_call = Some((id, name, arguments));
-                        },
-                        StreamingEvent::ToolCallDelta { delta: Some(delta)} => {
-                            // Skip the delta if there's any missing information,
-                            // though this *should* all be present
-                            let Some(message) = &delta.message else { continue; };
-                            let Some(tool_calls) = &message.tool_calls else { continue; };
-                            let Some(function) = &tool_calls.function else { continue; };
-                            let Some(arguments) = function.arguments.clone() else { continue; };
+                            StreamingEvent::ToolCallStart { delta: Some(delta) } => {
+                                let Some(message) = &delta.message else { continue; };
+                                let Some(tool_calls) = &message.tool_calls else { continue; };
+                                let Some(id) = tool_calls.id.clone() else { continue; };
+                                let Some(function) = &tool_calls.function else { continue; };
+                                let Some(name) = function.name.clone() else { continue; };
+                                let Some(arguments) = function.arguments.clone() else { continue; };
 
-                            if let Some(tc) = current_tool_call.clone() {
-                                current_tool_call = Some((
-                                    tc.0,
-                                    tc.1,
-                                    format!("{}{}", tc.2, arguments)
-                                ));
-                            };
-                        },
-                        StreamingEvent::ToolCallEnd => {
-                            let Some(tc) = current_tool_call.clone() else { continue; };
+                                current_tool_call = Some((id, name, arguments));
+                            },
 
-                            let Ok(args) = serde_json::from_str(&tc.2) else { continue; };
+                            StreamingEvent::ToolCallDelta { delta: Some(delta) } => {
+                                let Some(message) = &delta.message else { continue; };
+                                let Some(tool_calls) = &message.tool_calls else { continue; };
+                                let Some(function) = &tool_calls.function else { continue; };
+                                let Some(arguments) = function.arguments.clone() else { continue; };
 
-                            yield Ok(RawStreamingChoice::ToolCall {
-                                id: tc.0,
-                                name: tc.1,
-                                arguments: args,
-                                call_id: None
-                            });
+                                let Some(tc) = current_tool_call.clone() else { continue; };
+                                current_tool_call = Some((tc.0, tc.1, format!("{}{}", tc.2, arguments)));
+                            },
 
-                            current_tool_call = None;
-                        },
-                        _ => {}
-                    };
+                            StreamingEvent::ToolCallEnd => {
+                                let Some(tc) = current_tool_call.clone() else { continue; };
+                                let Ok(args) = serde_json::from_str(&tc.2) else { continue; };
+
+                                yield Ok(RawStreamingChoice::ToolCall {
+                                    id: tc.0,
+                                    name: tc.1,
+                                    arguments: args,
+                                    call_id: None
+                                });
+
+                                current_tool_call = None;
+                            },
+
+                            _ => {}
+                        }
+                    },
+
+                    Err(reqwest_eventsource::Error::StreamEnded) => break,
+
+                    Err(err) => {
+                        tracing::error!(?err, "SSE error");
+                        yield Err(CompletionError::ResponseError(err.to_string()));
+                        break;
+                    }
                 }
             }
+
+            event_source.close();
         });
 
         Ok(streaming::StreamingCompletionResponse::stream(stream))

--- a/rig-core/src/providers/ollama.rs
+++ b/rig-core/src/providers/ollama.rs
@@ -56,6 +56,7 @@ use crate::{
 use async_stream::stream;
 use futures::StreamExt;
 use reqwest;
+use reqwest_eventsource::{Event, RequestBuilderExt};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::{convert::TryFrom, str::FromStr};
@@ -563,134 +564,73 @@ impl completion::CompletionModel for CompletionModel {
         let mut request_payload = self.create_completion_request(request)?;
         merge_inplace(&mut request_payload, json!({"stream": true}));
 
-        let response = self
+        let mut event_source = self
             .client
             .post("api/chat")?
             .json(&request_payload)
-            .send()
-            .await
-            .map_err(|e| CompletionError::ProviderError(e.to_string()))?;
-
-        if !response.status().is_success() {
-            let err_text = response
-                .text()
-                .await
-                .map_err(|e| CompletionError::ProviderError(e.to_string()))?;
-            return Err(CompletionError::ProviderError(err_text));
-        }
+            .eventsource()
+            .expect("Cloning request must succeed");
 
         let stream = Box::pin(stream! {
-            while let Some(event_result) = event_source.next().await {
-                match event_result {
-                    Ok(Event::Open) => {
-                        tracing::trace!("SSE connection opened");
-                        continue;
-                    }
+        while let Some(event_result) = event_source.next().await {
+            match event_result {
+                Ok(Event::Open) => {
+                    tracing::trace!("SSE connection opened");
+                    continue;
+                }
 
-                    Ok(Event::Message(message)) => {
-                        let data_str = message.data.trim();
+                Ok(Event::Message(message)) => {
+                    let data_str = message.data.trim();
 
-                        let parsed = serde_json::from_str::<CompletionResponse>(&data_str);
-                        let Ok(response) = parsed else {
-                            tracing::debug!("Couldn't parse SSE payload as CompletionResponse");
-                            continue;
-                        };
-
-                        match response.message {
-                            Message::Assistant { content, tool_calls, .. } => {
-                                if !content.is_empty() {
-                                    yield Ok(RawStreamingChoice::Message(content));
-                                }
-
-                                for tool_call in tool_calls {
-                                    let function = tool_call.function.clone();
-                                    yield Ok(RawStreamingChoice::ToolCall {
-                                        id: "".to_string(),
-                                        name: function.name,
-                                        arguments: function.arguments,
-                                        call_id: None,
-                                    });
-                                }
-                            }
-                            _ => continue,
-                        }
-
-                        if response.done {
-                            yield Ok(RawStreamingChoice::FinalResponse(
-                                StreamingCompletionResponse {
-                                    total_duration: response.total_duration,
-                                    load_duration: response.load_duration,
-                                    prompt_eval_count: response.prompt_eval_count,
-                                    prompt_eval_duration: response.prompt_eval_duration,
-                                    eval_count: response.eval_count,
-                                    eval_duration: response.eval_duration,
-                                    done_reason: response.done_reason,
-                                }
-                            ));
-                        }
-                    }
-
-                    Err(reqwest_eventsource::Error::StreamEnded) => break,
-
-                    Err(err) => {
-                        tracing::error!(?err, "SSE error");
-                        yield Err(CompletionError::ResponseError(err.to_string()));
-                        break;
-                    }
-                };
-
-                let text = match String::from_utf8(chunk.to_vec()) {
-                    Ok(t) => t,
-                    Err(e) => {
-                        yield Err(CompletionError::ResponseError(e.to_string()));
-                        break;
-                    }
-                };
-
-
-                for line in text.lines() {
-                    let line = line.to_string();
-
-                    let Ok(response) = serde_json::from_str::<CompletionResponse>(&line) else {
+                    let parsed = serde_json::from_str::<CompletionResponse>(&data_str);
+                    let Ok(response) = parsed else {
+                        tracing::debug!("Couldn't parse SSE payload as CompletionResponse");
                         continue;
                     };
 
                     match response.message {
-                        Message::Assistant{ content, tool_calls, .. } => {
+                        Message::Assistant { content, tool_calls, .. } => {
                             if !content.is_empty() {
-                                yield Ok(RawStreamingChoice::Message(content))
+                                yield Ok(RawStreamingChoice::Message(content));
                             }
 
-                            for tool_call in tool_calls.iter() {
+                            for tool_call in tool_calls {
                                 let function = tool_call.function.clone();
-
                                 yield Ok(RawStreamingChoice::ToolCall {
                                     id: "".to_string(),
                                     name: function.name,
                                     arguments: function.arguments,
-                                    call_id: None
+                                    call_id: None,
                                 });
                             }
                         }
-                        _ => {
-                            continue;
-                        }
+                        _ => continue,
                     }
 
                     if response.done {
-                        yield Ok(RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
-                            total_duration: response.total_duration,
-                            load_duration: response.load_duration,
-                            prompt_eval_count: response.prompt_eval_count,
-                            prompt_eval_duration: response.prompt_eval_duration,
-                            eval_count: response.eval_count,
-                            eval_duration: response.eval_duration,
-                            done_reason: response.done_reason,
-                        }));
+                        yield Ok(RawStreamingChoice::FinalResponse(
+                            StreamingCompletionResponse {
+                                total_duration: response.total_duration,
+                                load_duration: response.load_duration,
+                                prompt_eval_count: response.prompt_eval_count,
+                                prompt_eval_duration: response.prompt_eval_duration,
+                                eval_count: response.eval_count,
+                                eval_duration: response.eval_duration,
+                                done_reason: response.done_reason,
+                            }
+                        ));
                     }
                 }
-            }
-        });
+
+                Err(reqwest_eventsource::Error::StreamEnded) => break,
+
+                Err(err) => {
+                    tracing::error!(?err, "SSE error");
+                    yield Err(CompletionError::ResponseError(err.to_string()));
+                    break;
+                }
+            };
+        }});
 
         Ok(streaming::StreamingCompletionResponse::stream(stream))
     }

--- a/rig-core/src/providers/ollama.rs
+++ b/rig-core/src/providers/ollama.rs
@@ -582,7 +582,7 @@ impl completion::CompletionModel for CompletionModel {
                 Ok(Event::Message(message)) => {
                     let data_str = message.data.trim();
 
-                    let parsed = serde_json::from_str::<CompletionResponse>(&data_str);
+                    let parsed = serde_json::from_str::<CompletionResponse>(data_str);
                     let Ok(response) = parsed else {
                         tracing::debug!("Couldn't parse SSE payload as CompletionResponse");
                         continue;

--- a/rig-core/src/providers/openrouter/streaming.rs
+++ b/rig-core/src/providers/openrouter/streaming.rs
@@ -346,20 +346,6 @@ pub async fn send_streaming_request1(
                 Ok(Event::Message(event_message)) => {
                     let raw = event_message.data;
 
-                    // let raw_trimmed = raw.trim();
-                    // // Skip empty data, SSE comments/heartbeats (lines starting with ':'), and done markers
-                    // if raw_trimmed.is_empty()
-                    //     || raw_trimmed == "[DONE]"
-                    //     || raw_trimmed.starts_with(':')
-                    //     || raw_trimmed == ": OPENROUTER PROCESSING"
-                    // {
-                    //     continue;
-                    // }
-
-                    // // Some endpoints include a "data: " prefix in the raw stream; be tolerant.
-                    // let payload = raw_trimmed.strip_prefix("data: ").unwrap_or(raw_trimmed);
-
-                    // Try to parse the payload as the expected response object
                     let parsed = serde_json::from_str::<StreamingCompletionResponse>(&raw);
                     let Ok(data) = parsed else {
                         tracing::debug!("Couldn't parse OpenRouter payload as StreamingCompletionResponse; skipping chunk");


### PR DESCRIPTION
Follow on from #814. Just needed to clean up code a bit.

Closes #811 as basically all providers have the new implementation.