### PR TITLE
fix(openai): strengthen streaming tool call dedup to prevent false evictions

### DIFF
--- a/rig/rig-core/src/providers/openai/completion/streaming.rs
+++ b/rig/rig-core/src/providers/openai/completion/streaming.rs
@@ -205,14 +205,20 @@ where
 
                             // Some API gateways (e.g. LiteLLM, OneAPI) emit multiple
                             // distinct tool calls all sharing index 0.  Detect this by
-                            // comparing the provider-supplied `id`: if a new, non-empty
-                            // id arrives for an index that already has a different id,
-                            // flush the old entry as a completed tool call first.
+                            // comparing both the `id` and `name`: only evict when a new
+                            // chunk carries a different non-empty id AND a different
+                            // non-empty name.  Checking the name prevents false evictions
+                            // from providers (e.g. GLM-4) that send a unique id on every
+                            // SSE chunk for the same logical tool call.
                             if let Some(new_id) = &tool_call.id
                                 && !new_id.is_empty()
+                                && let Some(new_name) = &tool_call.function.name
+                                && !new_name.is_empty()
                                 && let Some(existing) = tool_calls.get(&index)
                                 && !existing.id.is_empty()
                                 && existing.id != *new_id
+                                && !existing.name.is_empty()
+                                && existing.name != *new_name
                             {
                                 let evicted = tool_calls.remove(&index).expect("checked above");
                                 yield Ok(streaming::RawStreamingChoice::ToolCall(evicted));
@@ -667,6 +673,70 @@ mod tests {
         assert_eq!(
             collected_tool_calls[1].function.arguments,
             serde_json::json!({"action": "log"})
+        );
+    }
+
+    /// Reproduces the bug where a provider (e.g. GLM-4 via OpenAI-compatible
+    /// endpoint) sends a unique `id` on every SSE delta chunk for the same
+    /// logical tool call.  Without the fix, each chunk triggers an eviction,
+    /// yielding incomplete fragments as "completed" tool calls.
+    #[tokio::test]
+    async fn test_unique_id_per_chunk_single_tool_call() {
+        use crate::http_client::mock::MockStreamingClient;
+        use bytes::Bytes;
+        use futures::StreamExt;
+
+        // Each chunk carries a different id but they all represent delta
+        // fragments of the SAME tool call at index 0.
+        let sse = concat!(
+            "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"chatcmpl-tool-aaa\",\"function\":{\"name\":\"web_search\",\"arguments\":\"null\"}}]},\"finish_reason\":null}],\"usage\":null}\n\n",
+            "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"chatcmpl-tool-bbb\",\"function\":{\"name\":\"\",\"arguments\":\"{\\\"query\\\": \\\"META\"}}]},\"finish_reason\":null}],\"usage\":null}\n\n",
+            "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"chatcmpl-tool-ccc\",\"function\":{\"name\":\"\",\"arguments\":\" Platforms news\\\"}\"}}]},\"finish_reason\":null}],\"usage\":null}\n\n",
+            "data: {\"choices\":[{\"delta\":{\"tool_calls\":[]},\"finish_reason\":\"tool_calls\"}],\"usage\":null}\n\n",
+            "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":15,\"completion_tokens\":8,\"total_tokens\":23}}\n\n",
+            "data: [DONE]\n\n",
+        );
+
+        let client = MockStreamingClient {
+            sse_bytes: Bytes::from(sse),
+        };
+
+        let req = http::Request::builder()
+            .method("POST")
+            .uri("http://localhost/v1/chat/completions")
+            .body(Vec::new())
+            .unwrap();
+
+        let mut stream = send_compatible_streaming_request(client, req)
+            .await
+            .unwrap();
+
+        let mut collected_tool_calls = Vec::new();
+        while let Some(chunk) = stream.next().await {
+            if let streaming::StreamedAssistantContent::ToolCall {
+                tool_call,
+                internal_call_id: _,
+            } = chunk.unwrap()
+            {
+                collected_tool_calls.push(tool_call);
+            }
+        }
+
+        assert_eq!(
+            collected_tool_calls.len(),
+            1,
+            "expected 1 tool call (all chunks are fragments of the same call), got {collected_tool_calls:?}"
+        );
+
+        assert_eq!(collected_tool_calls[0].function.name, "web_search");
+        // The arguments should be the fully accumulated string, not fragments
+        let args_str = match &collected_tool_calls[0].function.arguments {
+            serde_json::Value::String(s) => s.clone(),
+            v => v.to_string(),
+        };
+        assert!(
+            args_str.contains("META Platforms news"),
+            "expected accumulated arguments containing the full query, got: {args_str}"
         );
     }
 }


### PR DESCRIPTION
## Summary

The deduplication heuristic added in v0.32 (`streaming.rs` ~line 211) evicts a tool call entry when a new SSE chunk arrives at the same index with a different `id`. This breaks providers (e.g. GLM-4 via OpenAI-compatible endpoints) that send a **unique `id` on every SSE delta chunk** for the same logical tool call — each chunk triggers a false eviction, yielding incomplete fragments as "completed" tool calls.

**Fix:** Strengthen the eviction condition to require both `id` AND `name` to be non-empty and different from the existing entry. A genuinely new tool call at the same index (the LiteLLM/OneAPI gateway case) always carries a new non-empty name, while continuation chunks from providers like GLM-4 have an empty name.

Fixes #1508

## Changes

- Added `name` comparison to the dedup eviction guard: eviction now requires **both** a new non-empty `id` that differs **and** a new non-empty `name` that differs
- Added regression test `test_unique_id_per_chunk_single_tool_call` reproducing the exact GLM-4 scenario from the issue

## Test plan

- [x] New test `test_unique_id_per_chunk_single_tool_call` verifies GLM-4 chunks with unique IDs accumulate into one tool call
- [x] Existing test `test_duplicate_index_different_id_tool_calls` still passes (LiteLLM/OneAPI gateway case)
- [x] All 10 streaming tests pass
- [x] `cargo fmt` clean
- [x] `cargo clippy` clean