### PR TITLE
fix: vLLM tool use support with Granite 4

### DIFF
--- a/rig-core/src/agent/prompt_request/mod.rs
+++ b/rig-core/src/agent/prompt_request/mod.rs
@@ -18,6 +18,7 @@ use tracing::info_span;
 use crate::{
     OneOrMany,
     completion::{Completion, CompletionModel, Message, PromptError, Usage},
+    json_utils,
     message::{AssistantContent, UserContent},
     tool::ToolSetError,
     wasm_compat::{WasmBoxedFuture, WasmCompatSend, WasmCompatSync},
@@ -457,7 +458,8 @@ where
                     async move {
                         if let AssistantContent::ToolCall(tool_call) = choice {
                             let tool_name = &tool_call.function.name;
-                            let args = tool_call.function.arguments.to_string();
+                            let args =
+                                json_utils::value_to_json_string(&tool_call.function.arguments);
                             let tool_span = tracing::Span::current();
                             tool_span.record("gen_ai.tool.name", tool_name);
                             tool_span.record("gen_ai.tool.call.id", &tool_call.id);

--- a/rig-core/src/json_utils.rs
+++ b/rig-core/src/json_utils.rs
@@ -29,6 +29,16 @@ pub fn merge_inplace(a: &mut serde_json::Value, b: serde_json::Value) {
     }
 }
 
+/// Convert a serde_json::Value to a JSON string for tool arguments.
+/// Handles the case where vLLM returns arguments as a JSON string (Value::String)
+/// instead of a JSON object (Value::Object) like OpenAI does.
+pub fn value_to_json_string(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
 /// This module is helpful in cases where raw json objects are serialized and deserialized as
 ///  strings such as `"{\"key\": \"value\"}"`. This might seem odd but it's actually how some
 ///  some providers such as OpenAI return function arguments (for some reason).


### PR DESCRIPTION
Quick patch that adds a utility to check if `.to_string()` is necessary on the tool call arguments. This seems to just be how vLLM chooses to handle "OpenAI-like" tool calling  and already returns the JSON as a String. This fixes vLLM tool calling using Rig described in the Issue, and now the response I get is

`Granite: "The current date today is Wednesday, November 26, 2025."`

As expected.

Fixes #1085 