### PR TITLE
feat: make history generic and immutable

### DIFF
--- a/rig/rig-core/Cargo.toml
+++ b/rig/rig-core/Cargo.toml
@@ -63,7 +63,9 @@ reqwest-middleware = { version = "0.5.1", optional = true, features = [
 # Native-only dependency for OpenAI Responses websocket mode.
 # Keeping it target-scoped avoids pulling a tokio socket transport into wasm builds.
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-tokio-tungstenite = { version = "0.23.1", features = ["rustls-tls-webpki-roots"] }
+tokio-tungstenite = { version = "0.23.1", features = [
+  "rustls-tls-webpki-roots",
+] }
 
 [dev-dependencies]
 anyhow = { workspace = true }
@@ -134,6 +136,9 @@ reqwest-middleware-rustls = ["reqwest-middleware", "reqwest-middleware/rustls"]
 [[test]]
 name = "embed_macro"
 required-features = ["derive"]
+
+[[example]]
+name = "context_fold"
 
 [[example]]
 name = "rag"

--- a/rig/rig-core/Cargo.toml
+++ b/rig/rig-core/Cargo.toml
@@ -138,9 +138,6 @@ name = "embed_macro"
 required-features = ["derive"]
 
 [[example]]
-name = "context_fold"
-
-[[example]]
 name = "rag"
 required-features = ["derive"]
 

--- a/rig/rig-core/examples/agent_stream_chat.rs
+++ b/rig/rig-core/examples/agent_stream_chat.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), anyhow::Error> {
     ];
 
     // Prompt the agent and print the response
-    let mut stream = comedian_agent.stream_chat("Entertain me!", messages).await;
+    let mut stream = comedian_agent.stream_chat("Entertain me!", &messages).await;
 
     let res = stream_to_stdout(&mut stream).await.unwrap();
 

--- a/rig/rig-core/examples/anthropic_think_tool_with_other_tools.rs
+++ b/rig/rig-core/examples/anthropic_think_tool_with_other_tools.rs
@@ -275,19 +275,22 @@ async fn main() -> Result<(), anyhow::Error> {
                  Lastly, how much would it cost to buy product A + 2 product B with slow shipping?
                  ";
 
-    let mut chat_history: Vec<Message> = Vec::new();
+    let empty_history: &[Message] = &[];
     let resp = agent
         .prompt(prompt)
-        .with_history(&mut chat_history)
+        .with_history(empty_history)
         .max_turns(10)
+        .extended_details()
         .await?;
 
     println!("Chat history:");
-    for entry in &chat_history {
-        println!("{}\n", serde_json::to_string_pretty(entry).unwrap());
+    if let Some(messages) = &resp.messages {
+        for entry in messages.clone().into_iter() {
+            println!("{}\n", serde_json::to_string_pretty(&entry).unwrap());
+        }
     }
 
-    println!("\n\nResponse: {}", resp);
+    println!("\n\nResponse: {}", resp.output);
 
     Ok(())
 }

--- a/rig/rig-core/examples/complex_agentic_loop_claude.rs
+++ b/rig/rig-core/examples/complex_agentic_loop_claude.rs
@@ -166,37 +166,39 @@ async fn main() -> Result<(), anyhow::Error> {
     println!("Query: {}", query);
     println!("\nProcessing...\n");
 
-    // Store chat history to track the agentic loop
-    let mut chat_history: Vec<Message> = Vec::new();
-
-    // Send the query to the orchestrator agent
+    // Send the query to the orchestrator agent with extended details to get chat history
+    let empty_history: &[Message] = &[];
     let response = orchestrator_agent
         .prompt(query)
-        .with_history(&mut chat_history)
+        .with_history(empty_history)
         .max_turns(15) // Allow multiple turns to demonstrate the complex loop
+        .extended_details()
         .await?;
 
     // Print the final response
-    println!("\nFinal Response:\n{}", response);
+    println!("\nFinal Response:\n{}", response.output);
 
     // Print the chat history to show the agentic loop
     println!("\nAgentic Loop Details:");
-    for (i, message) in chat_history.iter().enumerate() {
-        match message {
-            Message::User { content } => println!(
-                "\nUser [{}]: {}",
-                i,
-                serde_json::to_string_pretty(content).expect("Failed to serialize user message")
-            ),
-            Message::Assistant { content, .. } => println!(
-                "Assistant [{}]: {}",
-                i,
-                serde_json::to_string_pretty(content)
-                    .expect("Failed to serialize assistant message")
-            ),
-            _ => {
-                // Ignore other message types - the only other type of message that exists is system messages
-                // which can be ignored
+    if let Some(messages) = &response.messages {
+        for (i, message) in messages.clone().into_iter().enumerate() {
+            match message {
+                Message::User { content } => println!(
+                    "\nUser [{}]: {}",
+                    i,
+                    serde_json::to_string_pretty(&content)
+                        .expect("Failed to serialize user message")
+                ),
+                Message::Assistant { content, .. } => println!(
+                    "Assistant [{}]: {}",
+                    i,
+                    serde_json::to_string_pretty(&content)
+                        .expect("Failed to serialize assistant message")
+                ),
+                _ => {
+                    // Ignore other message types - the only other type of message that exists is system messages
+                    // which can be ignored
+                }
             }
         }
     }

--- a/rig/rig-core/examples/debate.rs
+++ b/rig/rig-core/examples/debate.rs
@@ -46,18 +46,30 @@ impl Debater {
             let resp_a = self
                 .gpt_4
                 .prompt(prompt_a.as_str())
-                .with_history(&mut history_a)
+                .with_history(&history_a)
+                .extended_details()
                 .await?;
-            println!("GPT-4:\n{resp_a}");
+            // Extract updated history for next iteration
+            history_a = resp_a
+                .messages
+                .map(|m| m.into_iter().collect())
+                .unwrap_or_default();
+            println!("GPT-4:\n{}", resp_a.output);
             println!("================================================================");
             let resp_b = self
                 .coral
-                .prompt(resp_a.as_str())
-                .with_history(&mut history_b)
+                .prompt(resp_a.output.as_str())
+                .with_history(&history_b)
+                .extended_details()
                 .await?;
-            println!("Coral:\n{resp_b}");
+            // Extract updated history for next iteration
+            history_b = resp_b
+                .messages
+                .map(|m| m.into_iter().collect())
+                .unwrap_or_default();
+            println!("Coral:\n{}", resp_b.output);
             println!("================================================================");
-            last_resp_b = Some(resp_b)
+            last_resp_b = Some(resp_b.output)
         }
         Ok(())
     }

--- a/rig/rig-core/examples/deepseek_streaming.rs
+++ b/rig/rig-core/examples/deepseek_streaming.rs
@@ -2,7 +2,11 @@ use rig::agent::stream_to_stdout;
 use rig::prelude::*;
 use rig::providers::deepseek::DEEPSEEK_CHAT;
 use rig::streaming::{StreamingChat, StreamingPrompt};
-use rig::{completion::ToolDefinition, providers, tool::Tool};
+use rig::{
+    completion::{Message, ToolDefinition},
+    providers,
+    tool::Tool,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
@@ -35,8 +39,9 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Prompt the agent and print the response
     println!("Calculate 2 - 5");
+    let empty_history: &[Message] = &[];
     let mut answer = calculator_agent
-        .stream_chat("Calculate 2 - 5", vec![])
+        .stream_chat("Calculate 2 - 5", empty_history)
         .await;
     print!("DeepSeek Calculator Agent Stream ");
     stream_to_stdout(&mut answer).await?;

--- a/rig/rig-core/examples/multi_agent.rs
+++ b/rig/rig-core/examples/multi_agent.rs
@@ -4,7 +4,7 @@ use rig::prelude::*;
 use rig::providers::openai;
 use rig::{
     agent::{Agent, AgentBuilder},
-    completion::{Chat, CompletionModel, PromptError, ToolDefinition},
+    completion::{Chat, CompletionModel, Message, PromptError, ToolDefinition},
     providers::openai::Client as OpenAIClient,
     tool::Tool,
 };
@@ -21,7 +21,7 @@ struct TranslatorArgs {
     prompt: String,
 }
 
-impl<M: CompletionModel> Tool for TranslatorTool<M> {
+impl<M: CompletionModel + 'static> Tool for TranslatorTool<M> {
     const NAME: &'static str = "translator";
 
     type Args = TranslatorArgs;
@@ -47,7 +47,8 @@ impl<M: CompletionModel> Tool for TranslatorTool<M> {
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
-        match self.0.chat(&args.prompt, vec![]).await {
+        let empty_history: &[Message] = &[];
+        match self.0.chat(&args.prompt, empty_history).await {
             Ok(response) => {
                 println!("Translated prompt: {response}");
                 Ok(response)

--- a/rig/rig-core/examples/multi_turn_streaming_gemini.rs
+++ b/rig/rig-core/examples/multi_turn_streaming_gemini.rs
@@ -82,7 +82,7 @@ where
 
         'outer: loop {
             let mut stream = agent
-                .stream_completion(current_prompt.clone(), chat_history.clone())
+                .stream_completion(current_prompt.clone(), &chat_history)
                 .await?
                 .stream()
                 .await?;

--- a/rig/rig-core/examples/reasoning_loop.rs
+++ b/rig/rig-core/examples/reasoning_loop.rs
@@ -26,11 +26,11 @@ struct ReasoningAgent<M: CompletionModel> {
     executor: Agent<M>,
 }
 
-impl<M: CompletionModel> Prompt for ReasoningAgent<M> {
+impl<M: CompletionModel + 'static> Prompt for ReasoningAgent<M> {
     #[allow(refining_impl_trait)]
     async fn prompt(&self, prompt: impl Into<Message> + Send) -> Result<String, PromptError> {
         let prompt: Message = prompt.into();
-        let mut chat_history = vec![prompt.clone()];
+        let chat_history = vec![prompt.clone()];
         let extracted = self
             .chain_of_thought_extractor
             .extract(prompt)
@@ -49,14 +49,18 @@ impl<M: CompletionModel> Prompt for ReasoningAgent<M> {
         let response = self
             .executor
             .prompt(reasoning_prompt.as_str())
-            .with_history(&mut chat_history)
+            .with_history(&chat_history)
             .max_turns(20)
+            .extended_details()
             .await?;
-        tracing::info!(
-            "full chat history generated: {}",
-            serde_json::to_string_pretty(&chat_history).unwrap()
-        );
-        Ok(response)
+        if let Some(messages) = &response.messages {
+            let history_vec: Vec<_> = messages.clone().into_iter().collect();
+            tracing::info!(
+                "full chat history generated: {}",
+                serde_json::to_string_pretty(&history_vec).unwrap()
+            );
+        }
+        Ok(response.output)
     }
 }
 

--- a/rig/rig-core/src/agent/completion.rs
+++ b/rig/rig-core/src/agent/completion.rs
@@ -32,7 +32,7 @@ pub type DynamicContextStore = Arc<
 pub(crate) async fn build_completion_request<M: CompletionModel>(
     model: &Arc<M>,
     prompt: Message,
-    chat_history: Vec<Message>,
+    chat_history: &[Message],
     preamble: Option<&str>,
     static_context: &[Document],
     temperature: Option<f64>,
@@ -52,13 +52,13 @@ pub(crate) async fn build_completion_request<M: CompletionModel>(
             .find_map(|message| message.rag_text())
     });
 
-    let chat_history = if let Some(preamble) = preamble {
-        let mut with_system = Vec::with_capacity(chat_history.len() + 1);
-        with_system.push(Message::system(preamble.to_owned()));
-        with_system.extend(chat_history);
-        with_system
+    // Prepend preamble as system message if present
+    let chat_history: Vec<Message> = if let Some(preamble) = preamble {
+        std::iter::once(Message::system(preamble.to_owned()))
+            .chain(chat_history.iter().cloned())
+            .collect()
     } else {
-        chat_history
+        chat_history.to_vec()
     };
 
     let completion_request = model
@@ -211,15 +211,20 @@ where
     M: CompletionModel,
     P: PromptHook<M>,
 {
-    async fn completion(
+    async fn completion<I, T>(
         &self,
         prompt: impl Into<Message> + WasmCompatSend,
-        chat_history: Vec<Message>,
-    ) -> Result<CompletionRequestBuilder<M>, CompletionError> {
+        chat_history: I,
+    ) -> Result<CompletionRequestBuilder<M>, CompletionError>
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<Message>,
+    {
+        let history: Vec<Message> = chat_history.into_iter().map(Into::into).collect();
         build_completion_request(
             &self.model,
             prompt.into(),
-            chat_history,
+            &history,
             self.preamble.as_deref(),
             &self.static_context,
             self.temperature,
@@ -244,13 +249,13 @@ where
 #[allow(refining_impl_trait)]
 impl<M, P> Prompt for Agent<M, P>
 where
-    M: CompletionModel,
+    M: CompletionModel + 'static,
     P: PromptHook<M> + 'static,
 {
     fn prompt(
         &self,
         prompt: impl Into<Message> + WasmCompatSend,
-    ) -> PromptRequest<'_, prompt_request::Standard, M, P> {
+    ) -> PromptRequest<prompt_request::Standard, M, P> {
         PromptRequest::from_agent(self, prompt)
     }
 }
@@ -258,14 +263,14 @@ where
 #[allow(refining_impl_trait)]
 impl<M, P> Prompt for &Agent<M, P>
 where
-    M: CompletionModel,
+    M: CompletionModel + 'static,
     P: PromptHook<M> + 'static,
 {
     #[tracing::instrument(skip(self, prompt), fields(agent_name = self.name()))]
     fn prompt(
         &self,
         prompt: impl Into<Message> + WasmCompatSend,
-    ) -> PromptRequest<'_, prompt_request::Standard, M, P> {
+    ) -> PromptRequest<prompt_request::Standard, M, P> {
         PromptRequest::from_agent(*self, prompt)
     }
 }
@@ -273,17 +278,21 @@ where
 #[allow(refining_impl_trait)]
 impl<M, P> Chat for Agent<M, P>
 where
-    M: CompletionModel,
+    M: CompletionModel + 'static,
     P: PromptHook<M> + 'static,
 {
     #[tracing::instrument(skip(self, prompt, chat_history), fields(agent_name = self.name()))]
-    async fn chat(
+    async fn chat<I, T>(
         &self,
         prompt: impl Into<Message> + WasmCompatSend,
-        mut chat_history: Vec<Message>,
-    ) -> Result<String, PromptError> {
+        chat_history: I,
+    ) -> Result<String, PromptError>
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<Message>,
+    {
         PromptRequest::from_agent(self, prompt)
-            .with_history(&mut chat_history)
+            .with_history(chat_history)
             .await
     }
 }
@@ -293,11 +302,15 @@ where
     M: CompletionModel,
     P: PromptHook<M>,
 {
-    async fn stream_completion(
+    async fn stream_completion<I, T>(
         &self,
         prompt: impl Into<Message> + WasmCompatSend,
-        chat_history: Vec<Message>,
-    ) -> Result<CompletionRequestBuilder<M>, CompletionError> {
+        chat_history: I,
+    ) -> Result<CompletionRequestBuilder<M>, CompletionError>
+    where
+        I: IntoIterator<Item = T> + WasmCompatSend,
+        T: Into<Message>,
+    {
         // Reuse the existing completion implementation to build the request
         // This ensures streaming and non-streaming use the same request building logic
         self.completion(prompt, chat_history).await
@@ -328,11 +341,15 @@ where
 {
     type Hook = P;
 
-    fn stream_chat(
+    fn stream_chat<I, T>(
         &self,
         prompt: impl Into<Message> + WasmCompatSend,
-        chat_history: Vec<Message>,
-    ) -> StreamingPromptRequest<M, P> {
+        chat_history: I,
+    ) -> StreamingPromptRequest<M, P>
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<Message>,
+    {
         StreamingPromptRequest::<M, P>::from_agent(self, prompt).with_history(chat_history)
     }
 }
@@ -344,14 +361,13 @@ use serde::de::DeserializeOwned;
 #[allow(refining_impl_trait)]
 impl<M, P> TypedPrompt for Agent<M, P>
 where
-    M: CompletionModel,
+    M: CompletionModel + 'static,
     P: PromptHook<M> + 'static,
 {
-    type TypedRequest<'a, T>
-        = TypedPromptRequest<'a, T, prompt_request::Standard, M, P>
+    type TypedRequest<T>
+        = TypedPromptRequest<T, prompt_request::Standard, M, P>
     where
-        Self: 'a,
-        T: JsonSchema + DeserializeOwned + WasmCompatSend + 'a;
+        T: JsonSchema + DeserializeOwned + WasmCompatSend + 'static;
 
     /// Send a prompt and receive a typed structured response.
     ///
@@ -388,7 +404,7 @@ where
     fn prompt_typed<T>(
         &self,
         prompt: impl Into<Message> + WasmCompatSend,
-    ) -> TypedPromptRequest<'_, T, prompt_request::Standard, M, P>
+    ) -> TypedPromptRequest<T, prompt_request::Standard, M, P>
     where
         T: JsonSchema + DeserializeOwned + WasmCompatSend,
     {
@@ -399,19 +415,18 @@ where
 #[allow(refining_impl_trait)]
 impl<M, P> TypedPrompt for &Agent<M, P>
 where
-    M: CompletionModel,
+    M: CompletionModel + 'static,
     P: PromptHook<M> + 'static,
 {
-    type TypedRequest<'a, T>
-        = TypedPromptRequest<'a, T, prompt_request::Standard, M, P>
+    type TypedRequest<T>
+        = TypedPromptRequest<T, prompt_request::Standard, M, P>
     where
-        Self: 'a,
-        T: JsonSchema + DeserializeOwned + WasmCompatSend + 'a;
+        T: JsonSchema + DeserializeOwned + WasmCompatSend + 'static;
 
     fn prompt_typed<T>(
         &self,
         prompt: impl Into<Message> + WasmCompatSend,
-    ) -> TypedPromptRequest<'_, T, prompt_request::Standard, M, P>
+    ) -> TypedPromptRequest<T, prompt_request::Standard, M, P>
     where
         T: JsonSchema + DeserializeOwned + WasmCompatSend,
     {

--- a/rig/rig-core/src/agent/prompt_request/mod.rs
+++ b/rig/rig-core/src/agent/prompt_request/mod.rs
@@ -1,6 +1,19 @@
 pub mod hooks;
 pub mod streaming;
 
+use super::{
+    Agent,
+    completion::{DynamicContextStore, build_completion_request},
+};
+use crate::{
+    OneOrMany,
+    completion::{CompletionModel, Document, Message, PromptError, Usage},
+    json_utils,
+    message::{AssistantContent, ToolChoice, ToolResultContent, UserContent},
+    tool::server::ToolServerHandle,
+    wasm_compat::{WasmBoxedFuture, WasmCompatSend},
+};
+use futures::{StreamExt, stream};
 use hooks::{HookAction, PromptHook, ToolCallHookAction};
 use std::{
     future::IntoFuture,
@@ -10,24 +23,8 @@ use std::{
         atomic::{AtomicU64, Ordering},
     },
 };
-use tracing::{Instrument, span::Id};
-
-use futures::{StreamExt, stream};
 use tracing::info_span;
-
-use crate::{
-    OneOrMany,
-    completion::{CompletionModel, Document, Message, PromptError, Usage},
-    json_utils,
-    message::{AssistantContent, ToolChoice, ToolResultContent, UserContent},
-    tool::server::ToolServerHandle,
-    wasm_compat::{WasmBoxedFuture, WasmCompatSend},
-};
-
-use super::{
-    Agent,
-    completion::{DynamicContextStore, build_completion_request},
-};
+use tracing::{Instrument, span::Id};
 
 pub trait PromptType {}
 pub struct Standard;
@@ -44,7 +41,7 @@ impl PromptType for Extended {}
 /// attempting to await (which will send the prompt request) can potentially return
 /// [`crate::completion::request::PromptError::MaxTurnsError`] if the agent decides to call tools
 /// back to back.
-pub struct PromptRequest<'a, S, M, P>
+pub struct PromptRequest<S, M, P>
 where
     S: PromptType,
     M: CompletionModel,
@@ -52,9 +49,8 @@ where
 {
     /// The prompt message to send to the model
     prompt: Message,
-    /// Optional chat history to include with the prompt
-    /// Note: chat history needs to outlive the agent as it might be used with other agents
-    chat_history: Option<&'a mut Vec<Message>>,
+    /// Optional chat history provided by the caller.
+    input_history: Option<Vec<Message>>,
     /// Maximum depth for multi-turn conversations (0 means no multi-turn)
     max_turns: usize,
 
@@ -90,7 +86,7 @@ where
     output_schema: Option<schemars::Schema>,
 }
 
-impl<'a, M, P> PromptRequest<'a, Standard, M, P>
+impl<M, P> PromptRequest<Standard, M, P>
 where
     M: CompletionModel,
     P: PromptHook<M>,
@@ -99,7 +95,7 @@ where
     pub fn from_agent(agent: &Agent<M, P>, prompt: impl Into<Message>) -> Self {
         PromptRequest {
             prompt: prompt.into(),
-            chat_history: None,
+            input_history: None,
             max_turns: agent.default_max_turns.unwrap_or_default(),
             model: agent.model.clone(),
             agent_name: agent.name.clone(),
@@ -119,7 +115,7 @@ where
     }
 }
 
-impl<'a, S, M, P> PromptRequest<'a, S, M, P>
+impl<S, M, P> PromptRequest<S, M, P>
 where
     S: PromptType,
     M: CompletionModel,
@@ -131,10 +127,10 @@ where
     /// Note: This changes the type of the response from `.send` to return a `PromptResponse` struct
     /// instead of a simple `String`. This is useful for tracking token usage across multiple turns
     /// of conversation and inspecting the full message exchange.
-    pub fn extended_details(self) -> PromptRequest<'a, Extended, M, P> {
+    pub fn extended_details(self) -> PromptRequest<Extended, M, P> {
         PromptRequest {
             prompt: self.prompt,
-            chat_history: self.chat_history,
+            input_history: self.input_history,
             max_turns: self.max_turns,
             model: self.model,
             agent_name: self.agent_name,
@@ -167,21 +163,25 @@ where
         self
     }
 
-    /// Add chat history to the prompt request
-    pub fn with_history(mut self, history: &'a mut Vec<Message>) -> Self {
-        self.chat_history = Some(history);
+    /// Add chat history to the prompt request.
+    pub fn with_history<I, T>(mut self, history: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<Message>,
+    {
+        self.input_history = Some(history.into_iter().map(Into::into).collect());
         self
     }
 
     /// Attach a per-request hook for tool call events.
     /// This overrides any default hook set on the agent.
-    pub fn with_hook<P2>(self, hook: P2) -> PromptRequest<'a, S, M, P2>
+    pub fn with_hook<P2>(self, hook: P2) -> PromptRequest<S, M, P2>
     where
         P2: PromptHook<M>,
     {
         PromptRequest {
             prompt: self.prompt,
-            chat_history: self.chat_history,
+            input_history: self.input_history,
             max_turns: self.max_turns,
             model: self.model,
             agent_name: self.agent_name,
@@ -204,33 +204,33 @@ where
 /// Due to: [RFC 2515](https://github.com/rust-lang/rust/issues/63063), we have to use a `BoxFuture`
 ///  for the `IntoFuture` implementation. In the future, we should be able to use `impl Future<...>`
 ///  directly via the associated type.
-impl<'a, M, P> IntoFuture for PromptRequest<'a, Standard, M, P>
+impl<M, P> IntoFuture for PromptRequest<Standard, M, P>
 where
-    M: CompletionModel + 'a,
+    M: CompletionModel + 'static,
     P: PromptHook<M> + 'static,
 {
     type Output = Result<String, PromptError>;
-    type IntoFuture = WasmBoxedFuture<'a, Self::Output>; // This future should not outlive the agent
+    type IntoFuture = WasmBoxedFuture<'static, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(self.send())
     }
 }
 
-impl<'a, M, P> IntoFuture for PromptRequest<'a, Extended, M, P>
+impl<M, P> IntoFuture for PromptRequest<Extended, M, P>
 where
-    M: CompletionModel + 'a,
+    M: CompletionModel + 'static,
     P: PromptHook<M> + 'static,
 {
     type Output = Result<PromptResponse, PromptError>;
-    type IntoFuture = WasmBoxedFuture<'a, Self::Output>; // This future should not outlive the agent
+    type IntoFuture = WasmBoxedFuture<'static, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(self.send())
     }
 }
 
-impl<M, P> PromptRequest<'_, Standard, M, P>
+impl<M, P> PromptRequest<Standard, M, P>
 where
     M: CompletionModel,
     P: PromptHook<M>,
@@ -245,8 +245,6 @@ where
 pub struct PromptResponse {
     pub output: String,
     pub usage: Usage,
-    /// The message history accumulated during the agent loop.
-    /// Always populated when using `extended_details()`.
     pub messages: Option<Vec<Message>>,
 }
 
@@ -285,7 +283,25 @@ impl<T> TypedPromptResponse<T> {
 
 const UNKNOWN_AGENT_NAME: &str = "Unnamed Agent";
 
-impl<M, P> PromptRequest<'_, Extended, M, P>
+/// Combine input history with new messages for building completion requests.
+fn build_history_for_request(
+    input_history: Option<&[Message]>,
+    new_messages: &[Message],
+) -> Vec<Message> {
+    let input = input_history.unwrap_or(&[]);
+    input.iter().chain(new_messages.iter()).cloned().collect()
+}
+
+/// Build the full history for error reporting (input + new messages).
+fn build_full_history(
+    input_history: Option<&[Message]>,
+    new_messages: Vec<Message>,
+) -> Vec<Message> {
+    let input = input_history.unwrap_or(&[]);
+    input.iter().cloned().chain(new_messages).collect()
+}
+
+impl<M, P> PromptRequest<Extended, M, P>
 where
     M: CompletionModel,
     P: PromptHook<M>,
@@ -294,7 +310,7 @@ where
         self.agent_name.as_deref().unwrap_or(UNKNOWN_AGENT_NAME)
     }
 
-    async fn send(mut self) -> Result<PromptResponse, PromptError> {
+    async fn send(self) -> Result<PromptResponse, PromptError> {
         let agent_span = if tracing::Span::current().is_disabled() {
             info_span!(
                 "invoke_agent",
@@ -315,15 +331,9 @@ where
             agent_span.record("gen_ai.prompt", text);
         }
 
-        // Capture agent_name before borrowing chat_history
         let agent_name_for_span = self.agent_name.clone();
-
-        let chat_history = if let Some(history) = self.chat_history.as_mut() {
-            history.push(self.prompt.to_owned());
-            history
-        } else {
-            &mut vec![self.prompt.to_owned()]
-        };
+        let input_history = self.input_history;
+        let mut new_messages: Vec<Message> = vec![self.prompt.clone()];
 
         let mut current_max_turns = 0;
         let mut usage = Usage::new();
@@ -331,10 +341,11 @@ where
 
         // We need to do at least 2 loops for 1 roundtrip (user expects normal message)
         let last_prompt = loop {
-            let prompt = chat_history
+            // Get the last message (the current prompt)
+            let prompt = new_messages
                 .last()
-                .cloned()
-                .expect("there should always be at least one message in the chat history");
+                .expect("there should always be at least one message")
+                .clone();
 
             if current_max_turns > self.max_turns + 1 {
                 break prompt;
@@ -350,12 +361,20 @@ where
                 );
             }
 
+            // Build history for hook callback (input + new messages except last)
+            let history_for_hook = build_history_for_request(
+                input_history.as_deref(),
+                &new_messages[..new_messages.len().saturating_sub(1)],
+            );
+
             if let Some(ref hook) = self.hook
-                && let HookAction::Terminate { reason } = hook
-                    .on_completion_call(&prompt, &chat_history[..chat_history.len() - 1])
-                    .await
+                && let HookAction::Terminate { reason } =
+                    hook.on_completion_call(&prompt, &history_for_hook).await
             {
-                return Err(PromptError::prompt_cancelled(chat_history.to_vec(), reason));
+                return Err(PromptError::prompt_cancelled(
+                    build_full_history(input_history.as_deref(), new_messages),
+                    reason,
+                ));
             }
 
             let span = tracing::Span::current();
@@ -388,10 +407,16 @@ where
                 current_span_id.store(id.into_u64(), Ordering::SeqCst);
             };
 
+            // Build history for completion request (input + new messages except last)
+            let history_for_request = build_history_for_request(
+                input_history.as_deref(),
+                &new_messages[..new_messages.len().saturating_sub(1)],
+            );
+
             let resp = build_completion_request(
                 &self.model,
                 prompt.clone(),
-                chat_history[..chat_history.len() - 1].to_vec(),
+                &history_for_request,
                 self.preamble.as_deref(),
                 &self.static_context,
                 self.temperature,
@@ -413,7 +438,10 @@ where
                 && let HookAction::Terminate { reason } =
                     hook.on_completion_response(&prompt, &resp).await
             {
-                return Err(PromptError::prompt_cancelled(chat_history.to_vec(), reason));
+                return Err(PromptError::prompt_cancelled(
+                    build_full_history(input_history.as_deref(), new_messages),
+                    reason,
+                ));
             }
 
             let (tool_calls, texts): (Vec<_>, Vec<_>) = resp
@@ -421,7 +449,7 @@ where
                 .iter()
                 .partition(|choice| matches!(choice, AssistantContent::ToolCall(_)));
 
-            chat_history.push(Message::Assistant {
+            new_messages.push(Message::Assistant {
                 id: resp.message_id.clone(),
                 content: resp.choice.clone(),
             });
@@ -448,14 +476,15 @@ where
                 agent_span.record("gen_ai.usage.output_tokens", usage.output_tokens);
                 agent_span.record("gen_ai.usage.cached_tokens", usage.cached_input_tokens);
 
-                // If there are no tool calls, depth is not relevant, we can just return the merged text response.
-                return Ok(
-                    PromptResponse::new(merged_texts, usage).with_messages(chat_history.to_vec())
-                );
+                return Ok(PromptResponse::new(merged_texts, usage).with_messages(new_messages));
             }
 
             let hook = self.hook.clone();
             let tool_server_handle = self.tool_server_handle.clone();
+
+            // For error handling in concurrent tool execution, we need to build full history
+            let full_history_for_errors =
+                build_full_history(input_history.as_deref(), new_messages.clone());
 
             let tool_calls: Vec<AssistantContent> = tool_calls.into_iter().cloned().collect();
             let tool_content = stream::iter(tool_calls)
@@ -485,7 +514,8 @@ where
                         current_span_id.store(id.into_u64(), Ordering::SeqCst);
                     };
 
-                    let cloned_chat_history = chat_history.clone().to_vec();
+                    // Clone full history for error reporting in concurrent tool execution
+                    let cloned_history_for_error = full_history_for_errors.clone();
 
                     async move {
                         if let AssistantContent::ToolCall(tool_call) = choice {
@@ -509,7 +539,7 @@ where
 
                                 if let ToolCallHookAction::Terminate { reason } = action {
                                     return Err(PromptError::prompt_cancelled(
-                                        cloned_chat_history,
+                                        cloned_history_for_error,
                                         reason,
                                     ));
                                 }
@@ -555,7 +585,7 @@ where
                                     .await
                             {
                                 return Err(PromptError::prompt_cancelled(
-                                    cloned_chat_history,
+                                    cloned_history_for_error,
                                     reason,
                                 ));
                             }
@@ -590,16 +620,16 @@ where
                 .into_iter()
                 .collect::<Result<Vec<_>, _>>()?;
 
-            chat_history.push(Message::User {
-                content: OneOrMany::many(tool_content).expect("There is atleast one tool call"),
+            new_messages.push(Message::User {
+                content: OneOrMany::many(tool_content).expect("There is at least one tool call"),
             });
         };
 
-        // If we reach here, we never resolved the final tool call. We need to do ... something.
+        // If we reach here, we exceeded max turns without a final response
         Err(PromptError::MaxTurnsError {
             max_turns: self.max_turns,
-            chat_history: Box::new(chat_history.clone()),
-            prompt: Box::new(last_prompt),
+            chat_history: build_full_history(input_history.as_deref(), new_messages),
+            prompt: last_prompt,
         })
     }
 }
@@ -628,18 +658,18 @@ use serde::de::DeserializeOwned;
 ///     .max_turns(3)
 ///     .await?;
 /// ```
-pub struct TypedPromptRequest<'a, T, S, M, P>
+pub struct TypedPromptRequest<T, S, M, P>
 where
     T: JsonSchema + DeserializeOwned + WasmCompatSend,
     S: PromptType,
     M: CompletionModel,
     P: PromptHook<M>,
 {
-    inner: PromptRequest<'a, S, M, P>,
+    inner: PromptRequest<S, M, P>,
     _phantom: std::marker::PhantomData<T>,
 }
 
-impl<'a, T, M, P> TypedPromptRequest<'a, T, Standard, M, P>
+impl<T, M, P> TypedPromptRequest<T, Standard, M, P>
 where
     T: JsonSchema + DeserializeOwned + WasmCompatSend,
     M: CompletionModel,
@@ -659,7 +689,7 @@ where
     }
 }
 
-impl<'a, T, S, M, P> TypedPromptRequest<'a, T, S, M, P>
+impl<T, S, M, P> TypedPromptRequest<T, S, M, P>
 where
     T: JsonSchema + DeserializeOwned + WasmCompatSend,
     S: PromptType,
@@ -671,7 +701,7 @@ where
     /// Note: This changes the type of the response from `.send()` to return a `TypedPromptResponse<T>` struct
     /// instead of just `T`. This is useful for tracking token usage across multiple turns
     /// of conversation.
-    pub fn extended_details(self) -> TypedPromptRequest<'a, T, Extended, M, P> {
+    pub fn extended_details(self) -> TypedPromptRequest<T, Extended, M, P> {
         TypedPromptRequest {
             inner: self.inner.extended_details(),
             _phantom: std::marker::PhantomData,
@@ -697,7 +727,11 @@ where
     }
 
     /// Add chat history to the prompt request.
-    pub fn with_history(mut self, history: &'a mut Vec<Message>) -> Self {
+    pub fn with_history<I, H>(mut self, history: I) -> Self
+    where
+        I: IntoIterator<Item = H>,
+        H: Into<Message>,
+    {
         self.inner = self.inner.with_history(history);
         self
     }
@@ -705,7 +739,7 @@ where
     /// Attach a per-request hook for tool call events.
     ///
     /// This overrides any default hook set on the agent.
-    pub fn with_hook<P2>(self, hook: P2) -> TypedPromptRequest<'a, T, S, M, P2>
+    pub fn with_hook<P2>(self, hook: P2) -> TypedPromptRequest<T, S, M, P2>
     where
         P2: PromptHook<M>,
     {
@@ -716,7 +750,7 @@ where
     }
 }
 
-impl<'a, T, M, P> TypedPromptRequest<'a, T, Standard, M, P>
+impl<T, M, P> TypedPromptRequest<T, Standard, M, P>
 where
     T: JsonSchema + DeserializeOwned + WasmCompatSend,
     M: CompletionModel,
@@ -735,7 +769,7 @@ where
     }
 }
 
-impl<'a, T, M, P> TypedPromptRequest<'a, T, Extended, M, P>
+impl<T, M, P> TypedPromptRequest<T, Extended, M, P>
 where
     T: JsonSchema + DeserializeOwned + WasmCompatSend,
     M: CompletionModel,
@@ -754,28 +788,28 @@ where
     }
 }
 
-impl<'a, T, M, P> IntoFuture for TypedPromptRequest<'a, T, Standard, M, P>
+impl<T, M, P> IntoFuture for TypedPromptRequest<T, Standard, M, P>
 where
-    T: JsonSchema + DeserializeOwned + WasmCompatSend + 'a,
-    M: CompletionModel + 'a,
+    T: JsonSchema + DeserializeOwned + WasmCompatSend + 'static,
+    M: CompletionModel + 'static,
     P: PromptHook<M> + 'static,
 {
     type Output = Result<T, StructuredOutputError>;
-    type IntoFuture = WasmBoxedFuture<'a, Self::Output>;
+    type IntoFuture = WasmBoxedFuture<'static, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(self.send())
     }
 }
 
-impl<'a, T, M, P> IntoFuture for TypedPromptRequest<'a, T, Extended, M, P>
+impl<T, M, P> IntoFuture for TypedPromptRequest<T, Extended, M, P>
 where
-    T: JsonSchema + DeserializeOwned + WasmCompatSend + 'a,
-    M: CompletionModel + 'a,
+    T: JsonSchema + DeserializeOwned + WasmCompatSend + 'static,
+    M: CompletionModel + 'static,
     P: PromptHook<M> + 'static,
 {
     type Output = Result<TypedPromptResponse<T>, StructuredOutputError>;
-    type IntoFuture = WasmBoxedFuture<'a, Self::Output>;
+    type IntoFuture = WasmBoxedFuture<'static, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(self.send())

--- a/rig/rig-core/src/agent/prompt_request/mod.rs
+++ b/rig/rig-core/src/agent/prompt_request/mod.rs
@@ -50,7 +50,7 @@ where
     /// The prompt message to send to the model
     prompt: Message,
     /// Optional chat history provided by the caller.
-    input_history: Option<Vec<Message>>,
+    chat_history: Option<Vec<Message>>,
     /// Maximum depth for multi-turn conversations (0 means no multi-turn)
     max_turns: usize,
 
@@ -95,7 +95,7 @@ where
     pub fn from_agent(agent: &Agent<M, P>, prompt: impl Into<Message>) -> Self {
         PromptRequest {
             prompt: prompt.into(),
-            input_history: None,
+            chat_history: None,
             max_turns: agent.default_max_turns.unwrap_or_default(),
             model: agent.model.clone(),
             agent_name: agent.name.clone(),
@@ -130,7 +130,7 @@ where
     pub fn extended_details(self) -> PromptRequest<Extended, M, P> {
         PromptRequest {
             prompt: self.prompt,
-            input_history: self.input_history,
+            chat_history: self.chat_history,
             max_turns: self.max_turns,
             model: self.model,
             agent_name: self.agent_name,
@@ -169,7 +169,7 @@ where
         I: IntoIterator<Item = T>,
         T: Into<Message>,
     {
-        self.input_history = Some(history.into_iter().map(Into::into).collect());
+        self.chat_history = Some(history.into_iter().map(Into::into).collect());
         self
     }
 
@@ -181,7 +181,7 @@ where
     {
         PromptRequest {
             prompt: self.prompt,
-            input_history: self.input_history,
+            chat_history: self.chat_history,
             max_turns: self.max_turns,
             model: self.model,
             agent_name: self.agent_name,
@@ -285,19 +285,19 @@ const UNKNOWN_AGENT_NAME: &str = "Unnamed Agent";
 
 /// Combine input history with new messages for building completion requests.
 fn build_history_for_request(
-    input_history: Option<&[Message]>,
+    chat_history: Option<&[Message]>,
     new_messages: &[Message],
 ) -> Vec<Message> {
-    let input = input_history.unwrap_or(&[]);
+    let input = chat_history.unwrap_or(&[]);
     input.iter().chain(new_messages.iter()).cloned().collect()
 }
 
 /// Build the full history for error reporting (input + new messages).
 fn build_full_history(
-    input_history: Option<&[Message]>,
+    chat_history: Option<&[Message]>,
     new_messages: Vec<Message>,
 ) -> Vec<Message> {
-    let input = input_history.unwrap_or(&[]);
+    let input = chat_history.unwrap_or(&[]);
     input.iter().cloned().chain(new_messages).collect()
 }
 
@@ -332,7 +332,7 @@ where
         }
 
         let agent_name_for_span = self.agent_name.clone();
-        let input_history = self.input_history;
+        let chat_history = self.chat_history;
         let mut new_messages: Vec<Message> = vec![self.prompt.clone()];
 
         let mut current_max_turns = 0;
@@ -363,7 +363,7 @@ where
 
             // Build history for hook callback (input + new messages except last)
             let history_for_hook = build_history_for_request(
-                input_history.as_deref(),
+                chat_history.as_deref(),
                 &new_messages[..new_messages.len().saturating_sub(1)],
             );
 
@@ -372,7 +372,7 @@ where
                     hook.on_completion_call(&prompt, &history_for_hook).await
             {
                 return Err(PromptError::prompt_cancelled(
-                    build_full_history(input_history.as_deref(), new_messages),
+                    build_full_history(chat_history.as_deref(), new_messages),
                     reason,
                 ));
             }
@@ -409,7 +409,7 @@ where
 
             // Build history for completion request (input + new messages except last)
             let history_for_request = build_history_for_request(
-                input_history.as_deref(),
+                chat_history.as_deref(),
                 &new_messages[..new_messages.len().saturating_sub(1)],
             );
 
@@ -439,7 +439,7 @@ where
                     hook.on_completion_response(&prompt, &resp).await
             {
                 return Err(PromptError::prompt_cancelled(
-                    build_full_history(input_history.as_deref(), new_messages),
+                    build_full_history(chat_history.as_deref(), new_messages),
                     reason,
                 ));
             }
@@ -484,7 +484,7 @@ where
 
             // For error handling in concurrent tool execution, we need to build full history
             let full_history_for_errors =
-                build_full_history(input_history.as_deref(), new_messages.clone());
+                build_full_history(chat_history.as_deref(), new_messages.clone());
 
             let tool_calls: Vec<AssistantContent> = tool_calls.into_iter().cloned().collect();
             let tool_content = stream::iter(tool_calls)
@@ -628,8 +628,8 @@ where
         // If we reach here, we exceeded max turns without a final response
         Err(PromptError::MaxTurnsError {
             max_turns: self.max_turns,
-            chat_history: build_full_history(input_history.as_deref(), new_messages),
-            prompt: last_prompt,
+            chat_history: build_full_history(chat_history.as_deref(), new_messages).into(),
+            prompt: last_prompt.into(),
         })
     }
 }

--- a/rig/rig-core/src/agent/prompt_request/mod.rs
+++ b/rig/rig-core/src/agent/prompt_request/mod.rs
@@ -758,7 +758,7 @@ where
 {
     /// Send the typed prompt request and deserialize the response.
     async fn send(self) -> Result<T, StructuredOutputError> {
-        let response = self.inner.send().await?;
+        let response = self.inner.send().await.map_err(Box::new)?;
 
         if response.is_empty() {
             return Err(StructuredOutputError::EmptyResponse);
@@ -777,7 +777,7 @@ where
 {
     /// Send the typed prompt request with extended details and deserialize the response.
     async fn send(self) -> Result<TypedPromptResponse<T>, StructuredOutputError> {
-        let response = self.inner.send().await?;
+        let response = self.inner.send().await.map_err(Box::new)?;
 
         if response.output.is_empty() {
             return Err(StructuredOutputError::EmptyResponse);

--- a/rig/rig-core/src/agent/prompt_request/streaming.rs
+++ b/rig/rig-core/src/agent/prompt_request/streaming.rs
@@ -124,29 +124,29 @@ fn merge_reasoning_blocks(
 
 /// Build full history for error reporting (input + new messages).
 fn build_full_history(
-    input_history: Option<&[Message]>,
+    chat_history: Option<&[Message]>,
     new_messages: Vec<Message>,
 ) -> Vec<Message> {
-    let input = input_history.unwrap_or(&[]);
+    let input = chat_history.unwrap_or(&[]);
     input.iter().cloned().chain(new_messages).collect()
 }
 
 /// Combine input history with new messages for building completion requests.
 fn build_history_for_request(
-    input_history: Option<&[Message]>,
+    chat_history: Option<&[Message]>,
     new_messages: &[Message],
 ) -> Vec<Message> {
-    let input = input_history.unwrap_or(&[]);
+    let input = chat_history.unwrap_or(&[]);
     input.iter().chain(new_messages.iter()).cloned().collect()
 }
 
 async fn cancelled_prompt_error(
-    input_history: Option<&[Message]>,
+    chat_history: Option<&[Message]>,
     new_messages: Vec<Message>,
     reason: String,
 ) -> StreamingError {
     StreamingError::Prompt(
-        PromptError::prompt_cancelled(build_full_history(input_history, new_messages), reason)
+        PromptError::prompt_cancelled(build_full_history(chat_history, new_messages), reason)
             .into(),
     )
 }
@@ -195,7 +195,7 @@ where
     /// The prompt message to send to the model
     prompt: Message,
     /// Optional chat history provided by the caller.
-    input_history: Option<Vec<Message>>,
+    chat_history: Option<Vec<Message>>,
     /// Maximum Turns for multi-turn conversations (0 means no multi-turn)
     max_turns: usize,
 
@@ -237,7 +237,7 @@ where
     pub fn new(agent: Arc<Agent<M>>, prompt: impl Into<Message>) -> StreamingPromptRequest<M, ()> {
         StreamingPromptRequest {
             prompt: prompt.into(),
-            input_history: None,
+            chat_history: None,
             max_turns: agent.default_max_turns.unwrap_or_default(),
             model: agent.model.clone(),
             agent_name: agent.name.clone(),
@@ -264,7 +264,7 @@ where
     {
         StreamingPromptRequest {
             prompt: prompt.into(),
-            input_history: None,
+            chat_history: None,
             max_turns: agent.default_max_turns.unwrap_or_default(),
             model: agent.model.clone(),
             agent_name: agent.name.clone(),
@@ -293,12 +293,23 @@ where
     }
 
     /// Add chat history to the prompt request.
+    ///
+    /// When history is provided, the final [`FinalResponse`] will include the
+    /// updated chat history (original messages + new user prompt + assistant response).
+    /// ```ignore
+    /// let mut stream = agent
+    ///     .stream_prompt("Hello")
+    ///     .with_history(vec![])
+    ///     .await;
+    /// // ... consume stream ...
+    /// // Access updated history from FinalResponse::history()
+    /// ```
     pub fn with_history<I, T>(mut self, history: I) -> Self
     where
         I: IntoIterator<Item = T>,
         T: Into<Message>,
     {
-        self.input_history = Some(history.into_iter().map(Into::into).collect());
+        self.chat_history = Some(history.into_iter().map(Into::into).collect());
         self
     }
 
@@ -310,7 +321,7 @@ where
     {
         StreamingPromptRequest {
             prompt: self.prompt,
-            input_history: self.input_history,
+            chat_history: self.chat_history,
             max_turns: self.max_turns,
             model: self.model,
             agent_name: self.agent_name,
@@ -360,8 +371,8 @@ where
         let dynamic_context = self.dynamic_context.clone();
         let tool_choice = self.tool_choice.clone();
         let agent_name = self.agent_name.clone();
-        let has_history = self.input_history.is_some();
-        let input_history = self.input_history;
+        let has_history = self.chat_history.is_some();
+        let chat_history = self.chat_history;
         let mut new_messages: Vec<Message> = vec![prompt.clone()];
 
         let mut current_max_turns = 0;
@@ -401,10 +412,10 @@ where
                 }
 
                 if let Some(ref hook) = self.hook {
-                    let history_snapshot: Vec<Message> = build_history_for_request(input_history.as_deref(), &new_messages[..new_messages.len().saturating_sub(1)]);
+                    let history_snapshot: Vec<Message> = build_history_for_request(chat_history.as_deref(), &new_messages[..new_messages.len().saturating_sub(1)]);
                     if let HookAction::Terminate { reason } = hook.on_completion_call(&current_prompt, &history_snapshot)
                         .await {
-                        yield Err(cancelled_prompt_error(input_history.as_deref(), new_messages.clone(), reason).await);
+                        yield Err(cancelled_prompt_error(chat_history.as_deref(), new_messages.clone(), reason).await);
                         break 'outer;
                     }
                 }
@@ -427,7 +438,7 @@ where
                     gen_ai.output.messages = tracing::field::Empty,
                 );
 
-                let history_snapshot: Vec<Message> = build_history_for_request(input_history.as_deref(), &new_messages[..new_messages.len().saturating_sub(1)]);
+                let history_snapshot: Vec<Message> = build_history_for_request(chat_history.as_deref(), &new_messages[..new_messages.len().saturating_sub(1)]);
                 let mut stream = tracing::Instrument::instrument(
                     build_completion_request(
                         &model,
@@ -470,7 +481,7 @@ where
                             last_text_response.push_str(&text.text);
                             if let Some(ref hook) = self.hook &&
                                 let HookAction::Terminate { reason } = hook.on_text_delta(&text.text, &last_text_response).await {
-                                    yield Err(cancelled_prompt_error(input_history.as_deref(), new_messages.clone(), reason).await);
+                                    yield Err(cancelled_prompt_error(chat_history.as_deref(), new_messages.clone(), reason).await);
                                     break 'outer;
                             }
 
@@ -499,7 +510,7 @@ where
                                         .await;
 
                                     if let ToolCallHookAction::Terminate { reason } = action {
-                                        return Err(cancelled_prompt_error(input_history.as_deref(), new_messages.clone(), reason).await);
+                                        return Err(cancelled_prompt_error(chat_history.as_deref(), new_messages.clone(), reason).await);
                                     }
 
                                     if let ToolCallHookAction::Skip { reason } = action {
@@ -541,7 +552,7 @@ where
                                         &tool_result.to_string()
                                     )
                                     .await {
-                                        return Err(cancelled_prompt_error(input_history.as_deref(), new_messages.clone(), reason).await);
+                                        return Err(cancelled_prompt_error(chat_history.as_deref(), new_messages.clone(), reason).await);
                                     }
 
                                 let tool_call_msg = AssistantContent::ToolCall(tool_call.clone());
@@ -573,7 +584,7 @@ where
 
                                 if let HookAction::Terminate { reason } = hook.on_tool_call_delta(&id, &internal_call_id, name, delta)
                                 .await {
-                                    yield Err(cancelled_prompt_error(input_history.as_deref(), new_messages.clone(), reason).await);
+                                    yield Err(cancelled_prompt_error(chat_history.as_deref(), new_messages.clone(), reason).await);
                                     break 'outer;
                                 }
                             }
@@ -600,7 +611,7 @@ where
                             if is_text_response {
                                 if let Some(ref hook) = self.hook &&
                                      let HookAction::Terminate { reason } = hook.on_stream_completion_response_finish(&prompt, &final_resp).await {
-                                        yield Err(cancelled_prompt_error(input_history.as_deref(), new_messages.clone(), reason).await);
+                                        yield Err(cancelled_prompt_error(chat_history.as_deref(), new_messages.clone(), reason).await);
                                         break 'outer;
                                     }
 
@@ -686,8 +697,8 @@ where
             if max_turns_reached {
                 yield Err(Box::new(PromptError::MaxTurnsError {
                     max_turns: self.max_turns,
-                    chat_history: build_full_history(input_history.as_deref(), new_messages.clone()),
-                    prompt: last_prompt_error.clone().into(),
+                    chat_history: build_full_history(chat_history.as_deref(), new_messages.clone()).into(),
+                    prompt: Box::new(last_prompt_error.clone().into()),
                 }).into());
             }
         };

--- a/rig/rig-core/src/agent/prompt_request/streaming.rs
+++ b/rig/rig-core/src/agent/prompt_request/streaming.rs
@@ -122,8 +122,33 @@ fn merge_reasoning_blocks(
     }
 }
 
-async fn cancelled_prompt_error(chat_history: &Vec<Message>, reason: String) -> StreamingError {
-    StreamingError::Prompt(PromptError::prompt_cancelled(chat_history.to_owned(), reason).into())
+/// Build full history for error reporting (input + new messages).
+fn build_full_history(
+    input_history: Option<&[Message]>,
+    new_messages: Vec<Message>,
+) -> Vec<Message> {
+    let input = input_history.unwrap_or(&[]);
+    input.iter().cloned().chain(new_messages).collect()
+}
+
+/// Combine input history with new messages for building completion requests.
+fn build_history_for_request(
+    input_history: Option<&[Message]>,
+    new_messages: &[Message],
+) -> Vec<Message> {
+    let input = input_history.unwrap_or(&[]);
+    input.iter().chain(new_messages.iter()).cloned().collect()
+}
+
+async fn cancelled_prompt_error(
+    input_history: Option<&[Message]>,
+    new_messages: Vec<Message>,
+    reason: String,
+) -> StreamingError {
+    StreamingError::Prompt(
+        PromptError::prompt_cancelled(build_full_history(input_history, new_messages), reason)
+            .into(),
+    )
 }
 
 fn tool_result_to_user_message(
@@ -169,8 +194,8 @@ where
 {
     /// The prompt message to send to the model
     prompt: Message,
-    /// Optional chat history to include with the prompt.
-    chat_history: Option<Vec<Message>>,
+    /// Optional chat history provided by the caller.
+    input_history: Option<Vec<Message>>,
     /// Maximum Turns for multi-turn conversations (0 means no multi-turn)
     max_turns: usize,
 
@@ -212,7 +237,7 @@ where
     pub fn new(agent: Arc<Agent<M>>, prompt: impl Into<Message>) -> StreamingPromptRequest<M, ()> {
         StreamingPromptRequest {
             prompt: prompt.into(),
-            chat_history: None,
+            input_history: None,
             max_turns: agent.default_max_turns.unwrap_or_default(),
             model: agent.model.clone(),
             agent_name: agent.name.clone(),
@@ -239,7 +264,7 @@ where
     {
         StreamingPromptRequest {
             prompt: prompt.into(),
-            chat_history: None,
+            input_history: None,
             max_turns: agent.default_max_turns.unwrap_or_default(),
             model: agent.model.clone(),
             agent_name: agent.name.clone(),
@@ -268,19 +293,12 @@ where
     }
 
     /// Add chat history to the prompt request.
-    ///
-    /// When history is provided, the final [`FinalResponse`] will include the
-    /// updated chat history (original messages + new user prompt + assistant response).
-    /// ```ignore
-    /// let mut stream = agent
-    ///     .stream_prompt("Hello")
-    ///     .with_history(vec![])
-    ///     .await;
-    /// // ... consume stream ...
-    /// // Access updated history from FinalResponse::history()
-    /// ```
-    pub fn with_history(mut self, history: Vec<Message>) -> Self {
-        self.chat_history = Some(history);
+    pub fn with_history<I, T>(mut self, history: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<Message>,
+    {
+        self.input_history = Some(history.into_iter().map(Into::into).collect());
         self
     }
 
@@ -292,7 +310,7 @@ where
     {
         StreamingPromptRequest {
             prompt: self.prompt,
-            chat_history: self.chat_history,
+            input_history: self.input_history,
             max_turns: self.max_turns,
             model: self.model,
             agent_name: self.agent_name,
@@ -342,8 +360,9 @@ where
         let dynamic_context = self.dynamic_context.clone();
         let tool_choice = self.tool_choice.clone();
         let agent_name = self.agent_name.clone();
-        let has_history = self.chat_history.is_some();
-        let mut chat_history = self.chat_history.unwrap_or_default();
+        let has_history = self.input_history.is_some();
+        let input_history = self.input_history;
+        let mut new_messages: Vec<Message> = vec![prompt.clone()];
 
         let mut current_max_turns = 0;
         let mut last_prompt_error = String::new();
@@ -382,10 +401,10 @@ where
                 }
 
                 if let Some(ref hook) = self.hook {
-                    let history_snapshot = chat_history.clone();
+                    let history_snapshot: Vec<Message> = build_history_for_request(input_history.as_deref(), &new_messages[..new_messages.len().saturating_sub(1)]);
                     if let HookAction::Terminate { reason } = hook.on_completion_call(&current_prompt, &history_snapshot)
                         .await {
-                        yield Err(cancelled_prompt_error(&chat_history, reason).await);
+                        yield Err(cancelled_prompt_error(input_history.as_deref(), new_messages.clone(), reason).await);
                         break 'outer;
                     }
                 }
@@ -408,12 +427,12 @@ where
                     gen_ai.output.messages = tracing::field::Empty,
                 );
 
-                let history_snapshot = chat_history.clone();
+                let history_snapshot: Vec<Message> = build_history_for_request(input_history.as_deref(), &new_messages[..new_messages.len().saturating_sub(1)]);
                 let mut stream = tracing::Instrument::instrument(
                     build_completion_request(
                         &model,
                         current_prompt.clone(),
-                        history_snapshot,
+                        &history_snapshot,
                         preamble.as_deref(),
                         &static_context,
                         temperature,
@@ -430,7 +449,7 @@ where
 
                 .await?;
 
-                chat_history.push(current_prompt.clone());
+                new_messages.push(current_prompt.clone());
 
                 let mut tool_calls = vec![];
                 let mut tool_results = vec![];
@@ -451,7 +470,7 @@ where
                             last_text_response.push_str(&text.text);
                             if let Some(ref hook) = self.hook &&
                                 let HookAction::Terminate { reason } = hook.on_text_delta(&text.text, &last_text_response).await {
-                                    yield Err(cancelled_prompt_error(&chat_history, reason).await);
+                                    yield Err(cancelled_prompt_error(input_history.as_deref(), new_messages.clone(), reason).await);
                                     break 'outer;
                             }
 
@@ -480,7 +499,7 @@ where
                                         .await;
 
                                     if let ToolCallHookAction::Terminate { reason } = action {
-                                        return Err(cancelled_prompt_error(&chat_history, reason).await);
+                                        return Err(cancelled_prompt_error(input_history.as_deref(), new_messages.clone(), reason).await);
                                     }
 
                                     if let ToolCallHookAction::Skip { reason } = action {
@@ -522,7 +541,7 @@ where
                                         &tool_result.to_string()
                                     )
                                     .await {
-                                        return Err(cancelled_prompt_error(&chat_history, reason).await);
+                                        return Err(cancelled_prompt_error(input_history.as_deref(), new_messages.clone(), reason).await);
                                     }
 
                                 let tool_call_msg = AssistantContent::ToolCall(tool_call.clone());
@@ -554,7 +573,7 @@ where
 
                                 if let HookAction::Terminate { reason } = hook.on_tool_call_delta(&id, &internal_call_id, name, delta)
                                 .await {
-                                    yield Err(cancelled_prompt_error(&chat_history, reason).await);
+                                    yield Err(cancelled_prompt_error(input_history.as_deref(), new_messages.clone(), reason).await);
                                     break 'outer;
                                 }
                             }
@@ -581,7 +600,7 @@ where
                             if is_text_response {
                                 if let Some(ref hook) = self.hook &&
                                      let HookAction::Terminate { reason } = hook.on_stream_completion_response_finish(&prompt, &final_resp).await {
-                                        yield Err(cancelled_prompt_error(&chat_history, reason).await);
+                                        yield Err(cancelled_prompt_error(input_history.as_deref(), new_messages.clone(), reason).await);
                                         break 'outer;
                                     }
 
@@ -621,7 +640,7 @@ where
                     content_items.extend(tool_calls.clone());
 
                     if !content_items.is_empty() {
-                        chat_history.push(Message::Assistant {
+                        new_messages.push(Message::Assistant {
                             id: stream.message_id.clone(),
                             content: OneOrMany::many(content_items).expect("Should have at least one item"),
                         });
@@ -629,20 +648,20 @@ where
                 }
 
                 for (id, call_id, tool_result) in tool_results {
-                    chat_history.push(tool_result_to_user_message(id, call_id, tool_result));
+                    new_messages.push(tool_result_to_user_message(id, call_id, tool_result));
                 }
 
-                // Set the current prompt to the last message in the chat history
-                current_prompt = match chat_history.pop() {
+                // Set the current prompt to the last message in new_messages
+                current_prompt = match new_messages.pop() {
                     Some(prompt) => prompt,
-                    None => unreachable!("Chat history should never be empty at this point"),
+                    None => unreachable!("New messages should never be empty at this point"),
                 };
 
                 if !saw_tool_call_this_turn {
                     // Add user message and assistant response to history before finishing
-                    chat_history.push(current_prompt.clone());
+                    new_messages.push(current_prompt.clone());
                     if !last_text_response.is_empty() {
-                        chat_history.push(Message::assistant(&last_text_response));
+                        new_messages.push(Message::assistant(&last_text_response));
                     }
 
                     let current_span = tracing::Span::current();
@@ -650,15 +669,15 @@ where
                     current_span.record("gen_ai.usage.output_tokens", aggregated_usage.output_tokens);
                     current_span.record("gen_ai.usage.cached_tokens", aggregated_usage.cached_input_tokens);
                     tracing::info!("Agent multi-turn stream finished");
-                    let history_snapshot = if has_history {
-                        Some(chat_history.clone())
+                    let final_messages: Option<Vec<Message>> = if has_history {
+                        Some(new_messages.clone())
                     } else {
                         None
                     };
                     yield Ok(MultiTurnStreamItem::final_response_with_history(
                         &last_text_response,
                         aggregated_usage,
-                        history_snapshot,
+                        final_messages,
                     ));
                     break;
                 }
@@ -667,8 +686,8 @@ where
             if max_turns_reached {
                 yield Err(Box::new(PromptError::MaxTurnsError {
                     max_turns: self.max_turns,
-                    chat_history: Box::new(chat_history.clone()),
-                    prompt: Box::new(last_prompt_error.clone().into()),
+                    chat_history: build_full_history(input_history.as_deref(), new_messages.clone()),
+                    prompt: last_prompt_error.clone().into(),
                 }).into());
             }
         };
@@ -1087,9 +1106,10 @@ mod tests {
             .build();
 
         // Send streaming request with history
+        let empty_history: &[Message] = &[];
         let mut stream = agent
             .stream_prompt("Say 'hello' and nothing else.")
-            .with_history(vec![])
+            .with_history(empty_history)
             .await;
 
         // Consume the stream and collect FinalResponse

--- a/rig/rig-core/src/agent/tool.rs
+++ b/rig/rig-core/src/agent/tool.rs
@@ -12,7 +12,7 @@ pub struct AgentToolArgs {
     prompt: String,
 }
 
-impl<M: CompletionModel> Tool for Agent<M> {
+impl<M: CompletionModel + 'static> Tool for Agent<M> {
     const NAME: &'static str = "agent_tool";
 
     type Error = PromptError;

--- a/rig/rig-core/src/completion/message.rs
+++ b/rig/rig-core/src/completion/message.rs
@@ -1138,6 +1138,12 @@ impl FromStr for Text {
     }
 }
 
+impl From<&Message> for Message {
+    fn from(msg: &Message) -> Self {
+        msg.clone()
+    }
+}
+
 impl From<String> for Message {
     fn from(text: String) -> Self {
         Message::User {

--- a/rig/rig-core/src/completion/request.rs
+++ b/rig/rig-core/src/completion/request.rs
@@ -119,7 +119,6 @@ pub enum CompletionError {
 }
 
 /// Prompt errors
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Error)]
 pub enum PromptError {
     /// Something went wrong with the completion
@@ -132,7 +131,7 @@ pub enum PromptError {
 
     /// There was an issue while executing a tool on a tool server
     #[error("ToolServerError: {0}")]
-    ToolServerError(#[from] ToolServerError),
+    ToolServerError(#[from] Box<ToolServerError>),
 
     /// The LLM tried to call too many tools during a multi-turn conversation.
     /// To fix this, you may either need to lower the amount of tools your model has access to (and then create other agents to share the tool load)
@@ -140,8 +139,8 @@ pub enum PromptError {
     #[error("MaxTurnError: (reached max turn limit: {max_turns})")]
     MaxTurnsError {
         max_turns: usize,
-        chat_history: Vec<Message>,
-        prompt: Message,
+        chat_history: Box<Vec<Message>>,
+        prompt: Box<Message>,
     },
 
     /// A prompting loop was cancelled.
@@ -165,12 +164,11 @@ impl PromptError {
 }
 
 /// Errors that can occur when using typed structured output via [`TypedPrompt::prompt_typed`].
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Error)]
 pub enum StructuredOutputError {
     /// An error occurred during the prompt execution.
     #[error("PromptError: {0}")]
-    PromptError(#[from] PromptError),
+    PromptError(#[from] Box<PromptError>),
 
     /// Failed to deserialize the model's response into the target type.
     #[error("DeserializationError: {0}")]

--- a/rig/rig-core/src/completion/request.rs
+++ b/rig/rig-core/src/completion/request.rs
@@ -119,6 +119,7 @@ pub enum CompletionError {
 }
 
 /// Prompt errors
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Error)]
 pub enum PromptError {
     /// Something went wrong with the completion
@@ -139,28 +140,32 @@ pub enum PromptError {
     #[error("MaxTurnError: (reached max turn limit: {max_turns})")]
     MaxTurnsError {
         max_turns: usize,
-        chat_history: Box<Vec<Message>>,
-        prompt: Box<Message>,
+        chat_history: Vec<Message>,
+        prompt: Message,
     },
 
     /// A prompting loop was cancelled.
     #[error("PromptCancelled: {reason}")]
     PromptCancelled {
-        chat_history: Box<Vec<Message>>,
+        chat_history: Vec<Message>,
         reason: String,
     },
 }
 
 impl PromptError {
-    pub(crate) fn prompt_cancelled(chat_history: Vec<Message>, reason: impl Into<String>) -> Self {
+    pub(crate) fn prompt_cancelled(
+        chat_history: impl IntoIterator<Item = Message>,
+        reason: impl Into<String>,
+    ) -> Self {
         Self::PromptCancelled {
-            chat_history: Box::new(chat_history),
+            chat_history: chat_history.into_iter().collect(),
             reason: reason.into(),
         }
     }
 }
 
 /// Errors that can occur when using typed structured output via [`TypedPrompt::prompt_typed`].
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Error)]
 pub enum StructuredOutputError {
     /// An error occurred during the prompt execution.
@@ -272,11 +277,14 @@ pub trait Chat: WasmCompatSend + WasmCompatSync {
     /// is returned as a string.
     ///
     /// If the tool does not exist, or the tool call fails, then an error is returned.
-    fn chat(
+    fn chat<I, T>(
         &self,
         prompt: impl Into<Message> + WasmCompatSend,
-        chat_history: Vec<Message>,
-    ) -> impl std::future::IntoFuture<Output = Result<String, PromptError>, IntoFuture: WasmCompatSend>;
+        chat_history: I,
+    ) -> impl std::future::Future<Output = Result<String, PromptError>> + WasmCompatSend
+    where
+        I: IntoIterator<Item = T> + WasmCompatSend,
+        T: Into<Message>;
 }
 
 /// Trait defining a high-level typed prompt interface for structured output.
@@ -304,10 +312,9 @@ pub trait Chat: WasmCompatSend + WasmCompatSync {
 /// ```
 pub trait TypedPrompt: WasmCompatSend + WasmCompatSync {
     /// The type of the typed prompt request returned by `prompt_typed`.
-    type TypedRequest<'a, T>: std::future::IntoFuture<Output = Result<T, StructuredOutputError>>
+    type TypedRequest<T>: std::future::IntoFuture<Output = Result<T, StructuredOutputError>>
     where
-        Self: 'a,
-        T: schemars::JsonSchema + DeserializeOwned + WasmCompatSend + 'a;
+        T: schemars::JsonSchema + DeserializeOwned + WasmCompatSend + 'static;
 
     /// Send a prompt and receive a typed structured response.
     ///
@@ -328,10 +335,7 @@ pub trait TypedPrompt: WasmCompatSend + WasmCompatSync {
     /// // Or specified explicitly with turbofish
     /// let forecast = agent.prompt_typed::<WeatherForecast>("What's the weather?").await?;
     /// ```
-    fn prompt_typed<T>(
-        &self,
-        prompt: impl Into<Message> + WasmCompatSend,
-    ) -> Self::TypedRequest<'_, T>
+    fn prompt_typed<T>(&self, prompt: impl Into<Message> + WasmCompatSend) -> Self::TypedRequest<T>
     where
         T: schemars::JsonSchema + DeserializeOwned + WasmCompatSend;
 }
@@ -349,12 +353,15 @@ pub trait Completion<M: CompletionModel> {
     ///
     /// For example, the request builder returned by [`Agent::completion`](crate::agent::Agent::completion) will already
     /// contain the `preamble` provided when creating the agent.
-    fn completion(
+    fn completion<I, T>(
         &self,
         prompt: impl Into<Message> + WasmCompatSend,
-        chat_history: Vec<Message>,
+        chat_history: I,
     ) -> impl std::future::Future<Output = Result<CompletionRequestBuilder<M>, CompletionError>>
-    + WasmCompatSend;
+    + WasmCompatSend
+    where
+        I: IntoIterator<Item = T> + WasmCompatSend,
+        T: Into<Message>;
 }
 
 /// General completion response struct that contains the high-level completion choice
@@ -797,14 +804,15 @@ impl<M: CompletionModel> CompletionRequestBuilder<M> {
     /// Adds a message to the chat history for the completion request.
     pub fn message(mut self, message: Message) -> Self {
         self.chat_history.push(message);
+
         self
     }
 
     /// Adds a list of messages to the chat history for the completion request.
-    pub fn messages(self, messages: Vec<Message>) -> Self {
-        messages
-            .into_iter()
-            .fold(self, |builder, msg| builder.message(msg))
+    pub fn messages(mut self, messages: impl IntoIterator<Item = Message>) -> Self {
+        self.chat_history.extend(messages);
+
+        self
     }
 
     /// Adds a document to the completion request.
@@ -814,7 +822,7 @@ impl<M: CompletionModel> CompletionRequestBuilder<M> {
     }
 
     /// Adds a list of documents to the completion request.
-    pub fn documents(self, documents: Vec<Document>) -> Self {
+    pub fn documents(self, documents: impl IntoIterator<Item = Document>) -> Self {
         documents
             .into_iter()
             .fold(self, |builder, doc| builder.document(doc))
@@ -928,12 +936,15 @@ impl<M: CompletionModel> CompletionRequestBuilder<M> {
 
     /// Builds the completion request.
     pub fn build(self) -> CompletionRequest {
+        // Build the final message list, prepending preamble if present
         let mut chat_history = self.chat_history;
         if let Some(preamble) = self.preamble {
             chat_history.insert(0, Message::system(preamble));
         }
-        let chat_history = OneOrMany::many([chat_history, vec![self.prompt]].concat())
-            .expect("There will always be atleast the prompt");
+        chat_history.push(self.prompt);
+
+        let chat_history =
+            OneOrMany::many(chat_history).expect("There will always be at least the prompt");
         let additional_params = merge_provider_tools_into_additional_params(
             self.additional_params,
             self.provider_tools,

--- a/rig/rig-core/src/extractor.rs
+++ b/rig/rig-core/src/extractor.rs
@@ -240,7 +240,7 @@ where
         text: impl Into<Message> + WasmCompatSend,
         messages: Vec<Message>,
     ) -> Result<(T, Usage), ExtractionError> {
-        let response = self.agent.completion(text, messages).await?.send().await?;
+        let response = self.agent.completion(text, &messages).await?.send().await?;
         let usage = response.usage;
 
         if !response.choice.iter().any(|x| {

--- a/rig/rig-core/src/integrations/cli_chatbot.rs
+++ b/rig/rig-core/src/integrations/cli_chatbot.rs
@@ -52,7 +52,7 @@ where
         prompt: &str,
         history: Vec<Message>,
     ) -> Result<String, PromptError> {
-        let res = self.0.chat(prompt, history).await?;
+        let res = self.0.chat(prompt, &history).await?;
         println!("{res}");
 
         Ok(res)
@@ -71,7 +71,7 @@ where
         let mut response_stream = self
             .agent
             .stream_prompt(prompt)
-            .with_history(history)
+            .with_history(&history)
             .multi_turn(self.max_turns)
             .await;
 

--- a/rig/rig-core/src/pipeline/mod.rs
+++ b/rig/rig-core/src/pipeline/mod.rs
@@ -280,10 +280,9 @@ impl<E> PipelineBuilder<E> {
 }
 
 #[derive(Debug, thiserror::Error)]
-#[allow(clippy::large_enum_variant)]
 pub enum ChainError {
     #[error("Failed to prompt agent: {0}")]
-    PromptError(#[from] completion::PromptError),
+    PromptError(#[from] Box<completion::PromptError>),
 
     #[error("Failed to lookup documents: {0}")]
     LookupError(#[from] vector_store::VectorStoreError),

--- a/rig/rig-core/src/pipeline/mod.rs
+++ b/rig/rig-core/src/pipeline/mod.rs
@@ -280,6 +280,7 @@ impl<E> PipelineBuilder<E> {
 }
 
 #[derive(Debug, thiserror::Error)]
+#[allow(clippy::large_enum_variant)]
 pub enum ChainError {
     #[error("Failed to prompt agent: {0}")]
     PromptError(#[from] completion::PromptError),

--- a/rig/rig-core/src/providers/anthropic/completion.rs
+++ b/rig/rig-core/src/providers/anthropic/completion.rs
@@ -966,7 +966,21 @@ fn sanitize_schema(schema: &mut serde_json::Value) {
             sanitize_schema(items);
         }
 
-        for key in ["anyOf", "oneOf", "allOf"] {
+        // Anthropic doesn't support oneOf, convert to anyOf
+        if let Some(one_of) = obj.remove("oneOf") {
+            match obj.get_mut("anyOf") {
+                Some(Value::Array(existing)) => {
+                    if let Value::Array(mut incoming) = one_of {
+                        existing.append(&mut incoming);
+                    }
+                }
+                _ => {
+                    obj.insert("anyOf".to_string(), one_of);
+                }
+            }
+        }
+
+        for key in ["anyOf", "allOf"] {
             if let Some(variants) = obj.get_mut(key)
                 && let Value::Array(variants_array) = variants
             {

--- a/rig/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/rig/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -448,7 +448,7 @@ mod tests {
     use serde_json::{self, json};
 
     use crate::{
-        completion::ToolDefinition,
+        completion::{Message, ToolDefinition},
         tool::{Tool, ToolError},
     };
 
@@ -646,9 +646,9 @@ mod tests {
             }))
             .build();
 
-        let chat_history = Vec::new();
+        let chat_history: Vec<Message> = Vec::new();
         let mut stream = agent
-            .stream_chat("Call my example tool", chat_history)
+            .stream_chat("Call my example tool", &chat_history)
             .multi_turn(5)
             .await;
 

--- a/rig/rig-core/src/streaming.rs
+++ b/rig/rig-core/src/streaming.rs
@@ -490,6 +490,29 @@ where
     type Hook: PromptHook<M>;
 
     /// Stream a chat with history to the model.
+    ///
+    /// The messages returned by the model can be accessed via [`FinalResponse::history()`]
+    ///
+    /// You are responsible for managing history, a simple linear solution could look like:
+    /// ```ignore
+    ///  let mut history = vec![];
+    ///
+    ///  loop {
+    ///      let prompt = "Create GPT-67, make no mistakes";
+    ///      let mut stream = agent.stream_chat(prompt, &history).await;
+    ///
+    ///      while let Some(msg) = stream.next().await {
+    ///         match msg {
+    ///              Ok(MultiTurnStreamItem::FinalResponse(fin)) => {
+    ///                  history.extend_from_slice(fin.history().unwrap_or_default());
+    ///                  break;
+    ///             }
+    ///             Ok(_other) => { /* Do something with this chunk */ }
+    ///             Err(e) => return Err(e.into()),
+    ///         }
+    ///     }
+    /// }
+    /// ```
     fn stream_chat<I, T>(
         &self,
         prompt: impl Into<Message> + WasmCompatSend,

--- a/rig/rig-core/src/streaming.rs
+++ b/rig/rig-core/src/streaming.rs
@@ -491,7 +491,7 @@ where
 
     /// Stream a chat with history to the model.
     ///
-    /// The messages returned by the model can be accessed via [`FinalResponse::history()`]
+    /// The messages returned by the model can be accessed via `FinalResponse::history()`
     ///
     /// You are responsible for managing history, a simple linear solution could look like:
     /// ```ignore

--- a/rig/rig-core/src/streaming.rs
+++ b/rig/rig-core/src/streaming.rs
@@ -489,25 +489,28 @@ where
     /// ```
     type Hook: PromptHook<M>;
 
-    /// Stream a chat with history to the model
-    ///
-    /// The updated history (including the new prompt and response) is returned
-    /// in [`FinalResponse::history()`](crate::agent::prompt_request::streaming::FinalResponse::history).
-    fn stream_chat(
+    /// Stream a chat with history to the model.
+    fn stream_chat<I, T>(
         &self,
         prompt: impl Into<Message> + WasmCompatSend,
-        chat_history: Vec<Message>,
-    ) -> StreamingPromptRequest<M, Self::Hook>;
+        chat_history: I,
+    ) -> StreamingPromptRequest<M, Self::Hook>
+    where
+        I: IntoIterator<Item = T> + WasmCompatSend,
+        T: Into<Message>;
 }
 
 /// Trait for low-level streaming completion interface
 pub trait StreamingCompletion<M: CompletionModel> {
     /// Generate a streaming completion from a request
-    fn stream_completion(
+    fn stream_completion<I, T>(
         &self,
         prompt: impl Into<Message> + WasmCompatSend,
-        chat_history: Vec<Message>,
-    ) -> impl Future<Output = Result<CompletionRequestBuilder<M>, CompletionError>>;
+        chat_history: I,
+    ) -> impl Future<Output = Result<CompletionRequestBuilder<M>, CompletionError>>
+    where
+        I: IntoIterator<Item = T> + WasmCompatSend,
+        T: Into<Message>;
 }
 
 pub(crate) struct StreamingResultDyn<R: Clone + Unpin + GetTokenUsage> {

--- a/rig/rig-core/tests/prompt_response_messages.rs
+++ b/rig/rig-core/tests/prompt_response_messages.rs
@@ -229,60 +229,57 @@ async fn extended_details_populates_messages() {
     }
 }
 
-/// Test 3: `with_history()` + `extended_details()` — both the external mutable
-/// history AND `PromptResponse.messages` should contain the same data.
+/// Test 3: `with_history()` + `extended_details()` — the response messages
+/// should contain the full conversation including any provided history.
 #[tokio::test]
 async fn extended_with_history_both_populated() {
     let agent = AgentBuilder::new(SimpleTextModel).build();
 
-    let mut external_history: Vec<Message> = Vec::new();
+    let initial_history: Vec<Message> = Vec::new();
 
     let resp = agent
         .prompt("hello")
-        .with_history(&mut external_history)
+        .with_history(&initial_history)
         .extended_details()
         .await
         .expect("prompt should succeed");
 
     let response_messages = resp.messages.expect("messages should be Some");
 
-    // Both should have the same length and content
-    assert_eq!(external_history.len(), response_messages.len());
-    assert_eq!(external_history.len(), 2);
+    // Response should contain the full conversation (User + Assistant)
+    assert_eq!(response_messages.len(), 2);
 
-    // Verify they contain the same data
-    for (ext, resp_msg) in external_history.iter().zip(response_messages.iter()) {
-        // Compare debug representations (Message implements Debug)
-        assert_eq!(format!("{ext:?}"), format!("{resp_msg:?}"));
+    // First message: User
+    match &response_messages[0] {
+        Message::User { .. } => {}
+        other => panic!("expected User, got: {other:?}"),
+    }
+
+    // Second message: Assistant
+    match &response_messages[1] {
+        Message::Assistant { .. } => {}
+        other => panic!("expected Assistant, got: {other:?}"),
     }
 }
 
-/// Test 4: Standard path with `with_history()` — the external history should
-/// still be mutated in place (backward compat for the mutable borrow pattern).
+/// Test 4: Standard path with `with_history()` — verify the API works with
+/// an immutable history reference.
 #[tokio::test]
-async fn standard_with_history_still_mutates() {
+async fn standard_with_history_works() {
     let agent = AgentBuilder::new(SimpleTextModel).build();
 
-    let mut history: Vec<Message> = Vec::new();
+    let history: Vec<Message> = Vec::new();
 
     let result = agent
         .prompt("test")
-        .with_history(&mut history)
+        .with_history(&history)
         .await
         .expect("prompt should succeed");
 
     assert_eq!(result, "hello from mock");
 
-    // External history should contain [User, Assistant]
-    assert_eq!(history.len(), 2);
-    match &history[0] {
-        Message::User { .. } => {}
-        other => panic!("expected User, got: {other:?}"),
-    }
-    match &history[1] {
-        Message::Assistant { .. } => {}
-        other => panic!("expected Assistant, got: {other:?}"),
-    }
+    // Note: The input history is not mutated. To get the updated history,
+    // use `.extended_details()` and access `response.messages`.
 }
 
 /// Test 5: Multi-turn agent loop with tool calls — messages should contain the

--- a/rig/rig-core/tests/reasoning_tool_roundtrip.rs
+++ b/rig/rig-core/tests/reasoning_tool_roundtrip.rs
@@ -34,6 +34,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use futures::StreamExt;
 use rig::agent::{MultiTurnStreamItem, StreamingError};
 use rig::client::{CompletionClient, ProviderClient};
+use rig::completion::Message;
 use rig::completion::request::ToolDefinition;
 use rig::message::{Reasoning, ReasoningContent};
 use rig::streaming::{StreamedAssistantContent, StreamedUserContent, StreamingChat};
@@ -411,7 +412,10 @@ async fn test_openai_tool_call_with_reasoning() {
         }))
         .build();
 
-    let stream = agent.stream_chat(USER_PROMPT, vec![]).multi_turn(3).await;
+    let stream = agent
+        .stream_chat(USER_PROMPT, Vec::<Message>::new())
+        .multi_turn(3)
+        .await;
 
     let stats = collect_stream_stats(stream, "openai").await;
     assert_universal(&stats, &call_count, "openai");
@@ -453,7 +457,10 @@ async fn test_anthropic_tool_call_with_reasoning() {
         }))
         .build();
 
-    let stream = agent.stream_chat(USER_PROMPT, vec![]).multi_turn(3).await;
+    let stream = agent
+        .stream_chat(USER_PROMPT, Vec::<Message>::new())
+        .multi_turn(3)
+        .await;
 
     let stats = collect_stream_stats(stream, "anthropic").await;
     assert_universal(&stats, &call_count, "anthropic");
@@ -502,7 +509,10 @@ async fn test_gemini_tool_call_with_reasoning() {
         }))
         .build();
 
-    let stream = agent.stream_chat(USER_PROMPT, vec![]).multi_turn(3).await;
+    let stream = agent
+        .stream_chat(USER_PROMPT, Vec::<Message>::new())
+        .multi_turn(3)
+        .await;
 
     let stats = collect_stream_stats(stream, "gemini").await;
     assert_universal(&stats, &call_count, "gemini");
@@ -529,7 +539,10 @@ async fn test_xai_tool_call_with_reasoning() {
         .tool(tool)
         .build();
 
-    let stream = agent.stream_chat(USER_PROMPT, vec![]).multi_turn(3).await;
+    let stream = agent
+        .stream_chat(USER_PROMPT, Vec::<Message>::new())
+        .multi_turn(3)
+        .await;
 
     let stats = collect_stream_stats(stream, "xai").await;
     assert_universal(&stats, &call_count, "xai");
@@ -557,7 +570,10 @@ async fn test_openrouter_tool_call_with_reasoning() {
         }))
         .build();
 
-    let stream = agent.stream_chat(USER_PROMPT, vec![]).multi_turn(3).await;
+    let stream = agent
+        .stream_chat(USER_PROMPT, Vec::<Message>::new())
+        .multi_turn(3)
+        .await;
 
     let stats = collect_stream_stats(stream, "openrouter").await;
 
@@ -703,7 +719,7 @@ async fn test_openai_tool_call_nonstreaming() {
         .build();
 
     let result = agent
-        .chat(USER_PROMPT, vec![])
+        .chat(USER_PROMPT, Vec::<Message>::new())
         .await
         .expect("[openai] Non-streaming chat failed — likely 400 from dropped reasoning");
 
@@ -734,7 +750,7 @@ async fn test_anthropic_tool_call_nonstreaming() {
         .build();
 
     let result = agent
-        .chat(USER_PROMPT, vec![])
+        .chat(USER_PROMPT, Vec::<Message>::new())
         .await
         .expect("[anthropic] Non-streaming chat failed — likely 400 from dropped reasoning");
 
@@ -767,7 +783,7 @@ async fn test_gemini_tool_call_nonstreaming() {
         .build();
 
     let result = agent
-        .chat(USER_PROMPT, vec![])
+        .chat(USER_PROMPT, Vec::<Message>::new())
         .await
         .expect("[gemini] Non-streaming chat failed — likely 400 from dropped reasoning");
 
@@ -795,7 +811,7 @@ async fn test_xai_tool_call_nonstreaming() {
         .build();
 
     let result = agent
-        .chat(USER_PROMPT, vec![])
+        .chat(USER_PROMPT, Vec::<Message>::new())
         .await
         .expect("[xai] Non-streaming chat failed — likely 400 from dropped reasoning");
 
@@ -827,7 +843,7 @@ async fn test_openrouter_tool_call_nonstreaming() {
         .build();
 
     let result = agent
-        .chat(USER_PROMPT, vec![])
+        .chat(USER_PROMPT, Vec::<Message>::new())
         .await
         .expect("[openrouter] Non-streaming chat failed — likely 400 from dropped reasoning");
 


### PR DESCRIPTION
This changes prompt generation methods like `prompt` and `stream_prompt` etc to take iterators over references to `Message` as opposed to owned or mutable vectors so that users may decide how to manage chat history and potentially avoid performance pitfalls like cloning large histories.

Because these changes were mostly mechanical I did use Claude Code, but have gone back in and cleaned up any code I felt was low quality. Still, I may have missed some 