### PR TITLE
docs: fix link in rig-core README

### DIFF
--- a/rig/rig-core/README.md
+++ b/rig/rig-core/README.md
@@ -1,7 +1,7 @@
 # Rig
 Rig is a Rust library for building LLM-powered applications that focuses on ergonomics and modularity.
 
-More information about this crate can be found in the [crate documentation](https://docs/rig-core/latest/rig/).
+More information about this crate can be found in the [crate documentation](https://docs.rs/rig-core/latest/rig/).
 ## Table of contents
 
 - [Rig](#rig)


### PR DESCRIPTION
I just stumbled over this broken docs link.

Will close #1503 