### PR TITLE
openai: fix get_text_response reading wrong role and truncating output

### DIFF
--- a/rig/rig-core/src/providers/openai/completion/mod.rs
+++ b/rig/rig-core/src/providers/openai/completion/mod.rs
@@ -879,15 +879,28 @@ impl ProviderResponseExt for CompletionResponse {
     }
 
     fn get_text_response(&self) -> Option<String> {
-        let Message::User { ref content, .. } = self.choices.last()?.message.clone() else {
+        // OpenAI chat completions return the assistant's reply as
+        // `Message::Assistant`, not `Message::User`. Matching on `User`
+        // here caused `get_text_response()` to always return `None` for
+        // real provider responses, and even if the match were corrected
+        // to `Assistant`, returning only the first content item would
+        // truncate multi-part assistant replies.
+        let Message::Assistant { ref content, .. } = self.choices.last()?.message else {
             return None;
         };
 
-        let UserContent::Text { text } = content.first() else {
-            return None;
-        };
+        let mut text = String::new();
+        for item in content {
+            if let AssistantContent::Text { text: part } = item {
+                text.push_str(part);
+            }
+        }
 
-        Some(text)
+        if text.is_empty() {
+            None
+        } else {
+            Some(text)
+        }
     }
 
     fn get_usage(&self) -> Option<Self::Usage> {


### PR DESCRIPTION
`ProviderResponseExt::get_text_response()` for the OpenAI chat completions provider matched `Message::User` on the response message and returned only the first text content item. OpenAI chat completions return the assistant reply as `Message::Assistant`, so this always returned `None` for real provider responses, and even if the match were corrected, returning only the first item would truncate multi-part assistant replies.

This patch matches `Message::Assistant` and concatenates all `Text` content items into the returned string.

Fixes #1602