### PR TITLE
feat: Add the ```encoding_format``` parameter to openai-embedding.

### DIFF
--- a/rig/rig-core/src/providers/openai/embedding.rs
+++ b/rig/rig-core/src/providers/openai/embedding.rs
@@ -108,8 +108,8 @@ where
             body["dimensions"] = json!(self.ndims);
         }
 
-        if let Some(encoding_format) = &self.encoding_format { 
-             body["encoding_format"] = json!(encoding_format);
+        if let Some(encoding_format) = &self.encoding_format {
+            body["encoding_format"] = json!(encoding_format);
         }
 
         let body = serde_json::to_vec(&body)?;


### PR DESCRIPTION
When using an OpenAI-compatible embedding model, I encountered an error indicating that ```encoding_format```  and ```user``` is missing.

Here is the documentation for OpenAI

![PixPin_2026-01-06_17-57-00](https://github.com/user-attachments/assets/d311e058-7832-49bd-868f-dd1635d9f079)
