### PR TITLE
rig-surrealdb: support dynamic_context 

### DIFF
--- a/rig-integrations/rig-surrealdb/Cargo.toml
+++ b/rig-integrations/rig-surrealdb/Cargo.toml
@@ -25,4 +25,8 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [[example]]
 name = "vector_search_surreal"
-required-features = ["rig-core/derive"]
+required-features = ["rig-core/derive", "rig-core/rustls"]
+
+[[example]]
+name = "vector_store"
+required-features = ["rig-core/derive", "rig-core/rustls"]

--- a/rig-integrations/rig-surrealdb/examples/vector_store.rs
+++ b/rig-integrations/rig-surrealdb/examples/vector_store.rs
@@ -1,0 +1,103 @@
+use rig::client::{EmbeddingsClient, ProviderClient};
+use rig::providers::openai;
+use rig::vector_store::request::VectorSearchRequest;
+use rig::{
+    Embed,
+    embeddings::EmbeddingsBuilder,
+    vector_store::{InsertDocuments, VectorStoreIndex},
+};
+use rig_surrealdb::{Mem, SurrealVectorStore};
+use serde::{Deserialize, Serialize};
+use surrealdb::Surreal;
+
+// A vector search is performed on the `description` field, so we derive `Embed`
+// and mark that field with `#[embed]`.
+#[derive(Embed, Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
+struct TopicDefinition {
+    topic: String,
+    #[serde(skip)] // used for embeddings but not persisted in the example document payload
+    #[embed]
+    description: String,
+}
+
+impl std::fmt::Display for TopicDefinition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.topic)
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    // Create OpenAI client
+    let openai_client = openai::Client::from_env();
+    let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_ADA_002);
+
+    let surreal = Surreal::new::<Mem>(()).await?;
+
+    surreal.use_ns("example").use_db("example").await?;
+
+    let topics = vec![
+        TopicDefinition {
+            topic: "pasta carbonara".to_string(),
+            description: "A traditional Roman pasta dish made with eggs, pecorino romano, black pepper, and guanciale.".to_string(),
+        },
+        TopicDefinition {
+            topic: "green tea".to_string(),
+            description: "A drink made by steeping unoxidized tea leaves in hot water for a light, grassy flavor.".to_string(),
+        },
+        TopicDefinition {
+            topic: "solar eclipse".to_string(),
+            description: "An event where the moon passes between Earth and the sun, temporarily blocking the sun's light.".to_string(),
+        },
+    ];
+
+    let documents = EmbeddingsBuilder::new(model.clone())
+        .documents(topics)?
+        .build()
+        .await?;
+
+    let vector_store = SurrealVectorStore::with_defaults(model, surreal);
+
+    vector_store.insert_documents(documents).await?;
+
+    let query = "Which dish is a Roman pasta recipe made with eggs, pecorino romano, black pepper, and guanciale?";
+    println!("Attempting vector search with query: {query}");
+
+    let req = VectorSearchRequest::builder()
+        .query(query.to_string())
+        .samples(3)
+        .build();
+
+    let results = vector_store.top_n::<TopicDefinition>(req).await?;
+
+    assert_eq!(results.len(), 3);
+    assert_eq!(results[0].2.topic, "pasta carbonara");
+
+    println!("{} results for query: {}", results.len(), query);
+    for (distance, _id, doc) in results.iter() {
+        println!("Result distance {distance} for topic: {doc}");
+    }
+
+    let midpoint = (results[0].0 + results[1].0) / 2.0;
+
+    println!(
+        "Attempting vector search with cosine similarity threshold of {midpoint} and query: {query}"
+    );
+    let req = VectorSearchRequest::builder()
+        .query(query.to_string())
+        .samples(1)
+        .threshold(midpoint)
+        .build();
+
+    let results = vector_store.top_n::<TopicDefinition>(req).await?;
+
+    println!("{} results for query: {}", results.len(), query);
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].2.topic, "pasta carbonara");
+
+    for (distance, _id, doc) in results.iter() {
+        println!("Result distance {distance} for topic: {doc}");
+    }
+
+    Ok(())
+}

--- a/rig-integrations/rig-surrealdb/src/lib.rs
+++ b/rig-integrations/rig-surrealdb/src/lib.rs
@@ -4,9 +4,10 @@ use rig::{
     Embed, OneOrMany,
     embeddings::{Embedding, EmbeddingModel},
     vector_store::{
-        InsertDocuments, VectorStoreError, VectorStoreIndex,
-        request::{SearchFilter, VectorSearchRequest},
+        InsertDocuments, TopNResults, VectorStoreError, VectorStoreIndex, VectorStoreIndexDyn,
+        request::{Filter, FilterError, SearchFilter, VectorSearchRequest},
     },
+    wasm_compat::WasmBoxedFuture,
 };
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use surrealdb::{
@@ -130,6 +131,20 @@ pub struct SurrealSearchFilter(String);
 impl SurrealSearchFilter {
     fn inner(self) -> String {
         self.0
+    }
+}
+
+impl TryFrom<Filter<serde_json::Value>> for SurrealSearchFilter {
+    type Error = FilterError;
+
+    fn try_from(value: Filter<serde_json::Value>) -> Result<Self, Self::Error> {
+        match value {
+            Filter::Eq(key, value) => Ok(Self::eq(key, Value::from_t(value))),
+            Filter::Gt(key, value) => Ok(Self::gt(key, Value::from_t(value))),
+            Filter::Lt(key, value) => Ok(Self::lt(key, Value::from_t(value))),
+            Filter::And(lhs, rhs) => Ok(Self::try_from(*lhs)?.and(Self::try_from(*rhs)?)),
+            Filter::Or(lhs, rhs) => Ok(Self::try_from(*lhs)?.or(Self::try_from(*rhs)?)),
+        }
     }
 }
 
@@ -371,5 +386,111 @@ where
             .collect();
 
         Ok(rows)
+    }
+}
+
+// SurrealDB keeps a native filter value type, so it cannot use the blanket
+// `VectorStoreIndexDyn` impl that assumes JSON-valued filters.
+impl<C, Model> VectorStoreIndexDyn for SurrealVectorStore<C, Model>
+where
+    C: Connection,
+    Model: EmbeddingModel + Send + Sync,
+{
+    fn top_n<'a>(
+        &'a self,
+        req: VectorSearchRequest<Filter<serde_json::Value>>,
+    ) -> WasmBoxedFuture<'a, TopNResults> {
+        Box::pin(async move {
+            let req = req.try_map_filter(SurrealSearchFilter::try_from)?;
+            let results = <Self as VectorStoreIndex>::top_n::<serde_json::Value>(self, req).await?;
+            Ok(results)
+        })
+    }
+
+    fn top_n_ids<'a>(
+        &'a self,
+        req: VectorSearchRequest<Filter<serde_json::Value>>,
+    ) -> WasmBoxedFuture<'a, Result<Vec<(f64, String)>, VectorStoreError>> {
+        Box::pin(async move {
+            let req = req.try_map_filter(SurrealSearchFilter::try_from)?;
+            <Self as VectorStoreIndex>::top_n_ids(self, req).await
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Mem, SurrealSearchFilter, SurrealVectorStore};
+    use rig::{
+        client::Nothing,
+        embeddings::{Embedding, EmbeddingError, EmbeddingModel},
+        vector_store::{VectorStoreIndexDyn, request::Filter},
+    };
+    use serde_json::json;
+    use surrealdb::Surreal;
+
+    #[derive(Clone)]
+    struct MockEmbeddingModel;
+
+    impl EmbeddingModel for MockEmbeddingModel {
+        const MAX_DOCUMENTS: usize = 4;
+
+        type Client = Nothing;
+
+        fn make(_: &Self::Client, _: impl Into<String>, _: Option<usize>) -> Self {
+            Self
+        }
+
+        fn ndims(&self) -> usize {
+            3
+        }
+
+        async fn embed_texts(
+            &self,
+            texts: impl IntoIterator<Item = String> + Send,
+        ) -> Result<Vec<Embedding>, EmbeddingError> {
+            Ok(texts
+                .into_iter()
+                .map(|text| Embedding {
+                    document: text,
+                    vec: vec![0.0, 0.0, 0.0],
+                })
+                .collect())
+        }
+    }
+
+    #[test]
+    fn filter_from_json_preserves_nested_values() {
+        let filter = match SurrealSearchFilter::try_from(Filter::Eq(
+            "metadata".to_string(),
+            json!({
+                "name": "rig",
+                "flags": { "native": true },
+                "tags": ["surreal", "json"]
+            }),
+        )) {
+            Ok(filter) => filter,
+            Err(err) => panic!("unexpected surreal filter conversion failure: {err}"),
+        };
+
+        let sql = filter.to_string();
+
+        assert!(sql.starts_with("metadata = {"));
+        assert!(sql.contains("name: 'rig'"));
+        assert!(sql.contains("flags: { native: true }"));
+        assert!(sql.contains("tags: ['surreal', 'json']"));
+    }
+
+    #[tokio::test]
+    async fn surreal_vector_store_supports_dynamic_context_filters() {
+        fn assert_dyn<T: VectorStoreIndexDyn + Send + Sync + 'static>(_: T) {}
+
+        let surreal = match Surreal::new::<Mem>(()).await {
+            Ok(surreal) => surreal,
+            Err(err) => panic!("failed to create in-memory surreal client: {err}"),
+        };
+        let vector_store = SurrealVectorStore::with_defaults(MockEmbeddingModel, surreal);
+
+        assert_dyn(vector_store);
     }
 }


### PR DESCRIPTION
Fixes #1644.

## Summary

`dynamic_context(...)` currently does not work with `rig-surrealdb` because the blanket
`VectorStoreIndexDyn` impl in `rig-core` assumes backends whose filter value type is
`serde_json::Value`, while `SurrealSearchFilter` intentionally uses native
`surrealdb::types::Value`.

This PR fixes that incompatibility without changing the public SurrealDB filter API.

## What changed

- kept `SurrealSearchFilter::Value = surrealdb::types::Value`
- added `TryFrom<Filter<serde_json::Value>> for SurrealSearchFilter`
- added an explicit `VectorStoreIndexDyn` impl for `SurrealVectorStore`
  that converts canonical JSON filters with `try_map_filter(SurrealSearchFilter::try_from)`
  before delegating to the native `VectorStoreIndex` implementation
- used SurrealDB’s native `Value::from_t(...)` conversion path instead of a custom JSON-to-Value mapper
- added regression tests for:
  - nested JSON filter conversion
  - dyn compatibility for `SurrealVectorStore`
- added a clearer `vector_store` example with explicit top-hit assertions
- updated SurrealDB example targets to require `rig-core/rustls`, since they call OpenAI

Manually ran:

- `cargo run -p rig-surrealdb --example vector_store --features rig-core/rustls`

The updated example now returns `pasta carbonara` as the expected top hit and
asserts that the thresholded query narrows to that single result.
