### PR TITLE
fix(rig-core): make model listing wasm-compatible

### DIFF
--- a/rig/rig-core/src/client/mod.rs
+++ b/rig/rig-core/src/client/mod.rs
@@ -686,8 +686,8 @@ where
 impl<M, Ext, H> ModelListingClient for Client<Ext, H>
 where
     Ext: Capabilities<H, ModelListing = Capable<M>> + Clone,
-    M: ModelLister<H, Client = Self> + Send + Sync + Clone + 'static,
-    H: Send + Sync + Clone,
+    M: ModelLister<H, Client = Self> + WasmCompatSend + WasmCompatSync + Clone + 'static,
+    H: WasmCompatSend + WasmCompatSync + Clone,
 {
     fn list_models(
         &self,
@@ -696,6 +696,104 @@ where
     > + WasmCompatSend {
         let lister = M::new(self.clone());
         async move { lister.list_all().await }
+    }
+}
+
+#[cfg(all(feature = "wasm", target_arch = "wasm32"))]
+mod wasm_model_listing_compile_checks {
+    use super::{ModelListingClient, Nothing};
+    use crate::{
+        http_client::{self, HttpClientExt, LazyBody, MultipartForm, Request, Response},
+        providers::{anthropic, mistral, ollama, openai, openrouter},
+        wasm_compat::WasmCompatSend,
+    };
+    use bytes::Bytes;
+    use std::{
+        future::{self, Future},
+        marker::PhantomData,
+        rc::Rc,
+    };
+
+    #[derive(Clone, Default)]
+    struct WasmOnlyHttpClient {
+        _not_send_sync: PhantomData<Rc<()>>,
+    }
+
+    impl HttpClientExt for WasmOnlyHttpClient {
+        fn send<T, U>(
+            &self,
+            _req: Request<T>,
+        ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+        where
+            T: Into<Bytes> + WasmCompatSend,
+            U: From<Bytes> + WasmCompatSend + 'static,
+        {
+            future::ready(Err(http_client::Error::StreamEnded))
+        }
+
+        fn send_multipart<U>(
+            &self,
+            _req: Request<MultipartForm>,
+        ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+        where
+            U: From<Bytes> + WasmCompatSend + 'static,
+        {
+            future::ready(Err(http_client::Error::StreamEnded))
+        }
+
+        fn send_streaming<T>(
+            &self,
+            _req: Request<T>,
+        ) -> impl Future<Output = http_client::Result<http_client::StreamingResponse>> + WasmCompatSend
+        where
+            T: Into<Bytes>,
+        {
+            future::ready(Err(http_client::Error::StreamEnded))
+        }
+    }
+
+    fn assert_model_listing_client<C>(client: C)
+    where
+        C: ModelListingClient,
+    {
+        let _ = client.list_models();
+    }
+
+    fn assert_simple_model_listers_accept_wasm_only_http_clients() {
+        let _ = openrouter::Client::builder()
+            .api_key("dummy-key")
+            .http_client(WasmOnlyHttpClient::default())
+            .build()
+            .map(assert_model_listing_client);
+
+        let _ = openai::Client::builder()
+            .api_key("dummy-key")
+            .http_client(WasmOnlyHttpClient::default())
+            .build()
+            .map(assert_model_listing_client);
+
+        let _ = mistral::Client::builder()
+            .api_key("dummy-key")
+            .http_client(WasmOnlyHttpClient::default())
+            .build()
+            .map(assert_model_listing_client);
+
+        let _ = anthropic::Client::builder()
+            .api_key("dummy-key")
+            .http_client(WasmOnlyHttpClient::default())
+            .build()
+            .map(assert_model_listing_client);
+
+        let _ = ollama::Client::builder()
+            .api_key(Nothing)
+            .http_client(WasmOnlyHttpClient::default())
+            .build()
+            .map(assert_model_listing_client);
+    }
+
+    #[allow(dead_code)]
+    fn compile_assertions() {
+        assert_simple_model_listers_accept_wasm_only_http_clients();
     }
 }
 

--- a/rig/rig-core/src/client/model_listing.rs
+++ b/rig/rig-core/src/client/model_listing.rs
@@ -94,7 +94,7 @@ pub trait ModelListingClient {
 ///
 /// impl<H> ModelLister<H> for MyProviderModelLister<H>
 /// where
-///     H: HttpClientExt + Send + Sync,
+///     H: HttpClientExt + WasmCompatSend + WasmCompatSync,
 /// {
 ///     type Client = Client<MyProviderExt, H>;
 ///

--- a/rig/rig-core/src/providers/anthropic/model_listing.rs
+++ b/rig/rig-core/src/providers/anthropic/model_listing.rs
@@ -3,6 +3,7 @@ use crate::{
     http_client::{self, HttpClientExt},
     model::{Model, ModelList, ModelListingError},
     providers::anthropic::Client,
+    wasm_compat::{WasmCompatSend, WasmCompatSync},
 };
 use serde::Deserialize;
 
@@ -35,7 +36,7 @@ pub struct AnthropicModelLister<H = reqwest::Client> {
 
 impl<H> ModelLister<H> for AnthropicModelLister<H>
 where
-    H: HttpClientExt + Send + Sync + 'static,
+    H: HttpClientExt + WasmCompatSend + WasmCompatSync + 'static,
 {
     type Client = Client<H>;
 

--- a/rig/rig-core/src/providers/mistral/model_listing.rs
+++ b/rig/rig-core/src/providers/mistral/model_listing.rs
@@ -3,6 +3,7 @@ use crate::{
     http_client::{self, HttpClientExt},
     model::{Model, ModelList, ModelListingError},
     providers::mistral::Client,
+    wasm_compat::{WasmCompatSend, WasmCompatSync},
 };
 use serde::Deserialize;
 
@@ -37,7 +38,7 @@ pub struct MistralModelLister<H = reqwest::Client> {
 
 impl<H> ModelLister<H> for MistralModelLister<H>
 where
-    H: HttpClientExt + Send + Sync + 'static,
+    H: HttpClientExt + WasmCompatSend + WasmCompatSync + 'static,
 {
     type Client = Client<H>;
 

--- a/rig/rig-core/src/providers/ollama.rs
+++ b/rig/rig-core/src/providers/ollama.rs
@@ -47,6 +47,7 @@ use crate::{
     json_utils, message,
     message::{ImageDetail, Text},
     streaming,
+    wasm_compat::{WasmCompatSend, WasmCompatSync},
 };
 use async_stream::try_stream;
 use bytes::Bytes;
@@ -756,7 +757,7 @@ pub struct OllamaModelLister<H = reqwest::Client> {
 
 impl<H> ModelLister<H> for OllamaModelLister<H>
 where
-    H: HttpClientExt + Send + Sync + 'static,
+    H: HttpClientExt + WasmCompatSend + WasmCompatSync + 'static,
 {
     type Client = Client<H>;
 

--- a/rig/rig-core/src/providers/openai/model_listing.rs
+++ b/rig/rig-core/src/providers/openai/model_listing.rs
@@ -3,6 +3,7 @@ use crate::{
     http_client::{self, HttpClientExt},
     model::{Model, ModelList, ModelListingError},
     providers::openai::Client,
+    wasm_compat::{WasmCompatSend, WasmCompatSync},
 };
 use serde::Deserialize;
 
@@ -35,7 +36,7 @@ pub struct OpenAIModelLister<H = reqwest::Client> {
 
 impl<H> ModelLister<H> for OpenAIModelLister<H>
 where
-    H: HttpClientExt + Send + Sync + 'static,
+    H: HttpClientExt + WasmCompatSend + WasmCompatSync + 'static,
 {
     type Client = Client<H>;
 

--- a/rig/rig-core/src/providers/openrouter/model_listing.rs
+++ b/rig/rig-core/src/providers/openrouter/model_listing.rs
@@ -3,6 +3,7 @@ use crate::{
     http_client::{self, HttpClientExt},
     model::{Model, ModelList, ModelListingError},
     providers::openrouter::Client,
+    wasm_compat::{WasmCompatSend, WasmCompatSync},
 };
 use serde::Deserialize;
 
@@ -42,7 +43,7 @@ pub struct OpenRouterModelLister<H = reqwest::Client> {
 
 impl<H> ModelLister<H> for OpenRouterModelLister<H>
 where
-    H: HttpClientExt + Send + Sync + 'static,
+    H: HttpClientExt + WasmCompatSend + WasmCompatSync + 'static,
 {
     type Client = Client<H>;
 


### PR DESCRIPTION
## Summary

This updates model listing to use Rig's wasm-compatible bounds instead of reintroducing raw `Send + Sync` requirements.

Changes:
- switch the shared `ModelListingClient` blanket impl to `WasmCompatSend` / `WasmCompatSync`
- convert the simple provider model listers to the same bounds:
  - OpenAI
  - OpenRouter
  - Mistral
  - Anthropic
  - Ollama
- add a wasm-only compile check that type-checks `list_models()` with a non-`Send` / non-`Sync` HTTP backend to catch regressions on `wasm32`

Also updates the `ModelLister` example docs to match the new bound pattern.

## Notes

- no public API changes
- this is a compatibility fix for the model-listing path rather than a behavior change
