### PR TITLE
feat(rig-core): add optional model override to CompletionRequest (#1278)

### DIFF
--- a/rig-integrations/rig-bedrock/src/types/completion_request.rs
+++ b/rig-integrations/rig-bedrock/src/types/completion_request.rs
@@ -141,6 +141,7 @@ mod tests {
     // Helper to create a minimal CompletionRequest for testing
     fn minimal_request() -> CompletionRequest {
         CompletionRequest {
+            model: None,
             preamble: None,
             chat_history: OneOrMany::one(Message::User {
                 content: OneOrMany::one(UserContent::Text(Text {
@@ -160,6 +161,7 @@ mod tests {
     fn test_tool_choice_auto_conversion() {
         // Test that rig's ToolChoice::Auto converts to AWS Auto
         let request = CompletionRequest {
+            model: None,
             tool_choice: Some(ToolChoice::Auto),
             tools: vec![ToolDefinition {
                 name: "test_tool".to_string(),
@@ -192,6 +194,7 @@ mod tests {
     fn test_tool_choice_required_conversion() {
         // Test that rig's ToolChoice::Required converts to AWS Any
         let request = CompletionRequest {
+            model: None,
             tool_choice: Some(ToolChoice::Required),
             tools: vec![ToolDefinition {
                 name: "test_tool".to_string(),
@@ -224,6 +227,7 @@ mod tests {
     fn test_tool_choice_none_conversion() {
         // Test that rig's ToolChoice::None results in no tool_choice set
         let request = CompletionRequest {
+            model: None,
             tool_choice: Some(ToolChoice::None),
             tools: vec![ToolDefinition {
                 name: "test_tool".to_string(),
@@ -251,6 +255,7 @@ mod tests {
     fn test_tool_choice_specific_conversion() {
         // Test that rig's ToolChoice::Specific converts to AWS Tool
         let request = CompletionRequest {
+            model: None,
             tool_choice: Some(ToolChoice::Specific {
                 function_names: vec!["specific_tool".to_string()],
             }),
@@ -285,6 +290,7 @@ mod tests {
     fn test_no_tool_choice_when_not_specified() {
         // Test that when tool_choice is None (not set), it defaults to None in AWS
         let request = CompletionRequest {
+            model: None,
             tool_choice: None, // Not set
             tools: vec![ToolDefinition {
                 name: "test_tool".to_string(),
@@ -312,6 +318,7 @@ mod tests {
     fn test_tool_with_empty_parameters() {
         // Test that tools with empty parameters (like document_list) work correctly
         let request = CompletionRequest {
+            model: None,
             tools: vec![ToolDefinition {
                 name: "document_list".to_string(),
                 description: "Lists all documents".to_string(),
@@ -346,6 +353,7 @@ mod tests {
     fn test_tool_with_parameters() {
         // Test that tools with parameters work correctly
         let request = CompletionRequest {
+            model: None,
             tools: vec![ToolDefinition {
                 name: "get_weather".to_string(),
                 description: "Get weather for a location".to_string(),

--- a/rig-integrations/rig-vertexai/src/types/completion_request.rs
+++ b/rig-integrations/rig-vertexai/src/types/completion_request.rs
@@ -99,6 +99,7 @@ mod tests {
     // Helper to create a minimal CompletionRequest for testing
     fn minimal_request() -> CompletionRequest {
         CompletionRequest {
+            model: None,
             preamble: None,
             chat_history: OneOrMany::one(Message::User {
                 content: OneOrMany::one(UserContent::Text(Text {
@@ -118,6 +119,7 @@ mod tests {
     fn test_tool_choice_auto_conversion() {
         // Test that rig's ToolChoice::Auto converts to Vertex AI Auto mode
         let request = CompletionRequest {
+            model: None,
             tool_choice: Some(ToolChoice::Auto),
             tools: vec![ToolDefinition {
                 name: "test_tool".to_string(),
@@ -148,6 +150,7 @@ mod tests {
     fn test_tool_choice_required_conversion() {
         // Test that rig's ToolChoice::Required converts to Vertex AI Any mode
         let request = CompletionRequest {
+            model: None,
             tool_choice: Some(ToolChoice::Required),
             tools: vec![ToolDefinition {
                 name: "test_tool".to_string(),
@@ -178,6 +181,7 @@ mod tests {
     fn test_tool_choice_none_conversion() {
         // Test that rig's ToolChoice::None converts to Vertex AI None mode
         let request = CompletionRequest {
+            model: None,
             tool_choice: Some(ToolChoice::None),
             tools: vec![ToolDefinition {
                 name: "test_tool".to_string(),
@@ -208,6 +212,7 @@ mod tests {
     fn test_tool_choice_specific_conversion() {
         // Test that rig's ToolChoice::Specific converts to Vertex AI Any mode with allowed function names
         let request = CompletionRequest {
+            model: None,
             tool_choice: Some(ToolChoice::Specific {
                 function_names: vec!["test_tool".to_string()],
             }),
@@ -245,6 +250,7 @@ mod tests {
     fn test_system_instruction_from_preamble() {
         // Test that preamble converts to system instruction
         let request = CompletionRequest {
+            model: None,
             preamble: Some("You are a helpful assistant.".to_string()),
             ..minimal_request()
         };
@@ -266,6 +272,7 @@ mod tests {
     fn test_tools_conversion() {
         // Test that ToolDefinition converts to FunctionDeclaration
         let request = CompletionRequest {
+            model: None,
             tools: vec![ToolDefinition {
                 name: "add".to_string(),
                 description: "Add two numbers".to_string(),
@@ -300,6 +307,7 @@ mod tests {
     fn test_no_tool_choice_when_not_specified() {
         // Test that when tool_choice is None (not set), it defaults to Auto in Vertex AI
         let request = CompletionRequest {
+            model: None,
             tool_choice: None, // Not set
             tools: vec![ToolDefinition {
                 name: "test_tool".to_string(),
@@ -331,6 +339,7 @@ mod tests {
     fn test_tool_with_empty_parameters() {
         // Test that tools with empty parameters work correctly
         let request = CompletionRequest {
+            model: None,
             tools: vec![ToolDefinition {
                 name: "document_list".to_string(),
                 description: "Lists all documents".to_string(),
@@ -360,6 +369,7 @@ mod tests {
     fn test_tool_with_parameters() {
         // Test that tools with complex parameters work correctly
         let request = CompletionRequest {
+            model: None,
             tools: vec![ToolDefinition {
                 name: "get_weather".to_string(),
                 description: "Get weather for a location".to_string(),
@@ -399,6 +409,7 @@ mod tests {
     fn test_generation_config_with_temperature_and_max_tokens() {
         // Test that temperature and max_tokens convert to GenerationConfig
         let request = CompletionRequest {
+            model: None,
             temperature: Some(0.7),
             max_tokens: Some(100),
             ..minimal_request()

--- a/rig/rig-core/src/client/builder.rs
+++ b/rig/rig-core/src/client/builder.rs
@@ -527,6 +527,7 @@ impl DynClientBuilder {
         let completion = self.completion(provider_name.into(), model)?;
 
         let request = CompletionRequest {
+            model: None,
             preamble: None,
             tools: vec![],
             documents: vec![],
@@ -556,6 +557,7 @@ impl DynClientBuilder {
 
         history.push(prompt.into());
         let request = CompletionRequest {
+            model: None,
             preamble: None,
             tools: vec![],
             documents: vec![],

--- a/rig/rig-core/src/completion/request.rs
+++ b/rig/rig-core/src/completion/request.rs
@@ -464,6 +464,8 @@ where
 /// Struct representing a general completion request that can be sent to a completion model provider.
 #[derive(Debug, Clone)]
 pub struct CompletionRequest {
+    /// Optional model override for this request.
+    pub model: Option<String>,
     /// The preamble to be sent to the completion model provider
     pub preamble: Option<String>,
     /// The chat history to be sent to the completion model provider.
@@ -560,6 +562,7 @@ impl CompletionRequest {
 pub struct CompletionRequestBuilder<M: CompletionModel> {
     model: M,
     prompt: Message,
+    request_model: Option<String>,
     preamble: Option<String>,
     chat_history: Vec<Message>,
     documents: Vec<Document>,
@@ -575,6 +578,7 @@ impl<M: CompletionModel> CompletionRequestBuilder<M> {
         Self {
             model,
             prompt: prompt.into(),
+            request_model: None,
             preamble: None,
             chat_history: Vec::new(),
             documents: Vec::new(),
@@ -589,6 +593,18 @@ impl<M: CompletionModel> CompletionRequestBuilder<M> {
     /// Sets the preamble for the completion request.
     pub fn preamble(mut self, preamble: String) -> Self {
         self.preamble = Some(preamble);
+        self
+    }
+
+    /// Overrides the model used for this request.
+    pub fn model(mut self, model: impl Into<String>) -> Self {
+        self.request_model = Some(model.into());
+        self
+    }
+
+    /// Overrides the model used for this request.
+    pub fn model_opt(mut self, model: Option<String>) -> Self {
+        self.request_model = model;
         self
     }
 
@@ -701,6 +717,7 @@ impl<M: CompletionModel> CompletionRequestBuilder<M> {
             .expect("There will always be atleast the prompt");
 
         CompletionRequest {
+            model: self.request_model,
             preamble: self.preamble,
             chat_history,
             documents: self.documents,
@@ -784,6 +801,7 @@ mod tests {
         };
 
         let request = CompletionRequest {
+            model: None,
             preamble: None,
             chat_history: OneOrMany::one("What is the capital of France?".into()),
             documents: vec![doc1, doc2],
@@ -814,6 +832,7 @@ mod tests {
     #[test]
     fn test_normalize_documents_without_documents() {
         let request = CompletionRequest {
+            model: None,
             preamble: None,
             chat_history: OneOrMany::one("What is the capital of France?".into()),
             documents: Vec::new(),

--- a/rig/rig-core/src/providers/anthropic/completion.rs
+++ b/rig/rig-core/src/providers/anthropic/completion.rs
@@ -935,13 +935,17 @@ where
         &self,
         mut completion_request: completion::CompletionRequest,
     ) -> Result<completion::CompletionResponse<CompletionResponse>, CompletionError> {
+        let request_model = completion_request
+            .model
+            .clone()
+            .unwrap_or_else(|| self.model.clone());
         let span = if tracing::Span::current().is_disabled() {
             info_span!(
                 target: "rig::completions",
                 "chat",
                 gen_ai.operation.name = "chat",
                 gen_ai.provider.name = "anthropic",
-                gen_ai.request.model = &self.model,
+                gen_ai.request.model = &request_model,
                 gen_ai.system_instructions = &completion_request.preamble,
                 gen_ai.response.id = tracing::field::Empty,
                 gen_ai.response.model = tracing::field::Empty,
@@ -964,7 +968,7 @@ where
         }
 
         let request = AnthropicCompletionRequest::try_from(AnthropicRequestParams {
-            model: &self.model,
+            model: &request_model,
             request: completion_request,
             prompt_caching: self.prompt_caching,
         })?;

--- a/rig/rig-core/src/providers/anthropic/streaming.rs
+++ b/rig/rig-core/src/providers/anthropic/streaming.rs
@@ -129,16 +129,20 @@ where
         completion_request: CompletionRequest,
     ) -> Result<streaming::StreamingCompletionResponse<StreamingCompletionResponse>, CompletionError>
     {
+        let request_model = completion_request
+            .model
+            .clone()
+            .unwrap_or_else(|| self.model.clone());
         let span = if tracing::Span::current().is_disabled() {
             info_span!(
                 target: "rig::completions",
                 "chat_streaming",
                 gen_ai.operation.name = "chat_streaming",
                 gen_ai.provider.name = "anthropic",
-                gen_ai.request.model = self.model,
+                gen_ai.request.model = &request_model,
                 gen_ai.system_instructions = &completion_request.preamble,
                 gen_ai.response.id = tracing::field::Empty,
-                gen_ai.response.model = self.model,
+                gen_ai.response.model = &request_model,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
                 gen_ai.input.messages = tracing::field::Empty,
@@ -189,7 +193,7 @@ where
         }
 
         let mut body = json!({
-            "model": self.model,
+            "model": request_model,
             "messages": messages,
             "max_tokens": max_tokens,
             "stream": true,

--- a/rig/rig-core/src/providers/azure.rs
+++ b/rig/rig-core/src/providers/azure.rs
@@ -577,6 +577,7 @@ impl TryFrom<(&str, CompletionRequest)> for AzureOpenAICompletionRequest {
     type Error = CompletionError;
 
     fn try_from((model, req): (&str, CompletionRequest)) -> Result<Self, Self::Error> {
+        let model = req.model.clone().unwrap_or_else(|| model.to_string());
         //FIXME: Must fix!
         if req.tool_choice.is_some() {
             tracing::warn!(
@@ -1076,6 +1077,7 @@ mod azure_tests {
         let model = client.completion_model(GPT_4O_MINI);
         let completion = model
             .completion(CompletionRequest {
+                model: None,
                 preamble: Some("You are a helpful assistant.".to_string()),
                 chat_history: OneOrMany::one("Hello!".into()),
                 documents: vec![],

--- a/rig/rig-core/src/providers/cohere/completion.rs
+++ b/rig/rig-core/src/providers/cohere/completion.rs
@@ -547,6 +547,7 @@ impl TryFrom<(&str, CompletionRequest)> for CohereCompletionRequest {
     type Error = CompletionError;
 
     fn try_from((model, req): (&str, CompletionRequest)) -> Result<Self, Self::Error> {
+        let model = req.model.clone().unwrap_or_else(|| model.to_string());
         let mut partial_history = vec![];
         if let Some(docs) = req.normalized_documents() {
             partial_history.push(docs);

--- a/rig/rig-core/src/providers/deepseek.rs
+++ b/rig/rig-core/src/providers/deepseek.rs
@@ -477,6 +477,7 @@ impl TryFrom<(&str, CompletionRequest)> for DeepseekCompletionRequest {
     type Error = CompletionError;
 
     fn try_from((model, req): (&str, CompletionRequest)) -> Result<Self, Self::Error> {
+        let model = req.model.clone().unwrap_or_else(|| model.to_string());
         let mut full_history: Vec<Message> = match &req.preamble {
             Some(preamble) => vec![Message::system(preamble)],
             None => vec![],

--- a/rig/rig-core/src/providers/galadriel.rs
+++ b/rig/rig-core/src/providers/galadriel.rs
@@ -441,6 +441,7 @@ impl TryFrom<(&str, CompletionRequest)> for GaladrielCompletionRequest {
     type Error = CompletionError;
 
     fn try_from((model, req): (&str, CompletionRequest)) -> Result<Self, Self::Error> {
+        let model = req.model.clone().unwrap_or_else(|| model.to_string());
         // Build up the order of messages (context, chat_history, prompt)
         let mut partial_history = vec![];
         if let Some(docs) = req.normalized_documents() {

--- a/rig/rig-core/src/providers/gemini/completion.rs
+++ b/rig/rig-core/src/providers/gemini/completion.rs
@@ -85,13 +85,14 @@ where
         &self,
         completion_request: CompletionRequest,
     ) -> Result<completion::CompletionResponse<GenerateContentResponse>, CompletionError> {
+        let request_model = resolve_request_model(&self.model, &completion_request);
         let span = if tracing::Span::current().is_disabled() {
             info_span!(
                 target: "rig::completions",
                 "generate_content",
                 gen_ai.operation.name = "generate_content",
                 gen_ai.provider.name = "gcp.gemini",
-                gen_ai.request.model = self.model,
+                gen_ai.request.model = &request_model,
                 gen_ai.system_instructions = &completion_request.preamble,
                 gen_ai.response.id = tracing::field::Empty,
                 gen_ai.response.model = tracing::field::Empty,
@@ -114,7 +115,7 @@ where
 
         let body = serde_json::to_vec(&request)?;
 
-        let path = format!("/v1beta/models/{}:generateContent", self.model);
+        let path = completion_endpoint(&request_model);
 
         let request = self
             .client
@@ -246,6 +247,24 @@ pub(crate) fn create_request_body(
     };
 
     Ok(request)
+}
+
+pub(crate) fn resolve_request_model(
+    default_model: &str,
+    completion_request: &CompletionRequest,
+) -> String {
+    completion_request
+        .model
+        .clone()
+        .unwrap_or_else(|| default_model.to_string())
+}
+
+pub(crate) fn completion_endpoint(model: &str) -> String {
+    format!("/v1beta/models/{model}:generateContent")
+}
+
+pub(crate) fn streaming_endpoint(model: &str) -> String {
+    format!("/v1beta/models/{model}:streamGenerateContent")
 }
 
 impl TryFrom<completion::ToolDefinition> for Tool {
@@ -1823,6 +1842,52 @@ mod tests {
 
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn test_resolve_request_model_uses_override() {
+        let request = CompletionRequest {
+            model: Some("gemini-2.5-flash".to_string()),
+            preamble: None,
+            chat_history: crate::OneOrMany::one("Hello".into()),
+            documents: vec![],
+            tools: vec![],
+            temperature: None,
+            max_tokens: None,
+            tool_choice: None,
+            additional_params: None,
+        };
+
+        let request_model = resolve_request_model("gemini-2.0-flash", &request);
+        assert_eq!(request_model, "gemini-2.5-flash");
+        assert_eq!(
+            completion_endpoint(&request_model),
+            "/v1beta/models/gemini-2.5-flash:generateContent"
+        );
+        assert_eq!(
+            streaming_endpoint(&request_model),
+            "/v1beta/models/gemini-2.5-flash:streamGenerateContent"
+        );
+    }
+
+    #[test]
+    fn test_resolve_request_model_uses_default_when_unset() {
+        let request = CompletionRequest {
+            model: None,
+            preamble: None,
+            chat_history: crate::OneOrMany::one("Hello".into()),
+            documents: vec![],
+            tools: vec![],
+            temperature: None,
+            max_tokens: None,
+            tool_choice: None,
+            additional_params: None,
+        };
+
+        assert_eq!(
+            resolve_request_model("gemini-2.0-flash", &request),
+            "gemini-2.0-flash"
+        );
+    }
 
     #[test]
     fn test_deserialize_message_user() {

--- a/rig/rig-core/src/providers/groq.rs
+++ b/rig/rig-core/src/providers/groq.rs
@@ -183,6 +183,7 @@ impl TryFrom<(&str, CompletionRequest)> for GroqCompletionRequest {
     type Error = CompletionError;
 
     fn try_from((model, req): (&str, CompletionRequest)) -> Result<Self, Self::Error> {
+        let model = req.model.clone().unwrap_or_else(|| model.to_string());
         // Build up the order of messages (context, chat_history, prompt)
         let mut partial_history = vec![];
         if let Some(docs) = req.normalized_documents() {

--- a/rig/rig-core/src/providers/huggingface/completion.rs
+++ b/rig/rig-core/src/providers/huggingface/completion.rs
@@ -631,6 +631,7 @@ impl TryFrom<(&str, CompletionRequest)> for HuggingfaceCompletionRequest {
     type Error = CompletionError;
 
     fn try_from((model, req): (&str, CompletionRequest)) -> Result<Self, Self::Error> {
+        let model = req.model.clone().unwrap_or_else(|| model.to_string());
         let mut full_history: Vec<Message> = match &req.preamble {
             Some(preamble) => vec![Message::system(preamble)],
             None => vec![],
@@ -707,13 +708,17 @@ where
         &self,
         completion_request: CompletionRequest,
     ) -> Result<completion::CompletionResponse<CompletionResponse>, CompletionError> {
+        let request_model = completion_request
+            .model
+            .clone()
+            .unwrap_or_else(|| self.model.clone());
         let span = if tracing::Span::current().is_disabled() {
             info_span!(
                 target: "rig::completions",
                 "chat",
                 gen_ai.operation.name = "chat",
                 gen_ai.provider.name = "huggingface",
-                gen_ai.request.model = self.model,
+                gen_ai.request.model = &request_model,
                 gen_ai.system_instructions = &completion_request.preamble,
                 gen_ai.response.id = tracing::field::Empty,
                 gen_ai.response.model = tracing::field::Empty,
@@ -724,7 +729,7 @@ where
             tracing::Span::current()
         };
 
-        let model = self.client.subprovider().model_identifier(&self.model);
+        let model = self.client.subprovider().model_identifier(&request_model);
         let request = HuggingfaceCompletionRequest::try_from((model.as_ref(), completion_request))?;
 
         if enabled!(Level::TRACE) {
@@ -737,7 +742,10 @@ where
 
         let request = serde_json::to_vec(&request)?;
 
-        let path = self.client.subprovider().completion_endpoint(&self.model);
+        let path = self
+            .client
+            .subprovider()
+            .completion_endpoint(&request_model);
         let request = self
             .client
             .post(&path)?
@@ -802,6 +810,48 @@ where
 mod tests {
     use super::*;
     use serde_path_to_error::deserialize;
+
+    #[test]
+    fn test_huggingface_request_uses_request_model_override() {
+        let request = CompletionRequest {
+            model: Some("meta-llama/Meta-Llama-3.1-8B-Instruct".to_string()),
+            preamble: None,
+            chat_history: crate::OneOrMany::one("Hello".into()),
+            documents: vec![],
+            tools: vec![],
+            temperature: None,
+            max_tokens: None,
+            tool_choice: None,
+            additional_params: None,
+        };
+
+        let hf_request = HuggingfaceCompletionRequest::try_from(("mistralai/Mistral-7B", request))
+            .expect("request conversion should succeed");
+        let serialized = serde_json::to_value(hf_request).expect("serialization should succeed");
+
+        assert_eq!(serialized["model"], "meta-llama/Meta-Llama-3.1-8B-Instruct");
+    }
+
+    #[test]
+    fn test_huggingface_request_uses_default_model_when_override_unset() {
+        let request = CompletionRequest {
+            model: None,
+            preamble: None,
+            chat_history: crate::OneOrMany::one("Hello".into()),
+            documents: vec![],
+            tools: vec![],
+            temperature: None,
+            max_tokens: None,
+            tool_choice: None,
+            additional_params: None,
+        };
+
+        let hf_request = HuggingfaceCompletionRequest::try_from(("mistralai/Mistral-7B", request))
+            .expect("request conversion should succeed");
+        let serialized = serde_json::to_value(hf_request).expect("serialization should succeed");
+
+        assert_eq!(serialized["model"], "mistralai/Mistral-7B");
+    }
 
     #[test]
     fn test_deserialize_message() {

--- a/rig/rig-core/src/providers/hyperbolic.rs
+++ b/rig/rig-core/src/providers/hyperbolic.rs
@@ -261,6 +261,7 @@ impl TryFrom<(&str, CompletionRequest)> for HyperbolicCompletionRequest {
     type Error = CompletionError;
 
     fn try_from((model, req): (&str, CompletionRequest)) -> Result<Self, Self::Error> {
+        let model = req.model.clone().unwrap_or_else(|| model.to_string());
         if req.tool_choice.is_some() {
             tracing::warn!("WARNING: `tool_choice` not supported on Hyperbolic");
         }

--- a/rig/rig-core/src/providers/mira.rs
+++ b/rig/rig-core/src/providers/mira.rs
@@ -219,6 +219,7 @@ impl TryFrom<(&str, CompletionRequest)> for MiraCompletionRequest {
     type Error = CompletionError;
 
     fn try_from((model, req): (&str, CompletionRequest)) -> Result<Self, Self::Error> {
+        let model = req.model.clone().unwrap_or_else(|| model.to_string());
         let mut messages = Vec::new();
 
         if let Some(content) = &req.preamble {

--- a/rig/rig-core/src/providers/mistral/completion.rs
+++ b/rig/rig-core/src/providers/mistral/completion.rs
@@ -340,6 +340,7 @@ impl TryFrom<(&str, CompletionRequest)> for MistralCompletionRequest {
     type Error = CompletionError;
 
     fn try_from((model, req): (&str, CompletionRequest)) -> Result<Self, Self::Error> {
+        let model = req.model.clone().unwrap_or_else(|| model.to_string());
         let mut full_history: Vec<Message> = match &req.preamble {
             Some(preamble) => vec![Message::system(preamble.clone())],
             None => vec![],

--- a/rig/rig-core/src/providers/moonshot.rs
+++ b/rig/rig-core/src/providers/moonshot.rs
@@ -133,6 +133,7 @@ impl TryFrom<(&str, CompletionRequest)> for MoonshotCompletionRequest {
     type Error = CompletionError;
 
     fn try_from((model, req): (&str, CompletionRequest)) -> Result<Self, Self::Error> {
+        let model = req.model.clone().unwrap_or_else(|| model.to_string());
         // Build up the order of messages (context, chat_history, prompt)
         let mut partial_history = vec![];
         if let Some(docs) = req.normalized_documents() {

--- a/rig/rig-core/src/providers/ollama.rs
+++ b/rig/rig-core/src/providers/ollama.rs
@@ -380,6 +380,7 @@ impl TryFrom<(&str, CompletionRequest)> for OllamaCompletionRequest {
     type Error = CompletionError;
 
     fn try_from((model, req): (&str, CompletionRequest)) -> Result<Self, Self::Error> {
+        let model = req.model.clone().unwrap_or_else(|| model.to_string());
         if req.tool_choice.is_some() {
             tracing::warn!("WARNING: `tool_choice` not supported for Ollama");
         }
@@ -1424,6 +1425,7 @@ mod tests {
 
         // Create a CompletionRequest with "think": true, "keep_alive", and "num_ctx" in additional_params
         let completion_request = CompletionRequest {
+            model: None,
             preamble: Some("You are a helpful assistant.".to_string()),
             chat_history: OneOrMany::one(CompletionMessage::User {
                 content: OneOrMany::one(UserContent::Text(Text {
@@ -1490,6 +1492,7 @@ mod tests {
 
         // Create a CompletionRequest WITHOUT "think" in additional_params
         let completion_request = CompletionRequest {
+            model: None,
             preamble: Some("You are a helpful assistant.".to_string()),
             chat_history: OneOrMany::one(CompletionMessage::User {
                 content: OneOrMany::one(UserContent::Text(Text {

--- a/rig/rig-core/src/providers/openai/completion/mod.rs
+++ b/rig/rig-core/src/providers/openai/completion/mod.rs
@@ -1039,6 +1039,7 @@ impl TryFrom<OpenAIRequestParams> for CompletionRequest {
             partial_history.push(docs);
         }
         let CoreCompletionRequest {
+            model: request_model,
             preamble,
             chat_history,
             tools,
@@ -1082,7 +1083,7 @@ impl TryFrom<OpenAIRequestParams> for CompletionRequest {
             .collect();
 
         let res = Self {
-            model,
+            model: request_model.unwrap_or(model),
             messages: full_history,
             tools,
             tool_choice,
@@ -1269,5 +1270,64 @@ where
         serializer.serialize_str("")
     } else {
         value.serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CompletionRequest, OpenAIRequestParams};
+
+    #[test]
+    fn test_openai_request_uses_request_model_override() {
+        let request = crate::completion::CompletionRequest {
+            model: Some("gpt-4.1".to_string()),
+            preamble: None,
+            chat_history: crate::OneOrMany::one("Hello".into()),
+            documents: vec![],
+            tools: vec![],
+            temperature: None,
+            max_tokens: None,
+            tool_choice: None,
+            additional_params: None,
+        };
+
+        let openai_request = CompletionRequest::try_from(OpenAIRequestParams {
+            model: "gpt-4o-mini".to_string(),
+            request,
+            strict_tools: false,
+            tool_result_array_content: false,
+        })
+        .expect("request conversion should succeed");
+        let serialized =
+            serde_json::to_value(openai_request).expect("serialization should succeed");
+
+        assert_eq!(serialized["model"], "gpt-4.1");
+    }
+
+    #[test]
+    fn test_openai_request_uses_default_model_when_override_unset() {
+        let request = crate::completion::CompletionRequest {
+            model: None,
+            preamble: None,
+            chat_history: crate::OneOrMany::one("Hello".into()),
+            documents: vec![],
+            tools: vec![],
+            temperature: None,
+            max_tokens: None,
+            tool_choice: None,
+            additional_params: None,
+        };
+
+        let openai_request = CompletionRequest::try_from(OpenAIRequestParams {
+            model: "gpt-4o-mini".to_string(),
+            request,
+            strict_tools: false,
+            tool_result_array_content: false,
+        })
+        .expect("request conversion should succeed");
+        let serialized =
+            serde_json::to_value(openai_request).expect("serialization should succeed");
+
+        assert_eq!(serialized["model"], "gpt-4o-mini");
     }
 }

--- a/rig/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/rig/rig-core/src/providers/openai/responses_api/mod.rs
@@ -632,6 +632,7 @@ impl TryFrom<(String, crate::completion::CompletionRequest)> for CompletionReque
     fn try_from(
         (model, req): (String, crate::completion::CompletionRequest),
     ) -> Result<Self, Self::Error> {
+        let model = req.model.clone().unwrap_or(model);
         let input = {
             let mut partial_history = vec![];
             if let Some(docs) = req.normalized_documents() {

--- a/rig/rig-core/src/providers/openrouter/streaming.rs
+++ b/rig/rig-core/src/providers/openrouter/streaming.rs
@@ -116,9 +116,13 @@ where
         completion_request: CompletionRequest,
     ) -> Result<streaming::StreamingCompletionResponse<StreamingCompletionResponse>, CompletionError>
     {
+        let request_model = completion_request
+            .model
+            .clone()
+            .unwrap_or_else(|| self.model.clone());
         let preamble = completion_request.preamble.clone();
         let mut request = OpenrouterCompletionRequest::try_from(OpenRouterRequestParams {
-            model: self.model.as_ref(),
+            model: request_model.as_ref(),
             request: completion_request,
             strict_tools: self.strict_tools,
         })?;
@@ -144,7 +148,7 @@ where
                 "chat_streaming",
                 gen_ai.operation.name = "chat_streaming",
                 gen_ai.provider.name = "openrouter",
-                gen_ai.request.model = self.model,
+                gen_ai.request.model = &request_model,
                 gen_ai.system_instructions = preamble,
                 gen_ai.response.id = tracing::field::Empty,
                 gen_ai.response.model = tracing::field::Empty,

--- a/rig/rig-core/src/providers/perplexity.rs
+++ b/rig/rig-core/src/providers/perplexity.rs
@@ -215,6 +215,7 @@ impl TryFrom<(&str, CompletionRequest)> for PerplexityCompletionRequest {
     type Error = CompletionError;
 
     fn try_from((model, req): (&str, CompletionRequest)) -> Result<Self, Self::Error> {
+        let model = req.model.clone().unwrap_or_else(|| model.to_string());
         let mut partial_history = vec![];
         if let Some(docs) = req.normalized_documents() {
             partial_history.push(docs);

--- a/rig/rig-core/src/providers/together/completion.rs
+++ b/rig/rig-core/src/providers/together/completion.rs
@@ -147,6 +147,7 @@ impl TryFrom<(&str, CompletionRequest)> for TogetherAICompletionRequest {
     type Error = CompletionError;
 
     fn try_from((model, req): (&str, CompletionRequest)) -> Result<Self, Self::Error> {
+        let model = req.model.clone().unwrap_or_else(|| model.to_string());
         let mut full_history: Vec<openai::Message> = match &req.preamble {
             Some(preamble) => vec![openai::Message::system(preamble)],
             None => vec![],

--- a/rig/rig-core/src/providers/xai/completion.rs
+++ b/rig/rig-core/src/providers/xai/completion.rs
@@ -50,6 +50,7 @@ impl TryFrom<(&str, CompletionRequest)> for XAICompletionRequest {
     type Error = CompletionError;
 
     fn try_from((model, req): (&str, CompletionRequest)) -> Result<Self, Self::Error> {
+        let model = req.model.clone().unwrap_or_else(|| model.to_string());
         let mut input: Vec<Message> = req
             .preamble
             .as_ref()


### PR DESCRIPTION
## Summary
Implements #1278 by adding a request-scoped model override to `CompletionRequest`, allowing callers to override the model selected in `T: CompletionModel` (needed for batch workflows).

Fixes #1278

## Problem
Today, model selection is fixed by the `CompletionModel` instance. Batch-style or mixed-model workflows need a way to override model per request.

## Implementation
- Added `model: Option<String>` to `CompletionRequest`.
- Added builder APIs:
  - `CompletionRequestBuilder::model(...)`
  - `CompletionRequestBuilder::model_opt(...)`
- Wired model resolution across provider conversions using the pattern:
  - use `req.model` when provided
  - fallback to provider/default model otherwise
- Updated path-based providers so routing uses the effective request model:
  - Gemini
  - HuggingFace
  - OpenRouter
- Updated internal struct literals and tests to include `model: None` where needed.

## Tests
Validated with:
- `cargo check -p rig-core`
- `cargo test -p rig-core openai_request_uses_ -- --nocapture`
- `cargo test -p rig-core openrouter_request_uses_ -- --nocapture`
- `cargo test -p rig-core resolve_request_model_uses_ -- --nocapture`
- `cargo test -p rig-core huggingface_request_uses_ -- --nocapture`

New focused tests were added for override/fallback behavior in:
- OpenAI request conversion
- OpenRouter request conversion
- Gemini request-model resolver + endpoint construction
- HuggingFace request conversion

## Public API breakage and migration path
### Breaking
- `completion::CompletionRequest` added a new public field:
  - `model: Option<String>`
- Any downstream manual struct literal construction of `CompletionRequest` now requires this field.

### Migration
- For existing behavior, set:
  - `model: None`
- To override model per request, set:
  - `model: Some("provider-model-id".to_string())`
- Preferred API:
  - `completion_request(...).model("provider-model-id")`

## Risk / remaining failure points
- Runtime provider validation can still fail for invalid/unsupported override model IDs.
- Provider/deployment-specific restrictions (especially path/deployment scoped backends) can reject overrides even when compile-time checks pass.
- Full-repo `cargo test` may still include unrelated failures outside this change scope.