### PR TITLE
fix: missing json header on send_streaming

### DIFF
--- a/rig/rig-core/src/client/mod.rs
+++ b/rig/rig-core/src/client/mod.rs
@@ -312,11 +312,16 @@ where
 
     fn send_streaming<T>(
         &self,
-        req: Request<T>,
+        mut req: Request<T>,
     ) -> impl Future<Output = http_client::Result<http_client::StreamingResponse>> + WasmCompatSend
     where
         T: Into<Bytes>,
     {
+        req.headers_mut().insert(
+            http::header::CONTENT_TYPE,
+            http::HeaderValue::from_static("application/json"),
+        );
+
         self.http_client.send_streaming(req)
     }
 }


### PR DESCRIPTION
I checked that all providers currently use JSON for the initial request.
I think to make things cleaner we should create a wrapper `Json` that implements `Into<Bytes>` but also implement a trait like:
```rust
trait ContentType {
    fn content_type -> &'static str
}
```

That way the HttpClient doesn't have to guess.