### PR TITLE
Fix: Update deprecated Anthropic model constants to current versions

### DIFF
--- a/rig/rig-core/examples/agent_with_default_max_depth.rs
+++ b/rig/rig-core/examples/agent_with_default_max_depth.rs
@@ -19,7 +19,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Create RAG agent with a single context prompt and a dynamic tool source
     let agent = openai_client
-        .agent(anthropic::completion::CLAUDE_3_5_SONNET)
+        .agent(anthropic::completion::CLAUDE_SONNET_4_5)
         .preamble(
             "You are an assistant here to help the user select which tool is most appropriate to perform arithmetic operations.
             Follow these instructions closely.

--- a/rig/rig-core/examples/agent_with_mira.rs
+++ b/rig/rig-core/examples/agent_with_mira.rs
@@ -1,5 +1,5 @@
 use rig::prelude::*;
-use rig::providers::anthropic::completion::CLAUDE_3_5_SONNET;
+use rig::providers::anthropic::completion::CLAUDE_SONNET_4_5;
 use rig::providers::openai::GPT_4O;
 use rig::{
     completion::{Prompt, ToolDefinition},
@@ -54,7 +54,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Create a calculator agent with tools
     let calculator_agent = client
-        .agent(CLAUDE_3_5_SONNET)
+        .agent(CLAUDE_SONNET_4_5)
         .preamble("You are a calculator here to help the user perform arithmetic operations. Use the tools provided to answer the user's question.")
         .max_tokens(1024)
         .tool(Adder)

--- a/rig/rig-core/examples/anthropic_agent.rs
+++ b/rig/rig-core/examples/anthropic_agent.rs
@@ -11,7 +11,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Create agent with a single context prompt
     let agent = client
-        .agent(anthropic::completion::CLAUDE_3_5_SONNET)
+        .agent(anthropic::completion::CLAUDE_SONNET_4_5)
         .preamble("Be precise and concise.")
         .temperature(0.5)
         .build();

--- a/rig/rig-core/examples/anthropic_streaming.rs
+++ b/rig/rig-core/examples/anthropic_streaming.rs
@@ -8,7 +8,7 @@ use rig::{
 async fn main() -> Result<(), anyhow::Error> {
     // Create streaming agent with a single context prompt
     let agent = anthropic::Client::from_env()
-        .agent(anthropic::completion::CLAUDE_3_5_SONNET)
+        .agent(anthropic::completion::CLAUDE_SONNET_4_5)
         .preamble("Be precise and concise.")
         .temperature(0.5)
         .build();

--- a/rig/rig-core/examples/anthropic_streaming_with_tools.rs
+++ b/rig/rig-core/examples/anthropic_streaming_with_tools.rs
@@ -89,7 +89,7 @@ async fn main() -> Result<(), anyhow::Error> {
     tracing_subscriber::fmt().init();
     // Create agent with a single context prompt and two tools
     let calculator_agent = providers::anthropic::Client::from_env()
-        .agent(providers::anthropic::completion::CLAUDE_3_5_SONNET)
+        .agent(providers::anthropic::completion::CLAUDE_SONNET_4_5)
         .preamble(
             "You are a calculator here to help the user perform arithmetic
             operations. Use the tools provided to answer the user's question.

--- a/rig/rig-core/examples/anthropic_think_tool.rs
+++ b/rig/rig-core/examples/anthropic_think_tool.rs
@@ -11,7 +11,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Create agent with the Think tool
     let agent = providers::anthropic::Client::from_env()
-        .agent(providers::anthropic::completion::CLAUDE_3_7_SONNET)
+        .agent(providers::anthropic::completion::CLAUDE_SONNET_4_5)
         .name("Anthropic Thinker")
         .preamble(
             "You are a helpful assistant that can solve complex problems.

--- a/rig/rig-core/examples/anthropic_think_tool_with_other_tools.rs
+++ b/rig/rig-core/examples/anthropic_think_tool_with_other_tools.rs
@@ -239,7 +239,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Create agent with the Think tool and other tools
     let agent = client
-        .agent(providers::anthropic::completion::CLAUDE_3_7_SONNET)
+        .agent(providers::anthropic::completion::CLAUDE_SONNET_4_5)
         .name("Customer Service Agent")
         .preamble(
             "You are a customer service agent for an online store.

--- a/rig/rig-core/examples/complex_agentic_loop_claude.rs
+++ b/rig/rig-core/examples/complex_agentic_loop_claude.rs
@@ -85,7 +85,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Create specialized research agent that will be used as a tool
     let research_agent = anthropic_client
-        .agent(anthropic::completion::CLAUDE_3_7_SONNET)
+        .agent(anthropic::completion::CLAUDE_SONNET_4_5)
         .preamble(
             "You are a specialized research agent focused on environmental science and sustainability.
             Your role is to provide detailed, accurate information about climate change, renewable energy,
@@ -97,7 +97,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Create a data analysis agent that will be used as a tool
     let analysis_agent = anthropic_client
-        .agent(anthropic::completion::CLAUDE_3_7_SONNET)
+        .agent(anthropic::completion::CLAUDE_SONNET_4_5)
         .preamble(
             "You are a data analysis agent specialized in interpreting environmental and sustainability data.
             When given data or statistics, you analyze trends, identify patterns, and draw meaningful conclusions.
@@ -109,7 +109,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Create a recommendation agent that will be used as a tool
     let recommendation_agent = anthropic_client
-        .agent(anthropic::completion::CLAUDE_3_7_SONNET)
+        .agent(anthropic::completion::CLAUDE_SONNET_4_5)
         .preamble(
             "You are a recommendation agent specialized in suggesting practical sustainability solutions.
             Based on research findings and analysis, you provide actionable recommendations for individuals,
@@ -122,7 +122,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Create the main orchestrator agent that will use all the tools
     let orchestrator_agent = anthropic_client
-        .agent(anthropic::completion::CLAUDE_3_7_SONNET)
+        .agent(anthropic::completion::CLAUDE_SONNET_4_5)
         .preamble(
             "You are an environmental sustainability advisor that helps users understand complex environmental issues
             and find practical solutions. You have access to several specialized tools:

--- a/rig/rig-core/examples/enum_dispatch.rs
+++ b/rig/rig-core/examples/enum_dispatch.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use rig::agent::Agent;
 use rig::client::{CompletionClient, ProviderClient};
 use rig::completion::{Prompt, PromptError};
-use rig::providers::anthropic::completion::CLAUDE_3_7_SONNET;
+use rig::providers::anthropic::completion::CLAUDE_SONNET_4_5;
 use rig::providers::openai::GPT_4O;
 use rig::providers::{anthropic, openai};
 
@@ -32,7 +32,7 @@ struct ProviderRegistry(HashMap<&'static str, fn(AgentConfig) -> Agents>);
 
 fn anthropic_agent(AgentConfig { name, preamble }: AgentConfig) -> Agents {
     let agent = anthropic::Client::from_env()
-        .agent(CLAUDE_3_7_SONNET)
+        .agent(CLAUDE_SONNET_4_5)
         .name(name)
         .preamble(preamble)
         .build();

--- a/rig/rig-core/examples/image.rs
+++ b/rig/rig-core/examples/image.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Create agent with a single context prompt
     let agent = client
-        .agent(anthropic::completion::CLAUDE_3_5_SONNET)
+        .agent(anthropic::completion::CLAUDE_SONNET_4_5)
         .preamble("You are an image describer.")
         .temperature(0.5)
         .build();

--- a/rig/rig-core/examples/multi_turn_agent.rs
+++ b/rig/rig-core/examples/multi_turn_agent.rs
@@ -19,7 +19,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Create RAG agent with a single context prompt and a dynamic tool source
     let agent = openai_client
-        .agent(anthropic::completion::CLAUDE_3_5_SONNET)
+        .agent(anthropic::completion::CLAUDE_SONNET_4_5)
         .preamble(
             "You are an assistant here to help the user select which tool is most appropriate to perform arithmetic operations.
             Follow these instructions closely.

--- a/rig/rig-core/examples/multi_turn_agent_extended.rs
+++ b/rig/rig-core/examples/multi_turn_agent_extended.rs
@@ -19,7 +19,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Create RAG agent with a single context prompt and a dynamic tool source
     let agent = openai_client
-        .agent(anthropic::completion::CLAUDE_3_5_SONNET)
+        .agent(anthropic::completion::CLAUDE_SONNET_4_5)
         .preamble(
             "You are an assistant here to help the user select which tool is most appropriate to perform arithmetic operations.
             Follow these instructions closely.

--- a/rig/rig-core/examples/multi_turn_streaming.rs
+++ b/rig/rig-core/examples/multi_turn_streaming.rs
@@ -22,7 +22,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Create agent with a single context prompt and a calculator tools
     let calculator_agent = anthropic_client
-        .agent(anthropic::completion::CLAUDE_3_5_SONNET)
+        .agent(anthropic::completion::CLAUDE_SONNET_4_5)
         .preamble(
             "You are an assistant here to help the user select which tool is most appropriate to perform arithmetic operations.
             Follow these instructions closely.

--- a/rig/rig-core/examples/reasoning_loop.rs
+++ b/rig/rig-core/examples/reasoning_loop.rs
@@ -71,12 +71,12 @@ async fn main() -> anyhow::Result<()> {
     let anthropic_client = anthropic::Client::from_env();
     let agent = ReasoningAgent {
         chain_of_thought_extractor: anthropic_client
-            .extractor(anthropic::completion::CLAUDE_3_5_SONNET)
+            .extractor(anthropic::completion::CLAUDE_SONNET_4_5)
             .preamble(CHAIN_OF_THOUGHT_PROMPT)
             .build(),
 
         executor: anthropic_client
-            .agent(anthropic::completion::CLAUDE_3_5_SONNET)
+            .agent(anthropic::completion::CLAUDE_SONNET_4_5)
             .preamble(
                 "You are an assistant here to help the user select which tool is most appropriate to perform arithmetic operations.
                 Follow these instructions closely.

--- a/rig/rig-core/src/agent/prompt_request/streaming.rs
+++ b/rig/rig-core/src/agent/prompt_request/streaming.rs
@@ -680,7 +680,7 @@ mod tests {
         // (rig reuses current span if one exists, so we need to ensure there's no current span)
         let client = anthropic::Client::from_env();
         let agent = client
-            .agent(anthropic::completion::CLAUDE_3_5_HAIKU)
+            .agent(anthropic::completion::CLAUDE_HAIKU_4_5)
             .preamble("You are a helpful assistant.")
             .temperature(0.1)
             .max_tokens(100)

--- a/rig/rig-core/src/providers/anthropic/completion.rs
+++ b/rig/rig-core/src/providers/anthropic/completion.rs
@@ -22,16 +22,12 @@ use tracing::{Instrument, Level, enabled, info_span};
 // Anthropic Completion API
 // ================================================================
 
-/// `claude-opus-4-0` completion model
-pub const CLAUDE_4_OPUS: &str = "claude-opus-4-0";
-/// `claude-sonnet-4-0` completion model
-pub const CLAUDE_4_SONNET: &str = "claude-sonnet-4-0";
-/// `claude-3-7-sonnet-latest` completion model
-pub const CLAUDE_3_7_SONNET: &str = "claude-3-7-sonnet-latest";
-/// `claude-3-5-sonnet-latest` completion model
-pub const CLAUDE_3_5_SONNET: &str = "claude-3-5-sonnet-latest";
-/// `claude-3-5-haiku-latest` completion model
-pub const CLAUDE_3_5_HAIKU: &str = "claude-3-5-haiku-latest";
+/// `claude-opus-4-6` completion model (latest Opus)
+pub const CLAUDE_OPUS_4_6: &str = "claude-opus-4-6";
+/// `claude-sonnet-4-5-20250929` completion model (latest Sonnet)
+pub const CLAUDE_SONNET_4_5: &str = "claude-sonnet-4-5-20250929";
+/// `claude-haiku-4-5-20251001` completion model (latest Haiku)
+pub const CLAUDE_HAIKU_4_5: &str = "claude-haiku-4-5-20251001";
 
 pub const ANTHROPIC_VERSION_2023_01_01: &str = "2023-01-01";
 pub const ANTHROPIC_VERSION_2023_06_01: &str = "2023-06-01";

--- a/rig/rig-core/src/providers/anthropic/mod.rs
+++ b/rig/rig-core/src/providers/anthropic/mod.rs
@@ -6,7 +6,7 @@
 //!
 //! let client = anthropic::Anthropic::new("YOUR_API_KEY");
 //!
-//! let sonnet = client.completion_model(anthropic::CLAUDE_3_5_SONNET);
+//! let sonnet = client.completion_model(anthropic::CLAUDE_SONNET_4_5);
 //! ```
 
 pub mod client;


### PR DESCRIPTION
Title:
  fix: Update deprecated Anthropic model constants to current versions

  Description:
  Fixes #1370

  ## Summary
  Updates Rig's Anthropic model constants to use current, supported model IDs.
   The previous constants pointed to deprecated or retired models that return
  404 errors from Anthropic's API.

  ## Changes
  - Replace `CLAUDE_4_OPUS`/`CLAUDE_4_SONNET` with
  `CLAUDE_OPUS_4_6`/`CLAUDE_SONNET_4_5`
  - Remove deprecated `CLAUDE_3_7_SONNET` and retired `CLAUDE_3_5_SONNET`
  constants
  - Replace `CLAUDE_3_5_HAIKU` with `CLAUDE_HAIKU_4_5`
  - Update all examples and tests to use new model constants
  - Use accurate model IDs: `claude-opus-4-6`, `claude-sonnet-4-5-20250929`,
  `claude-haiku-4-5-20251001`

  ## Model Status (per [Anthropic's
  docs](https://docs.anthropic.com/en/docs/about-claude/models))
  - ❌ `claude-3-5-sonnet-latest` - **Retired** Oct 28, 2025 (404 error)
  - ⚠️ `claude-3-7-sonnet-latest` - **Deprecated**, retiring Feb 19, 2026
  - ✅ `claude-opus-4-6` - **Active** (latest Opus)
  - ✅ `claude-sonnet-4-5-20250929` - **Active** (latest Sonnet)
  - ✅ `claude-haiku-4-5-20251001` - **Active** (latest Haiku)

  ## Testing
  - ✅ `cargo fmt --check` passed
  - ✅ `cargo clippy --all-features --all-targets` passed
  - ✅ `cargo check` passed
  - ✅ All examples updated to reference new model constants