### PR TITLE
Fixes Issue#1169, finish the `from_val` case not included in PR#1170

### DIFF
--- a/rig/rig-core/src/providers/deepseek.rs
+++ b/rig/rig-core/src/providers/deepseek.rs
@@ -90,17 +90,17 @@ impl ProviderClient for Client {
     // If you prefer the environment variable approach:
     fn from_env() -> Self {
         let api_key = std::env::var("DEEPSEEK_API_KEY").expect("DEEPSEEK_API_KEY not set");
+        Self::from_val(api_key.into())
+    }
+
+    fn from_val(input: Self::Input) -> Self {
         let mut client_builder = Self::builder();
         client_builder.headers_mut().insert(
             http::header::CONTENT_TYPE,
             http::HeaderValue::from_static("application/json"),
         );
-        let client_builder = client_builder.api_key(&api_key);
+        let client_builder = client_builder.api_key(input);
         client_builder.build().unwrap()
-    }
-
-    fn from_val(input: Self::Input) -> Self {
-        Self::new(input).unwrap()
     }
 }
 


### PR DESCRIPTION
In #1170, Issue #1169 has been fixed for clients built with `from_env`. However, #1170 did not implement the fix for `from_val`. This PR adds the fix to clients built with `from_val`.