### PR TITLE
feat: add streaming support to DynClientBuilder

### DIFF
--- a/rig-core/examples/dyn_client_streaming.rs
+++ b/rig-core/examples/dyn_client_streaming.rs
@@ -1,0 +1,157 @@
+use futures::StreamExt;
+/// This example showcases using streaming with multiple clients by using a dynamic ClientBuilder.
+/// In this example, we will use both OpenAI and Anthropic with streaming responses - so ensure you have your `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` set when using this example!
+use rig::{client::builder::DynClientBuilder, providers::anthropic::CLAUDE_3_7_SONNET};
+
+#[tokio::main]
+async fn main() {
+    let multi_client = DynClientBuilder::new();
+
+    // Test streaming with OpenAI
+    println!("=== Testing OpenAI Streaming ===");
+    match test_openai_streaming(&multi_client).await {
+        Ok(_) => println!("OpenAI streaming test completed successfully"),
+        Err(e) => println!("OpenAI streaming test failed: {}", e),
+    }
+
+    // Test streaming with Anthropic
+    println!("\n=== Testing Anthropic Streaming ===");
+    match test_anthropic_streaming(&multi_client).await {
+        Ok(_) => println!("Anthropic streaming test completed successfully"),
+        Err(e) => println!("Anthropic streaming test failed: {}", e),
+    }
+
+    // Test streaming with ProviderModelId
+    println!("\n=== Testing ProviderModelId Streaming ===");
+    match test_provider_model_id_streaming(&multi_client).await {
+        Ok(_) => println!("ProviderModelId streaming test completed successfully"),
+        Err(e) => println!("ProviderModelId streaming test failed: {}", e),
+    }
+}
+
+async fn test_openai_streaming(
+    client: &DynClientBuilder,
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!(
+        "Streaming prompt to OpenAI (gpt-4o): 'Tell me a short story about a robot learning to paint'"
+    );
+
+    let mut stream = client
+        .stream_prompt(
+            "openai",
+            "gpt-4o",
+            "Tell me a short story about a robot learning to paint",
+        )
+        .await?;
+
+    print!("Response: ");
+    while let Some(chunk) = stream.next().await {
+        match chunk {
+            Ok(rig::streaming::StreamedAssistantContent::Text(text)) => {
+                print!("{}", text.text);
+                std::io::Write::flush(&mut std::io::stdout())?;
+            }
+            Ok(rig::streaming::StreamedAssistantContent::Reasoning(reasoning)) => {
+                println!("\n[Reasoning: {}]", reasoning.reasoning.join(""));
+            }
+            Ok(rig::streaming::StreamedAssistantContent::ToolCall(tool_call)) => {
+                println!("\n[Tool Call: {}]", tool_call.function.name);
+            }
+            Ok(rig::streaming::StreamedAssistantContent::Final(_)) => {
+                println!("\n[Stream completed]");
+                break;
+            }
+            Err(e) => {
+                println!("\n[Error: {}]", e);
+                break;
+            }
+        }
+    }
+    println!();
+
+    Ok(())
+}
+
+async fn test_anthropic_streaming(
+    client: &DynClientBuilder,
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!(
+        "Streaming prompt to Anthropic (Claude 3.7 Sonnet): 'Explain quantum computing in simple terms'"
+    );
+
+    let mut stream = client
+        .stream_prompt(
+            "anthropic",
+            CLAUDE_3_7_SONNET,
+            "Explain quantum computing in simple terms",
+        )
+        .await?;
+
+    print!("Response: ");
+    while let Some(chunk) = stream.next().await {
+        match chunk {
+            Ok(rig::streaming::StreamedAssistantContent::Text(text)) => {
+                print!("{}", text.text);
+                std::io::Write::flush(&mut std::io::stdout())?;
+            }
+            Ok(rig::streaming::StreamedAssistantContent::Reasoning(reasoning)) => {
+                println!("\n[Reasoning: {}]", reasoning.reasoning.join(""));
+            }
+            Ok(rig::streaming::StreamedAssistantContent::ToolCall(tool_call)) => {
+                println!("\n[Tool Call: {}]", tool_call.function.name);
+            }
+            Ok(rig::streaming::StreamedAssistantContent::Final(_)) => {
+                println!("\n[Stream completed]");
+                break;
+            }
+            Err(e) => {
+                println!("\n[Error: {}]", e);
+                break;
+            }
+        }
+    }
+    println!();
+
+    Ok(())
+}
+
+async fn test_provider_model_id_streaming(
+    client: &DynClientBuilder,
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!(
+        "Streaming prompt using ProviderModelId: 'What are the benefits of renewable energy?'"
+    );
+
+    let provider_model = client.id("openai:gpt-4o")?;
+    let mut stream = provider_model
+        .stream_prompt("What are the benefits of renewable energy?")
+        .await?;
+
+    print!("Response: ");
+    while let Some(chunk) = stream.next().await {
+        match chunk {
+            Ok(rig::streaming::StreamedAssistantContent::Text(text)) => {
+                print!("{}", text.text);
+                std::io::Write::flush(&mut std::io::stdout())?;
+            }
+            Ok(rig::streaming::StreamedAssistantContent::Reasoning(reasoning)) => {
+                println!("\n[Reasoning: {}]", reasoning.reasoning.join(""));
+            }
+            Ok(rig::streaming::StreamedAssistantContent::ToolCall(tool_call)) => {
+                println!("\n[Tool Call: {}]", tool_call.function.name);
+            }
+            Ok(rig::streaming::StreamedAssistantContent::Final(_)) => {
+                println!("\n[Stream completed]");
+                break;
+            }
+            Err(e) => {
+                println!("\n[Error: {}]", e);
+                break;
+            }
+        }
+    }
+    println!();
+
+    Ok(())
+}
+

--- a/rig-core/src/client/builder.rs
+++ b/rig-core/src/client/builder.rs
@@ -1,10 +1,12 @@
 use crate::agent::Agent;
 use crate::client::ProviderClient;
+use crate::completion::{CompletionRequest, Message};
 use crate::embeddings::embedding::EmbeddingModelDyn;
 use crate::providers::{
     anthropic, azure, cohere, deepseek, galadriel, gemini, groq, huggingface, hyperbolic, mira,
     moonshot, ollama, openai, openrouter, perplexity, together, xai,
 };
+use crate::streaming::StreamingCompletionResponse;
 use crate::transcription::TranscriptionModelDyn;
 use rig::completion::CompletionModelDyn;
 use std::collections::HashMap;
@@ -373,6 +375,122 @@ impl<'a> DynClientBuilder {
             model,
         })
     }
+
+    /// Stream a completion request to the specified provider and model.
+    ///
+    /// # Arguments
+    /// * `provider` - The name of the provider (e.g., "openai", "anthropic")
+    /// * `model` - The name of the model (e.g., "gpt-4o", "claude-3-sonnet")
+    /// * `request` - The completion request containing prompt, parameters, etc.
+    ///
+    /// # Returns
+    /// A future that resolves to a streaming completion response
+    pub async fn stream_completion(
+        &self,
+        provider: &str,
+        model: &str,
+        request: CompletionRequest,
+    ) -> Result<StreamingCompletionResponse<()>, ClientBuildError> {
+        let client = self.build(provider)?;
+        let completion = client
+            .as_completion()
+            .ok_or(ClientBuildError::UnsupportedFeature(
+                provider.to_string(),
+                "completion".to_string(),
+            ))?;
+
+        let model = completion.completion_model(model);
+        model
+            .stream(request)
+            .await
+            .map_err(|e| ClientBuildError::FactoryError(e.to_string()))
+    }
+
+    /// Stream a simple prompt to the specified provider and model.
+    ///
+    /// # Arguments
+    /// * `provider` - The name of the provider (e.g., "openai", "anthropic")
+    /// * `model` - The name of the model (e.g., "gpt-4o", "claude-3-sonnet")
+    /// * `prompt` - The prompt to send to the model
+    ///
+    /// # Returns
+    /// A future that resolves to a streaming completion response
+    pub async fn stream_prompt(
+        &self,
+        provider: &str,
+        model: &str,
+        prompt: impl Into<Message> + Send,
+    ) -> Result<StreamingCompletionResponse<()>, ClientBuildError> {
+        let client = self.build(provider)?;
+        let completion = client
+            .as_completion()
+            .ok_or(ClientBuildError::UnsupportedFeature(
+                provider.to_string(),
+                "completion".to_string(),
+            ))?;
+
+        let model = completion.completion_model(model);
+        let request = CompletionRequest {
+            preamble: None,
+            tools: vec![],
+            documents: vec![],
+            temperature: None,
+            max_tokens: None,
+            additional_params: None,
+            chat_history: crate::OneOrMany::one(prompt.into()),
+        };
+
+        model
+            .stream(request)
+            .await
+            .map_err(|e| ClientBuildError::FactoryError(e.to_string()))
+    }
+
+    /// Stream a chat with history to the specified provider and model.
+    ///
+    /// # Arguments
+    /// * `provider` - The name of the provider (e.g., "openai", "anthropic")
+    /// * `model` - The name of the model (e.g., "gpt-4o", "claude-3-sonnet")
+    /// * `prompt` - The new prompt to send to the model
+    /// * `chat_history` - The chat history to include with the request
+    ///
+    /// # Returns
+    /// A future that resolves to a streaming completion response
+    pub async fn stream_chat(
+        &self,
+        provider: &str,
+        model: &str,
+        prompt: impl Into<Message> + Send,
+        chat_history: Vec<Message>,
+    ) -> Result<StreamingCompletionResponse<()>, ClientBuildError> {
+        let client = self.build(provider)?;
+        let completion = client
+            .as_completion()
+            .ok_or(ClientBuildError::UnsupportedFeature(
+                provider.to_string(),
+                "completion".to_string(),
+            ))?;
+
+        let model = completion.completion_model(model);
+        let mut history = chat_history;
+        history.push(prompt.into());
+
+        let request = CompletionRequest {
+            preamble: None,
+            tools: vec![],
+            documents: vec![],
+            temperature: None,
+            max_tokens: None,
+            additional_params: None,
+            chat_history: crate::OneOrMany::many(history)
+                .unwrap_or_else(|_| crate::OneOrMany::one(Message::user(""))),
+        };
+
+        model
+            .stream(request)
+            .await
+            .map_err(|e| ClientBuildError::FactoryError(e.to_string()))
+    }
 }
 
 pub struct ProviderModelId<'builder, 'id> {
@@ -396,6 +514,56 @@ impl<'builder> ProviderModelId<'builder, '_> {
 
     pub fn transcription(self) -> Result<BoxTranscriptionModel<'builder>, ClientBuildError> {
         self.builder.transcription(self.provider, self.model)
+    }
+
+    /// Stream a completion request using this provider and model.
+    ///
+    /// # Arguments
+    /// * `request` - The completion request containing prompt, parameters, etc.
+    ///
+    /// # Returns
+    /// A future that resolves to a streaming completion response
+    pub async fn stream_completion(
+        self,
+        request: CompletionRequest,
+    ) -> Result<StreamingCompletionResponse<()>, ClientBuildError> {
+        self.builder
+            .stream_completion(self.provider, self.model, request)
+            .await
+    }
+
+    /// Stream a simple prompt using this provider and model.
+    ///
+    /// # Arguments
+    /// * `prompt` - The prompt to send to the model
+    ///
+    /// # Returns
+    /// A future that resolves to a streaming completion response
+    pub async fn stream_prompt(
+        self,
+        prompt: impl Into<Message> + Send,
+    ) -> Result<StreamingCompletionResponse<()>, ClientBuildError> {
+        self.builder
+            .stream_prompt(self.provider, self.model, prompt)
+            .await
+    }
+
+    /// Stream a chat with history using this provider and model.
+    ///
+    /// # Arguments
+    /// * `prompt` - The new prompt to send to the model
+    /// * `chat_history` - The chat history to include with the request
+    ///
+    /// # Returns
+    /// A future that resolves to a streaming completion response
+    pub async fn stream_chat(
+        self,
+        prompt: impl Into<Message> + Send,
+        chat_history: Vec<Message>,
+    ) -> Result<StreamingCompletionResponse<()>, ClientBuildError> {
+        self.builder
+            .stream_chat(self.provider, self.model, prompt, chat_history)
+            .await
     }
 }
 


### PR DESCRIPTION
Implemented streaming interfaces for DynClientBuilder to support real-time responses across multiple LLM providers:

- Added `stream_completion()` method for custom completion requests
- Added `stream_prompt()` method for simple streaming prompts
- Added `stream_chat()` method for streaming chat with history
- Added corresponding methods to ProviderModelId for provider:model syntax
- Created comprehensive example demonstrating streaming with OpenAI and Anthropic
- All methods return `StreamingCompletionResponse<()>` for consistent API
- Integrated with existing error handling and provider abstraction

This enables unified streaming interface across all supported providers (OpenAI, Anthropic, Cohere, etc.) through the dynamic client builder.

🤖 Generated with [Claude Code](https://claude.ai/code)