### PR TITLE
feat: make integration filters usable with Rig agent RAG store (breaking)

### DIFF
--- a/rig-integrations/rig-milvus/src/filter.rs
+++ b/rig-integrations/rig-milvus/src/filter.rs
@@ -1,4 +1,5 @@
 use rig::vector_store::request::SearchFilter;
+use serde::{Deserialize, Serialize};
 
 pub enum MilvusValue {
     Number(f64),
@@ -84,7 +85,7 @@ where
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Filter(String);
 
 impl SearchFilter for Filter {

--- a/rig-integrations/rig-mongodb/src/lib.rs
+++ b/rig-integrations/rig-mongodb/src/lib.rs
@@ -249,7 +249,7 @@ impl SearchParams {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MongoDbSearchFilter(Document);
 
 impl SearchFilter for MongoDbSearchFilter {

--- a/rig-integrations/rig-neo4j/src/lib.rs
+++ b/rig-integrations/rig-neo4j/src/lib.rs
@@ -93,7 +93,7 @@ use rig::{
     embeddings::EmbeddingModel,
     vector_store::{VectorStoreError, request::SearchFilter},
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use vector_index::{IndexConfig, Neo4jVectorIndex, VectorSimilarityFunction};
 
 pub struct Neo4jClient {
@@ -104,7 +104,7 @@ fn neo4j_to_rig_error(e: neo4rs::Error) -> VectorStoreError {
     VectorStoreError::DatastoreError(Box::new(e))
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Neo4jSearchFilter(String);
 
 impl SearchFilter for Neo4jSearchFilter {

--- a/rig-integrations/rig-qdrant/src/filter.rs
+++ b/rig-integrations/rig-qdrant/src/filter.rs
@@ -3,9 +3,10 @@ use qdrant_client::qdrant::{
     condition::ConditionOneOf, r#match::MatchValue,
 };
 use rig::vector_store::request::{FilterError, SearchFilter};
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QdrantFilter(serde_json::Value);
 
 impl SearchFilter for QdrantFilter {

--- a/rig-integrations/rig-s3vectors/src/lib.rs
+++ b/rig-integrations/rig-s3vectors/src/lib.rs
@@ -24,6 +24,7 @@ pub struct CreateRecord {
     embedded_text: String,
 }
 
+// NOTE: Cannot be used in dynamic store due to aws_smithy_types::Document not impl'ing Serialize or Deserialize
 #[derive(Clone, Debug)]
 pub struct S3SearchFilter(aws_smithy_types::Document);
 

--- a/rig-integrations/rig-scylladb/src/lib.rs
+++ b/rig-integrations/rig-scylladb/src/lib.rs
@@ -41,6 +41,7 @@ pub struct ScyllaDbVectorStore<M: EmbeddingModel> {
     cache: Arc<RwLock<HashMap<u64, PreparedStatement>>>,
 }
 
+// NOTE: Cannot be used as a dynamic store due to CqlValue not impl'ing Serialize or Deserialize
 /// TODO: Write tests for this !
 #[derive(Clone, Debug)]
 pub struct ScyllaSearchFilter {

--- a/rig-integrations/rig-sqlite/src/lib.rs
+++ b/rig-integrations/rig-sqlite/src/lib.rs
@@ -3,7 +3,7 @@ use rig::embeddings::{Embedding, EmbeddingModel};
 use rig::vector_store::request::{FilterError, SearchFilter, VectorSearchRequest};
 use rig::vector_store::{VectorStoreError, VectorStoreIndex};
 use rusqlite::types::Value;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 use std::ops::RangeInclusive;
 use tokio_rusqlite::Connection;
@@ -245,7 +245,7 @@ where
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Deserialize, Serialize, Debug)]
 pub struct SqliteSearchFilter {
     condition: String,
     params: Vec<serde_json::Value>,


### PR DESCRIPTION
Context: #1186 

Added impls back for all stores barring Postgres (see #1233) and some noted sections where the types don't impl (de)Serialize so we can't add it

## Breaking
This is a breaking change as it adds new trait impls for currently existing items.