### PR TITLE
fix(gemini-request): add `#[serde(default)]` for missing `generation_config` field

### DIFF
--- a/rig-core/src/providers/gemini/completion.rs
+++ b/rig-core/src/providers/gemini/completion.rs
@@ -407,6 +407,7 @@ pub mod gemini_api_types {
     #[serde(rename_all = "camelCase")]
     pub struct AdditionalParameters {
         /// Change your Gemini request configuration.
+        #[serde(default)]
         pub generation_config: GenerationConfig,
         /// Any additional parameters that you want.
         #[serde(flatten, skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
Fixes #1059