### PR TITLE
bugfix: bedrock provider SDK has issue with DocumentBlock text variant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,9 +937,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-bedrockruntime"
-version = "1.102.0"
+version = "1.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e2fce23c31248b7f46d3b346089ab087dd16bbb33b680ddb77a2a36331a1994"
+checksum = "1574d1fad8f4bbf71aeb5dbb16653e7db48463f031ae77fdc161621019364d4a"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1515,7 +1515,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
  "log",
@@ -6455,7 +6455,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.2",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -12816,7 +12816,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/rig-bedrock/src/types/document.rs
+++ b/rig-bedrock/src/types/document.rs
@@ -35,7 +35,12 @@ impl TryFrom<RigDocument> for aws_bedrock::DocumentBlock {
 
                 aws_bedrock::DocumentSource::Bytes(aws_smithy_types::Blob::new(bytes))
             }
-            DocumentSourceKind::String(str) => aws_bedrock::DocumentSource::Text(str),
+            // NOTE: until [aws-sdk-bedrockruntime DocumentSource bug #1365](https://github.com/awslabs/aws-sdk-rust/issues/1365)
+            // is resolved we will use this as a workaround
+            // DocumentSourceKind::String(str) => aws_bedrock::DocumentSource::Text(str),
+            DocumentSourceKind::String(str) => {
+                aws_bedrock::DocumentSource::Bytes(aws_smithy_types::Blob::new(str.as_bytes()))
+            }
             doc => {
                 return Err(CompletionError::RequestError(
                     format!("Unsupported document kind: {doc}").into(),


### PR DESCRIPTION
this is a workaround for a bug inside aws bedrock sdk.


Bug is reported here: [aws-sdk-bedrockruntime DocumentSource bug #1365](https://github.com/awslabs/aws-sdk-rust/issues/1365)