### PR TITLE
feat(telemetry): emit gen_ai.usage.cached_tokens across all providers

### DIFF
--- a/rig/rig-core/src/agent/prompt_request/mod.rs
+++ b/rig/rig-core/src/agent/prompt_request/mod.rs
@@ -305,6 +305,7 @@ where
                 gen_ai.completion = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()
@@ -371,6 +372,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
                 gen_ai.input.messages = tracing::field::Empty,
                 gen_ai.output.messages = tracing::field::Empty,
             );
@@ -444,6 +446,7 @@ where
                 agent_span.record("gen_ai.completion", &merged_texts);
                 agent_span.record("gen_ai.usage.input_tokens", usage.input_tokens);
                 agent_span.record("gen_ai.usage.output_tokens", usage.output_tokens);
+                agent_span.record("gen_ai.usage.cached_tokens", usage.cached_input_tokens);
 
                 // If there are no tool calls, depth is not relevant, we can just return the merged text response.
                 return Ok(

--- a/rig/rig-core/src/agent/prompt_request/streaming.rs
+++ b/rig/rig-core/src/agent/prompt_request/streaming.rs
@@ -320,6 +320,7 @@ where
                 gen_ai.completion = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()
@@ -402,6 +403,7 @@ where
                     gen_ai.response.model = tracing::field::Empty,
                     gen_ai.usage.output_tokens = tracing::field::Empty,
                     gen_ai.usage.input_tokens = tracing::field::Empty,
+                    gen_ai.usage.cached_tokens = tracing::field::Empty,
                     gen_ai.input.messages = tracing::field::Empty,
                     gen_ai.output.messages = tracing::field::Empty,
                 );
@@ -646,6 +648,7 @@ where
                     let current_span = tracing::Span::current();
                     current_span.record("gen_ai.usage.input_tokens", aggregated_usage.input_tokens);
                     current_span.record("gen_ai.usage.output_tokens", aggregated_usage.output_tokens);
+                    current_span.record("gen_ai.usage.cached_tokens", aggregated_usage.cached_input_tokens);
                     tracing::info!("Agent multi-turn stream finished");
                     let history_snapshot = if has_history {
                         Some(chat_history.clone())

--- a/rig/rig-core/src/providers/anthropic/completion.rs
+++ b/rig/rig-core/src/providers/anthropic/completion.rs
@@ -1160,6 +1160,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/anthropic/streaming.rs
+++ b/rig/rig-core/src/providers/anthropic/streaming.rs
@@ -146,6 +146,7 @@ where
                 gen_ai.response.model = &request_model,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
                 gen_ai.input.messages = tracing::field::Empty,
                 gen_ai.output.messages = tracing::field::Empty,
             )

--- a/rig/rig-core/src/providers/azure.rs
+++ b/rig/rig-core/src/providers/azure.rs
@@ -702,6 +702,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()
@@ -801,6 +802,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/cohere/completion.rs
+++ b/rig/rig-core/src/providers/cohere/completion.rs
@@ -630,6 +630,7 @@ where
             gen_ai.response.model = self.model,
             gen_ai.usage.output_tokens = tracing::field::Empty,
             gen_ai.usage.input_tokens = tracing::field::Empty,
+            gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/cohere/streaming.rs
+++ b/rig/rig-core/src/providers/cohere/streaming.rs
@@ -111,6 +111,7 @@ where
                 gen_ai.response.model = self.model,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/deepseek.rs
+++ b/rig/rig-core/src/providers/deepseek.rs
@@ -553,6 +553,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()
@@ -590,6 +591,15 @@ where
                         span.record(
                             "gen_ai.usage.output_tokens",
                             response.usage.completion_tokens,
+                        );
+                        span.record(
+                            "gen_ai.usage.cached_tokens",
+                            response
+                                .usage
+                                .prompt_tokens_details
+                                .as_ref()
+                                .and_then(|d| d.cached_tokens)
+                                .unwrap_or(0),
                         );
                         if enabled!(Level::TRACE) {
                             tracing::trace!(target: "rig::completions",
@@ -656,6 +666,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/galadriel.rs
+++ b/rig/rig-core/src/providers/galadriel.rs
@@ -547,6 +547,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()
@@ -646,6 +647,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
                 gen_ai.input.messages = serde_json::to_string(&request.messages)?,
                 gen_ai.output.messages = tracing::field::Empty,
             )

--- a/rig/rig-core/src/providers/gemini/completion.rs
+++ b/rig/rig-core/src/providers/gemini/completion.rs
@@ -98,6 +98,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/gemini/streaming.rs
+++ b/rig/rig-core/src/providers/gemini/streaming.rs
@@ -92,6 +92,7 @@ where
                 gen_ai.response.model = &request_model,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/groq.rs
+++ b/rig/rig-core/src/providers/groq.rs
@@ -303,6 +303,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()
@@ -342,6 +343,14 @@ where
                             span.record(
                                 "gen_ai.usage.output_tokens",
                                 usage.total_tokens - usage.prompt_tokens,
+                            );
+                            span.record(
+                                "gen_ai.usage.cached_tokens",
+                                usage
+                                    .prompt_tokens_details
+                                    .as_ref()
+                                    .map(|d| d.cached_tokens)
+                                    .unwrap_or(0),
                             );
                         }
 
@@ -385,6 +394,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()
@@ -714,6 +724,14 @@ where
         span.record("gen_ai.output.messages", serde_json::to_string(&vec![response_message]).unwrap());
         span.record("gen_ai.usage.input_tokens", final_usage.prompt_tokens);
         span.record("gen_ai.usage.output_tokens", final_usage.total_tokens - final_usage.prompt_tokens);
+        span.record(
+            "gen_ai.usage.cached_tokens",
+            final_usage
+                .prompt_tokens_details
+                .as_ref()
+                .map(|d| d.cached_tokens)
+                .unwrap_or(0),
+        );
 
         // Final response
         yield Ok(crate::streaming::RawStreamingChoice::FinalResponse(

--- a/rig/rig-core/src/providers/huggingface/completion.rs
+++ b/rig/rig-core/src/providers/huggingface/completion.rs
@@ -742,6 +742,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/huggingface/streaming.rs
+++ b/rig/rig-core/src/providers/huggingface/streaming.rs
@@ -65,6 +65,7 @@ where
             gen_ai.response.model = &request_model,
             gen_ai.usage.output_tokens = tracing::field::Empty,
             gen_ai.usage.input_tokens = tracing::field::Empty,
+            gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/hyperbolic.rs
+++ b/rig/rig-core/src/providers/hyperbolic.rs
@@ -361,6 +361,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()
@@ -431,6 +432,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/mira.rs
+++ b/rig/rig-core/src/providers/mira.rs
@@ -343,6 +343,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()
@@ -447,6 +448,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/mistral/completion.rs
+++ b/rig/rig-core/src/providers/mistral/completion.rs
@@ -604,6 +604,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/moonshot.rs
+++ b/rig/rig-core/src/providers/moonshot.rs
@@ -252,6 +252,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()
@@ -333,6 +334,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/ollama.rs
+++ b/rig/rig-core/src/providers/ollama.rs
@@ -536,6 +536,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()
@@ -615,6 +616,7 @@ where
                 gen_ai.response.model = self.model,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/openai/completion/mod.rs
+++ b/rig/rig-core/src/providers/openai/completion/mod.rs
@@ -1236,6 +1236,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/openai/completion/streaming.rs
+++ b/rig/rig-core/src/providers/openai/completion/streaming.rs
@@ -135,6 +135,7 @@ where
                 gen_ai.response.model = self.model,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
                 gen_ai.input.messages = request_messages,
                 gen_ai.output.messages = tracing::field::Empty,
             )
@@ -310,6 +311,14 @@ where
         if !span.is_disabled() {
             span.record("gen_ai.usage.input_tokens", final_usage.prompt_tokens);
             span.record("gen_ai.usage.output_tokens", final_usage.total_tokens - final_usage.prompt_tokens);
+            span.record(
+                "gen_ai.usage.cached_tokens",
+                final_usage
+                    .prompt_tokens_details
+                    .as_ref()
+                    .map(|d| d.cached_tokens)
+                    .unwrap_or(0),
+            );
         }
 
         yield Ok(RawStreamingChoice::FinalResponse(StreamingCompletionResponse {

--- a/rig/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/rig/rig-core/src/providers/openai/responses_api/mod.rs
@@ -1156,6 +1156,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
                 gen_ai.input.messages = tracing::field::Empty,
                 gen_ai.output.messages = tracing::field::Empty,
             )
@@ -1194,6 +1195,14 @@ where
                 if let Some(ref usage) = response.usage {
                     span.record("gen_ai.usage.output_tokens", usage.output_tokens);
                     span.record("gen_ai.usage.input_tokens", usage.input_tokens);
+                    span.record(
+                        "gen_ai.usage.cached_tokens",
+                        usage
+                            .input_tokens_details
+                            .as_ref()
+                            .map(|d| d.cached_tokens)
+                            .unwrap_or(0),
+                    );
                 }
                 if enabled!(Level::TRACE) {
                     tracing::trace!(

--- a/rig/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/rig/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -273,6 +273,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()
@@ -415,6 +416,14 @@ where
 
             span.record("gen_ai.usage.input_tokens", final_usage.input_tokens);
             span.record("gen_ai.usage.output_tokens", final_usage.output_tokens);
+            span.record(
+                "gen_ai.usage.cached_tokens",
+                final_usage
+                    .input_tokens_details
+                    .as_ref()
+                    .map(|d| d.cached_tokens)
+                    .unwrap_or(0),
+            );
             tracing::info!("OpenAI stream finished");
 
             yield Ok(RawStreamingChoice::FinalResponse(StreamingCompletionResponse {

--- a/rig/rig-core/src/providers/openrouter/completion.rs
+++ b/rig/rig-core/src/providers/openrouter/completion.rs
@@ -1724,6 +1724,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/openrouter/streaming.rs
+++ b/rig/rig-core/src/providers/openrouter/streaming.rs
@@ -154,6 +154,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/perplexity.rs
+++ b/rig/rig-core/src/providers/perplexity.rs
@@ -360,6 +360,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()
@@ -445,6 +446,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/together/completion.rs
+++ b/rig/rig-core/src/providers/together/completion.rs
@@ -247,6 +247,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/together/streaming.rs
+++ b/rig/rig-core/src/providers/together/streaming.rs
@@ -58,6 +58,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/xai/completion.rs
+++ b/rig/rig-core/src/providers/xai/completion.rs
@@ -184,6 +184,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/xai/streaming.rs
+++ b/rig/rig-core/src/providers/xai/streaming.rs
@@ -66,6 +66,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()
@@ -231,6 +232,14 @@ where
         if !span.is_disabled() {
             span.record("gen_ai.usage.input_tokens", final_usage.input_tokens);
             span.record("gen_ai.usage.output_tokens", final_usage.output_tokens);
+            span.record(
+                "gen_ai.usage.cached_tokens",
+                final_usage
+                    .input_tokens_details
+                    .as_ref()
+                    .map(|d| d.cached_tokens)
+                    .unwrap_or(0),
+            );
         }
 
         yield Ok(RawStreamingChoice::FinalResponse(StreamingCompletionResponse {

--- a/rig/rig-core/src/telemetry/mod.rs
+++ b/rig/rig-core/src/telemetry/mod.rs
@@ -62,6 +62,7 @@ impl SpanCombinator for tracing::Span {
         if let Some(usage) = usage.token_usage() {
             self.record("gen_ai.usage.input_tokens", usage.input_tokens);
             self.record("gen_ai.usage.output_tokens", usage.output_tokens);
+            self.record("gen_ai.usage.cached_tokens", usage.cached_input_tokens);
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds `gen_ai.usage.cached_tokens` to tracing spans across all providers and agent-level spans
- Updates `record_token_usage` in `SpanCombinator` to automatically emit `cached_input_tokens` for providers using the telemetry trait
- Manually records cached tokens in providers that record usage directly on spans (OpenAI, DeepSeek, Groq, xAI)

Cached input tokens are billed at reduced rates (typically 50-90% cheaper) and processed faster. Emitting them in telemetry spans enables accurate cost tracking, cache hit rate monitoring, and latency correlation.

This PR was generated with assistance from Claude.

## Test plan
- [x] `cargo check -p rig-core` passes
- [x] `cargo clippy -p rig-core --all-targets --all-features` passes
- [x] `cargo fmt -- --check` passes