### PR TITLE
fix: correct broken crate documentation link in rig-core README

### DIFF
--- a/rig/rig-core/README.md
+++ b/rig/rig-core/README.md
@@ -1,7 +1,7 @@
 # Rig
 Rig is a Rust library for building LLM-powered applications that focuses on ergonomics and modularity.
 
-More information about this crate can be found in the [crate documentation](https://docs/rig-core/latest/rig/).
+More information about this crate can be found in the [crate documentation](https://docs.rs/rig-core/latest/rig/).
 ## Table of contents
 
 - [Rig](#rig)


### PR DESCRIPTION
## Summary
- Fixes the broken docs.rs link in `rig/rig-core/README.md`
- The URL was `https://docs/rig-core/latest/rig/` (missing `.rs` TLD)
- Changed to `https://docs.rs/rig-core/latest/rig/`

## Test plan
- [ ] Click the "crate documentation" link in the rig-core README — should navigate to docs.rs

Fixes #1503

🤖 Generated with [Claude Code](https://claude.com/claude-code)