### PR TITLE
fix: ollama embedding_model dims Option panic.

### DIFF
--- a/rig/rig-core/src/providers/ollama.rs
+++ b/rig/rig-core/src/providers/ollama.rs
@@ -147,6 +147,14 @@ enum ApiResponse<T> {
 pub const ALL_MINILM: &str = "all-minilm";
 pub const NOMIC_EMBED_TEXT: &str = "nomic-embed-text";
 
+fn model_dimensions_from_identifier(identifier: &str) -> Option<usize> {
+    match identifier {
+        ALL_MINILM => Some(384),
+        NOMIC_EMBED_TEXT => Some(768),
+        _ => None,
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct EmbeddingResponse {
     pub model: String,
@@ -208,7 +216,11 @@ where
     type Client = Client<T>;
 
     fn make(client: &Self::Client, model: impl Into<String>, dims: Option<usize>) -> Self {
-        Self::new(client.clone(), model, dims.unwrap())
+        let model = model.into();
+        let dims = dims
+            .or(model_dimensions_from_identifier(&model))
+            .unwrap_or_default();
+        Self::new(client.clone(), model, dims)
     }
 
     const MAX_DOCUMENTS: usize = 1024;


### PR DESCRIPTION
use ollama embedding_model， Missing model dimensions.
```rust
    let ollama_client = ollama::Client::from_env();
   // this will panic.
    let model = ollama_client.embedding_model("nomic-embed-text");
```
add function `model_dimensions_from_identifier` to give a default dimension.
maybe fix [1189](https://github.com/0xPlaygrounds/rig/issues/1189)