### PR TITLE
feat(gemini): add Gemini 3 model constants and thinking_level support

### DIFF
--- a/rig/rig-core/examples/gemini_streaming.rs
+++ b/rig/rig-core/examples/gemini_streaming.rs
@@ -1,7 +1,7 @@
 use rig::agent::stream_to_stdout;
 use rig::prelude::*;
 use rig::providers::gemini::completion::gemini_api_types::{
-    AdditionalParameters, GenerationConfig, ThinkingConfig,
+    AdditionalParameters, GenerationConfig, ThinkingConfig, ThinkingLevel,
 };
 use rig::{
     providers::gemini::{self},
@@ -13,8 +13,8 @@ async fn main() -> Result<(), anyhow::Error> {
     tracing_subscriber::fmt().init();
     let gen_cfg = GenerationConfig {
         thinking_config: Some(ThinkingConfig {
-            thinking_budget: Some(2048),
-            thinking_level: None,
+            thinking_budget: None,
+            thinking_level: Some(ThinkingLevel::Medium),
             include_thoughts: Some(true),
         }),
         ..Default::default()
@@ -22,7 +22,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let cfg = AdditionalParameters::default().with_config(gen_cfg);
     // Create streaming agent with a single context prompt
     let agent = gemini::Client::from_env()
-        .agent(gemini::completion::GEMINI_2_0_FLASH)
+        .agent(gemini::completion::GEMINI_3_FLASH_PREVIEW)
         .preamble("Be precise and concise.")
         .temperature(0.5)
         .additional_params(serde_json::to_value(cfg).unwrap())

--- a/rig/rig-core/src/providers/gemini/completion.rs
+++ b/rig/rig-core/src/providers/gemini/completion.rs
@@ -1518,6 +1518,16 @@ pub mod gemini_api_types {
         }
     }
 
+    /// Thinking depth level for Gemini 3 models.
+    #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+    #[serde(rename_all = "snake_case")]
+    pub enum ThinkingLevel {
+        Minimal,
+        Low,
+        Medium,
+        High,
+    }
+
     /// Configuration for the model's thinking/reasoning process.
     /// Note: `thinking_budget` (Gemini 2.5) and `thinking_level` (Gemini 3) are mutually exclusive
     /// and cannot be set in the same request.
@@ -1528,9 +1538,8 @@ pub mod gemini_api_types {
         #[serde(skip_serializing_if = "Option::is_none")]
         pub thinking_budget: Option<u32>,
         /// Thinking depth level. Used by Gemini 3 models.
-        /// Values: "minimal", "low", "medium", "high".
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub thinking_level: Option<String>,
+        pub thinking_level: Option<ThinkingLevel>,
         /// When true, includes summarized versions of the model's reasoning in the response.
         #[serde(skip_serializing_if = "Option::is_none")]
         pub include_thoughts: Option<bool>,


### PR DESCRIPTION
## Summary

- Add model constants for Gemini 3 series (`GEMINI_3_FLASH_PREVIEW`, `GEMINI_3_1_FLASH_LITE_PREVIEW`)
- Add `thinking_level: Option<String>` field to `ThinkingConfig` for Gemini 3 models, which use `thinkingLevel` ("minimal", "low", "medium", "high") instead of Gemini 2.5's `thinkingBudget`
- Make `thinking_budget` optional (`Option<u32>`) so users can set either field depending on their model family
- Updated the example file to use new gemini model 

## Context

Gemini 3 models (released March 2026) use a different parameter for controlling reasoning depth. Per the [Gemini 3 Developer Guide](https://ai.google.dev/gemini-api/docs/gemini-3), `thinking_level` and `thinking_budget` are mutually exclusive and cannot be set in the same request.

Both fields use `skip_serializing_if = "Option::is_none"` so existing Gemini 2.5 configurations that set `thinking_budget` via `additional_params` JSON continue to work unchanged.

## Example usage

```rust
// Gemini 3
GenerationConfig {
    thinking_config: Some(ThinkingConfig {
        thinking_budget: None,
        thinking_level: Some("medium".to_string()),
        include_thoughts: Some(true),
    }),
    ..Default::default()
}

// Gemini 2.5 (unchanged)
GenerationConfig {
    thinking_config: Some(ThinkingConfig {
        thinking_budget: Some(2048),
        thinking_level: None,
        include_thoughts: Some(true),
    }),
    ..Default::default()
}
```

## Test plan

Tested with 

```rust
 .additional_params(serde_json::json!({
            "generationConfig": {
                "thinkingConfig": {
                    "thinking_level": "High",
                    "includeThoughts": true
                }
            }
        }))
```

and

```rust
let gen_cfg = GenerationConfig {
    thinking_config: Some(ThinkingConfig {
        thinking_budget: None,
        thinking_level: Some(ThinkingLevel::Medium),
        include_thoughts: Some(true),
    }),
    ..Default::default()
};
let cfg = AdditionalParameters::default().with_config(gen_cfg);
```