### PR TITLE
refactor: implement standardized client builders across providers

### DIFF
--- a/rig-core/examples/agent_with_galadriel.rs
+++ b/rig-core/examples/agent_with_galadriel.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<(), anyhow::Error> {
     if let Some(fine_tune_api_key) = fine_tune_api_key.as_deref() {
         builder = builder.fine_tune_api_key(fine_tune_api_key);
     }
-    let client = builder.build();
+    let client = builder.build()?;
 
     // Create agent with a single context prompt
     let comedian_agent = client

--- a/rig-core/examples/anthropic_think_tool_with_other_tools.rs
+++ b/rig-core/examples/anthropic_think_tool_with_other_tools.rs
@@ -232,7 +232,7 @@ async fn main() -> Result<(), anyhow::Error> {
     tracing_subscriber::fmt().init();
 
     let api_key = std::env::var("ANTHROPIC_API_KEY").expect("ANTHROPIC_API_KEY not set");
-    let client = providers::anthropic::ClientBuilder::<reqwest::Client>::new(&api_key)
+    let client = providers::anthropic::Client::builder(&api_key)
         .anthropic_beta("token-efficient-tools-2025-02-19")
         .build()?;
 

--- a/rig-core/examples/complex_agentic_loop_claude.rs
+++ b/rig-core/examples/complex_agentic_loop_claude.rs
@@ -5,7 +5,7 @@ use rig::{
     completion::Prompt,
     embeddings::EmbeddingsBuilder,
     message::Message,
-    providers::anthropic::{CLAUDE_3_7_SONNET, ClientBuilder},
+    providers::anthropic::{self, CLAUDE_3_7_SONNET},
     tools::ThinkTool,
     vector_store::in_memory_store::InMemoryVectorStore,
 };
@@ -31,7 +31,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Create Anthropic client
     let anthropic_api_key = env::var("ANTHROPIC_API_KEY").expect("ANTHROPIC_API_KEY not set");
-    let anthropic_client = ClientBuilder::<reqwest::Client>::new(&anthropic_api_key)
+    let anthropic_client = anthropic::Client::builder(&anthropic_api_key)
         .anthropic_beta("token-efficient-tools-2025-02-19") // Enable efficient tool calling
         .build()?;
 

--- a/rig-core/examples/huggingface_streaming.rs
+++ b/rig-core/examples/huggingface_streaming.rs
@@ -39,7 +39,7 @@ async fn hf_inference(api_key: &str) -> Result<(), anyhow::Error> {
 }
 
 async fn together(api_key: &str) -> Result<(), anyhow::Error> {
-    let agent = huggingface::ClientBuilder::<reqwest::Client>::new(api_key)
+    let agent = huggingface::Client::builder(api_key)
         .sub_provider(huggingface::SubProvider::Together)
         .build()?
         .agent("deepseek-ai/DeepSeek-R1")

--- a/rig-core/examples/huggingface_subproviders.rs
+++ b/rig-core/examples/huggingface_subproviders.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
 fn client(sub_provider: SubProvider) -> providers::huggingface::Client {
     let api_key = &env::var("HUGGINGFACE_API_KEY").expect("HUGGINGFACE_API_KEY not set");
-    providers::huggingface::ClientBuilder::new(api_key)
+    providers::huggingface::Client::builder(api_key)
         .sub_provider(sub_provider)
         .build()
         .expect("Failed to build client")

--- a/rig-core/examples/pdf_agent.rs
+++ b/rig-core/examples/pdf_agent.rs
@@ -55,7 +55,7 @@ async fn main() -> Result<()> {
     // Initialize Ollama client
     let client = openai::Client::builder("ollama")
         .base_url("http://localhost:11434/v1")
-        .build();
+        .build()?;
 
     // Load PDFs using Rig's built-in PDF loader
     let documents_dir = std::env::current_dir()?.join("rig-core/examples/documents");

--- a/rig-core/examples/vector_search_ollama.rs
+++ b/rig-core/examples/vector_search_ollama.rs
@@ -22,9 +22,9 @@ struct WordDefinition {
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     // Create ollama client
-    let client = providers::ollama::Client::builder()
+    let client = providers::ollama::Client::builder("")
         .base_url("http://localhost:11434")
-        .build();
+        .build()?;
     let embedding_model = client.embedding_model("nomic-embed-text");
 
     let embeddings = EmbeddingsBuilder::new(embedding_model.clone())

--- a/rig-core/src/client/mod.rs
+++ b/rig-core/src/client/mod.rs
@@ -10,6 +10,9 @@ pub mod image_generation;
 pub mod transcription;
 pub mod verify;
 
+mod standard_builder;
+pub use standard_builder::{Builder, StandardClientBuilder};
+
 #[cfg(feature = "derive")]
 pub use rig_derive::ProviderClient;
 use std::fmt::Debug;

--- a/rig-core/src/client/standard_builder.rs
+++ b/rig-core/src/client/standard_builder.rs
@@ -1,0 +1,174 @@
+use crate::http_client::HttpClientExt;
+use reqwest::header::HeaderMap;
+
+/// Standard builder for creating client instances
+///
+/// Supports optional extension data for providers with custom fields.
+/// For standard providers, `Ext` defaults to `()`.
+pub struct Builder<'a, Client, T, Ext = ()> {
+    api_key: &'a str,
+    base_url: Option<&'a str>,
+    http_client: Option<T>,
+    custom_headers: Option<HeaderMap>,
+    extension: Ext,
+    _phantom: std::marker::PhantomData<Client>,
+}
+
+impl<'a, Client, T> Builder<'a, Client, T, ()>
+where
+    T: HttpClientExt + Default,
+    Client: StandardClientBuilder<T>,
+{
+    fn new(api_key: &'a str) -> Self {
+        Self {
+            api_key,
+            base_url: None,
+            http_client: None,
+            custom_headers: None,
+            extension: (),
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<'a, Client, T, Ext> Builder<'a, Client, T, Ext>
+where
+    T: HttpClientExt + Default,
+    Client: StandardClientBuilder<T>,
+{
+    /// Set the base URL for the API endpoint
+    pub fn base_url(mut self, base_url: &'a str) -> Self {
+        self.base_url = Some(base_url);
+        self
+    }
+
+    /// Set the HTTP client for the API endpoint
+    pub fn http_client(mut self, http_client: T) -> Self {
+        self.http_client = Some(http_client);
+        self
+    }
+
+    /// Set custom headers for the API endpoint
+    pub fn custom_headers(mut self, headers: HeaderMap) -> Self {
+        self.custom_headers = Some(headers);
+        self
+    }
+
+    /// Add extension data to the builder
+    pub fn with_extension<NewExt>(self, extension: NewExt) -> Builder<'a, Client, T, NewExt> {
+        Builder {
+            api_key: self.api_key,
+            base_url: self.base_url,
+            http_client: self.http_client,
+            custom_headers: self.custom_headers,
+            extension,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    /// Update the extension data with a function
+    pub fn update_extension<F>(mut self, f: F) -> Self
+    where
+        F: FnOnce(Ext) -> Ext,
+    {
+        self.extension = f(self.extension);
+        self
+    }
+
+    /// Get the base URL, using the default if not set
+    pub fn get_base_url<'b>(&self, default_base_url: &'b str) -> &'b str
+    where
+        'a: 'b,
+    {
+        self.base_url.unwrap_or(default_base_url)
+    }
+
+    /// Get the HTTP client, using the default if not set
+    pub fn get_http_client(&self) -> T
+    where
+        T: Default + Clone,
+    {
+        self.http_client.clone().unwrap_or_default()
+    }
+
+    /// Get the API key
+    pub fn get_api_key(&self) -> &str {
+        self.api_key
+    }
+
+    /// Get the custom headers, with content-type header if `has_default_headers` is true
+    pub fn get_headers(&self, has_default_headers: bool) -> HeaderMap {
+        if has_default_headers {
+            let mut headers = default_headers();
+            headers.extend(self.custom_headers.clone().unwrap_or_default());
+            headers
+        } else {
+            self.custom_headers.clone().unwrap_or_default()
+        }
+    }
+
+    /// Try to get the extension as a specific type
+    ///
+    /// Returns `Some(T)` if the extension type matches, `None` otherwise.
+    pub fn try_get_extension<ExtType>(&self) -> Option<ExtType>
+    where
+        ExtType: Clone + 'static,
+        Ext: 'static,
+    {
+        use std::any::Any;
+        (&self.extension as &dyn Any)
+            .downcast_ref::<ExtType>()
+            .cloned()
+    }
+
+    /// Build the client from the builder
+    pub fn build(self) -> Result<Client, crate::client::ClientBuilderError>
+    where
+        T: Default + Clone,
+        Client: StandardClientBuilder<T>,
+        Ext: Default + 'static,
+    {
+        Client::build_from_builder(self)
+    }
+}
+
+/// Trait for standardizing client builder implementations across providers
+///
+/// Implement this trait to get a standardized builder API. The `build_from_builder`
+/// method handles both standard and extended cases through the `extension` parameter.
+pub trait StandardClientBuilder<T>: Sized
+where
+    T: HttpClientExt,
+{
+    /// Build client from builder, including optional extension data
+    ///
+    /// For standard builders (Ext = ()), the extension field will be `()`.
+    /// For extended builders, you can use `try_get_extension` to safely extract the extension.
+    ///
+    /// Returns `Result` to allow error handling.
+    fn build_from_builder<Ext>(
+        builder: Builder<'_, Self, T, Ext>,
+    ) -> Result<Self, crate::client::ClientBuilderError>
+    where
+        Ext: Default + 'static,
+        T: Default + Clone;
+
+    fn builder(api_key: &str) -> Builder<'_, Self, T>
+    where
+        T: Default,
+    {
+        Builder::new(api_key)
+    }
+}
+
+/// Default headers for the API endpoint
+///
+/// This includes the Content-Type header for JSON requests.
+pub(crate) fn default_headers() -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        reqwest::header::CONTENT_TYPE,
+        "application/json".parse().unwrap(),
+    );
+    headers
+}

--- a/rig-core/src/pipeline/op.rs
+++ b/rig-core/src/pipeline/op.rs
@@ -155,7 +155,7 @@ pub trait Op: WasmCompatSend + WasmCompatSync {
     /// ```rust
     /// use rig::chain::{self, Chain};
     ///
-    /// let agent = &openai_client.agent("gpt-4").build();
+    /// let agent = &openai_client.agent("gpt-4").build()?;
     ///
     /// let chain = chain::new()
     ///    .map(|name| format!("Find funny nicknames for the following name: {name}!"))

--- a/rig-core/src/prelude.rs
+++ b/rig-core/src/prelude.rs
@@ -15,4 +15,5 @@ pub use crate::client::image_generation::ImageGenerationClient;
 #[cfg(feature = "audio")]
 pub use crate::client::audio_generation::AudioGenerationClient;
 
+pub use crate::client::{Builder, StandardClientBuilder};
 pub use crate::client::{VerifyClient, VerifyError};

--- a/rig-core/src/providers/anthropic/mod.rs
+++ b/rig-core/src/providers/anthropic/mod.rs
@@ -14,7 +14,7 @@ pub mod completion;
 pub mod decoders;
 pub mod streaming;
 
-pub use client::{Client, ClientBuilder};
+pub use client::Client;
 pub use completion::{
     ANTHROPIC_VERSION_2023_01_01, ANTHROPIC_VERSION_2023_06_01, ANTHROPIC_VERSION_LATEST,
     CLAUDE_3_5_SONNET, CLAUDE_3_7_SONNET, CLAUDE_3_HAIKU, CLAUDE_3_OPUS, CLAUDE_3_SONNET,

--- a/rig-core/src/providers/deepseek.rs
+++ b/rig-core/src/providers/deepseek.rs
@@ -16,7 +16,9 @@ use http::{Method, Request};
 use std::collections::HashMap;
 use tracing::{Instrument, info_span};
 
-use crate::client::{CompletionClient, ProviderClient, VerifyClient, VerifyError};
+use crate::client::{
+    CompletionClient, ProviderClient, StandardClientBuilder, VerifyClient, VerifyError,
+};
 use crate::completion::GetTokenUsage;
 use crate::http_client::sse::{Event, GenericEventSource};
 use crate::http_client::{self, HttpClientExt};
@@ -35,56 +37,8 @@ use super::openai::StreamingToolCall;
 // ================================================================
 // Main DeepSeek Client
 // ================================================================
+
 const DEEPSEEK_API_BASE_URL: &str = "https://api.deepseek.com";
-
-pub struct ClientBuilder<'a, T = reqwest::Client> {
-    api_key: &'a str,
-    base_url: &'a str,
-    http_client: T,
-}
-
-impl<'a, T> ClientBuilder<'a, T>
-where
-    T: Default,
-{
-    pub fn new(api_key: &'a str) -> Self {
-        Self {
-            api_key,
-            base_url: DEEPSEEK_API_BASE_URL,
-            http_client: Default::default(),
-        }
-    }
-}
-
-impl<'a, T> ClientBuilder<'a, T> {
-    pub fn new_with_client(api_key: &'a str, http_client: T) -> Self {
-        Self {
-            api_key,
-            base_url: DEEPSEEK_API_BASE_URL,
-            http_client,
-        }
-    }
-    pub fn base_url(mut self, base_url: &'a str) -> Self {
-        self.base_url = base_url;
-        self
-    }
-
-    pub fn with_client<U>(self, http_client: U) -> ClientBuilder<'a, U> {
-        ClientBuilder {
-            api_key: self.api_key,
-            base_url: self.base_url,
-            http_client,
-        }
-    }
-
-    pub fn build(self) -> Client<T> {
-        Client {
-            base_url: self.base_url.to_string(),
-            api_key: self.api_key.to_string(),
-            http_client: self.http_client,
-        }
-    }
-}
 
 #[derive(Clone)]
 pub struct Client<T = reqwest::Client> {
@@ -140,16 +94,41 @@ where
 }
 
 impl Client<reqwest::Client> {
-    pub fn builder(api_key: &str) -> ClientBuilder<'_, reqwest::Client> {
-        ClientBuilder::new(api_key)
-    }
-
     pub fn new(api_key: &str) -> Self {
-        ClientBuilder::new(api_key).build()
+        Self::builder(api_key)
+            .build()
+            .expect("DeepSeek client should build")
     }
 
     pub fn from_env() -> Self {
         <Self as ProviderClient>::from_env()
+    }
+
+    /// Create a new DeepSeek client builder
+    pub fn builder(api_key: &str) -> crate::client::Builder<'_, Self, reqwest::Client> {
+        <Self as StandardClientBuilder<reqwest::Client>>::builder(api_key)
+    }
+}
+
+impl<T> StandardClientBuilder<T> for Client<T>
+where
+    T: HttpClientExt,
+{
+    fn build_from_builder<Ext>(
+        builder: crate::client::Builder<'_, Self, T, Ext>,
+    ) -> Result<Self, crate::client::ClientBuilderError>
+    where
+        Ext: Default,
+        T: Default + Clone,
+    {
+        let api_key = builder.get_api_key();
+        let base_url = builder.get_base_url(DEEPSEEK_API_BASE_URL);
+        let http_client = builder.get_http_client();
+        Ok(Client {
+            base_url: base_url.to_string(),
+            api_key: api_key.to_string(),
+            http_client,
+        })
     }
 }
 
@@ -157,17 +136,20 @@ impl<T> ProviderClient for Client<T>
 where
     T: HttpClientExt + Clone + std::fmt::Debug + Default + Send + 'static,
 {
-    // If you prefer the environment variable approach:
     fn from_env() -> Self {
         let api_key = std::env::var("DEEPSEEK_API_KEY").expect("DEEPSEEK_API_KEY not set");
-        ClientBuilder::<T>::new(&api_key).build()
+        Self::builder(&api_key)
+            .build()
+            .expect("DeepSeek client should build")
     }
 
     fn from_val(input: crate::client::ProviderValue) -> Self {
         let crate::client::ProviderValue::Simple(api_key) = input else {
             panic!("Incorrect provider value type")
         };
-        ClientBuilder::<T>::new(&api_key).build()
+        Self::builder(&api_key)
+            .build()
+            .expect("DeepSeek client should build")
     }
 }
 

--- a/rig-core/src/providers/groq.rs
+++ b/rig-core/src/providers/groq.rs
@@ -15,7 +15,9 @@ use tracing::info_span;
 use tracing_futures::Instrument;
 
 use super::openai::{CompletionResponse, StreamingToolCall, TranscriptionResponse, Usage};
-use crate::client::{CompletionClient, TranscriptionClient, VerifyClient, VerifyError};
+use crate::client::{
+    CompletionClient, StandardClientBuilder, TranscriptionClient, VerifyClient, VerifyError,
+};
 use crate::completion::GetTokenUsage;
 use crate::http_client::sse::{Event, GenericEventSource};
 use crate::http_client::{self, HttpClientExt};
@@ -42,56 +44,6 @@ use serde_json::{Value, json};
 // Main Groq Client
 // ================================================================
 const GROQ_API_BASE_URL: &str = "https://api.groq.com/openai/v1";
-
-pub struct ClientBuilder<'a, T = reqwest::Client> {
-    api_key: &'a str,
-    base_url: &'a str,
-    http_client: T,
-}
-
-impl<'a, T> ClientBuilder<'a, T>
-where
-    T: Default,
-{
-    pub fn new(api_key: &'a str) -> Self {
-        Self {
-            api_key,
-            base_url: GROQ_API_BASE_URL,
-            http_client: Default::default(),
-        }
-    }
-}
-
-impl<'a, T> ClientBuilder<'a, T> {
-    pub fn new_with_client(api_key: &'a str, http_client: T) -> Self {
-        Self {
-            api_key,
-            base_url: GROQ_API_BASE_URL,
-            http_client,
-        }
-    }
-
-    pub fn base_url(mut self, base_url: &'a str) -> Self {
-        self.base_url = base_url;
-        self
-    }
-
-    pub fn with_client<U>(self, http_client: U) -> ClientBuilder<'a, U> {
-        ClientBuilder {
-            api_key: self.api_key,
-            base_url: self.base_url,
-            http_client,
-        }
-    }
-
-    pub fn build(self) -> Client<T> {
-        Client {
-            base_url: self.base_url.to_string(),
-            api_key: self.api_key.to_string(),
-            http_client: self.http_client,
-        }
-    }
-}
 
 #[derive(Clone)]
 pub struct Client<T = reqwest::Client> {
@@ -136,16 +88,41 @@ where
 }
 
 impl Client<reqwest::Client> {
-    pub fn builder(api_key: &str) -> ClientBuilder<'_, reqwest::Client> {
-        ClientBuilder::new(api_key)
-    }
-
     pub fn new(api_key: &str) -> Self {
-        ClientBuilder::new(api_key).build()
+        Self::builder(api_key)
+            .build()
+            .expect("Groq client should build")
     }
 
     pub fn from_env() -> Self {
         <Self as ProviderClient>::from_env()
+    }
+
+    /// Create a new Groq client builder
+    pub fn builder(api_key: &str) -> crate::client::Builder<'_, Self, reqwest::Client> {
+        <Self as StandardClientBuilder<reqwest::Client>>::builder(api_key)
+    }
+}
+
+impl<T> StandardClientBuilder<T> for Client<T>
+where
+    T: HttpClientExt,
+{
+    fn build_from_builder<Ext>(
+        builder: crate::client::Builder<'_, Self, T, Ext>,
+    ) -> Result<Self, crate::client::ClientBuilderError>
+    where
+        Ext: Default,
+        T: Default + Clone,
+    {
+        let api_key = builder.get_api_key();
+        let base_url = builder.get_base_url(GROQ_API_BASE_URL);
+        let http_client = builder.get_http_client();
+        Ok(Client {
+            base_url: base_url.to_string(),
+            api_key: api_key.to_string(),
+            http_client,
+        })
     }
 }
 
@@ -157,14 +134,18 @@ where
     /// Panics if the environment variable is not set.
     fn from_env() -> Self {
         let api_key = std::env::var("GROQ_API_KEY").expect("GROQ_API_KEY not set");
-        ClientBuilder::<T>::new(&api_key).build()
+        Self::builder(&api_key)
+            .build()
+            .expect("Groq client should build")
     }
 
     fn from_val(input: crate::client::ProviderValue) -> Self {
         let crate::client::ProviderValue::Simple(api_key) = input else {
             panic!("Incorrect provider value type")
         };
-        ClientBuilder::<T>::new(&api_key).build()
+        Self::builder(&api_key)
+            .build()
+            .expect("Groq client should build")
     }
 }
 

--- a/rig-core/src/providers/huggingface/mod.rs
+++ b/rig-core/src/providers/huggingface/mod.rs
@@ -19,7 +19,7 @@ pub mod image_generation;
 pub mod streaming;
 pub mod transcription;
 
-pub use client::{Client, ClientBuilder, SubProvider};
+pub use client::{Client, SubProvider};
 pub use completion::{
     GEMMA_2, META_LLAMA_3_1, PHI_4, QWEN_QVQ_PREVIEW, QWEN2_5, QWEN2_5_CODER, QWEN2_VL,
     SMALLTHINKER_PREVIEW,

--- a/rig-core/src/providers/hyperbolic.rs
+++ b/rig-core/src/providers/hyperbolic.rs
@@ -10,7 +10,9 @@
 //! ```
 use super::openai::{AssistantContent, send_compatible_streaming_request};
 
-use crate::client::{CompletionClient, ProviderClient, VerifyClient, VerifyError};
+use crate::client::{
+    CompletionClient, ProviderClient, StandardClientBuilder, VerifyClient, VerifyError,
+};
 use crate::http_client::{self, HttpClientExt};
 use crate::json_utils::merge_inplace;
 use crate::message;
@@ -33,56 +35,6 @@ use serde_json::{Value, json};
 // ================================================================
 const HYPERBOLIC_API_BASE_URL: &str = "https://api.hyperbolic.xyz";
 
-pub struct ClientBuilder<'a, T = reqwest::Client> {
-    api_key: &'a str,
-    base_url: &'a str,
-    http_client: T,
-}
-
-impl<'a, T> ClientBuilder<'a, T>
-where
-    T: Default,
-{
-    pub fn new(api_key: &'a str) -> Self {
-        Self {
-            api_key,
-            base_url: HYPERBOLIC_API_BASE_URL,
-            http_client: Default::default(),
-        }
-    }
-}
-
-impl<'a, T> ClientBuilder<'a, T> {
-    pub fn new_with_client(api_key: &'a str, http_client: T) -> Self {
-        Self {
-            api_key,
-            base_url: HYPERBOLIC_API_BASE_URL,
-            http_client,
-        }
-    }
-
-    pub fn base_url(mut self, base_url: &'a str) -> Self {
-        self.base_url = base_url;
-        self
-    }
-
-    pub fn with_client<U>(self, http_client: U) -> ClientBuilder<'a, U> {
-        ClientBuilder {
-            api_key: self.api_key,
-            base_url: self.base_url,
-            http_client,
-        }
-    }
-
-    pub fn build(self) -> Client<T> {
-        Client {
-            base_url: self.base_url.to_string(),
-            api_key: self.api_key.to_string(),
-            http_client: self.http_client,
-        }
-    }
-}
-
 #[derive(Clone)]
 pub struct Client<T = reqwest::Client> {
     base_url: String,
@@ -104,16 +56,19 @@ where
 }
 
 impl Client<reqwest::Client> {
-    pub fn builder(api_key: &str) -> ClientBuilder<'_, reqwest::Client> {
-        ClientBuilder::new(api_key)
-    }
-
     pub fn new(api_key: &str) -> Self {
-        Self::builder(api_key).build()
+        Self::builder(api_key)
+            .build()
+            .expect("Hyperbolic client should build")
     }
 
     pub fn from_env() -> Self {
         <Self as ProviderClient>::from_env()
+    }
+
+    /// Create a new Hyperbolic client builder
+    pub fn builder(api_key: &str) -> crate::client::Builder<'_, Self, reqwest::Client> {
+        <Self as StandardClientBuilder<reqwest::Client>>::builder(api_key)
     }
 }
 
@@ -139,6 +94,28 @@ where
     }
 }
 
+impl<T> StandardClientBuilder<T> for Client<T>
+where
+    T: HttpClientExt,
+{
+    fn build_from_builder<Ext>(
+        builder: crate::client::Builder<'_, Self, T, Ext>,
+    ) -> Result<Self, crate::client::ClientBuilderError>
+    where
+        Ext: Default,
+        T: Default + Clone,
+    {
+        let api_key = builder.get_api_key();
+        let base_url = builder.get_base_url(HYPERBOLIC_API_BASE_URL);
+        let http_client = builder.get_http_client();
+        Ok(Client {
+            base_url: base_url.to_string(),
+            api_key: api_key.to_string(),
+            http_client,
+        })
+    }
+}
+
 impl<T> ProviderClient for Client<T>
 where
     T: HttpClientExt + Clone + Default + std::fmt::Debug + Send + 'static,
@@ -147,14 +124,18 @@ where
     /// Panics if the environment variable is not set.
     fn from_env() -> Self {
         let api_key = std::env::var("HYPERBOLIC_API_KEY").expect("HYPERBOLIC_API_KEY not set");
-        ClientBuilder::<T>::new(&api_key).build()
+        Self::builder(&api_key)
+            .build()
+            .expect("Hyperbolic client should build")
     }
 
     fn from_val(input: crate::client::ProviderValue) -> Self {
         let crate::client::ProviderValue::Simple(api_key) = input else {
             panic!("Incorrect provider value type")
         };
-        ClientBuilder::<T>::new(&api_key).build()
+        Self::builder(&api_key)
+            .build()
+            .expect("Hyperbolic client should build")
     }
 }
 

--- a/rig-core/src/providers/mistral/client.rs
+++ b/rig-core/src/providers/mistral/client.rs
@@ -6,63 +6,15 @@ use super::{
     embedding::{EmbeddingModel, MISTRAL_EMBED},
 };
 use crate::{
-    client::{CompletionClient, EmbeddingsClient, ProviderClient, VerifyClient, VerifyError},
+    client::{
+        CompletionClient, EmbeddingsClient, ProviderClient, StandardClientBuilder, VerifyClient,
+        VerifyError,
+    },
     http_client::HttpClientExt,
 };
 use crate::{http_client, impl_conversion_traits};
 use std::fmt::Debug;
-
 const MISTRAL_API_BASE_URL: &str = "https://api.mistral.ai";
-
-pub struct ClientBuilder<'a, T = reqwest::Client> {
-    api_key: &'a str,
-    base_url: &'a str,
-    http_client: T,
-}
-
-impl<'a, T> ClientBuilder<'a, T>
-where
-    T: Default,
-{
-    pub fn new(api_key: &'a str) -> Self {
-        Self {
-            api_key,
-            base_url: MISTRAL_API_BASE_URL,
-            http_client: Default::default(),
-        }
-    }
-}
-
-impl<'a, T> ClientBuilder<'a, T> {
-    pub fn new_with_client(api_key: &'a str, http_client: T) -> Self {
-        Self {
-            api_key,
-            base_url: MISTRAL_API_BASE_URL,
-            http_client,
-        }
-    }
-
-    pub fn with_client<U>(self, http_client: U) -> ClientBuilder<'a, U> {
-        ClientBuilder {
-            api_key: self.api_key,
-            base_url: self.base_url,
-            http_client,
-        }
-    }
-
-    pub fn base_url(mut self, base_url: &'a str) -> Self {
-        self.base_url = base_url;
-        self
-    }
-
-    pub fn build(self) -> Client<T> {
-        Client {
-            base_url: self.base_url.to_string(),
-            api_key: self.api_key.to_string(),
-            http_client: self.http_client,
-        }
-    }
-}
 
 #[derive(Clone)]
 pub struct Client<T = reqwest::Client> {
@@ -86,29 +38,19 @@ where
 
 impl Client<reqwest::Client> {
     /// Create a new Mistral client. For more control, use the `builder` method.
-    ///
-    /// # Panics
-    /// - If the reqwest client cannot be built (if the TLS backend cannot be initialized).
     pub fn new(api_key: &str) -> Self {
-        Self::builder(api_key).build()
-    }
-
-    /// Create a new Mistral client builder.
-    ///
-    /// # Example
-    /// ```
-    /// use rig::providers::mistral::{ClientBuilder, self};
-    ///
-    /// // Initialize the Mistral client
-    /// let mistral = Client::builder("your-mistral-api-key")
-    ///    .build()
-    /// ```
-    pub fn builder(api_key: &str) -> ClientBuilder<'_, reqwest::Client> {
-        ClientBuilder::new(api_key)
+        Self::builder(api_key)
+            .build()
+            .expect("Mistral client should build")
     }
 
     pub fn from_env() -> Self {
         <Self as ProviderClient>::from_env()
+    }
+
+    /// Create a new Mistral client builder
+    pub fn builder(api_key: &str) -> crate::client::Builder<'_, Self, reqwest::Client> {
+        <Self as StandardClientBuilder<reqwest::Client>>::builder(api_key)
     }
 }
 
@@ -140,6 +82,28 @@ where
     }
 }
 
+impl<T> StandardClientBuilder<T> for Client<T>
+where
+    T: HttpClientExt,
+{
+    fn build_from_builder<Ext>(
+        builder: crate::client::Builder<'_, Self, T, Ext>,
+    ) -> Result<Self, crate::client::ClientBuilderError>
+    where
+        Ext: Default,
+        T: Default + Clone,
+    {
+        let api_key = builder.get_api_key();
+        let base_url = builder.get_base_url(MISTRAL_API_BASE_URL);
+        let http_client = builder.get_http_client();
+        Ok(Client {
+            base_url: base_url.to_string(),
+            api_key: api_key.to_string(),
+            http_client,
+        })
+    }
+}
+
 impl<T> ProviderClient for Client<T>
 where
     T: HttpClientExt + Clone + Default + std::fmt::Debug + Send + 'static,
@@ -151,14 +115,18 @@ where
         Self: Sized,
     {
         let api_key = std::env::var("MISTRAL_API_KEY").expect("MISTRAL_API_KEY not set");
-        ClientBuilder::<T>::new(&api_key).build()
+        Self::builder(&api_key)
+            .build()
+            .expect("Mistral client should build")
     }
 
     fn from_val(input: crate::client::ProviderValue) -> Self {
         let crate::client::ProviderValue::Simple(api_key) = input else {
             panic!("Incorrect provider value type")
         };
-        ClientBuilder::<T>::new(&api_key).build()
+        Self::builder(&api_key)
+            .build()
+            .expect("Mistral client should build")
     }
 }
 

--- a/rig-core/src/providers/moonshot.rs
+++ b/rig-core/src/providers/moonshot.rs
@@ -8,7 +8,9 @@
 //!
 //! let moonshot_model = client.completion_model(moonshot::MOONSHOT_CHAT);
 //! ```
-use crate::client::{CompletionClient, ProviderClient, VerifyClient, VerifyError};
+use crate::client::{
+    CompletionClient, ProviderClient, StandardClientBuilder, VerifyClient, VerifyError,
+};
 use crate::http_client::HttpClientExt;
 use crate::json_utils::merge;
 use crate::providers::openai::send_compatible_streaming_request;
@@ -28,56 +30,6 @@ use tracing::{Instrument, info_span};
 // Main Moonshot Client
 // ================================================================
 const MOONSHOT_API_BASE_URL: &str = "https://api.moonshot.cn/v1";
-
-pub struct ClientBuilder<'a, T = reqwest::Client> {
-    api_key: &'a str,
-    base_url: &'a str,
-    http_client: T,
-}
-
-impl<'a, T> ClientBuilder<'a, T>
-where
-    T: Default,
-{
-    pub fn new(api_key: &'a str) -> Self {
-        Self {
-            api_key,
-            base_url: MOONSHOT_API_BASE_URL,
-            http_client: Default::default(),
-        }
-    }
-}
-
-impl<'a, T> ClientBuilder<'a, T> {
-    pub fn new_with_client(api_key: &'a str, http_client: T) -> Self {
-        Self {
-            api_key,
-            base_url: MOONSHOT_API_BASE_URL,
-            http_client,
-        }
-    }
-
-    pub fn base_url(mut self, base_url: &'a str) -> Self {
-        self.base_url = base_url;
-        self
-    }
-
-    pub fn with_client<U>(self, http_client: U) -> ClientBuilder<'a, U> {
-        ClientBuilder {
-            api_key: self.api_key,
-            base_url: self.base_url,
-            http_client,
-        }
-    }
-
-    pub fn build(self) -> Client<T> {
-        Client {
-            base_url: self.base_url.to_string(),
-            api_key: self.api_key.to_string(),
-            http_client: self.http_client,
-        }
-    }
-}
 
 #[derive(Clone)]
 pub struct Client<T = reqwest::Client> {
@@ -122,16 +74,41 @@ where
 }
 
 impl Client<reqwest::Client> {
-    pub fn builder(api_key: &str) -> ClientBuilder<'_, reqwest::Client> {
-        ClientBuilder::new(api_key)
-    }
-
     pub fn new(api_key: &str) -> Self {
-        Self::builder(api_key).build()
+        Self::builder(api_key)
+            .build()
+            .expect("Moonshot client should build")
     }
 
     pub fn from_env() -> Self {
         <Self as ProviderClient>::from_env()
+    }
+
+    /// Create a new Moonshot client builder
+    pub fn builder(api_key: &str) -> crate::client::Builder<'_, Self, reqwest::Client> {
+        <Self as StandardClientBuilder<reqwest::Client>>::builder(api_key)
+    }
+}
+
+impl<T> StandardClientBuilder<T> for Client<T>
+where
+    T: HttpClientExt,
+{
+    fn build_from_builder<Ext>(
+        builder: crate::client::Builder<'_, Self, T, Ext>,
+    ) -> Result<Self, crate::client::ClientBuilderError>
+    where
+        Ext: Default,
+        T: Default + Clone,
+    {
+        let api_key = builder.get_api_key();
+        let base_url = builder.get_base_url(MOONSHOT_API_BASE_URL);
+        let http_client = builder.get_http_client();
+        Ok(Client {
+            base_url: base_url.to_string(),
+            api_key: api_key.to_string(),
+            http_client,
+        })
     }
 }
 
@@ -143,14 +120,18 @@ where
     /// Panics if the environment variable is not set.
     fn from_env() -> Self {
         let api_key = std::env::var("MOONSHOT_API_KEY").expect("MOONSHOT_API_KEY not set");
-        ClientBuilder::<T>::new(&api_key).build()
+        Self::builder(&api_key)
+            .build()
+            .expect("Moonshot client should build")
     }
 
     fn from_val(input: crate::client::ProviderValue) -> Self {
         let crate::client::ProviderValue::Simple(api_key) = input else {
             panic!("Incorrect provider value type")
         };
-        ClientBuilder::<T>::new(&api_key).build()
+        Self::builder(&api_key)
+            .build()
+            .expect("Moonshot client should build")
     }
 }
 

--- a/rig-core/src/providers/together/client.rs
+++ b/rig-core/src/providers/together/client.rs
@@ -1,6 +1,9 @@
 use super::{M2_BERT_80M_8K_RETRIEVAL, completion::CompletionModel, embedding::EmbeddingModel};
 use crate::{
-    client::{EmbeddingsClient, ProviderClient, VerifyClient, VerifyError, impl_conversion_traits},
+    client::{
+        EmbeddingsClient, ProviderClient, StandardClientBuilder, VerifyClient, VerifyError,
+        impl_conversion_traits,
+    },
     http_client::{self, HttpClientExt},
 };
 use bytes::Bytes;
@@ -11,62 +14,6 @@ use rig::client::CompletionClient;
 // ================================================================
 const TOGETHER_AI_BASE_URL: &str = "https://api.together.xyz";
 
-pub struct ClientBuilder<'a, T = reqwest::Client> {
-    api_key: &'a str,
-    base_url: &'a str,
-    http_client: T,
-}
-
-impl<'a, T> ClientBuilder<'a, T>
-where
-    T: Default,
-{
-    pub fn new(api_key: &'a str) -> Self {
-        Self {
-            api_key,
-            base_url: TOGETHER_AI_BASE_URL,
-            http_client: Default::default(),
-        }
-    }
-}
-
-impl<'a, T> ClientBuilder<'a, T> {
-    pub fn new_with_client(api_key: &'a str, http_client: T) -> Self {
-        Self {
-            api_key,
-            base_url: TOGETHER_AI_BASE_URL,
-            http_client,
-        }
-    }
-
-    pub fn base_url(mut self, base_url: &'a str) -> Self {
-        self.base_url = base_url;
-        self
-    }
-
-    pub fn with_client<U>(self, http_client: U) -> ClientBuilder<'a, U> {
-        ClientBuilder {
-            api_key: self.api_key,
-            base_url: self.base_url,
-            http_client,
-        }
-    }
-
-    pub fn build(self) -> Client<T> {
-        let mut default_headers = reqwest::header::HeaderMap::new();
-        default_headers.insert(
-            reqwest::header::CONTENT_TYPE,
-            "application/json".parse().unwrap(),
-        );
-
-        Client {
-            base_url: self.base_url.to_string(),
-            api_key: self.api_key.to_string(),
-            default_headers,
-            http_client: self.http_client,
-        }
-    }
-}
 #[derive(Clone)]
 pub struct Client<T = reqwest::Client> {
     base_url: String,
@@ -134,16 +81,44 @@ where
 }
 
 impl Client<reqwest::Client> {
-    pub fn builder(api_key: &str) -> ClientBuilder<'_, reqwest::Client> {
-        ClientBuilder::new(api_key)
-    }
-
     pub fn new(api_key: &str) -> Self {
-        Self::builder(api_key).build()
+        Self::builder(api_key)
+            .build()
+            .expect("Together AI client should build")
     }
 
     pub fn from_env() -> Self {
         <Self as ProviderClient>::from_env()
+    }
+
+    /// Create a new Together AI client builder
+    pub fn builder(api_key: &str) -> crate::client::Builder<'_, Self, reqwest::Client> {
+        <Self as StandardClientBuilder<reqwest::Client>>::builder(api_key)
+    }
+}
+
+impl<T> StandardClientBuilder<T> for Client<T>
+where
+    T: HttpClientExt,
+{
+    fn build_from_builder<Ext>(
+        builder: crate::client::Builder<'_, Self, T, Ext>,
+    ) -> Result<Self, crate::client::ClientBuilderError>
+    where
+        Ext: Default,
+        T: Default + Clone,
+    {
+        let api_key = builder.get_api_key();
+        let base_url = builder.get_base_url(TOGETHER_AI_BASE_URL);
+        let http_client = builder.get_http_client();
+        let default_headers = builder.get_headers(true);
+
+        Ok(Client {
+            base_url: base_url.to_string(),
+            api_key: api_key.to_string(),
+            default_headers,
+            http_client,
+        })
     }
 }
 
@@ -155,14 +130,18 @@ where
     /// Panics if the environment variable is not set.
     fn from_env() -> Self {
         let api_key = std::env::var("TOGETHER_API_KEY").expect("TOGETHER_API_KEY not set");
-        ClientBuilder::<T>::new(&api_key).build()
+        Self::builder(&api_key)
+            .build()
+            .expect("Together AI client should build")
     }
 
     fn from_val(input: crate::client::ProviderValue) -> Self {
         let crate::client::ProviderValue::Simple(api_key) = input else {
             panic!("Incorrect provider value type")
         };
-        ClientBuilder::<T>::new(&api_key).build()
+        Self::builder(&api_key)
+            .build()
+            .expect("Together AI client should build")
     }
 }
 

--- a/rig-lancedb/tests/integration_tests.rs
+++ b/rig-lancedb/tests/integration_tests.rs
@@ -109,7 +109,8 @@ async fn vector_search_test() {
     // Initialize OpenAI client
     let openai_client = openai::Client::builder("TEST")
         .base_url(&server.base_url())
-        .build();
+        .build()
+        .unwrap();
 
     // Select an embedding model.
     let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_ADA_002);
@@ -323,7 +324,8 @@ async fn agent_with_dynamic_context_test() {
     // Initialize OpenAI client
     let openai_client = openai::Client::builder("TEST")
         .base_url(&server.base_url())
-        .build();
+        .build()
+        .unwrap();
 
     // Select an embedding model.
     let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_ADA_002);

--- a/rig-mongodb/tests/integration_tests.rs
+++ b/rig-mongodb/tests/integration_tests.rs
@@ -114,7 +114,8 @@ async fn vector_search_test() {
     // Initialize OpenAI client
     let openai_client = openai::Client::builder("TEST")
         .base_url(&server.base_url())
-        .build();
+        .build()
+        .unwrap();
 
     // Select the embedding model and generate our embeddings
     let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_ADA_002);
@@ -219,7 +220,8 @@ async fn insert_documents_test() {
     // Initialize OpenAI client
     let openai_client = openai::Client::builder("TEST")
         .base_url(&server.base_url())
-        .build();
+        .build()
+        .unwrap();
     let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_ADA_002);
 
     // Setup MongoDB container

--- a/rig-neo4j/tests/integration_tests.rs
+++ b/rig-neo4j/tests/integration_tests.rs
@@ -125,7 +125,8 @@ async fn vector_search_test() {
     // Initialize OpenAI client
     let openai_client = openai::Client::builder("TEST")
         .base_url(&server.base_url())
-        .build();
+        .build()
+        .unwrap();
 
     // Select the embedding model and generate our embeddings
     let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_ADA_002);

--- a/rig-postgres/tests/integration_tests.rs
+++ b/rig-postgres/tests/integration_tests.rs
@@ -52,7 +52,8 @@ async fn vector_search_test() {
     let openai_mock = create_openai_mock_service().await;
     let openai_client = rig::providers::openai::Client::builder("TEST")
         .base_url(&openai_mock.base_url())
-        .build();
+        .build()
+        .unwrap();
 
     let model = openai_client.embedding_model(rig::providers::openai::TEXT_EMBEDDING_ADA_002);
 

--- a/rig-qdrant/tests/integration_tests.rs
+++ b/rig-qdrant/tests/integration_tests.rs
@@ -142,7 +142,8 @@ async fn vector_search_test() {
     // Initialize OpenAI client
     let openai_client = openai::Client::builder("TEST")
         .base_url(&server.base_url())
-        .build();
+        .build()
+        .unwrap();
     // let openai_client = openai::Client::from_env();
 
     let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_ADA_002);

--- a/rig-scylladb/tests/integration_tests.rs
+++ b/rig-scylladb/tests/integration_tests.rs
@@ -75,7 +75,8 @@ async fn vector_search_test() {
     let openai_mock = create_openai_mock_service().await;
     let openai_client = rig::providers::openai::Client::builder("TEST")
         .base_url(&openai_mock.base_url())
-        .build();
+        .build()
+        .unwrap();
 
     let model = openai_client.embedding_model(rig::providers::openai::TEXT_EMBEDDING_ADA_002);
 
@@ -347,7 +348,8 @@ async fn test_mock_server_setup() {
     let server = create_openai_mock_service().await;
     let openai_client = rig::providers::openai::Client::builder("TEST")
         .base_url(&server.base_url())
-        .build();
+        .build()
+        .unwrap();
     let model = openai_client.embedding_model(rig::providers::openai::TEXT_EMBEDDING_ADA_002);
 
     // Test that we can create embeddings with the mock

--- a/rig-sqlite/tests/integration_test.rs
+++ b/rig-sqlite/tests/integration_test.rs
@@ -141,7 +141,8 @@ async fn vector_search_test() {
     // Initialize OpenAI client
     let openai_client = openai::Client::builder("TEST")
         .base_url(&server.base_url())
-        .build();
+        .build()
+        .unwrap();
 
     // Select the embedding model and generate our embeddings
     let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_ADA_002);

--- a/rig-wasm/src/providers/anthropic.rs
+++ b/rig-wasm/src/providers/anthropic.rs
@@ -4,6 +4,7 @@ use futures::{StreamExt, TryStreamExt};
 use rig::client::completion::CompletionClient;
 use rig::completion::CompletionModel;
 use rig::completion::{Chat, Prompt};
+use rig::providers::anthropic;
 use rig::streaming::StreamingPrompt;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::js_sys::{Array, Reflect};
@@ -107,7 +108,7 @@ impl AnthropicAgent {
                 }
             });
 
-        let mut agent = rig::providers::anthropic::ClientBuilder::new(&api_key)
+        let mut agent = anthropic::Client::builder(&api_key)
             .build()
             .map_err(|x| JsError::new(x.to_string().as_ref()))?
             .agent(&model);
@@ -204,7 +205,7 @@ impl AnthropicCompletionModel {
         let model_opts: ModelOpts = serde_wasm_bindgen::from_value(opts.obj)
             .map_err(|x| JsError::new(format!("Failed to create model options: {x}").as_ref()))?;
 
-        let client = rig::providers::anthropic::ClientBuilder::new(&model_opts.api_key)
+        let client = anthropic::Client::builder(&model_opts.api_key)
             .build()
             .map_err(|x| JsError::new(x.to_string().as_ref()))?;
 


### PR DESCRIPTION
## Description
issues: #1045
This PR introduces a standardized client builder pattern across multiple providers to ensure consistency, maintainability, and ease of extension.

## Key Changes
- Added a new `StandardClientBuilder` trait to unify builder APIs.
- Refactored provider-specific client builders (Anthropic, Azure, Cohere, DeepSeek, Galadriel, Gemini, Groq, HuggingFace, Ollama) to adopt the standardized builder.
- Improved error handling with `ClientBuilderError` for invalid properties.
- Enabled optional extension data for providers with custom fields.
- Updated examples to reflect the new builder usage.

## Benefits
- Consistent API surface across providers.
- Easier onboarding for developers using multiple providers.
- Simplified maintenance and reduced duplication.
- Extensible design for future provider integrations.