### PR TITLE
feat(gemini): Add support for RAG documents in dynamic context

### DIFF
--- a/rig/rig-core/src/providers/gemini/completion.rs
+++ b/rig/rig-core/src/providers/gemini/completion.rs
@@ -2375,6 +2375,8 @@ mod tests {
             );
         }
     }
+
+    #[test]
     fn test_tool_result_with_image_content() {
         // Test that a ToolResult with image content converts correctly to Gemini's Part format
         use crate::OneOrMany;
@@ -2406,6 +2408,8 @@ mod tests {
 
         // Convert to Gemini Content
         let content: Content = msg.try_into().expect("Should convert to Gemini Content");
+        assert_eq!(content.role, Some(Role::User));
+        assert_eq!(content.parts.len(), 1);
 
         // Verify the part is a FunctionResponse with both response and parts
         if let Some(Part {
@@ -2432,9 +2436,6 @@ mod tests {
             assert!(!inline_data.data.is_empty());
         } else {
             panic!("Expected FunctionResponse part");
-
-            assert_eq!(content.role, Some(Role::User));
-            assert_eq!(content.parts.len(), 1);
         }
     }
 
@@ -2467,6 +2468,8 @@ mod tests {
             );
         }
     }
+
+    #[test]
     fn test_tool_result_with_url_image() {
         // Test that a ToolResult with a URL-based image converts to file_data
         use crate::OneOrMany;
@@ -2491,6 +2494,8 @@ mod tests {
         };
 
         let content: Content = msg.try_into().expect("Should convert to Gemini Content");
+        assert_eq!(content.role, Some(Role::User));
+        assert_eq!(content.parts.len(), 1);
 
         if let Some(Part {
             part: PartKind::FunctionResponse(function_response),
@@ -2511,9 +2516,6 @@ mod tests {
             assert_eq!(file_data.mime_type.as_ref().unwrap(), "image/png");
         } else {
             panic!("Expected FunctionResponse part");
-
-            assert_eq!(content.role, Some(Role::User));
-            assert_eq!(content.parts.len(), 1);
         }
     }
 
@@ -2633,6 +2635,7 @@ mod tests {
         }
     }
 
+    #[test]
     fn test_from_tool_output_parses_image_json() {
         // Test the ToolResultContent::from_tool_output helper with image JSON
         use crate::message::{DocumentSourceKind, ToolResultContent};


### PR DESCRIPTION
# Add RAG Documents Support to Gemini Provider

## Summary

This PR adds support for RAG (Retrieval-Augmented Generation) documents in the Gemini provider's `dynamic_context()` functionality. Previously, documents retrieved from vector stores were silently ignored, causing RAG agents to fail.

## Problem

When using `.dynamic_context()` with Gemini agents, the retrieved documents were never passed to the Gemini API. The `create_request_body()` function in the Gemini provider ignored the `documents` field from `CompletionRequest`, making it impossible to use RAG with Gemini.

## Solution

### Changes Made

1. **Document Injection**: Modified `create_request_body()` to check for documents and inject them as a user message at the beginning of chat history using the existing `normalized_documents()` helper method.

2. **Text Document Handling**: Added special handling for `DocumentMediaType::TXT` and other text-based documents to convert them to plain text parts (`PartKind::Text`) instead of trying to send them as base64-encoded inline data.

3. **Backward Compatibility**: Preserved existing behavior for other document types (images, PDFs, etc.) that use `InlineData` or `FileData`.

### Code Changes

File: `rig/rig-core/src/providers/gemini/completion.rs`

- Lines ~189-195: Added document injection logic
- Lines ~773-838: Added TXT and other text-based document to text conversion

## Testing

Tested with a real-world RAG application:
- **Application**: Obsidian vault note organizer with 175+ markdown notes
- **Vector Store**: In-memory vector store with Ollama embeddings (nomic-embed-text)
- **Query**: "<some_query>"
- **Result**: Successfully retrieved 10 relevant notes and Gemini correctly received and processed them

### Before Fix
```
=== NOTES IN CONTEXT ===
NO NOTES IN CONTEXT
=== END OF NOTES ===
```

### After Fix
```
=== NOTES IN CONTEXT ===
<list_of_notes>
=== END OF NOTES ===
```

## Impact

- ✅ Enables RAG functionality for Gemini provider
- ✅ No breaking changes
- ✅ Maintains backward compatibility
- ✅ Follows existing patterns (uses `normalized_documents()`)

## Additional Notes

The fix aligns Gemini's behavior with other providers like Cohere and Anthropic that already support documents in RAG scenarios.
