### PR TITLE
Fix: CompletionError: ProviderError when tools is empty in OpenAI-compatible requests

### DIFF
--- a/rig-core/src/providers/openai/completion/mod.rs
+++ b/rig-core/src/providers/openai/completion/mod.rs
@@ -818,8 +818,11 @@ where
 pub struct CompletionRequest {
     model: String,
     messages: Vec<Message>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     tools: Vec<ToolDefinition>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     tool_choice: Option<ToolChoice>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     temperature: Option<f64>,
     #[serde(flatten)]
     additional_params: Option<serde_json::Value>,


### PR DESCRIPTION
Background: 
When sending requests to OpenAI-compatible providers (e.g. aliyun), an empty tools array causes the following error:
```
CompletionError: ProviderError: {"error":{"code":null,"param":null,"message":"[] is too short - 'tools'","type":"invalid_request_error"},}
```

Solution:

Added conditional serialization to skip the tools field when it's empty.

Updated request construction logic to only include tools and tool_choice if tools is non-empty.


hanges Made:

In rig-core/src/providers/openai/completion/mod.rs, added #[serde(skip_serializing_if = "Vec::is_empty")] to the tools field.

In rig-core/src/providers/openrouter/completion.rs, added logic to omit tools and tool_choice from the request payload if tools is empty.

Impact:

Prevents request failures due to empty tools arrays.

Improves compatibility and robustness across OpenAI-compatible providers.
