### PR TITLE
feat(lancedb): implement InsertDocuments for LanceDbVectorIndex

### DIFF
--- a/rig-integrations/rig-lancedb/Cargo.toml
+++ b/rig-integrations/rig-lancedb/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 lancedb = { workspace = true }
 rig-core = { path = "../../rig/rig-core", version = "0.35.0", default-features = false }
 arrow-array = { workspace = true }
+arrow-json = "56"
 serde_json = { workspace = true }
 serde = { workspace = true }
 futures = { workspace = true }

--- a/rig-integrations/rig-lancedb/src/lib.rs
+++ b/rig-integrations/rig-lancedb/src/lib.rs
@@ -1,17 +1,25 @@
 use std::ops::Range;
+use std::sync::Arc;
 
+use arrow_array::{
+    ArrayRef, FixedSizeListArray, RecordBatch, RecordBatchIterator,
+    types::{Float32Type, Float64Type},
+};
+use arrow_json::ReaderBuilder;
 use lancedb::{
     DistanceType,
+    arrow::arrow_schema::{DataType, Field, Fields, Schema},
     query::{QueryBase, VectorQuery},
 };
 use rig::{
-    embeddings::embedding::EmbeddingModel,
+    Embed, OneOrMany,
+    embeddings::{Embedding, embedding::EmbeddingModel},
     vector_store::{
-        VectorStoreError, VectorStoreIndex,
+        InsertDocuments, VectorStoreError, VectorStoreIndex,
         request::{FilterError, SearchFilter, VectorSearchRequest},
     },
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use utils::{FilterTableColumns, QueryToJson};
 
@@ -23,6 +31,10 @@ fn lancedb_to_rig_error(e: lancedb::Error) -> VectorStoreError {
 
 fn serde_to_rig_error(e: serde_json::Error) -> VectorStoreError {
     VectorStoreError::JsonError(e)
+}
+
+fn arrow_to_rig_error(e: lancedb::arrow::arrow_schema::ArrowError) -> VectorStoreError {
+    VectorStoreError::DatastoreError(Box::new(e))
 }
 
 /// Type on which vector searches can be performed for a lanceDb table.
@@ -107,6 +119,50 @@ where
         }
 
         query
+    }
+
+    /// Resolve the embedding column name from `search_params.column` or by
+    /// auto-detecting the single `FixedSizeList<Float32|Float64>` column in the
+    /// table schema (mirroring LanceDB's default vector-column inference).
+    fn resolve_embedding_column(
+        &self,
+        schema: &Schema,
+    ) -> Result<String, VectorStoreError> {
+        if let Some(col) = &self.search_params.column {
+            return Ok(col.clone());
+        }
+
+        let candidates: Vec<&str> = schema
+            .fields()
+            .iter()
+            .filter(|f| {
+                matches!(
+                    f.data_type(),
+                    DataType::FixedSizeList(inner, _)
+                        if matches!(
+                            inner.data_type(),
+                            DataType::Float32 | DataType::Float64
+                        )
+                )
+            })
+            .map(|f| f.name().as_str())
+            .collect();
+
+        match candidates.as_slice() {
+            [only] => Ok((*only).to_string()),
+            [] => Err(VectorStoreError::DatastoreError(
+                "no FixedSizeList<Float32|Float64> column found in table schema; \
+                 set SearchParams::column to specify the embedding column"
+                    .into(),
+            )),
+            _ => Err(VectorStoreError::DatastoreError(
+                format!(
+                    "multiple FixedSizeList columns found ({candidates:?}); \
+                     set SearchParams::column to disambiguate"
+                )
+                .into(),
+            )),
+        }
     }
 }
 
@@ -476,5 +532,182 @@ where
                 ))
             })
             .collect()
+    }
+}
+
+/// Implement the `InsertDocuments` trait for `LanceDbVectorIndex` so callers can
+/// push `(Doc, OneOrMany<Embedding>)` pairs directly into the backing table
+/// without hand-building Arrow `RecordBatch`es.
+///
+/// Behaviour:
+/// - Each embedding produces one row: the document fields are flattened onto
+///   that row (or stored under a `document` field if the serialized doc is not
+///   a JSON object), and the embedding vector is written to the table's
+///   `FixedSizeList<Float32|Float64>` column.
+/// - The embedding column is taken from `SearchParams::column` if set; otherwise
+///   it is auto-detected as the sole `FixedSizeList<Float32|Float64>` column in
+///   the table schema (same default LanceDB uses for search).
+/// - Doc JSON fields that are absent from the table schema are silently dropped
+///   by the Arrow JSON decoder. Rows should be consistent with the schema the
+///   table was created with.
+impl<M> InsertDocuments for LanceDbVectorIndex<M>
+where
+    M: EmbeddingModel + Sync + Send,
+{
+    async fn insert_documents<Doc: Serialize + Embed + Send>(
+        &self,
+        documents: Vec<(Doc, OneOrMany<Embedding>)>,
+    ) -> Result<(), VectorStoreError> {
+        if documents.is_empty() {
+            return Ok(());
+        }
+
+        let table_schema: Arc<Schema> =
+            self.table.schema().await.map_err(lancedb_to_rig_error)?;
+        let embedding_column = self.resolve_embedding_column(&table_schema)?;
+
+        // Extract embedding field + its vector datatype + dims.
+        let embedding_field = table_schema
+            .field_with_name(&embedding_column)
+            .map_err(arrow_to_rig_error)?
+            .clone();
+        let (embedding_inner_dtype, embedding_dims) = match embedding_field.data_type() {
+            DataType::FixedSizeList(inner, dims) => (inner.data_type().clone(), *dims),
+            _ => {
+                return Err(VectorStoreError::DatastoreError(
+                    format!(
+                        "embedding column `{embedding_column}` is not a FixedSizeList"
+                    )
+                    .into(),
+                ));
+            }
+        };
+
+        // Build a schema for the non-embedding columns. We decode the JSON rows
+        // against this schema, then splice the embedding column back in.
+        let non_embedding_fields: Vec<Arc<Field>> = table_schema
+            .fields()
+            .iter()
+            .filter(|f| f.name() != &embedding_column)
+            .cloned()
+            .collect();
+        let non_embedding_schema = Arc::new(Schema::new(Fields::from(
+            non_embedding_fields.clone(),
+        )));
+
+        // Flatten (Doc, OneOrMany<Embedding>) into parallel vectors of
+        // JSON doc-rows and embedding vectors (one row per embedding).
+        let mut json_rows: Vec<Value> = Vec::new();
+        let mut embedding_vecs: Vec<Vec<f64>> = Vec::new();
+
+        for (doc, embeddings) in documents {
+            let doc_value = serde_json::to_value(&doc).map_err(serde_to_rig_error)?;
+            for embedding in embeddings.into_iter() {
+                let row = match &doc_value {
+                    Value::Object(_) => doc_value.clone(),
+                    other => {
+                        let mut map = serde_json::Map::new();
+                        map.insert("document".to_string(), other.clone());
+                        Value::Object(map)
+                    }
+                };
+                json_rows.push(row);
+                if embedding.vec.len() != embedding_dims as usize {
+                    return Err(VectorStoreError::DatastoreError(
+                        format!(
+                            "embedding dim mismatch: got {} expected {} \
+                             for column `{embedding_column}`",
+                            embedding.vec.len(),
+                            embedding_dims
+                        )
+                        .into(),
+                    ));
+                }
+                embedding_vecs.push(embedding.vec);
+            }
+        }
+
+        if json_rows.is_empty() {
+            return Ok(());
+        }
+
+        // Decode JSON rows into Arrow columns matching non-embedding schema.
+        let mut decoder = ReaderBuilder::new(non_embedding_schema.clone())
+            .build_decoder()
+            .map_err(arrow_to_rig_error)?;
+        decoder.serialize(&json_rows).map_err(arrow_to_rig_error)?;
+        let partial_batch = decoder
+            .flush()
+            .map_err(arrow_to_rig_error)?
+            .ok_or_else(|| {
+                VectorStoreError::DatastoreError(
+                    "arrow-json decoder produced no batch".into(),
+                )
+            })?;
+
+        // Build the embedding column as FixedSizeList<Float32|Float64>.
+        let embedding_array: ArrayRef = match embedding_inner_dtype {
+            DataType::Float64 => Arc::new(FixedSizeListArray::from_iter_primitive::<
+                Float64Type,
+                _,
+                _,
+            >(
+                embedding_vecs
+                    .iter()
+                    .map(|v| Some(v.iter().copied().map(Some).collect::<Vec<_>>()))
+                    .collect::<Vec<_>>(),
+                embedding_dims,
+            )),
+            DataType::Float32 => Arc::new(FixedSizeListArray::from_iter_primitive::<
+                Float32Type,
+                _,
+                _,
+            >(
+                embedding_vecs
+                    .iter()
+                    .map(|v| {
+                        Some(
+                            v.iter()
+                                .map(|x| Some(*x as f32))
+                                .collect::<Vec<_>>(),
+                        )
+                    })
+                    .collect::<Vec<_>>(),
+                embedding_dims,
+            )),
+            other => {
+                return Err(VectorStoreError::DatastoreError(
+                    format!(
+                        "unsupported embedding inner dtype `{other:?}`; \
+                         expected Float32 or Float64"
+                    )
+                    .into(),
+                ));
+            }
+        };
+
+        // Stitch columns back together in the order the table schema expects.
+        let mut columns: Vec<ArrayRef> = Vec::with_capacity(table_schema.fields().len());
+        for field in table_schema.fields() {
+            if field.name() == &embedding_column {
+                columns.push(embedding_array.clone());
+            } else {
+                let idx = non_embedding_schema
+                    .index_of(field.name())
+                    .map_err(arrow_to_rig_error)?;
+                columns.push(partial_batch.column(idx).clone());
+            }
+        }
+
+        let batch = RecordBatch::try_new(table_schema.clone(), columns)
+            .map_err(arrow_to_rig_error)?;
+
+        self.table
+            .add(RecordBatchIterator::new(vec![Ok(batch)], table_schema))
+            .execute()
+            .await
+            .map_err(lancedb_to_rig_error)?;
+
+        Ok(())
     }
 }

--- a/rig-integrations/rig-lancedb/tests/integration_tests.rs
+++ b/rig-integrations/rig-lancedb/tests/integration_tests.rs
@@ -9,7 +9,7 @@ use rig::{
     embeddings::{EmbeddingModel, EmbeddingsBuilder},
     prelude::CompletionClient,
     providers::openai,
-    vector_store::{VectorStoreIndex, request::VectorSearchRequest},
+    vector_store::{InsertDocuments, VectorStoreIndex, request::VectorSearchRequest},
 };
 use rig_lancedb::{LanceDbVectorIndex, SearchParams};
 use std::sync::Arc;
@@ -407,6 +407,131 @@ async fn agent_with_dynamic_context_test() {
 
     assert!(response.contains("zindle") || response.contains("pretend to be working"));
     assert!(response.contains("important") || response.contains("unproductive"));
+
+    db.drop_table(table_name, &[]).await.unwrap();
+}
+
+#[tokio::test]
+async fn insert_documents_round_trip() {
+    // Setup mock openai API with embeddings for both the initial seed row and
+    // the batch that will be inserted via InsertDocuments. We don't assert the
+    // specific payload here because ordering of calls depends on how the
+    // EmbeddingsBuilder chunks requests; we just return a fixed embedding.
+    let server = httpmock::MockServer::start();
+
+    server.mock(|when, then| {
+        when.method(httpmock::Method::POST)
+            .path("/embeddings")
+            .header("Authorization", "Bearer TEST");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "object": "list",
+                "data": [
+                    {
+                        "object": "embedding",
+                        "embedding": vec![0.0023064254; 1536],
+                        "index": 0
+                    }
+                ],
+                "model": "text-embedding-ada-002",
+                "usage": { "prompt_tokens": 8, "total_tokens": 8 }
+            }));
+    });
+
+    let openai_client = openai::Client::builder()
+        .api_key("TEST")
+        .base_url(server.base_url())
+        .build()
+        .unwrap();
+    let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_ADA_002);
+
+    let db = lancedb::connect("data/lancedb-insert-docs")
+        .execute()
+        .await
+        .unwrap();
+
+    // Seed the table with a single row so we have a concrete Arrow schema
+    // in place; InsertDocuments will then append against that schema.
+    let seed_embeddings = EmbeddingsBuilder::new(model.clone())
+        .documents(vec![Word {
+            id: "seed".to_string(),
+            definition: "seed row".to_string(),
+        }])
+        .unwrap()
+        .build()
+        .await
+        .unwrap();
+
+    let table_name = "insert_docs_test";
+    if db
+        .table_names()
+        .execute()
+        .await
+        .unwrap()
+        .contains(&table_name.to_string())
+    {
+        db.drop_table(table_name, &[]).await.unwrap();
+    }
+    let table = db
+        .create_table(
+            table_name,
+            RecordBatchIterator::new(
+                vec![as_record_batch(seed_embeddings, model.ndims())],
+                Arc::new(schema(model.ndims())),
+            ),
+        )
+        .execute()
+        .await
+        .unwrap();
+
+    let initial_rows = table.count_rows(None).await.unwrap();
+    assert_eq!(initial_rows, 1);
+
+    // Build an index and insert two new documents via the trait under test.
+    let vector_store_index =
+        LanceDbVectorIndex::new(table, model.clone(), "id", SearchParams::default())
+            .await
+            .unwrap();
+
+    let new_docs = EmbeddingsBuilder::new(model.clone())
+        .documents(vec![
+            Word {
+                id: "inserted-1".to_string(),
+                definition: "first inserted row".to_string(),
+            },
+            Word {
+                id: "inserted-2".to_string(),
+                definition: "second inserted row".to_string(),
+            },
+        ])
+        .unwrap()
+        .build()
+        .await
+        .unwrap();
+
+    vector_store_index.insert_documents(new_docs).await.unwrap();
+
+    // Round-trip: re-open the table and verify the row count grew by 2.
+    let table_after = db.open_table(table_name).execute().await.unwrap();
+    let after_rows = table_after.count_rows(None).await.unwrap();
+    assert_eq!(after_rows, 3, "expected 1 seed + 2 inserted rows");
+
+    // And verify the inserted ids are actually present via a filtered search.
+    let req = VectorSearchRequest::builder()
+        .query("anything")
+        .samples(5)
+        .build();
+    let results = vector_store_index
+        .top_n::<serde_json::Value>(req)
+        .await
+        .unwrap();
+    let ids: Vec<String> = results
+        .iter()
+        .map(|(_, id, _)| id.clone())
+        .collect();
+    assert!(ids.contains(&"inserted-1".to_string()), "ids = {ids:?}");
+    assert!(ids.contains(&"inserted-2".to_string()), "ids = {ids:?}");
 
     db.drop_table(table_name, &[]).await.unwrap();
 }


### PR DESCRIPTION
## Summary

Implements the `InsertDocuments` trait for `LanceDbVectorIndex`, matching the existing implementations for MongoDB / Postgres / Qdrant / Milvus / ScyllaDB / SurrealDB / HelixDB / S3 Vectors / SQLite. LanceDB was one of only two integrations still missing this trait (Neo4j is the other, and is covered by #1636).

Before this PR, users had to hand-build Arrow `RecordBatch`es to insert data into LanceDB; they can now do:

```rust
let index = LanceDbVectorIndex::new(table, model, "id", SearchParams::default()).await?;
let docs = EmbeddingsBuilder::new(model).documents(my_docs)?.build().await?;
index.insert_documents(docs).await?;
```

### Behaviour

- Each `Embedding` produces one row. Document fields are flattened onto that row (or stored under a `document` field when the serialized doc is not a JSON object), and the embedding vector goes into the table's `FixedSizeList<Float32|Float64>` column.
- The embedding column is taken from `SearchParams::column` when set; otherwise it is auto-detected as the sole `FixedSizeList<Float32|Float64>` column in the table schema (the same default LanceDB uses for search column inference). An explicit error is returned when zero or multiple candidate columns exist.
- Supports both `Float32` and `Float64` embedding columns; embedding dimensionality is validated against the schema before the write is attempted.
- Uses `arrow_json::ReaderBuilder::build_decoder().serialize(&rows)` to decode serialized docs against the non-embedding portion of the schema, then splices the embedding column back in to produce a batch that matches the full table schema. This avoids having to reimplement per-column Arrow conversion for every scalar type.

### Implementation notes

- Added `arrow-json = "56"` as a dependency (aligned with the workspace's `arrow-array = "56"`).
- No public API change to `LanceDbVectorIndex` / `SearchParams`; the trait impl reads the embedding column name from existing config.
- `RecordBatchIterator` + `Table::add(...).execute()` is used for the write (same API pattern the examples already use for initial table creation).

## Test plan

Added `insert_documents_round_trip` to `tests/integration_tests.rs`:

- Seeds a LanceDB table with one row using the existing fixture schema (id, definition, embedding as `FixedSizeList<Float64, 1536>`).
- Calls `InsertDocuments::insert_documents` with two fresh `(Word, Embeddings)` pairs driven by a mocked OpenAI embeddings endpoint.
- Asserts that `Table::count_rows()` grows from 1 to 3 after the insert.
- Asserts that the two new ids (`inserted-1`, `inserted-2`) are returned by `top_n` via the same `VectorStoreIndex` handle — proving that the rows were written to the correct columns and the embedding column was populated with a valid FSL vector.

- [x] New integration test added and covers the happy path.
- [ ] `cargo check -p rig-lancedb` / `cargo test -p rig-lancedb --test integration_tests` — unable to run locally (host disk full); happy to rebase / adjust on CI feedback.

---

— [kcolbchain](https://kcolbchain.com) / [Abhishek Krishna](https://abhishekkrishna.com)