### PR TITLE
feat(rig-1076): Providers should route all requests through `client::Client`

### DIFF
--- a/rig-core/src/providers/anthropic/streaming.rs
+++ b/rig-core/src/providers/anthropic/streaming.rs
@@ -204,7 +204,7 @@ where
             .body(body)
             .map_err(http_client::Error::Protocol)?;
 
-        let stream = GenericEventSource::new(self.client.http_client().clone(), req);
+        let stream = GenericEventSource::new(self.client.clone(), req);
 
         // Use our SSE decoder to directly handle Server-Sent Events format
         let stream: StreamingResult<StreamingCompletionResponse> = Box::pin(stream! {

--- a/rig-core/src/providers/cohere/completion.rs
+++ b/rig-core/src/providers/cohere/completion.rs
@@ -649,7 +649,6 @@ where
         async {
             let response = self
                 .client
-                .http_client()
                 .send::<_, bytes::Bytes>(req)
                 .await
                 .map_err(|e| http_client::Error::Instance(e.into()))?;

--- a/rig-core/src/providers/cohere/streaming.rs
+++ b/rig-core/src/providers/cohere/streaming.rs
@@ -133,7 +133,7 @@ where
 
         let req = self.client.post("/v2/chat")?.body(body).unwrap();
 
-        let mut event_source = GenericEventSource::new(self.client.http_client().clone(), req);
+        let mut event_source = GenericEventSource::new(self.client.clone(), req);
 
         let stream = stream! {
             let mut current_tool_call: Option<(String, String, String)> = None;

--- a/rig-core/src/providers/deepseek.rs
+++ b/rig-core/src/providers/deepseek.rs
@@ -638,7 +638,7 @@ where
         };
 
         tracing::Instrument::instrument(
-            send_compatible_streaming_request(self.client.http_client().clone(), req),
+            send_compatible_streaming_request(self.client.clone(), req),
             span,
         )
         .await

--- a/rig-core/src/providers/galadriel.rs
+++ b/rig-core/src/providers/galadriel.rs
@@ -631,7 +631,7 @@ where
             tracing::Span::current()
         };
 
-        send_compatible_streaming_request(self.client.http_client().clone(), req)
+        send_compatible_streaming_request(self.client.clone(), req)
             .instrument(span)
             .await
     }

--- a/rig-core/src/providers/gemini/embedding.rs
+++ b/rig-core/src/providers/gemini/embedding.rs
@@ -44,7 +44,7 @@ impl<T> EmbeddingModel<T> {
 
 impl<T> embeddings::EmbeddingModel for EmbeddingModel<T>
 where
-    T: Clone + HttpClientExt,
+    T: Clone + HttpClientExt + 'static,
 {
     type Client = Client<T>;
 

--- a/rig-core/src/providers/gemini/streaming.rs
+++ b/rig-core/src/providers/gemini/streaming.rs
@@ -111,7 +111,7 @@ where
             .body(body)
             .map_err(|e| CompletionError::HttpError(e.into()))?;
 
-        let mut event_source = GenericEventSource::new(self.client.http_client().clone(), req);
+        let mut event_source = GenericEventSource::new(self.client.clone(), req);
 
         let stream = stream! {
             let mut text_response = String::new();

--- a/rig-core/src/providers/gemini/transcription.rs
+++ b/rig-core/src/providers/gemini/transcription.rs
@@ -36,7 +36,7 @@ impl<T> TranscriptionModel<T> {
 
 impl<T> transcription::TranscriptionModel for TranscriptionModel<T>
 where
-    T: HttpClientExt + WasmCompatSend + WasmCompatSync + Clone,
+    T: HttpClientExt + WasmCompatSend + WasmCompatSync + Clone + 'static,
 {
     type Response = GenerateContentResponse;
     type Client = Client<T>;

--- a/rig-core/src/providers/groq.rs
+++ b/rig-core/src/providers/groq.rs
@@ -468,7 +468,7 @@ where
         };
 
         tracing::Instrument::instrument(
-            send_compatible_streaming_request(self.client.http_client().clone(), req),
+            send_compatible_streaming_request(self.client.clone(), req),
             span,
         )
         .await
@@ -554,12 +554,7 @@ where
             .body(body)
             .unwrap();
 
-        let response = self
-            .client
-            .http_client()
-            .send_multipart::<Bytes>(req)
-            .await
-            .unwrap();
+        let response = self.client.send_multipart::<Bytes>(req).await.unwrap();
 
         let status = response.status();
         let response_body = response.into_body().into_future().await?.to_vec();

--- a/rig-core/src/providers/huggingface/streaming.rs
+++ b/rig-core/src/providers/huggingface/streaming.rs
@@ -55,7 +55,7 @@ where
             tracing::Span::current()
         };
 
-        send_compatible_streaming_request(self.client.http_client().clone(), req)
+        send_compatible_streaming_request(self.client.clone(), req)
             .instrument(span)
             .await
     }

--- a/rig-core/src/providers/huggingface/transcription.rs
+++ b/rig-core/src/providers/huggingface/transcription.rs
@@ -49,7 +49,7 @@ impl<T> TranscriptionModel<T> {
 }
 impl<T> transcription::TranscriptionModel for TranscriptionModel<T>
 where
-    T: HttpClientExt + Clone + WasmCompatSync,
+    T: HttpClientExt + Clone + WasmCompatSync + 'static,
 {
     type Response = TranscriptionResponse;
 

--- a/rig-core/src/providers/hyperbolic.rs
+++ b/rig-core/src/providers/hyperbolic.rs
@@ -439,7 +439,7 @@ where
             .body(body)
             .map_err(http_client::Error::from)?;
 
-        send_compatible_streaming_request(self.client.http_client().clone(), req)
+        send_compatible_streaming_request(self.client.clone(), req)
             .instrument(span)
             .await
     }

--- a/rig-core/src/providers/mira.rs
+++ b/rig-core/src/providers/mira.rs
@@ -158,7 +158,7 @@ struct ModelInfo {
 
 impl<T> Client<T>
 where
-    T: HttpClientExt,
+    T: HttpClientExt + 'static,
 {
     /// List available models
     pub async fn list_models(&self) -> Result<Vec<String>, MiraError> {
@@ -458,7 +458,7 @@ where
             .body(body)
             .map_err(http_client::Error::from)?;
 
-        send_compatible_streaming_request(self.client.http_client().clone(), req)
+        send_compatible_streaming_request(self.client.clone(), req)
             .instrument(span)
             .await
     }

--- a/rig-core/src/providers/mistral/embedding.rs
+++ b/rig-core/src/providers/mistral/embedding.rs
@@ -42,7 +42,7 @@ impl<T> EmbeddingModel<T> {
 
 impl<T> embeddings::EmbeddingModel for EmbeddingModel<T>
 where
-    T: HttpClientExt + Clone,
+    T: HttpClientExt + Clone + 'static,
 {
     type Client = Client<T>;
 

--- a/rig-core/src/providers/moonshot.rs
+++ b/rig-core/src/providers/moonshot.rs
@@ -325,7 +325,7 @@ where
             .body(body)
             .map_err(http_client::Error::from)?;
 
-        send_compatible_streaming_request(self.client.http_client().clone(), req)
+        send_compatible_streaming_request(self.client.clone(), req)
             .instrument(span)
             .await
     }

--- a/rig-core/src/providers/ollama.rs
+++ b/rig-core/src/providers/ollama.rs
@@ -233,7 +233,7 @@ where
             .body(body)
             .map_err(|e| EmbeddingError::HttpError(e.into()))?;
 
-        let response = HttpClientExt::send(self.client.http_client(), req).await?;
+        let response = self.client.send(req).await?;
 
         if !response.status().is_success() {
             let text = http_client::text(response).await?;
@@ -593,7 +593,7 @@ where
             .body(body)
             .map_err(http_client::Error::from)?;
 
-        let response = self.client.http_client().send_streaming(req).await?;
+        let response = self.client.send_streaming(req).await?;
         let status = response.status();
         let mut byte_stream = response.into_body();
 

--- a/rig-core/src/providers/openai/client.rs
+++ b/rig-core/src/providers/openai/client.rs
@@ -134,12 +134,7 @@ where
     /// Create a Completions API client from this Responses API client.
     /// Useful for switching to the traditional Chat Completions API.
     pub fn completions_api(self) -> CompletionsClient<H> {
-        client::Client::from_parts(
-            self.base_url().to_string(),
-            self.headers().clone(),
-            self.http_client().clone(),
-            OpenAICompletionsExt,
-        )
+        self.with_ext(OpenAICompletionsExt)
     }
 }
 
@@ -168,12 +163,7 @@ where
     /// Create a Responses API client from this Completions API client.
     /// Useful for switching to the newer Responses API.
     pub fn responses_api(self) -> Client<H> {
-        client::Client::from_parts(
-            self.base_url().to_string(),
-            self.headers().clone(),
-            self.http_client().clone(),
-            OpenAIResponsesExt,
-        )
+        self.with_ext(OpenAIResponsesExt)
     }
 }
 

--- a/rig-core/src/providers/openai/completion/streaming.rs
+++ b/rig-core/src/providers/openai/completion/streaming.rs
@@ -123,7 +123,7 @@ where
             tracing::Span::current()
         };
 
-        let client = self.client.http_client().clone();
+        let client = self.client.clone();
 
         tracing::Instrument::instrument(send_compatible_streaming_request(client, req), span).await
     }

--- a/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -240,7 +240,7 @@ where
         span.record("gen_ai.provider.name", "openai");
         span.record("gen_ai.request.model", &self.model);
         // Build the request with proper headers for SSE
-        let client = self.client.http_client().clone();
+        let client = self.client.clone();
 
         let mut event_source = GenericEventSource::new(client, req);
 

--- a/rig-core/src/providers/openai/transcription.rs
+++ b/rig-core/src/providers/openai/transcription.rs
@@ -102,12 +102,7 @@ where
             .body(body)
             .unwrap();
 
-        let response = self
-            .client
-            .http_client()
-            .send_multipart::<Bytes>(req)
-            .await
-            .unwrap();
+        let response = self.client.send_multipart::<Bytes>(req).await.unwrap();
 
         let status = response.status();
         let response_body = response.into_body().into_future().await?.to_vec();

--- a/rig-core/src/providers/openrouter/streaming.rs
+++ b/rig-core/src/providers/openrouter/streaming.rs
@@ -151,7 +151,7 @@ where
         };
 
         tracing::Instrument::instrument(
-            send_compatible_streaming_request(self.client.http_client().clone(), req),
+            send_compatible_streaming_request(self.client.clone(), req),
             span,
         )
         .await

--- a/rig-core/src/providers/perplexity.rs
+++ b/rig-core/src/providers/perplexity.rs
@@ -450,7 +450,7 @@ where
         } else {
             tracing::Span::current()
         };
-        send_compatible_streaming_request(self.client.http_client().clone(), req)
+        send_compatible_streaming_request(self.client.clone(), req)
             .instrument(span)
             .await
     }

--- a/rig-core/src/providers/together/streaming.rs
+++ b/rig-core/src/providers/together/streaming.rs
@@ -56,7 +56,7 @@ where
             tracing::Span::current()
         };
 
-        send_compatible_streaming_request(self.client.http_client().clone(), req)
+        send_compatible_streaming_request(self.client.clone(), req)
             .instrument(span)
             .await
     }

--- a/rig-core/src/providers/xai/completion.rs
+++ b/rig-core/src/providers/xai/completion.rs
@@ -154,7 +154,7 @@ where
             .map_err(|e| CompletionError::HttpError(e.into()))?;
 
         async move {
-            let response = self.client.http_client().send::<_, Bytes>(req).await?;
+            let response = self.client.send::<_, Bytes>(req).await?;
             let status = response.status();
             let response_body = response.into_body().into_future().await?.to_vec();
 

--- a/rig-core/src/providers/xai/streaming.rs
+++ b/rig-core/src/providers/xai/streaming.rs
@@ -51,7 +51,7 @@ where
             tracing::Span::current()
         };
 
-        send_compatible_streaming_request(self.client.http_client().clone(), req)
+        send_compatible_streaming_request(self.client.clone(), req)
             .instrument(span)
             .await
     }


### PR DESCRIPTION
fixes #1107