### PR TITLE
Fix incorrect variable name in AgentBuilder doc examples

### DIFF
--- a/rig/rig-core/src/agent/builder.rs
+++ b/rig/rig-core/src/agent/builder.rs
@@ -29,7 +29,7 @@ use super::Agent;
 /// let gpt4o = openai.completion_model("gpt-4o");
 ///
 /// // Configure the agent
-/// let agent = AgentBuilder::new(model)
+/// let agent = AgentBuilder::new(gpt4o)
 ///     .preamble("System prompt")
 ///     .context("Context document 1")
 ///     .context("Context document 2")
@@ -324,7 +324,7 @@ where
 /// let gpt4o = openai.completion_model("gpt-4o");
 ///
 /// // Configure the agent
-/// let agent = AgentBuilder::new(model)
+/// let agent = AgentBuilder::new(gpt4o)
 ///     .preamble("System prompt")
 ///     .context("Context document 1")
 ///     .context("Context document 2")


### PR DESCRIPTION
This PR fixes a minor documentation issue in AgentBuilder where the example code used an undefined variable name model instead of the correctly defined gpt4o.

Before
```rust
let gpt4o = openai.completion_model("gpt-4o");
let agent = AgentBuilder::new(model)  // ❌ `model` is undefined
```
After
```rust
let gpt4o = openai.completion_model("gpt-4o");
let agent = AgentBuilder::new(gpt4o)  // ✅ correct variable name
```
