### PR TITLE
fix: enhance ApiErrorResponse structure to match openrouter protocol

### DIFF
--- a/rig-core/src/providers/openrouter/client.rs
+++ b/rig-core/src/providers/openrouter/client.rs
@@ -209,7 +209,19 @@ impl_conversion_traits!(
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct ApiErrorResponse {
+    pub error: ErrorDetails,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct ErrorDetails {
     pub message: String,
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub code: Option<serde_json::Value>,
+    #[serde(rename = "type")]
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub error_type: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/rig-core/src/providers/openrouter/completion.rs
+++ b/rig-core/src/providers/openrouter/completion.rs
@@ -46,7 +46,7 @@ pub struct CompletionResponse {
 
 impl From<ApiErrorResponse> for CompletionError {
     fn from(err: ApiErrorResponse) -> Self {
-        CompletionError::ProviderError(err.message)
+        CompletionError::ProviderError(err.error.message)
     }
 }
 
@@ -301,7 +301,7 @@ where
                             "OpenRouter response: {response:?}");
                         response.try_into()
                     }
-                    ApiResponse::Err(err) => Err(CompletionError::ProviderError(err.message)),
+                    ApiResponse::Err(err) => Err(CompletionError::ProviderError(err.error.message)),
                 }
             } else {
                 Err(CompletionError::ProviderError(


### PR DESCRIPTION
Fix: OpenRouter provider fails to deserialize error responses

Issue:

The OpenRouter provider in rig incorrectly expects error responses to have a flat message field, but OpenRouter's actual API returns errors with a nested structure according to their https://openrouter.ai/docs/api-reference/errors.

Current behavior:

When OpenRouter returns any error (e.g., invalid parameters, rate limits, model errors), rig fails with:
`CompletionError: JsonError: data did not match any variant of untagged enum ApiResponse`

This is because the ApiErrorResponse struct expects:

```
pub(crate) struct ApiErrorResponse {
    pub message: String,
}

```
But OpenRouter actually returns:

```
{
    "error": {
        "code": 400,
        "message": "Invalid request",
        "metadata": { ... }
    }
}
```

Root cause:

The ApiResponse enum in rig-core/src/providers/openrouter/client.rs uses `#[serde(untagged)]` to deserialize responses. When OpenRouter returns an error,
serde tries to match it against:
1. CompletionResponse - fails (missing required fields)
2. ApiErrorResponse - fails (expects message at root, not nested in error)

Since neither variant matches, deserialization fails entirely.

Testing:
This can be reproduced by:
1. Using rig with OpenRouter and MCP tools
2. Triggering any error condition (invalid parameters, rate limits, etc.)
3. Observing the deserialization failure

What I don't understand is that I did not have this error before `rmcp` depency was updated to 0.8.