### PR TITLE
fix(openai): add None variant to ReasoningEffort enum

### DIFF
--- a/rig/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/rig/rig-core/src/providers/openai/responses_api/mod.rs
@@ -882,6 +882,7 @@ pub enum OpenAIServiceTier {
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ReasoningEffort {
+    None,
     Minimal,
     Low,
     #[default]


### PR DESCRIPTION
## Summary

Add `None` variant to `ReasoningEffort` enum to handle responses from non-reasoning OpenAI models.

## Problem

Non-reasoning models (e.g., gpt-4o, gpt-5.2) return `"effort": "none"` in API responses, which causes a deserialization error:

```
JsonError: unknown variant `none`, expected one of `minimal`, `low`, `medium`, `high`
```

## Solution

Add `None` as the first variant of `ReasoningEffort` enum to properly deserialize responses from non-reasoning models.

## Test Plan

- All existing tests pass (`cargo test --lib` - 175 tests)
- `cargo clippy --all-features --all-targets` passes
- `cargo fmt -- --check` passes

Fixes #1156

---

This PR was generated with assistance from Claude Code.