### PR TITLE
fix(openai): read Message::Assistant in get_text_response and collect all text blocks

### DIFF
--- a/rig/rig-core/src/providers/openai/completion/mod.rs
+++ b/rig/rig-core/src/providers/openai/completion/mod.rs
@@ -884,15 +884,21 @@ impl ProviderResponseExt for CompletionResponse {
     }
 
     fn get_text_response(&self) -> Option<String> {
-        let Message::User { ref content, .. } = self.choices.last()?.message.clone() else {
+        let Message::Assistant { content, .. } = self.choices.last()?.message.clone() else {
             return None;
         };
 
-        let UserContent::Text { text } = content.first() else {
-            return None;
-        };
+        let texts: Vec<String> = content.iter().filter_map(|c| match c {
+            AssistantContent::Text { text } => Some(text.clone()),
+            AssistantContent::Refusal { refusal } => Some(refusal.clone()),
+            _ => None,
+        }).collect();
 
-        Some(text)
+        if texts.is_empty() {
+            None
+        } else {
+            Some(texts.join("\n"))
+        }
     }
 
     fn get_usage(&self) -> Option<Self::Usage> {


### PR DESCRIPTION
## Bug

The `get_text_response()` method in the OpenAI completion provider incorrectly reads `Message::User` instead of `Message::Assistant`, and only extracts the first text block instead of all text blocks.

## Fix

1. Changed match target from `Message::User` to `Message::Assistant`
2. Iterate through all `AssistantContent` items instead of taking only `content.first()`
3. Extract text from both `Text` and `Refusal` variants (both are valid textual content)
4. Join all text segments with newlines

This aligns `get_text_response()` with the behavior of other providers (e.g., Anthropic) that aggregate all assistant text blocks.

## Testing

The existing `rig-core` tests are verified to pass with this change.