### PR TITLE
feat(azure-openai): Add structured outputs support

### DIFF
--- a/rig/rig-core/src/providers/azure.rs
+++ b/rig/rig-core/src/providers/azure.rs
@@ -1058,7 +1058,7 @@ mod audio_generation {
 
 #[cfg(test)]
 mod azure_tests {
-    use schemars::{JsonSchema, schema_for};
+    use schemars::JsonSchema;
 
     use super::*;
 


### PR DESCRIPTION
Hi @joshua-mo-143,

Thank you for getting structured outputs into Rig! I've copied the code from the regular OpenAI provider into the Azure OpenAI provider.

I also noticed that the ToolChoice struct was being imported from openrouter instead of openai. I'm assuming this was done by mistake, and fixed it. I wanted to call this out on the off chance it wasn't a mistake. 

I added a test for structured outputs as well, and it passed without issues.

Let me know if you need anything else.

Thank you!