### PR TITLE
streaming: parse multimodal tool outputs in chat-history message

### DIFF
--- a/rig/rig-core/src/agent/prompt_request/streaming.rs
+++ b/rig/rig-core/src/agent/prompt_request/streaming.rs
@@ -159,7 +159,14 @@ fn tool_result_to_user_message(
     call_id: Option<String>,
     tool_result: String,
 ) -> Message {
-    let content = OneOrMany::one(ToolResultContent::text(tool_result));
+    // Use from_tool_output so the chat-history path parses hybrid
+    // {"response", "parts": [...]} / {"parts": [...]} / image JSON
+    // outputs into ToolResultContent variants the same way the
+    // immediate stream yield does (see StreamedUserContent::ToolResult
+    // above).  The old ::text(...) wrapping dumped base64 image data
+    // verbatim into the next turn's context, blowing past provider
+    // token limits on multimodal tool results.
+    let content = ToolResultContent::from_tool_output(tool_result);
     let user_content = match call_id {
         Some(call_id) => UserContent::tool_result_with_call_id(id, call_id, content),
         None => UserContent::tool_result(id, content),


### PR DESCRIPTION
`tool_result_to_user_message` wrapped the entire tool output string as `ToolResultContent::text`, so hybrid outputs like `{"response":..., "parts":[{"type":"image", ...}]}` ended up in chat history as plain text with the full base64 image data. On the next agent turn that blob was tokenized as text and blew past provider context limits (Gemini 1M in the reporter's case).

Use `ToolResultContent::from_tool_output`, which is already what the streaming yield path uses (see `StreamedUserContent::ToolResult` above). It parses hybrid / image JSON into the correct `ToolResultContent` variants so multimodal tool results round-trip through chat history as native image parts.

Fixes #1650