### PR TITLE
fix(providers): fixed azure openai embedding dimension

### DIFF
--- a/rig/rig-core/src/providers/azure.rs
+++ b/rig/rig-core/src/providers/azure.rs
@@ -449,10 +449,15 @@ where
     ) -> Result<Vec<embeddings::Embedding>, EmbeddingError> {
         let documents = documents.into_iter().collect::<Vec<_>>();
 
-        let body = serde_json::to_vec(&json!({
+        let mut body = json!({
             "input": documents,
-            "dimensions": self.ndims,
-        }))?;
+        });
+
+        if self.ndims > 0 && self.model.as_str() != TEXT_EMBEDDING_ADA_002 {
+            body["dimensions"] = json!(self.ndims);
+        }
+
+        let body = serde_json::to_vec(&body)?;
 
         let req = self
             .client


### PR DESCRIPTION
Hi All,

I hit a small issue with using the Azure OpenAI provider. I'm creating an embedding model with `emedding_model_with_ndims`, but the ndims property isn't used in the client. This PR adds the embedding model dimension to the request body.

I've also added a test that verifies the fix.

Please let me know if you need anything else from me!

Thank you!