### PR TITLE
feat(bedrock): Implement usage

### DIFF
--- a/rig-bedrock/src/completion.rs
+++ b/rig-bedrock/src/completion.rs
@@ -173,7 +173,7 @@ impl CompletionModel {
 
 impl completion::CompletionModel for CompletionModel {
     type Response = AwsConverseOutput;
-    type StreamingResponse = ();
+    type StreamingResponse = crate::streaming::BedrockStreamingResponse;
 
     async fn completion(
         &self,

--- a/rig-bedrock/src/streaming.rs
+++ b/rig-bedrock/src/streaming.rs
@@ -2,8 +2,32 @@ use crate::types::completion_request::AwsCompletionRequest;
 use crate::{completion::CompletionModel, types::errors::AwsSdkConverseStreamError};
 use async_stream::stream;
 use aws_sdk_bedrockruntime::types as aws_bedrock;
+use rig::completion::GetTokenUsage;
 use rig::streaming::StreamingCompletionResponse;
 use rig::{completion::CompletionError, streaming::RawStreamingChoice};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, Serialize)]
+pub struct BedrockStreamingResponse {
+    pub usage: Option<BedrockUsage>,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+pub struct BedrockUsage {
+    pub input_tokens: i32,
+    pub output_tokens: i32,
+    pub total_tokens: i32,
+}
+
+impl GetTokenUsage for BedrockStreamingResponse {
+    fn token_usage(&self) -> Option<rig::completion::Usage> {
+        self.usage.as_ref().map(|u| rig::completion::Usage {
+            input_tokens: u.input_tokens as u64,
+            output_tokens: u.output_tokens as u64,
+            total_tokens: u.total_tokens as u64,
+        })
+    }
+}
 
 #[derive(Default)]
 struct ToolCallState {
@@ -16,7 +40,7 @@ impl CompletionModel {
     pub(crate) async fn stream(
         &self,
         completion_request: rig::completion::CompletionRequest,
-    ) -> Result<StreamingCompletionResponse<()>, CompletionError> {
+    ) -> Result<StreamingCompletionResponse<BedrockStreamingResponse>, CompletionError> {
         let request = AwsCompletionRequest(completion_request);
 
         let mut converse_builder = self
@@ -93,11 +117,130 @@ impl CompletionModel {
                             _ => {}
                         }
                     },
+                    aws_bedrock::ConverseStreamOutput::Metadata(metadata_event) => {
+                        // Extract usage information from metadata
+                        if let Some(usage) = metadata_event.usage {
+                            yield Ok(RawStreamingChoice::FinalResponse(BedrockStreamingResponse {
+                                usage: Some(BedrockUsage {
+                                    input_tokens: usage.input_tokens,
+                                    output_tokens: usage.output_tokens,
+                                    total_tokens: usage.total_tokens,
+                                }),
+                            }));
+                        }
+                    },
                     _ => {}
                 }
             }
         });
 
         Ok(StreamingCompletionResponse::stream(stream))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bedrock_usage_creation() {
+        let usage = BedrockUsage {
+            input_tokens: 100,
+            output_tokens: 50,
+            total_tokens: 150,
+        };
+
+        assert_eq!(usage.input_tokens, 100);
+        assert_eq!(usage.output_tokens, 50);
+        assert_eq!(usage.total_tokens, 150);
+    }
+
+    #[test]
+    fn test_bedrock_streaming_response_with_usage() {
+        let response = BedrockStreamingResponse {
+            usage: Some(BedrockUsage {
+                input_tokens: 200,
+                output_tokens: 75,
+                total_tokens: 275,
+            }),
+        };
+
+        let rig_usage = response.token_usage();
+        assert!(rig_usage.is_some());
+
+        let usage = rig_usage.unwrap();
+        assert_eq!(usage.input_tokens, 200);
+        assert_eq!(usage.output_tokens, 75);
+        assert_eq!(usage.total_tokens, 275);
+    }
+
+    #[test]
+    fn test_bedrock_streaming_response_without_usage() {
+        let response = BedrockStreamingResponse { usage: None };
+
+        let rig_usage = response.token_usage();
+        assert!(rig_usage.is_none());
+    }
+
+    #[test]
+    fn test_get_token_usage_trait() {
+        let response = BedrockStreamingResponse {
+            usage: Some(BedrockUsage {
+                input_tokens: 448,
+                output_tokens: 68,
+                total_tokens: 516,
+            }),
+        };
+
+        // Test that GetTokenUsage trait is properly implemented
+        let usage = response.token_usage().expect("Usage should be present");
+        assert_eq!(usage.input_tokens, 448);
+        assert_eq!(usage.output_tokens, 68);
+        assert_eq!(usage.total_tokens, 516);
+    }
+
+    #[test]
+    fn test_bedrock_usage_serde() {
+        let usage = BedrockUsage {
+            input_tokens: 100,
+            output_tokens: 50,
+            total_tokens: 150,
+        };
+
+        // Test serialization
+        let json = serde_json::to_string(&usage).expect("Should serialize");
+        assert!(json.contains("\"input_tokens\":100"));
+        assert!(json.contains("\"output_tokens\":50"));
+        assert!(json.contains("\"total_tokens\":150"));
+
+        // Test deserialization
+        let deserialized: BedrockUsage = serde_json::from_str(&json).expect("Should deserialize");
+        assert_eq!(deserialized.input_tokens, usage.input_tokens);
+        assert_eq!(deserialized.output_tokens, usage.output_tokens);
+        assert_eq!(deserialized.total_tokens, usage.total_tokens);
+    }
+
+    #[test]
+    fn test_bedrock_streaming_response_serde() {
+        let response = BedrockStreamingResponse {
+            usage: Some(BedrockUsage {
+                input_tokens: 200,
+                output_tokens: 75,
+                total_tokens: 275,
+            }),
+        };
+
+        // Test serialization
+        let json = serde_json::to_string(&response).expect("Should serialize");
+        assert!(json.contains("\"input_tokens\":200"));
+
+        // Test deserialization
+        let deserialized: BedrockStreamingResponse =
+            serde_json::from_str(&json).expect("Should deserialize");
+        assert!(deserialized.usage.is_some());
+        let usage = deserialized.usage.unwrap();
+        assert_eq!(usage.input_tokens, 200);
+        assert_eq!(usage.output_tokens, 75);
+        assert_eq!(usage.total_tokens, 275);
     }
 }


### PR DESCRIPTION
Implementation - Added Bedrock Usage Tracking

- `BedrockUsage` struct:
  - Stores `input_tokens`, `output_tokens`, and `total_tokens`
- `BedrockStreamingResponse` struct:
  - Contains optional `BedrockUsage`
- `GetTokenUsage` trait implementation:
  - Converts `BedrockUsage` (i32 tokens) to rig's `Usage` (u64 tokens)
- `Metadata` event handler:
  - Extracts usage from `ConverseStreamOutput::Metadata` events
  - Yields `RawStreamingChoice::FinalResponse` with usage data