### PR TITLE
fix: forward max_tokens in Chat Completions API requests

### DIFF
--- a/rig/rig-core/src/providers/openai/completion/mod.rs
+++ b/rig/rig-core/src/providers/openai/completion/mod.rs
@@ -1018,6 +1018,8 @@ pub struct CompletionRequest {
     tool_choice: Option<ToolChoice>,
     #[serde(skip_serializing_if = "Option::is_none")]
     temperature: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_tokens: Option<u64>,
     #[serde(flatten)]
     additional_params: Option<serde_json::Value>,
 }
@@ -1050,6 +1052,7 @@ impl TryFrom<OpenAIRequestParams> for CompletionRequest {
             chat_history,
             tools,
             temperature,
+            max_tokens,
             additional_params,
             tool_choice,
             output_schema,
@@ -1133,6 +1136,7 @@ impl TryFrom<OpenAIRequestParams> for CompletionRequest {
             tools,
             tool_choice,
             temperature,
+            max_tokens,
             additional_params,
         };
 
@@ -1429,6 +1433,62 @@ mod tests {
             }
             _ => panic!("expected assistant message"),
         }
+    }
+
+    #[test]
+    fn test_max_tokens_is_forwarded_to_request() {
+        let request = crate::completion::CompletionRequest {
+            model: None,
+            preamble: None,
+            chat_history: crate::OneOrMany::one("Hello".into()),
+            documents: vec![],
+            tools: vec![],
+            temperature: None,
+            max_tokens: Some(4096),
+            tool_choice: None,
+            additional_params: None,
+            output_schema: None,
+        };
+
+        let openai_request = CompletionRequest::try_from(OpenAIRequestParams {
+            model: "gpt-4o-mini".to_string(),
+            request,
+            strict_tools: false,
+            tool_result_array_content: false,
+        })
+        .expect("request conversion should succeed");
+        let serialized =
+            serde_json::to_value(openai_request).expect("serialization should succeed");
+
+        assert_eq!(serialized["max_tokens"], 4096);
+    }
+
+    #[test]
+    fn test_max_tokens_omitted_when_none() {
+        let request = crate::completion::CompletionRequest {
+            model: None,
+            preamble: None,
+            chat_history: crate::OneOrMany::one("Hello".into()),
+            documents: vec![],
+            tools: vec![],
+            temperature: None,
+            max_tokens: None,
+            tool_choice: None,
+            additional_params: None,
+            output_schema: None,
+        };
+
+        let openai_request = CompletionRequest::try_from(OpenAIRequestParams {
+            model: "gpt-4o-mini".to_string(),
+            request,
+            strict_tools: false,
+            tool_result_array_content: false,
+        })
+        .expect("request conversion should succeed");
+        let serialized =
+            serde_json::to_value(openai_request).expect("serialization should succeed");
+
+        assert!(serialized.get("max_tokens").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- The Chat Completions provider's `CompletionRequest` struct is missing a `max_tokens` field. When `.max_tokens(N)` is called on the agent builder, the value flows into the core `CompletionRequest` but is silently discarded during `TryFrom<OpenAIRequestParams>` conversion — the destructuring uses `..` which drops it, and the provider struct has no field to receive it.
- The Responses API provider handles this correctly via `max_output_tokens`, so only the Chat Completions path is affected.
- Adds `max_tokens: Option<u64>` to the provider's `CompletionRequest`, extracts it during conversion, and serializes it in the API request body.

## Test plan

- [x] Added `test_max_tokens_is_forwarded_to_request` — verifies `max_tokens` appears in serialized JSON when set
- [x] Added `test_max_tokens_omitted_when_none` — verifies `max_tokens` is omitted from JSON when `None`
- [x] All existing `providers::openai::completion::tests` pass (7/7)