### PR TITLE
fix(#1604): delay response_format on initial tool turns 

### DIFF
--- a/rig/rig-core/src/providers/openai/completion/mod.rs
+++ b/rig/rig-core/src/providers/openai/completion/mod.rs
@@ -186,6 +186,12 @@ impl Message {
     }
 }
 
+fn history_contains_tool_result(messages: &[Message]) -> bool {
+    messages
+        .iter()
+        .any(|message| matches!(message, Message::ToolResult { .. }))
+}
+
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct AudioAssistant {
     pub id: String,
@@ -1097,6 +1103,8 @@ impl TryFrom<OpenAIRequestParams> for CompletionRequest {
             }
         }
 
+        let history_has_tool_result = history_contains_tool_result(&full_history);
+
         let tool_choice = tool_choice.map(ToolChoice::try_from).transpose()?;
 
         let tools: Vec<ToolDefinition> = tools
@@ -1107,8 +1115,16 @@ impl TryFrom<OpenAIRequestParams> for CompletionRequest {
             })
             .collect();
 
+        // Some OpenAI-compatible backends such as llama.cpp will skip tool execution
+        // if `response_format` is sent on the first turn alongside tools. Delay the
+        // schema until after the conversation contains a tool result.
+        let should_apply_response_format =
+            output_schema.is_some() && (tools.is_empty() || history_has_tool_result);
+
         // Map output_schema to OpenAI's response_format and merge into additional_params
-        let additional_params = if let Some(schema) = output_schema {
+        let additional_params = if let Some(schema) = output_schema
+            && should_apply_response_format
+        {
             let name = schema
                 .as_object()
                 .and_then(|o| o.get("title"))
@@ -1523,6 +1539,129 @@ mod tests {
         });
 
         assert!(matches!(result, Err(CompletionError::RequestError(_))));
+    }
+
+    #[test]
+    fn request_conversion_omits_response_format_on_initial_tool_turn() {
+        let request = CoreCompletionRequest {
+            model: None,
+            preamble: None,
+            chat_history: OneOrMany::one(message::Message::user(
+                "Hello, whats the weather in London?",
+            )),
+            documents: vec![],
+            tools: vec![completion::ToolDefinition {
+                name: "weather".to_string(),
+                description: "Get the weather".to_string(),
+                parameters: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "city": { "type": "string" }
+                    },
+                    "required": ["city"]
+                }),
+            }],
+            temperature: None,
+            max_tokens: None,
+            tool_choice: None,
+            additional_params: None,
+            output_schema: Some(
+                serde_json::from_value(serde_json::json!({
+                    "title": "WeatherResponse",
+                    "type": "object",
+                    "properties": {
+                        "city": { "type": "string" },
+                        "weather": { "type": "string" }
+                    },
+                    "required": ["city", "weather"]
+                }))
+                .expect("schema should deserialize"),
+            ),
+        };
+
+        let openai_request = CompletionRequest::try_from(OpenAIRequestParams {
+            model: "gpt-4o-mini".to_string(),
+            request,
+            strict_tools: false,
+            tool_result_array_content: false,
+        })
+        .expect("request conversion should succeed");
+
+        let serialized =
+            serde_json::to_value(openai_request).expect("serialization should succeed");
+
+        assert!(
+            serialized.get("response_format").is_none(),
+            "initial tool turn should omit response_format: {serialized:?}"
+        );
+    }
+
+    #[test]
+    fn request_conversion_restores_response_format_after_tool_result() {
+        let request = CoreCompletionRequest {
+            model: None,
+            preamble: None,
+            chat_history: OneOrMany::many(vec![
+                message::Message::user("Hello, whats the weather in London?"),
+                message::Message::Assistant {
+                    id: None,
+                    content: OneOrMany::one(message::AssistantContent::tool_call(
+                        "call_1",
+                        "weather",
+                        serde_json::json!({ "city": "London" }),
+                    )),
+                },
+                message::Message::tool_result(
+                    "call_1",
+                    "The weather in London is all fire and brimstone",
+                ),
+            ])
+            .expect("history should be non-empty"),
+            documents: vec![],
+            tools: vec![completion::ToolDefinition {
+                name: "weather".to_string(),
+                description: "Get the weather".to_string(),
+                parameters: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "city": { "type": "string" }
+                    },
+                    "required": ["city"]
+                }),
+            }],
+            temperature: None,
+            max_tokens: None,
+            tool_choice: None,
+            additional_params: None,
+            output_schema: Some(
+                serde_json::from_value(serde_json::json!({
+                    "title": "WeatherResponse",
+                    "type": "object",
+                    "properties": {
+                        "city": { "type": "string" },
+                        "weather": { "type": "string" }
+                    },
+                    "required": ["city", "weather"]
+                }))
+                .expect("schema should deserialize"),
+            ),
+        };
+
+        let openai_request = CompletionRequest::try_from(OpenAIRequestParams {
+            model: "gpt-4o-mini".to_string(),
+            request,
+            strict_tools: false,
+            tool_result_array_content: false,
+        })
+        .expect("request conversion should succeed");
+
+        let serialized =
+            serde_json::to_value(openai_request).expect("serialization should succeed");
+
+        assert!(
+            serialized.get("response_format").is_some(),
+            "follow-up turn should restore response_format: {serialized:?}"
+        );
     }
 
     #[test]

--- a/rig/rig-core/tests/llamacpp.rs
+++ b/rig/rig-core/tests/llamacpp.rs
@@ -1,0 +1,20 @@
+//! llama.cpp OpenAI-compatible integration tests.
+//!
+//! Run the full provider target with:
+//! `cargo test -p rig-core --test llamacpp`
+//!
+//! Run all ignored provider-backed tests serially with:
+//! `cargo test -p rig-core --test llamacpp -- --ignored --test-threads=1`
+//!
+//! Use `--test-threads=1` because these ignored tests talk to real model
+//! backends, and running them concurrently creates avoidable load-related
+//! flakiness.
+//!
+//! Run a single ignored smoke test with:
+//! `cargo test -p rig-core --test llamacpp llamacpp::typed_prompt_tools::prompt_typed_with_tool_call_smoke -- --ignored --nocapture`
+
+#[path = "common/support.rs"]
+mod support;
+
+#[path = "llamacpp/mod.rs"]
+mod llamacpp;

--- a/rig/rig-core/tests/llamacpp.rs
+++ b/rig/rig-core/tests/llamacpp.rs
@@ -13,6 +13,12 @@
 //! Run a single ignored smoke test with:
 //! `cargo test -p rig-core --test llamacpp llamacpp::agent::completion_smoke -- --ignored`
 //!
+//! Run a single structured-output test with:
+//! `cargo test -p rig-core --test llamacpp llamacpp::structured_output::output_schema_structured_output -- --ignored`
+//!
+//! Run the verbatim tool roundtrip test with:
+//! `cargo test -p rig-core --test llamacpp llamacpp::typed_prompt_tools::prompt_typed_with_tool_call_verbatim_roundtrip -- --ignored --nocapture`
+//!
 //! Optional environment variables:
 //! - `LLAMACPP_API_BASE_URL` (default: `http://localhost:8080/v1`)
 //! - `LLAMACPP_API_KEY` (default: `none`)

--- a/rig/rig-core/tests/llamacpp.rs
+++ b/rig/rig-core/tests/llamacpp.rs
@@ -11,7 +11,12 @@
 //! flakiness.
 //!
 //! Run a single ignored smoke test with:
-//! `cargo test -p rig-core --test llamacpp llamacpp::typed_prompt_tools::prompt_typed_with_tool_call_smoke -- --ignored --nocapture`
+//! `cargo test -p rig-core --test llamacpp llamacpp::agent::completion_smoke -- --ignored`
+//!
+//! Optional environment variables:
+//! - `LLAMACPP_API_BASE_URL` (default: `http://localhost:8080/v1`)
+//! - `LLAMACPP_API_KEY` (default: `none`)
+//! - `LLAMACPP_MODEL` (default: `model`)
 
 #[path = "common/support.rs"]
 mod support;

--- a/rig/rig-core/tests/llamacpp/agent.rs
+++ b/rig/rig-core/tests/llamacpp/agent.rs
@@ -1,0 +1,25 @@
+//! llama.cpp agent completion smoke test.
+
+use rig::client::CompletionClient;
+use rig::completion::Prompt;
+
+use crate::support::{BASIC_PREAMBLE, BASIC_PROMPT, assert_nonempty_response};
+
+use super::support;
+
+#[tokio::test]
+#[ignore = "requires a local llama.cpp OpenAI-compatible server"]
+async fn completion_smoke() {
+    let client = support::completions_client();
+    let agent = client
+        .agent(support::model_name())
+        .preamble(BASIC_PREAMBLE)
+        .build();
+
+    let response = agent
+        .prompt(BASIC_PROMPT)
+        .await
+        .expect("completion should succeed");
+
+    assert_nonempty_response(&response);
+}

--- a/rig/rig-core/tests/llamacpp/completions_api.rs
+++ b/rig/rig-core/tests/llamacpp/completions_api.rs
@@ -1,0 +1,26 @@
+//! Migrated from `examples/openai_agent_completions_api.rs` against a local llama.cpp server.
+
+use rig::client::CompletionClient;
+use rig::completion::Prompt;
+
+use crate::support::assert_nonempty_response;
+
+use super::support;
+
+#[tokio::test]
+#[ignore = "requires a local llama.cpp OpenAI-compatible server"]
+async fn completions_api_agent_prompt() {
+    let agent = support::client()
+        .completion_model(support::model_name())
+        .completions_api()
+        .into_agent_builder()
+        .preamble("You are a helpful assistant.")
+        .build();
+
+    let response = agent
+        .prompt("Hello world!")
+        .await
+        .expect("completions api prompt should succeed");
+
+    assert_nonempty_response(&response);
+}

--- a/rig/rig-core/tests/llamacpp/extractor.rs
+++ b/rig/rig-core/tests/llamacpp/extractor.rs
@@ -1,0 +1,36 @@
+//! llama.cpp extractor smoke test.
+
+use crate::support::{EXTRACTOR_TEXT, SmokePerson, assert_nonempty_response};
+
+use super::support;
+
+#[tokio::test]
+#[ignore = "requires a local llama.cpp OpenAI-compatible server"]
+async fn extractor_smoke() {
+    let client = support::completions_client();
+    let extractor = client
+        .extractor::<SmokePerson>(support::model_name())
+        .build();
+
+    let response = extractor
+        .extract_with_usage(EXTRACTOR_TEXT)
+        .await
+        .expect("extractor request should succeed");
+
+    let first_name = response
+        .data
+        .first_name
+        .as_deref()
+        .expect("first_name should be present");
+    let last_name = response
+        .data
+        .last_name
+        .as_deref()
+        .expect("last_name should be present");
+    let job = response.data.job.as_deref().expect("job should be present");
+
+    assert_nonempty_response(first_name);
+    assert_nonempty_response(last_name);
+    assert_nonempty_response(job);
+    assert!(response.usage.total_tokens > 0, "usage should be populated");
+}

--- a/rig/rig-core/tests/llamacpp/extractor_usage.rs
+++ b/rig/rig-core/tests/llamacpp/extractor_usage.rs
@@ -1,0 +1,155 @@
+//! Integration tests for llama.cpp extractor usage tracking.
+
+use anyhow::Result;
+use rig::extractor::ExtractionResponse;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use super::support;
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
+struct Person {
+    name: Option<String>,
+    age: Option<u8>,
+    profession: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
+struct Address {
+    street: Option<String>,
+    city: Option<String>,
+    state: Option<String>,
+    zip_code: Option<String>,
+}
+
+fn assert_compatible_professions(left: Option<&str>, right: Option<&str>) {
+    let left = left
+        .expect("profession should be present")
+        .trim()
+        .to_ascii_lowercase();
+    let right = right
+        .expect("profession should be present")
+        .trim()
+        .to_ascii_lowercase();
+
+    assert!(
+        left == right || left.contains(&right) || right.contains(&left),
+        "expected compatible professions, got {left:?} and {right:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a local llama.cpp OpenAI-compatible server"]
+async fn extract_backward_compatibility() -> Result<()> {
+    let model = support::model_name();
+    let client = support::completions_client();
+    let extractor = client.extractor::<Person>(model).build();
+
+    let person = extractor
+        .extract("John Doe is a 30 year old software engineer.")
+        .await?;
+
+    assert_eq!(person.name, Some("John Doe".to_string()));
+    assert_eq!(person.age, Some(30));
+    assert_eq!(person.profession, Some("software engineer".to_string()));
+
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "requires a local llama.cpp OpenAI-compatible server"]
+async fn extract_with_usage_returns_data_and_usage() -> Result<()> {
+    let model = support::model_name();
+    let client = support::completions_client();
+    let extractor = client.extractor::<Person>(model).build();
+
+    let response: ExtractionResponse<Person> = extractor
+        .extract_with_usage("Jane Smith is a 45 year old data scientist.")
+        .await?;
+
+    assert_eq!(response.data.name, Some("Jane Smith".to_string()));
+    assert_eq!(response.data.age, Some(45));
+    assert_eq!(response.data.profession, Some("data scientist".to_string()));
+    assert!(response.usage.input_tokens > 0);
+    assert!(response.usage.output_tokens > 0);
+    assert!(response.usage.total_tokens > 0);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "requires a local llama.cpp OpenAI-compatible server"]
+async fn extract_with_chat_history_with_usage_works() -> Result<()> {
+    use rig::message::Message;
+
+    let model = support::model_name();
+    let client = support::completions_client();
+    let extractor = client.extractor::<Address>(model).build();
+
+    let chat_history = vec![Message::user(
+        "I'm looking at a property that might be interesting.",
+    )];
+
+    let response: ExtractionResponse<Address> = extractor
+        .extract_with_chat_history_with_usage(
+            "The address is 123 Main St in Springfield, IL 62701.",
+            chat_history,
+        )
+        .await?;
+
+    assert_eq!(response.data.street, Some("123 Main St".to_string()));
+    assert_eq!(response.data.city, Some("Springfield".to_string()));
+    assert_eq!(response.data.state, Some("IL".to_string()));
+    assert_eq!(response.data.zip_code, Some("62701".to_string()));
+    assert!(response.usage.input_tokens > 0);
+    assert!(response.usage.total_tokens > 0);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "requires a local llama.cpp OpenAI-compatible server"]
+async fn extract_and_extract_with_usage_return_same_data() -> Result<()> {
+    let model = support::model_name();
+    let client = support::completions_client();
+    let extractor = client.extractor::<Person>(model).build();
+
+    let text = "Bob Johnson is a 55 year old retired teacher.";
+    let person = extractor.extract(text).await?;
+    let response = extractor.extract_with_usage(text).await?;
+
+    assert_eq!(person.name, Some("Bob Johnson".to_string()));
+    assert_eq!(response.data.name, Some("Bob Johnson".to_string()));
+    assert_eq!(person.age, Some(55));
+    assert_eq!(response.data.age, Some(55));
+    assert_compatible_professions(
+        person.profession.as_deref(),
+        response.data.profession.as_deref(),
+    );
+    assert!(response.usage.total_tokens > 0, "usage should be populated");
+
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "requires a local llama.cpp OpenAI-compatible server"]
+async fn usage_tracking_works_for_different_schemas() -> Result<()> {
+    let model = support::model_name();
+    let client = support::completions_client();
+
+    let person_extractor = client.extractor::<Person>(model.clone()).build();
+    let person_response = person_extractor
+        .extract_with_usage("Alice is a 25 year old developer.")
+        .await?;
+
+    assert!(person_response.usage.total_tokens > 0);
+
+    let address_extractor = client.extractor::<Address>(model).build();
+    let address_response = address_extractor
+        .extract_with_usage("456 Oak Avenue, Cambridge, MA 02139")
+        .await?;
+
+    assert!(address_response.usage.total_tokens > 0);
+
+    Ok(())
+}

--- a/rig/rig-core/tests/llamacpp/mod.rs
+++ b/rig/rig-core/tests/llamacpp/mod.rs
@@ -1,1 +1,13 @@
+mod agent;
+mod completions_api;
+mod extractor;
+mod extractor_usage;
+mod models;
+mod multi_extract;
+mod permission_control;
+mod request_hook;
+mod streaming;
+mod streaming_tools;
+mod structured_output;
+mod support;
 mod typed_prompt_tools;

--- a/rig/rig-core/tests/llamacpp/mod.rs
+++ b/rig/rig-core/tests/llamacpp/mod.rs
@@ -1,0 +1,1 @@
+mod typed_prompt_tools;

--- a/rig/rig-core/tests/llamacpp/models.rs
+++ b/rig/rig-core/tests/llamacpp/models.rs
@@ -1,0 +1,22 @@
+//! llama.cpp model listing smoke test.
+
+use rig::client::ModelListingClient;
+
+use super::support;
+
+#[tokio::test]
+#[ignore = "requires a local llama.cpp OpenAI-compatible server"]
+async fn list_models_smoke() {
+    let client = support::client();
+    let models = match client.list_models().await {
+        Ok(models) => models,
+        Err(error) => {
+            panic!("listing llama.cpp models should succeed\nDisplay: {error}\nDebug: {error:#?}")
+        }
+    };
+
+    assert!(
+        !models.is_empty(),
+        "expected llama.cpp to return at least one model\nModel list: {models:#?}"
+    );
+}

--- a/rig/rig-core/tests/llamacpp/multi_extract.rs
+++ b/rig/rig-core/tests/llamacpp/multi_extract.rs
@@ -1,0 +1,83 @@
+//! Preserves the live multi-extract example as provider-local regression coverage.
+
+use anyhow::Result;
+use rig::pipeline::{self, TryOp, agent_ops};
+use rig::try_parallel;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::support::assert_nonempty_response;
+
+use super::support;
+
+#[derive(Debug, Deserialize, JsonSchema, Serialize)]
+struct Names {
+    names: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema, Serialize)]
+struct Topics {
+    topics: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema, Serialize)]
+struct Sentiment {
+    sentiment: f64,
+    confidence: f64,
+}
+
+#[tokio::test]
+#[ignore = "requires a local llama.cpp OpenAI-compatible server"]
+async fn batch_multi_extract_chain() -> Result<()> {
+    let client = support::completions_client();
+    let model = support::model_name();
+    let names_extractor = client
+        .extractor::<Names>(model.clone())
+        .preamble("Extract names from the given text.")
+        .retries(2)
+        .build();
+    let topics_extractor = client
+        .extractor::<Topics>(model.clone())
+        .preamble("Extract topics from the given text.")
+        .retries(2)
+        .build();
+    let sentiment_extractor = client
+        .extractor::<Sentiment>(model)
+        .preamble("Extract sentiment and confidence from the given text.")
+        .retries(2)
+        .build();
+
+    let chain = pipeline::new()
+        .chain(try_parallel!(
+            agent_ops::extract(names_extractor),
+            agent_ops::extract(topics_extractor),
+            agent_ops::extract(sentiment_extractor),
+        ))
+        .map_ok(|(names, topics, sentiment)| {
+            format!(
+                "Extracted names: {}\nExtracted topics: {}\nExtracted sentiment: {} ({})",
+                names.names.join(", "),
+                topics.topics.join(", "),
+                sentiment.sentiment,
+                sentiment.confidence,
+            )
+        });
+
+    let responses = chain
+        .try_batch_call(
+            4,
+            vec![
+                "Screw you Putin!",
+                "I love my dog, but I hate my cat.",
+                "I'm going to the store to buy some milk.",
+            ],
+        )
+        .await?;
+
+    assert_eq!(responses.len(), 3);
+    for response in responses {
+        assert_nonempty_response(&response);
+    }
+
+    Ok(())
+}

--- a/rig/rig-core/tests/llamacpp/permission_control.rs
+++ b/rig/rig-core/tests/llamacpp/permission_control.rs
@@ -1,0 +1,227 @@
+use anyhow::Result;
+use rig::agent::{HookAction, PromptHook, ToolCallHookAction, stream_to_stdout};
+use rig::client::CompletionClient;
+use rig::completion::{CompletionModel, Prompt, ToolDefinition};
+use rig::streaming::StreamingPrompt;
+use rig::tool::Tool;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crate::support::assert_nonempty_response;
+
+use super::support;
+
+const TEST_FILE: &str = "test.txt";
+const TEST_CONTENT: &str = "hello world\n";
+
+struct FileCleanup;
+
+impl FileCleanup {
+    fn new() -> Result<Self> {
+        std::fs::write(TEST_FILE, TEST_CONTENT)?;
+        Ok(Self)
+    }
+}
+
+impl Drop for FileCleanup {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(TEST_FILE);
+    }
+}
+
+#[derive(Deserialize)]
+struct ReadFileArgs {}
+
+#[derive(Debug, thiserror::Error)]
+#[error("File operation error")]
+struct FileError;
+
+#[derive(Deserialize, Serialize)]
+struct ReadFileHead;
+
+impl Tool for ReadFileHead {
+    const NAME: &'static str = "read_file_head";
+    type Error = FileError;
+    type Args = ReadFileArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: "read_file_head".to_string(),
+            description: "Read the first line of test.txt using the head command".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {},
+            }),
+        }
+    }
+
+    async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
+        let output = std::process::Command::new("head")
+            .arg("-1")
+            .arg(TEST_FILE)
+            .output()
+            .map_err(|_| FileError)?;
+
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+struct ReadFileTail;
+
+impl Tool for ReadFileTail {
+    const NAME: &'static str = "read_file_tail";
+    type Error = FileError;
+    type Args = ReadFileArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: "read_file_tail".to_string(),
+            description: "Read the last line of test.txt using the tail command".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {},
+            }),
+        }
+    }
+
+    async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
+        let output = std::process::Command::new("tail")
+            .arg("-1")
+            .arg(TEST_FILE)
+            .output()
+            .map_err(|_| FileError)?;
+
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    }
+}
+
+#[derive(Clone)]
+struct PermissionHook {
+    call_count: Arc<AtomicUsize>,
+    last_result: Arc<Mutex<Option<String>>>,
+}
+
+impl<M: CompletionModel> PromptHook<M> for PermissionHook {
+    async fn on_tool_call(
+        &self,
+        tool_name: &str,
+        _tool_call_id: Option<String>,
+        _internal_call_id: &str,
+        _args: &str,
+    ) -> ToolCallHookAction {
+        let count = self.call_count.fetch_add(1, Ordering::SeqCst);
+
+        if count == 0 {
+            ToolCallHookAction::Skip {
+                reason: format!(
+                    "Tool '{}' is currently unavailable. \
+                     Please use 'read_file_tail' instead to read the file.",
+                    tool_name
+                ),
+            }
+        } else {
+            ToolCallHookAction::Continue
+        }
+    }
+
+    async fn on_tool_result(
+        &self,
+        _tool_name: &str,
+        _tool_call_id: Option<String>,
+        _internal_call_id: &str,
+        _args: &str,
+        result: &str,
+    ) -> HookAction {
+        let normalized =
+            serde_json::from_str::<String>(result).unwrap_or_else(|_| result.to_string());
+        let mut last = self.last_result.lock().expect("lock last_result");
+        *last = Some(normalized);
+
+        HookAction::cont()
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires a local llama.cpp OpenAI-compatible server"]
+async fn permission_control_prompt_example() -> Result<()> {
+    let _cleanup = FileCleanup::new()?;
+
+    let agent = support::completions_client()
+        .agent(support::model_name())
+        .preamble("You are a helpful assistant that can read files using different methods.")
+        .tool(ReadFileHead)
+        .tool(ReadFileTail)
+        .build();
+
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let last_result = Arc::new(Mutex::new(None));
+    let hook = PermissionHook {
+        call_count: call_count.clone(),
+        last_result: last_result.clone(),
+    };
+
+    let _response = agent
+        .prompt(
+            "Use the available tools to read test.txt now. \
+             Do not ask any follow-up questions; just read the file and report its content.",
+        )
+        .max_turns(5)
+        .with_hook(hook)
+        .await?;
+
+    let last = last_result.lock().expect("lock last_result").clone();
+    assert_eq!(last.as_deref(), Some("hello world"));
+    assert_eq!(call_count.load(Ordering::SeqCst), 2);
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "requires a local llama.cpp OpenAI-compatible server"]
+async fn permission_control_streaming_example() -> Result<()> {
+    let _cleanup = FileCleanup::new()?;
+
+    let agent = support::completions_client()
+        .agent(support::model_name())
+        .preamble("You are a helpful assistant that can read files using different methods.")
+        .tool(ReadFileHead)
+        .tool(ReadFileTail)
+        .build();
+
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let last_result = Arc::new(Mutex::new(None));
+    let hook = PermissionHook {
+        call_count: call_count.clone(),
+        last_result: last_result.clone(),
+    };
+
+    let mut stream = agent
+        .stream_prompt(
+            "Use the available tools to read test.txt now. \
+             Do not ask any follow-up questions; just read the file and report its content.",
+        )
+        .multi_turn(5)
+        .with_hook(hook)
+        .await;
+
+    let final_response = stream_to_stdout(&mut stream).await?;
+    let last = last_result.lock().expect("lock last_result").clone();
+    assert_nonempty_response(final_response.response());
+    assert!(
+        final_response
+            .response()
+            .to_ascii_lowercase()
+            .contains("hello world"),
+        "expected the streamed final response to mention the file content, got {:?}",
+        final_response.response()
+    );
+    assert_eq!(last.as_deref(), Some("hello world"));
+    assert_eq!(call_count.load(Ordering::SeqCst), 2);
+
+    Ok(())
+}

--- a/rig/rig-core/tests/llamacpp/request_hook.rs
+++ b/rig/rig-core/tests/llamacpp/request_hook.rs
@@ -1,0 +1,117 @@
+//! Preserves the live request-hook example as provider-local regression coverage.
+
+use anyhow::{Result, anyhow};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use rig::agent::{HookAction, PromptHook};
+use rig::client::CompletionClient;
+use rig::completion::{CompletionModel, CompletionResponse, Message, Prompt};
+use rig::message::UserContent;
+
+use crate::support::assert_nonempty_response;
+
+use super::support;
+
+#[derive(Clone)]
+struct SessionIdHook<'a> {
+    session_id: &'a str,
+    prompt_calls: Arc<AtomicUsize>,
+    response_calls: Arc<AtomicUsize>,
+    seen_prompt: Arc<Mutex<Option<String>>>,
+    seen_response: Arc<Mutex<Option<String>>>,
+}
+
+impl<'a, M> PromptHook<M> for SessionIdHook<'a>
+where
+    M: CompletionModel,
+{
+    async fn on_completion_call(&self, prompt: &Message, _history: &[Message]) -> HookAction {
+        let Message::User { content } = prompt else {
+            return HookAction::terminate("expected a user message");
+        };
+
+        let prompt_text = content
+            .iter()
+            .filter_map(|content| match content {
+                UserContent::Text(text) => Some(text.text.clone()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        self.prompt_calls.fetch_add(1, Ordering::SeqCst);
+        match self.seen_prompt.lock() {
+            Ok(mut seen_prompt) => {
+                *seen_prompt = Some(format!("{}:{prompt_text}", self.session_id));
+                HookAction::cont()
+            }
+            Err(_) => HookAction::terminate("prompt hook state unavailable"),
+        }
+    }
+
+    async fn on_completion_response(
+        &self,
+        _prompt: &Message,
+        response: &CompletionResponse<M::Response>,
+    ) -> HookAction {
+        self.response_calls.fetch_add(1, Ordering::SeqCst);
+        match self.seen_response.lock() {
+            Ok(mut seen_response) => {
+                *seen_response = Some(format!("{:?}", response.choice));
+                HookAction::cont()
+            }
+            Err(_) => HookAction::terminate("response hook state unavailable"),
+        }
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires a local llama.cpp OpenAI-compatible server"]
+async fn request_hook_records_prompt_and_response() -> Result<()> {
+    let agent = support::completions_client()
+        .agent(support::model_name())
+        .preamble("You are a comedian here to entertain the user using humour and jokes.")
+        .build();
+
+    let hook = SessionIdHook {
+        session_id: "abc123",
+        prompt_calls: Arc::new(AtomicUsize::new(0)),
+        response_calls: Arc::new(AtomicUsize::new(0)),
+        seen_prompt: Arc::new(Mutex::new(None)),
+        seen_response: Arc::new(Mutex::new(None)),
+    };
+
+    let response = agent
+        .prompt("Entertain me!")
+        .with_hook(hook.clone())
+        .await?;
+
+    assert_nonempty_response(&response);
+    assert_eq!(hook.prompt_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(hook.response_calls.load(Ordering::SeqCst), 1);
+
+    let seen_prompt = hook
+        .seen_prompt
+        .lock()
+        .map_err(|_| anyhow!("prompt hook state unavailable"))?
+        .clone();
+    let seen_response = hook
+        .seen_response
+        .lock()
+        .map_err(|_| anyhow!("response hook state unavailable"))?
+        .clone();
+
+    assert!(
+        seen_prompt
+            .as_deref()
+            .is_some_and(|prompt| prompt.contains("Entertain me!"))
+    );
+    assert!(
+        seen_response
+            .as_deref()
+            .is_some_and(|captured| !captured.is_empty())
+    );
+
+    Ok(())
+}

--- a/rig/rig-core/tests/llamacpp/streaming.rs
+++ b/rig/rig-core/tests/llamacpp/streaming.rs
@@ -1,0 +1,47 @@
+//! llama.cpp streaming coverage, including the migrated example path.
+
+use rig::client::CompletionClient;
+use rig::streaming::StreamingPrompt;
+
+use crate::support::{
+    STREAMING_PREAMBLE, STREAMING_PROMPT, assert_nonempty_response, collect_stream_final_response,
+};
+
+use super::support;
+
+#[tokio::test]
+#[ignore = "requires a local llama.cpp OpenAI-compatible server"]
+async fn streaming_smoke() {
+    let client = support::completions_client();
+    let agent = client
+        .agent(support::model_name())
+        .preamble(STREAMING_PREAMBLE)
+        .build();
+
+    let mut stream = agent.stream_prompt(STREAMING_PROMPT).await;
+    let response = collect_stream_final_response(&mut stream)
+        .await
+        .expect("streaming prompt should succeed");
+
+    assert_nonempty_response(&response);
+}
+
+#[tokio::test]
+#[ignore = "requires a local llama.cpp OpenAI-compatible server"]
+async fn example_streaming_prompt() {
+    let client = support::completions_client();
+    let agent = client
+        .agent(support::model_name())
+        .preamble("Be precise and concise.")
+        .temperature(0.5)
+        .build();
+
+    let mut stream = agent
+        .stream_prompt("When and where and what type is the next solar eclipse?")
+        .await;
+    let response = collect_stream_final_response(&mut stream)
+        .await
+        .expect("streaming prompt should succeed");
+
+    assert_nonempty_response(&response);
+}

--- a/rig/rig-core/tests/llamacpp/streaming_tools.rs
+++ b/rig/rig-core/tests/llamacpp/streaming_tools.rs
@@ -1,0 +1,53 @@
+//! llama.cpp streaming tools coverage, including the migrated example path.
+
+use rig::client::CompletionClient;
+use rig::streaming::StreamingPrompt;
+
+use crate::support::{
+    Adder, STREAMING_TOOLS_PREAMBLE, STREAMING_TOOLS_PROMPT, Subtract,
+    assert_mentions_expected_number, collect_stream_final_response,
+};
+
+use super::support;
+
+#[tokio::test]
+#[ignore = "requires a local llama.cpp OpenAI-compatible server"]
+async fn streaming_tools_smoke() {
+    let client = support::completions_client();
+    let agent = client
+        .agent(support::model_name())
+        .preamble(STREAMING_TOOLS_PREAMBLE)
+        .tool(Adder)
+        .tool(Subtract)
+        .build();
+
+    let mut stream = agent.stream_prompt(STREAMING_TOOLS_PROMPT).await;
+    let response = collect_stream_final_response(&mut stream)
+        .await
+        .expect("streaming tool prompt should succeed");
+
+    assert_mentions_expected_number(&response, -3);
+}
+
+#[tokio::test]
+#[ignore = "requires a local llama.cpp OpenAI-compatible server"]
+async fn example_streaming_with_tools() {
+    let client = support::completions_client();
+    let agent = client
+        .agent(support::model_name())
+        .preamble(
+            "You are a calculator here to help the user perform arithmetic operations. \
+             Use the tools provided to answer the user's question and answer in a full sentence.",
+        )
+        .max_tokens(1024)
+        .tool(Adder)
+        .tool(Subtract)
+        .build();
+
+    let mut stream = agent.stream_prompt("Calculate 2 - 5").await;
+    let response = collect_stream_final_response(&mut stream)
+        .await
+        .expect("streaming tools prompt should succeed");
+
+    assert_mentions_expected_number(&response, -3);
+}

--- a/rig/rig-core/tests/llamacpp/structured_output.rs
+++ b/rig/rig-core/tests/llamacpp/structured_output.rs
@@ -12,6 +12,9 @@ use crate::support::{
 
 use super::support;
 
+const WEATHER_PREAMBLE: &str =
+    "You are a helpful weather assistant. Respond with realistic weather data.";
+
 #[derive(Debug, Deserialize, JsonSchema, Serialize)]
 struct Conditions {
     temperature_f: f64,
@@ -61,19 +64,24 @@ async fn structured_output_smoke() {
 
 #[tokio::test]
 #[ignore = "requires a local llama.cpp OpenAI-compatible server"]
-async fn prompt_typed_and_output_schema() {
+async fn prompt_typed_structured_output() {
     let client = support::completions_client();
     let model = support::model_name();
-    let agent = client
-        .agent(model.clone())
-        .preamble("You are a helpful weather assistant. Respond with realistic weather data.")
-        .build();
+    let agent = client.agent(model).preamble(WEATHER_PREAMBLE).build();
 
     let forecast: WeatherForecast = agent
         .prompt_typed("What's the weather forecast for New York City today?")
         .await
         .expect("prompt_typed should succeed");
     assert_weather_forecast(&forecast, &["new york", "nyc"]);
+}
+
+#[tokio::test]
+#[ignore = "requires a local llama.cpp OpenAI-compatible server"]
+async fn prompt_typed_extended_details_structured_output() {
+    let client = support::completions_client();
+    let model = support::model_name();
+    let agent = client.agent(model).preamble(WEATHER_PREAMBLE).build();
 
     let extended = agent
         .prompt_typed::<WeatherForecast>("What's the weather forecast for Los Angeles?")
@@ -82,10 +90,16 @@ async fn prompt_typed_and_output_schema() {
         .expect("extended prompt_typed should succeed");
     assert_weather_forecast(&extended.output, &["los angeles", "la"]);
     assert!(extended.usage.total_tokens > 0, "usage should be populated");
+}
 
+#[tokio::test]
+#[ignore = "requires a local llama.cpp OpenAI-compatible server"]
+async fn output_schema_structured_output() {
+    let client = support::completions_client();
+    let model = support::model_name();
     let agent_with_schema = client
         .agent(model)
-        .preamble("You are a helpful weather assistant. Respond with realistic weather data.")
+        .preamble(WEATHER_PREAMBLE)
         .output_schema::<WeatherForecast>()
         .build();
     let response = agent_with_schema

--- a/rig/rig-core/tests/llamacpp/structured_output.rs
+++ b/rig/rig-core/tests/llamacpp/structured_output.rs
@@ -1,0 +1,98 @@
+//! llama.cpp structured output coverage, including the migrated example path.
+
+use rig::client::CompletionClient;
+use rig::completion::{Prompt, TypedPrompt};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::support::{
+    STRUCTURED_OUTPUT_PROMPT, SmokeStructuredOutput, assert_contains_any_case_insensitive,
+    assert_nonempty_response, assert_smoke_structured_output,
+};
+
+use super::support;
+
+#[derive(Debug, Deserialize, JsonSchema, Serialize)]
+struct Conditions {
+    temperature_f: f64,
+    humidity_pct: u8,
+    description: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema, Serialize)]
+struct WeatherForecast {
+    city: String,
+    current: Conditions,
+}
+
+fn assert_weather_forecast(forecast: &WeatherForecast, expected_city: &[&str]) {
+    assert_nonempty_response(&forecast.city);
+    assert_contains_any_case_insensitive(&forecast.city, expected_city);
+    assert_nonempty_response(&forecast.current.description);
+    assert!(
+        forecast.current.temperature_f.is_finite(),
+        "temperature should be finite"
+    );
+    assert!(
+        (-100.0..=150.0).contains(&forecast.current.temperature_f),
+        "temperature should be in a plausible Fahrenheit range, got {}",
+        forecast.current.temperature_f
+    );
+    assert!(
+        forecast.current.humidity_pct <= 100,
+        "humidity should be within 0..=100, got {}",
+        forecast.current.humidity_pct
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a local llama.cpp OpenAI-compatible server"]
+async fn structured_output_smoke() {
+    let client = support::completions_client();
+    let agent = client.agent(support::model_name()).build();
+
+    let response: SmokeStructuredOutput = agent
+        .prompt_typed(STRUCTURED_OUTPUT_PROMPT)
+        .await
+        .expect("structured output prompt should succeed");
+
+    assert_smoke_structured_output(&response);
+}
+
+#[tokio::test]
+#[ignore = "requires a local llama.cpp OpenAI-compatible server"]
+async fn prompt_typed_and_output_schema() {
+    let client = support::completions_client();
+    let model = support::model_name();
+    let agent = client
+        .agent(model.clone())
+        .preamble("You are a helpful weather assistant. Respond with realistic weather data.")
+        .build();
+
+    let forecast: WeatherForecast = agent
+        .prompt_typed("What's the weather forecast for New York City today?")
+        .await
+        .expect("prompt_typed should succeed");
+    assert_weather_forecast(&forecast, &["new york", "nyc"]);
+
+    let extended = agent
+        .prompt_typed::<WeatherForecast>("What's the weather forecast for Los Angeles?")
+        .extended_details()
+        .await
+        .expect("extended prompt_typed should succeed");
+    assert_weather_forecast(&extended.output, &["los angeles", "la"]);
+    assert!(extended.usage.total_tokens > 0, "usage should be populated");
+
+    let agent_with_schema = client
+        .agent(model)
+        .preamble("You are a helpful weather assistant. Respond with realistic weather data.")
+        .output_schema::<WeatherForecast>()
+        .build();
+    let response = agent_with_schema
+        .prompt("What's the weather forecast for Chicago?")
+        .await
+        .expect("output schema prompt should succeed");
+    let parsed: WeatherForecast =
+        serde_json::from_str(&response).expect("schema response should deserialize");
+    assert_weather_forecast(&parsed, &["chicago"]);
+}

--- a/rig/rig-core/tests/llamacpp/support.rs
+++ b/rig/rig-core/tests/llamacpp/support.rs
@@ -1,0 +1,32 @@
+use rig::providers::openai;
+
+const DEFAULT_API_BASE_URL: &str = "http://localhost:8080/v1";
+const DEFAULT_API_KEY: &str = "none";
+const DEFAULT_MODEL: &str = "model";
+
+pub(super) fn api_base_url() -> String {
+    std::env::var("LLAMACPP_API_BASE_URL").unwrap_or_else(|_| DEFAULT_API_BASE_URL.to_string())
+}
+
+pub(super) fn api_key() -> String {
+    std::env::var("LLAMACPP_API_KEY").unwrap_or_else(|_| DEFAULT_API_KEY.to_string())
+}
+
+pub(super) fn model_name() -> String {
+    std::env::var("LLAMACPP_MODEL").unwrap_or_else(|_| DEFAULT_MODEL.to_string())
+}
+
+pub(super) fn client() -> openai::Client {
+    let api_key = api_key();
+    let base_url = api_base_url();
+
+    openai::Client::builder()
+        .api_key(&api_key)
+        .base_url(&base_url)
+        .build()
+        .expect("llama.cpp OpenAI-compatible client should build")
+}
+
+pub(super) fn completions_client() -> openai::CompletionsClient {
+    client().completions_api()
+}

--- a/rig/rig-core/tests/llamacpp/typed_prompt_tools.rs
+++ b/rig/rig-core/tests/llamacpp/typed_prompt_tools.rs
@@ -159,10 +159,7 @@ impl Tool for WeatherTool {
         args: Self::Args,
     ) -> impl std::future::Future<Output = Result<Self::Output, Self::Error>> + Send {
         self.call_count.fetch_add(1, Ordering::SeqCst);
-        let result = format!(
-            "The weather in {} is all fire and brimstone",
-            args.city
-        );
+        let result = format!("The weather in {} is all fire and brimstone", args.city);
 
         println!("\n=== weather tool implementation ===");
         println!(
@@ -179,7 +176,7 @@ impl Tool for WeatherTool {
 
 #[tokio::test]
 #[ignore = "requires a local llama.cpp OpenAI-compatible server"]
-async fn prompt_typed_with_tool_call_smoke() -> Result<()> {
+async fn prompt_typed_with_tool_call_verbatim_roundtrip() -> Result<()> {
     let model = support::model_name();
     let hook = StepLogger::default();
 

--- a/rig/rig-core/tests/llamacpp/typed_prompt_tools.rs
+++ b/rig/rig-core/tests/llamacpp/typed_prompt_tools.rs
@@ -6,10 +6,12 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+use rig::agent::{HookAction, PromptHook, ToolCallHookAction};
 use rig::client::CompletionClient;
-use rig::completion::{ToolDefinition, TypedPrompt};
-use rig::providers::openai;
+use rig::completion::{CompletionModel, CompletionResponse, Message, ToolDefinition, TypedPrompt};
 use rig::tool::Tool;
+
+use super::support;
 
 #[derive(Debug, Deserialize, JsonSchema, Serialize)]
 struct WeatherResponse {
@@ -31,6 +33,101 @@ impl WeatherTool {
     fn new(call_count: Arc<AtomicUsize>) -> Self {
         Self { call_count }
     }
+}
+
+#[derive(Clone, Default)]
+struct StepLogger {
+    completion_calls: Arc<AtomicUsize>,
+    tool_calls: Arc<AtomicUsize>,
+}
+
+impl StepLogger {
+    fn next_completion_call(&self) -> usize {
+        self.completion_calls.fetch_add(1, Ordering::SeqCst) + 1
+    }
+
+    fn current_completion_call(&self) -> usize {
+        self.completion_calls.load(Ordering::SeqCst)
+    }
+
+    fn next_tool_call(&self) -> usize {
+        self.tool_calls.fetch_add(1, Ordering::SeqCst) + 1
+    }
+}
+
+impl<M> PromptHook<M> for StepLogger
+where
+    M: CompletionModel,
+    M::Response: Serialize,
+{
+    async fn on_completion_call(&self, prompt: &Message, history: &[Message]) -> HookAction {
+        let call_no = self.next_completion_call();
+
+        println!("\n=== completion call #{call_no}: model input ===");
+        println!("history:\n{}", pretty_json(history));
+        println!("prompt:\n{}", pretty_json(prompt));
+
+        HookAction::cont()
+    }
+
+    async fn on_completion_response(
+        &self,
+        _prompt: &Message,
+        response: &CompletionResponse<M::Response>,
+    ) -> HookAction {
+        let call_no = self.current_completion_call();
+
+        println!("\n=== completion response #{call_no}: normalized choice ===");
+        println!("{}", pretty_json(&response.choice));
+        println!("\n=== completion response #{call_no}: raw provider payload ===");
+        println!("{}", pretty_json(&response.raw_response));
+
+        HookAction::cont()
+    }
+
+    async fn on_tool_call(
+        &self,
+        tool_name: &str,
+        tool_call_id: Option<String>,
+        internal_call_id: &str,
+        args: &str,
+    ) -> ToolCallHookAction {
+        let tool_no = self.next_tool_call();
+
+        println!("\n=== tool call #{tool_no}: model requested tool ===");
+        println!("tool_name: {tool_name}");
+        println!("tool_call_id: {tool_call_id:?}");
+        println!("internal_call_id: {internal_call_id}");
+        println!("args: {args}");
+
+        ToolCallHookAction::cont()
+    }
+
+    async fn on_tool_result(
+        &self,
+        tool_name: &str,
+        tool_call_id: Option<String>,
+        internal_call_id: &str,
+        args: &str,
+        result: &str,
+    ) -> HookAction {
+        println!("\n=== tool result: tool returned ===");
+        println!("tool_name: {tool_name}");
+        println!("tool_call_id: {tool_call_id:?}");
+        println!("internal_call_id: {internal_call_id}");
+        println!("args: {args}");
+        println!("result: {result}");
+
+        HookAction::cont()
+    }
+}
+
+fn pretty_json<T>(value: &T) -> String
+where
+    T: Serialize + ?Sized,
+{
+    serde_json::to_string_pretty(value)
+        .unwrap_or_else(|err| format!("<failed to serialize debug payload as JSON: {err}>"))
 }
 
 impl Tool for WeatherTool {
@@ -62,27 +159,32 @@ impl Tool for WeatherTool {
         args: Self::Args,
     ) -> impl std::future::Future<Output = Result<Self::Output, Self::Error>> + Send {
         self.call_count.fetch_add(1, Ordering::SeqCst);
-        std::future::ready(Ok(format!(
+        let result = format!(
             "The weather in {} is all fire and brimstone",
             args.city
-        )))
+        );
+
+        println!("\n=== weather tool implementation ===");
+        println!(
+            "{}",
+            pretty_json(&serde_json::json!({
+                "args": { "city": args.city },
+                "returned": result,
+            }))
+        );
+
+        std::future::ready(Ok(result))
     }
 }
 
 #[tokio::test]
 #[ignore = "requires a local llama.cpp OpenAI-compatible server"]
 async fn prompt_typed_with_tool_call_smoke() -> Result<()> {
-    let base_url = std::env::var("LLAMACPP_API_BASE_URL")
-        .unwrap_or_else(|_| "http://localhost:8080/v1".to_string());
-    let model = std::env::var("LLAMACPP_MODEL").unwrap_or_else(|_| "model".to_string());
-    let api_key = std::env::var("LLAMACPP_API_KEY").unwrap_or_else(|_| "none".to_string());
+    let model = support::model_name();
+    let hook = StepLogger::default();
 
     let call_count = Arc::new(AtomicUsize::new(0));
-    let client = openai::Client::builder()
-        .api_key(&api_key)
-        .base_url(&base_url)
-        .build()?
-        .completions_api();
+    let client = support::completions_client();
 
     let agent = client
         .agent(model)
@@ -94,6 +196,7 @@ async fn prompt_typed_with_tool_call_smoke() -> Result<()> {
 
     let result = agent
         .prompt_typed::<WeatherResponse>("Hello, whats the weather in London?")
+        .with_hook(hook)
         .await;
 
     println!("prompt_typed result: {result:#?}");

--- a/rig/rig-core/tests/llamacpp/typed_prompt_tools.rs
+++ b/rig/rig-core/tests/llamacpp/typed_prompt_tools.rs
@@ -1,0 +1,115 @@
+//! Smoke coverage for issue #1604 against a local llama.cpp OpenAI-compatible server.
+
+use anyhow::Result;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use rig::client::CompletionClient;
+use rig::completion::{ToolDefinition, TypedPrompt};
+use rig::providers::openai;
+use rig::tool::Tool;
+
+#[derive(Debug, Deserialize, JsonSchema, Serialize)]
+struct WeatherResponse {
+    city: String,
+    weather: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct WeatherArgs {
+    city: String,
+}
+
+#[derive(Clone)]
+struct WeatherTool {
+    call_count: Arc<AtomicUsize>,
+}
+
+impl WeatherTool {
+    fn new(call_count: Arc<AtomicUsize>) -> Self {
+        Self { call_count }
+    }
+}
+
+impl Tool for WeatherTool {
+    const NAME: &'static str = "weather";
+
+    type Error = std::io::Error;
+    type Args = WeatherArgs;
+    type Output = String;
+
+    fn definition(
+        &self,
+        _prompt: String,
+    ) -> impl std::future::Future<Output = ToolDefinition> + Send + Sync {
+        std::future::ready(ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "Get the current weather for a city".to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "city": { "type": "string" }
+                },
+                "required": ["city"]
+            }),
+        })
+    }
+
+    fn call(
+        &self,
+        args: Self::Args,
+    ) -> impl std::future::Future<Output = Result<Self::Output, Self::Error>> + Send {
+        self.call_count.fetch_add(1, Ordering::SeqCst);
+        std::future::ready(Ok(format!(
+            "The weather in {} is all fire and brimstone",
+            args.city
+        )))
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires a local llama.cpp OpenAI-compatible server"]
+async fn prompt_typed_with_tool_call_smoke() -> Result<()> {
+    let base_url = std::env::var("LLAMACPP_API_BASE_URL")
+        .unwrap_or_else(|_| "http://localhost:8080/v1".to_string());
+    let model = std::env::var("LLAMACPP_MODEL").unwrap_or_else(|_| "model".to_string());
+    let api_key = std::env::var("LLAMACPP_API_KEY").unwrap_or_else(|_| "none".to_string());
+
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let client = openai::Client::builder()
+        .api_key(&api_key)
+        .base_url(&base_url)
+        .build()?
+        .completions_api();
+
+    let agent = client
+        .agent(model)
+        .tool(WeatherTool::new(call_count.clone()))
+        .preamble(
+            "You are a helpful assistant. When asked about weather, use the weather tool to get the current conditions. After calling the tool, return a JSON response with the city name and the weather description. DO NOT modify the description from the tool result.",
+        )
+        .build();
+
+    let result = agent
+        .prompt_typed::<WeatherResponse>("Hello, whats the weather in London?")
+        .await;
+
+    println!("prompt_typed result: {result:#?}");
+
+    let response = result?;
+    println!("agent response: {response:#?}");
+
+    assert!(
+        call_count.load(Ordering::SeqCst) >= 1,
+        "expected the weather tool to be executed at least once"
+    );
+    assert_eq!(response.city, "London");
+    assert_eq!(
+        response.weather,
+        "The weather in London is all fire and brimstone"
+    );
+
+    Ok(())
+}

--- a/rig/rig-core/tests/openai/mod.rs
+++ b/rig/rig-core/tests/openai/mod.rs
@@ -18,5 +18,6 @@ mod streaming;
 mod streaming_tools;
 mod structured_output;
 mod transcription;
+mod typed_prompt_tools;
 #[cfg(feature = "websocket")]
 mod websocket;

--- a/rig/rig-core/tests/openai/typed_prompt_tools.rs
+++ b/rig/rig-core/tests/openai/typed_prompt_tools.rs
@@ -1,0 +1,114 @@
+//! Live OpenAI coverage for combining `prompt_typed()` with tool calling.
+
+use anyhow::Result;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use rig::client::CompletionClient;
+use rig::completion::{ToolDefinition, TypedPrompt};
+use rig::providers::openai;
+use rig::tool::Tool;
+
+#[derive(Debug, Deserialize, JsonSchema, Serialize)]
+struct WeatherResponse {
+    city: String,
+    weather: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct WeatherArgs {
+    city: String,
+}
+
+#[derive(Clone)]
+struct WeatherTool {
+    call_count: Arc<AtomicUsize>,
+}
+
+impl WeatherTool {
+    fn new(call_count: Arc<AtomicUsize>) -> Self {
+        Self { call_count }
+    }
+}
+
+impl Tool for WeatherTool {
+    const NAME: &'static str = "weather";
+
+    type Error = std::io::Error;
+    type Args = WeatherArgs;
+    type Output = String;
+
+    fn definition(
+        &self,
+        _prompt: String,
+    ) -> impl std::future::Future<Output = ToolDefinition> + Send + Sync {
+        std::future::ready(ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "Get the current weather for a city.".to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "city": { "type": "string" }
+                },
+                "required": ["city"]
+            }),
+        })
+    }
+
+    fn call(
+        &self,
+        args: Self::Args,
+    ) -> impl std::future::Future<Output = Result<Self::Output, Self::Error>> + Send {
+        self.call_count.fetch_add(1, Ordering::SeqCst);
+        std::future::ready(Ok(format!(
+            "The weather in {} is all fire and brimstone",
+            args.city
+        )))
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires OPENAI_API_KEY"]
+async fn prompt_typed_with_tool_call_roundtrip() -> Result<()> {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let api_key = std::env::var("OPENAI_API_KEY")?;
+    let mut builder = openai::Client::builder().api_key(&api_key);
+
+    if let Ok(base_url) = std::env::var("OPENAI_BASE_URL") {
+        builder = builder.base_url(&base_url);
+    }
+
+    let client = builder.build()?.completions_api();
+    let agent = client
+        .agent(openai::GPT_4O)
+        .preamble(
+            "You are a helpful assistant. When asked about weather, use the weather tool to get the current conditions. \
+             After calling the tool, return a JSON response with the city name and the weather description. \
+             DO NOT modify the description from the tool result.",
+        )
+        .tool(WeatherTool::new(call_count.clone()))
+        .build();
+
+    let result = agent
+        .prompt_typed("Hello, whats the weather in London?")
+        .await;
+
+    println!("prompt_typed result: {result:#?}");
+
+    let response: WeatherResponse = result?;
+    println!("agent response: {response:#?}");
+
+    assert!(
+        call_count.load(Ordering::SeqCst) >= 1,
+        "expected the weather tool to be executed at least once"
+    );
+    assert_eq!(response.city, "London");
+    assert_eq!(
+        response.weather,
+        "The weather in London is all fire and brimstone"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Partial fix for #1604 

Delay response_format / json_schema on OpenAI Chat Completions requests until after the conversation contains a tool result.

When using llamacpp tools are now properly called, but the tool output is not always completely preserved. This might just be due to local models not being as good at following instructions, but I'm not too sure yet. 

In theory we could start returning tool output earlier if it parses into the Response object on the first try, but this requires more exploration. 

Added many ignored tests for llamacpp for regression testing. Not all of them currently pass but it's a start.