### PR TITLE
fix(openai): capture ResponseFailed errors in stream mode

### DIFF
--- a/rig/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/rig/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -429,15 +429,9 @@ where
                                         final_usage = usage;
                                     }
                                 }
-                                ResponseChunkKind::ResponseFailed => {
+                                ResponseChunkKind::ResponseFailed | ResponseChunkKind::ResponseIncomplete => {
                                     let error_message = response_chunk_error_message(&kind, &response)
-                                        .expect("failed response should have an error message");
-                                    yield Err(CompletionError::ProviderError(error_message));
-                                    break;
-                                }
-                                ResponseChunkKind::ResponseIncomplete => {
-                                    let error_message = response_chunk_error_message(&kind, &response)
-                                        .expect("incomplete response should have an error message");
+                                        .expect("terminal response should have an error message");
                                     yield Err(CompletionError::ProviderError(error_message));
                                     break;
                                 }


### PR DESCRIPTION
Fixes #1562

When OpenAI returns an error during streaming (e.g. `context_length_exceeded`), the response chunk arrives as `ResponseFailed` but was silently ignored by the `else` branch, resulting in an empty `FinalResponse` with zero tokens.

This change replaces the `if-let` with an explicit `match` on `ResponseChunkKind`:

- **`ResponseCompleted`**: existing behavior (record span, extract usage)
- **`ResponseFailed | ResponseIncomplete`**: extract `response.error` (code + message) and yield `CompletionError::ProviderError`, consistent with how SSE errors and the WebSocket implementation handle failures
- **Other variants**: continue (no change)