### PR TITLE
Fix(gemini): Make `prompt_token_count` optional in gemini response

### DIFF
--- a/rig/rig-core/src/providers/gemini/completion.rs
+++ b/rig/rig-core/src/providers/gemini/completion.rs
@@ -503,7 +503,7 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse<Generat
             .usage_metadata
             .as_ref()
             .map(|usage| completion::Usage {
-                input_tokens: usage.prompt_token_count.unwrap_or(0) as u64,
+                input_tokens: usage.prompt_token_count as u64,
                 output_tokens: usage.candidates_token_count.unwrap_or(0) as u64,
                 total_tokens: usage.total_token_count as u64,
                 cached_input_tokens: 0,
@@ -1300,8 +1300,8 @@ pub mod gemini_api_types {
     #[derive(Debug, Deserialize, Clone, Default, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct UsageMetadata {
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub prompt_token_count: Option<i32>,
+        #[serde(default)]
+        pub prompt_token_count: i32,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub cached_content_token_count: Option<i32>,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -1316,10 +1316,7 @@ pub mod gemini_api_types {
             write!(
                 f,
                 "Prompt token count: {}\nCached content token count: {}\nCandidates token count: {}\nTotal token count: {}",
-                match self.prompt_token_count {
-                    Some(count) => count.to_string(),
-                    None => "n/a".to_string(),
-                },
+                self.prompt_token_count,
                 match self.cached_content_token_count {
                     Some(count) => count.to_string(),
                     None => "n/a".to_string(),
@@ -1337,7 +1334,7 @@ pub mod gemini_api_types {
         fn token_usage(&self) -> Option<crate::completion::Usage> {
             let mut usage = crate::completion::Usage::new();
 
-            usage.input_tokens = self.prompt_token_count.unwrap_or_default() as u64;
+            usage.input_tokens = self.prompt_token_count as u64;
             usage.output_tokens = (self.cached_content_token_count.unwrap_or_default()
                 + self.candidates_token_count.unwrap_or_default()
                 + self.thoughts_token_count.unwrap_or_default())

--- a/rig/rig-core/src/providers/gemini/completion.rs
+++ b/rig/rig-core/src/providers/gemini/completion.rs
@@ -503,7 +503,7 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse<Generat
             .usage_metadata
             .as_ref()
             .map(|usage| completion::Usage {
-                input_tokens: usage.prompt_token_count as u64,
+                input_tokens: usage.prompt_token_count.unwrap_or(0) as u64,
                 output_tokens: usage.candidates_token_count.unwrap_or(0) as u64,
                 total_tokens: usage.total_token_count as u64,
                 cached_input_tokens: 0,
@@ -1300,7 +1300,8 @@ pub mod gemini_api_types {
     #[derive(Debug, Deserialize, Clone, Default, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct UsageMetadata {
-        pub prompt_token_count: i32,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub prompt_token_count: Option<i32>,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub cached_content_token_count: Option<i32>,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -1315,7 +1316,10 @@ pub mod gemini_api_types {
             write!(
                 f,
                 "Prompt token count: {}\nCached content token count: {}\nCandidates token count: {}\nTotal token count: {}",
-                self.prompt_token_count,
+                match self.prompt_token_count {
+                    Some(count) => count.to_string(),
+                    None => "n/a".to_string(),
+                },
                 match self.cached_content_token_count {
                     Some(count) => count.to_string(),
                     None => "n/a".to_string(),
@@ -1333,7 +1337,7 @@ pub mod gemini_api_types {
         fn token_usage(&self) -> Option<crate::completion::Usage> {
             let mut usage = crate::completion::Usage::new();
 
-            usage.input_tokens = self.prompt_token_count as u64;
+            usage.input_tokens = self.prompt_token_count.unwrap_or_default() as u64;
             usage.output_tokens = (self.cached_content_token_count.unwrap_or_default()
                 + self.candidates_token_count.unwrap_or_default()
                 + self.thoughts_token_count.unwrap_or_default())

--- a/rig/rig-core/src/providers/gemini/streaming.rs
+++ b/rig/rig-core/src/providers/gemini/streaming.rs
@@ -25,14 +25,15 @@ pub struct PartialUsage {
     pub candidates_token_count: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub thoughts_token_count: Option<i32>,
-    pub prompt_token_count: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_token_count: Option<i32>,
 }
 
 impl GetTokenUsage for PartialUsage {
     fn token_usage(&self) -> Option<crate::completion::Usage> {
         let mut usage = crate::completion::Usage::new();
 
-        usage.input_tokens = self.prompt_token_count as u64;
+        usage.input_tokens = self.prompt_token_count.unwrap_or_default() as u64;
         usage.output_tokens = (self.cached_content_token_count.unwrap_or_default()
             + self.candidates_token_count.unwrap_or_default()
             + self.thoughts_token_count.unwrap_or_default()) as u64;
@@ -65,7 +66,7 @@ impl GetTokenUsage for StreamingCompletionResponse {
             .candidates_token_count
             .map(|x| x as u64)
             .unwrap_or(0);
-        usage.input_tokens = self.usage_metadata.prompt_token_count as u64;
+        usage.input_tokens = self.usage_metadata.prompt_token_count.unwrap_or(0) as u64;
         Some(usage)
     }
 }
@@ -515,7 +516,7 @@ mod tests {
             cached_content_token_count: Some(20),
             candidates_token_count: Some(30),
             thoughts_token_count: Some(10),
-            prompt_token_count: 40,
+            prompt_token_count: Some(40),
         };
 
         let token_usage = usage.token_usage().unwrap();
@@ -531,7 +532,7 @@ mod tests {
             cached_content_token_count: None,
             candidates_token_count: Some(30),
             thoughts_token_count: None,
-            prompt_token_count: 20,
+            prompt_token_count: Some(20),
         };
 
         let token_usage = usage.token_usage().unwrap();
@@ -548,7 +549,7 @@ mod tests {
                 cached_content_token_count: None,
                 candidates_token_count: Some(75),
                 thoughts_token_count: None,
-                prompt_token_count: 75,
+                prompt_token_count: Some(75),
             },
         };
 

--- a/rig/rig-core/src/providers/gemini/streaming.rs
+++ b/rig/rig-core/src/providers/gemini/streaming.rs
@@ -25,15 +25,15 @@ pub struct PartialUsage {
     pub candidates_token_count: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub thoughts_token_count: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub prompt_token_count: Option<i32>,
+    #[serde(default)]
+    pub prompt_token_count: i32,
 }
 
 impl GetTokenUsage for PartialUsage {
     fn token_usage(&self) -> Option<crate::completion::Usage> {
         let mut usage = crate::completion::Usage::new();
 
-        usage.input_tokens = self.prompt_token_count.unwrap_or_default() as u64;
+        usage.input_tokens = self.prompt_token_count as u64;
         usage.output_tokens = (self.cached_content_token_count.unwrap_or_default()
             + self.candidates_token_count.unwrap_or_default()
             + self.thoughts_token_count.unwrap_or_default()) as u64;
@@ -66,7 +66,7 @@ impl GetTokenUsage for StreamingCompletionResponse {
             .candidates_token_count
             .map(|x| x as u64)
             .unwrap_or(0);
-        usage.input_tokens = self.usage_metadata.prompt_token_count.unwrap_or(0) as u64;
+        usage.input_tokens = self.usage_metadata.prompt_token_count as u64;
         Some(usage)
     }
 }
@@ -516,7 +516,7 @@ mod tests {
             cached_content_token_count: Some(20),
             candidates_token_count: Some(30),
             thoughts_token_count: Some(10),
-            prompt_token_count: Some(40),
+            prompt_token_count: 40,
         };
 
         let token_usage = usage.token_usage().unwrap();
@@ -532,7 +532,7 @@ mod tests {
             cached_content_token_count: None,
             candidates_token_count: Some(30),
             thoughts_token_count: None,
-            prompt_token_count: Some(20),
+            prompt_token_count: 20,
         };
 
         let token_usage = usage.token_usage().unwrap();
@@ -549,7 +549,7 @@ mod tests {
                 cached_content_token_count: None,
                 candidates_token_count: Some(75),
                 thoughts_token_count: None,
-                prompt_token_count: Some(75),
+                prompt_token_count: 75,
             },
         };
 


### PR DESCRIPTION
Sometimes, gemini doesn't return the field `UsageMetadata.prompt_token_count` or `PartialUsage.prompt_token_count`. Since those structs are expecting this field to be set, this results in a de-serialization error. The completion request should not fail if this field is not returned - set it to 0 if it's not present.

## Implementation
Uses `#[serde(default)]` instead of setting `prompt_token_count` to `Optional` to prevent breaking changes