### PR TITLE
fix: `total_usage` -> `usage`

### DIFF
--- a/rig/rig-core/examples/openai_structured_output.rs
+++ b/rig/rig-core/examples/openai_structured_output.rs
@@ -101,7 +101,7 @@ async fn main() -> Result<(), anyhow::Error> {
     println!(
         "{}\nUsage: {:?}",
         serde_json::to_string_pretty(&forecast.output)?,
-        forecast.total_usage
+        forecast.usage
     );
 
     // This approach sets the schema at agent build time. The response is a

--- a/rig/rig-core/src/agent/prompt_request/mod.rs
+++ b/rig/rig-core/src/agent/prompt_request/mod.rs
@@ -257,15 +257,12 @@ impl PromptResponse {
 #[derive(Debug, Clone)]
 pub struct TypedPromptResponse<T> {
     pub output: T,
-    pub total_usage: Usage,
+    pub usage: Usage,
 }
 
 impl<T> TypedPromptResponse<T> {
-    pub fn new(output: T, total_usage: Usage) -> Self {
-        Self {
-            output,
-            total_usage,
-        }
+    pub fn new(output: T, usage: Usage) -> Self {
+        Self { output, usage }
     }
 }
 
@@ -731,7 +728,7 @@ where
         }
 
         let parsed: T = serde_json::from_str(&response.output)?;
-        Ok(TypedPromptResponse::new(parsed, response.total_usage))
+        Ok(TypedPromptResponse::new(parsed, response.usage))
     }
 }
 


### PR DESCRIPTION
I think this broke due to the merge queue from this PR #1447 as it renamed a variable the other PR needed.