### PR TITLE
feat(gemini): include dynamic context for extraction builder

### DIFF
--- a/rig/rig-core/Cargo.toml
+++ b/rig/rig-core/Cargo.toml
@@ -28,7 +28,7 @@ epub = { workspace = true, optional = true }
 futures = { workspace = true }
 glob = { workspace = true }
 lopdf = { workspace = true, optional = true }
-mime_guess.workspace = true
+mime_guess = { workspace = true }
 ordered-float = { workspace = true }
 quick-xml = { workspace = true, optional = true }
 rayon = { workspace = true, optional = true }
@@ -198,3 +198,7 @@ required-features = ["discord-bot"]
 
 [[example]]
 name = "custom_vector_store"
+
+[[example]]
+name = "gemini_extractor_with_rag"
+required-features = ["derive"]

--- a/rig/rig-core/examples/gemini_extractor_with_rag.rs
+++ b/rig/rig-core/examples/gemini_extractor_with_rag.rs
@@ -1,0 +1,112 @@
+use rig::prelude::*;
+use rig::providers::gemini;
+use rig::providers::gemini::client::Client;
+use rig::{
+    Embed, embeddings::EmbeddingsBuilder, vector_store::in_memory_store::InMemoryVectorStore,
+};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::vec;
+
+// Data to be RAGged.
+// A vector search needs to be performed on the `definitions` field, so we derive the `Embed` trait for `WordDefinition`
+// and tag that field with `#[embed]`.
+#[derive(Embed, Serialize, Clone, Debug, Eq, PartialEq, Default)]
+struct Question {
+    #[embed]
+    id: String,
+    #[embed]
+    text: String,
+    #[embed]
+    answer_options: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema, Serialize)]
+struct Answer {
+    /// The id of the question you are answering
+    id: String,
+    /// The answer to the question
+    text: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema, Serialize)]
+struct QuestionnaireResponses {
+    /// The list of responses to the questionnaire
+    responses: Vec<Answer>,
+}
+
+const APPLICANT_INFO: &str = r#"
+Subject: Application details / quick background
+
+Hi Procurement Team,
+
+Thanks for reaching out. Here are a few details about me so you can route my application to the right person.
+
+My full name is John Doe. I’ve been working in and around manufacturing for about 6 years now (mostly in operations + automation support). Over the last couple of roles I’ve done a bit of everything: supporting production lines, troubleshooting recurring quality issues, and helping roll out small process improvements that reduce downtime.
+
+On the technical side, I’m comfortable with Python for data cleanup/automation, SQL for reporting, and I’ve done some light work with PLC/HMI troubleshooting (Siemens/Allen-Bradley basics). I also use Excel heavily (Power Query, pivot tables) and I’m familiar with Git and basic CI setups from internal tooling projects.
+
+Unrelated but possibly helpful: I’m based in Montreal, can travel a couple times per quarter, and I’m generally available for calls after 2pm ET. I’m also finishing a part-time course in project management this spring.
+
+Also, if you need references, I can share them once you confirm which role this is being matched to.
+
+Best regards,
+John Doe
+"#;
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    // Initialize tracing
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG)
+        .with_target(false)
+        .init();
+
+    // Create Gemini client
+    let gemini_client = Client::from_env();
+    let embedding_model = gemini_client.embedding_model(gemini::EMBEDDING_001);
+
+    // Generate embeddings for the definitions of all the documents using the specified embedding model.
+    let embeddings = EmbeddingsBuilder::new(embedding_model.clone())
+        .documents(vec![
+            Question {
+                id: "question_1".to_string(),
+                text: "Complete name".to_string(),
+                answer_options: "Open question".to_string(),
+            },
+            Question {
+                id: "question_2".to_string(),
+                text: "Years of experience in the manufacturing industry".to_string(),
+                answer_options:
+                    "The answers should be one of the following: Less than 1 year, 1-2 years, 2-5 years, 5-10 years, More than 10 years"
+                        .to_string(),
+            },
+            Question {
+                id: "question_3".to_string(),
+                text: "Which technical skills do you have related to the job offer?".to_string(),
+                answer_options: "Open question. Examples are: Python, SQL, Excel, Git, CI, PLC/HMI troubleshooting (Siemens/Allen-Bradley basics)".to_string(),
+            },
+        ])?
+        .build()
+        .await?;
+
+    // Create vector store with the embeddings
+    let vector_store = InMemoryVectorStore::from_documents(embeddings);
+    // Create vector store index
+    let index = vector_store.index(embedding_model);
+    let rag_extractor = gemini_client.extractor::<QuestionnaireResponses>("gemini-2.5-flash")
+        .preamble("
+            You are a questionnaire assistant provided by the procurement department to assist the user in answering the questions.
+            You are provided with the questions and based on the information available, you must answer the questions with the right format.
+            Use the answer ID field to map the answer to the right question ID. Answer as much as possible without inventing information.
+            ")
+        .dynamic_context(3, index) // Samples should match the number of questions
+        .build();
+
+    // Prompt the agent and print the response
+    let response = rag_extractor.extract(APPLICANT_INFO).await?;
+
+    println!("{response:#?}");
+
+    Ok(())
+}

--- a/rig/rig-core/src/extractor.rs
+++ b/rig/rig-core/src/extractor.rs
@@ -39,6 +39,7 @@ use crate::{
     completion::{Completion, CompletionError, CompletionModel, ToolDefinition, Usage},
     message::{AssistantContent, Message, ToolCall, ToolChoice, ToolFunction},
     tool::Tool,
+    vector_store::VectorStoreIndexDyn,
     wasm_compat::{WasmCompatSend, WasmCompatSync},
 };
 
@@ -380,6 +381,19 @@ where
             _t: PhantomData,
             retries: self.retries.unwrap_or(0),
         }
+    }
+
+    /// Add dynamic context (RAG) to the extractor.
+    ///
+    /// On each prompt, `sample` documents will be retrieved from the index based on the RAG text
+    /// and inserted in the request.
+    pub fn dynamic_context(
+        mut self,
+        sample: usize,
+        dynamic_context: impl VectorStoreIndexDyn + Send + Sync + 'static,
+    ) -> Self {
+        self.agent_builder = self.agent_builder.dynamic_context(sample, dynamic_context);
+        self
     }
 }
 

--- a/rig/rig-core/src/providers/gemini/embedding.rs
+++ b/rig/rig-core/src/providers/gemini/embedding.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 /// `embedding-001` embedding model
-pub const EMBEDDING_001: &str = "embedding-001";
+pub const EMBEDDING_001: &str = "gemini-embedding-001";
 /// `text-embedding-004` embedding model
 pub const EMBEDDING_004: &str = "text-embedding-004";
 


### PR DESCRIPTION
Addition of the dynamic context to the extractor builder per [this](https://github.com/0xPlaygrounds/rig/pull/1357):

- Update Gemini embedding model id.
- Add dynamic context to the extractor builder:
    - Add an example to test and showcase the usage
