### PR TITLE
feat(rig-derive): replace hand-rolled schema with schemars in #[rig_tool]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9253,6 +9253,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rig-core",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "syn 2.0.117",

--- a/crates/rig-core/src/lib.rs
+++ b/crates/rig-core/src/lib.rs
@@ -185,6 +185,7 @@ pub use completion::message;
 pub use embeddings::Embed;
 pub use extractor::ExtractionResponse;
 pub use one_or_many::{EmptyListError, OneOrMany};
+pub use schemars;
 
 #[cfg(feature = "derive")]
 #[cfg_attr(docsrs, doc(cfg(feature = "derive")))]

--- a/crates/rig-core/src/providers/openai/mod.rs
+++ b/crates/rig-core/src/providers/openai/mod.rs
@@ -50,6 +50,11 @@ pub(crate) fn sanitize_schema(schema: &mut serde_json::Value) {
         let is_object_schema = obj.get("type") == Some(&Value::String("object".to_string()))
             || obj.contains_key("properties");
 
+        // OpenAI requires "properties" on all object schemas, even empty ones.
+        if is_object_schema && !obj.contains_key("properties") {
+            obj.insert("properties".to_string(), Value::Object(Default::default()));
+        }
+
         // This is required by OpenAI's Responses API when using strict mode.
         // Source: https://platform.openai.com/docs/guides/structured-outputs#additionalproperties-false-must-always-be-set-in-objects
         if is_object_schema && !obj.contains_key("additionalProperties") {

--- a/crates/rig-derive/Cargo.toml
+++ b/crates/rig-derive/Cargo.toml
@@ -25,6 +25,7 @@ proc-macro = true
 [dev-dependencies]
 anyhow = { workspace = true }
 rig-core = { path = "../rig-core" }
+schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
@@ -46,3 +47,7 @@ path = "examples/rig_tool/full.rs"
 [[example]]
 name = "async_tool"
 path = "examples/rig_tool/async_tool.rs"
+
+[[example]]
+name = "complex_types"
+path = "examples/rig_tool/complex_types.rs"

--- a/crates/rig-derive/examples/rig_tool/async_tool.rs
+++ b/crates/rig-derive/examples/rig_tool/async_tool.rs
@@ -5,16 +5,14 @@ use rig_core::tool::{Tool, ToolError};
 use rig_derive::rig_tool;
 use std::time::Duration;
 
-// Example demonstrating async tool usage
-#[rig_tool(
-    description = "A tool that simulates an async operation",
-    params(
-        input = "Input value to process",
-        delay_ms = "Delay in milliseconds before returning result"
-    ),
-    required(input, delay_ms)
-)]
-async fn async_operation(input: String, delay_ms: u64) -> Result<String, ToolError> {
+/// A tool that simulates an async operation
+#[rig_tool]
+async fn async_operation(
+    /// Input value to process
+    input: String,
+    /// Delay in milliseconds before returning result
+    delay_ms: u64,
+) -> Result<String, ToolError> {
     tokio::time::sleep(Duration::from_millis(delay_ms)).await;
 
     Ok(format!(

--- a/crates/rig-derive/examples/rig_tool/complex_types.rs
+++ b/crates/rig-derive/examples/rig_tool/complex_types.rs
@@ -31,10 +31,9 @@ fn list_items(
 }
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), anyhow::Error> {
     let def = ListItems.definition(String::default()).await;
-    println!(
-        "Tool definition:\n{}",
-        serde_json::to_string_pretty(&def).unwrap()
-    );
+    println!("Tool definition:\n{}", serde_json::to_string_pretty(&def)?);
+
+    Ok(())
 }

--- a/crates/rig-derive/examples/rig_tool/complex_types.rs
+++ b/crates/rig-derive/examples/rig_tool/complex_types.rs
@@ -1,0 +1,40 @@
+use rig_core::tool::Tool;
+use rig_derive::rig_tool;
+
+#[derive(serde::Deserialize, schemars::JsonSchema)]
+pub enum SortOrder {
+    #[serde(rename = "asc")]
+    Ascending,
+    #[serde(rename = "desc")]
+    Descending,
+}
+
+/// List items with sorting and filtering
+#[rig_tool]
+fn list_items(
+    /// Field to sort by
+    sort_by: String,
+    /// Sort direction
+    order: SortOrder,
+    /// Filter tags
+    tags: Vec<String>,
+    /// Maximum number of results
+    limit: Option<i32>,
+) -> Result<Vec<String>, rig_core::tool::ToolError> {
+    let direction = match order {
+        SortOrder::Ascending => "ascending",
+        SortOrder::Descending => "descending",
+    };
+    Ok(vec![format!(
+        "sorted by {sort_by} {direction}, tags={tags:?}, limit={limit:?}"
+    )])
+}
+
+#[tokio::main]
+async fn main() {
+    let def = ListItems.definition(String::default()).await;
+    println!(
+        "Tool definition:\n{}",
+        serde_json::to_string_pretty(&def).unwrap()
+    );
+}

--- a/crates/rig-derive/examples/rig_tool/full.rs
+++ b/crates/rig-derive/examples/rig_tool/full.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<(), anyhow::Error> {
     println!("Tool definition:");
     println!(
         "STRINGPROCESSOR: {}",
-        serde_json::to_string_pretty(&StringProcessor.definition(String::default()).await).unwrap()
+        serde_json::to_string_pretty(&StringProcessor.definition(String::default()).await)?
     );
 
     for prompt in [

--- a/crates/rig-derive/examples/rig_tool/full.rs
+++ b/crates/rig-derive/examples/rig_tool/full.rs
@@ -4,16 +4,14 @@ use rig_core::providers;
 use rig_core::tool::Tool;
 use rig_derive::rig_tool;
 
-// Example with full attributes including parameter descriptions
-#[rig_tool(
-    description = "A tool that performs string operations",
-    params(
-        text = "The input text to process",
-        operation = "The operation to perform (uppercase, lowercase, reverse)",
-    ),
-    required(text, operation)
-)]
-fn string_processor(text: String, operation: String) -> Result<String, rig_core::tool::ToolError> {
+/// A tool that performs string operations
+#[rig_tool]
+fn string_processor(
+    /// The input text to process
+    text: String,
+    /// The operation to perform (uppercase, lowercase, reverse)
+    operation: String,
+) -> Result<String, rig_core::tool::ToolError> {
     let result = match operation.as_str() {
         "uppercase" => text.to_uppercase(),
         "lowercase" => text.to_lowercase(),
@@ -42,7 +40,7 @@ async fn main() -> Result<(), anyhow::Error> {
     println!("Tool definition:");
     println!(
         "STRINGPROCESSOR: {}",
-        serde_json::to_string_pretty(&StringProcessor.definition(String::default()).await)?
+        serde_json::to_string_pretty(&StringProcessor.definition(String::default()).await).unwrap()
     );
 
     for prompt in [

--- a/crates/rig-derive/examples/rig_tool/simple.rs
+++ b/crates/rig-derive/examples/rig_tool/simple.rs
@@ -3,23 +3,23 @@ use rig_core::completion::Prompt;
 use rig_core::providers;
 use rig_derive::rig_tool;
 
-// Simple example with no attributes (`required` is still needed for OpenAI's strict function tool calling)
-#[rig_tool(required(a, b))]
+// Simple example: all parameters are required by default.
+#[rig_tool]
 fn add(a: i32, b: i32) -> Result<i32, rig_core::tool::ToolError> {
     Ok(a + b)
 }
 
-#[rig_tool(required(a, b))]
+#[rig_tool]
 fn subtract(a: i32, b: i32) -> Result<i32, rig_core::tool::ToolError> {
     Ok(a - b)
 }
 
-#[rig_tool(required(a, b))]
+#[rig_tool]
 fn multiply(a: i32, b: i32) -> Result<i32, rig_core::tool::ToolError> {
     Ok(a * b)
 }
 
-#[rig_tool(required(a, b))]
+#[rig_tool]
 fn divide(a: i32, b: i32) -> Result<i32, rig_core::tool::ToolError> {
     if b == 0 {
         Err(rig_core::tool::ToolError::ToolCallError(

--- a/crates/rig-derive/examples/rig_tool/simple.rs
+++ b/crates/rig-derive/examples/rig_tool/simple.rs
@@ -3,24 +3,47 @@ use rig_core::completion::Prompt;
 use rig_core::providers;
 use rig_derive::rig_tool;
 
-// Simple example: all parameters are required by default.
+/// Add two numbers
 #[rig_tool]
-fn add(a: i32, b: i32) -> Result<i32, rig_core::tool::ToolError> {
+fn add(
+    /// First number
+    a: i32,
+    /// Second number
+    b: i32,
+) -> Result<i32, rig_core::tool::ToolError> {
     Ok(a + b)
 }
 
+/// Subtract two numbers
 #[rig_tool]
-fn subtract(a: i32, b: i32) -> Result<i32, rig_core::tool::ToolError> {
+fn subtract(
+    /// First number
+    a: i32,
+    /// Second number
+    b: i32,
+) -> Result<i32, rig_core::tool::ToolError> {
     Ok(a - b)
 }
 
+/// Multiply two numbers
 #[rig_tool]
-fn multiply(a: i32, b: i32) -> Result<i32, rig_core::tool::ToolError> {
+fn multiply(
+    /// First number
+    a: i32,
+    /// Second number
+    b: i32,
+) -> Result<i32, rig_core::tool::ToolError> {
     Ok(a * b)
 }
 
+/// Divide two numbers
 #[rig_tool]
-fn divide(a: i32, b: i32) -> Result<i32, rig_core::tool::ToolError> {
+fn divide(
+    /// Dividend
+    a: i32,
+    /// Divisor
+    b: i32,
+) -> Result<i32, rig_core::tool::ToolError> {
     if b == 0 {
         Err(rig_core::tool::ToolError::ToolCallError(
             "Division by zero".into(),
@@ -30,21 +53,30 @@ fn divide(a: i32, b: i32) -> Result<i32, rig_core::tool::ToolError> {
     }
 }
 
+/// Answer the secret question
 #[rig_tool]
 fn answer_secret_question() -> Result<(bool, bool, bool, bool, bool), rig_core::tool::ToolError> {
     Ok((false, false, true, false, false))
 }
 
+/// Count the number of R characters in a string
 #[rig_tool]
-fn how_many_rs(s: String) -> Result<usize, rig_core::tool::ToolError> {
+fn how_many_rs(
+    /// The string to search
+    s: String,
+) -> Result<usize, rig_core::tool::ToolError> {
     Ok(s.chars()
         .filter(|c| *c == 'r' || *c == 'R')
         .collect::<Vec<_>>()
         .len())
 }
 
+/// Sum a list of numbers
 #[rig_tool]
-fn sum_numbers(numbers: Vec<i64>) -> Result<i64, rig_core::tool::ToolError> {
+fn sum_numbers(
+    /// Numbers to sum
+    numbers: Vec<i64>,
+) -> Result<i64, rig_core::tool::ToolError> {
     Ok(numbers.iter().sum())
 }
 

--- a/crates/rig-derive/examples/rig_tool/with_description.rs
+++ b/crates/rig-derive/examples/rig_tool/with_description.rs
@@ -4,12 +4,20 @@ use rig_core::providers;
 use rig_core::tool::Tool;
 use rig_derive::rig_tool;
 
-// Example with description attribute
+// Demonstrates explicit attribute override.
+// The description and params() attributes override any doc comments.
 #[rig_tool(
     description = "Perform basic arithmetic operations",
     required(x, y, operation)
 )]
-fn calculator(x: i32, y: i32, operation: String) -> Result<i32, rig_core::tool::ToolError> {
+fn calculator(
+    /// The first operand
+    x: i32,
+    /// The second operand
+    y: i32,
+    /// The operation to perform
+    operation: String,
+) -> Result<i32, rig_core::tool::ToolError> {
     match operation.as_str() {
         "add" => Ok(x + y),
         "subtract" => Ok(x - y),
@@ -43,7 +51,7 @@ async fn main() -> Result<(), anyhow::Error> {
     println!("Tool definition:");
     println!(
         "CALCULATOR: {}",
-        serde_json::to_string_pretty(&CALCULATOR.definition(String::default()).await)?
+        serde_json::to_string_pretty(&CALCULATOR.definition(String::default()).await).unwrap()
     );
 
     for prompt in [

--- a/crates/rig-derive/examples/rig_tool/with_description.rs
+++ b/crates/rig-derive/examples/rig_tool/with_description.rs
@@ -51,7 +51,7 @@ async fn main() -> Result<(), anyhow::Error> {
     println!("Tool definition:");
     println!(
         "CALCULATOR: {}",
-        serde_json::to_string_pretty(&CALCULATOR.definition(String::default()).await).unwrap()
+        serde_json::to_string_pretty(&CALCULATOR.definition(String::default()).await)?
     );
 
     for prompt in [

--- a/crates/rig-derive/src/lib.rs
+++ b/crates/rig-derive/src/lib.rs
@@ -72,7 +72,7 @@ struct MacroArgs {
     name: Option<String>,
     description: Option<String>,
     param_descriptions: HashMap<String, String>,
-    required: Vec<String>,
+    required: Option<Vec<String>>,
 }
 
 fn parse_string_literal(expr: &Expr, field_name: &str) -> syn::Result<String> {
@@ -126,7 +126,7 @@ impl Parse for MacroArgs {
         let mut name = None;
         let mut description = None;
         let mut param_descriptions = HashMap::new();
-        let mut required = Vec::new();
+        let mut required = None;
 
         // If the input is empty, return default values
         if input.is_empty() {
@@ -202,9 +202,12 @@ impl Parse for MacroArgs {
                             let required_variables: Punctuated<Ident, Token![,]> =
                                 list.parse_args_with(Punctuated::parse_terminated)?;
 
-                            required_variables.into_iter().for_each(|x| {
-                                required.push(x.to_string());
-                            });
+                            required = Some(
+                                required_variables
+                                    .into_iter()
+                                    .map(|x| x.to_string())
+                                    .collect(),
+                            );
                         }
                         _ => {
                             return Err(syn::Error::new_spanned(
@@ -492,12 +495,10 @@ pub fn rig_tool(args: TokenStream, input: TokenStream) -> TokenStream {
         }
     }
 
-    // Default required to all parameters when not explicitly specified
-    let required_args: Vec<String> = if args.required.is_empty() {
-        param_names.iter().map(|n| n.to_string()).collect()
-    } else {
-        args.required
-    };
+    // Default required to all parameters only when required(...) was omitted.
+    let required_args: Vec<String> = args
+        .required
+        .unwrap_or_else(|| param_names.iter().map(|n| n.to_string()).collect());
 
     let params_struct_name = format_ident!("{}Parameters", struct_name);
     let static_name = format_ident!("{}", fn_name_str.to_uppercase());

--- a/crates/rig-derive/src/lib.rs
+++ b/crates/rig-derive/src/lib.rs
@@ -5,7 +5,8 @@ use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use std::{collections::HashMap, ops::Deref};
 use syn::{
-    DeriveInput, Expr, ExprLit, Ident, Lit, Meta, PathArguments, ReturnType, Token, Type,
+    Attribute, DeriveInput, Expr, ExprLit, Ident, Lit, Meta, PathArguments, ReturnType, Token,
+    Type,
     parse::{Parse, ParseStream},
     parse_macro_input,
     punctuated::Punctuated,
@@ -234,49 +235,48 @@ impl Parse for MacroArgs {
     }
 }
 
-fn get_json_type(ty: &Type) -> proc_macro2::TokenStream {
-    match ty {
-        Type::Path(type_path) => {
-            let Some(segment) = type_path.path.segments.first() else {
-                return quote! { "type": "object" };
-            };
-            let type_name = segment.ident.to_string();
-
-            // Handle Vec types
-            if type_name == "Vec" {
-                if let syn::PathArguments::AngleBracketed(args) = &segment.arguments
-                    && let Some(syn::GenericArgument::Type(inner_type)) = args.args.first()
-                {
-                    let inner_json_type = get_json_type(inner_type);
-                    return quote! {
-                        "type": "array",
-                        "items": { #inner_json_type }
-                    };
-                }
-                return quote! { "type": "array" };
+/// Extract doc comment text from `#[doc = "..."]` attributes.
+fn extract_doc_comment(attrs: &[Attribute]) -> Option<String> {
+    let lines: Vec<String> = attrs
+        .iter()
+        .filter_map(|attr| {
+            if !attr.path().is_ident("doc") {
+                return None;
             }
-
-            // Handle primitive types
-            match type_name.as_str() {
-                "i8" | "i16" | "i32" | "i64" | "u8" | "u16" | "u32" | "u64" | "f32" | "f64" => {
-                    quote! { "type": "number" }
-                }
-                "String" | "str" => {
-                    quote! { "type": "string" }
-                }
-                "bool" => {
-                    quote! { "type": "boolean" }
-                }
-                // Handle other types as objects
-                _ => {
-                    quote! { "type": "object" }
-                }
+            if let Meta::NameValue(nv) = &attr.meta
+                && let Expr::Lit(ExprLit {
+                    lit: Lit::Str(s), ..
+                }) = &nv.value
+            {
+                return Some(s.value());
             }
-        }
-        _ => {
-            quote! { "type": "object" }
-        }
+            None
+        })
+        .collect();
+
+    if lines.is_empty() {
+        return None;
     }
+
+    Some(
+        lines
+            .iter()
+            .map(|l| l.strip_prefix(' ').unwrap_or(l))
+            .collect::<Vec<_>>()
+            .join("\n")
+            .trim()
+            .to_string(),
+    )
+}
+
+/// Check if a type is `Option<T>`.
+fn is_option_type(ty: &Type) -> bool {
+    if let Type::Path(type_path) = ty
+        && let Some(segment) = type_path.path.segments.last()
+    {
+        return segment.ident == "Option";
+    }
+    false
 }
 
 fn result_type_tokens(
@@ -416,6 +416,18 @@ pub fn rig_tool(args: TokenStream, input: TokenStream) -> TokenStream {
     let vis = &input_fn.vis;
     let is_async = input_fn.sig.asyncness.is_some();
 
+    // Build a cleaned copy of the function with doc attrs stripped from parameters,
+    // since `#[doc]` on function parameters is not allowed by the compiler.
+    let cleaned_fn = {
+        let mut f = input_fn.clone();
+        for arg in f.sig.inputs.iter_mut() {
+            if let syn::FnArg::Typed(pat_type) = arg {
+                pat_type.attrs.retain(|a| !a.path().is_ident("doc"));
+            }
+        }
+        f
+    };
+
     // Extract return type and get Output and Error types from Result<T, E>
     let return_type = &input_fn.sig.output;
     let (output_type, error_type) = match result_type_tokens(return_type) {
@@ -426,17 +438,19 @@ pub fn rig_tool(args: TokenStream, input: TokenStream) -> TokenStream {
     // Generate PascalCase struct name from the function name
     let struct_name = format_ident!("{}", { fn_name_str.to_case(Case::Pascal) });
 
-    // Use provided description or generate a default one
+    // Tool description: explicit attribute > doc comment > default
+    let fn_doc = extract_doc_comment(&input_fn.attrs);
     let tool_description = match args.description {
         Some(desc) => quote! { #desc.to_string() },
-        None => quote! { format!("Function to {}", Self::NAME) },
+        None => match fn_doc {
+            Some(doc) => quote! { #doc.to_string() },
+            None => quote! { format!("Function to {}", Self::NAME) },
+        },
     };
 
-    // Extract parameter names, types, and descriptions
+    // Extract parameter names, doc comments, and build struct field tokens
     let mut param_names = Vec::new();
-    let mut param_types = Vec::new();
-    let mut param_descriptions = Vec::new();
-    let mut json_types = Vec::new();
+    let mut field_tokens = Vec::new();
 
     for arg in input_fn.sig.inputs.iter() {
         if let syn::FnArg::Typed(pat_type) = arg
@@ -445,22 +459,41 @@ pub fn rig_tool(args: TokenStream, input: TokenStream) -> TokenStream {
             let param_name = &param_ident.ident;
             let param_name_str = param_name.to_string();
             let ty = &pat_type.ty;
-            let default_parameter_description = format!("Parameter {param_name_str}");
-            let description = args
-                .param_descriptions
-                .get(&param_name_str)
-                .map(|s| s.to_owned())
-                .unwrap_or(default_parameter_description);
+
+            // Determine the description for this field:
+            // explicit params() > parameter doc comment > default
+            let field_doc_attr =
+                if let Some(explicit) = args.param_descriptions.get(&param_name_str) {
+                    // Explicit override via params() — use #[schemars(description = "...")]
+                    quote! { #[schemars(description = #explicit)] }
+                } else if let Some(doc) = extract_doc_comment(&pat_type.attrs) {
+                    // Doc comment on the parameter — propagate as #[doc = "..."]
+                    quote! { #[doc = #doc] }
+                } else {
+                    // Default fallback
+                    let default_desc = format!("Parameter {param_name_str}");
+                    quote! { #[schemars(description = #default_desc)] }
+                };
+
+            // Auto-add #[serde(default)] for Option<T> fields
+            let serde_default = if is_option_type(ty) {
+                quote! { #[serde(default)] }
+            } else {
+                quote! {}
+            };
+
+            field_tokens.push(quote! {
+                #field_doc_attr
+                #serde_default
+                #vis #param_name: #ty
+            });
 
             param_names.push(param_name);
-            param_types.push(ty);
-            param_descriptions.push(description);
-            json_types.push(get_json_type(ty));
         }
     }
 
     // Default required to all parameters when not explicitly specified
-    let required_args = if args.required.is_empty() {
+    let required_args: Vec<String> = if args.required.is_empty() {
         param_names.iter().map(|n| n.to_string()).collect()
     } else {
         args.required
@@ -485,13 +518,15 @@ pub fn rig_tool(args: TokenStream, input: TokenStream) -> TokenStream {
     };
 
     let rig_core = rig_core_path();
+    let schemars_crate = format!("{}::schemars", rig_core.to_string().replace(' ', ""));
     let expanded = quote! {
-        #[derive(serde::Deserialize)]
+        #[derive(serde::Deserialize, #rig_core::schemars::JsonSchema)]
+        #[schemars(crate = #schemars_crate)]
         #vis struct #params_struct_name {
-            #(#vis #param_names: #param_types,)*
+            #(#field_tokens,)*
         }
 
-        #input_fn
+        #cleaned_fn
 
         #[derive(Default)]
         #vis struct #struct_name;
@@ -508,23 +543,15 @@ pub fn rig_tool(args: TokenStream, input: TokenStream) -> TokenStream {
             }
 
             async fn definition(&self, _prompt: String) -> #rig_core::completion::ToolDefinition {
-                let parameters = serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        #(
-                            stringify!(#param_names): {
-                                #json_types,
-                                "description": #param_descriptions
-                            }
-                        ),*
-                    },
-                    "required": [#(#required_args),*]
-                });
+                let mut schema = serde_json::to_value(
+                    #rig_core::schemars::schema_for!(#params_struct_name)
+                ).expect("schema serialization");
+                schema["required"] = serde_json::json!([#(#required_args),*]);
 
                 #rig_core::completion::ToolDefinition {
                     name: #tool_name.to_string(),
                     description: #tool_description.to_string(),
-                    parameters,
+                    parameters: schema,
                 }
             }
 

--- a/crates/rig-derive/src/lib.rs
+++ b/crates/rig-derive/src/lib.rs
@@ -438,8 +438,6 @@ pub fn rig_tool(args: TokenStream, input: TokenStream) -> TokenStream {
     let mut param_descriptions = Vec::new();
     let mut json_types = Vec::new();
 
-    let required_args = args.required;
-
     for arg in input_fn.sig.inputs.iter() {
         if let syn::FnArg::Typed(pat_type) = arg
             && let syn::Pat::Ident(param_ident) = &*pat_type.pat
@@ -460,6 +458,13 @@ pub fn rig_tool(args: TokenStream, input: TokenStream) -> TokenStream {
             json_types.push(get_json_type(ty));
         }
     }
+
+    // Default required to all parameters when not explicitly specified
+    let required_args = if args.required.is_empty() {
+        param_names.iter().map(|n| n.to_string()).collect()
+    } else {
+        args.required
+    };
 
     let params_struct_name = format_ident!("{}Parameters", struct_name);
     let static_name = format_ident!("{}", fn_name_str.to_uppercase());

--- a/crates/rig-derive/tests/calculator.rs
+++ b/crates/rig-derive/tests/calculator.rs
@@ -67,16 +67,31 @@ fn sync_calculator(x: i32, y: i32, operation: String) -> Result<i32, rig_core::t
 
 #[tokio::test]
 async fn test_calculator_tool() {
-    // Create an instance of our tool
     let calculator = Calculator;
 
-    // Test tool information
     let definition = calculator.definition(String::default()).await;
-    println!("{definition:?}");
     assert_eq!(calculator.name(), "calculator");
     assert_eq!(
         definition.description,
         "Perform basic arithmetic operations"
+    );
+
+    // Verify schema structure from schemars
+    let props = definition.parameters["properties"].as_object().unwrap();
+    assert!(props.contains_key("x"));
+    assert!(props.contains_key("y"));
+    assert!(props.contains_key("operation"));
+
+    // schemars produces "integer" for i32 (not "number")
+    assert_eq!(props["x"]["type"], "integer");
+    assert_eq!(props["y"]["type"], "integer");
+    assert_eq!(props["operation"]["type"], "string");
+
+    // Descriptions from params() attribute
+    assert_eq!(props["x"]["description"], "First number in the calculation");
+    assert_eq!(
+        props["y"]["description"],
+        "Second number in the calculation"
     );
 
     // Test valid operations

--- a/crates/rig-derive/tests/required_defaults.rs
+++ b/crates/rig-derive/tests/required_defaults.rs
@@ -1,0 +1,71 @@
+//! Test that `#[rig_tool]` defaults `required` to all parameters when not
+//! explicitly specified, matching OpenAI's strict function calling expectations.
+
+use rig::tool::Tool;
+use rig_derive::rig_tool;
+
+// No `required(...)` — should default to all params required
+#[rig_tool(
+    description = "Add two numbers",
+    params(a = "First number", b = "Second number")
+)]
+fn add_implicit(a: i32, b: i32) -> Result<i32, rig::tool::ToolError> {
+    Ok(a + b)
+}
+
+// Explicit `required(a)` — only `a` should be required
+#[rig_tool(
+    description = "Add two numbers with optional b",
+    params(a = "First number", b = "Second number"),
+    required(a)
+)]
+fn add_explicit(a: i32, b: i32) -> Result<i32, rig::tool::ToolError> {
+    Ok(a + b)
+}
+
+// No params at all — required should be empty
+#[rig_tool(description = "Returns a constant")]
+fn constant() -> Result<i32, rig::tool::ToolError> {
+    Ok(42)
+}
+
+#[tokio::test]
+async fn test_required_defaults_to_all_params() {
+    let def = AddImplicit.definition(String::default()).await;
+    let required = def.parameters["required"].as_array().unwrap();
+    let names: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
+
+    assert!(
+        names.contains(&"a"),
+        "expected 'a' in required, got {names:?}"
+    );
+    assert!(
+        names.contains(&"b"),
+        "expected 'b' in required, got {names:?}"
+    );
+    assert_eq!(names.len(), 2);
+}
+
+#[tokio::test]
+async fn test_explicit_required_overrides_default() {
+    let def = AddExplicit.definition(String::default()).await;
+    let required = def.parameters["required"].as_array().unwrap();
+    let names: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
+
+    assert_eq!(
+        names,
+        vec!["a"],
+        "expected only 'a' in required, got {names:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_no_params_means_empty_required() {
+    let def = Constant.definition(String::default()).await;
+    let required = def.parameters["required"].as_array().unwrap();
+
+    assert!(
+        required.is_empty(),
+        "expected empty required for no-param tool"
+    );
+}

--- a/crates/rig-derive/tests/required_defaults.rs
+++ b/crates/rig-derive/tests/required_defaults.rs
@@ -31,6 +31,12 @@ fn add_explicit(a: i32, b: i32) -> Result<i32, rig_core::tool::ToolError> {
     Ok(a + b)
 }
 
+// Explicit `required()` means all params are optional.
+#[rig_tool(description = "Search optionally", required())]
+fn search_optional(limit: Option<i32>) -> Result<String, rig_core::tool::ToolError> {
+    Ok(format!("{limit:?}"))
+}
+
 // No params at all — required should be empty
 #[rig_tool(description = "Returns a constant")]
 fn constant() -> Result<i32, rig_core::tool::ToolError> {
@@ -64,6 +70,17 @@ async fn test_explicit_required_overrides_default() {
         names,
         vec!["a"],
         "expected only 'a' in required, got {names:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_explicit_empty_required_overrides_default() {
+    let def = SearchOptional.definition(String::default()).await;
+    let required = def.parameters["required"].as_array().unwrap();
+
+    assert!(
+        required.is_empty(),
+        "expected explicit required() to make all params optional, got {required:?}"
     );
 }
 

--- a/crates/rig-derive/tests/required_defaults.rs
+++ b/crates/rig-derive/tests/required_defaults.rs
@@ -1,7 +1,7 @@
 //! Test that `#[rig_tool]` defaults `required` to all parameters when not
 //! explicitly specified, matching OpenAI's strict function calling expectations.
 
-use rig::tool::Tool;
+use rig_core::tool::Tool;
 use rig_derive::rig_tool;
 
 // No `required(...)` — should default to all params required
@@ -9,7 +9,7 @@ use rig_derive::rig_tool;
     description = "Add two numbers",
     params(a = "First number", b = "Second number")
 )]
-fn add_implicit(a: i32, b: i32) -> Result<i32, rig::tool::ToolError> {
+fn add_implicit(a: i32, b: i32) -> Result<i32, rig_core::tool::ToolError> {
     Ok(a + b)
 }
 
@@ -19,13 +19,13 @@ fn add_implicit(a: i32, b: i32) -> Result<i32, rig::tool::ToolError> {
     params(a = "First number", b = "Second number"),
     required(a)
 )]
-fn add_explicit(a: i32, b: i32) -> Result<i32, rig::tool::ToolError> {
+fn add_explicit(a: i32, b: i32) -> Result<i32, rig_core::tool::ToolError> {
     Ok(a + b)
 }
 
 // No params at all — required should be empty
 #[rig_tool(description = "Returns a constant")]
-fn constant() -> Result<i32, rig::tool::ToolError> {
+fn constant() -> Result<i32, rig_core::tool::ToolError> {
     Ok(42)
 }
 

--- a/crates/rig-derive/tests/required_defaults.rs
+++ b/crates/rig-derive/tests/required_defaults.rs
@@ -1,6 +1,14 @@
 //! Test that `#[rig_tool]` defaults `required` to all parameters when not
 //! explicitly specified, matching OpenAI's strict function calling expectations.
 
+#![allow(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::unwrap_used,
+    clippy::unreachable
+)]
+
 use rig_core::tool::Tool;
 use rig_derive::rig_tool;
 

--- a/crates/rig-derive/tests/schemars_schema.rs
+++ b/crates/rig-derive/tests/schemars_schema.rs
@@ -1,0 +1,351 @@
+//! Tests for schemars-based schema generation in `#[rig_tool]`.
+
+use std::collections::HashMap;
+
+use rig_core::tool::Tool;
+use rig_derive::rig_tool;
+
+// --- Doc comment description ---
+
+/// Add two numbers
+#[rig_tool]
+fn add_doc(
+    /// First number
+    a: i32,
+    /// Second number
+    b: i32,
+) -> Result<i32, rig_core::tool::ToolError> {
+    Ok(a + b)
+}
+
+#[tokio::test]
+async fn test_doc_comment_description() {
+    let def = AddDoc.definition(String::default()).await;
+    assert_eq!(def.description, "Add two numbers");
+}
+
+#[tokio::test]
+async fn test_param_doc_comments() {
+    let def = AddDoc.definition(String::default()).await;
+    let props = def.parameters["properties"].as_object().unwrap();
+    assert_eq!(props["a"]["description"], "First number");
+    assert_eq!(props["b"]["description"], "Second number");
+}
+
+// --- Explicit overrides doc ---
+
+/// This doc comment should be ignored
+#[rig_tool(
+    description = "Override description",
+    params(query = "Override param doc")
+)]
+fn search_override(
+    /// This param doc should be ignored
+    query: String,
+) -> Result<String, rig_core::tool::ToolError> {
+    Ok(query)
+}
+
+#[tokio::test]
+async fn test_explicit_overrides_doc() {
+    let def = SearchOverride.definition(String::default()).await;
+    assert_eq!(def.description, "Override description");
+    let props = def.parameters["properties"].as_object().unwrap();
+    assert_eq!(props["query"]["description"], "Override param doc");
+}
+
+// --- Option<T> nullable ---
+
+/// Search documents
+#[rig_tool]
+fn search_optional(
+    /// The search query
+    query: String,
+    /// Maximum results
+    limit: Option<i32>,
+) -> Result<String, rig_core::tool::ToolError> {
+    Ok(format!("{query} limit={limit:?}"))
+}
+
+#[tokio::test]
+async fn test_option_nullable() {
+    let def = SearchOptional.definition(String::default()).await;
+    let props = def.parameters["properties"].as_object().unwrap();
+
+    // query is a plain string
+    assert_eq!(props["query"]["type"], "string");
+
+    // limit is nullable — schemars represents Option<T> as "type": ["integer", "null"]
+    let limit = &props["limit"];
+    let types = limit["type"].as_array().unwrap();
+    let type_names: Vec<&str> = types.iter().filter_map(|v| v.as_str()).collect();
+    assert!(
+        type_names.contains(&"integer"),
+        "expected integer in type array"
+    );
+    assert!(type_names.contains(&"null"), "expected null in type array");
+}
+
+#[tokio::test]
+async fn test_option_deserialization() {
+    // Option<T> field absent -> None
+    let json = serde_json::json!({"query": "test"});
+    let params: SearchOptionalParameters = serde_json::from_value(json).unwrap();
+    assert_eq!(params.limit, None);
+
+    // Option<T> field null -> None
+    let json = serde_json::json!({"query": "test", "limit": null});
+    let params: SearchOptionalParameters = serde_json::from_value(json).unwrap();
+    assert_eq!(params.limit, None);
+
+    // Option<T> field present -> Some
+    let json = serde_json::json!({"query": "test", "limit": 10});
+    let params: SearchOptionalParameters = serde_json::from_value(json).unwrap();
+    assert_eq!(params.limit, Some(10));
+}
+
+// --- Integer vs number ---
+
+/// Test numeric types
+#[rig_tool]
+fn numeric_types(
+    /// An integer
+    int_val: i32,
+    /// A float
+    float_val: f64,
+) -> Result<String, rig_core::tool::ToolError> {
+    Ok(format!("{int_val} {float_val}"))
+}
+
+#[tokio::test]
+async fn test_integer_vs_number() {
+    let def = NumericTypes.definition(String::default()).await;
+    let props = def.parameters["properties"].as_object().unwrap();
+    assert_eq!(props["int_val"]["type"], "integer");
+    assert_eq!(props["float_val"]["type"], "number");
+}
+
+// --- Vec param ---
+
+/// Sum numbers
+#[rig_tool]
+fn sum_vec(
+    /// Numbers to sum
+    numbers: Vec<i64>,
+) -> Result<i64, rig_core::tool::ToolError> {
+    Ok(numbers.iter().sum())
+}
+
+#[tokio::test]
+async fn test_vec_param() {
+    let def = SumVec.definition(String::default()).await;
+    let props = def.parameters["properties"].as_object().unwrap();
+    assert_eq!(props["numbers"]["type"], "array");
+    assert_eq!(props["numbers"]["items"]["type"], "integer");
+}
+
+// --- No params ---
+
+/// Return constant
+#[rig_tool]
+fn no_params() -> Result<i32, rig_core::tool::ToolError> {
+    Ok(42)
+}
+
+#[tokio::test]
+async fn test_no_params() {
+    let def = NoParams.definition(String::default()).await;
+    let required = def.parameters["required"].as_array().unwrap();
+    assert!(required.is_empty());
+
+    // properties may be absent or empty for a zero-field struct
+    if let Some(props) = def.parameters["properties"].as_object() {
+        assert!(props.is_empty());
+    }
+}
+
+// --- Bool param ---
+
+/// Toggle flag
+#[rig_tool]
+fn toggle(
+    /// Whether to enable
+    enabled: bool,
+) -> Result<bool, rig_core::tool::ToolError> {
+    Ok(!enabled)
+}
+
+#[tokio::test]
+async fn test_bool_param() {
+    let def = Toggle.definition(String::default()).await;
+    let props = def.parameters["properties"].as_object().unwrap();
+    assert_eq!(props["enabled"]["type"], "boolean");
+}
+
+// --- Default description fallback ---
+
+#[rig_tool]
+fn no_docs(x: i32) -> Result<i32, rig_core::tool::ToolError> {
+    Ok(x)
+}
+
+#[tokio::test]
+async fn test_default_description_fallback() {
+    let def = NoDocs.definition(String::default()).await;
+    assert_eq!(def.description, "Function to no_docs");
+
+    let props = def.parameters["properties"].as_object().unwrap();
+    assert_eq!(props["x"]["description"], "Parameter x");
+}
+
+// --- Schema type is "object" ---
+
+#[tokio::test]
+async fn test_schema_type_object() {
+    let def = AddDoc.definition(String::default()).await;
+    assert_eq!(def.parameters["type"], "object");
+}
+
+// --- All params in required by default ---
+
+#[tokio::test]
+async fn test_required_all_by_default() {
+    let def = AddDoc.definition(String::default()).await;
+    let required = def.parameters["required"].as_array().unwrap();
+    let names: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
+    assert_eq!(names.len(), 2);
+    assert!(names.contains(&"a"));
+    assert!(names.contains(&"b"));
+}
+
+// --- Enum param ---
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub enum SortOrder {
+    #[serde(rename = "asc")]
+    Ascending,
+    #[serde(rename = "desc")]
+    Descending,
+}
+
+/// Sort items
+#[rig_tool]
+fn sort_items(
+    /// Sort direction
+    order: SortOrder,
+) -> Result<String, rig_core::tool::ToolError> {
+    Ok(format!("{order:?}"))
+}
+
+#[tokio::test]
+async fn test_enum_param() {
+    let def = SortItems.definition(String::default()).await;
+    let schema_str = serde_json::to_string(&def.parameters).unwrap();
+
+    // schemars may use $defs/$ref or inline the enum — verify the renamed
+    // variants appear somewhere in the schema
+    assert!(schema_str.contains("asc"), "expected 'asc' in schema");
+    assert!(schema_str.contains("desc"), "expected 'desc' in schema");
+}
+
+// --- HashMap param ---
+
+/// Store metadata
+#[rig_tool]
+fn store_metadata(
+    /// Key-value pairs
+    metadata: HashMap<String, String>,
+) -> Result<String, rig_core::tool::ToolError> {
+    Ok(format!("{metadata:?}"))
+}
+
+#[tokio::test]
+async fn test_hashmap_param() {
+    let def = StoreMetadata.definition(String::default()).await;
+    let props = def.parameters["properties"].as_object().unwrap();
+    let meta = &props["metadata"];
+    assert_eq!(meta["type"], "object");
+    // HashMap<String, String> should have additionalProperties with string type
+    assert_eq!(meta["additionalProperties"]["type"], "string");
+}
+
+// --- Nested struct param ---
+
+#[derive(serde::Deserialize, schemars::JsonSchema)]
+pub struct Coordinates {
+    /// Latitude
+    pub lat: f64,
+    /// Longitude
+    pub lng: f64,
+}
+
+/// Find nearby places
+#[rig_tool]
+fn find_nearby(
+    /// The location to search from
+    location: Coordinates,
+    /// Search radius in km
+    radius: f64,
+) -> Result<Vec<String>, rig_core::tool::ToolError> {
+    Ok(vec![format!(
+        "{},{} r={radius}",
+        location.lat, location.lng
+    )])
+}
+
+#[tokio::test]
+async fn test_nested_struct_param() {
+    let def = FindNearby.definition(String::default()).await;
+    let props = def.parameters["properties"].as_object().unwrap();
+
+    // The location field should reference a nested struct definition
+    let _location = &props["location"];
+    // schemars may inline the struct or use $ref/$defs
+    // Either way, the schema should mention lat and lng
+    let schema_str = serde_json::to_string(&def.parameters).unwrap();
+    assert!(schema_str.contains("lat"), "expected 'lat' in schema");
+    assert!(schema_str.contains("lng"), "expected 'lng' in schema");
+
+    // radius should be a number
+    assert_eq!(props["radius"]["type"], "number");
+
+    // Verify the nested struct's field descriptions are present somewhere
+    assert!(
+        schema_str.contains("Latitude"),
+        "expected 'Latitude' description in schema"
+    );
+    assert!(
+        schema_str.contains("Longitude"),
+        "expected 'Longitude' description in schema"
+    );
+}
+
+// --- Async tool with doc comments ---
+
+/// Fetch a URL asynchronously
+#[rig_tool]
+async fn fetch_url(
+    /// The URL to fetch
+    url: String,
+) -> Result<String, rig_core::tool::ToolError> {
+    Ok(format!("fetched: {url}"))
+}
+
+#[tokio::test]
+async fn test_async_tool_with_docs() {
+    let def = FetchUrl.definition(String::default()).await;
+    assert_eq!(def.description, "Fetch a URL asynchronously");
+    assert_eq!(def.name, "fetch_url");
+
+    let props = def.parameters["properties"].as_object().unwrap();
+    assert_eq!(props["url"]["description"], "The URL to fetch");
+
+    // Verify it actually works (async call)
+    let result = FetchUrl
+        .call(FetchUrlParameters {
+            url: "https://example.com".to_string(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(result, serde_json::json!("fetched: https://example.com"));
+}

--- a/crates/rig-derive/tests/schemars_schema.rs
+++ b/crates/rig-derive/tests/schemars_schema.rs
@@ -228,7 +228,7 @@ async fn test_required_all_by_default() {
 
 // --- Enum param ---
 
-#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+#[derive(Debug, serde::Deserialize, rig_core::schemars::JsonSchema)]
 pub enum SortOrder {
     #[serde(rename = "asc")]
     Ascending,
@@ -279,7 +279,7 @@ async fn test_hashmap_param() {
 
 // --- Nested struct param ---
 
-#[derive(serde::Deserialize, schemars::JsonSchema)]
+#[derive(serde::Deserialize, rig_core::schemars::JsonSchema)]
 pub struct Coordinates {
     /// Latitude
     pub lat: f64,

--- a/crates/rig-derive/tests/schemars_schema.rs
+++ b/crates/rig-derive/tests/schemars_schema.rs
@@ -1,5 +1,13 @@
 //! Tests for schemars-based schema generation in `#[rig_tool]`.
 
+#![allow(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::unwrap_used,
+    clippy::unreachable
+)]
+
 use std::collections::HashMap;
 
 use rig_core::tool::Tool;

--- a/tests/core/mod.rs
+++ b/tests/core/mod.rs
@@ -4,3 +4,5 @@ mod loaders;
 mod prompt_response_messages;
 mod provider_layout;
 mod reasoning_stream_stats;
+#[cfg(feature = "derive")]
+mod tool_macro;

--- a/tests/core/tool_macro.rs
+++ b/tests/core/tool_macro.rs
@@ -1,0 +1,32 @@
+#[derive(serde::Deserialize, rig::schemars::JsonSchema)]
+struct FacadeCoordinates {
+    /// Latitude
+    lat: f64,
+    /// Longitude
+    lng: f64,
+}
+
+/// Find nearby places
+#[rig::tool_macro]
+fn facade_find_nearby(
+    /// Location to search from
+    location: FacadeCoordinates,
+) -> Result<String, rig::tool::ToolError> {
+    Ok(format!("{},{}", location.lat, location.lng))
+}
+
+#[tokio::test]
+async fn test_tool_macro_accepts_facade_schemars_reexport() {
+    use rig::tool::Tool;
+
+    let definition = FacadeFindNearby.definition(String::default()).await;
+    let schema = serde_json::to_string(&definition.parameters).unwrap();
+
+    assert!(schema.contains("lat"), "expected lat in schema: {schema}");
+    assert!(schema.contains("lng"), "expected lng in schema: {schema}");
+    assert!(
+        schema.contains("Latitude"),
+        "expected Latitude description in schema: {schema}"
+    );
+    assert_eq!(definition.description, "Find nearby places");
+}


### PR DESCRIPTION
# Summary

Replace the hand-rolled `get_json_type()` helper in `#[rig_tool]` with `schemars::JsonSchema` derivation — the same pattern `AgentToolArgs` already uses. This eliminates a limited type mapper (only primitives + `Vec<T>`, everything else fell back to `"type": "object"`) in favor of full JSON Schema generation that supports nested structs, enums, `HashMap`, tuples, and proper `Option<T>` nullable handling.

## Key changes

### Schema generation via schemars

- Derive `JsonSchema` on the generated params struct, use `schema_for!()` in `definition()`
- Delete `get_json_type()` entirely
- Re-export schemars from rig-core as `rig::schemars` (no new dependency — rig-core already depends on schemars 1.0)
- Add `#[schemars(crate = "rig::schemars")]` so downstream crates compile without a direct schemars dependency

### Doc comments as descriptions (zero-config)

- Function `///` doc comments → tool description
- Parameter `///` doc comments → property descriptions in schema
- Explicit `description = "..."` and `params(x = "...")` still work as overrides
- Strips `#[doc]` attrs from function parameters before re-emitting (compiler rejects them on params)

### Required defaults to all parameters

- Previously, omitting `required(...)` produced an empty `required` array, silently breaking strict function calling (OpenAI rejects this)
- Now all parameters are required by default; explicit `required(...)` still works as override
- Aligns pass-through providers (Ollama, xAI, etc.) with what OpenAI/Anthropic sanitizers already enforce

### OpenAI schema sanitizer fix

- OpenAI rejects object schemas without a `"properties"` key (400 error), even for zero-parameter tools
- Added missing-properties injection to `openai::sanitize_schema` (also covers Azure)

## Breaking

- `i32` now correctly produces `"type": "integer"` (was `"number"`) per JSON Schema spec. LLMs handle both, but downstream code matching on `"number"` for integer params will need updating.

## Before / After

```rust
// Before: manual annotation duplicating what the code already expresses
#[rig_tool(
    description = "Add two numbers",
    params(a = "First number", b = "Second number"),
    required(a, b)
)]
fn add(a: i32, b: i32) -> Result<i32, ToolError> {
    Ok(a + b)
}

// After: zero-config, derived from Rust source
/// Add two numbers
#[rig_tool]
fn add(
    /// First number
    a: i32,
    /// Second number
    b: i32,
) -> Result<i32, ToolError> {
    Ok(a + b)
}
```

## Test plan

- [x] 23 unit tests passing: doc comments, `Option<T>`, enums, `HashMap`, nested structs, `Vec`, async, visibility, required defaults, integer vs number, no-params edge case
- [x] Integration tests with real OpenAI and Anthropic APIs (extractor, reasoning roundtrip) — all pass
- [x] `cargo clippy --all-features --all-targets` clean
- [x] `cargo fmt` clean