### PR TITLE
feat(rig-bedrock): add OpenTelemetry tracing to completion model

### DIFF
--- a/rig-integrations/rig-bedrock/src/completion.rs
+++ b/rig-integrations/rig-bedrock/src/completion.rs
@@ -10,6 +10,8 @@ use crate::{
 
 use rig::completion::{self, CompletionError, CompletionRequest};
 use rig::streaming::StreamingCompletionResponse;
+use rig::telemetry::SpanCombinator;
+use tracing::Instrument;
 
 /// `ai21.jamba-1-5-large-v1:0`
 pub const AI21_JAMBA_1_5_LARGE: &str = "ai21.jamba-1-5-large-v1:0";
@@ -185,6 +187,29 @@ impl completion::CompletionModel for CompletionModel {
         &self,
         completion_request: completion::CompletionRequest,
     ) -> Result<completion::CompletionResponse<AwsConverseOutput>, CompletionError> {
+        let request_model = completion_request
+            .model
+            .clone()
+            .unwrap_or_else(|| self.model.clone());
+
+        let span = if tracing::Span::current().is_disabled() {
+            tracing::info_span!(
+                target: "rig::completions",
+                "chat",
+                gen_ai.operation.name = "chat",
+                gen_ai.provider.name = "aws_bedrock",
+                gen_ai.request.model = &request_model,
+                gen_ai.system_instructions = &completion_request.preamble,
+                gen_ai.response.id = tracing::field::Empty,
+                gen_ai.response.model = tracing::field::Empty,
+                gen_ai.usage.output_tokens = tracing::field::Empty,
+                gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cached_tokens = tracing::field::Empty,
+            )
+        } else {
+            tracing::Span::current()
+        };
+
         let request = AwsCompletionRequest(completion_request);
 
         let mut converse_builder = self
@@ -203,16 +228,30 @@ impl completion::CompletionModel for CompletionModel {
             .set_system(request.system_prompt())
             .set_messages(Some(messages));
 
-        let response = converse_builder
-            .send()
-            .await
-            .map_err(|sdk_error| Into::<CompletionError>::into(AwsSdkConverseError(sdk_error)))?;
+        async move {
+            let response = converse_builder
+                .send()
+                .await
+                .map_err(|sdk_error| {
+                    Into::<CompletionError>::into(AwsSdkConverseError(sdk_error))
+                })?;
 
-        let response: InternalConverseOutput = response
-            .try_into()
-            .map_err(|x| CompletionError::ProviderError(format!("Type conversion error: {x}")))?;
+            let response: InternalConverseOutput = response
+                .try_into()
+                .map_err(|x| {
+                    CompletionError::ProviderError(format!("Type conversion error: {x}"))
+                })?;
 
-        AwsConverseOutput(response).try_into()
+            let aws_output = AwsConverseOutput(response);
+
+            let span = tracing::Span::current();
+            span.record_response_metadata(&aws_output);
+            span.record_token_usage(&aws_output);
+
+            aws_output.try_into()
+        }
+        .instrument(span)
+        .await
     }
 
     async fn stream(

--- a/rig-integrations/rig-bedrock/src/types/assistant_content.rs
+++ b/rig-integrations/rig-bedrock/src/types/assistant_content.rs
@@ -9,11 +9,64 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::message::RigMessage;
 
-use super::{converse_output::InternalConverseOutput, json::AwsDocument};
-use rig::completion;
+use super::{
+    converse_output::{ContentBlock, InternalConverseOutput},
+    json::AwsDocument,
+};
+use rig::completion::{self, GetTokenUsage};
+use rig::telemetry::ProviderResponseExt;
 
 #[derive(Clone, Deserialize, Serialize)]
 pub struct AwsConverseOutput(pub InternalConverseOutput);
+
+impl ProviderResponseExt for AwsConverseOutput {
+    type OutputMessage = serde_json::Value;
+    type Usage = completion::Usage;
+
+    fn get_response_id(&self) -> Option<String> {
+        None // Bedrock Converse API doesn't return a response ID
+    }
+
+    fn get_response_model_name(&self) -> Option<String> {
+        None // Bedrock doesn't echo model name in response
+    }
+
+    fn get_output_messages(&self) -> Vec<Self::OutputMessage> {
+        self.0
+            .output
+            .as_ref()
+            .map(|output| vec![serde_json::to_value(output).unwrap_or_default()])
+            .unwrap_or_default()
+    }
+
+    fn get_text_response(&self) -> Option<String> {
+        let output = self.0.output.as_ref()?;
+        let message = output.as_message().ok()?;
+        message.content.iter().find_map(|block| {
+            if let ContentBlock::Text(text) = block {
+                Some(text.clone())
+            } else {
+                None
+            }
+        })
+    }
+
+    fn get_usage(&self) -> Option<Self::Usage> {
+        self.0.usage().map(|u| completion::Usage {
+            input_tokens: u.input_tokens as u64,
+            output_tokens: u.output_tokens as u64,
+            total_tokens: u.total_tokens as u64,
+            cached_input_tokens: u.cache_read_input_tokens.unwrap_or_default() as u64
+                + u.cache_write_input_tokens.unwrap_or_default() as u64,
+        })
+    }
+}
+
+impl GetTokenUsage for AwsConverseOutput {
+    fn token_usage(&self) -> Option<completion::Usage> {
+        self.get_usage()
+    }
+}
 
 impl TryFrom<AwsConverseOutput> for completion::CompletionResponse<AwsConverseOutput> {
     type Error = CompletionError;
@@ -203,8 +256,89 @@ mod tests {
     use aws_sdk_bedrockruntime::types as aws_bedrock;
     use rig::{
         OneOrMany, completion,
+        completion::GetTokenUsage,
         message::{AssistantContent, ReasoningContent},
+        telemetry::ProviderResponseExt,
     };
+
+    /// Helper: build an AwsConverseOutput with text content and optional usage.
+    fn make_output(text: &str, usage: Option<aws_bedrock::TokenUsage>) -> AwsConverseOutput {
+        let message = aws_bedrock::Message::builder()
+            .role(aws_bedrock::ConversationRole::Assistant)
+            .content(aws_bedrock::ContentBlock::Text(text.into()))
+            .build()
+            .unwrap();
+        let mut builder =
+            aws_sdk_bedrockruntime::operation::converse::ConverseOutput::builder()
+                .output(aws_bedrock::ConverseOutput::Message(message))
+                .stop_reason(aws_bedrock::StopReason::EndTurn);
+        if let Some(u) = usage {
+            builder = builder.usage(u);
+        }
+        let internal: InternalConverseOutput = builder.build().unwrap().try_into().unwrap();
+        AwsConverseOutput(internal)
+    }
+
+    fn make_usage(input: i32, output: i32, total: i32) -> aws_bedrock::TokenUsage {
+        aws_bedrock::TokenUsage::builder()
+            .input_tokens(input)
+            .output_tokens(output)
+            .total_tokens(total)
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn provider_response_ext_get_text_response() {
+        let out = make_output("hello world", None);
+        assert_eq!(out.get_text_response(), Some("hello world".to_string()));
+    }
+
+    #[test]
+    fn provider_response_ext_response_id_is_none() {
+        let out = make_output("x", None);
+        assert!(out.get_response_id().is_none());
+        assert!(out.get_response_model_name().is_none());
+    }
+
+    #[test]
+    fn provider_response_ext_get_usage_with_tokens() {
+        let out = make_output("x", Some(make_usage(100, 50, 150)));
+        let usage = out.get_usage().unwrap();
+        assert_eq!(usage.input_tokens, 100);
+        assert_eq!(usage.output_tokens, 50);
+        assert_eq!(usage.total_tokens, 150);
+    }
+
+    #[test]
+    fn provider_response_ext_get_usage_none_when_missing() {
+        let out = make_output("x", None);
+        assert!(out.get_usage().is_none());
+    }
+
+    #[test]
+    fn provider_response_ext_output_messages_serializable() {
+        let out = make_output("test", None);
+        let msgs = out.get_output_messages();
+        assert_eq!(msgs.len(), 1);
+        // Should be valid JSON
+        assert!(msgs[0].is_object());
+    }
+
+    #[test]
+    fn get_token_usage_delegates_to_provider_response_ext() {
+        let out = make_output("x", Some(make_usage(10, 20, 30)));
+        let usage = out.token_usage().unwrap();
+        assert_eq!(usage.input_tokens, 10);
+        assert_eq!(usage.output_tokens, 20);
+        assert_eq!(usage.total_tokens, 30);
+    }
+
+    #[test]
+    fn get_token_usage_none_when_no_usage() {
+        let out = make_output("x", None);
+        assert!(out.token_usage().is_none());
+    }
 
     #[test]
     fn aws_converse_output_to_completion_response() {


### PR DESCRIPTION
# PR: Add OpenTelemetry tracing instrumentation to rig-bedrock

## Title

`feat(rig-bedrock): add OpenTelemetry tracing to completion model`

## Problem

`rig-bedrock` is the only completion model provider that has **zero tracing instrumentation**.
All built-in providers (OpenAI, Anthropic, Cohere, Gemini, HuggingFace, Mistral) implement
`ProviderResponseExt` and `GetTokenUsage`, and record `gen_ai.*` span attributes on the chat
span created by rig-core's agent loop. Because rig-bedrock doesn't, observability backends
(Langfuse, Jaeger, etc.) show:

- `gen_ai.provider.name`: missing
- `gen_ai.request.model`: missing
- `gen_ai.usage.input_tokens` / `output_tokens`: zeros
- `gen_ai.response.id` / `gen_ai.response.model`: missing

Tool spans (`execute_tool`) work fine because rig-core handles those directly.
Only the `chat` GENERATION spans are broken.

## Root Cause

rig-core creates chat spans with `gen_ai.*` fields set to `tracing::field::Empty`
(see `rig-core/src/agent/prompt_request/`). It expects the **completion model provider**
to call `span.record(...)` to fill them in — exactly as Anthropic does in
`rig-core/src/providers/anthropic/completion.rs`:

```rust
let span = tracing::Span::current();
span.record_response_metadata(&completion);
span.record_token_usage(&completion.usage);
```

`rig-bedrock`'s `CompletionModel::completion()` never touches the span.

## Changes

### 1. `rig-integrations/rig-bedrock/src/types/assistant_content.rs`

Implement `ProviderResponseExt` and `GetTokenUsage` for `AwsConverseOutput`:

```rust
impl ProviderResponseExt for AwsConverseOutput {
    type OutputMessage = serde_json::Value;
    type Usage = completion::Usage;

    fn get_response_id(&self) -> Option<String> {
        None // Bedrock Converse API doesn't return a response ID
    }

    fn get_response_model_name(&self) -> Option<String> {
        None // Bedrock doesn't echo model name in response
    }

    fn get_output_messages(&self) -> Vec<Self::OutputMessage> {
        self.0
            .output
            .as_ref()
            .map(|output| vec![serde_json::to_value(output).unwrap_or_default()])
            .unwrap_or_default()
    }

    fn get_text_response(&self) -> Option<String> {
        let output = self.0.output.as_ref()?;
        let message = output.as_message().ok()?;
        message.content.iter().find_map(|block| {
            if let ContentBlock::Text(text) = block {
                Some(text.clone())
            } else {
                None
            }
        })
    }

    fn get_usage(&self) -> Option<Self::Usage> {
        self.0.usage().map(|u| completion::Usage {
            input_tokens: u.input_tokens as u64,
            output_tokens: u.output_tokens as u64,
            total_tokens: u.total_tokens as u64,
            cached_input_tokens: u.cache_read_input_tokens.unwrap_or_default() as u64
                + u.cache_write_input_tokens.unwrap_or_default() as u64,
        })
    }
}

impl GetTokenUsage for AwsConverseOutput {
    fn token_usage(&self) -> Option<completion::Usage> {
        self.get_usage()
    }
}
```

### 2. `rig-integrations/rig-bedrock/src/completion.rs`

Record span attributes in `completion()`, matching the Anthropic pattern:

```rust
use rig::telemetry::SpanCombinator;
use tracing::Instrument;

// Inside CompletionModel::completion():

let request_model = completion_request
    .model
    .clone()
    .unwrap_or_else(|| self.model.clone());

let span = if tracing::Span::current().is_disabled() {
    tracing::info_span!(
        target: "rig::completions",
        "chat",
        gen_ai.operation.name = "chat",
        gen_ai.provider.name = "aws_bedrock",
        gen_ai.request.model = &request_model,
        gen_ai.system_instructions = &completion_request.preamble,
        gen_ai.response.id = tracing::field::Empty,
        gen_ai.response.model = tracing::field::Empty,
        gen_ai.usage.output_tokens = tracing::field::Empty,
        gen_ai.usage.input_tokens = tracing::field::Empty,
        gen_ai.usage.cached_tokens = tracing::field::Empty,
    )
} else {
    tracing::Span::current()
};

// ... build request ...

async move {
    // ... send request, get response ...

    let aws_output = AwsConverseOutput(response);

    let span = tracing::Span::current();
    span.record_response_metadata(&aws_output);
    span.record_token_usage(&aws_output);

    aws_output.try_into()
}
.instrument(span)
.await
```

No `Cargo.toml` change needed — `tracing` is already a dependency.

## What This Fixes

After this change, observability backends will show for each chat span:

| Field | Before | After |
|-------|--------|-------|
| `gen_ai.provider.name` | _(missing)_ | `aws_bedrock` |
| `gen_ai.request.model` | _(missing)_ | e.g. `anthropic.claude-3-5-sonnet-20241022-v2:0` |
| `gen_ai.system_instructions` | _(missing)_ | preamble text |
| `gen_ai.usage.input_tokens` | 0 | actual token count |
| `gen_ai.usage.output_tokens` | 0 | actual token count |
| `gen_ai.usage.cached_tokens` | 0 | cache_read + cache_write tokens |

Note: Bedrock's Converse API does not return `response_id` or echo the model name
in the response body, so `gen_ai.response.id` and `gen_ai.response.model` will
remain empty. This is a Bedrock API limitation, not a rig issue.

## Tests

7 new unit tests added for the trait implementations:

- `provider_response_ext_get_text_response` — text extraction from content blocks
- `provider_response_ext_response_id_is_none` — Bedrock API limitation
- `provider_response_ext_get_usage_with_tokens` — token count extraction
- `provider_response_ext_get_usage_none_when_missing` — no usage in response
- `provider_response_ext_output_messages_serializable` — JSON serialization
- `get_token_usage_delegates_to_provider_response_ext` — trait delegation
- `get_token_usage_none_when_no_usage` — None propagation

All 60 tests pass (53 existing + 7 new). Zero clippy warnings.

## Scope

- **Non-streaming completion only.** Streaming tracing is not implemented by any
  external integration (rig-vertexai, rig-gemini-grpc) and is a separate concern.
- **First external integration with full tracing.** rig-gemini-grpc implements
  `ProviderResponseExt` but never records spans. rig-vertexai has no tracing at all.

## Reference

Pattern follows existing built-in providers:
- `rig-core/src/providers/anthropic/completion.rs` (ProviderResponseExt + span recording)
- `rig-core/src/providers/openai/completion/mod.rs` (ProviderResponseExt + GetTokenUsage)
- `rig-core/src/telemetry/mod.rs` (SpanCombinator trait, impl for tracing::Span)

## gh CLI Commands

```bash
# 1. Fork + clone
gh repo fork 0xPlaygrounds/rig --clone
cd rig

# 2. Branch
git checkout -b feat/bedrock-tracing

# 3. Make the changes listed above in:
#    - rig-integrations/rig-bedrock/src/types/assistant_content.rs
#    - rig-integrations/rig-bedrock/src/completion.rs

# 4. Test + lint
cargo test -p rig-bedrock
cargo clippy -p rig-bedrock

# 5. Commit
git add -A
git commit -m "feat(rig-bedrock): add OpenTelemetry tracing to completion model

Record gen_ai.* span attributes (provider, model, system_instructions,
usage) on the chat span in CompletionModel::completion(), matching the
pattern used by all built-in providers (OpenAI, Anthropic, Gemini, etc.).

- Implement ProviderResponseExt for AwsConverseOutput
- Implement GetTokenUsage for AwsConverseOutput
- Create info_span with gen_ai.* fields in completion()
- Record response metadata and token usage after response
- Add 7 unit tests for the new trait implementations"

# 6. Push + PR
git push origin feat/bedrock-tracing

gh pr create \
  --repo 0xPlaygrounds/rig \
  --title "feat(rig-bedrock): add OpenTelemetry tracing to completion model" \
  --body-file docs/pr-rig-bedrock-tracing.md
```
