### PR TITLE
feat(neo4j): implement InsertDocuments for Neo4jVectorIndex

### DIFF
--- a/rig-integrations/rig-neo4j/src/lib.rs
+++ b/rig-integrations/rig-neo4j/src/lib.rs
@@ -279,9 +279,9 @@ where
 impl Neo4jClient {
     const GET_INDEX_QUERY: &'static str = "
     SHOW VECTOR INDEXES
-    YIELD name, properties, options
+    YIELD name, labelsOrTypes, properties, options
     WHERE name=$index_name
-    RETURN name, properties, options
+    RETURN name, labelsOrTypes, properties, options
     ";
 
     const SHOW_INDEXES_QUERY: &'static str = "SHOW VECTOR INDEXES YIELD name RETURN name";
@@ -332,8 +332,10 @@ impl Neo4jClient {
         index_name: &str,
     ) -> Result<Neo4jVectorIndex<M>, VectorStoreError> {
         #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
         struct IndexInfo {
             name: String,
+            labels_or_types: Vec<String>,
             properties: Vec<String>,
             options: IndexOptions,
         }
@@ -368,11 +370,15 @@ impl Neo4jClient {
                     model.ndims()
                 );
             }
-            IndexConfig::new(index.name.clone())
+            let mut config = IndexConfig::new(index.name.clone())
                 .embedding_property(index.properties.first().unwrap())
                 .similarity_function(VectorSimilarityFunction::from_str(
                     &index.options.index_config.vector_similarity_function,
-                )?)
+                )?);
+            if let Some(label) = index.labels_or_types.first() {
+                config = config.node_label(label);
+            }
+            config
         } else {
             let indexes = Self::execute_and_collect::<String>(
                 &self.graph,

--- a/rig-integrations/rig-neo4j/src/vector_index.rs
+++ b/rig-integrations/rig-neo4j/src/vector_index.rs
@@ -8,10 +8,12 @@ use neo4rs::{Graph, Query};
 use rig::{
     embeddings::{Embedding, EmbeddingModel},
     vector_store::{
-        VectorStoreError, VectorStoreIndex,
+        InsertDocuments, VectorStoreError, VectorStoreIndex,
         request::{SearchFilter, VectorSearchRequest},
     },
 };
+use rig::Embed;
+use rig::OneOrMany;
 use serde::{Deserialize, Serialize, de::Error};
 
 use crate::{Neo4jClient, Neo4jSearchFilter};
@@ -37,6 +39,7 @@ pub struct IndexConfig {
     pub index_name: String,
     pub embedding_property: String,
     pub similarity_function: VectorSimilarityFunction,
+    pub node_label: Option<String>,
 }
 
 impl Default for IndexConfig {
@@ -45,6 +48,7 @@ impl Default for IndexConfig {
             index_name: "vector_index".to_string(),
             embedding_property: "embedding".to_string(),
             similarity_function: VectorSimilarityFunction::Cosine,
+            node_label: None,
         }
     }
 }
@@ -55,6 +59,7 @@ impl IndexConfig {
             index_name: index_name.into(),
             embedding_property: "embedding".to_string(),
             similarity_function: VectorSimilarityFunction::Cosine,
+            node_label: None,
         }
     }
 
@@ -70,6 +75,11 @@ impl IndexConfig {
 
     pub fn embedding_property(mut self, embedding_property: &str) -> Self {
         self.embedding_property = embedding_property.to_string();
+        self
+    }
+
+    pub fn node_label(mut self, node_label: &str) -> Self {
+        self.node_label = Some(node_label.to_string());
         self
     }
 }
@@ -266,5 +276,69 @@ where
             .collect::<Vec<_>>();
 
         Ok(results)
+    }
+}
+
+impl<M> InsertDocuments for Neo4jVectorIndex<M>
+where
+    M: EmbeddingModel + Send + Sync,
+{
+    async fn insert_documents<Doc: Serialize + Embed + Send>(
+        &self,
+        documents: Vec<(Doc, OneOrMany<Embedding>)>,
+    ) -> Result<(), VectorStoreError> {
+        let node_label = self
+            .index_config
+            .node_label
+            .as_deref()
+            .unwrap_or("Document");
+
+        let embedding_property = &self.index_config.embedding_property;
+
+        // Build a list of parameter maps for UNWIND
+        let mut items: Vec<neo4rs::BoltType> = Vec::new();
+
+        for (document, embeddings) in documents {
+            let json_doc = serde_json::to_value(&document)?;
+
+            for embedding in embeddings {
+                let mut props = neo4rs::BoltMap::new();
+                // Flatten document properties into the node
+                if let serde_json::Value::Object(map) = &json_doc {
+                    for (k, v) in map {
+                        props.put(
+                            neo4rs::BoltString::new(k),
+                            crate::ToBoltType::to_bolt_type(v),
+                        );
+                    }
+                } else {
+                    props.put(
+                        neo4rs::BoltString::new("document"),
+                        crate::ToBoltType::to_bolt_type(&json_doc),
+                    );
+                }
+                props.put(
+                    neo4rs::BoltString::new("embedded_text"),
+                    neo4rs::BoltType::String(neo4rs::BoltString::new(&embedding.document)),
+                );
+                props.put(
+                    neo4rs::BoltString::new(embedding_property),
+                    crate::ToBoltType::to_bolt_type(&embedding.vec),
+                );
+                items.push(neo4rs::BoltType::Map(props));
+            }
+        }
+
+        let query_str = format!(
+            "UNWIND $items AS item CREATE (n:{}) SET n = item",
+            node_label
+        );
+
+        self.graph
+            .run(neo4rs::query(&query_str).param("items", items))
+            .await
+            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- Implements the `InsertDocuments` trait for `Neo4jVectorIndex`, enabling document insertion with embeddings
- Uses `UNWIND $items AS item CREATE (n:Label) SET n = item` Cypher pattern for efficient batch insertion
- Flattens serialized document properties directly onto the node (object docs) or stores as a `document` property (non-object docs)
- Stores embedding vector and `embedded_text` alongside document properties
- Adds `node_label` field to `IndexConfig` so the correct label is used for inserted nodes
- `get_index` now fetches `labelsOrTypes` from `SHOW VECTOR INDEXES` and populates `node_label` automatically

Partial fix for #565 (Neo4j provider; other providers can follow the same pattern)

## Test plan
- [x] `cargo check -p rig-neo4j` passes
- [ ] Integration test with a live Neo4j instance: insert documents, then query via `top_n` to verify round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)