### PR TITLE
fix: replace unwrap with graceful handling on mime_str

### DIFF
--- a/rig/rig-core/src/http_client/multipart.rs
+++ b/rig/rig-core/src/http_client/multipart.rs
@@ -199,7 +199,9 @@ impl From<MultipartForm> for reqwest::multipart::Form {
                         req_part = req_part.file_name(filename);
                     }
                     if let Some(content_type) = part.content_type {
-                        req_part = req_part.mime_str(content_type.as_ref()).unwrap();
+                        if let Ok(part_with_mime) = req_part.mime_str(content_type.as_ref()) {
+                            req_part = part_with_mime;
+                        }
                     }
 
                     form = form.part(part.name, req_part);


### PR DESCRIPTION
## Summary
`reqwest::multipart::Part::mime_str()` returns `Result` and panics when unwrapped on invalid MIME type strings. Since the `From<MultipartForm>` impl cannot propagate errors, replaced `.unwrap()` with `if let Ok(...)` to gracefully skip invalid MIME types instead of panicking.

## Test plan
- [ ] Valid MIME types (e.g., `image/png`) still get set correctly
- [ ] Invalid MIME types no longer cause a panic
- [ ] Multipart form submission works end-to-end