### PR TITLE
fix(copilot): add missing cache_creation_input_tokens field

### DIFF
--- a/rig/rig-core/src/providers/copilot/completion.rs
+++ b/rig/rig-core/src/providers/copilot/completion.rs
@@ -147,6 +147,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                     .as_ref()
                     .map(|d| d.cached_tokens as u64)
                     .unwrap_or(0),
+                cache_creation_input_tokens: 0,
             })
             .unwrap_or_default();
 


### PR DESCRIPTION
The Copilot provider's Usage construction was missing the cache_creation_input_tokens field that was added to the completion module's Usage struct. This caused a compilation error (E0063) on main after the Copilot provider was merged.