### PR TITLE
fix(llamafile): apply embedding Number->f64 conversion

### DIFF
--- a/rig/rig-core/src/providers/llamafile.rs
+++ b/rig/rig-core/src/providers/llamafile.rs
@@ -627,7 +627,11 @@ where
                         .zip(documents.into_iter())
                         .map(|(embedding, document)| embeddings::Embedding {
                             document,
-                            vec: embedding.embedding,
+                            vec: embedding
+                                .embedding
+                                .into_iter()
+                                .filter_map(|n| n.as_f64())
+                                .collect(),
                         })
                         .collect())
                 }


### PR DESCRIPTION
## Summary

- Applies the `Vec<serde_json::Number>` → `Vec<f64>` conversion to the llamafile provider's embedding implementation
- PR #1519 (llamafile provider) and #1518 (embedding `arbitrary_precision` fix) were developed in parallel — the llamafile provider reuses OpenAI's `EmbeddingData` type, whose `embedding` field changed from `Vec<f64>` to `Vec<serde_json::Number>` in #1518
- This is the same `into_iter().filter_map(|n| n.as_f64()).collect()` pattern used by all other providers