### PR TITLE
fix(huggingface): align tool message serialization with OpenAI API spec

### DIFF
--- a/rig-core/src/providers/huggingface/completion.rs
+++ b/rig-core/src/providers/huggingface/completion.rs
@@ -10,7 +10,7 @@ use crate::{
     message::{self},
     one_or_many::string_or_one_or_many,
 };
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::{Value, json};
 use std::{convert::Infallible, str::FromStr};
 use tracing::info_span;
@@ -58,14 +58,14 @@ pub struct Function {
     pub arguments: serde_json::Value,
 }
 
-fn deserialize_arguments<'de, D>(deserializer: D) -> Result<serde_json::Value, D::Error>
+fn deserialize_arguments<'de, D>(deserializer: D) -> Result<Value, D::Error>
 where
-    D: serde::Deserializer<'de>,
+    D: Deserializer<'de>,
 {
-    let value = serde_json::Value::deserialize(deserializer)?;
+    let value = Value::deserialize(deserializer)?;
 
     match value {
-        serde_json::Value::String(s) => serde_json::from_str(&s).map_err(serde::de::Error::custom),
+        Value::String(s) => serde_json::from_str(&s).map_err(serde::de::Error::custom),
         other => Ok(other),
     }
 }
@@ -267,7 +267,7 @@ pub enum Message {
 
 fn serialize_tool_content<S>(content: &OneOrMany<String>, serializer: S) -> Result<S::Ok, S::Error>
 where
-    S: serde::Serializer,
+    S: Serializer,
 {
     // OpenAI-compatible APIs expect tool content as a string, not an array
     let joined = content


### PR DESCRIPTION
## Summary

Fixes tool calling in the HuggingFace provider by aligning Message serialization with the OpenAI Chat Completions API specification.

The HuggingFace provider's custom `Message` types were not fully compliant with the OpenAI API spec, causing **422 Unprocessable Entity** errors when calling OpenAI-compatible endpoints (router.huggingface.co sub-providers, Cerebras via custom base_url, and other OpenAI-compatible endpoints).

## Problem

When using tool calling with the HuggingFace provider, requests would fail with validation errors:

1. **Tool role capitalization error**
   ```
   messages[N].role: Input should be 'system', 'user', 'assistant' or 'tool'
   ```
   - Received: `"Tool"` (capitalized)

2. **Function arguments format error**
   ```
   messages[N].tool_calls[N].function.arguments: Input should be a valid string
   ```
   - Received: `{"cluster_id":"..."}` (JSON object)

3. **Tool content format error**
   ```
   messages[N].content: Input should be a valid string
   ```
   - Received: `["result"]` (JSON array)

## Solution

Three serialization fixes to match OpenAI API specification:

### 1. Tool role capitalization
```rust
#[serde(rename = "tool", alias = "Tool")]
ToolResult { ... }
```
- Serializes as lowercase `"tool"` (OpenAI requirement)
- Accepts both capitalizations for deserialization (backward compatibility)

### 2. Function arguments format
```rust
#[serde(with = "json_utils::stringified_json")]
pub arguments: serde_json::Value,
```
- Uses `stringified_json` serializer (consistent with OpenAI provider)
- Serializes arguments as JSON string: `"{\"cluster_id\":\"...\"}"`

### 3. Tool content format
```rust
#[serde(
    deserialize_with = "string_or_one_or_many",
    serialize_with = "serialize_tool_content"
)]
content: OneOrMany<String>,
```
- Custom serializer joins array elements with newlines
- `OneOrMany::one("result")` → `"result"`
- `OneOrMany::many(["a", "b"])` → `"a\nb"`

## Testing

Tested with **Qwen/Qwen3-235B-A22B-Instruct-2507** via:
- HuggingFace router (router.huggingface.co)
- Cerebras Inference API (custom base_url)

Multi-turn tool conversations now work correctly without 422 errors.

## References

- [OpenAI Function Calling Examples](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_call_functions_with_chat_models.ipynb)
- [Cerebras Tool Use Documentation](https://inference-docs.cerebras.ai/capabilities/tool-use)
