### PR TITLE
fix: StreamingPromptHook panic when chat_history is empty

### DIFF
--- a/rig-core/src/agent/prompt_request/streaming.rs
+++ b/rig-core/src/agent/prompt_request/streaming.rs
@@ -228,11 +228,8 @@ where
 
                 if let Some(ref hook) = self.hook {
                     let reader = chat_history.read().await;
-                    let prompt = reader.last().cloned().expect("there should always be at least one message in the chat history");
-                    let chat_history_except_last = reader[..reader.len() - 1].to_vec();
-
-                    hook.on_completion_call(&prompt, &chat_history_except_last, cancel_signal.clone())
-                    .await;
+                    hook.on_completion_call(&current_prompt, &reader.to_vec(), cancel_signal.clone())
+                        .await;
 
                     if cancel_signal.is_cancelled() {
                         yield Err(StreamingError::Prompt(PromptError::prompt_cancelled(chat_history.read().await.to_vec()).into()));


### PR DESCRIPTION
## Summary

- Fixes panic when using `.with_hook()` on streaming prompts without prior chat history
- Fixes incorrect hook semantics where wrong message was passed as `prompt`

## Problem

The streaming implementation's `on_completion_call` hook was incorrectly trying to get the prompt from `chat_history.last()` instead of using the `current_prompt` variable. This caused:

1. **Panic** when using `.with_hook()` without prior chat history (empty vec)
2. **Wrong semantics** - hook received last history message (could be an assistant message) instead of the actual user prompt being sent

## Root Cause

The streaming architecture keeps `current_prompt` separate from `chat_history` until *after* the completion (line 267). But the hook code was trying to extract the prompt from `chat_history.last()`, which doesn't contain the current prompt at that point.

## Fix

Use `current_prompt` directly in the hook call, and pass the full `chat_history` (which correctly represents prior conversation only):

```rust
// Before (buggy)
let prompt = reader.last().cloned().expect("...");
let chat_history_except_last = reader[..reader.len() - 1].to_vec();
hook.on_completion_call(&prompt, &chat_history_except_last, ...)

// After (fixed)
hook.on_completion_call(&current_prompt, &reader.to_vec(), ...)
```

## Test plan

- [x] `cargo check -p rig-core` passes
- [x] `cargo test -p rig-core --lib` passes (172 tests)
- [ ] Manual test with streaming hook and empty history (no longer panics)

Fixes #1131