### PR TITLE
feat: add default max depth to agents

### DIFF
--- a/rig/rig-core/examples/agent_with_default_max_depth.rs
+++ b/rig/rig-core/examples/agent_with_default_max_depth.rs
@@ -1,0 +1,207 @@
+use rig::prelude::*;
+use rig::{
+    completion::{Prompt, ToolDefinition},
+    providers::anthropic,
+    tool::Tool,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG)
+        .with_target(false)
+        .init();
+
+    // Create OpenAI client
+    let openai_client = anthropic::Client::from_env();
+
+    // Create RAG agent with a single context prompt and a dynamic tool source
+    let agent = openai_client
+        .agent(anthropic::completion::CLAUDE_3_5_SONNET)
+        .preamble(
+            "You are an assistant here to help the user select which tool is most appropriate to perform arithmetic operations.
+            Follow these instructions closely.
+            1. Consider the user's request carefully and identify the core elements of the request.
+            2. Select which tool among those made available to you is appropriate given the context.
+            3. This is very important: never perform the operation yourself.
+            "
+        )
+        .tool(Add)
+        .tool(Subtract)
+        .tool(Multiply)
+        .tool(Divide)
+        .default_max_depth(20)
+        .build();
+
+    // Prompt the agent and print the response
+    let result = agent
+        .prompt("Calculate 5 - 2 = ?. Describe the result to me.")
+        .await?;
+
+    println!("\n\nOpenAI Calculator Agent: {result}");
+
+    // Prompt the agent again and print the response
+    let result = agent
+        .prompt("Calculate (3 + 5) / 9  = ?. Describe the result to me.")
+        .await?;
+
+    println!("\n\nOpenAI Calculator Agent: {result}");
+
+    Ok(())
+}
+
+#[derive(Deserialize)]
+struct OperationArgs {
+    x: i32,
+    y: i32,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("Math error")]
+struct MathError;
+
+#[derive(Deserialize, Serialize)]
+struct Add;
+
+impl Tool for Add {
+    const NAME: &'static str = "add";
+    type Error = MathError;
+    type Args = OperationArgs;
+    type Output = i32;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        serde_json::from_value(json!({
+            "name": "add",
+            "description": "Add x and y together",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "x": {
+                        "type": "number",
+                        "description": "The first number to add"
+                    },
+                    "y": {
+                        "type": "number",
+                        "description": "The second number to add"
+                    }
+                }
+            }
+        }))
+        .expect("Tool Definition")
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        let result = args.x + args.y;
+        Ok(result)
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+struct Subtract;
+
+impl Tool for Subtract {
+    const NAME: &'static str = "subtract";
+    type Error = MathError;
+    type Args = OperationArgs;
+    type Output = i32;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        serde_json::from_value(json!({
+            "name": "subtract",
+            "description": "Subtract y from x (i.e.: x - y)",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "x": {
+                        "type": "number",
+                        "description": "The number to subtract from"
+                    },
+                    "y": {
+                        "type": "number",
+                        "description": "The number to subtract"
+                    }
+                }
+            }
+        }))
+        .expect("Tool Definition")
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        let result = args.x - args.y;
+        Ok(result)
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+struct Multiply;
+
+impl Tool for Multiply {
+    const NAME: &'static str = "multiply";
+    type Error = MathError;
+    type Args = OperationArgs;
+    type Output = i32;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        serde_json::from_value(json!({
+            "name": "multiply",
+            "description": "Compute the product of x and y (i.e.: x * y)",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "x": {
+                        "type": "number",
+                        "description": "The first factor in the product"
+                    },
+                    "y": {
+                        "type": "number",
+                        "description": "The second factor in the product"
+                    }
+                }
+            }
+        }))
+        .expect("Tool Definition")
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        let result = args.x * args.y;
+        Ok(result)
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+struct Divide;
+
+impl Tool for Divide {
+    const NAME: &'static str = "divide";
+    type Error = MathError;
+    type Args = OperationArgs;
+    type Output = i32;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        serde_json::from_value(json!({
+            "name": "divide",
+            "description": "Compute the Quotient of x and y (i.e.: x / y). Useful for ratios.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "x": {
+                        "type": "number",
+                        "description": "The Dividend of the division. The number being divided"
+                    },
+                    "y": {
+                        "type": "number",
+                        "description": "The Divisor of the division. The number by which the dividend is being divided"
+                    }
+                }
+            }
+        }))
+        .expect("Tool Definition")
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        let result = args.x / args.y;
+        Ok(result)
+    }
+}

--- a/rig/rig-core/src/agent/builder.rs
+++ b/rig/rig-core/src/agent/builder.rs
@@ -65,6 +65,8 @@ where
     tool_server_handle: Option<ToolServerHandle>,
     /// Whether or not the underlying LLM should be forced to use a tool before providing a response.
     tool_choice: Option<ToolChoice>,
+    /// Default maximum depth for recursive agent calls
+    default_max_depth: Option<usize>,
 }
 
 impl<M> AgentBuilder<M>
@@ -84,6 +86,7 @@ where
             dynamic_context: vec![],
             tool_server_handle: None,
             tool_choice: None,
+            default_max_depth: None,
         }
     }
 
@@ -151,6 +154,7 @@ where
             temperature: self.temperature,
             tools,
             tool_choice: self.tool_choice,
+            default_max_depth: self.default_max_depth,
         }
     }
 
@@ -174,6 +178,7 @@ where
             temperature: self.temperature,
             tools,
             tool_choice: self.tool_choice,
+            default_max_depth: self.default_max_depth,
         }
     }
 
@@ -208,6 +213,7 @@ where
             temperature: self.temperature,
             tools,
             tool_choice: self.tool_choice,
+            default_max_depth: self.default_max_depth,
         }
     }
 
@@ -246,6 +252,7 @@ where
             temperature: self.temperature,
             tools,
             tool_choice: self.tool_choice,
+            default_max_depth: self.default_max_depth,
         }
     }
 
@@ -263,6 +270,11 @@ where
 
     pub fn tool_choice(mut self, tool_choice: ToolChoice) -> Self {
         self.tool_choice = Some(tool_choice);
+        self
+    }
+
+    pub fn default_max_depth(mut self, default_max_depth: usize) -> Self {
+        self.default_max_depth = Some(default_max_depth);
         self
     }
 
@@ -291,6 +303,7 @@ where
             temperature: self.temperature,
             tools: toolset,
             tool_choice: self.tool_choice,
+            default_max_depth: self.default_max_depth,
         }
     }
 
@@ -332,6 +345,7 @@ where
             tool_choice: self.tool_choice,
             dynamic_context: Arc::new(RwLock::new(self.dynamic_context)),
             tool_server_handle,
+            default_max_depth: self.default_max_depth,
         }
     }
 }
@@ -387,6 +401,8 @@ where
     tools: ToolSet,
     /// Whether or not the underlying LLM should be forced to use a tool before providing a response.
     tool_choice: Option<ToolChoice>,
+    /// Default maximum depth for recursive agent calls
+    default_max_depth: Option<usize>,
 }
 
 impl<M> AgentBuilderSimple<M>
@@ -408,6 +424,7 @@ where
             dynamic_tools: vec![],
             tools: ToolSet::default(),
             tool_choice: None,
+            default_max_depth: None,
         }
     }
 
@@ -506,6 +523,11 @@ where
         self
     }
 
+    pub fn default_max_depth(mut self, default_max_depth: usize) -> Self {
+        self.default_max_depth = Some(default_max_depth);
+        self
+    }
+
     /// Add some dynamic tools to the agent. On each prompt, `sample` tools from the
     /// dynamic toolset will be inserted in the request.
     pub fn dynamic_tools(
@@ -557,6 +579,7 @@ where
             tool_choice: self.tool_choice,
             dynamic_context: Arc::new(RwLock::new(self.dynamic_context)),
             tool_server_handle,
+            default_max_depth: self.default_max_depth,
         }
     }
 }

--- a/rig/rig-core/src/agent/builder.rs
+++ b/rig/rig-core/src/agent/builder.rs
@@ -65,7 +65,7 @@ where
     tool_server_handle: Option<ToolServerHandle>,
     /// Whether or not the underlying LLM should be forced to use a tool before providing a response.
     tool_choice: Option<ToolChoice>,
-    /// Default maximum depth for recursive agent calls
+    /// Default maximum depth for multi-turn agent calls
     default_max_depth: Option<usize>,
 }
 
@@ -273,6 +273,7 @@ where
         self
     }
 
+    /// Set the default maximum depth that an agent will use for multi-turn.
     pub fn default_max_depth(mut self, default_max_depth: usize) -> Self {
         self.default_max_depth = Some(default_max_depth);
         self
@@ -401,7 +402,7 @@ where
     tools: ToolSet,
     /// Whether or not the underlying LLM should be forced to use a tool before providing a response.
     tool_choice: Option<ToolChoice>,
-    /// Default maximum depth for recursive agent calls
+    /// Default maximum depth for multi-turn agent calls
     default_max_depth: Option<usize>,
 }
 
@@ -523,6 +524,7 @@ where
         self
     }
 
+    /// Set the default maximum depth that an agent will use for multi-turn.
     pub fn default_max_depth(mut self, default_max_depth: usize) -> Self {
         self.default_max_depth = Some(default_max_depth);
         self

--- a/rig/rig-core/src/agent/completion.rs
+++ b/rig/rig-core/src/agent/completion.rs
@@ -73,6 +73,8 @@ where
     pub dynamic_context: DynamicContextStore,
     /// Whether or not the underlying LLM should be forced to use a tool before providing a response.
     pub tool_choice: Option<ToolChoice>,
+    /// Default maximum depth for recursive agent calls
+    pub default_max_depth: Option<usize>,
 }
 
 impl<M> Agent<M>

--- a/rig/rig-core/src/agent/prompt_request/mod.rs
+++ b/rig/rig-core/src/agent/prompt_request/mod.rs
@@ -73,7 +73,7 @@ where
         Self {
             prompt: prompt.into(),
             chat_history: None,
-            max_depth: 0,
+            max_depth: agent.default_max_depth.unwrap_or(0),
             agent,
             state: PhantomData,
             hook: None,

--- a/rig/rig-core/src/agent/prompt_request/mod.rs
+++ b/rig/rig-core/src/agent/prompt_request/mod.rs
@@ -73,7 +73,7 @@ where
         Self {
             prompt: prompt.into(),
             chat_history: None,
-            max_depth: agent.default_max_depth.unwrap_or(0),
+            max_depth: agent.default_max_depth.unwrap_or_default(),
             agent,
             state: PhantomData,
             hook: None,

--- a/rig/rig-core/src/agent/prompt_request/streaming.rs
+++ b/rig/rig-core/src/agent/prompt_request/streaming.rs
@@ -125,7 +125,7 @@ where
         Self {
             prompt: prompt.into(),
             chat_history: None,
-            max_depth: agent.default_max_depth.unwrap_or(0),
+            max_depth: agent.default_max_depth.unwrap_or_default(),
             agent,
             hook: None,
         }

--- a/rig/rig-core/src/agent/prompt_request/streaming.rs
+++ b/rig/rig-core/src/agent/prompt_request/streaming.rs
@@ -125,7 +125,7 @@ where
         Self {
             prompt: prompt.into(),
             chat_history: None,
-            max_depth: 0,
+            max_depth: agent.default_max_depth.unwrap_or(0),
             agent,
             hook: None,
         }


### PR DESCRIPTION
Adds a `.default_max_depth` to `Agent` and it's various builders. `PromptRequest` will look at this (if defined) and use it by default. Otherwise, works the same as before (starts at 0). This number can still be overridden by `.multi_turn`.