### PR TITLE
fix(streaming): preserve tool call history, deduplicate prompt

### DIFF
--- a/rig/rig-core/src/agent/prompt_request/streaming.rs
+++ b/rig/rig-core/src/agent/prompt_request/streaming.rs
@@ -420,12 +420,15 @@ where
                     &new_messages[..new_messages.len().saturating_sub(1)],
                 );
 
-                if let Some(ref hook) = self.hook {
-                    if let HookAction::Terminate { reason } = hook.on_completion_call(&current_prompt, &history_snapshot)
-                        .await {
-                        yield Err(cancelled_prompt_error(chat_history.as_deref(), new_messages.clone(), reason).await);
-                        break 'outer;
-                    }
+                if let Some(ref hook) = self.hook
+                    && let HookAction::Terminate { reason } =
+                        hook.on_completion_call(&current_prompt, &history_snapshot).await
+                {
+                    yield Err(
+                        cancelled_prompt_error(chat_history.as_deref(), new_messages.clone(), reason)
+                            .await,
+                    );
+                    break 'outer;
                 }
 
                 let chat_stream_span = info_span!(
@@ -1009,13 +1012,11 @@ mod tests {
                         .with_call_id("call_1".to_string()),
                     ));
                     yield Ok(RawStreamingChoice::FinalResponse(MockStreamingResponse::new(4)));
+                } else if let Some(error) = validation_error {
+                    yield Err(CompletionError::ProviderError(error));
                 } else {
-                    if let Some(error) = validation_error {
-                        yield Err(CompletionError::ProviderError(error));
-                    } else {
-                        yield Ok(RawStreamingChoice::Message("done".to_string()));
-                        yield Ok(RawStreamingChoice::FinalResponse(MockStreamingResponse::new(6)));
-                    }
+                    yield Ok(RawStreamingChoice::Message("done".to_string()));
+                    yield Ok(RawStreamingChoice::FinalResponse(MockStreamingResponse::new(6)));
                 }
             };
 


### PR DESCRIPTION
Fixes #1588.

## Summary

The generic multi-turn streaming loop was mixing the pending prompt with accumulated history.

After a tool-call turn, the follow-up request would:
- duplicate the original user prompt
- drop the assistant tool-call message
- send only the tool result on the next turn

That is especially visible with OpenAI Responses streaming, which requires the assistant `function_call` and the user `function_call_output` to be paired by `call_id`.

## Changes

- align `agent::prompt_request::streaming` bookkeeping with the non-streaming prompt loop
- keep `new_messages` as completed history plus a single pending prompt
- stop pushing the current prompt into history twice
- preserve assistant tool-call messages before user tool results on follow-up turns
- use the current turn prompt for `on_stream_completion_response_finish`

## Tests

- strengthened `stream_prompt_continues_after_tool_call_turn` to assert the exact second-turn history shape:
  - original user prompt
  - assistant tool call
  - user tool result

## Why this matters

Without this fix, strict providers can reject the follow-up request with errors like:

`No tool call found for function call output with call_id ...`