### PR TITLE
feat(rig-derive): support custom tool names (#1619)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9464,6 +9464,7 @@ dependencies = [
  "syn 2.0.114",
  "tokio",
  "tracing-subscriber",
+ "trybuild",
 ]
 
 [[package]]
@@ -10567,6 +10568,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -11776,6 +11786,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-triple"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+
+[[package]]
 name = "tempfile"
 version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11818,6 +11834,15 @@ checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -12235,6 +12260,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.0.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1d7e18e3dd1d31e0ee5e863a8091ffec2fcc271636586042452b656a22c8ee1"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.14",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12245,6 +12285,15 @@ name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -12280,6 +12329,12 @@ checksum = "247eaa3197818b831697600aadf81514e577e0cba5eab10f7e064e78ae154df1"
 dependencies = [
  "winnow 0.7.14",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -12580,6 +12635,21 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "trybuild"
+version = "1.0.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c635f0191bd3a2941013e5062667100969f8c4e9cd787c14f977265d73616e"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml",
+]
 
 [[package]]
 name = "tungstenite"

--- a/rig/rig-core/src/tool/mod.rs
+++ b/rig/rig-core/src/tool/mod.rs
@@ -110,7 +110,8 @@ impl fmt::Display for ToolError {
 /// }
 /// ```
 pub trait Tool: Sized + WasmCompatSend + WasmCompatSync {
-    /// The name of the tool. This name should be unique.
+    /// The name of the tool. This name should be unique within a single
+    /// [`ToolSet`] or other registration scope that dispatches tools by name.
     const NAME: &'static str;
 
     /// The error type of the tool.

--- a/rig/rig-derive/Cargo.toml
+++ b/rig/rig-derive/Cargo.toml
@@ -27,6 +27,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing-subscriber = { workspace = true }
+trybuild = "1.0"
 
 [[example]]
 name = "simple"

--- a/rig/rig-derive/src/lib.rs
+++ b/rig/rig-derive/src/lib.rs
@@ -47,6 +47,7 @@ pub fn derive_embedding_trait(item: TokenStream) -> TokenStream {
 }
 
 struct MacroArgs {
+    name: Option<String>,
     description: Option<String>,
     param_descriptions: HashMap<String, String>,
     required: Vec<String>,
@@ -54,6 +55,7 @@ struct MacroArgs {
 
 impl Parse for MacroArgs {
     fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut name = None;
         let mut description = None;
         let mut param_descriptions = HashMap::new();
         let mut required = Vec::new();
@@ -61,6 +63,7 @@ impl Parse for MacroArgs {
         // If the input is empty, return default values
         if input.is_empty() {
             return Ok(MacroArgs {
+                name,
                 description,
                 param_descriptions,
                 required,
@@ -77,9 +80,12 @@ impl Parse for MacroArgs {
                         lit: Lit::Str(lit_str),
                         ..
                     }) = nv.value
-                        && ident.as_str() == "description"
                     {
-                        description = Some(lit_str.value());
+                        match ident.as_str() {
+                            "name" => name = Some(lit_str.value()),
+                            "description" => description = Some(lit_str.value()),
+                            _ => {}
+                        }
                     }
                 }
                 Meta::List(list) if list.path.is_ident("params") => {
@@ -111,6 +117,7 @@ impl Parse for MacroArgs {
         }
 
         Ok(MacroArgs {
+            name,
             description,
             param_descriptions,
             required,
@@ -191,6 +198,16 @@ fn get_json_type(ty: &Type) -> proc_macro2::TokenStream {
 /// }
 /// ```
 ///
+/// With a custom tool name:
+/// ```rust
+/// use rig_derive::rig_tool;
+///
+/// #[rig_tool(name = "search-docs", description = "Search the documentation")]
+/// fn search_docs_impl(query: String) -> Result<String, rig::tool::ToolError> {
+///     Ok(format!("Searching docs for {query}"))
+/// }
+/// ```
+///
 /// With parameter descriptions:
 /// ```rust
 /// use rig_derive::rig_tool;
@@ -219,6 +236,7 @@ pub fn rig_tool(args: TokenStream, input: TokenStream) -> TokenStream {
     // Extract function details
     let fn_name = &input_fn.sig.ident;
     let fn_name_str = fn_name.to_string();
+    let tool_name = args.name.clone().unwrap_or_else(|| fn_name_str.clone());
     let vis = &input_fn.vis;
     let is_async = input_fn.sig.asyncness.is_some();
 
@@ -322,14 +340,14 @@ pub fn rig_tool(args: TokenStream, input: TokenStream) -> TokenStream {
         #vis struct #struct_name;
 
         impl rig::tool::Tool for #struct_name {
-            const NAME: &'static str = #fn_name_str;
+            const NAME: &'static str = #tool_name;
 
             type Args = #params_struct_name;
             type Output = #output_type;
             type Error = #error_type;
 
             fn name(&self) -> String {
-                #fn_name_str.to_string()
+                #tool_name.to_string()
             }
 
             async fn definition(&self, _prompt: String) -> rig::completion::ToolDefinition {
@@ -347,7 +365,7 @@ pub fn rig_tool(args: TokenStream, input: TokenStream) -> TokenStream {
                 });
 
                 rig::completion::ToolDefinition {
-                    name: #fn_name_str.to_string(),
+                    name: #tool_name.to_string(),
                     description: #tool_description.to_string(),
                     parameters,
                 }

--- a/rig/rig-derive/src/lib.rs
+++ b/rig/rig-derive/src/lib.rs
@@ -53,6 +53,52 @@ struct MacroArgs {
     required: Vec<String>,
 }
 
+fn parse_string_literal(expr: &Expr, field_name: &str) -> syn::Result<String> {
+    match expr {
+        Expr::Lit(ExprLit {
+            lit: Lit::Str(lit_str),
+            ..
+        }) => Ok(lit_str.value()),
+        _ => Err(syn::Error::new_spanned(
+            expr,
+            format!("`{field_name}` must be a string literal"),
+        )),
+    }
+}
+
+fn validate_explicit_tool_name(name: &str, expr: &Expr) -> syn::Result<()> {
+    if name.is_empty() || name.len() > 64 {
+        return Err(syn::Error::new_spanned(
+            expr,
+            "`name` must be between 1 and 64 characters long",
+        ));
+    }
+
+    let mut chars = name.chars();
+    let Some(first_char) = chars.next() else {
+        return Err(syn::Error::new_spanned(
+            expr,
+            "`name` must be between 1 and 64 characters long",
+        ));
+    };
+
+    if !first_char.is_ascii_alphabetic() && first_char != '_' {
+        return Err(syn::Error::new_spanned(
+            expr,
+            "`name` must start with an ASCII letter or underscore",
+        ));
+    }
+
+    if chars.any(|ch| !ch.is_ascii_alphanumeric() && ch != '_' && ch != '-') {
+        return Err(syn::Error::new_spanned(
+            expr,
+            "`name` may only contain ASCII letters, digits, underscores, or hyphens",
+        ));
+    }
+
+    Ok(())
+}
+
 impl Parse for MacroArgs {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let mut name = None;
@@ -75,44 +121,80 @@ impl Parse for MacroArgs {
         for meta in meta_list {
             match meta {
                 Meta::NameValue(nv) => {
-                    let ident = nv.path.get_ident().unwrap().to_string();
-                    if let Expr::Lit(ExprLit {
-                        lit: Lit::Str(lit_str),
-                        ..
-                    }) = nv.value
-                    {
-                        match ident.as_str() {
-                            "name" => name = Some(lit_str.value()),
-                            "description" => description = Some(lit_str.value()),
-                            _ => {}
+                    let ident = nv.path.get_ident().ok_or_else(|| {
+                        syn::Error::new_spanned(
+                            &nv.path,
+                            "unsupported top-level #[rig_tool] argument",
+                        )
+                    })?;
+
+                    match ident.to_string().as_str() {
+                        "name" => {
+                            let parsed_name = parse_string_literal(&nv.value, "name")?;
+                            validate_explicit_tool_name(&parsed_name, &nv.value)?;
+                            name = Some(parsed_name);
+                        }
+                        "description" => {
+                            description = Some(parse_string_literal(&nv.value, "description")?);
+                        }
+                        _ => {
+                            return Err(syn::Error::new_spanned(
+                                &nv.path,
+                                format!("unsupported top-level #[rig_tool] argument `{}`", ident),
+                            ));
                         }
                     }
                 }
-                Meta::List(list) if list.path.is_ident("params") => {
-                    let nested: Punctuated<Meta, Token![,]> =
-                        list.parse_args_with(Punctuated::parse_terminated)?;
+                Meta::List(list) => {
+                    let ident = list.path.get_ident().ok_or_else(|| {
+                        syn::Error::new_spanned(
+                            &list.path,
+                            "unsupported top-level #[rig_tool] argument",
+                        )
+                    })?;
 
-                    for meta in nested {
-                        if let Meta::NameValue(nv) = meta
-                            && let Expr::Lit(ExprLit {
-                                lit: Lit::Str(lit_str),
-                                ..
-                            }) = nv.value
-                        {
-                            let param_name = nv.path.get_ident().unwrap().to_string();
-                            param_descriptions.insert(param_name, lit_str.value());
+                    match ident.to_string().as_str() {
+                        "params" => {
+                            let nested: Punctuated<Meta, Token![,]> =
+                                list.parse_args_with(Punctuated::parse_terminated)?;
+
+                            for meta in nested {
+                                if let Meta::NameValue(nv) = meta
+                                    && let Expr::Lit(ExprLit {
+                                        lit: Lit::Str(lit_str),
+                                        ..
+                                    }) = nv.value
+                                {
+                                    let param_name = nv.path.get_ident().unwrap().to_string();
+                                    param_descriptions.insert(param_name, lit_str.value());
+                                }
+                            }
+                        }
+                        "required" => {
+                            let required_variables: Punctuated<Ident, Token![,]> =
+                                list.parse_args_with(Punctuated::parse_terminated)?;
+
+                            required_variables.into_iter().for_each(|x| {
+                                required.push(x.to_string());
+                            });
+                        }
+                        _ => {
+                            return Err(syn::Error::new_spanned(
+                                &list.path,
+                                format!("unsupported top-level #[rig_tool] argument `{}`", ident),
+                            ));
                         }
                     }
                 }
-                Meta::List(list) if list.path.is_ident("required") => {
-                    let required_variables: Punctuated<Ident, Token![,]> =
-                        list.parse_args_with(Punctuated::parse_terminated)?;
+                Meta::Path(path) => {
+                    let message = if let Some(ident) = path.get_ident() {
+                        format!("unsupported top-level #[rig_tool] argument `{ident}`")
+                    } else {
+                        "unsupported top-level #[rig_tool] argument".to_string()
+                    };
 
-                    required_variables.into_iter().for_each(|x| {
-                        required.push(x.to_string());
-                    });
+                    return Err(syn::Error::new_spanned(path, message));
                 }
-                _ => {}
             }
         }
 
@@ -202,6 +284,9 @@ fn get_json_type(ty: &Type) -> proc_macro2::TokenStream {
 /// ```rust
 /// use rig_derive::rig_tool;
 ///
+/// // Explicit names must be string literals that start with an ASCII letter
+/// // or `_`, may contain ASCII letters, digits, `_`, or `-`, and be at most
+/// // 64 characters long.
 /// #[rig_tool(name = "search-docs", description = "Search the documentation")]
 /// fn search_docs_impl(query: String) -> Result<String, rig::tool::ToolError> {
 ///     Ok(format!("Searching docs for {query}"))

--- a/rig/rig-derive/tests/custom_name.rs
+++ b/rig/rig-derive/tests/custom_name.rs
@@ -1,9 +1,7 @@
 use rig::tool::Tool;
 use rig_derive::rig_tool;
 
-#[rig_tool(
-    name = "search-docs"
-)]
+#[rig_tool(name = "search-docs")]
 fn search_docs_impl() -> Result<String, rig::tool::ToolError> {
     Ok("ok".to_string())
 }

--- a/rig/rig-derive/tests/custom_name.rs
+++ b/rig/rig-derive/tests/custom_name.rs
@@ -30,3 +30,16 @@ async fn test_tool_name_falls_back_to_function_name() {
     assert_eq!(tool.name(), "fallback_name_tool");
     assert_eq!(definition.name, "fallback_name_tool");
 }
+
+#[test]
+fn test_custom_name_trybuild_cases() {
+    let tests = trybuild::TestCases::new();
+
+    tests.pass("tests/ui/custom_name/pass_explicit_name.rs");
+    tests.pass("tests/ui/custom_name/pass_fallback_name.rs");
+    tests.compile_fail("tests/ui/custom_name/fail_name_non_string.rs");
+    tests.compile_fail("tests/ui/custom_name/fail_name_invalid_characters.rs");
+    tests.compile_fail("tests/ui/custom_name/fail_name_invalid_start.rs");
+    tests.compile_fail("tests/ui/custom_name/fail_name_too_long.rs");
+    tests.compile_fail("tests/ui/custom_name/fail_unknown_top_level_argument.rs");
+}

--- a/rig/rig-derive/tests/custom_name.rs
+++ b/rig/rig-derive/tests/custom_name.rs
@@ -1,0 +1,34 @@
+use rig::tool::Tool;
+use rig_derive::rig_tool;
+
+#[rig_tool(
+    name = "search-docs"
+)]
+fn search_docs_impl() -> Result<String, rig::tool::ToolError> {
+    Ok("ok".to_string())
+}
+
+#[rig_tool]
+fn fallback_name_tool() -> Result<String, rig::tool::ToolError> {
+    Ok("fallback".to_string())
+}
+
+#[tokio::test]
+async fn test_custom_tool_name_overrides_function_name() {
+    let tool = SearchDocsImpl;
+    let definition = tool.definition(String::default()).await;
+
+    assert_eq!(SearchDocsImpl::NAME, "search-docs");
+    assert_eq!(tool.name(), "search-docs");
+    assert_eq!(definition.name, "search-docs");
+}
+
+#[tokio::test]
+async fn test_tool_name_falls_back_to_function_name() {
+    let tool = FallbackNameTool;
+    let definition = tool.definition(String::default()).await;
+
+    assert_eq!(FallbackNameTool::NAME, "fallback_name_tool");
+    assert_eq!(tool.name(), "fallback_name_tool");
+    assert_eq!(definition.name, "fallback_name_tool");
+}

--- a/rig/rig-derive/tests/ui/custom_name/fail_name_invalid_characters.rs
+++ b/rig/rig-derive/tests/ui/custom_name/fail_name_invalid_characters.rs
@@ -1,0 +1,10 @@
+#![allow(dead_code)]
+
+use rig_derive::rig_tool;
+
+#[rig_tool(name = "bad name!")]
+fn invalid_name_characters() -> Result<String, rig::tool::ToolError> {
+    Ok("ok".to_string())
+}
+
+fn main() {}

--- a/rig/rig-derive/tests/ui/custom_name/fail_name_invalid_characters.stderr
+++ b/rig/rig-derive/tests/ui/custom_name/fail_name_invalid_characters.stderr
@@ -1,0 +1,5 @@
+error: `name` may only contain ASCII letters, digits, underscores, or hyphens
+ --> tests/ui/custom_name/fail_name_invalid_characters.rs:5:19
+  |
+5 | #[rig_tool(name = "bad name!")]
+  |                   ^^^^^^^^^^^

--- a/rig/rig-derive/tests/ui/custom_name/fail_name_invalid_start.rs
+++ b/rig/rig-derive/tests/ui/custom_name/fail_name_invalid_start.rs
@@ -1,0 +1,10 @@
+#![allow(dead_code)]
+
+use rig_derive::rig_tool;
+
+#[rig_tool(name = "9bad")]
+fn invalid_name_start() -> Result<String, rig::tool::ToolError> {
+    Ok("ok".to_string())
+}
+
+fn main() {}

--- a/rig/rig-derive/tests/ui/custom_name/fail_name_invalid_start.stderr
+++ b/rig/rig-derive/tests/ui/custom_name/fail_name_invalid_start.stderr
@@ -1,0 +1,5 @@
+error: `name` must start with an ASCII letter or underscore
+ --> tests/ui/custom_name/fail_name_invalid_start.rs:5:19
+  |
+5 | #[rig_tool(name = "9bad")]
+  |                   ^^^^^^

--- a/rig/rig-derive/tests/ui/custom_name/fail_name_non_string.rs
+++ b/rig/rig-derive/tests/ui/custom_name/fail_name_non_string.rs
@@ -1,0 +1,10 @@
+#![allow(dead_code)]
+
+use rig_derive::rig_tool;
+
+#[rig_tool(name = 123)]
+fn invalid_name_value() -> Result<String, rig::tool::ToolError> {
+    Ok("ok".to_string())
+}
+
+fn main() {}

--- a/rig/rig-derive/tests/ui/custom_name/fail_name_non_string.stderr
+++ b/rig/rig-derive/tests/ui/custom_name/fail_name_non_string.stderr
@@ -1,0 +1,5 @@
+error: `name` must be a string literal
+ --> tests/ui/custom_name/fail_name_non_string.rs:5:19
+  |
+5 | #[rig_tool(name = 123)]
+  |                   ^^^

--- a/rig/rig-derive/tests/ui/custom_name/fail_name_too_long.rs
+++ b/rig/rig-derive/tests/ui/custom_name/fail_name_too_long.rs
@@ -1,0 +1,10 @@
+#![allow(dead_code)]
+
+use rig_derive::rig_tool;
+
+#[rig_tool(name = "a2345678a2345678a2345678a2345678a2345678a2345678a2345678a2345678x")]
+fn invalid_name_length() -> Result<String, rig::tool::ToolError> {
+    Ok("ok".to_string())
+}
+
+fn main() {}

--- a/rig/rig-derive/tests/ui/custom_name/fail_name_too_long.stderr
+++ b/rig/rig-derive/tests/ui/custom_name/fail_name_too_long.stderr
@@ -1,0 +1,5 @@
+error: `name` must be between 1 and 64 characters long
+ --> tests/ui/custom_name/fail_name_too_long.rs:5:19
+  |
+5 | #[rig_tool(name = "a2345678a2345678a2345678a2345678a2345678a2345678a2345678a2345678x")]
+  |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/rig/rig-derive/tests/ui/custom_name/fail_unknown_top_level_argument.rs
+++ b/rig/rig-derive/tests/ui/custom_name/fail_unknown_top_level_argument.rs
@@ -1,0 +1,10 @@
+#![allow(dead_code)]
+
+use rig_derive::rig_tool;
+
+#[rig_tool(nam = "search-docs")]
+fn unknown_argument() -> Result<String, rig::tool::ToolError> {
+    Ok("ok".to_string())
+}
+
+fn main() {}

--- a/rig/rig-derive/tests/ui/custom_name/fail_unknown_top_level_argument.stderr
+++ b/rig/rig-derive/tests/ui/custom_name/fail_unknown_top_level_argument.stderr
@@ -1,0 +1,5 @@
+error: unsupported top-level #[rig_tool] argument `nam`
+ --> tests/ui/custom_name/fail_unknown_top_level_argument.rs:5:12
+  |
+5 | #[rig_tool(nam = "search-docs")]
+  |            ^^^

--- a/rig/rig-derive/tests/ui/custom_name/pass_explicit_name.rs
+++ b/rig/rig-derive/tests/ui/custom_name/pass_explicit_name.rs
@@ -1,0 +1,10 @@
+#![allow(dead_code)]
+
+use rig_derive::rig_tool;
+
+#[rig_tool(name = "search-docs")]
+fn search_docs_impl() -> Result<String, rig::tool::ToolError> {
+    Ok("ok".to_string())
+}
+
+fn main() {}

--- a/rig/rig-derive/tests/ui/custom_name/pass_fallback_name.rs
+++ b/rig/rig-derive/tests/ui/custom_name/pass_fallback_name.rs
@@ -1,0 +1,10 @@
+#![allow(dead_code)]
+
+use rig_derive::rig_tool;
+
+#[rig_tool]
+fn fallback_name_tool() -> Result<String, rig::tool::ToolError> {
+    Ok("fallback".to_string())
+}
+
+fn main() {}


### PR DESCRIPTION
Allow #[rig_tool] to override the exposed tool name so tool contracts can stay stable even when Rust function names differ. Clarify that tool names only need to be unique within a single registration scope.

Ref: #1619