### PR TITLE
feat(providers): add grok xAI TTS

### DIFF
--- a/rig/rig-core/Cargo.toml
+++ b/rig/rig-core/Cargo.toml
@@ -183,6 +183,10 @@ name = "hyperbolic_audio_generation"
 required-features = ["audio"]
 
 [[example]]
+name = "xai_audio_generation"
+required-features = ["audio"]
+
+[[example]]
 name = "mistral_embeddings"
 required-features = ["derive"]
 

--- a/rig/rig-core/examples/xai_audio_generation.rs
+++ b/rig/rig-core/examples/xai_audio_generation.rs
@@ -1,0 +1,41 @@
+use rig::audio_generation::AudioGenerationModel;
+use rig::client::audio_generation::AudioGenerationClient;
+use rig::prelude::*;
+use rig::providers::xai;
+use serde_json::json;
+use std::env::args;
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+const DEFAULT_PATH: &str = "./output.wav";
+
+#[tokio::main]
+async fn main() {
+    let arguments: Vec<String> = args().collect();
+
+    let path = if arguments.len() > 1 {
+        arguments[1].clone()
+    } else {
+        DEFAULT_PATH.to_string()
+    };
+
+    let path = Path::new(&path);
+    let mut file = File::create_new(path).expect("Failed to create file");
+
+    let client = xai::Client::from_env();
+    let tts = client.audio_generation_model(xai::TTS_1);
+
+    let response = tts
+        .audio_generation_request()
+        .text("The quick brown fox jumps over the lazy dog")
+        .voice("eve")
+        .additional_params(json!({
+            "language": "en",
+        }))
+        .send()
+        .await
+        .expect("Failed to generate audio");
+
+    let _ = file.write(&response.audio);
+}

--- a/rig/rig-core/src/providers/xai/audio_generation.rs
+++ b/rig/rig-core/src/providers/xai/audio_generation.rs
@@ -1,0 +1,89 @@
+use crate::audio_generation::{
+    self, AudioGenerationError, AudioGenerationRequest, AudioGenerationResponse,
+};
+use crate::http_client::{self, HttpClientExt};
+use crate::json_utils::merge_inplace;
+use crate::providers::xai::Client;
+use bytes::Bytes;
+use serde_json::json;
+
+// ================================================================
+// xAI TTS API
+// ================================================================
+pub const TTS_1: &str = "tts-1";
+
+#[derive(Clone)]
+pub struct AudioGenerationModel<T = reqwest::Client> {
+    client: Client<T>,
+    pub model: String,
+}
+
+impl<T> AudioGenerationModel<T> {
+    pub(crate) fn new(client: Client<T>, model: impl Into<String>) -> Self {
+        Self {
+            client,
+            model: model.into(),
+        }
+    }
+}
+
+impl<T> audio_generation::AudioGenerationModel for AudioGenerationModel<T>
+where
+    T: HttpClientExt + Clone + std::fmt::Debug + Default + 'static,
+{
+    type Response = Bytes;
+
+    type Client = Client<T>;
+
+    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
+        Self::new(client.clone(), model)
+    }
+
+    async fn audio_generation(
+        &self,
+        request: AudioGenerationRequest,
+    ) -> Result<AudioGenerationResponse<Self::Response>, AudioGenerationError> {
+        let voice = if request.voice.is_empty() {
+            "eve".to_string()
+        } else {
+            request.voice
+        };
+
+        let mut body = json!({
+            "text": request.text,
+            "voice_id": voice,
+            "language": "en",
+        });
+
+        if let Some(additional_params) = request.additional_params {
+            merge_inplace(&mut body, additional_params);
+        }
+
+        let body = serde_json::to_vec(&body)?;
+
+        let req = self
+            .client
+            .post("/v1/tts")?
+            .body(body)
+            .map_err(http_client::Error::from)?;
+
+        let response = self.client.send(req).await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = http_client::text(response).await?;
+
+            return Err(AudioGenerationError::ProviderError(format!(
+                "{}: {}",
+                status, text,
+            )));
+        }
+
+        let bytes: Bytes = response.into_body().await?.into();
+
+        Ok(AudioGenerationResponse {
+            audio: bytes.to_vec(),
+            response: bytes,
+        })
+    }
+}

--- a/rig/rig-core/src/providers/xai/client.rs
+++ b/rig/rig-core/src/providers/xai/client.rs
@@ -33,7 +33,7 @@ impl<H> Capabilities<H> for XAiExt {
     #[cfg(feature = "image")]
     type ImageGeneration = Capable<super::image_generation::ImageGenerationModel<H>>;
     #[cfg(feature = "audio")]
-    type AudioGeneration = Nothing;
+    type AudioGeneration = Capable<super::audio_generation::AudioGenerationModel<H>>;
 }
 
 impl DebugExt for XAiExt {}

--- a/rig/rig-core/src/providers/xai/mod.rs
+++ b/rig/rig-core/src/providers/xai/mod.rs
@@ -10,12 +10,16 @@
 //! ```
 
 mod api;
+#[cfg(feature = "audio")]
+pub mod audio_generation;
 pub mod client;
 pub mod completion;
 #[cfg(feature = "image")]
 pub mod image_generation;
 mod streaming;
 
+#[cfg(feature = "audio")]
+pub use audio_generation::{AudioGenerationModel, TTS_1};
 pub use client::Client;
 pub use completion::{
     CompletionModel, CompletionResponse, GROK_2_1212, GROK_2_IMAGE_1212, GROK_2_VISION_1212,


### PR DESCRIPTION
## Summary

Adds text-to-speech (TTS) support for the xAI provider.

- Implements `AudioGenerationModel` for xAI using the `/v1/tts` endpoint
- Declares `AudioGeneration` as `Capable` in xAI's `Capabilities`
- Exports `TTS_1` model constant and `AudioGenerationModel`
- Adds `xai_audio_generation` example demonstrating usage

Fixes #1531