### PR TITLE
fix(openai): make strict field optional in StructuredOutputsInput

### DIFF
--- a/rig/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/rig/rig-core/src/providers/openai/responses_api/mod.rs
@@ -1075,6 +1075,7 @@ pub struct StructuredOutputsInput {
     /// Your required output schema. It is recommended that you use the JsonSchema macro, which you can check out at <https://docs.rs/schemars/latest/schemars/trait.JsonSchema.html>.
     pub schema: serde_json::Value,
     /// Enable strict output. If you are using your AI agent in a data pipeline or another scenario that requires the data to be absolutely fixed to a given schema, it is recommended to set this to true.
+    #[serde(default)]
     pub strict: bool,
 }
 


### PR DESCRIPTION
The strict field in StructuredOutputsInput was required during deserialization, causing JsonError when using models like Qwen3.5 via OpenRouter that don't include this field in responses.

Adding #[serde(default)] allows the field to default to false when not present, matching the intended behavior.

Fixes #1512