### PR TITLE
feat(rig-951): generic HTTP client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9033,6 +9033,7 @@ dependencies = [
  "epub",
  "futures",
  "glob",
+ "http 1.3.1",
  "hyper-util",
  "lopdf",
  "mime_guess",

--- a/rig-core/Cargo.toml
+++ b/rig-core/Cargo.toml
@@ -43,6 +43,7 @@ worker = { workspace = true, optional = true }
 rmcp = { version = "0.6", optional = true, features = ["client"] }
 reqwest-eventsource = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
+http = "1.3.1"
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/rig-core/src/client/verify.rs
+++ b/rig-core/src/client/verify.rs
@@ -1,4 +1,7 @@
-use crate::client::{AsVerify, ProviderClient};
+use crate::{
+    client::{AsVerify, ProviderClient},
+    http_client,
+};
 use futures::future::BoxFuture;
 use thiserror::Error;
 
@@ -12,7 +15,7 @@ pub enum VerifyError {
     HttpError(
         #[from]
         #[source]
-        reqwest::Error,
+        http_client::HttpClientError,
     ),
 }
 

--- a/rig-core/src/completion/chat.rs
+++ b/rig-core/src/completion/chat.rs
@@ -1,0 +1,203 @@
+use crate::{
+    agent::{Agent, MultiTurnStreamItem, Text},
+    completion::{Chat, CompletionError, CompletionModel, PromptError, Usage},
+    message::Message,
+    streaming::{StreamedAssistantContent, StreamingPrompt},
+};
+use futures::StreamExt;
+use std::io::{self, Write};
+
+pub struct NoImplProvided;
+
+pub struct ChatImpl<T: Chat>(T);
+
+pub struct AgentImpl<M: CompletionModel + 'static> {
+    agent: Agent<M>,
+    multi_turn_depth: usize,
+    show_usage: bool,
+    usage: Usage,
+}
+
+pub struct ChatBotBuilder<T>(T);
+
+pub struct ChatBot<T>(T);
+
+/// Trait to abstract message behavior away from cli_chat/`run` loop
+#[allow(private_interfaces)]
+trait CliChat {
+    async fn request(&mut self, prompt: &str, history: Vec<Message>)
+    -> Result<String, PromptError>;
+
+    fn show_usage(&self) -> bool {
+        false
+    }
+
+    fn usage(&self) -> Option<Usage> {
+        None
+    }
+}
+
+impl<T: Chat> CliChat for ChatImpl<T> {
+    async fn request(
+        &mut self,
+        prompt: &str,
+        history: Vec<Message>,
+    ) -> Result<String, PromptError> {
+        let res = self.0.chat(prompt, history).await?;
+        println!("{res}");
+
+        Ok(res)
+    }
+}
+
+impl<M: CompletionModel + 'static> CliChat for AgentImpl<M> {
+    async fn request(
+        &mut self,
+        prompt: &str,
+        history: Vec<Message>,
+    ) -> Result<String, PromptError> {
+        let mut response_stream = self
+            .agent
+            .stream_prompt(prompt)
+            .with_history(history)
+            .multi_turn(self.multi_turn_depth)
+            .await;
+
+        let mut acc = String::new();
+
+        loop {
+            let Some(chunk) = response_stream.next().await else {
+                break Ok(acc);
+            };
+
+            match chunk {
+                Ok(MultiTurnStreamItem::StreamItem(StreamedAssistantContent::Text(Text {
+                    text,
+                }))) => {
+                    print!("{}", text);
+                    acc.push_str(&text);
+                }
+                Ok(MultiTurnStreamItem::FinalResponse(final_response)) => {
+                    self.usage = final_response.usage();
+                }
+                Err(e) => {
+                    break Err(PromptError::CompletionError(
+                        CompletionError::ResponseError(e.to_string()),
+                    ));
+                }
+                _ => continue,
+            }
+        }
+    }
+
+    fn show_usage(&self) -> bool {
+        self.show_usage
+    }
+
+    fn usage(&self) -> Option<Usage> {
+        Some(self.usage)
+    }
+}
+
+impl Default for ChatBotBuilder<NoImplProvided> {
+    fn default() -> Self {
+        Self(NoImplProvided)
+    }
+}
+
+impl ChatBotBuilder<NoImplProvided> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn agent<M: CompletionModel + 'static>(
+        self,
+        agent: Agent<M>,
+    ) -> ChatBotBuilder<AgentImpl<M>> {
+        ChatBotBuilder(AgentImpl {
+            agent,
+            multi_turn_depth: 1,
+            show_usage: false,
+            usage: Usage::default(),
+        })
+    }
+
+    pub fn chat<T: Chat>(self, chatbot: T) -> ChatBotBuilder<ChatImpl<T>> {
+        ChatBotBuilder(ChatImpl(chatbot))
+    }
+}
+
+impl<T: Chat> ChatBotBuilder<ChatImpl<T>> {
+    pub fn build(self) -> ChatBot<ChatImpl<T>> {
+        let ChatBotBuilder(chat_impl) = self;
+        ChatBot(chat_impl)
+    }
+}
+
+impl<M: CompletionModel + 'static> ChatBotBuilder<AgentImpl<M>> {
+    pub fn multi_turn_depth(self, multi_turn_depth: usize) -> Self {
+        ChatBotBuilder(AgentImpl {
+            multi_turn_depth,
+            ..self.0
+        })
+    }
+
+    pub fn show_usage(self) -> Self {
+        ChatBotBuilder(AgentImpl {
+            show_usage: true,
+            ..self.0
+        })
+    }
+
+    pub fn build(self) -> ChatBot<AgentImpl<M>> {
+        ChatBot(self.0)
+    }
+}
+
+#[allow(private_bounds)]
+impl<T: CliChat> ChatBot<T> {
+    pub async fn run(mut self) -> Result<(), PromptError> {
+        let stdin = io::stdin();
+        let mut stdout = io::stdout();
+        let mut history = vec![];
+
+        loop {
+            print!("> ");
+            stdout.flush().unwrap();
+
+            let mut input = String::new();
+            match stdin.read_line(&mut input) {
+                Ok(_) => {
+                    let input = input.trim();
+                    if input == "exit" {
+                        break;
+                    }
+
+                    tracing::info!("Prompt:\n{input}\n");
+
+                    println!();
+                    println!("========================== Response ============================");
+
+                    let response = self.0.request(input, history.clone()).await?;
+                    history.push(Message::user(input));
+                    history.push(Message::assistant(response));
+
+                    println!("================================================================");
+                    println!();
+
+                    if self.0.show_usage() {
+                        let Usage {
+                            input_tokens,
+                            output_tokens,
+                            ..
+                        } = self.0.usage().unwrap();
+                        println!("Input {input_tokens} tokens\nOutput {output_tokens} tokens");
+                    }
+                }
+                Err(e) => println!("Error reading request: {e}"),
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/rig-core/src/completion/request.rs
+++ b/rig-core/src/completion/request.rs
@@ -66,7 +66,7 @@
 use super::message::{AssistantContent, DocumentMediaType};
 use crate::client::completion::CompletionModelHandle;
 use crate::streaming::StreamingCompletionResponse;
-use crate::{OneOrMany, streaming};
+use crate::{OneOrMany, http_client, streaming};
 use crate::{
     json_utils,
     message::{Message, UserContent},
@@ -85,7 +85,7 @@ use thiserror::Error;
 pub enum CompletionError {
     /// Http error (e.g.: connection error, timeout, etc.)
     #[error("HttpError: {0}")]
-    HttpError(#[from] reqwest::Error),
+    HttpError(#[from] http_client::HttpClientError),
 
     /// Json error (e.g.: serialization, deserialization)
     #[error("JsonError: {0}")]

--- a/rig-core/src/embeddings/embedding.rs
+++ b/rig-core/src/embeddings/embedding.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 pub enum EmbeddingError {
     /// Http error (e.g.: connection error, timeout, etc.)
     #[error("HttpError: {0}")]
-    HttpError(#[from] reqwest::Error),
+    HttpError(Box<dyn std::error::Error + Send + Sync + 'static>),
 
     /// Json error (e.g.: serialization, deserialization)
     #[error("JsonError: {0}")]

--- a/rig-core/src/http_client.rs
+++ b/rig-core/src/http_client.rs
@@ -1,0 +1,147 @@
+use bytes::Bytes;
+use futures::stream::{BoxStream, StreamExt};
+pub use http::{HeaderValue, Method, Request, Response, Uri, request::Builder};
+use std::future::Future;
+use std::pin::Pin;
+
+#[derive(Debug, thiserror::Error)]
+pub enum HttpClientError {
+    #[error("Http error: {0}")]
+    Protocol(#[from] http::Error),
+    #[error("Http client error: {0}")]
+    Instance(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
+}
+
+fn instance_error<E: std::error::Error + Send + Sync + 'static>(error: E) -> HttpClientError {
+    HttpClientError::Instance(error.into())
+}
+
+pub type LazyBytes = Pin<Box<dyn Future<Output = Result<Bytes, HttpClientError>> + Send + 'static>>;
+pub type LazyBody<T> = Pin<Box<dyn Future<Output = Result<T, HttpClientError>> + Send + 'static>>;
+
+pub type ByteStream = BoxStream<'static, Result<Bytes, HttpClientError>>;
+pub type StreamingResponse = Response<ByteStream>;
+
+pub struct NoBody;
+
+impl From<NoBody> for Bytes {
+    fn from(_: NoBody) -> Self {
+        Bytes::new()
+    }
+}
+
+pub trait HttpClientExt: Send + Sync {
+    fn request<T, U>(
+        &self,
+        req: Request<T>,
+    ) -> impl Future<Output = Result<Response<LazyBody<U>>, HttpClientError>> + Send
+    where
+        T: Into<Bytes>,
+        U: From<Bytes> + Send;
+
+    fn request_streaming<T>(
+        &self,
+        req: Request<T>,
+    ) -> impl Future<Output = Result<StreamingResponse, HttpClientError>> + Send
+    where
+        T: Into<Bytes>;
+
+    async fn get<T>(&self, uri: Uri) -> Result<Response<LazyBody<T>>, HttpClientError>
+    where
+        T: From<Bytes> + Send,
+    {
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri(uri)
+            .body(NoBody)?;
+
+        self.request(req).await
+    }
+
+    async fn post<T, U, V>(
+        &self,
+        uri: Uri,
+        body: T,
+    ) -> Result<Response<LazyBody<V>>, HttpClientError>
+    where
+        U: TryInto<Uri>,
+        <U as TryInto<Uri>>::Error: Into<HttpClientError>,
+        T: Into<Bytes>,
+        V: From<Bytes> + Send,
+    {
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri(uri)
+            .body(body.into())?;
+
+        self.request(req).await
+    }
+}
+
+impl HttpClientExt for reqwest::Client {
+    fn request<T, U>(
+        &self,
+        req: Request<T>,
+    ) -> impl Future<Output = Result<Response<LazyBody<U>>, HttpClientError>> + Send
+    where
+        T: Into<Bytes>,
+        U: From<Bytes> + Send,
+    {
+        let (parts, body) = req.into_parts();
+        let req = self
+            .request(parts.method, parts.uri.to_string())
+            .headers(parts.headers)
+            .body(body.into());
+
+        async move {
+            let response = req.send().await.map_err(instance_error)?;
+
+            let mut res = Response::builder()
+                .status(response.status())
+                .version(response.version());
+
+            if let Some(hs) = res.headers_mut() {
+                *hs = response.headers().clone();
+            }
+
+            let body: LazyBody<U> = Box::pin(async move {
+                let bytes = response.bytes().await.map_err(instance_error)?;
+                let body = U::from(bytes);
+                Ok(body)
+            });
+
+            res.body(body).map_err(HttpClientError::Protocol)
+        }
+    }
+
+    fn request_streaming<T>(
+        &self,
+        req: Request<T>,
+    ) -> impl Future<Output = Result<StreamingResponse, HttpClientError>> + Send
+    where
+        T: Into<Bytes>,
+    {
+        let (parts, body) = req.into_parts();
+        let req = self
+            .request(parts.method, parts.uri.to_string())
+            .headers(parts.headers)
+            .body(body.into());
+
+        async move {
+            let response: reqwest::Response = req.send().await.map_err(instance_error)?;
+
+            let mut res = Response::builder()
+                .status(response.status())
+                .version(response.version());
+
+            if let Some(hs) = res.headers_mut() {
+                *hs = response.headers().clone();
+            }
+
+            let stream: ByteStream =
+                Box::pin(response.bytes_stream().map(|r| r.map_err(instance_error)));
+
+            Ok(res.body(stream)?)
+        }
+    }
+}

--- a/rig-core/src/lib.rs
+++ b/rig-core/src/lib.rs
@@ -115,6 +115,7 @@ pub mod client;
 pub mod completion;
 pub mod embeddings;
 pub mod extractor;
+pub mod http_client;
 #[cfg(feature = "image")]
 #[cfg_attr(docsrs, doc(cfg(feature = "image")))]
 pub mod image_generation;

--- a/rig-core/src/providers/anthropic/client.rs
+++ b/rig-core/src/providers/anthropic/client.rs
@@ -1,8 +1,14 @@
 //! Anthropic client api implementation
+use bytes::Bytes;
+use http_client::{Method, Request, Uri};
+
 use super::completion::{ANTHROPIC_VERSION_LATEST, CompletionModel};
-use crate::client::{
-    ClientBuilderError, CompletionClient, ProviderClient, ProviderValue, VerifyClient, VerifyError,
-    impl_conversion_traits,
+use crate::{
+    client::{
+        ClientBuilderError, CompletionClient, ProviderClient, ProviderValue, VerifyClient,
+        VerifyError, impl_conversion_traits,
+    },
+    http_client::{self, HttpClientError, HttpClientExt},
 };
 
 // ================================================================
@@ -10,12 +16,12 @@ use crate::client::{
 // ================================================================
 const ANTHROPIC_API_BASE_URL: &str = "https://api.anthropic.com";
 
-pub struct ClientBuilder<'a> {
+pub struct ClientBuilder<'a, T> {
     api_key: &'a str,
     base_url: &'a str,
     anthropic_version: &'a str,
     anthropic_betas: Option<Vec<&'a str>>,
-    http_client: Option<reqwest::Client>,
+    http_client: T,
 }
 
 /// Create a new anthropic client using the builder
@@ -30,14 +36,27 @@ pub struct ClientBuilder<'a> {
 ///    .anthropic_beta("prompt-caching-2024-07-31")
 ///    .build()
 /// ```
-impl<'a> ClientBuilder<'a> {
+impl<'a, T> ClientBuilder<'a, T>
+where
+    T: HttpClientExt + Default,
+{
     pub fn new(api_key: &'a str) -> Self {
+        ClientBuilder {
+            api_key,
+            base_url: ANTHROPIC_API_BASE_URL,
+            anthropic_version: ANTHROPIC_VERSION_LATEST,
+            anthropic_betas: None,
+            http_client: Default::default(),
+        }
+    }
+
+    pub fn with_client(api_key: &'a str, http_client: T) -> Self {
         Self {
             api_key,
             base_url: ANTHROPIC_API_BASE_URL,
             anthropic_version: ANTHROPIC_VERSION_LATEST,
             anthropic_betas: None,
-            http_client: None,
+            http_client,
         }
     }
 
@@ -61,12 +80,7 @@ impl<'a> ClientBuilder<'a> {
         self
     }
 
-    pub fn custom_client(mut self, client: reqwest::Client) -> Self {
-        self.http_client = Some(client);
-        self
-    }
-
-    pub fn build(self) -> Result<Client, ClientBuilderError> {
+    pub fn build(self) -> Result<Client<T>, ClientBuilderError> {
         let mut default_headers = reqwest::header::HeaderMap::new();
         default_headers.insert(
             "anthropic-version",
@@ -74,6 +88,7 @@ impl<'a> ClientBuilder<'a> {
                 .parse()
                 .map_err(|_| ClientBuilderError::InvalidProperty("anthropic-version"))?,
         );
+
         if let Some(betas) = self.anthropic_betas {
             default_headers.insert(
                 "anthropic-beta",
@@ -84,34 +99,31 @@ impl<'a> ClientBuilder<'a> {
             );
         };
 
-        let http_client = if let Some(http_client) = self.http_client {
-            http_client
-        } else {
-            reqwest::Client::builder().build()?
-        };
-
         Ok(Client {
             base_url: self.base_url.to_string(),
             api_key: self.api_key.to_string(),
             default_headers,
-            http_client,
+            http_client: self.http_client,
         })
     }
 }
 
 #[derive(Clone)]
-pub struct Client {
+pub struct Client<T> {
     /// The base URL
     base_url: String,
     /// The API key
     api_key: String,
     /// The underlying HTTP client
-    http_client: reqwest::Client,
+    http_client: T,
     /// Default headers that will be automatically added to any given request with this client (API key, Anthropic Version and any betas that have been added)
     default_headers: reqwest::header::HeaderMap,
 }
 
-impl std::fmt::Debug for Client {
+impl<T> std::fmt::Debug for Client<T>
+where
+    T: HttpClientExt + std::fmt::Debug,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)
@@ -122,56 +134,102 @@ impl std::fmt::Debug for Client {
     }
 }
 
-impl Client {
-    /// Create a new Anthropic client builder.
-    ///
-    /// # Example
-    /// ```
-    /// use rig::providers::anthropic::{ClientBuilder, self};
-    ///
-    /// // Initialize the Anthropic client
-    /// let anthropic_client = Client::builder("your-claude-api-key")
-    ///    .anthropic_version(ANTHROPIC_VERSION_LATEST)
-    ///    .anthropic_beta("prompt-caching-2024-07-31")
-    ///    .build()
-    /// ```
-    pub fn builder(api_key: &str) -> ClientBuilder<'_> {
-        ClientBuilder::new(api_key)
-    }
+fn build_uri(path: &str) -> Result<Uri, http::Error> {
+    Uri::builder()
+        .scheme("https")
+        .authority("api.anthropic.com")
+        .path_and_query(path)
+        .build()
+}
 
+impl<T> Client<T>
+where
+    T: HttpClientExt + Clone + Default,
+{
     /// Create a new Anthropic client. For more control, use the `builder` method.
     ///
     /// # Panics
     /// - If the API key or version cannot be parsed as a Json value from a String.
     /// - If the reqwest client cannot be built (if the TLS backend cannot be initialized).
     pub fn new(api_key: &str) -> Self {
-        Self::builder(api_key)
+        ClientBuilder::new(api_key)
             .build()
             .expect("Anthropic client should build")
     }
 
-    pub(crate) fn post(&self, path: &str) -> reqwest::RequestBuilder {
-        let url = format!("{}/{}", self.base_url, path).replace("//", "/");
-        self.http_client
-            .post(url)
-            .header("X-Api-Key", &self.api_key)
-            .headers(self.default_headers.clone())
+    pub async fn send<U, V>(
+        &self,
+        req: http_client::Request<U>,
+    ) -> Result<http_client::Response<http_client::LazyBody<V>>, http_client::HttpClientError>
+    where
+        U: Into<Bytes>,
+        V: From<Bytes> + Send,
+    {
+        self.http_client.request(req).await
     }
 
-    pub(crate) fn get(&self, path: &str) -> reqwest::RequestBuilder {
-        let url = format!("{}/{}", self.base_url, path).replace("//", "/");
-        self.http_client
-            .get(url)
-            .header("X-Api-Key", &self.api_key)
-            .headers(self.default_headers.clone())
+    pub async fn send_streaming<U>(
+        &self,
+        req: Request<U>,
+    ) -> Result<http_client::StreamingResponse, http_client::HttpClientError>
+    where
+        U: Into<Bytes>,
+    {
+        self.http_client.request_streaming(req).await
+    }
+
+    pub(crate) fn post(&self, path: &str) -> http_client::Builder {
+        let uri = format!("{}/{}", ANTHROPIC_API_BASE_URL, path).replace("//", "/");
+
+        let mut headers = self.default_headers.clone();
+
+        headers.insert(
+            "X-Api-Key",
+            http_client::HeaderValue::from_str(&self.api_key).unwrap(),
+        );
+
+        let mut req = http_client::Request::builder()
+            .method(Method::POST)
+            .uri(uri);
+
+        if let Some(hs) = req.headers_mut() {
+            *hs = headers;
+        }
+
+        req
+    }
+
+    pub(crate) fn get(
+        &self,
+        path: &str,
+    ) -> Result<http_client::Request<http_client::NoBody>, http::Error> {
+        let uri = format!("{}/{}", self.base_url, path).replace("//", "/");
+
+        let mut headers = self.default_headers.clone();
+        headers.insert(
+            "X-Api-Key",
+            http_client::HeaderValue::from_str(&self.api_key).unwrap(),
+        );
+
+        let mut req = http_client::Request::builder().method(Method::GET).uri(uri);
+
+        if let Some(hs) = req.headers_mut() {
+            *hs = headers;
+        }
+
+        req.body(http_client::NoBody)
     }
 }
 
-impl ProviderClient for Client {
+impl<T> ProviderClient for Client<T>
+where
+    T: HttpClientExt + Clone + std::fmt::Debug + Default + 'static,
+{
     /// Create a new Anthropic client from the `ANTHROPIC_API_KEY` environment variable.
     /// Panics if the environment variable is not set.
     fn from_env() -> Self {
         let api_key = std::env::var("ANTHROPIC_API_KEY").expect("ANTHROPIC_API_KEY not set");
+
         Client::new(&api_key)
     }
 
@@ -179,35 +237,60 @@ impl ProviderClient for Client {
         let ProviderValue::Simple(api_key) = input else {
             panic!("Incorrect provider value type")
         };
+
         Client::new(&api_key)
     }
 }
 
-impl CompletionClient for Client {
-    type CompletionModel = CompletionModel;
-    fn completion_model(&self, model: &str) -> CompletionModel {
+impl<T> CompletionClient for Client<T>
+where
+    T: HttpClientExt + Clone + std::fmt::Debug + Default + 'static,
+{
+    type CompletionModel = CompletionModel<T>;
+
+    fn completion_model(&self, model: &str) -> CompletionModel<T> {
         CompletionModel::new(self.clone(), model)
     }
 }
 
-impl VerifyClient for Client {
+impl<T> VerifyClient for Client<T>
+where
+    T: HttpClientExt + Clone + std::fmt::Debug + Default + 'static,
+{
     #[cfg_attr(feature = "worker", worker::send)]
     async fn verify(&self) -> Result<(), VerifyError> {
-        let response = self.get("/v1/models").send().await?;
+        let response: http_client::Response<http_client::LazyBody<Vec<u8>>> = self
+            .http_client
+            .request(
+                self.get("/v1/models")
+                    .map_err(|e| http_client::HttpClientError::Protocol(e))?,
+            )
+            .await?;
+
         match response.status() {
-            reqwest::StatusCode::OK => Ok(()),
-            reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN => {
+            http::StatusCode::OK => Ok(()),
+            http::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN => {
                 Err(VerifyError::InvalidAuthentication)
             }
-            reqwest::StatusCode::INTERNAL_SERVER_ERROR => {
-                Err(VerifyError::ProviderError(response.text().await?))
+            http::StatusCode::INTERNAL_SERVER_ERROR => {
+                let text = String::from_utf8_lossy(&response.into_body().await?).into();
+                Err(VerifyError::ProviderError(text))
             }
             status if status.as_u16() == 529 => {
-                Err(VerifyError::ProviderError(response.text().await?))
+                let text = String::from_utf8_lossy(&response.into_body().await?).into();
+                Err(VerifyError::ProviderError(text))
             }
             _ => {
-                response.error_for_status()?;
-                Ok(())
+                let status = response.status();
+
+                if status.is_success() {
+                    Ok(())
+                } else {
+                    let text: String = String::from_utf8_lossy(&response.into_body().await?).into();
+                    Err(VerifyError::HttpError(HttpClientError::Instance(
+                        format!("Failed with '{status}': {text}").into(),
+                    )))
+                }
             }
         }
     }
@@ -217,5 +300,6 @@ impl_conversion_traits!(
     AsTranscription,
     AsEmbeddings,
     AsImageGeneration,
-    AsAudioGeneration for Client
+    AsAudioGeneration
+    for Client<T>
 );

--- a/rig-core/src/providers/anthropic/streaming.rs
+++ b/rig-core/src/providers/anthropic/streaming.rs
@@ -6,6 +6,7 @@ use serde_json::json;
 use super::completion::{CompletionModel, Content, Message, ToolChoice, ToolDefinition, Usage};
 use super::decoders::sse::from_response as sse_from_response;
 use crate::completion::{CompletionError, CompletionRequest, GetTokenUsage};
+use crate::http_client::{self, HttpClientExt};
 use crate::json_utils::merge_inplace;
 use crate::streaming;
 use crate::streaming::{RawStreamingChoice, StreamingResult};
@@ -92,7 +93,10 @@ impl GetTokenUsage for StreamingCompletionResponse {
     }
 }
 
-impl CompletionModel {
+impl<T> CompletionModel<T>
+where
+    T: HttpClientExt + Clone + Default,
+{
     pub(crate) async fn stream(
         &self,
         completion_request: CompletionRequest,
@@ -119,7 +123,7 @@ impl CompletionModel {
             .map(Message::try_from)
             .collect::<Result<Vec<Message>, _>>()?;
 
-        let mut request = json!({
+        let mut body = json!({
             "model": self.model,
             "messages": full_history,
             "max_tokens": max_tokens,
@@ -128,12 +132,12 @@ impl CompletionModel {
         });
 
         if let Some(temperature) = completion_request.temperature {
-            merge_inplace(&mut request, json!({ "temperature": temperature }));
+            merge_inplace(&mut body, json!({ "temperature": temperature }));
         }
 
         if !completion_request.tools.is_empty() {
             merge_inplace(
-                &mut request,
+                &mut body,
                 json!({
                     "tools": completion_request
                         .tools
@@ -150,26 +154,42 @@ impl CompletionModel {
         }
 
         if let Some(ref params) = completion_request.additional_params {
-            merge_inplace(&mut request, params.clone())
+            merge_inplace(&mut body, params.clone())
         }
 
-        let response = self
+        let body: Vec<u8> = serde_json::to_vec(&body)?;
+
+        let req = self
             .client
             .post("/v1/messages")
-            .json(&request)
-            .send()
-            .await?;
+            .body(body)
+            .map_err(|e| http_client::HttpClientError::Protocol(e))?;
+
+        let response: http_client::StreamingResponse = self.client.send_streaming(req).await?;
 
         if !response.status().is_success() {
-            return Err(CompletionError::ProviderError(response.text().await?));
+            let mut stream = response.into_body();
+            let mut text = String::with_capacity(1024);
+            loop {
+                let Some(chunk) = stream.next().await else {
+                    break;
+                };
+
+                let chunk = chunk?;
+
+                let str = String::from_utf8_lossy(&chunk);
+
+                text.push_str(&str)
+            }
+            return Err(CompletionError::ProviderError(text));
         }
 
-        // Use our SSE decoder to directly handle Server-Sent Events format
-        let sse_stream = sse_from_response(response);
+        let stream = sse_from_response(response.into_body());
 
+        // Use our SSE decoder to directly handle Server-Sent Events format
         let stream: StreamingResult<StreamingCompletionResponse> = Box::pin(stream! {
             let mut current_tool_call: Option<ToolCallState> = None;
-            let mut sse_stream = Box::pin(sse_stream);
+            let mut sse_stream = Box::pin(stream);
             let mut input_tokens = 0;
 
             while let Some(sse_result) = sse_stream.next().await {
@@ -184,7 +204,6 @@ impl CompletionModel {
                                     },
                                     StreamingEvent::MessageDelta { delta, usage } => {
                                         if delta.stop_reason.is_some() {
-
                                             yield Ok(RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
                                                 usage: PartialUsage {
                                                     output_tokens: usage.output_tokens,
@@ -253,7 +272,7 @@ fn handle_event(
             _ => None,
         },
         StreamingEvent::ContentBlockStop { .. } => {
-            if let Some(tool_call) = current_tool_call.take() {
+            if let Some(tool_call) = Option::take(current_tool_call) {
                 let json_str = if tool_call.input_json.is_empty() {
                     "{}"
                 } else {

--- a/rig-core/src/providers/cohere/client.rs
+++ b/rig-core/src/providers/cohere/client.rs
@@ -2,13 +2,13 @@ use crate::{
     Embed,
     client::{VerifyClient, VerifyError},
     embeddings::EmbeddingsBuilder,
+    http_client::{self, HttpClientExt},
 };
 
 use super::{CompletionModel, EmbeddingModel};
-use crate::client::{
-    ClientBuilderError, CompletionClient, EmbeddingsClient, ProviderClient, impl_conversion_traits,
-};
+use crate::client::{CompletionClient, EmbeddingsClient, ProviderClient, impl_conversion_traits};
 use serde::Deserialize;
+use url::ParseError;
 
 #[derive(Debug, Deserialize)]
 pub struct ApiErrorResponse {
@@ -27,18 +27,32 @@ pub enum ApiResponse<T> {
 // ================================================================
 const COHERE_API_BASE_URL: &str = "https://api.cohere.ai";
 
-pub struct ClientBuilder<'a> {
+pub struct ClientBuilder<'a, T>
+where
+    T: HttpClientExt,
+{
     api_key: &'a str,
     base_url: &'a str,
-    http_client: Option<reqwest::Client>,
+    http_client: T,
 }
 
-impl<'a> ClientBuilder<'a> {
-    pub fn new(api_key: &'a str) -> Self {
-        Self {
+impl<'a, T> ClientBuilder<'a, T>
+where
+    T: HttpClientExt,
+{
+    pub fn new(api_key: &'a str) -> ClientBuilder<'a, reqwest::Client> {
+        ClientBuilder {
             api_key,
             base_url: COHERE_API_BASE_URL,
-            http_client: None,
+            http_client: reqwest::Client::new(),
+        }
+    }
+
+    pub fn with_client(api_key: &'a str, http_client: T) -> Self {
+        ClientBuilder {
+            api_key,
+            base_url: COHERE_API_BASE_URL,
+            http_client,
         }
     }
 
@@ -47,34 +61,26 @@ impl<'a> ClientBuilder<'a> {
         self
     }
 
-    pub fn custom_client(mut self, client: reqwest::Client) -> Self {
-        self.http_client = Some(client);
-        self
-    }
-
-    pub fn build(self) -> Result<Client, ClientBuilderError> {
-        let http_client = if let Some(http_client) = self.http_client {
-            http_client
-        } else {
-            reqwest::Client::builder().build()?
-        };
-
-        Ok(Client {
+    pub fn build(self) -> Client<T> {
+        Client {
             base_url: self.base_url.to_string(),
             api_key: self.api_key.to_string(),
-            http_client,
-        })
+            http_client: self.http_client,
+        }
     }
 }
 
 #[derive(Clone)]
-pub struct Client {
+pub struct Client<T> {
     base_url: String,
     api_key: String,
-    http_client: reqwest::Client,
+    http_client: T,
 }
 
-impl std::fmt::Debug for Client {
+impl<T> std::fmt::Debug for Client<T>
+where
+    T: HttpClientExt + std::fmt::Debug,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Client")
             .field("base_url", &self.base_url)
@@ -84,52 +90,49 @@ impl std::fmt::Debug for Client {
     }
 }
 
-impl Client {
-    /// Create a new Cohere client builder.
-    ///
-    /// # Example
-    /// ```
-    /// use rig::providers::cohere::{ClientBuilder, self};
-    ///
-    /// // Initialize the Cohere client
-    /// let cohere_client = Client::builder("your-cohere-api-key")
-    ///    .build()
-    /// ```
-    pub fn builder(api_key: &str) -> ClientBuilder<'_> {
-        ClientBuilder::new(api_key)
-    }
-
+impl<T> Client<T>
+where
+    T: HttpClientExt + Clone,
+{
     /// Create a new Cohere client. For more control, use the `builder` method.
     ///
     /// # Panics
     /// - If the reqwest client cannot be built (if the TLS backend cannot be initialized).
-    pub fn new(api_key: &str) -> Self {
-        Self::builder(api_key)
-            .build()
-            .expect("Cohere client should build")
+    pub fn new(api_key: &str) -> Client<reqwest::Client> {
+        ClientBuilder::with_client(api_key, reqwest::Client::new()).build()
     }
 
-    pub(crate) fn post(&self, path: &str) -> reqwest::RequestBuilder {
+    pub(crate) fn post<U>(&self, path: &str) -> Result<http_client::Request<U>, ParseError>
+    where
+        U: From<Bytes> + Send,
+    {
         let url = format!("{}/{}", self.base_url, path).replace("//", "/");
-        self.http_client.post(url).bearer_auth(&self.api_key)
+        Ok(http_client::Request::post(url.as_str())?.bearer_auth(self.api_key.as_str()))
     }
 
-    pub(crate) fn get(&self, path: &str) -> reqwest::RequestBuilder {
+    pub(crate) fn get(&self, path: &str) -> Result<http_client::Request, ParseError> {
         let url = format!("{}/{}", self.base_url, path).replace("//", "/");
-        self.http_client.get(url).bearer_auth(&self.api_key)
+        Ok(http_client::Request::get(url.as_str())?.bearer_auth(self.api_key.as_str()))
+    }
+
+    pub(crate) async fn send(
+        &self,
+        req: http_client::Request,
+    ) -> Result<http_client::Response, <T as HttpClientExt>::Error> {
+        self.http_client.request(req).await
     }
 
     pub fn embeddings<D: Embed>(
         &self,
         model: &str,
         input_type: &str,
-    ) -> EmbeddingsBuilder<EmbeddingModel, D> {
+    ) -> EmbeddingsBuilder<EmbeddingModel<T>, D> {
         EmbeddingsBuilder::new(self.embedding_model(model, input_type))
     }
 
     /// Note: default embedding dimension of 0 will be used if model is not known.
     /// If this is the case, it's better to use function `embedding_model_with_ndims`
-    pub fn embedding_model(&self, model: &str, input_type: &str) -> EmbeddingModel {
+    pub fn embedding_model(&self, model: &str, input_type: &str) -> EmbeddingModel<T> {
         let ndims = match model {
             super::EMBED_ENGLISH_V3
             | super::EMBED_MULTILINGUAL_V3
@@ -148,12 +151,19 @@ impl Client {
         model: &str,
         input_type: &str,
         ndims: usize,
-    ) -> EmbeddingModel {
+    ) -> EmbeddingModel<T> {
         EmbeddingModel::new(self.clone(), model, input_type, ndims)
     }
 }
 
-impl ProviderClient for Client {
+impl Client<reqwest::Client> {
+    pub(crate) async fn eventsource(&self, req: http_client::Request) -> _ {
+        let req: reqwest::Request = req.into();
+        todo!()
+    }
+}
+
+impl ProviderClient for Client<reqwest::Client> {
     /// Create a new Cohere client from the `COHERE_API_KEY` environment variable.
     /// Panics if the environment variable is not set.
     fn from_env() -> Self {
@@ -169,16 +179,16 @@ impl ProviderClient for Client {
     }
 }
 
-impl CompletionClient for Client {
-    type CompletionModel = CompletionModel;
+impl CompletionClient for Client<reqwest::Client> {
+    type CompletionModel = CompletionModel<reqwest::Client>;
 
     fn completion_model(&self, model: &str) -> Self::CompletionModel {
         CompletionModel::new(self.clone(), model)
     }
 }
 
-impl EmbeddingsClient for Client {
-    type EmbeddingModel = EmbeddingModel;
+impl EmbeddingsClient for Client<reqwest::Client> {
+    type EmbeddingModel = EmbeddingModel<reqwest::Client>;
 
     fn embedding_model(&self, model: &str) -> Self::EmbeddingModel {
         self.embedding_model(model, "search_document")
@@ -193,10 +203,11 @@ impl EmbeddingsClient for Client {
     }
 }
 
-impl VerifyClient for Client {
+impl VerifyClient for Client<reqwest::Client> {
     #[cfg_attr(feature = "worker", worker::send)]
     async fn verify(&self) -> Result<(), VerifyError> {
-        let response = self.get("/v1/models").send().await?;
+        let response = self.http_client.get("/v1/models").send().await?;
+
         match response.status() {
             reqwest::StatusCode::OK => Ok(()),
             reqwest::StatusCode::UNAUTHORIZED => Err(VerifyError::InvalidAuthentication),
@@ -214,5 +225,5 @@ impl VerifyClient for Client {
 impl_conversion_traits!(
     AsTranscription,
     AsImageGeneration,
-    AsAudioGeneration for Client
+    AsAudioGeneration for Client<T>
 );


### PR DESCRIPTION
I think I got this all worked out now that I'm using types from the `http` crate, and using return-position impls in trait methods vs the `async` keyword to enforce `Send` return types, but I figured I'd still put it up here.

Not sure that `Bytes` is the right type to bound request and response bodies by. For instance, `String` does not `impl From<Bytes>` so it's sort of a pain to get the text out of a response. The `Arc` overhead is less than ideal as well. Same with the error handling, we have a `Box<dyn Error>` which I think is generally suboptimal.

But it is, at the very least, typechecking for the anthropic provider 