### PR TITLE
feat: add `.extended_details` to `TypedPromptRequest` via typestate

### DIFF
--- a/rig/rig-core/examples/openai_structured_output.rs
+++ b/rig/rig-core/examples/openai_structured_output.rs
@@ -91,6 +91,19 @@ async fn main() -> Result<(), anyhow::Error> {
     println!("\n=== With turbofish syntax ===");
     println!("{}", serde_json::to_string_pretty(&forecast)?);
 
+    // And use extended details for usage information!
+    let forecast = agent
+        .prompt_typed::<WeatherForecast>("What's the weather forecast for Los Angeles?")
+        .extended_details()
+        .await?;
+
+    println!("\n=== With turbofish syntax ===");
+    println!(
+        "{}\nUsage: {:?}",
+        serde_json::to_string_pretty(&forecast.output)?,
+        forecast.total_usage
+    );
+
     // This approach sets the schema at agent build time. The response is a
     // JSON string that you must manually deserialize.
     // This method is more suited towards agent being used as tools

--- a/rig/rig-core/src/agent/completion.rs
+++ b/rig/rig-core/src/agent/completion.rs
@@ -3,7 +3,7 @@ use crate::{
     agent::prompt_request::streaming::StreamingPromptRequest,
     completion::{
         Chat, Completion, CompletionError, CompletionModel, CompletionRequestBuilder, Document,
-        GetTokenUsage, Message, Prompt, PromptError,
+        GetTokenUsage, Message, Prompt, PromptError, TypedPrompt,
     },
     message::ToolChoice,
     streaming::{StreamingChat, StreamingCompletion, StreamingPrompt},
@@ -334,7 +334,7 @@ where
     }
 }
 
-use crate::{agent::prompt_request::TypedPromptRequest, completion::TypedPrompt};
+use crate::agent::prompt_request::TypedPromptRequest;
 use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 
@@ -345,7 +345,7 @@ where
     P: PromptHook<M> + 'static,
 {
     type TypedRequest<'a, T>
-        = TypedPromptRequest<'a, T, M, P>
+        = TypedPromptRequest<'a, T, prompt_request::Standard, M, P>
     where
         Self: 'a,
         T: JsonSchema + DeserializeOwned + WasmCompatSend + 'a;
@@ -385,7 +385,7 @@ where
     fn prompt_typed<T>(
         &self,
         prompt: impl Into<Message> + WasmCompatSend,
-    ) -> TypedPromptRequest<'_, T, M, P>
+    ) -> TypedPromptRequest<'_, T, prompt_request::Standard, M, P>
     where
         T: JsonSchema + DeserializeOwned + WasmCompatSend,
     {
@@ -400,7 +400,7 @@ where
     P: PromptHook<M> + 'static,
 {
     type TypedRequest<'a, T>
-        = TypedPromptRequest<'a, T, M, P>
+        = TypedPromptRequest<'a, T, prompt_request::Standard, M, P>
     where
         Self: 'a,
         T: JsonSchema + DeserializeOwned + WasmCompatSend + 'a;
@@ -408,7 +408,7 @@ where
     fn prompt_typed<T>(
         &self,
         prompt: impl Into<Message> + WasmCompatSend,
-    ) -> TypedPromptRequest<'_, T, M, P>
+    ) -> TypedPromptRequest<'_, T, prompt_request::Standard, M, P>
     where
         T: JsonSchema + DeserializeOwned + WasmCompatSend,
     {

--- a/rig/rig-core/src/agent/mod.rs
+++ b/rig/rig-core/src/agent/mod.rs
@@ -119,4 +119,4 @@ pub use prompt_request::streaming::{
     FinalResponse, MultiTurnStreamItem, StreamingError, StreamingPromptRequest, StreamingResult,
     stream_to_stdout,
 };
-pub use prompt_request::{PromptRequest, PromptResponse, TypedPromptRequest};
+pub use prompt_request::{PromptRequest, PromptResponse, TypedPromptRequest, TypedPromptResponse};


### PR DESCRIPTION
Updated the typestate to match normal `PromptRequest`.
I used the linear branch name, hopefully thats ok!

We could also make the normal `PromptRequest` generic on type T making the output `String` for normal sitatuations and save a type.