### PR TITLE
feat(rig-core): Add model listing capability to OpenRouter client

### DIFF
--- a/rig/rig-core/src/providers/openrouter/client.rs
+++ b/rig/rig-core/src/providers/openrouter/client.rs
@@ -35,7 +35,7 @@ impl<H> Capabilities<H> for OpenRouterExt {
     type Completion = Capable<super::CompletionModel<H>>;
     type Embeddings = Capable<super::EmbeddingModel<H>>;
     type Transcription = Nothing;
-    type ModelListing = Nothing;
+    type ModelListing = Capable<super::OpenRouterModelLister<H>>;
     #[cfg(feature = "image")]
     type ImageGeneration = Nothing;
 

--- a/rig/rig-core/src/providers/openrouter/mod.rs
+++ b/rig/rig-core/src/providers/openrouter/mod.rs
@@ -12,8 +12,10 @@
 pub mod client;
 pub mod completion;
 pub mod embedding;
+pub mod model_listing;
 pub mod streaming;
 
 pub use client::*;
 pub use completion::*;
 pub use embedding::*;
+pub use model_listing::OpenRouterModelLister;

--- a/rig/rig-core/src/providers/openrouter/model_listing.rs
+++ b/rig/rig-core/src/providers/openrouter/model_listing.rs
@@ -1,0 +1,77 @@
+use crate::{
+    client::ModelLister,
+    http_client::{self, HttpClientExt},
+    model::{Model, ModelList, ModelListingError},
+    providers::openrouter::Client,
+};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct ListModelsResponse {
+    data: Vec<ModelEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ModelEntry {
+    id: String,
+    name: String,
+    description: Option<String>,
+    created: u64,
+    context_length: Option<u32>,
+}
+
+impl From<ModelEntry> for Model {
+    fn from(value: ModelEntry) -> Self {
+        Model {
+            id: value.id,
+            name: Some(value.name),
+            description: value.description,
+            r#type: None,
+            created_at: Some(value.created),
+            owned_by: None,
+            context_length: value.context_length,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct OpenRouterModelLister<H = reqwest::Client> {
+    client: Client<H>,
+}
+
+impl<H> ModelLister<H> for OpenRouterModelLister<H>
+where
+    H: HttpClientExt + Send + Sync + 'static,
+{
+    type Client = Client<H>;
+
+    fn new(client: Self::Client) -> Self {
+        Self { client }
+    }
+
+    async fn list_all(&self) -> Result<ModelList, ModelListingError> {
+        let path = "/models";
+        let req = self.client.get(path)?.body(http_client::NoBody)?;
+        let response = self.client.send::<_, Vec<u8>>(req).await?;
+
+        if !response.status().is_success() {
+            let status_code = response.status().as_u16();
+            let body = response.into_body().await?;
+            return Err(ModelListingError::api_error_with_context(
+                "OpenRouter",
+                path,
+                status_code,
+                &body,
+            ));
+        }
+
+        let body = response.into_body().await?;
+        let api_resp: ListModelsResponse = serde_json::from_slice(&body).map_err(|error| {
+            ModelListingError::parse_error_with_context("OpenRouter", path, &error, &body)
+        })?;
+        let models = api_resp.data.into_iter().map(Model::from).collect();
+
+        Ok(ModelList::new(models))
+    }
+}

--- a/rig/rig-core/tests/openrouter/mod.rs
+++ b/rig/rig-core/tests/openrouter/mod.rs
@@ -1,4 +1,5 @@
 mod agent;
+mod models;
 mod multimodal;
 mod provider_selection;
 mod reasoning_roundtrip;

--- a/rig/rig-core/tests/openrouter/models.rs
+++ b/rig/rig-core/tests/openrouter/models.rs
@@ -1,0 +1,26 @@
+//! OpenRouter model listing smoke test.
+//!
+//! Run with:
+//! `cargo test -p rig-core --test openrouter openrouter::models::list_models_smoke -- --ignored --nocapture`
+
+use rig::client::{ModelListingClient, ProviderClient};
+use rig::providers::openrouter;
+
+#[tokio::test]
+#[ignore = "requires OPENROUTER_API_KEY"]
+async fn list_models_smoke() {
+    let client = openrouter::Client::from_env();
+    let models = match client.list_models().await {
+        Ok(models) => models,
+        Err(error) => {
+            panic!("listing OpenRouter models should succeed\nDisplay: {error}\nDebug: {error:#?}")
+        }
+    };
+
+    assert!(
+        !models.is_empty(),
+        "expected OpenRouter to return at least one model\nModel list: {models:#?}"
+    );
+
+    println!("OpenRouter returned {} models", models.len());
+}


### PR DESCRIPTION
Add a new OpenRouterModelLister that calls the `/models` endpoint defined [by OpenRouter here](https://openrouter.ai/docs/api/api-reference/models/get-models).

Tested manually