### PR TITLE
Require 'static lifetime for CompletionModel

### DIFF
--- a/rig-core/src/client/completion.rs
+++ b/rig-core/src/client/completion.rs
@@ -17,7 +17,9 @@ use std::sync::Arc;
 /// Clone is required for conversions between client types.
 pub trait CompletionClient: ProviderClient + Clone {
     /// The type of CompletionModel used by the client.
-    type CompletionModel: CompletionModel;
+    // require the associated CompletionModel to be 'static so it can be used
+    // behind trait objects (Box/Arc<dyn ... + 'static>) safely
+    type CompletionModel: CompletionModel + 'static;
 
     /// Create a completion model with the given name.
     ///


### PR DESCRIPTION
Adds a 'static bound to the CompletionClient::CompletionModel associated type so implementations can be turned into trait objects (Box/Arc<dyn ...>). This addresses compiler lifetime/bound errors when converting CompletionModels into dynamic trait objects for CompletionClientDyn/AgentBuilder.
Notes: Most provider implementations already satisfy this because they bound their inner generic HTTP client with 'static