### PR TITLE
refactor(rig-975): split streaming portion of PromptHook

### DIFF
--- a/rig-core/src/agent/prompt_request/streaming.rs
+++ b/rig-core/src/agent/prompt_request/streaming.rs
@@ -1,6 +1,5 @@
 use crate::{
     OneOrMany,
-    agent::prompt_request::PromptHook,
     completion::GetTokenUsage,
     message::{AssistantContent, Reasoning, ToolResultContent, UserContent},
     streaming::{StreamedAssistantContent, StreamingCompletion},


### PR DESCRIPTION
Fixes #887 

(this is also a follow up to https://github.com/0xPlaygrounds/rig/commit/643bf82bc5c3b6b04909e934b63de74bcb021672 which was accidentally pushed straight to main)