### PR TITLE
feat(moonshot): add Kimi K2 and K2.5 model constants

### DIFF
--- a/rig/rig-core/src/providers/moonshot.rs
+++ b/rig/rig-core/src/providers/moonshot.rs
@@ -1,12 +1,26 @@
-//! Moonshot API client and Rig integration
+//! Moonshot AI (Kimi) API client and Rig integration
 //!
 //! # Example
+//! ```no_run
+//! use rig::providers::moonshot;
+//! use rig::client::CompletionClient;
+//!
+//! let client = moonshot::Client::new("YOUR_API_KEY").expect("Failed to build client");
+//!
+//! let kimi_model = client.completion_model(moonshot::KIMI_K2_5);
 //! ```
+//!
+//! # Custom base URL
+//! The default base URL is `https://api.moonshot.cn/v1`. For global access,
+//! use `https://api.moonshot.ai/v1`:
+//! ```no_run
 //! use rig::providers::moonshot;
 //!
-//! let client = moonshot::Client::new("YOUR_API_KEY");
-//!
-//! let moonshot_model = client.completion_model(moonshot::MOONSHOT_CHAT);
+//! let client = moonshot::Client::builder()
+//!     .api_key("YOUR_API_KEY")
+//!     .base_url("https://api.moonshot.ai/v1")
+//!     .build()
+//!     .expect("Failed to build Moonshot client");
 //! ```
 use crate::client::{
     self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
@@ -114,7 +128,14 @@ enum ApiResponse<T> {
 // Moonshot Completion API
 // ================================================================
 
+/// Moonshot v1 128K context model (legacy)
 pub const MOONSHOT_CHAT: &str = "moonshot-v1-128k";
+
+/// Kimi K2 — Mixture-of-Experts model (1T total params, 32B active)
+pub const KIMI_K2: &str = "kimi-k2";
+
+/// Kimi K2.5 — Native multimodal agentic model with 256K context
+pub const KIMI_K2_5: &str = "kimi-k2.5";
 
 #[derive(Debug, Serialize, Deserialize)]
 pub(super) struct MoonshotCompletionRequest {


### PR DESCRIPTION
## Summary

Add model constants for Moonshot AI's latest Kimi models and improve module documentation:

- **`KIMI_K2`**: Kimi K2 — Mixture-of-Experts model (1T total params, 32B active)
- **`KIMI_K2_5`**: Kimi K2.5 — Native multimodal agentic model with 256K context

### Documentation improvements
- Update doc example to showcase Kimi K2.5 (the current flagship model)
- Add custom base URL example (`https://api.moonshot.ai/v1` for global access vs the default `https://api.moonshot.cn/v1`)
- Fix doc example compilation by adding `CompletionClient` trait import and proper error handling

### Why
The existing Moonshot provider only defines `MOONSHOT_CHAT` (`moonshot-v1-128k`), which is a legacy model. Moonshot AI has since released the Kimi K2 and K2.5 series as their flagship models. Adding these constants makes it easier for users to use the latest models without having to look up the model name strings.

### References
- [Kimi K2](https://github.com/MoonshotAI/Kimi-K2) — 1T MoE, 32B active params
- [Kimi K2.5](https://github.com/MoonshotAI/Kimi-K2.5) — Multimodal agentic, 256K context
- [Moonshot API Platform](https://platform.moonshot.ai/)

### Checks
- [x] `cargo fmt` — passes
- [x] `cargo clippy -p rig-core -- -D warnings` — passes
- [x] `cargo test -p rig-core --lib` — passes
- [x] `cargo test -p rig-core --doc -- moonshot` — passes

This PR was generated with AI assistance (Claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)