### PR TITLE
Fix Gemini responses lacking content

### DIFF
--- a/rig-core/src/providers/gemini/completion.rs
+++ b/rig-core/src/providers/gemini/completion.rs
@@ -126,7 +126,18 @@ where
                 .await
                 .map_err(CompletionError::HttpError)?;
 
-            let response: GenerateContentResponse = serde_json::from_slice(&response_body)?;
+            let response_text = String::from_utf8_lossy(&response_body).to_string();
+            tracing::debug!("Received raw response from Gemini API: {}", response_text);
+
+            let response: GenerateContentResponse = serde_json::from_slice(&response_body)
+                .map_err(|err| {
+                    tracing::error!(
+                        error = %err,
+                        body = %response_text,
+                        "Failed to deserialize Gemini completion response"
+                    );
+                    CompletionError::JsonError(err)
+                })?;
 
             match response.usage_metadata {
                 Some(ref usage) => tracing::info!(target: "rig",
@@ -304,6 +315,21 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse<Generat
 
         let content = candidate
             .content
+            .as_ref()
+            .ok_or_else(|| {
+                let reason = candidate
+                    .finish_reason
+                    .as_ref()
+                    .map(|r| format!("finish_reason={r:?}"))
+                    .unwrap_or_else(|| "finish_reason=<unknown>".to_string());
+                let message = candidate
+                    .finish_message
+                    .as_deref()
+                    .unwrap_or("no finish message provided");
+                CompletionError::ResponseError(format!(
+                    "Gemini candidate missing content ({reason}, finish_message={message})"
+                ))
+            })?
             .parts
             .iter()
             .map(|Part { thought, part, .. }| {
@@ -439,12 +465,12 @@ pub mod gemini_api_types {
                 .candidates
                 .iter()
                 .filter_map(|x| {
-                    if x.content.role.as_ref().is_none_or(|y| y != &Role::Model) {
+                    let content = x.content.as_ref()?;
+                    if content.role.as_ref().is_none_or(|y| y != &Role::Model) {
                         return None;
                     }
 
-                    let res = x
-                        .content
+                    let res = content
                         .parts
                         .iter()
                         .filter_map(|part| {
@@ -475,7 +501,8 @@ pub mod gemini_api_types {
     #[serde(rename_all = "camelCase")]
     pub struct ContentCandidate {
         /// Output only. Generated content returned from the model.
-        pub content: Content,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub content: Option<Content>,
         /// Optional. Output only. The reason why the model stopped generating tokens.
         /// If empty, the model has not stopped generating tokens.
         pub finish_reason: Option<FinishReason>,
@@ -494,6 +521,8 @@ pub mod gemini_api_types {
         pub logprobs_result: Option<LogprobsResult>,
         /// Output only. Index of the candidate in the list of response candidates.
         pub index: Option<i32>,
+        /// Output only. Additional information about why the model stopped generating tokens.
+        pub finish_message: Option<String>,
     }
 
     #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/rig-core/src/providers/gemini/streaming.rs
+++ b/rig-core/src/providers/gemini/streaming.rs
@@ -152,7 +152,12 @@ where
                             continue;
                         };
 
-                        for part in &choice.content.parts {
+                        let Some(content) = choice.content.as_ref() else {
+                            tracing::debug!(finish_reason = ?choice.finish_reason, "Streaming candidate missing content");
+                            continue;
+                        };
+
+                        for part in &content.parts {
                             match part {
                                 Part {
                                     part: PartKind::Text(text),
@@ -165,7 +170,7 @@ where
                                     part: PartKind::Text(text),
                                     ..
                                 } => {
-                                    text_response += text;
+                                    text_response.push_str(text);
                                     yield Ok(streaming::RawStreamingChoice::Message(text.clone()));
                                 },
                                 Part {
@@ -186,7 +191,7 @@ where
                             }
                         }
 
-                        if choice.content.parts.is_empty() {
+                        if content.parts.is_empty() {
                             tracing::trace!(reason = ?choice.finish_reason, "There is no part in the streaming content");
                         }
 
@@ -252,12 +257,16 @@ mod tests {
 
         let response: StreamGenerateContentResponse = serde_json::from_value(json_data).unwrap();
         assert_eq!(response.candidates.len(), 1);
-        assert_eq!(response.candidates[0].content.parts.len(), 1);
+        let content = response.candidates[0]
+            .content
+            .as_ref()
+            .expect("candidate should contain content");
+        assert_eq!(content.parts.len(), 1);
 
         if let Part {
             part: PartKind::Text(text),
             ..
-        } = &response.candidates[0].content.parts[0]
+        } = &content.parts[0]
         {
             assert_eq!(text, "Hello, world!");
         } else {
@@ -289,14 +298,18 @@ mod tests {
 
         let response: StreamGenerateContentResponse = serde_json::from_value(json_data).unwrap();
         assert_eq!(response.candidates.len(), 1);
-        assert_eq!(response.candidates[0].content.parts.len(), 3);
+        let content = response.candidates[0]
+            .content
+            .as_ref()
+            .expect("candidate should contain content");
+        assert_eq!(content.parts.len(), 3);
 
         // Verify all three text parts are present
         for (i, expected_text) in ["Hello, ", "world!", " How are you?"].iter().enumerate() {
             if let Part {
                 part: PartKind::Text(text),
                 ..
-            } = &response.candidates[0].content.parts[i]
+            } = &content.parts[i]
             {
                 assert_eq!(text, expected_text);
             } else {
@@ -337,13 +350,17 @@ mod tests {
         });
 
         let response: StreamGenerateContentResponse = serde_json::from_value(json_data).unwrap();
-        assert_eq!(response.candidates[0].content.parts.len(), 2);
+        let content = response.candidates[0]
+            .content
+            .as_ref()
+            .expect("candidate should contain content");
+        assert_eq!(content.parts.len(), 2);
 
         // Verify first tool call
         if let Part {
             part: PartKind::FunctionCall(call),
             ..
-        } = &response.candidates[0].content.parts[0]
+        } = &content.parts[0]
         {
             assert_eq!(call.name, "get_weather");
         } else {
@@ -354,7 +371,7 @@ mod tests {
         if let Part {
             part: PartKind::FunctionCall(call),
             ..
-        } = &response.candidates[0].content.parts[1]
+        } = &content.parts[1]
         {
             assert_eq!(call.name, "get_temperature");
         } else {
@@ -399,7 +416,11 @@ mod tests {
         });
 
         let response: StreamGenerateContentResponse = serde_json::from_value(json_data).unwrap();
-        let parts = &response.candidates[0].content.parts;
+        let content = response.candidates[0]
+            .content
+            .as_ref()
+            .expect("candidate should contain content");
+        let parts = &content.parts;
         assert_eq!(parts.len(), 4);
 
         // Verify reasoning (thought) part
@@ -469,7 +490,11 @@ mod tests {
         });
 
         let response: StreamGenerateContentResponse = serde_json::from_value(json_data).unwrap();
-        assert_eq!(response.candidates[0].content.parts.len(), 0);
+        let content = response.candidates[0]
+            .content
+            .as_ref()
+            .expect("candidate should contain content");
+        assert_eq!(content.parts.len(), 0);
     }
 
     #[test]

--- a/rig-core/src/providers/gemini/transcription.rs
+++ b/rig-core/src/providers/gemini/transcription.rs
@@ -145,7 +145,10 @@ impl TryFrom<GenerateContentResponse>
             TranscriptionError::ResponseError("No response candidates in response".into())
         })?;
 
-        let part = candidate.content.parts.first();
+        let part = candidate
+            .content
+            .as_ref()
+            .and_then(|content| content.parts.first());
 
         let text = match part {
             Some(Part {


### PR DESCRIPTION
## Gemini: tolerate candidates without content; add raw-response logging on parse error

### Problem

- Gemini occasionally returns candidates with `finishReason` set (e.g., `MALFORMED_FUNCTION_CALL`) but no `candidate.content` field.
- When this happens, `rig-core`’s Gemini adapter fails deserializing into `ContentCandidate { content: Content, … }` with `JsonError: missing field content`, causing the entire call to error out in `serde` rather than surfacing a provider error.

### Evidence

- Real responses observed from the Gemini API for PDF + tool-calling scenarios include candidates without content and only `finishMessage`, e.g.:

  ```json
  {
    "candidates": [{
      "finishReason": "MALFORMED_FUNCTION_CALL",
      "finishMessage": "Malformed function call: …",
      "index": 0
    }],
    "usageMetadata": { … }
  }
  ```
- Similar reports in the wild:
    - Google AI forum: [“Getting FinishReason.MALFORMED_FUNCTION_CALL when function calling arguments contain large amount of text”](https://discuss.ai.google.dev/t/getting-finishreason-malformed-function-call-when-function-calling-arugments-contain-large-amount-of-text-content/69488)
    - Pydantic AI issue: [“MALFORMED_FUNCTION finishReason in Gemini candidate”](https://github.com/pydantic/pydantic-ai/issues/631)

### Summary of Changes

- Make `ContentCandidate.content` optional (`Option<Content>`).
- When content is absent, return a clear `CompletionError::ResponseError` that includes `finish_reason` and `finish_message`, instead of a `serde` failure.
- Add a debug log of the raw Gemini response when completion deserialization fails to aid diagnosis.
- Update streaming and transcription paths to handle optional content, and adjust tests accordingly.
- No change in behavior for well-formed responses; for malformed/safety cases we now fail gracefully with actionable errors rather than panicking in `serde`.

### Validation

- `cargo test -p rig-core --features "reqwest-rustls,image,audio,derive"` passes locally.
### Why this approach

- The provider sometimes omits content in error/edge cases; making the field optional aligns the adapter with real API behavior and prevents hard failures.
- Surfacing `finish_reason`/`finish_message` provides actionable context to callers.
- Logging the raw body on parse errors makes future provider changes easier to diagnose.
