### PR TITLE
refactor(anthropic): Replace `ContentFormat::String` with `ContentFormat::Url` for URL handling

### DIFF
--- a/rig-core/src/completion/message.rs
+++ b/rig-core/src/completion/message.rs
@@ -273,6 +273,7 @@ pub enum ContentFormat {
     #[default]
     Base64,
     String,
+    Url,
 }
 
 /// Helper enum that tracks the media type of the content.


### PR DESCRIPTION
Fixes #853

Adds `ContentFormat::Url` variant and updates Anthropic provider to use it instead of `ContentFormat::String` for URLs, eliminating the code smell where String was semantically incorrect for URL representation.