### PR TITLE
(refactor): replace legacy Anthropic constants 

### DIFF
--- a/rig/rig-core/examples/agent_with_default_max_turns.rs
+++ b/rig/rig-core/examples/agent_with_default_max_turns.rs
@@ -83,7 +83,7 @@ const PROMPT: &str = "Calculate (3 + 5) / 4 and describe the result.";
 #[tokio::main]
 async fn main() -> Result<()> {
     let agent = anthropic::Client::from_env()
-        .agent(anthropic::completion::CLAUDE_4_SONNET)
+        .agent(anthropic::completion::CLAUDE_SONNET_4_6)
         .preamble(
             "You are an assistant that must use the available tools for arithmetic. \
              Never compute the result yourself.",

--- a/rig/rig-core/examples/complex_agentic_loop_claude.rs
+++ b/rig/rig-core/examples/complex_agentic_loop_claude.rs
@@ -82,7 +82,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Create specialized research agent that will be used as a tool
     let research_agent = anthropic_client
-        .agent(anthropic::completion::CLAUDE_4_SONNET)
+        .agent(anthropic::completion::CLAUDE_SONNET_4_6)
         .preamble(
             "You are a specialized research agent focused on environmental science and sustainability.
             Your role is to provide detailed, accurate information about climate change, renewable energy,
@@ -94,7 +94,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Create a data analysis agent that will be used as a tool
     let analysis_agent = anthropic_client
-        .agent(anthropic::completion::CLAUDE_4_SONNET)
+        .agent(anthropic::completion::CLAUDE_SONNET_4_6)
         .preamble(
             "You are a data analysis agent specialized in interpreting environmental and sustainability data.
             When given data or statistics, you analyze trends, identify patterns, and draw meaningful conclusions.
@@ -106,7 +106,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Create a recommendation agent that will be used as a tool
     let recommendation_agent = anthropic_client
-        .agent(anthropic::completion::CLAUDE_4_SONNET)
+        .agent(anthropic::completion::CLAUDE_SONNET_4_6)
         .preamble(
             "You are a recommendation agent specialized in suggesting practical sustainability solutions.
             Based on research findings and analysis, you provide actionable recommendations for individuals,
@@ -119,7 +119,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Create the main orchestrator agent that will use all the tools
     let orchestrator_agent = anthropic_client
-        .agent(anthropic::completion::CLAUDE_4_SONNET)
+        .agent(anthropic::completion::CLAUDE_SONNET_4_6)
         .preamble(
             "You are an environmental sustainability advisor that helps users understand complex environmental issues
             and find practical solutions. You have access to several specialized tools:

--- a/rig/rig-core/examples/enum_dispatch.rs
+++ b/rig/rig-core/examples/enum_dispatch.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use rig::agent::Agent;
 use rig::client::{CompletionClient, ProviderClient};
 use rig::completion::{Prompt, PromptError};
-use rig::providers::anthropic::completion::CLAUDE_4_SONNET;
+use rig::providers::anthropic::completion::CLAUDE_SONNET_4_6;
 use rig::providers::openai::GPT_4O;
 use rig::providers::{anthropic, openai};
 
@@ -32,7 +32,7 @@ struct ProviderRegistry(HashMap<&'static str, fn(AgentConfig) -> Agents>);
 
 fn anthropic_agent(AgentConfig { name, preamble }: AgentConfig) -> Agents {
     let agent = anthropic::Client::from_env()
-        .agent(CLAUDE_4_SONNET)
+        .agent(CLAUDE_SONNET_4_6)
         .name(name)
         .preamble(preamble)
         .build();

--- a/rig/rig-core/examples/multi_turn_agent.rs
+++ b/rig/rig-core/examples/multi_turn_agent.rs
@@ -19,7 +19,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Create RAG agent with a single context prompt and a dynamic tool source
     let agent = openai_client
-        .agent(anthropic::completion::CLAUDE_4_SONNET)
+        .agent(anthropic::completion::CLAUDE_SONNET_4_6)
         .preamble(
             "You are an assistant here to help the user select which tool is most appropriate to perform arithmetic operations.
             Follow these instructions closely.

--- a/rig/rig-core/examples/multi_turn_agent_extended.rs
+++ b/rig/rig-core/examples/multi_turn_agent_extended.rs
@@ -19,7 +19,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Create RAG agent with a single context prompt and a dynamic tool source
     let agent = openai_client
-        .agent(anthropic::completion::CLAUDE_4_SONNET)
+        .agent(anthropic::completion::CLAUDE_SONNET_4_6)
         .preamble(
             "You are an assistant here to help the user select which tool is most appropriate to perform arithmetic operations.
             Follow these instructions closely.

--- a/rig/rig-core/examples/reasoning_loop.rs
+++ b/rig/rig-core/examples/reasoning_loop.rs
@@ -75,12 +75,12 @@ async fn main() -> anyhow::Result<()> {
     let anthropic_client = anthropic::Client::from_env();
     let agent = ReasoningAgent {
         chain_of_thought_extractor: anthropic_client
-            .extractor(anthropic::completion::CLAUDE_4_SONNET)
+            .extractor(anthropic::completion::CLAUDE_SONNET_4_6)
             .preamble(CHAIN_OF_THOUGHT_PROMPT)
             .build(),
 
         executor: anthropic_client
-            .agent(anthropic::completion::CLAUDE_4_SONNET)
+            .agent(anthropic::completion::CLAUDE_SONNET_4_6)
             .preamble(
                 "You are an assistant here to help the user select which tool is most appropriate to perform arithmetic operations.
                 Follow these instructions closely.

--- a/rig/rig-core/examples/reqwest_middleware.rs
+++ b/rig/rig-core/examples/reqwest_middleware.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<()> {
         .build()?;
 
     let agent = client
-        .agent("claude-sonnet-4-20250514")
+        .agent(anthropic::completion::CLAUDE_SONNET_4_6)
         .preamble("You are a helpful assistant.")
         .build();
 

--- a/rig/rig-core/src/agent/prompt_request/streaming.rs
+++ b/rig/rig-core/src/agent/prompt_request/streaming.rs
@@ -1278,7 +1278,7 @@ mod tests {
         // (rig reuses current span if one exists, so we need to ensure there's no current span)
         let client = anthropic::Client::from_env();
         let agent = client
-            .agent(anthropic::completion::CLAUDE_3_5_HAIKU)
+            .agent(anthropic::completion::CLAUDE_HAIKU_4_5)
             .preamble("You are a helpful assistant.")
             .temperature(0.1)
             .max_tokens(100)
@@ -1333,7 +1333,7 @@ mod tests {
 
         let client = anthropic::Client::from_env();
         let agent = client
-            .agent(anthropic::completion::CLAUDE_3_5_HAIKU)
+            .agent(anthropic::completion::CLAUDE_HAIKU_4_5)
             .preamble("You are a helpful assistant. Keep responses brief.")
             .temperature(0.1)
             .max_tokens(50)

--- a/rig/rig-core/src/providers/anthropic/completion.rs
+++ b/rig/rig-core/src/providers/anthropic/completion.rs
@@ -22,12 +22,12 @@ use tracing::{Instrument, Level, enabled, info_span};
 // Anthropic Completion API
 // ================================================================
 
-/// `claude-opus-4-0` completion model
-pub const CLAUDE_4_OPUS: &str = "claude-opus-4-0";
-/// `claude-sonnet-4-0` completion model
-pub const CLAUDE_4_SONNET: &str = "claude-sonnet-4-0";
-/// `claude-3-5-haiku-latest` completion model
-pub const CLAUDE_3_5_HAIKU: &str = "claude-3-5-haiku-latest";
+/// `claude-opus-4-6` completion model
+pub const CLAUDE_OPUS_4_6: &str = "claude-opus-4-6";
+/// `claude-sonnet-4-6` completion model
+pub const CLAUDE_SONNET_4_6: &str = "claude-sonnet-4-6";
+/// `claude-haiku-4-5` completion model
+pub const CLAUDE_HAIKU_4_5: &str = "claude-haiku-4-5";
 
 pub const ANTHROPIC_VERSION_2023_01_01: &str = "2023-01-01";
 pub const ANTHROPIC_VERSION_2023_06_01: &str = "2023-06-01";
@@ -847,7 +847,7 @@ where
 {
     pub fn new(client: Client<T>, model: impl Into<String>) -> Self {
         let model = model.into();
-        let default_max_tokens = calculate_max_tokens(&model);
+        let default_max_tokens = default_max_tokens_for_model(&model);
 
         Self {
             client,
@@ -863,7 +863,7 @@ where
         Self {
             client,
             model: model.to_string(),
-            default_max_tokens: Some(calculate_max_tokens_custom(model)),
+            default_max_tokens: Some(default_max_tokens_with_fallback(model)),
             prompt_caching: false,
             automatic_caching: false,
             automatic_caching_ttl: None,
@@ -897,7 +897,7 @@ where
     /// extended TTL.
     ///
     /// ```ignore
-    /// let model = client.completion_model(anthropic::CLAUDE_4_SONNET)
+    /// let model = client.completion_model(anthropic::completion::CLAUDE_SONNET_4_6)
     ///     .with_automatic_caching();
     /// ```
     ///
@@ -910,9 +910,8 @@ where
     /// |-------|---------------|
     /// | `claude-opus-4-6`, `claude-opus-4-5` | 4 096 |
     /// | `claude-sonnet-4-6` | 2 048 |
-    /// | `claude-sonnet-4-5`, `claude-opus-4-1`, `claude-opus-4`, `claude-sonnet-4`, `claude-sonnet-3-7` | 1 024 |
+    /// | `claude-sonnet-4-5`, `claude-opus-4-1`, `claude-opus-4`, `claude-sonnet-4` | 1 024 |
     /// | `claude-haiku-4-5` | 4 096 |
-    /// | `claude-haiku-3-5`, `claude-haiku-3` | 2 048 |
     ///
     /// [`with_prompt_caching`]: CompletionModel::with_prompt_caching
     pub fn with_automatic_caching(mut self) -> Self {
@@ -931,7 +930,7 @@ where
     ///     .api_key(std::env::var("ANTHROPIC_API_KEY").unwrap())
     ///     .anthropic_beta("extended-cache-ttl-2025-04-11")
     ///     .build()?;
-    /// let model = client.completion_model(anthropic::CLAUDE_4_SONNET)
+    /// let model = client.completion_model(anthropic::completion::CLAUDE_SONNET_4_6)
     ///     .with_automatic_caching_1h();
     /// ```
     ///
@@ -946,38 +945,21 @@ where
 /// Anthropic requires a `max_tokens` parameter to be set, which is dependent on the model. If not
 /// set or if set too high, the request will fail. The following values are based on the models
 /// available at the time of writing.
-fn calculate_max_tokens(model: &str) -> Option<u64> {
-    if model.starts_with("claude-opus-4") {
-        Some(32000)
-    } else if model.starts_with("claude-sonnet-4") || model.starts_with("claude-3-7-sonnet") {
-        Some(64000)
-    } else if model.starts_with("claude-3-5-sonnet") || model.starts_with("claude-3-5-haiku") {
-        Some(8192)
-    } else if model.starts_with("claude-3-opus")
-        || model.starts_with("claude-3-sonnet")
-        || model.starts_with("claude-3-haiku")
+fn default_max_tokens_for_model(model: &str) -> Option<u64> {
+    if model.starts_with("claude-opus-4-6") {
+        Some(128_000)
+    } else if model.starts_with("claude-opus-4")
+        || model.starts_with("claude-sonnet-4")
+        || model.starts_with("claude-haiku-4-5")
     {
-        Some(4096)
+        Some(64_000)
     } else {
         None
     }
 }
 
-fn calculate_max_tokens_custom(model: &str) -> u64 {
-    if model.starts_with("claude-opus-4") {
-        32000
-    } else if model.starts_with("claude-sonnet-4") || model.starts_with("claude-3-7-sonnet") {
-        64000
-    } else if model.starts_with("claude-3-5-sonnet") || model.starts_with("claude-3-5-haiku") {
-        8192
-    } else if model.starts_with("claude-3-opus")
-        || model.starts_with("claude-3-sonnet")
-        || model.starts_with("claude-3-haiku")
-    {
-        4096
-    } else {
-        2048
-    }
+fn default_max_tokens_with_fallback(model: &str) -> u64 {
+    default_max_tokens_for_model(model).unwrap_or(2_048)
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -1282,16 +1264,17 @@ impl TryFrom<AnthropicRequestParams<'_>> for AnthropicCompletionRequest {
             apply_cache_control(&mut system, &mut messages);
         }
 
-        // Map output_schema to Anthropic's output_config field
-        let output_config = req.output_schema.map(|schema| {
+        let output_config = if let Some(schema) = req.output_schema {
             let mut schema_value = schema.to_value();
             sanitize_schema(&mut schema_value);
-            OutputConfig {
+            Some(OutputConfig {
                 format: OutputFormat::JsonSchema {
                     schema: schema_value,
                 },
-            }
-        });
+            })
+        } else {
+            None
+        };
 
         Ok(Self {
             model: model.to_string(),

--- a/rig/rig-core/src/providers/anthropic/mod.rs
+++ b/rig/rig-core/src/providers/anthropic/mod.rs
@@ -4,9 +4,9 @@
 //! ```
 //! use rig::providers::anthropic;
 //!
-//! let client = anthropic::Anthropic::new("YOUR_API_KEY");
+//! let client = anthropic::Client::new("YOUR_API_KEY");
 //!
-//! let sonnet = client.completion_model(anthropic::CLAUDE_4_SONNET);
+//! let sonnet = client.completion_model(anthropic::completion::CLAUDE_SONNET_4_6);
 //! ```
 
 pub mod client;

--- a/rig/rig-core/tests/anthropic/agent.rs
+++ b/rig/rig-core/tests/anthropic/agent.rs
@@ -11,7 +11,7 @@ use crate::support::{BASIC_PREAMBLE, BASIC_PROMPT, assert_nonempty_response};
 async fn completion_smoke() {
     let client = anthropic::Client::from_env();
     let agent = client
-        .agent(anthropic::completion::CLAUDE_4_SONNET)
+        .agent(anthropic::completion::CLAUDE_SONNET_4_6)
         .preamble(BASIC_PREAMBLE)
         .build();
 

--- a/rig/rig-core/tests/anthropic/default_max_turns.rs
+++ b/rig/rig-core/tests/anthropic/default_max_turns.rs
@@ -82,7 +82,7 @@ impl Tool for Divide {
 #[ignore = "requires ANTHROPIC_API_KEY"]
 async fn default_max_turns_allows_multi_step_tool_use() -> Result<()> {
     let agent = anthropic::Client::from_env()
-        .agent(anthropic::completion::CLAUDE_4_SONNET)
+        .agent(anthropic::completion::CLAUDE_SONNET_4_6)
         .preamble(
             "You are an assistant that must use the available tools for arithmetic. \
              Never compute the result yourself.",

--- a/rig/rig-core/tests/anthropic/image.rs
+++ b/rig/rig-core/tests/anthropic/image.rs
@@ -18,7 +18,7 @@ use crate::support::{
 async fn image_prompt_from_fixture() {
     let client = anthropic::Client::from_env();
     let agent = client
-        .agent(anthropic::completion::CLAUDE_4_SONNET)
+        .agent(anthropic::completion::CLAUDE_SONNET_4_6)
         .preamble("You are an image describer.")
         .temperature(0.5)
         .build();

--- a/rig/rig-core/tests/anthropic/multi_turn_streaming.rs
+++ b/rig/rig-core/tests/anthropic/multi_turn_streaming.rs
@@ -160,7 +160,7 @@ async fn multi_turn_streaming_tools() {
 
     let client = anthropic::Client::from_env();
     let agent = client
-        .agent(anthropic::completion::CLAUDE_4_SONNET)
+        .agent(anthropic::completion::CLAUDE_SONNET_4_6)
         .preamble("You must use tools for arithmetic.")
         .tool(Add::new(add_calls.clone()))
         .tool(Subtract::new(subtract_calls.clone()))

--- a/rig/rig-core/tests/anthropic/plaintext_document.rs
+++ b/rig/rig-core/tests/anthropic/plaintext_document.rs
@@ -30,7 +30,7 @@ Key Features:
 async fn plaintext_document_prompt() {
     let client = anthropic::Client::from_env();
     let agent = client
-        .agent(anthropic::completion::CLAUDE_4_SONNET)
+        .agent(anthropic::completion::CLAUDE_SONNET_4_6)
         .preamble("You are a helpful assistant that analyzes documents.")
         .temperature(0.5)
         .build();
@@ -54,7 +54,7 @@ async fn plaintext_document_prompt() {
 async fn plaintext_document_with_instruction() {
     let client = anthropic::Client::from_env();
     let agent = client
-        .agent(anthropic::completion::CLAUDE_4_SONNET)
+        .agent(anthropic::completion::CLAUDE_SONNET_4_6)
         .preamble("You are a helpful assistant that analyzes documents.")
         .temperature(0.5)
         .build();

--- a/rig/rig-core/tests/anthropic/reasoning_roundtrip.rs
+++ b/rig/rig-core/tests/anthropic/reasoning_roundtrip.rs
@@ -4,7 +4,7 @@
 //! `cargo test -p rig-core --test anthropic anthropic::reasoning_roundtrip::streaming -- --ignored --nocapture`
 
 use rig::client::{CompletionClient, ProviderClient};
-use rig::providers::anthropic;
+use rig::providers::anthropic::{self, completion::CLAUDE_SONNET_4_6};
 
 use crate::reasoning::{self, ReasoningRoundtripAgent};
 
@@ -13,9 +13,9 @@ use crate::reasoning::{self, ReasoningRoundtripAgent};
 async fn streaming() {
     let client = anthropic::Client::from_env();
     reasoning::run_reasoning_roundtrip_streaming(ReasoningRoundtripAgent::new(
-        client.completion_model("claude-sonnet-4-5-20250929"),
+        client.completion_model(CLAUDE_SONNET_4_6),
         Some(serde_json::json!({
-            "thinking": { "type": "enabled", "budget_tokens": 2048 }
+            "thinking": { "type": "adaptive" }
         })),
     ))
     .await;
@@ -26,9 +26,9 @@ async fn streaming() {
 async fn nonstreaming() {
     let client = anthropic::Client::from_env();
     reasoning::run_reasoning_roundtrip_nonstreaming(ReasoningRoundtripAgent::new(
-        client.completion_model("claude-sonnet-4-5-20250929"),
+        client.completion_model(CLAUDE_SONNET_4_6),
         Some(serde_json::json!({
-            "thinking": { "type": "enabled", "budget_tokens": 2048 }
+            "thinking": { "type": "adaptive" }
         })),
     ))
     .await;

--- a/rig/rig-core/tests/anthropic/reasoning_tool_roundtrip.rs
+++ b/rig/rig-core/tests/anthropic/reasoning_tool_roundtrip.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::AtomicUsize;
 
 use rig::client::{CompletionClient, ProviderClient};
 use rig::completion::{Chat, Message};
-use rig::providers::anthropic;
+use rig::providers::anthropic::{self, completion::CLAUDE_SONNET_4_6};
 use rig::streaming::StreamingChat;
 
 use crate::reasoning::{self, WeatherTool};
@@ -19,12 +19,12 @@ async fn streaming() {
     let call_count = Arc::new(AtomicUsize::new(0));
     let client = anthropic::Client::from_env();
     let agent = client
-        .agent("claude-sonnet-4-5-20250929")
+        .agent(CLAUDE_SONNET_4_6)
         .preamble(reasoning::TOOL_SYSTEM_PROMPT)
         .max_tokens(16384)
         .tool(WeatherTool::new(call_count.clone()))
         .additional_params(serde_json::json!({
-            "thinking": { "type": "enabled", "budget_tokens": 4096 }
+            "thinking": { "type": "adaptive" }
         }))
         .build();
 
@@ -56,12 +56,12 @@ async fn nonstreaming() {
     let call_count = Arc::new(AtomicUsize::new(0));
     let client = anthropic::Client::from_env();
     let agent = client
-        .agent("claude-sonnet-4-5-20250929")
+        .agent(CLAUDE_SONNET_4_6)
         .preamble(reasoning::TOOL_SYSTEM_PROMPT)
         .max_tokens(16384)
         .tool(WeatherTool::new(call_count.clone()))
         .additional_params(serde_json::json!({
-            "thinking": { "type": "enabled", "budget_tokens": 4096 }
+            "thinking": { "type": "adaptive" }
         }))
         .build();
 

--- a/rig/rig-core/tests/anthropic/streaming.rs
+++ b/rig/rig-core/tests/anthropic/streaming.rs
@@ -13,7 +13,7 @@ use crate::support::{
 async fn streaming_smoke() {
     let client = anthropic::Client::from_env();
     let agent = client
-        .agent(anthropic::completion::CLAUDE_4_SONNET)
+        .agent(anthropic::completion::CLAUDE_SONNET_4_6)
         .preamble(STREAMING_PREAMBLE)
         .build();
 

--- a/rig/rig-core/tests/anthropic/streaming_tools.rs
+++ b/rig/rig-core/tests/anthropic/streaming_tools.rs
@@ -14,7 +14,7 @@ use crate::support::{
 async fn streaming_tools_smoke() {
     let client = anthropic::Client::from_env();
     let agent = client
-        .agent(anthropic::completion::CLAUDE_4_SONNET)
+        .agent(anthropic::completion::CLAUDE_SONNET_4_6)
         .preamble(STREAMING_TOOLS_PREAMBLE)
         .tool(Adder)
         .tool(Subtract)

--- a/rig/rig-core/tests/anthropic/structured_output.rs
+++ b/rig/rig-core/tests/anthropic/structured_output.rs
@@ -2,7 +2,7 @@
 
 use rig::client::{CompletionClient, ProviderClient};
 use rig::completion::Prompt;
-use rig::providers::anthropic;
+use rig::providers::anthropic::{self, completion::CLAUDE_SONNET_4_6};
 
 use crate::support::{
     STRUCTURED_OUTPUT_PROMPT, SmokeStructuredOutput, assert_smoke_structured_output,
@@ -13,7 +13,7 @@ use crate::support::{
 async fn structured_output_smoke() {
     let client = anthropic::Client::from_env();
     let agent = client
-        .agent("claude-sonnet-4-5")
+        .agent(CLAUDE_SONNET_4_6)
         .output_schema::<SmokeStructuredOutput>()
         .build();
 

--- a/rig/rig-core/tests/anthropic/think_tool.rs
+++ b/rig/rig-core/tests/anthropic/think_tool.rs
@@ -11,7 +11,7 @@ use crate::support::{assert_contains_any_case_insensitive, assert_nonempty_respo
 #[ignore = "requires ANTHROPIC_API_KEY"]
 async fn think_tool_menu_planning() {
     let agent = anthropic::Client::from_env()
-        .agent(anthropic::completion::CLAUDE_4_SONNET)
+        .agent(anthropic::completion::CLAUDE_SONNET_4_6)
         .name("Anthropic Thinker")
         .preamble(
             "You are a helpful assistant that can solve complex problems. \

--- a/rig/rig-core/tests/anthropic/think_tool_with_other_tools.rs
+++ b/rig/rig-core/tests/anthropic/think_tool_with_other_tools.rs
@@ -279,7 +279,7 @@ async fn think_tool_with_other_tools() -> Result<()> {
         .expect("client should build");
 
     let agent = client
-        .agent(anthropic::completion::CLAUDE_4_SONNET)
+        .agent(anthropic::completion::CLAUDE_SONNET_4_6)
         .name("Customer Service Agent")
         .preamble(
             "You are a customer service agent for an online store.

--- a/rig/rig-core/tests/common/reasoning.rs
+++ b/rig/rig-core/tests/common/reasoning.rs
@@ -330,7 +330,7 @@ pub(crate) struct StreamStats {
     pub(crate) tool_calls_in_stream: Vec<String>,
     pub(crate) tool_results_in_stream: usize,
     pub(crate) text_chunks: usize,
-    pub(crate) final_text: String,
+    pub(crate) final_turn_text: String,
     pub(crate) final_response_text: Option<String>,
     pub(crate) got_final_response: bool,
     pub(crate) errors: Vec<String>,
@@ -348,7 +348,7 @@ impl StreamStats {
             tool_calls_in_stream: vec![],
             tool_results_in_stream: 0,
             text_chunks: 0,
-            final_text: String::new(),
+            final_turn_text: String::new(),
             final_response_text: None,
             got_final_response: false,
             errors: vec![],
@@ -435,7 +435,7 @@ where
                 }
                 StreamedAssistantContent::Text(ref text) => {
                     stats.text_chunks += 1;
-                    stats.final_text.push_str(&text.text);
+                    stats.final_turn_text.push_str(&text.text);
                     if stats.events.last() != Some(&"text") {
                         stats.events.push("text");
                     }
@@ -452,6 +452,7 @@ where
             Ok(MultiTurnStreamItem::StreamUserItem(ref content)) => match content {
                 StreamedUserContent::ToolResult { .. } => {
                     stats.tool_results_in_stream += 1;
+                    stats.final_turn_text.clear();
                     stats.events.push("tool_result");
                 }
             },
@@ -507,11 +508,11 @@ pub(crate) fn assert_universal(
     );
 
     assert!(
-        !stats.final_text.trim().is_empty(),
+        !stats.final_turn_text.trim().is_empty(),
         "[{provider}] Final text is empty."
     );
 
-    let trimmed = stats.final_text.trim();
+    let trimmed = stats.final_turn_text.trim();
     assert!(
         trimmed.len() >= 30,
         "[{provider}] Final text suspiciously short ({} chars): {:?}",
@@ -519,7 +520,7 @@ pub(crate) fn assert_universal(
         &trimmed[..trimmed.len().min(100)]
     );
 
-    let text_lower = stats.final_text.to_ascii_lowercase();
+    let text_lower = stats.final_turn_text.to_ascii_lowercase();
     let references_tool_output = text_lower.contains("72")
         || text_lower.contains("22")
         || text_lower.contains("sunny")
@@ -539,7 +540,7 @@ pub(crate) fn assert_universal(
 
     assert_eq!(
         stats.final_response_text.as_deref(),
-        Some(stats.final_text.as_str()),
+        Some(stats.final_turn_text.as_str()),
         "[{provider}] FinalResponse.response() diverged from streamed text."
     );
 }

--- a/rig/rig-core/tests/core.rs
+++ b/rig/rig-core/tests/core.rs
@@ -8,3 +8,5 @@
 
 #[path = "core/mod.rs"]
 mod core;
+#[path = "common/reasoning.rs"]
+mod reasoning;

--- a/rig/rig-core/tests/core/mod.rs
+++ b/rig/rig-core/tests/core/mod.rs
@@ -3,3 +3,4 @@ mod embed_macro;
 mod loaders;
 mod prompt_response_messages;
 mod provider_layout;
+mod reasoning_stream_stats;

--- a/rig/rig-core/tests/core/reasoning_stream_stats.rs
+++ b/rig/rig-core/tests/core/reasoning_stream_stats.rs
@@ -1,0 +1,62 @@
+use futures::stream;
+use rig::OneOrMany;
+use rig::agent::MultiTurnStreamItem;
+use rig::completion::Usage;
+use rig::message::{ToolCall, ToolFunction, ToolResult, ToolResultContent};
+use rig::streaming::{StreamedAssistantContent, StreamedUserContent};
+
+use crate::reasoning::collect_stream_stats;
+
+#[tokio::test]
+async fn collect_stream_stats_tracks_only_final_turn_text() {
+    let internal_call_id = "call_internal_1".to_string();
+    let tool_call = ToolCall::new(
+        "tool_1".to_string(),
+        ToolFunction::new(
+            "get_weather".to_string(),
+            serde_json::json!({ "city": "Tokyo" }),
+        ),
+    );
+    let tool_result = ToolResult {
+        id: "tool_1".to_string(),
+        call_id: None,
+        content: OneOrMany::one(ToolResultContent::text("72F and sunny")),
+    };
+
+    let items = vec![
+        Ok(MultiTurnStreamItem::StreamAssistantItem(
+            StreamedAssistantContent::<()>::text("Sure! Let me check the weather right away!"),
+        )),
+        Ok(MultiTurnStreamItem::StreamAssistantItem(
+            StreamedAssistantContent::ToolCall {
+                tool_call,
+                internal_call_id: internal_call_id.clone(),
+            },
+        )),
+        Ok(MultiTurnStreamItem::StreamUserItem(
+            StreamedUserContent::tool_result(tool_result, internal_call_id),
+        )),
+        Ok(MultiTurnStreamItem::StreamAssistantItem(
+            StreamedAssistantContent::<()>::text("It's 72F and sunny in Tokyo."),
+        )),
+        Ok(MultiTurnStreamItem::final_response(
+            "It's 72F and sunny in Tokyo.",
+            Usage::new(),
+        )),
+    ];
+
+    let stats = collect_stream_stats(stream::iter(items), "test").await;
+
+    assert_eq!(stats.tool_calls_in_stream, vec!["get_weather".to_string()]);
+    assert_eq!(stats.tool_results_in_stream, 1);
+    assert!(stats.got_final_response, "expected final response event");
+    assert_eq!(
+        stats.final_turn_text, "It's 72F and sunny in Tokyo.",
+        "pre-tool assistant text should not be counted as final-turn text"
+    );
+    assert_eq!(
+        stats.final_response_text.as_deref(),
+        Some(stats.final_turn_text.as_str()),
+        "final response text should match the final turn's streamed text"
+    );
+}

--- a/rig/rig-core/tests/mira/tools.rs
+++ b/rig/rig-core/tests/mira/tools.rs
@@ -13,7 +13,7 @@ use crate::support::{
 async fn tools_smoke() {
     let client = mira::Client::from_env();
     let agent = client
-        .agent(anthropic::completion::CLAUDE_4_SONNET)
+        .agent(anthropic::completion::CLAUDE_SONNET_4_6)
         .preamble(TOOLS_PREAMBLE)
         .tool(Adder)
         .tool(Subtract)


### PR DESCRIPTION
## Summary

This PR updates `rig-core`'s direct Anthropic provider to the current Claude model families and removes the old public Anthropic constants.

It also fixes a shared streaming test helper bug that surfaced once Anthropic started emitting short pre-tool assistant text before the final tool-backed answer.

### What changed

- Removed the old Anthropic model constants from `rig-core`
- Added only the current family constants:
  - `CLAUDE_OPUS_4_6`
  - `CLAUDE_SONNET_4_6`
  - `CLAUDE_HAIKU_4_5`
- Updated `rig-core` examples, tests, and docs to use the new constants
- Refreshed Anthropic default max token resolution for the current 4.x families
- Switched Anthropic reasoning tests from `thinking.enabled + budget_tokens` to `thinking.type = "adaptive"`
- Fixed the shared reasoning streaming helper to compare `FinalResponse.response()` with the final assistant turn only, excluding pre-tool assistant chatter

## Breaking changes

This PR intentionally removes the previous Anthropic constants with no alias or deprecation layer.

Removed public API items:
- `anthropic::completion::CLAUDE_4_OPUS`
- `anthropic::completion::CLAUDE_4_SONNET`
- `anthropic::completion::CLAUDE_3_5_HAIKU`

Replacement migration path:
- `CLAUDE_4_OPUS` -> `CLAUDE_OPUS_4_6`
- `CLAUDE_4_SONNET` -> `CLAUDE_SONNET_4_6`
- `CLAUDE_3_5_HAIKU` -> `CLAUDE_HAIKU_4_5`
