### PR TITLE
bug: fix gemini streaming

### DIFF
--- a/rig/rig-core/src/providers/gemini/streaming.rs
+++ b/rig/rig-core/src/providers/gemini/streaming.rs
@@ -160,16 +160,20 @@ where
                                     thought: Some(true),
                                     ..
                                 } => {
-                                    yield Ok(streaming::RawStreamingChoice::ReasoningDelta {
-                                        id: None,
-                                        reasoning: text,
-                                    });
+                                    if !text.is_empty() {
+                                        yield Ok(streaming::RawStreamingChoice::ReasoningDelta {
+                                            id: None,
+                                            reasoning: text,
+                                        });
+                                    }
                                 },
                                 Part {
                                     part: PartKind::Text(text),
                                     ..
                                 } => {
-                                    yield Ok(streaming::RawStreamingChoice::Message(text));
+                                    if !text.is_empty() {
+                                        yield Ok(streaming::RawStreamingChoice::Message(text));
+                                    }
                                 },
                                 Part {
                                     part: PartKind::FunctionCall(function_call),


### PR DESCRIPTION
Gemini streaming wasn't correctly filtering empty messages, causing it to set `did_tool_call = false` erroneously and produce no further output.