### PR TITLE
fix(#1012): assign reqwest::Client as default for CompletionModel

### DIFF
--- a/rig-core/src/providers/groq.rs
+++ b/rig-core/src/providers/groq.rs
@@ -390,7 +390,7 @@ pub const LLAMA_3_8B_8192: &str = "llama3-8b-8192";
 pub const MIXTRAL_8X7B_32768: &str = "mixtral-8x7b-32768";
 
 #[derive(Clone, Debug)]
-pub struct CompletionModel<T> {
+pub struct CompletionModel<T = reqwest::Client> {
     client: Client<T>,
     /// Name of the model (e.g.: deepseek-r1-distill-llama-70b)
     pub model: String,

--- a/rig-core/src/providers/hyperbolic.rs
+++ b/rig-core/src/providers/hyperbolic.rs
@@ -369,7 +369,7 @@ pub struct Choice {
 }
 
 #[derive(Clone)]
-pub struct CompletionModel<T> {
+pub struct CompletionModel<T = reqwest::Client> {
     client: Client<T>,
     /// Name of the model (e.g.: deepseek-ai/DeepSeek-R1)
     pub model: String,

--- a/rig-core/src/providers/mira.rs
+++ b/rig-core/src/providers/mira.rs
@@ -332,7 +332,7 @@ impl_conversion_traits!(
 );
 
 #[derive(Clone)]
-pub struct CompletionModel<T> {
+pub struct CompletionModel<T = reqwest::Client> {
     client: Client<T>,
     /// Name of the model
     pub model: String,

--- a/rig-core/src/providers/ollama.rs
+++ b/rig-core/src/providers/ollama.rs
@@ -451,7 +451,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
 // ---------- Completion Model ----------
 
 #[derive(Clone)]
-pub struct CompletionModel<T> {
+pub struct CompletionModel<T = reqwest::Client> {
     client: Client<T>,
     pub model: String,
 }

--- a/rig-core/src/providers/perplexity.rs
+++ b/rig-core/src/providers/perplexity.rs
@@ -286,7 +286,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
 }
 
 #[derive(Clone)]
-pub struct CompletionModel<T> {
+pub struct CompletionModel<T = reqwest::Client> {
     client: Client<T>,
     pub model: String,
 }


### PR DESCRIPTION
fix: set default type for CompletionModel to reqwest::Client

This change addresses issue #1012 by explicitly setting the default type parameter for CompletionModel to reqwest::Client. This ensures consistent behavior across providers and simplifies usage when no custom client type is needed.