### PR TITLE
fix(client): add Content-Type header to send_streaming

### DIFF
--- a/rig/rig-core/src/client/mod.rs
+++ b/rig/rig-core/src/client/mod.rs
@@ -312,11 +312,16 @@ where
 
     fn send_streaming<T>(
         &self,
-        req: Request<T>,
+        mut req: Request<T>,
     ) -> impl Future<Output = http_client::Result<http_client::StreamingResponse>> + WasmCompatSend
     where
         T: Into<Bytes>,
     {
+        req.headers_mut().insert(
+            http::header::CONTENT_TYPE,
+            http::HeaderValue::from_static("application/json"),
+        );
+
         self.http_client.send_streaming(req)
     }
 }


### PR DESCRIPTION
Unlike `send`, `send_streaming` was not setting Content-Type header, causing 503 errors on strict API providers like OpenRouter.

Closes: #1206