### PR TITLE
fix: OpenAI required props for structured output

### DIFF
--- a/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/rig-core/src/providers/openai/responses_api/mod.rs
@@ -432,23 +432,31 @@ pub struct ResponsesToolDefinition {
     pub description: String,
 }
 
-/// Recursively ensures all object schemas in a JSON schema have `additionalProperties: false`.
+/// Recursively ensures all object schemas in a JSON schema respect OpenAI structured output restrictions.
 /// Nested arrays, schema $defs, object properties and enums should be handled through this method
-/// This seems to be required by OpenAI's Responses API when using strict mode.
-fn add_props_false(schema: &mut serde_json::Value) {
+fn sanitize_schema(schema: &mut serde_json::Value) {
     if let Value::Object(obj) = schema {
         let is_object_schema = obj.get("type") == Some(&Value::String("object".to_string()))
             || obj.contains_key("properties");
 
+        // This is required by OpenAI's Responses API when using strict mode.
+        // Source: https://platform.openai.com/docs/guides/structured-outputs#additionalproperties-false-must-always-be-set-in-objects
         if is_object_schema && !obj.contains_key("additionalProperties") {
             obj.insert("additionalProperties".to_string(), Value::Bool(false));
+        }
+
+        // This is also required by OpenAI's Responses API
+        // Source: https://platform.openai.com/docs/guides/structured-outputs#all-fields-must-be-required
+        if let Some(Value::Object(properties)) = obj.get("properties") {
+            let prop_keys = properties.keys().cloned().map(Value::String).collect();
+            obj.insert("required".to_string(), Value::Array(prop_keys));
         }
 
         if let Some(defs) = obj.get_mut("$defs")
             && let Value::Object(defs_obj) = defs
         {
             for (_, def_schema) in defs_obj.iter_mut() {
-                add_props_false(def_schema);
+                sanitize_schema(def_schema);
             }
         }
 
@@ -456,12 +464,12 @@ fn add_props_false(schema: &mut serde_json::Value) {
             && let Value::Object(props) = properties
         {
             for (_, prop_value) in props.iter_mut() {
-                add_props_false(prop_value);
+                sanitize_schema(prop_value);
             }
         }
 
         if let Some(items) = obj.get_mut("items") {
-            add_props_false(items);
+            sanitize_schema(items);
         }
 
         // should handle Enums (anyOf/oneOf)
@@ -470,7 +478,7 @@ fn add_props_false(schema: &mut serde_json::Value) {
                 && let Value::Array(variants_array) = variants
             {
                 for variant in variants_array.iter_mut() {
-                    add_props_false(variant);
+                    sanitize_schema(variant);
                 }
             }
         }
@@ -485,7 +493,7 @@ impl From<completion::ToolDefinition> for ResponsesToolDefinition {
             description,
         } = value;
 
-        add_props_false(&mut parameters);
+        sanitize_schema(&mut parameters);
 
         Self {
             name,


### PR DESCRIPTION
Small correction to comply with OpenAI's structured output restriction on `required` props
https://platform.openai.com/docs/guides/structured-outputs#all-fields-must-be-required

Fixes [#1089](https://github.com/0xPlaygrounds/rig/issues/1089).