### PR TITLE
fix: populate cached_input_tokens in Chat Completions streaming

### DIFF
--- a/rig/rig-core/src/providers/openai/completion/streaming.rs
+++ b/rig/rig-core/src/providers/openai/completion/streaming.rs
@@ -578,7 +578,14 @@ mod tests {
         let res = final_response.expect("expected a final response");
 
         // Verify provider-level usage has the cached_tokens
-        assert_eq!(res.usage.prompt_tokens_details.as_ref().unwrap().cached_tokens, 80);
+        assert_eq!(
+            res.usage
+                .prompt_tokens_details
+                .as_ref()
+                .unwrap()
+                .cached_tokens,
+            80
+        );
 
         // Verify core Usage also has cached_input_tokens via GetTokenUsage
         let core_usage = res.token_usage().expect("token_usage should return Some");


### PR DESCRIPTION
## Summary

The Chat Completions streaming path does not populate `cached_input_tokens` on the core `Usage` struct, even though the provider-specific `Usage` already deserializes `prompt_tokens_details.cached_tokens`.

The Responses API streaming path correctly maps it ([`responses_api/streaming.rs:74-79`](https://github.com/0xPlaygrounds/rig/blob/main/rig/rig-core/src/providers/openai/responses_api/streaming.rs#L74-L79)):

```rust
usage.cached_input_tokens = self
    .usage
    .input_tokens_details
    .as_ref()
    .map(|d| d.cached_tokens)
    .unwrap_or(0);
```

But the Chat Completions streaming path was missing the equivalent line ([`completion/streaming.rs:72-79`](https://github.com/0xPlaygrounds/rig/blob/main/rig/rig-core/src/providers/openai/completion/streaming.rs#L72-L79)).

## Changes

- Added the missing `cached_input_tokens` mapping in `GetTokenUsage for StreamingCompletionResponse` (Chat Completions path)
- Added a test that verifies `cached_input_tokens` is correctly populated from a streaming usage chunk containing `prompt_tokens_details.cached_tokens`

## Context

We noticed this while adding LLM metrics to our service. The `cached_input_tokens` field added in #1299 works correctly for Responses API streaming and Chat Completions non-streaming, but this streaming path was missed. Providers like OpenAI and Baseten return `prompt_tokens_details.cached_tokens` on streaming chunks — it was just being silently dropped.