### PR TITLE
bug: `client::Client` debug impl can leak info

### DIFF
--- a/rig-core/src/client/mod.rs
+++ b/rig-core/src/client/mod.rs
@@ -145,7 +145,13 @@ where
 
         d = d
             .field("base_url", &self.base_url)
-            .field("headers", &self.headers)
+            .field(
+                "headers",
+                &self.headers.iter().filter_map(|(k, v)| {
+                    (!(k == http::header::AUTHORIZATION || k.as_str().contains("api-key")))
+                        .then_some((k, v))
+                }),
+            )
             .field("http_client", &self.http_client);
 
         self.ext
@@ -401,6 +407,7 @@ where
 pub struct NeedsApiKey;
 
 // ApiKey is generic because Anthropic uses custom auth header, local models like Ollama use none
+#[derive(Clone)]
 pub struct ClientBuilder<Ext, ApiKey = NeedsApiKey, H = reqwest::Client> {
     base_url: String,
     api_key: ApiKey,

--- a/rig-core/src/providers/gemini/client.rs
+++ b/rig-core/src/providers/gemini/client.rs
@@ -39,7 +39,7 @@ impl ApiKey for GeminiApiKey {}
 
 impl DebugExt for GeminiExt {
     fn fields(&self) -> impl Iterator<Item = (&'static str, &dyn Debug)> {
-        std::iter::once(("api_key", (&self.api_key as &dyn Debug)))
+        std::iter::once(("api_key", (&"******") as &dyn Debug))
     }
 }
 


### PR DESCRIPTION
Realized `client::Client`'s `std::fmt::Debug` impl could potentially leak API keys from some providers