### PR TITLE
Add Serialize/Deserialize derives to CompletionRequest, PromptResponse, TypedPromptResponse

### DIFF
--- a/rig/rig-core/src/agent/prompt_request/mod.rs
+++ b/rig/rig-core/src/agent/prompt_request/mod.rs
@@ -271,7 +271,6 @@ impl PromptResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound = "T: Serialize + for<'a> Deserialize<'a>")]
 pub struct TypedPromptResponse<T> {
     pub output: T,
     pub usage: Usage,
@@ -824,5 +823,52 @@ where
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(self.send())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TypedPromptResponse;
+    use crate::completion::Usage;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize)]
+    struct SerializeOnly {
+        value: &'static str,
+    }
+
+    #[derive(Deserialize)]
+    struct DeserializeOnly {
+        value: String,
+    }
+
+    #[test]
+    fn typed_prompt_response_serializes_with_serialize_only_output() {
+        let response = TypedPromptResponse::new(
+            SerializeOnly { value: "ok" },
+            Usage {
+                input_tokens: 1,
+                output_tokens: 2,
+                total_tokens: 3,
+                cached_input_tokens: 0,
+                cache_creation_input_tokens: 0,
+            },
+        );
+
+        let json = serde_json::to_string(&response).expect("serialize typed prompt response");
+        assert!(json.contains("\"value\":\"ok\""));
+    }
+
+    #[test]
+    fn typed_prompt_response_deserializes_with_deserialize_only_output() {
+        let response: TypedPromptResponse<DeserializeOnly> = serde_json::from_str(
+            r#"{"output":{"value":"ok"},"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3,"cached_input_tokens":0,"cache_creation_input_tokens":0}}"#,
+        )
+        .expect("deserialize typed prompt response");
+
+        assert_eq!(response.output.value, "ok");
+        assert_eq!(response.usage.input_tokens, 1);
+        assert_eq!(response.usage.output_tokens, 2);
+        assert_eq!(response.usage.total_tokens, 3);
     }
 }

--- a/rig/rig-core/src/agent/prompt_request/mod.rs
+++ b/rig/rig-core/src/agent/prompt_request/mod.rs
@@ -15,6 +15,7 @@ use crate::{
 };
 use futures::{StreamExt, stream};
 use hooks::{HookAction, PromptHook, ToolCallHookAction};
+use serde::{Deserialize, Serialize};
 use std::{
     future::IntoFuture,
     marker::PhantomData,
@@ -240,7 +241,7 @@ where
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct PromptResponse {
     pub output: String,
@@ -269,7 +270,8 @@ impl PromptResponse {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(bound = "T: Serialize + for<'a> Deserialize<'a>")]
 pub struct TypedPromptResponse<T> {
     pub output: T,
     pub usage: Usage,

--- a/rig/rig-core/src/completion/request.rs
+++ b/rig/rig-core/src/completion/request.rs
@@ -501,7 +501,7 @@ pub trait CompletionModel: Clone + WasmCompatSend + WasmCompatSync {
 }
 
 /// Struct representing a general completion request that can be sent to a completion model provider.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CompletionRequest {
     /// Optional model override for this request.
     pub model: Option<String>,


### PR DESCRIPTION
All field types in `CompletionRequest`, `PromptResponse`, and `TypedPromptResponse<T>` already implement `Serialize` and `Deserialize`, but the structs themselves don't derive these traits. This prevents downstream code from serializing complete inference requests for debugging, replay, or persistence. Saving a fully-assembled `CompletionRequest` (with chat history, tools, preamble, etc.) to JSON for later replay is useful for reproducing inference behavior without running the full application stack.

Backward compatibility: adding trait implementations is non-breaking. No existing behavior or API changes.