### PR TITLE
Some compatible OpenAI service responses may not have `tools` field

### DIFF
--- a/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/rig-core/src/providers/openai/responses_api/mod.rs
@@ -755,6 +755,7 @@ pub struct CompletionResponse {
     /// The model output (messages, etc will go here)
     pub output: Vec<Output>,
     /// Tools
+    #[serde(default)]
     pub tools: Vec<ResponsesToolDefinition>,
     /// Additional parameters
     #[serde(flatten)]


### PR DESCRIPTION
Some compatible OpenAI service responses may not have `tools` field, e.g. LM Studio, this will cause deserialization failure.

Make this field optional to fix this issue.