### PR TITLE
bug(rig-982): `embedding_model_with_ndims()` doesn't pass dimensions parameter to OpenAI API

### DIFF
--- a/rig-core/src/providers/openai/embedding.rs
+++ b/rig-core/src/providers/openai/embedding.rs
@@ -69,10 +69,14 @@ where
     ) -> Result<Vec<embeddings::Embedding>, EmbeddingError> {
         let documents = documents.into_iter().collect::<Vec<_>>();
 
-        let body = json!({
+        let mut body = json!({
             "model": self.model,
             "input": documents,
         });
+
+        if self.ndims > 0 {
+            body["dimensions"] = json!(self.ndims);
+        }
 
         let body = serde_json::to_vec(&body)?;
 


### PR DESCRIPTION
Closes #906 