### PR TITLE
feat(agent): export StreamingError to public API

### DIFF
--- a/rig/rig-core/src/agent/mod.rs
+++ b/rig/rig-core/src/agent/mod.rs
@@ -115,7 +115,7 @@ pub use crate::message::Text;
 pub use builder::{AgentBuilder, AgentBuilderSimple};
 pub use completion::Agent;
 pub use prompt_request::streaming::{
-    FinalResponse, MultiTurnStreamItem, StreamingPromptRequest, stream_to_stdout,
+    FinalResponse, MultiTurnStreamItem, StreamingError, StreamingPromptRequest, stream_to_stdout,
 };
 pub use prompt_request::{CancelSignal, PromptRequest, PromptResponse};
 pub use prompt_request::{PromptHook, StreamingPromptHook};


### PR DESCRIPTION
Export `StreamingError` from the `rig::agent` module to enable proper error handling in multi-provider abstractions.

## Motivation

When building applications that support multiple LLM providers, a common pattern is to create an enum wrapper to abstract over different model types:

```rust
  pub enum AgentBuilder {
      Anthropic(agent::AgentBuilder<anthropic::completion::CompletionModel>),
      OpenAI(agent::AgentBuilder<openai::completion::CompletionModel>),
      Gemini(agent::AgentBuilder<gemini::completion::CompletionModel>),
      OpenRouter(agent::AgentBuilder<openai::completion::CompletionModel>),
  }
```

To unify error handling across these providers, users need to define their own error types and implement conversions from the underlying errors:

```rust
  pub enum MyStreamingError {
      Streaming(StreamingError),
      // ...
  }

  impl From<StreamingError> for MyStreamingError {
      fn from(e: StreamingError) -> Self {
          MyStreamingError::Streaming(e)
      }
  }
```

However, StreamingError was not re-exported from the agent module, making this pattern impossible.

## The Problem
StreamingResult<R> is defined as:
```rust
  pub type StreamingResult<R> =
      Pin<Box<dyn Stream<Item = Result<MultiTurnStreamItem<R>, StreamingError>> + Send>>;
```

- MultiTurnStreamItem — exported, users can pattern match on Ok variants
- StreamingError — not exported, users cannot pattern match on Err variants

This inconsistency prevents users from implementing fine-grained error handling or building provider-agnostic abstractions.

Closes: #1208 