### PR TITLE
docs: add ironclaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Below is a non-exhaustive list of companies and people who are using Rig:
 - [Ryzome](https://ryzome.ai) - Ryzome is a visual AI workspace that lets you build interconnected canvases of thoughts, research, and AI agents to orchestrate complex knowledge work.
 - [deepwiki-rs](https://github.com/sopaco/deepwiki-rs) - Turn code into clarity. Generate accurate technical docs and AI-ready context in minutes—perfectly structured for human teams and intelligent agents.
 - [Cortex Memory](https://github.com/sopaco/cortex-mem) - The production-ready memory system for intelligent agents. A complete solution for memory management, from extraction and vector search to automated optimization, with a REST API, MCP, CLI, and insights dashboard out-of-the-box.
+- [Ironclaw](https://github.com/nearai/ironclaw) - A secure personal AI assistant
 
 For a full list, check out our [ECOSYSTEM.md file.](https://www.github.com/0xPlaygrounds/rig/tree/main/ECOSYSTEM.md)
 

--- a/rig/rig-core/README.md
+++ b/rig/rig-core/README.md
@@ -102,5 +102,6 @@ Below is a non-exhaustive list of companies and people who are using Rig:
 - [Neon](https://neon.com) - Using Rig for their [app.build](https://github.com/neondatabase/appdotbuild-agent) V2 reboot in Rust.
 - [Listen](https://github.com/piotrostr/listen) - A framework aiming to become the go-to framework for AI portfolio management agents. Powers [the Listen app.](https://app.listen-rs.com/)
 - [Cairnify](https://cairnify.com/) - helps users find documents, links, and information instantly through an intelligent search bar. Rig provides the agentic foundation behind Cairnify’s AI search experience, enabling tool-calling, reasoning, and retrieval workflows.
+- [Ironclaw](https://github.com/nearai/ironclaw) - A secure personal AI assistant
 
 Are you also using Rig in production? [Open an issue](https://www.github.com/0xPlaygrounds/rig/issues) to have your name added!


### PR DESCRIPTION
Adds [ironclaw by Near AI](https://github.com/nearai/ironclaw) to the list of who's using Rig