### PR TITLE
feat(rig-core): add parallel tool execution to streaming multi-turn agents

### DIFF
--- a/rig/rig-core/src/agent/prompt_request/streaming.rs
+++ b/rig/rig-core/src/agent/prompt_request/streaming.rs
@@ -224,6 +224,8 @@ where
     output_schema: Option<schemars::Schema>,
     /// Optional per-request hook for events
     hook: Option<P>,
+    /// How many tools should be executed at the same time (1 by default).
+    concurrency: usize,
 }
 
 impl<M, P> StreamingPromptRequest<M, P>
@@ -251,6 +253,7 @@ where
             tool_choice: agent.tool_choice.clone(),
             output_schema: agent.output_schema.clone(),
             hook: None,
+            concurrency: 1,
         }
     }
 
@@ -278,6 +281,7 @@ where
             tool_choice: agent.tool_choice.clone(),
             output_schema: agent.output_schema.clone(),
             hook: agent.hook.clone(),
+            concurrency: 1,
         }
     }
 
@@ -289,6 +293,24 @@ where
     /// If the maximum turn number is exceeded, it will return a [`crate::completion::request::PromptError::MaxTurnsError`].
     pub fn multi_turn(mut self, turns: usize) -> Self {
         self.max_turns = turns;
+        self
+    }
+
+    /// Add concurrency to the streaming prompt request.
+    ///
+    /// When set to a value greater than 1, all tool calls from a single model
+    /// response are collected and executed concurrently (up to `concurrency`
+    /// at a time), rather than one-by-one as they arrive in the stream.
+    ///
+    /// Pre-execution hooks ([`PromptHook::on_tool_call`]) still run
+    /// sequentially before any tool is dispatched, so a
+    /// [`ToolCallHookAction::Terminate`] prevents all subsequent execution.
+    /// Post-execution hooks ([`PromptHook::on_tool_result`]) run sequentially
+    /// after all tools complete.
+    ///
+    /// Defaults to 1 (sequential execution, matching the previous behaviour).
+    pub fn with_tool_concurrency(mut self, concurrency: usize) -> Self {
+        self.concurrency = concurrency;
         self
     }
 
@@ -335,6 +357,7 @@ where
             tool_choice: self.tool_choice,
             output_schema: self.output_schema,
             hook: Some(hook),
+            concurrency: self.concurrency,
         }
     }
 
@@ -374,6 +397,7 @@ where
         let agent_name = self.agent_name.clone();
         let has_history = self.chat_history.is_some();
         let chat_history = self.chat_history;
+        let concurrency = self.concurrency;
         let mut new_messages: Vec<Message> = vec![prompt.clone()];
 
         let mut current_max_turns = 0;
@@ -472,6 +496,9 @@ where
                 let mut pending_reasoning_delta_text = String::new();
                 let mut pending_reasoning_delta_id: Option<String> = None;
                 let mut saw_tool_call_this_turn = false;
+                // When concurrency > 1, tool calls are buffered here during
+                // streaming and executed in parallel after the stream ends.
+                let mut deferred_tool_calls: Vec<(crate::message::ToolCall, String)> = vec![];
 
                 while let Some(content) = stream.next().await {
                     match content {
@@ -490,90 +517,95 @@ where
                             yield Ok(MultiTurnStreamItem::stream_item(StreamedAssistantContent::Text(text)));
                         },
                         Ok(StreamedAssistantContent::ToolCall { tool_call, internal_call_id }) => {
-                            let tool_span = info_span!(
-                                parent: tracing::Span::current(),
-                                "execute_tool",
-                                gen_ai.operation.name = "execute_tool",
-                                gen_ai.tool.type = "function",
-                                gen_ai.tool.name = tracing::field::Empty,
-                                gen_ai.tool.call.id = tracing::field::Empty,
-                                gen_ai.tool.call.arguments = tracing::field::Empty,
-                                gen_ai.tool.call.result = tracing::field::Empty
-                            );
-
                             yield Ok(MultiTurnStreamItem::stream_item(StreamedAssistantContent::ToolCall { tool_call: tool_call.clone(), internal_call_id: internal_call_id.clone() }));
 
-                            let tc_result = async {
-                                let tool_span = tracing::Span::current();
-                                let tool_args = json_utils::value_to_json_string(&tool_call.function.arguments);
-                                if let Some(ref hook) = self.hook {
-                                    let action = hook
-                                        .on_tool_call(&tool_call.function.name, tool_call.call_id.clone(), &internal_call_id, &tool_args)
-                                        .await;
+                            if concurrency > 1 {
+                                // Buffer for parallel execution after stream completes.
+                                deferred_tool_calls.push((tool_call, internal_call_id));
+                            } else {
+                                // Sequential (default): execute inline, matching prior behaviour.
+                                let tool_span = info_span!(
+                                    parent: tracing::Span::current(),
+                                    "execute_tool",
+                                    gen_ai.operation.name = "execute_tool",
+                                    gen_ai.tool.type = "function",
+                                    gen_ai.tool.name = tracing::field::Empty,
+                                    gen_ai.tool.call.id = tracing::field::Empty,
+                                    gen_ai.tool.call.arguments = tracing::field::Empty,
+                                    gen_ai.tool.call.result = tracing::field::Empty
+                                );
 
-                                    if let ToolCallHookAction::Terminate { reason } = action {
-                                        return Err(cancelled_prompt_error(chat_history.as_deref(), new_messages.clone(), reason).await);
+                                let tc_result = async {
+                                    let tool_span = tracing::Span::current();
+                                    let tool_args = json_utils::value_to_json_string(&tool_call.function.arguments);
+                                    if let Some(ref hook) = self.hook {
+                                        let action = hook
+                                            .on_tool_call(&tool_call.function.name, tool_call.call_id.clone(), &internal_call_id, &tool_args)
+                                            .await;
+
+                                        if let ToolCallHookAction::Terminate { reason } = action {
+                                            return Err(cancelled_prompt_error(chat_history.as_deref(), new_messages.clone(), reason).await);
+                                        }
+
+                                        if let ToolCallHookAction::Skip { reason } = action {
+                                            tracing::info!(
+                                                tool_name = tool_call.function.name.as_str(),
+                                                reason = reason,
+                                                "Tool call rejected"
+                                            );
+                                            let tool_call_msg = AssistantContent::ToolCall(tool_call.clone());
+                                            tool_calls.push(tool_call_msg);
+                                            tool_results.push((tool_call.id.clone(), tool_call.call_id.clone(), reason.clone()));
+                                            saw_tool_call_this_turn = true;
+                                            return Ok(reason);
+                                        }
                                     }
 
-                                    if let ToolCallHookAction::Skip { reason } = action {
-                                        // Tool execution rejected, return rejection message as tool result
-                                        tracing::info!(
-                                            tool_name = tool_call.function.name.as_str(),
-                                            reason = reason,
-                                            "Tool call rejected"
-                                        );
-                                        let tool_call_msg = AssistantContent::ToolCall(tool_call.clone());
-                                        tool_calls.push(tool_call_msg);
-                                        tool_results.push((tool_call.id.clone(), tool_call.call_id.clone(), reason.clone()));
-                                        saw_tool_call_this_turn = true;
-                                        return Ok(reason);
+                                    tool_span.record("gen_ai.tool.name", &tool_call.function.name);
+                                    tool_span.record("gen_ai.tool.call.arguments", &tool_args);
+
+                                    let tool_result = match
+                                    tool_server_handle.call_tool(&tool_call.function.name, &tool_args).await {
+                                        Ok(thing) => thing,
+                                        Err(e) => {
+                                            tracing::warn!("Error while calling tool: {e}");
+                                            e.to_string()
+                                        }
+                                    };
+
+                                    tool_span.record("gen_ai.tool.call.result", &tool_result);
+
+                                    if let Some(ref hook) = self.hook &&
+                                        let HookAction::Terminate { reason } =
+                                        hook.on_tool_result(
+                                            &tool_call.function.name,
+                                            tool_call.call_id.clone(),
+                                            &internal_call_id,
+                                            &tool_args,
+                                            &tool_result.to_string()
+                                        )
+                                        .await {
+                                            return Err(cancelled_prompt_error(chat_history.as_deref(), new_messages.clone(), reason).await);
+                                        }
+
+                                    let tool_call_msg = AssistantContent::ToolCall(tool_call.clone());
+
+                                    tool_calls.push(tool_call_msg);
+                                    tool_results.push((tool_call.id.clone(), tool_call.call_id.clone(), tool_result.clone()));
+
+                                    saw_tool_call_this_turn = true;
+                                    Ok(tool_result)
+                                }.instrument(tool_span).await;
+
+                                match tc_result {
+                                    Ok(text) => {
+                                        let tr = ToolResult { id: tool_call.id, call_id: tool_call.call_id, content: ToolResultContent::from_tool_output(text) };
+                                        yield Ok(MultiTurnStreamItem::StreamUserItem(StreamedUserContent::ToolResult{ tool_result: tr, internal_call_id }));
                                     }
-                                }
-
-                                tool_span.record("gen_ai.tool.name", &tool_call.function.name);
-                                tool_span.record("gen_ai.tool.call.arguments", &tool_args);
-
-                                let tool_result = match
-                                tool_server_handle.call_tool(&tool_call.function.name, &tool_args).await {
-                                    Ok(thing) => thing,
                                     Err(e) => {
-                                        tracing::warn!("Error while calling tool: {e}");
-                                        e.to_string()
+                                        yield Err(e);
+                                        break 'outer;
                                     }
-                                };
-
-                                tool_span.record("gen_ai.tool.call.result", &tool_result);
-
-                                if let Some(ref hook) = self.hook &&
-                                    let HookAction::Terminate { reason } =
-                                    hook.on_tool_result(
-                                        &tool_call.function.name,
-                                        tool_call.call_id.clone(),
-                                        &internal_call_id,
-                                        &tool_args,
-                                        &tool_result.to_string()
-                                    )
-                                    .await {
-                                        return Err(cancelled_prompt_error(chat_history.as_deref(), new_messages.clone(), reason).await);
-                                    }
-
-                                let tool_call_msg = AssistantContent::ToolCall(tool_call.clone());
-
-                                tool_calls.push(tool_call_msg);
-                                tool_results.push((tool_call.id.clone(), tool_call.call_id.clone(), tool_result.clone()));
-
-                                saw_tool_call_this_turn = true;
-                                Ok(tool_result)
-                            }.instrument(tool_span).await;
-
-                            match tc_result {
-                                Ok(text) => {
-                                    let tr = ToolResult { id: tool_call.id, call_id: tool_call.call_id, content: ToolResultContent::from_tool_output(text) };
-                                    yield Ok(MultiTurnStreamItem::StreamUserItem(StreamedUserContent::ToolResult{ tool_result: tr, internal_call_id }));
-                                }
-                                Err(e) => {
-                                    yield Err(e);
-                                    break 'outer;
                                 }
                             }
                         },
@@ -626,6 +658,99 @@ where
                             yield Err(e.into());
                             break 'outer;
                         }
+                    }
+                }
+
+                // ── Parallel tool execution (concurrency > 1) ──
+                // Tool calls were buffered during the stream above.
+                // Execute them concurrently, honouring hooks and cancellation.
+                if !deferred_tool_calls.is_empty() {
+                    saw_tool_call_this_turn = true;
+
+                    // Phase 1 – pre-execution hooks (sequential).
+                    // A Terminate stops everything; a Skip returns the
+                    // reason as the tool result without executing.
+                    let mut approved: Vec<(crate::message::ToolCall, String, String)> = vec![];
+                    for (tc, internal_id) in deferred_tool_calls.drain(..) {
+                        let tool_args = json_utils::value_to_json_string(&tc.function.arguments);
+                        if let Some(ref hook) = self.hook {
+                            let action = hook
+                                .on_tool_call(&tc.function.name, tc.call_id.clone(), &internal_id, &tool_args)
+                                .await;
+                            match action {
+                                ToolCallHookAction::Terminate { reason } => {
+                                    yield Err(cancelled_prompt_error(chat_history.as_deref(), new_messages.clone(), reason).await);
+                                    break 'outer;
+                                }
+                                ToolCallHookAction::Skip { reason } => {
+                                    tracing::info!(
+                                        tool_name = tc.function.name.as_str(),
+                                        reason = reason,
+                                        "Tool call rejected"
+                                    );
+                                    tool_calls.push(AssistantContent::ToolCall(tc.clone()));
+                                    tool_results.push((tc.id.clone(), tc.call_id.clone(), reason.clone()));
+                                    let tr = ToolResult { id: tc.id, call_id: tc.call_id, content: ToolResultContent::from_tool_output(reason) };
+                                    yield Ok(MultiTurnStreamItem::StreamUserItem(StreamedUserContent::ToolResult { tool_result: tr, internal_call_id: internal_id }));
+                                    continue;
+                                }
+                                ToolCallHookAction::Continue => {}
+                            }
+                        }
+                        approved.push((tc, internal_id, tool_args));
+                    }
+
+                    // Phase 2 – execute approved tools concurrently.
+                    let execution_futures: Vec<_> = approved.iter().map(|(tc, _internal_id, tool_args)| {
+                        let tool_span = info_span!(
+                            parent: tracing::Span::current(),
+                            "execute_tool",
+                            gen_ai.operation.name = "execute_tool",
+                            gen_ai.tool.r#type = "function",
+                            gen_ai.tool.name = tc.function.name.as_str(),
+                            gen_ai.tool.call.id = tc.id.as_str(),
+                            gen_ai.tool.call.arguments = tool_args.as_str(),
+                            gen_ai.tool.call.result = tracing::field::Empty
+                        );
+                        let name = tc.function.name.clone();
+                        let args = tool_args.clone();
+                        let handle = tool_server_handle.clone();
+                        async move {
+                            let result = match handle.call_tool(&name, &args).await {
+                                Ok(r) => r,
+                                Err(e) => {
+                                    tracing::warn!("Error while calling tool: {e}");
+                                    e.to_string()
+                                }
+                            };
+                            tracing::Span::current().record("gen_ai.tool.call.result", &result);
+                            result
+                        }.instrument(tool_span)
+                    }).collect();
+
+                    let results = futures::future::join_all(execution_futures).await;
+
+                    // Phase 3 – post-execution hooks (sequential) & yield results.
+                    for ((tc, internal_id, tool_args), result) in approved.into_iter().zip(results) {
+                        if let Some(ref hook) = self.hook &&
+                            let HookAction::Terminate { reason } =
+                            hook.on_tool_result(
+                                &tc.function.name,
+                                tc.call_id.clone(),
+                                &internal_id,
+                                &tool_args,
+                                &result,
+                            ).await
+                        {
+                            yield Err(cancelled_prompt_error(chat_history.as_deref(), new_messages.clone(), reason).await);
+                            break 'outer;
+                        }
+
+                        tool_calls.push(AssistantContent::ToolCall(tc.clone()));
+                        tool_results.push((tc.id.clone(), tc.call_id.clone(), result.clone()));
+
+                        let tr = ToolResult { id: tc.id, call_id: tc.call_id, content: ToolResultContent::from_tool_output(result) };
+                        yield Ok(MultiTurnStreamItem::StreamUserItem(StreamedUserContent::ToolResult { tool_result: tr, internal_call_id: internal_id }));
                     }
                 }
 

--- a/rig/rig-core/tests/parallel_streaming_tool_execution.rs
+++ b/rig/rig-core/tests/parallel_streaming_tool_execution.rs
@@ -1,0 +1,347 @@
+//! Integration test: parallel tool execution in streaming multi-turn agents.
+//!
+//! Verifies that `with_tool_concurrency(N)` causes multiple tool calls from a
+//! single model response to be dispatched concurrently rather than sequentially.
+//!
+//! The test uses two deliberately slow tools (100 ms each). With sequential
+//! execution the combined wall time would be ~200 ms+; with parallel execution
+//! it should be ~100 ms+ (i.e. the max of the individual durations).
+//!
+//! Run:
+//!   source .env && cargo test -p rig-core --test parallel_streaming_tool_execution -- --ignored --nocapture
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+use futures::StreamExt;
+use rig::agent::MultiTurnStreamItem;
+use rig::client::{CompletionClient, ProviderClient};
+use rig::completion::Message;
+use rig::completion::request::ToolDefinition;
+use rig::streaming::{StreamedAssistantContent, StreamedUserContent, StreamingChat};
+use rig::tool::Tool;
+use serde::Deserialize;
+use serde_json::json;
+
+// ── Slow tools ──────────────────────────────────────────────
+
+const TOOL_DELAY_MS: u64 = 500;
+
+#[derive(Debug, thiserror::Error)]
+#[error("Tool error")]
+struct ToolError;
+
+#[derive(Deserialize)]
+struct CityArgs {
+    city: String,
+}
+
+/// A weather tool that sleeps to simulate latency, then returns canned data.
+struct SlowWeatherTool {
+    call_count: Arc<AtomicUsize>,
+}
+
+impl Tool for SlowWeatherTool {
+    const NAME: &'static str = "get_weather";
+    type Error = ToolError;
+    type Args = CityArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: "get_weather".to_string(),
+            description: "Get current weather for a city. Always call this for weather questions."
+                .to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "city": { "type": "string", "description": "City name" }
+                },
+                "required": ["city"]
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        self.call_count.fetch_add(1, Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(TOOL_DELAY_MS)).await;
+        Ok(format!("{}: 72°F, sunny", args.city))
+    }
+}
+
+/// A population tool that sleeps to simulate latency, then returns canned data.
+struct SlowPopulationTool {
+    call_count: Arc<AtomicUsize>,
+}
+
+impl Tool for SlowPopulationTool {
+    const NAME: &'static str = "get_population";
+    type Error = ToolError;
+    type Args = CityArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: "get_population".to_string(),
+            description: "Get the population of a city. Always call this for population questions."
+                .to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "city": { "type": "string", "description": "City name" }
+                },
+                "required": ["city"]
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        self.call_count.fetch_add(1, Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(TOOL_DELAY_MS)).await;
+        Ok(format!("{}: 13.96 million", args.city))
+    }
+}
+
+// ── Shared constants ────────────────────────────────────────
+
+const PREAMBLE: &str = "\
+You are a helpful assistant with access to get_weather and get_population tools. \
+When asked about a city, you MUST call BOTH tools in the SAME response (parallel tool use). \
+Never guess data; always use the tools.";
+
+const PROMPT: &str = "\
+What is the weather and population of Tokyo? \
+Call both get_weather and get_population at the same time.";
+
+// ── Test helpers ────────────────────────────────────────────
+
+struct StreamResult {
+    tool_call_names: Vec<String>,
+    tool_results: usize,
+    final_text: String,
+    tool_execution_duration: Duration,
+    errors: Vec<String>,
+}
+
+async fn run_stream<R: std::fmt::Debug>(
+    stream: impl futures::Stream<Item = Result<MultiTurnStreamItem<R>, rig::agent::StreamingError>>
+    + Unpin,
+) -> StreamResult {
+    let mut result = StreamResult {
+        tool_call_names: vec![],
+        tool_results: 0,
+        final_text: String::new(),
+        tool_execution_duration: Duration::ZERO,
+        errors: vec![],
+    };
+
+    futures::pin_mut!(stream);
+
+    let mut first_tool_call_time: Option<Instant> = None;
+    let mut last_tool_result_time: Option<Instant> = None;
+
+    while let Some(item) = stream.next().await {
+        match item {
+            Ok(MultiTurnStreamItem::StreamAssistantItem(content)) => match content {
+                StreamedAssistantContent::ToolCall { ref tool_call, .. } => {
+                    if first_tool_call_time.is_none() {
+                        first_tool_call_time = Some(Instant::now());
+                    }
+                    result.tool_call_names.push(tool_call.function.name.clone());
+                }
+                StreamedAssistantContent::Text(ref text) => {
+                    result.final_text.push_str(&text.text);
+                }
+                _ => {}
+            },
+            Ok(MultiTurnStreamItem::StreamUserItem(ref user_content)) => match user_content {
+                StreamedUserContent::ToolResult { .. } => {
+                    result.tool_results += 1;
+                    last_tool_result_time = Some(Instant::now());
+                }
+            },
+            Ok(MultiTurnStreamItem::FinalResponse(_)) => {}
+            Ok(_) => {}
+            Err(ref e) => result.errors.push(e.to_string()),
+        }
+    }
+
+    if let (Some(start), Some(end)) = (first_tool_call_time, last_tool_result_time) {
+        result.tool_execution_duration = end.duration_since(start);
+    }
+
+    result
+}
+
+// ── Tests ───────────────────────────────────────────────────
+
+/// Parallel execution: both tools should complete in roughly the time of one tool.
+#[tokio::test]
+#[ignore = "requires OPENAI_API_KEY"]
+async fn test_parallel_streaming_openai() {
+    use rig::providers::openai;
+
+    let weather_count = Arc::new(AtomicUsize::new(0));
+    let pop_count = Arc::new(AtomicUsize::new(0));
+
+    let client = openai::Client::from_env();
+    let agent = client
+        .agent(openai::GPT_4O)
+        .preamble(PREAMBLE)
+        .max_tokens(1024)
+        .tool(SlowWeatherTool {
+            call_count: weather_count.clone(),
+        })
+        .tool(SlowPopulationTool {
+            call_count: pop_count.clone(),
+        })
+        .build();
+
+    let stream = agent
+        .stream_chat(PROMPT, Vec::<Message>::new())
+        .multi_turn(3)
+        .with_tool_concurrency(10)
+        .await;
+
+    let result = run_stream(stream).await;
+
+    assert!(result.errors.is_empty(), "Errors: {:?}", result.errors);
+    assert!(
+        weather_count.load(Ordering::SeqCst) >= 1,
+        "get_weather was not called"
+    );
+    assert!(
+        pop_count.load(Ordering::SeqCst) >= 1,
+        "get_population was not called"
+    );
+    assert!(result.tool_results >= 2, "Expected at least 2 tool results");
+
+    // With parallel execution of 2 tools (500ms each), total should be
+    // well under 2x (i.e. < 1000ms). Sequential would be >= 1000ms.
+    let max_parallel_time = Duration::from_millis(TOOL_DELAY_MS * 2);
+    eprintln!(
+        "Tool execution duration: {:?} (threshold: {:?})",
+        result.tool_execution_duration, max_parallel_time
+    );
+    if result.tool_call_names.len() >= 2 {
+        assert!(
+            result.tool_execution_duration < max_parallel_time,
+            "Tools took {:?}, expected < {:?} for parallel execution",
+            result.tool_execution_duration,
+            max_parallel_time
+        );
+    }
+}
+
+/// Sequential execution (default): tools should take roughly the sum of individual times.
+#[tokio::test]
+#[ignore = "requires OPENAI_API_KEY"]
+async fn test_sequential_streaming_openai() {
+    use rig::providers::openai;
+
+    let weather_count = Arc::new(AtomicUsize::new(0));
+    let pop_count = Arc::new(AtomicUsize::new(0));
+
+    let client = openai::Client::from_env();
+    let agent = client
+        .agent(openai::GPT_4O)
+        .preamble(PREAMBLE)
+        .max_tokens(1024)
+        .tool(SlowWeatherTool {
+            call_count: weather_count.clone(),
+        })
+        .tool(SlowPopulationTool {
+            call_count: pop_count.clone(),
+        })
+        .build();
+
+    // Default concurrency = 1 (sequential)
+    let stream = agent
+        .stream_chat(PROMPT, Vec::<Message>::new())
+        .multi_turn(3)
+        .await;
+
+    let result = run_stream(stream).await;
+
+    assert!(result.errors.is_empty(), "Errors: {:?}", result.errors);
+    assert!(
+        weather_count.load(Ordering::SeqCst) >= 1,
+        "get_weather was not called"
+    );
+    assert!(
+        pop_count.load(Ordering::SeqCst) >= 1,
+        "get_population was not called"
+    );
+
+    // With sequential execution of 2 tools (500ms each), total should be >= 1000ms.
+    if result.tool_call_names.len() >= 2 {
+        let min_sequential_time = Duration::from_millis(TOOL_DELAY_MS * 2 - 100); // small margin
+        eprintln!(
+            "Sequential tool execution duration: {:?} (expected >= {:?})",
+            result.tool_execution_duration, min_sequential_time
+        );
+        assert!(
+            result.tool_execution_duration >= min_sequential_time,
+            "Sequential execution took {:?}, expected >= {:?}",
+            result.tool_execution_duration,
+            min_sequential_time
+        );
+    }
+}
+
+/// Parallel execution with Anthropic provider.
+#[tokio::test]
+#[ignore = "requires ANTHROPIC_API_KEY"]
+async fn test_parallel_streaming_anthropic() {
+    use rig::providers::anthropic;
+
+    let weather_count = Arc::new(AtomicUsize::new(0));
+    let pop_count = Arc::new(AtomicUsize::new(0));
+
+    let client = anthropic::Client::from_env();
+    let agent = client
+        .agent("claude-sonnet-4-5-20250929")
+        .preamble(PREAMBLE)
+        .max_tokens(1024)
+        .tool(SlowWeatherTool {
+            call_count: weather_count.clone(),
+        })
+        .tool(SlowPopulationTool {
+            call_count: pop_count.clone(),
+        })
+        .build();
+
+    let stream = agent
+        .stream_chat(PROMPT, Vec::<Message>::new())
+        .multi_turn(3)
+        .with_tool_concurrency(10)
+        .await;
+
+    let result = run_stream(stream).await;
+
+    assert!(result.errors.is_empty(), "Errors: {:?}", result.errors);
+    assert!(
+        weather_count.load(Ordering::SeqCst) >= 1,
+        "get_weather was not called"
+    );
+    assert!(
+        pop_count.load(Ordering::SeqCst) >= 1,
+        "get_population was not called"
+    );
+    assert!(result.tool_results >= 2, "Expected at least 2 tool results");
+
+    let max_parallel_time = Duration::from_millis(TOOL_DELAY_MS * 2);
+    eprintln!(
+        "Tool execution duration: {:?} (threshold: {:?})",
+        result.tool_execution_duration, max_parallel_time
+    );
+    if result.tool_call_names.len() >= 2 {
+        assert!(
+            result.tool_execution_duration < max_parallel_time,
+            "Tools took {:?}, expected < {:?} for parallel execution",
+            result.tool_execution_duration,
+            max_parallel_time
+        );
+    }
+}


### PR DESCRIPTION
## Summary

The non-streaming `PromptRequest` already supports concurrent tool execution via `with_tool_concurrency(n)` and `buffer_unordered`. The streaming path (`StreamingPromptRequest`) was missing this — tool calls were always executed sequentially as they arrived in the stream, blocking on each one before processing the next.

This adds `with_tool_concurrency(n)` to `StreamingPromptRequest`, matching the existing non-streaming API.

### How it works

When `concurrency > 1`, tool calls from a single model response are:
1. **Buffered** during streaming (ToolCall events are still yielded immediately to consumers)
2. **Approved** via pre-execution hooks (`on_tool_call`) sequentially — a `Terminate` prevents all execution, a `Skip` only affects that tool
3. **Dispatched concurrently** via `futures::future::join_all`
4. **Post-processed** via `on_tool_result` hooks sequentially — a `Terminate` stops the agent loop

When `concurrency == 1` (default), the behaviour is **completely unchanged** — the existing inline sequential execution path is preserved.

### Usage

```rust
let stream = agent
    .stream_chat("Call both tools", history)
    .multi_turn(5)
    .with_tool_concurrency(10) // new
    .await;
```

### Design decisions

- **Opt-in only**: Default concurrency is 1 to avoid surprising existing users
- **API consistency**: Method name and semantics match the existing `PromptRequest::with_tool_concurrency`
- **Hook ordering preserved**: Pre-execution hooks run sequentially before dispatch (Terminate prevents everything). Post-execution hooks run sequentially after all tools complete
- **Sequential path untouched**: The `concurrency == 1` code path is the original code, unmodified

## Test plan

- [x] All existing `tool::server` unit tests pass
- [x] `cargo clippy` clean
- [x] New integration tests (behind `#[ignore]`) verify:
  - Parallel execution of 2 slow tools (500ms each) completes in ~500ms, not ~1000ms
  - Sequential execution (default) maintains expected ~1000ms timing
  - Tests for OpenAI and Anthropic providers