### PR TITLE
fix(providers): re-export gemini EmbeddingModel and constants

### DIFF
--- a/rig/rig-core/src/providers/gemini/mod.rs
+++ b/rig/rig-core/src/providers/gemini/mod.rs
@@ -6,7 +6,7 @@
 //!
 //! let client = gemini::Client::new("YOUR_API_KEY");
 //!
-//! let gemini_embedding_model = client.embedding_model(gemini::embedding::EMBEDDING_001);
+//! let gemini_embedding_model = client.embedding_model(gemini::EMBEDDING_001);
 //! ```
 
 pub mod client;
@@ -16,6 +16,8 @@ pub mod streaming;
 pub mod transcription;
 
 pub use client::Client;
+pub use completion::CompletionModel;
+pub use embedding::{EMBEDDING_001, EMBEDDING_004, EmbeddingModel};
 
 pub mod gemini_api_types {
     use serde::{Deserialize, Serialize};


### PR DESCRIPTION
- Re-export EmbeddingModel, CompletionModel, and embedding constants (EMBEDDING_001, EMBEDDING_004) at gemini module root for consistency with other providers like cohere
- Update gemini doc example to use the new shorter path