### PR TITLE
fix(openai): correct get_text_response to read assistant role and aggregate all text blocks

### DIFF
--- a/rig/rig-core/src/providers/openai/completion/mod.rs
+++ b/rig/rig-core/src/providers/openai/completion/mod.rs
@@ -884,15 +884,20 @@ impl ProviderResponseExt for CompletionResponse {
     }
 
     fn get_text_response(&self) -> Option<String> {
-        let Message::User { ref content, .. } = self.choices.last()?.message.clone() else {
+        let Message::Assistant { ref content, .. } = self.choices.last()?.message else {
             return None;
         };
 
-        let UserContent::Text { text } = content.first() else {
-            return None;
-        };
+        let text = content
+            .iter()
+            .filter_map(|c| match c {
+                AssistantContent::Text { text } => Some(text.as_str()),
+                AssistantContent::Refusal { refusal } => Some(refusal.as_str()),
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
 
-        Some(text)
+        if text.is_empty() { None } else { Some(text) }
     }
 
     fn get_usage(&self) -> Option<Self::Usage> {
@@ -1749,6 +1754,73 @@ mod tests {
         assert_eq!(
             tool_calls[0].function.arguments,
             serde_json::json!({"city": "Paris"})
+        );
+    }
+
+    #[test]
+    fn get_text_response_returns_assistant_text() {
+        let raw = r#"{
+            "choices": [{
+                "finish_reason": "stop",
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "Hello, world!"}]
+                }
+            }],
+            "created": 0,
+            "model": "gpt-4o-mini",
+            "system_fingerprint": null,
+            "object": "chat.completion",
+            "usage": { "completion_tokens": 5, "prompt_tokens": 10, "total_tokens": 15 },
+            "id": "chatcmpl-test"
+        }"#;
+
+        let ApiResponse::Ok(response) =
+            serde_json::from_str::<ApiResponse<CompletionResponse>>(raw).unwrap()
+        else {
+            panic!("expected successful response");
+        };
+
+        use crate::telemetry::ProviderResponseExt;
+        assert_eq!(
+            response.get_text_response(),
+            Some("Hello, world!".to_string())
+        );
+    }
+
+    #[test]
+    fn get_text_response_aggregates_multiple_text_blocks() {
+        let raw = r#"{
+            "choices": [{
+                "finish_reason": "stop",
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "First part."},
+                        {"type": "text", "text": "Second part."}
+                    ]
+                }
+            }],
+            "created": 0,
+            "model": "gpt-4o-mini",
+            "system_fingerprint": null,
+            "object": "chat.completion",
+            "usage": { "completion_tokens": 10, "prompt_tokens": 10, "total_tokens": 20 },
+            "id": "chatcmpl-test"
+        }"#;
+
+        let ApiResponse::Ok(response) =
+            serde_json::from_str::<ApiResponse<CompletionResponse>>(raw).unwrap()
+        else {
+            panic!("expected successful response");
+        };
+
+        use crate::telemetry::ProviderResponseExt;
+        assert_eq!(
+            response.get_text_response(),
+            Some("First part.\nSecond part.".to_string())
         );
     }
 }


### PR DESCRIPTION
Fixes #1602

## Problem

`ProviderResponseExt::get_text_response()` in the OpenAI Chat Completions provider had two bugs:

1. **Wrong role match**: It matched `Message::User` on the response message. Since OpenAI returns the assistant reply as `Message::Assistant`, this always returned `None` for real provider responses.
2. **Truncated output**: It returned only the first text content item, so multi-part assistant replies would be silently truncated even if the role check were corrected.

This made the OpenAI `ProviderResponseExt` behavior inconsistent with:
- The provider's own main response conversion path (which correctly handles `Message::Assistant`)
- Other providers such as Anthropic, which aggregate all assistant text blocks

## Solution

- Match `Message::Assistant` instead of `Message::User`
- Collect all `Text` and `Refusal` content blocks (mirroring the pattern in the Anthropic provider)
- Join segments with `"\n"`
- Return `None` only when there is no textual content at all

## Testing

Two new unit tests cover the fixed behavior:

- `get_text_response_returns_assistant_text` — verifies the correct role is matched
- `get_text_response_aggregates_multiple_text_blocks` — verifies all text blocks are collected

All 13 unit tests in `providers::openai::completion::tests` pass.

> Note: This PR was generated with AI assistance. The fix, tests, and correctness have been verified.