### PR TITLE
fix: #1559 include assistant text in chat_history during multi-turn streaming

### DIFF
--- a/rig/rig-core/src/agent/prompt_request/streaming.rs
+++ b/rig/rig-core/src/agent/prompt_request/streaming.rs
@@ -608,10 +608,16 @@ where
                     accumulated_reasoning.push(assembled);
                 }
 
-                // Add reasoning and tool calls to chat history.
+                // Add text, reasoning, and tool calls to chat history.
                 // OpenAI Responses API requires reasoning items to precede function_call items.
                 if !tool_calls.is_empty() || !accumulated_reasoning.is_empty() {
                     let mut content_items: Vec<rig::message::AssistantContent> = vec![];
+
+                    // Text before tool calls so the model sees its own prior output
+                    if !last_text_response.is_empty() {
+                        content_items.push(rig::message::AssistantContent::text(&last_text_response));
+                        last_text_response.clear();
+                    }
 
                     // Reasoning must come before tool calls (OpenAI requirement)
                     for reasoning in accumulated_reasoning.drain(..) {


### PR DESCRIPTION
  ## Summary

  - When using `stream_prompt` with tools, the assistant's text output was dropped
    from `chat_history` between turns, causing the model to repeat itself because
    it couldn't see its own prior output
  - The agent loop manually reconstructs the assistant message from separate
    accumulators (reasoning, tool calls) rather than using the stream's
    already-assembled `choice` — text was missed in this reconstruction
  - The non-streaming path doesn't have this bug because it pushes the complete
    `resp.choice` into history as a unit

  ## Fix

  Include `last_text_response` as an `AssistantContent::Text` item in the assistant
  message alongside reasoning and tool calls, and clear it after committing to
  history.

  A more thorough fix would refactor the agent loop to use `stream.choice` instead
  of parallel accumulators, eliminating the class of bug entirely. That's a larger
  change and could be a follow-up.

  ## Test plan

  - [x] Existing `cargo test` suite passes (466 tests, 0 failures)
  - [x] `cargo fmt` and `cargo clippy --all-features --all-targets` clean (no new warnings)
  - [x] Verified manually with a streaming agent that emits text before tool calls:
        model no longer repeats itself across turns

  Fixes #1559

  This PR was generated with AI assistance (Claude).

  🤖 Generated with [Claude Code](https://claude.com/claude-code)
