### PR TITLE
feat: add grok imagine as image generation

### DIFF
--- a/rig/rig-core/Cargo.toml
+++ b/rig/rig-core/Cargo.toml
@@ -202,3 +202,7 @@ name = "custom_vector_store"
 [[example]]
 name = "gemini_extractor_with_rag"
 required-features = ["derive"]
+
+[[example]]
+name = "xai_image_generation"
+required-features = ["image"]

--- a/rig/rig-core/examples/xai_image_generation.rs
+++ b/rig/rig-core/examples/xai_image_generation.rs
@@ -1,0 +1,40 @@
+use rig::image_generation::ImageGenerationModel;
+use rig::prelude::*;
+use rig::providers::xai;
+use serde_json::json;
+use std::env::args;
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+const DEFAULT_PATH: &str = "./output.png";
+
+#[tokio::main]
+async fn main() {
+    let arguments: Vec<String> = args().collect();
+
+    let path = if arguments.len() > 1 {
+        arguments[1].clone()
+    } else {
+        DEFAULT_PATH.to_string()
+    };
+
+    let path = Path::new(&path);
+    let mut file = File::create_new(path).expect("Failed to create file");
+
+    let client = xai::Client::from_env();
+    let model = client.image_generation_model(xai::image_generation::GROK_IMAGINE_IMAGE_PRO);
+
+    let response = model
+        .image_generation_request()
+        .prompt("A lone explorer in a steampunk diving suit discovering an underwater lost city overgrown with bioluminescent coral and ancient ruins. The diver has a large brass helmet with glowing portholes, holding a vintage lantern that illuminates schools of colorful fish and crumbling marble columns covered in barnacles. Soft volumetric light rays piercing the deep blue water from above, mysterious and wondrous atmosphere. Cinematic composition, highly detailed textures on the suit and architecture, in the style of James Cameron's The Abyss meets Hayao Miyazaki, photorealistic with fantasy elements, 8k, ultra-detailed, masterpiece")
+        .additional_params(json!({
+            "resolution": "2k",
+            "aspect_ratio": "4:3",
+        }))
+        .send()
+        .await
+        .expect("Failed to generate image");
+
+    let _ = file.write(&response.image);
+}

--- a/rig/rig-core/src/providers/xai/client.rs
+++ b/rig/rig-core/src/providers/xai/client.rs
@@ -31,7 +31,7 @@ impl<H> Capabilities<H> for XAiExt {
     type Transcription = Nothing;
     type ModelListing = Nothing;
     #[cfg(feature = "image")]
-    type ImageGeneration = Nothing;
+    type ImageGeneration = Capable<super::image_generation::ImageGenerationModel<H>>;
     #[cfg(feature = "audio")]
     type AudioGeneration = Nothing;
 }

--- a/rig/rig-core/src/providers/xai/image_generation.rs
+++ b/rig/rig-core/src/providers/xai/image_generation.rs
@@ -1,0 +1,121 @@
+use super::api::ApiResponse;
+use super::client::Client;
+use crate::http_client::HttpClientExt;
+use crate::image_generation::{ImageGenerationError, ImageGenerationRequest};
+use crate::json_utils::merge_inplace;
+use crate::{http_client, image_generation};
+use base64::Engine;
+use base64::prelude::BASE64_STANDARD;
+use serde::Deserialize;
+use serde_json::json;
+
+// ================================================================
+// xAI Image Generation API
+// ================================================================
+pub const GROK_IMAGINE_IMAGE: &str = "grok-imagine-image";
+pub const GROK_IMAGINE_IMAGE_PRO: &str = "grok-imagine-image-pro";
+
+#[derive(Debug, Deserialize)]
+pub struct ImageGenerationData {
+    pub b64_json: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ImageGenerationResponse {
+    pub data: Vec<ImageGenerationData>,
+}
+
+impl TryFrom<ImageGenerationResponse>
+    for image_generation::ImageGenerationResponse<ImageGenerationResponse>
+{
+    type Error = ImageGenerationError;
+
+    fn try_from(value: ImageGenerationResponse) -> Result<Self, Self::Error> {
+        let first = value
+            .data
+            .first()
+            .ok_or_else(|| ImageGenerationError::ResponseError("No image data returned".into()))?;
+
+        let bytes = BASE64_STANDARD.decode(&first.b64_json).map_err(|e| {
+            ImageGenerationError::ResponseError(format!("Base64 decode error: {e}"))
+        })?;
+
+        Ok(image_generation::ImageGenerationResponse {
+            image: bytes,
+            response: value,
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct ImageGenerationModel<T = reqwest::Client> {
+    client: Client<T>,
+    /// Name of the model (e.g.: grok-imagine-image)
+    pub model: String,
+}
+
+impl<T> ImageGenerationModel<T> {
+    pub(crate) fn new(client: Client<T>, model: impl Into<String>) -> Self {
+        Self {
+            client,
+            model: model.into(),
+        }
+    }
+}
+
+impl<T> image_generation::ImageGenerationModel for ImageGenerationModel<T>
+where
+    T: HttpClientExt + Clone + Default + std::fmt::Debug + Send + 'static,
+{
+    type Response = ImageGenerationResponse;
+
+    type Client = Client<T>;
+
+    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
+        Self::new(client.clone(), model)
+    }
+
+    async fn image_generation(
+        &self,
+        generation_request: ImageGenerationRequest,
+    ) -> Result<image_generation::ImageGenerationResponse<Self::Response>, ImageGenerationError>
+    {
+        let mut request = json!({
+            "model": self.model,
+            "prompt": generation_request.prompt,
+            "response_format": "b64_json",
+            "aspect_ratio": "1:1",
+        });
+
+        if let Some(additional_params) = generation_request.additional_params {
+            merge_inplace(&mut request, additional_params);
+        }
+
+        let body = serde_json::to_vec(&request)?;
+
+        let request = self
+            .client
+            .post("/v1/images/generations")?
+            .body(body)
+            .map_err(|e| ImageGenerationError::HttpError(e.into()))?;
+
+        let response = self.client.send(request).await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = http_client::text(response).await?;
+
+            return Err(ImageGenerationError::ProviderError(format!(
+                "{}: {}",
+                status, text,
+            )));
+        }
+
+        let text = http_client::text(response).await?;
+
+        match serde_json::from_str::<ApiResponse<ImageGenerationResponse>>(&text)? {
+            ApiResponse::Ok(response) => response.try_into(),
+            ApiResponse::Error(err) => Err(ImageGenerationError::ProviderError(err.message())),
+        }
+    }
+}

--- a/rig/rig-core/src/providers/xai/mod.rs
+++ b/rig/rig-core/src/providers/xai/mod.rs
@@ -12,6 +12,8 @@
 mod api;
 pub mod client;
 pub mod completion;
+#[cfg(feature = "image")]
+pub mod image_generation;
 mod streaming;
 
 pub use client::Client;
@@ -19,3 +21,5 @@ pub use completion::{
     CompletionModel, CompletionResponse, GROK_2_1212, GROK_2_IMAGE_1212, GROK_2_VISION_1212,
     GROK_3, GROK_3_FAST, GROK_3_MINI, GROK_3_MINI_FAST, GROK_4,
 };
+#[cfg(feature = "image")]
+pub use image_generation::{GROK_IMAGINE_IMAGE, GROK_IMAGINE_IMAGE_PRO, ImageGenerationModel};


### PR DESCRIPTION
## Summary
- Add image generation support for xAI's Grok Imagine API (`grok-imagine-image` and `grok-imagine-image-pro` models)
- Implement `ImageGenerationModel` trait for the xAI provider, following the same pattern as OpenAI's implementation
- xAI uses `aspect_ratio` and `resolution` instead of pixel-based `size`, so these are passed via `additional_params` (defaults to `"1:1"` aspect ratio)

## Changes
- **`rig-core/src/providers/xai/image_generation.rs`** — New module implementing the `ImageGenerationModel` trait for xAI
- **`rig-core/src/providers/xai/mod.rs`** — Register and re-export the `image_generation` module (behind `image` feature flag)
- **`rig-core/src/providers/xai/client.rs`** — Change `ImageGeneration = Nothing` to `Capable<ImageGenerationModel<H>>`
- **`rig-core/examples/xai_image_generation.rs`** — Example demonstrating usage with custom resolution and aspect ratio

## Test plan
- [x] `cargo clippy --example xai_image_generation --features image` passes
- [x] `cargo test --lib -p rig-core` passes
- [x] Example runs successfully and produces a valid image

Fixes https://github.com/0xPlaygrounds/rig/issues/1517