### PR TITLE
Handle error for HTTP client response

### DIFF
--- a/rig/rig-core/src/providers/azure.rs
+++ b/rig/rig-core/src/providers/azure.rs
@@ -678,8 +678,7 @@ where
             .map_err(http_client::Error::from)?;
 
         async move {
-            let response = self.client.send::<_, Bytes>(req).await
-                .map_err(http_client::Error::from)?;
+            let response = self.client.send::<_, Bytes>(req).await?;
 
             let status = response.status();
             let response_body = response.into_body().into_future().await?.to_vec();


### PR DESCRIPTION
Replace unwrap() with proper error propagation.