### PR TITLE
add tool name to tool call delta streaming events

### DIFF
--- a/rig-integrations/rig-bedrock/src/streaming.rs
+++ b/rig-integrations/rig-bedrock/src/streaming.rs
@@ -6,7 +6,7 @@ use rig::completion::GetTokenUsage;
 use rig::streaming::StreamingCompletionResponse;
 use rig::{
     completion::CompletionError,
-    streaming::{RawStreamingChoice, RawStreamingToolCall},
+    streaming::{RawStreamingChoice, RawStreamingToolCall, ToolCallDeltaContent},
 };
 use serde::{Deserialize, Serialize};
 
@@ -94,8 +94,7 @@ impl CompletionModel {
                                     // Emit the delta so UI can show progress
                                     yield Ok(RawStreamingChoice::ToolCallDelta {
                                         id: tool_call.id.clone(),
-                                        name: None,
-                                        delta,
+                                        content: ToolCallDeltaContent::Delta(delta),
                                     });
                                 }
                             },
@@ -142,8 +141,7 @@ impl CompletionModel {
                                 });
                                 yield Ok(RawStreamingChoice::ToolCallDelta {
                                     id: tool_use.tool_use_id,
-                                    name: Some(tool_use.name),
-                                    delta: String::new(),
+                                    content: ToolCallDeltaContent::Name(tool_use.name),
                                 });
                             },
                             _ => yield Err(CompletionError::ProviderError("Stream is empty".into()))

--- a/rig/rig-core/src/agent/prompt_request/streaming.rs
+++ b/rig/rig-core/src/agent/prompt_request/streaming.rs
@@ -348,9 +348,13 @@ where
                                 }
                             }
                         },
-                        Ok(StreamedAssistantContent::ToolCallDelta { id, name, delta }) => {
+                        Ok(StreamedAssistantContent::ToolCallDelta { id, content }) => {
                             if let Some(ref hook) = self.hook {
-                                hook.on_tool_call_delta(&id, name.as_deref(), &delta, cancel_signal.clone())
+                                let (name, delta) = match &content {
+                                    rig::streaming::ToolCallDeltaContent::Name(n) => (Some(n.as_str()), ""),
+                                    rig::streaming::ToolCallDeltaContent::Delta(d) => (None, d.as_str()),
+                                };
+                                hook.on_tool_call_delta(&id, name, delta, cancel_signal.clone())
                                 .await;
 
                                 if cancel_signal.is_cancelled() {

--- a/rig/rig-core/src/providers/cohere/streaming.rs
+++ b/rig/rig-core/src/providers/cohere/streaming.rs
@@ -5,7 +5,7 @@ use crate::providers::cohere::CompletionModel;
 use crate::providers::cohere::completion::{
     AssistantContent, CohereCompletionRequest, Message, ToolCall, ToolCallFunction, ToolType, Usage,
 };
-use crate::streaming::{RawStreamingChoice, RawStreamingToolCall};
+use crate::streaming::{RawStreamingChoice, RawStreamingToolCall, ToolCallDeltaContent};
 use crate::telemetry::SpanCombinator;
 use crate::{json_utils, streaming};
 use async_stream::stream;
@@ -203,8 +203,7 @@ where
 
                                 yield Ok(RawStreamingChoice::ToolCallDelta {
                                     id,
-                                    name: Some(name),
-                                    delta: String::new(),
+                                    content: ToolCallDeltaContent::Name(name),
                                 });
                             },
 
@@ -220,8 +219,7 @@ where
                                 // Emit the delta so UI can show progress
                                 yield Ok(RawStreamingChoice::ToolCallDelta {
                                     id: tc.0,
-                                    name: None,
-                                    delta: arguments,
+                                    content: ToolCallDeltaContent::Delta(arguments),
                                 });
                             },
 

--- a/rig/rig-core/src/providers/openai/completion/streaming.rs
+++ b/rig/rig-core/src/providers/openai/completion/streaming.rs
@@ -214,8 +214,7 @@ where
                                     existing_tool_call.function.name = name.clone();
                                     yield Ok(streaming::RawStreamingChoice::ToolCallDelta {
                                         id: existing_tool_call.id.clone(),
-                                        name: Some(name.clone()),
-                                        delta: String::new(),
+                                        content: streaming::ToolCallDeltaContent::Name(name.clone()),
                                     });
                             }
 
@@ -243,8 +242,7 @@ where
                                 // Emit the delta so UI can show progress
                                 yield Ok(streaming::RawStreamingChoice::ToolCallDelta {
                                     id: existing_tool_call.id.clone(),
-                                    name: None,
-                                    delta: chunk.clone(),
+                                    content: streaming::ToolCallDeltaContent::Delta(chunk.clone()),
                                 });
                             }
                         }

--- a/rig/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/rig/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -286,8 +286,7 @@ where
                                     if let StreamingItemDoneOutput { item: Output::FunctionCall(func), .. } = message {
                                         yield Ok(streaming::RawStreamingChoice::ToolCallDelta {
                                             id: func.id.clone(),
-                                            name: Some(func.name.clone()),
-                                            delta: String::new(),
+                                            content: streaming::ToolCallDeltaContent::Name(func.name.clone()),
                                         });
                                     }
                                 }
@@ -334,7 +333,7 @@ where
                                     yield Ok(streaming::RawStreamingChoice::Message(delta.delta.clone()))
                                 }
                                 ItemChunkKind::FunctionCallArgsDelta(delta) => {
-                                    yield Ok(streaming::RawStreamingChoice::ToolCallDelta { id: delta.item_id.clone(), name: None, delta: delta.delta.clone() })
+                                    yield Ok(streaming::RawStreamingChoice::ToolCallDelta { id: delta.item_id.clone(), content: streaming::ToolCallDeltaContent::Delta(delta.delta.clone()) })
                                 }
 
                                 _ => { continue }

--- a/rig/rig-core/src/providers/openrouter/streaming.rs
+++ b/rig/rig-core/src/providers/openrouter/streaming.rs
@@ -222,8 +222,7 @@ where
                                     existing_tool_call.name = name.clone();
                                     yield Ok(streaming::RawStreamingChoice::ToolCallDelta {
                                         id: existing_tool_call.id.clone(),
-                                        name: Some(name.clone()),
-                                        delta: String::new(),
+                                        content: streaming::ToolCallDeltaContent::Name(name.clone()),
                                     });
                             }
 
@@ -251,8 +250,7 @@ where
                                 // Emit the delta so UI can show progress
                                 yield Ok(streaming::RawStreamingChoice::ToolCallDelta {
                                     id: existing_tool_call.id.clone(),
-                                    name: None,
-                                    delta: chunk.clone(),
+                                    content: streaming::ToolCallDeltaContent::Delta(chunk.clone()),
                                 });
                             }
                         }


### PR DESCRIPTION
Adds tool name to `ToolCallDelta` streaming events so apps can display which tool is being called during streaming

Uses a `ToolCallDeltaContent` enum with `Name(String)` and `Delta(String)` variants since providers send either the name (first event) or argument deltas (subsequent events)

```rust
pub enum ToolCallDeltaContent {
    Name(String),
    Delta(String),
}

RawStreamingChoice::ToolCallDelta {
    id: String,
    content: ToolCallDeltaContent,
}
```