### PR TITLE
feat: support xhigh reasoning effort

### DIFF
--- a/rig/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/rig/rig-core/src/providers/openai/responses_api/mod.rs
@@ -889,6 +889,7 @@ pub enum ReasoningEffort {
     #[default]
     Medium,
     High,
+    Xhigh,
 }
 
 /// The amount of effort that will go into a reasoning summary by a given model.


### PR DESCRIPTION
## Summary
- add `xhigh` to Responses API reasoning effort enum
- add test for deserializing `reasoning.effort = "xhigh"`

## Testing
- `cargo test -p rig-core --test openai_responses_reasoning_effort`
