### PR TITLE
build(deps): update rmcp to use microsandbox/rust-sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,7 +1515,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
  "log",
@@ -5311,7 +5311,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -6455,7 +6455,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.2",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -9389,9 +9389,8 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7dd163d26e254725137b7933e4ba042ea6bf2d756a4260559aaea8b6ad4c27e"
+version = "0.6.4"
+source = "git+https://github.com/microsandbox/rust-sdk?branch=develop#f8a747eaca997c8382e7bfbc7de3a859700c51f5"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -9420,9 +9419,8 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a43bb4c90a0d4b12f7315eb681a73115d335a2cee81322eca96f3467fe4cd06f"
+version = "0.6.4"
+source = "git+https://github.com/microsandbox/rust-sdk?branch=develop#f8a747eaca997c8382e7bfbc7de3a859700c51f5"
 dependencies = [
  "darling 0.21.0",
  "proc-macro2",
@@ -12695,7 +12693,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/rig-core/Cargo.toml
+++ b/rig-core/Cargo.toml
@@ -40,7 +40,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 worker = { workspace = true, optional = true }
-rmcp = { version = "0.6", optional = true, features = ["client"] }
+rmcp = { git = "https://github.com/microsandbox/rust-sdk", branch = "develop", optional = true, features = ["client"] }
 reqwest-eventsource = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 
@@ -55,7 +55,7 @@ base64 = { workspace = true }
 
 # Required for `rmcp` example
 hyper-util = { version = "0.1.14", features = ["service", "server"] }
-rmcp = { version = "0.6", features = [
+rmcp = { git = "https://github.com/microsandbox/rust-sdk", branch = "develop", features = [
     "client",
     "macros",
     "reqwest",                                  # required for some strange reason


### PR DESCRIPTION
## Summary
- Update rmcp dependency from crates.io to Git repository source
- Point to microsandbox/rust-sdk repository's develop branch
- Ensures access to latest development features not yet on crates.io
- Maintains all existing feature configurations

## Changes
- Updated rmcp dependency in rig-core/Cargo.toml from crates.io v0.6 to Git source
- Updated both the optional dependency and dev-dependency entries
- Cargo.lock updated to reflect rmcp v0.6.4 from Git source

## Test Plan
- Run `cargo build` to verify successful compilation
- Run `cargo build --all-features` to ensure all feature combinations work
- Verify rmcp example compiles: `cargo build --example rmcp --features rmcp`