### PR TITLE
feat: Add the `user` parameter to openai-embedding.

### DIFF
--- a/rig/rig-core/src/providers/openai/embedding.rs
+++ b/rig/rig-core/src/providers/openai/embedding.rs
@@ -61,6 +61,7 @@ pub struct EmbeddingModel<T = reqwest::Client> {
     client: Client<T>,
     pub model: String,
     pub encoding_format: Option<EncodingFormat>,
+    pub user: Option<String>,
     ndims: usize,
 }
 
@@ -110,6 +111,10 @@ where
 
         if let Some(encoding_format) = &self.encoding_format {
             body["encoding_format"] = json!(encoding_format);
+        }
+
+        if let Some(user) = &self.user {
+            body["user"] = json!(user);
         }
 
         let body = serde_json::to_vec(&body)?;
@@ -165,6 +170,7 @@ impl<T> EmbeddingModel<T> {
             model: model.into(),
             encoding_format: None,
             ndims,
+            user: None,
         }
     }
 
@@ -174,6 +180,7 @@ impl<T> EmbeddingModel<T> {
             model: model.into(),
             encoding_format: None,
             ndims,
+            user: None,
         }
     }
 
@@ -188,11 +195,17 @@ impl<T> EmbeddingModel<T> {
             model: model.into(),
             encoding_format: Some(encoding_format),
             ndims,
+            user: None,
         }
     }
 
     pub fn encoding_format(mut self, encoding_format: EncodingFormat) -> Self {
         self.encoding_format = Some(encoding_format);
+        self
+    }
+
+    pub fn user(mut self, user: impl Into<String>) -> Self {
+        self.user = Some(user.into());
         self
     }
 }


### PR DESCRIPTION
Add the `user` parameter 

```rust
    let embedding_model = openai_client
        .embedding_model(std::env::var("EMBEDDING_MODEL")?)
        .encoding_format(openai::EncodingFormat::Float)
        .user("user");
```

<img width="858" height="680" alt="image" src="https://github.com/user-attachments/assets/08b285c8-5040-4beb-8df1-ae9d075223de" />
