### PR TITLE
fix: skip serializing encrypted_content when None

### DIFF
--- a/rig/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/rig/rig-core/src/providers/openai/responses_api/mod.rs
@@ -176,6 +176,7 @@ pub enum InputContent {
 pub struct OpenAIReasoning {
     id: String,
     pub summary: Vec<ReasoningSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub encrypted_content: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<ToolStatus>,


### PR DESCRIPTION
## Summary

Fixes #1515

Some providers (e.g., doubao-seed-2-0-pro) don't recognize the `encrypted_content` field in reasoning input items and reject requests with "unknown field" errors.

## Problem

When using the OpenAI-compatible Responses API with certain providers (like doubao-seed-2-0-pro), the API returns reasoning items that include an `encrypted_content` field. When these items are sent back as input in subsequent requests, providers that don't support this field reject the request with:

```
The parameter `input` specified in the request are not valid: `json: unknown field "encrypted_content"`
```

## Solution

Add `#[serde(skip_serializing_if = "Option::is_none")]` to the `encrypted_content` field in `OpenAIReasoning` to ensure the field is omitted from serialized JSON when it is `None`.

## Changes

- `rig/rig-core/src/providers/openai/responses_api/mod.rs`: Added `skip_serializing_if` attribute to `encrypted_content` field

## Testing

This change is backwards compatible:
- When `encrypted_content` has a value, it is serialized normally
- When `encrypted_content` is `None`, the field is omitted, preventing "unknown field" errors with providers that don't support it