### PR TITLE
fix(gemini): infer string type for enum schemas in anyOf/oneOf

### DIFF
--- a/rig/rig-core/src/providers/gemini/completion.rs
+++ b/rig/rig-core/src/providers/gemini/completion.rs
@@ -1744,6 +1744,9 @@ pub mod gemini_api_types {
                     obj.get("type").and_then(extract_type).or_else(|| {
                         if obj.contains_key("properties") {
                             Some("object".to_string())
+                        } else if obj.contains_key("enum") {
+                            // Enum schemas without explicit type are string-backed
+                            Some("string".to_string())
                         } else {
                             None
                         }


### PR DESCRIPTION
Fixes #1540

## Description

Schema conversion for `Option<enum>` fields (anyOf/oneOf containing objects with an `enum` key) was producing an empty type string, causing a 400 Bad Request from the Gemini API.

The root cause is in `extract_type_from_composition`: when iterating over anyOf/oneOf schemas, it checks for an explicit `type` field and `properties`, but not for the `enum` key. Enum schemas without an explicit type were falling through to `None` and ultimately returning an empty string.

The fix adds an `else if obj.contains_key("enum")` branch that returns `"string"`.

## Changes

- `rig-core/src/providers/gemini/completion.rs`: Added `enum` key check in `extract_type_from_composition` to return `"string"`

## Testing

`cargo test -p rig-core --lib` passes (439 tests).