### PR TITLE
fix: add Unknown variant to Output enum for web_search_call support

### DIFF
--- a/rig/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/rig/rig-core/src/providers/openai/responses_api/mod.rs
@@ -1179,6 +1179,8 @@ pub enum Output {
         #[serde(default)]
         status: Option<ToolStatus>,
     },
+    #[serde(other)]
+    Unknown,
 }
 
 impl From<Output> for Vec<completion::AssistantContent> {
@@ -1221,6 +1223,7 @@ impl From<Output> for Vec<completion::AssistantContent> {
                     },
                 )]
             }
+            Output::Unknown => Vec::new(),
         };
 
         res

--- a/rig/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/rig/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -357,6 +357,10 @@ where
                                         StreamingItemDoneOutput { item: Output::Message(msg), .. } => {
                                             yield Ok(streaming::RawStreamingChoice::MessageId(msg.id.clone()));
                                         }
+                                        StreamingItemDoneOutput { item: Output::Unknown, .. } => {
+                                            // Unknown output types (e.g. web_search_call, file_search_call)
+                                            // are silently skipped so they don't break usage tracking
+                                        }
                                     }
                                 }
                                 ItemChunkKind::OutputTextDelta(delta) => {


### PR DESCRIPTION
The `Output` enum in the OpenAI Responses API module was missing a catch-all variant for unknown output types like `web_search_call`. When OpenAI returns a `response.completed` event containing a `web_search_call` item, serde failed to deserialize the entire `CompletionResponse` (including the `usage` field) because it had no matching variant.

This caused streaming usage tracking to report 0 tokens since the deserialization error was silently caught and skipped.

Added `#[serde(other)] Unknown` variant to the `Output` enum and handled it in both the `From<Output>` conversion and the streaming `ItemChunkKind::OutputItemDone` match arm so unknown output types are skipped without breaking usage tracking or deserialization.

Fixes #1546