### PR TITLE
fix(deps): enable reqwest system-proxy for proxy env var support

### DIFF
--- a/rig/rig-core/Cargo.toml
+++ b/rig/rig-core/Cargo.toml
@@ -121,6 +121,7 @@ reqwest-rustls = [
   "reqwest/rustls",
   "reqwest/charset",
   "reqwest/http2",
+  "reqwest/system-proxy",
 ]
 reqwest-middleware = ["dep:reqwest-middleware"]
 reqwest-middleware-rustls = ["reqwest-middleware", "reqwest-middleware/rustls"]


### PR DESCRIPTION
reqwest 0.13 moved system proxy support behind a feature flag (system-proxy), unlike 0.12 where it was always enabled. Without this feature, reqwest ignores $http_proxy/$https_proxy environment variables and attempts direct TCP connections, which fails in environments that require a proxy for external access.