### PR TITLE
fix(openai): handle encrypted_content field in assistant messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4313,6 +4313,7 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3901269ec6d4f6068d3f09e5f02f995bd076398dcd1dfec407cd230b02d11b"
 dependencies = [
+ "earcutr",
  "float_next_after",
  "geo-types",
  "geographiclib-rs",
@@ -4324,6 +4325,7 @@ dependencies = [
  "rstar 0.12.2",
  "serde",
  "sif-itree",
+ "spade",
 ]
 
 [[package]]
@@ -5454,7 +5456,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core",
 ]
 
 [[package]]
@@ -11450,7 +11452,7 @@ dependencies = [
  "chrono",
  "flatbuffers",
  "futures",
- "geo 0.31.0",
+ "geo 0.32.0",
  "prost 0.14.3",
  "prost-types 0.14.3",
  "rust_decimal",
@@ -12167,6 +12169,22 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.23.36",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tungstenite 0.23.0",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
@@ -12579,6 +12597,26 @@ dependencies = [
  "sha1",
  "thiserror 1.0.69",
  "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "rustls 0.23.36",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 1.0.69",
  "utf-8",
 ]
 
@@ -13229,7 +13267,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -13241,19 +13279,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.61.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
-dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
+ "windows-core",
 ]
 
 [[package]]
@@ -13262,8 +13288,8 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -13275,20 +13301,9 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
  "windows-threading",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
 ]
 
 [[package]]
@@ -13296,17 +13311,6 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13342,7 +13346,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
 ]
 
@@ -13355,15 +13359,6 @@ dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/rig/rig-core/src/providers/groq.rs
+++ b/rig/rig-core/src/providers/groq.rs
@@ -792,7 +792,8 @@ where
             refusal: None,
             audio: None,
             name: None,
-            tool_calls
+            tool_calls,
+            additional_params: None,
         };
 
         span.record("gen_ai.output.messages", serde_json::to_string(&vec![response_message]).unwrap());

--- a/rig/rig-core/src/providers/openai/client.rs
+++ b/rig/rig-core/src/providers/openai/client.rs
@@ -527,6 +527,7 @@ mod tests {
             audio: None,
             name: None,
             tool_calls: vec![],
+            additional_params: None,
         };
 
         let converted_user_message: message::Message = user_message.clone().try_into().unwrap();

--- a/rig/rig-core/src/providers/openai/completion/mod.rs
+++ b/rig/rig-core/src/providers/openai/completion/mod.rs
@@ -169,6 +169,9 @@ pub enum Message {
             skip_serializing_if = "Vec::is_empty"
         )]
         tool_calls: Vec<ToolCall>,
+        /// Additional provider-specific fields (e.g., `encrypted_content` from some providers)
+        #[serde(flatten, skip_serializing_if = "Option::is_none")]
+        additional_params: Option<serde_json::Value>,
     },
     #[serde(rename = "tool")]
     ToolResult {
@@ -597,6 +600,7 @@ impl TryFrom<OneOrMany<message::AssistantContent>> for Vec<Message> {
                 .into_iter()
                 .map(|tool_call| tool_call.into())
                 .collect::<Vec<_>>(),
+            additional_params: None,
         }])
     }
 }
@@ -1519,5 +1523,63 @@ mod tests {
         });
 
         assert!(matches!(result, Err(CompletionError::RequestError(_))));
+    }
+
+    #[test]
+    fn test_assistant_message_with_encrypted_content_deserializes() {
+        // Regression test for issue #1515: some providers (e.g., Doubao) return
+        // encrypted_content field in the assistant message which should be handled
+        // gracefully via additional_params.
+        let json = r#"{
+            "role": "assistant",
+            "content": [{"type": "text", "text": "Hello"}],
+            "encrypted_content": "some_encrypted_data"
+        }"#;
+
+        let message: Message =
+            serde_json::from_str(json).expect("should deserialize with encrypted_content");
+
+        match message {
+            Message::Assistant {
+                content,
+                additional_params,
+                ..
+            } => {
+                assert_eq!(content.len(), 1);
+                assert!(additional_params.is_some());
+                let params = additional_params.unwrap();
+                assert_eq!(
+                    params.get("encrypted_content").unwrap(),
+                    "some_encrypted_data"
+                );
+            }
+            _ => panic!("expected assistant message"),
+        }
+    }
+
+    #[test]
+    fn test_assistant_message_with_unknown_fields_deserializes() {
+        // Test that any unknown fields are captured in additional_params
+        let json = r#"{
+            "role": "assistant",
+            "content": [{"type": "text", "text": "Hello"}],
+            "custom_field": "custom_value",
+            "another_field": 123
+        }"#;
+
+        let message: Message =
+            serde_json::from_str(json).expect("should deserialize with unknown fields");
+
+        match message {
+            Message::Assistant {
+                additional_params, ..
+            } => {
+                assert!(additional_params.is_some());
+                let params = additional_params.unwrap();
+                assert_eq!(params.get("custom_field").unwrap(), "custom_value");
+                assert_eq!(params.get("another_field").unwrap(), 123);
+            }
+            _ => panic!("expected assistant message"),
+        }
     }
 }

--- a/rig/rig-core/src/providers/openrouter/completion.rs
+++ b/rig/rig-core/src/providers/openrouter/completion.rs
@@ -1356,6 +1356,7 @@ impl From<openai::Message> for Message {
                 audio,
                 name,
                 tool_calls,
+                ..
             } => Self::Assistant {
                 content,
                 refusal,


### PR DESCRIPTION
Fixes #1515

## Problem
Some providers (e.g., Doubao/ByteDance) return an "encrypted_content" field in assistant messages that wasn't handled by the OpenAI completion API client, causing a JSON deserialization error.

## Solution
Added an `additional_params` field with `#[serde(flatten)]` to the `Message::Assistant` variant to capture any provider-specific fields, making deserialization flexible and forward-compatible.

## Changes
- Added `additional_params: Option<serde_json::Value>` to `Message::Assistant`
- Updated all code constructing/pattern-matching on `Message::Assistant`
- Added regression tests for `encrypted_content` and unknown field handling

## Testing
- All 441 tests pass
- Clippy and fmt checks pass