### PR TITLE
fix: update get-started documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ cargo add rig-core
 
 ### Simple example:
 ```rust
-use rig::{completion::Prompt, providers::openai};
+use rig::{client::CompletionClient, completion::Prompt, providers::openai};
 
 #[tokio::main]
 async fn main() {

--- a/rig-core/src/lib.rs
+++ b/rig-core/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! # Simple example:
 //! ```
-//! use rig::{completion::Prompt, providers::openai};
+//! use rig::{client::CompletionClient, completion::Prompt, providers::openai};
 //!
 //! #[tokio::main]
 //! async fn main() {


### PR DESCRIPTION
I've copied and pasted [simple-example](https://docs.rs/rig-core/latest/rig/index.html#simple-example) to explore the library and found that the example misses an import of `client::CompletionClient` trait