### PR TITLE
docs: add Con to ecosystem

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -10,6 +10,7 @@ Interested in having your project added here? Feel free to open an issue or PR.
 - [Litho (deepwiki-rs)](https://github.com/sopaco/deepwiki-rs) - an AI-powered documentation engine that builds out your docs using your codebase.
 - [git-iris](https://github.com/hyperb1iss/git-iris) - an AI-powered tool to help automate Git workflows
 - [VT Code](https://github.com/vinhnx/vtcode) - a (currently research-preview) terminal coding agent
+- [Con](https://github.com/nowledge-co/con) - a GPU-accelerated terminal emulator with a built-in AI agent harness powered by Rig
 - [rv](https://github.com/gi-dellav/rv) - a non-invasive AI code review tool
 - [Cortex Memory](https://github.com/sopaco/cortex-mem) - The production-ready memory system for intelligent agents. A complete solution for memory management, from extraction and vector search to automated optimization, with a REST API, MCP, CLI, and insights dashboard out-of-the-box.
 - [ChatShell](https://github.com/chatshellapp/chatshell-desktop) - an open-source agentic desktop AI client built on rig-core and Tauri 2. 9 built-in tools (web search, bash, file ops, grep), 40+ AI providers, MCP integration, and a composable skills system — all zero-config out of the box.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Below is a non-exhaustive list of companies and people who are using Rig:
 - [St Jude](https://www.stjude.org/) - Using Rig for a chatbot utility as part of [`proteinpaint`](https://github.com/stjude/proteinpaint), a genomics visualisation tool.
 - [Coral Protocol](https://www.coralprotocol.org/) - Using Rig extensively, both internally as well as part of the [Coral Rust SDK.](https://github.com/Coral-Protocol/coral-rs)
 - [VT Code](https://github.com/vinhnx/vtcode) - VT Code is a Rust-based terminal coding agent with semantic code intelligence via Tree-sitter and ast-grep. VT Code uses `rig` for simplifying LLM calls and implement model picker.
+- [Con](https://github.com/nowledge-co/con) - Con is a GPU-accelerated terminal emulator with a built-in AI agent harness. It uses Rig as the provider abstraction layer for its integrated coding agents.
 - [Dria](https://dria.co/) - a decentralised AI network. Currently using Rig as part of their [compute node.](https://github.com/firstbatchxyz/dkn-compute-node)
 - [Nethermind](https://www.nethermind.io/) - Using Rig as part of their [Neural Interconnected Nodes Engine](https://github.com/NethermindEth/nine) framework.
 - [Neon](https://neon.com) - Using Rig for their [app.build](https://github.com/neondatabase/appdotbuild-agent) V2 reboot in Rust.


### PR DESCRIPTION
## Summary
- add Con to the README "Who is using Rig?" list
- add Con to the ecosystem showcase

## Project
[Con](https://github.com/nowledge-co/con) is a GPU-accelerated terminal emulator with a built-in AI agent harness using Rig for provider integration.
