### PR TITLE
fix(agent): fix CancelSignal cancellation and reason sharing bugs

### DIFF
--- a/rig/rig-core/src/agent/prompt_request/mod.rs
+++ b/rig/rig-core/src/agent/prompt_request/mod.rs
@@ -160,14 +160,14 @@ where
 /// You can additionally add a reason for early termination with `CancelSignal::cancel_with_reason()`.
 pub struct CancelSignal {
     sig: Arc<AtomicBool>,
-    reason: OnceLock<String>,
+    reason: Arc<OnceLock<String>>,
 }
 
 impl CancelSignal {
     fn new() -> Self {
         Self {
             sig: Arc::new(AtomicBool::new(false)),
-            reason: OnceLock::new(),
+            reason: Arc::new(OnceLock::new()),
         }
     }
 
@@ -179,6 +179,7 @@ impl CancelSignal {
         // SAFETY: This can only be set once. We immediately return once the prompt hook is finished if the internal AtomicBool is set to true
         // It is technically on the user to return early when using this in a prompt hook, but this is relatively obvious
         let _ = self.reason.set(reason.to_string());
+        self.cancel();
     }
 
     fn is_cancelled(&self) -> bool {


### PR DESCRIPTION
## Summary

Fix two bugs in `CancelSignal` that prevent proper cancellation handling in prompt hooks.

Fixes #1281 

## Changes

1. **`cancel_with_reason()` now calls `cancel()`** - Previously it only set the reason without setting the cancelled flag, so `is_cancelled()` still returned `false`.

2. **Wrap `reason` in `Arc`** - Change from `OnceLock<String>` to `Arc<OnceLock<String>>` so cloned signals share the same reason instance.

```diff
 pub struct CancelSignal {
     sig: Arc<AtomicBool>,
-    reason: OnceLock<String>,
+    reason: Arc<OnceLock<String>>,
 }

 pub fn cancel_with_reason(&self, reason: &str) {
     let _ = self.reason.set(reason.to_string());
+    self.cancel();
 }
```

## Test Plan

```rust
#[test]
fn test_cancel_with_reason_sets_flag() {
    let sig = CancelSignal::new();
    sig.cancel_with_reason("test");
    assert!(sig.is_cancelled());
}

#[test]
fn test_clone_shares_reason() {
    let sig = CancelSignal::new();
    let cloned = sig.clone();
    cloned.cancel_with_reason("test");
    assert_eq!(sig.cancel_reason(), Some("test"));
}
```
