### PR TITLE
Fix VoyageAI Usage deserialization failure on missing prompt_tokens

### DIFF
--- a/rig/rig-core/src/providers/voyageai.rs
+++ b/rig/rig-core/src/providers/voyageai.rs
@@ -136,8 +136,6 @@ pub struct EmbeddingResponse {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct Usage {
-    #[serde(default)]
-    pub prompt_tokens: usize,
     pub total_tokens: usize,
 }
 


### PR DESCRIPTION
Fixes #1564

VoyageAI's embedding API doesn't return `prompt_tokens` in the usage response, but the `Usage` struct requires it during deserialization. This causes every embedding call to fail with a serde error.

Added `#[serde(default)]` to `prompt_tokens` so it falls back to 0 when the field is absent, matching how `total_tokens` is already handled.