### PR TITLE
refactor(rig-1085): groq reasoning format

### DIFF
--- a/rig/rig-core/src/providers/groq.rs
+++ b/rig/rig-core/src/providers/groq.rs
@@ -731,7 +731,7 @@ mod tests {
 
     #[test]
     fn serialize_groq_request() {
-        let mut additional_params = GroqAdditionalParameters {
+        let additional_params = GroqAdditionalParameters {
             include_reasoning: Some(true),
             reasoning_format: Some(super::ReasoningFormat::Parsed),
             ..Default::default()

--- a/rig/rig-core/src/providers/groq.rs
+++ b/rig/rig-core/src/providers/groq.rs
@@ -242,13 +242,13 @@ impl TryFrom<(&str, CompletionRequest)> for GroqCompletionRequest {
 pub struct GroqAdditionalParameters {
     /// The reasoning format. See Groq's API docs for more details.
     #[serde(skip_serializing_if = "Option::is_none")]
-    reasoning_format: Option<ReasoningFormat>,
+    pub reasoning_format: Option<ReasoningFormat>,
     /// Whether or not to include reasoning. See Groq's API docs for more details.
     #[serde(skip_serializing_if = "Option::is_none")]
-    include_reasoning: Option<bool>,
+    pub include_reasoning: Option<bool>,
     /// Any other properties not included by default on this struct (that you want to send)
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
-    extra: Option<Map<String, serde_json::Value>>,
+    pub extra: Option<Map<String, serde_json::Value>>,
 }
 
 impl Default for GroqAdditionalParameters {

--- a/rig/rig-core/src/providers/groq.rs
+++ b/rig/rig-core/src/providers/groq.rs
@@ -731,9 +731,11 @@ mod tests {
 
     #[test]
     fn serialize_groq_request() {
-        let mut additional_params = GroqAdditionalParameters::default();
-        additional_params.include_reasoning = Some(true);
-        additional_params.reasoning_format = Some(super::ReasoningFormat::Parsed);
+        let mut additional_params = GroqAdditionalParameters {
+            include_reasoning: Some(true),
+            reasoning_format: Some(super::ReasoningFormat::Parsed),
+            ..Default::default()
+        };
 
         let groq = GroqCompletionRequest {
             model: "openai/gpt-120b-oss".to_string(),

--- a/rig/rig-core/src/providers/groq.rs
+++ b/rig/rig-core/src/providers/groq.rs
@@ -238,7 +238,7 @@ impl TryFrom<(&str, CompletionRequest)> for GroqCompletionRequest {
 }
 
 /// Additional parameters to send to the Groq API
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct GroqAdditionalParameters {
     /// The reasoning format. See Groq's API docs for more details.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -249,16 +249,6 @@ pub struct GroqAdditionalParameters {
     /// Any other properties not included by default on this struct (that you want to send)
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
     pub extra: Option<Map<String, serde_json::Value>>,
-}
-
-impl Default for GroqAdditionalParameters {
-    fn default() -> Self {
-        Self {
-            reasoning_format: None,
-            include_reasoning: None,
-            extra: None,
-        }
-    }
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Fixes #1134 

EDIT: This adds a breaking change - users will now have to specify how they want the reasoning format instead of us doing it for them.