### PR TITLE
feat: add Anthropic prompt caching support

### DIFF
--- a/rig-core/src/one_or_many.rs
+++ b/rig-core/src/one_or_many.rs
@@ -42,7 +42,10 @@ impl<T: Clone> OneOrMany<T> {
 
     /// Get the last item in the list.
     pub fn last(&self) -> T {
-        self.rest.last().cloned().unwrap_or_else(|| self.first.clone())
+        self.rest
+            .last()
+            .cloned()
+            .unwrap_or_else(|| self.first.clone())
     }
 
     /// Get a reference to the last item in the list.

--- a/rig-core/src/providers/anthropic/completion.rs
+++ b/rig-core/src/providers/anthropic/completion.rs
@@ -806,7 +806,7 @@ fn set_content_cache_control(content: &mut Content, value: Option<CacheControl>)
 /// Strategy: cache the system prompt, and mark the last content block of the last message
 /// for caching. This allows the conversation history to be cached while new messages
 /// are added.
-pub fn apply_cache_control(system: &mut Vec<SystemContent>, messages: &mut [Message]) {
+pub fn apply_cache_control(system: &mut [SystemContent], messages: &mut [Message]) {
     // Add cache_control to the system prompt (if non-empty)
     if let Some(SystemContent::Text { cache_control, .. }) = system.last_mut() {
         *cache_control = Some(CacheControl::Ephemeral);
@@ -1438,21 +1438,15 @@ mod tests {
         // Only the last content block of last message should have cache_control
         // First message should NOT have cache_control
         for content in messages[0].content.iter() {
-            match content {
-                Content::Text { cache_control, .. } => {
-                    assert!(cache_control.is_none());
-                }
-                _ => {}
+            if let Content::Text { cache_control, .. } = content {
+                assert!(cache_control.is_none());
             }
         }
 
         // Last message SHOULD have cache_control
         for content in messages[1].content.iter() {
-            match content {
-                Content::Text { cache_control, .. } => {
-                    assert!(cache_control.is_some());
-                }
-                _ => {}
+            if let Content::Text { cache_control, .. } = content {
+                assert!(cache_control.is_some());
             }
         }
     }

--- a/rig-core/src/providers/anthropic/streaming.rs
+++ b/rig-core/src/providers/anthropic/streaming.rs
@@ -6,8 +6,8 @@ use tracing::{Level, enabled, info_span};
 use tracing_futures::Instrument;
 
 use super::completion::{
-    apply_cache_control, CompletionModel, Content, Message, SystemContent, ToolChoice,
-    ToolDefinition, Usage,
+    CompletionModel, Content, Message, SystemContent, ToolChoice, ToolDefinition, Usage,
+    apply_cache_control,
 };
 use crate::completion::{CompletionError, CompletionRequest, GetTokenUsage};
 use crate::http_client::sse::{Event, GenericEventSource};


### PR DESCRIPTION
## Summary

Add support for Anthropic's prompt caching feature, which can significantly reduce costs for multi-turn conversations by caching the system prompt and conversation history.

## Changes

- Add `cache_control` field to `Content` variants (Text, Image, ToolResult, Document)
- Add `SystemContent` enum for structured system prompts with cache control
- Add `prompt_caching` field to `CompletionModel` (default: false)
- Add `with_prompt_caching()` builder method to opt-in to caching
- Add `apply_cache_control()` helper to set cache breakpoints
- Add `last_mut()` and related accessor methods to `OneOrMany`

## How it works

When enabled via `with_prompt_caching()`, cache_control breakpoints are automatically added to:
- The system prompt (marked with `ephemeral` cache type)
- The last content block of the last message

This follows the caching strategy recommended by Anthropic for multi-turn conversations.

## Usage

```rust
let completion_model = client
    .completion_model("claude-sonnet-4-20250514")
    .with_prompt_caching();

let agent = AgentBuilder::new(completion_model)
    .preamble("You are a helpful assistant")
    .build();
```

## Test plan

- [x] All existing tests pass (172 tests)
- [x] Added `test_cache_control_serialization` test to verify cache_control serialization
- [x] Manually tested with Anthropic API - cache tokens visible in response usage