### PR TITLE
fix(anthropic): handle empty end_turn responses after tools

### DIFF
--- a/rig/rig-core/src/agent/prompt_request/mod.rs
+++ b/rig/rig-core/src/agent/prompt_request/mod.rs
@@ -302,6 +302,14 @@ fn build_full_history(
     input.iter().cloned().chain(new_messages).collect()
 }
 
+fn is_empty_assistant_turn(choice: &OneOrMany<AssistantContent>) -> bool {
+    choice.len() == 1
+        && matches!(
+            choice.first(),
+            AssistantContent::Text(text) if text.text.is_empty()
+        )
+}
+
 impl<M, P> PromptRequest<Extended, M, P>
 where
     M: CompletionModel,
@@ -452,10 +460,15 @@ where
                 .iter()
                 .partition(|choice| matches!(choice, AssistantContent::ToolCall(_)));
 
-            new_messages.push(Message::Assistant {
-                id: resp.message_id.clone(),
-                content: resp.choice.clone(),
-            });
+            // Some providers normalize textless terminal turns into a single empty text item
+            // because the generic completion response cannot represent an empty choice. Treat
+            // that sentinel as "no assistant output" so it does not pollute returned history.
+            if !is_empty_assistant_turn(&resp.choice) {
+                new_messages.push(Message::Assistant {
+                    id: resp.message_id.clone(),
+                    content: resp.choice.clone(),
+                });
+            }
 
             if tool_calls.is_empty() {
                 let merged_texts = texts
@@ -829,8 +842,22 @@ where
 #[cfg(test)]
 mod tests {
     use super::TypedPromptResponse;
-    use crate::completion::Usage;
+    use crate::{
+        OneOrMany,
+        agent::AgentBuilder,
+        completion::{
+            AssistantContent, CompletionError, CompletionModel, CompletionRequest,
+            CompletionResponse, Message, Prompt, Usage,
+        },
+        message::UserContent,
+        streaming::StreamingCompletionResponse,
+    };
     use serde::{Deserialize, Serialize};
+    use serde_json::json;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
 
     #[derive(Serialize)]
     struct SerializeOnly {
@@ -870,5 +897,170 @@ mod tests {
         assert_eq!(response.usage.input_tokens, 1);
         assert_eq!(response.usage.output_tokens, 2);
         assert_eq!(response.usage.total_tokens, 3);
+    }
+
+    fn validate_follow_up_tool_history(request: &CompletionRequest) {
+        let history = request.chat_history.iter().cloned().collect::<Vec<_>>();
+        assert_eq!(
+            history.len(),
+            3,
+            "follow-up request should contain the prompt, assistant tool call, and user tool result: {history:?}"
+        );
+
+        assert!(matches!(
+            history.first(),
+            Some(Message::User { content })
+                if matches!(
+                    content.first(),
+                    UserContent::Text(text) if text.text == "do tool work"
+                )
+        ));
+
+        assert!(matches!(
+            history.get(1),
+            Some(Message::Assistant { content, .. })
+                if matches!(
+                    content.first(),
+                    AssistantContent::ToolCall(tool_call)
+                        if tool_call.id == "tool_call_1"
+                            && tool_call.call_id.as_deref() == Some("call_1")
+                )
+        ));
+
+        assert!(matches!(
+            history.get(2),
+            Some(Message::User { content })
+                if matches!(
+                    content.first(),
+                    UserContent::ToolResult(tool_result)
+                        if tool_result.id == "tool_call_1"
+                            && tool_result.call_id.as_deref() == Some("call_1")
+                )
+        ));
+    }
+
+    #[derive(Clone, Default)]
+    struct EmptyFinalTurnMockModel {
+        turn_counter: Arc<AtomicUsize>,
+    }
+
+    #[allow(refining_impl_trait)]
+    impl CompletionModel for EmptyFinalTurnMockModel {
+        type Response = ();
+        type StreamingResponse = ();
+        type Client = ();
+
+        fn make(_: &Self::Client, _: impl Into<String>) -> Self {
+            Self::default()
+        }
+
+        async fn completion(
+            &self,
+            request: CompletionRequest,
+        ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+            let turn = self.turn_counter.fetch_add(1, Ordering::SeqCst);
+
+            let choice = if turn == 0 {
+                OneOrMany::one(AssistantContent::tool_call_with_call_id(
+                    "tool_call_1",
+                    "call_1".to_string(),
+                    "missing_tool",
+                    json!({"input": "value"}),
+                ))
+            } else {
+                validate_follow_up_tool_history(&request);
+                OneOrMany::one(AssistantContent::text(""))
+            };
+
+            Ok(CompletionResponse {
+                choice,
+                usage: Usage {
+                    input_tokens: 1,
+                    output_tokens: 1,
+                    total_tokens: 2,
+                    cached_input_tokens: 0,
+                    cache_creation_input_tokens: 0,
+                },
+                raw_response: (),
+                message_id: None,
+            })
+        }
+
+        async fn stream(
+            &self,
+            _request: CompletionRequest,
+        ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+            Err(CompletionError::ProviderError(
+                "stream is unused in this non-streaming test".to_string(),
+            ))
+        }
+    }
+
+    #[tokio::test]
+    async fn prompt_request_stops_cleanly_on_empty_terminal_turn() {
+        let model = EmptyFinalTurnMockModel::default();
+        let turn_counter = model.turn_counter.clone();
+        let agent = AgentBuilder::new(model).build();
+
+        let response = agent
+            .prompt("do tool work")
+            .max_turns(3)
+            .extended_details()
+            .await
+            .expect("empty terminal turn should not error");
+
+        assert!(response.output.is_empty());
+        assert_eq!(
+            response.usage,
+            Usage {
+                input_tokens: 2,
+                output_tokens: 2,
+                total_tokens: 4,
+                cached_input_tokens: 0,
+                cache_creation_input_tokens: 0,
+            }
+        );
+
+        let history = response
+            .messages
+            .expect("extended response should include history");
+        assert_eq!(history.len(), 3);
+        assert!(matches!(
+            history.first(),
+            Some(Message::User { content })
+                if matches!(
+                    content.first(),
+                    UserContent::Text(text) if text.text == "do tool work"
+                )
+        ));
+        assert!(history.iter().any(|message| matches!(
+            message,
+            Message::Assistant { content, .. }
+                if matches!(
+                    content.first(),
+                    AssistantContent::ToolCall(tool_call)
+                        if tool_call.id == "tool_call_1"
+                            && tool_call.call_id.as_deref() == Some("call_1")
+                )
+        )));
+        assert!(history.iter().any(|message| matches!(
+            message,
+            Message::User { content }
+                if matches!(
+                    content.first(),
+                    UserContent::ToolResult(tool_result)
+                        if tool_result.id == "tool_call_1"
+                            && tool_result.call_id.as_deref() == Some("call_1")
+                )
+        )));
+        assert!(!history.iter().any(|message| matches!(
+            message,
+            Message::Assistant { content, .. }
+                if content.iter().any(|item| matches!(
+                    item,
+                    AssistantContent::Text(text) if text.text.is_empty()
+                ))
+        )));
+        assert_eq!(turn_counter.load(Ordering::SeqCst), 2);
     }
 }

--- a/rig/rig-core/src/providers/anthropic/completion.rs
+++ b/rig/rig-core/src/providers/anthropic/completion.rs
@@ -31,6 +31,7 @@ pub const CLAUDE_HAIKU_4_5: &str = "claude-haiku-4-5";
 pub const ANTHROPIC_VERSION_2023_01_01: &str = "2023-01-01";
 pub const ANTHROPIC_VERSION_2023_06_01: &str = "2023-06-01";
 pub const ANTHROPIC_VERSION_LATEST: &str = ANTHROPIC_VERSION_2023_06_01;
+const EMPTY_RESPONSE_ERROR: &str = "Response contained no message or tool call (empty)";
 
 pub trait AnthropicCompatibleProvider: Provider {
     const PROVIDER_NAME: &'static str;
@@ -214,11 +215,21 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             .map(|content| content.clone().try_into())
             .collect::<Result<Vec<_>, _>>()?;
 
-        let choice = OneOrMany::many(content).map_err(|_| {
-            CompletionError::ResponseError(
-                "Response contained no message or tool call (empty)".to_owned(),
-            )
-        })?;
+        let choice = if content.is_empty() {
+            // Anthropic documents empty `end_turn` responses after tool-result round trips.
+            // The generic completion response still requires at least one assistant item, so
+            // normalize that terminal no-op into the same empty-text sentinel used by streaming.
+            if response.stop_reason.as_deref() == Some("end_turn") {
+                OneOrMany::one(completion::AssistantContent::text(""))
+            } else {
+                return Err(CompletionError::ResponseError(
+                    EMPTY_RESPONSE_ERROR.to_owned(),
+                ));
+            }
+        } else {
+            OneOrMany::many(content)
+                .map_err(|_| CompletionError::ResponseError(EMPTY_RESPONSE_ERROR.to_owned()))?
+        };
 
         let usage = completion::Usage {
             input_tokens: response.usage.input_tokens,
@@ -2290,6 +2301,60 @@ mod tests {
         assert!(matches!(
             converted_content.first(),
             Some(Content::RedactedThinking { data }) if data == "ciphertext"
+        ));
+    }
+
+    #[test]
+    fn empty_end_turn_response_normalizes_to_empty_text_choice() {
+        let response = CompletionResponse {
+            content: vec![],
+            id: "msg_123".to_string(),
+            model: CLAUDE_SONNET_4_6.to_string(),
+            role: "assistant".to_string(),
+            stop_reason: Some("end_turn".to_string()),
+            stop_sequence: None,
+            usage: Usage {
+                input_tokens: 7,
+                cache_read_input_tokens: None,
+                cache_creation_input_tokens: None,
+                output_tokens: 2,
+            },
+        };
+
+        let parsed: completion::CompletionResponse<CompletionResponse> = response
+            .try_into()
+            .expect("empty end_turn should not error");
+
+        assert_eq!(parsed.choice.len(), 1);
+        assert!(matches!(
+            parsed.choice.first(),
+            completion::AssistantContent::Text(text) if text.text.is_empty()
+        ));
+    }
+
+    #[test]
+    fn empty_non_end_turn_response_still_errors() {
+        let response = CompletionResponse {
+            content: vec![],
+            id: "msg_123".to_string(),
+            model: CLAUDE_SONNET_4_6.to_string(),
+            role: "assistant".to_string(),
+            stop_reason: Some("tool_use".to_string()),
+            stop_sequence: None,
+            usage: Usage {
+                input_tokens: 7,
+                cache_read_input_tokens: None,
+                cache_creation_input_tokens: None,
+                output_tokens: 2,
+            },
+        };
+
+        let err = completion::CompletionResponse::<CompletionResponse>::try_from(response)
+            .expect_err("empty non-end_turn should remain an error");
+
+        assert!(matches!(
+            err,
+            CompletionError::ResponseError(message) if message == EMPTY_RESPONSE_ERROR
         ));
     }
 }

--- a/rig/rig-core/tests/anthropic/empty_end_turn.rs
+++ b/rig/rig-core/tests/anthropic/empty_end_turn.rs
@@ -1,0 +1,283 @@
+//! Anthropic live regression coverage for empty `end_turn` tool follow-ups.
+//!
+//! Run only these ignored cases with:
+//! `cargo test -p rig-core --test anthropic anthropic::empty_end_turn -- --ignored --nocapture --test-threads=1`
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
+use rig::{
+    client::{CompletionClient, ProviderClient},
+    completion::{CompletionModel, Prompt, ToolDefinition},
+    message::{AssistantContent, Message, UserContent},
+    providers::anthropic::{self, completion::CLAUDE_SONNET_4_6},
+    tool::Tool,
+};
+use serde::Deserialize;
+use serde_json::json;
+
+const TERMINAL_NOTIFY_PREAMBLE: &str = "\
+When the user reports their status, call `notify` with a short summary. \
+Do not answer with any normal assistant text before or after the tool call. \
+Once the tool result is available, the assistant turn is complete and you must end the turn with no content.";
+
+const TERMINAL_NOTIFY_WITH_ACK_PREAMBLE: &str = "\
+When the user reports their status, first write one short sentence acknowledging that you are sending the notification. \
+Then call `notify` with a short summary. \
+After the tool result is available, stop immediately and do not send any more assistant text.";
+
+const TERMINAL_NOTIFY_PROMPT: &str = "I finished the deploy.";
+
+#[derive(Deserialize)]
+struct NotifyArgs {
+    msg: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("notify error")]
+struct NotifyError;
+
+fn notify_tool_definition() -> ToolDefinition {
+    ToolDefinition {
+        name: Notify::NAME.to_string(),
+        description: "Send a short notification for a user status update.".to_string(),
+        parameters: json!({
+            "type": "object",
+            "properties": {
+                "msg": {
+                    "type": "string",
+                    "description": "The short notification to send."
+                }
+            },
+            "required": ["msg"]
+        }),
+    }
+}
+
+struct Notify {
+    call_count: Arc<AtomicUsize>,
+}
+
+impl Notify {
+    fn new(call_count: Arc<AtomicUsize>) -> Self {
+        Self { call_count }
+    }
+}
+
+impl Tool for Notify {
+    const NAME: &'static str = "notify";
+    type Error = NotifyError;
+    type Args = NotifyArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        notify_tool_definition()
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        self.call_count.fetch_add(1, Ordering::SeqCst);
+        Ok(format!("sent: {}", args.msg))
+    }
+}
+
+fn assistant_message_has_notify_tool_call(message: &Message) -> bool {
+    matches!(
+        message,
+        Message::Assistant { content, .. }
+            if content.iter().any(|item| matches!(
+                item,
+                AssistantContent::ToolCall(tool_call) if tool_call.function.name == Notify::NAME
+            ))
+    )
+}
+
+fn assistant_message_has_nonempty_text_and_notify_tool_call(message: &Message) -> bool {
+    matches!(
+        message,
+        Message::Assistant { content, .. }
+            if content.iter().any(|item| matches!(
+                item,
+                AssistantContent::Text(text) if !text.text.trim().is_empty()
+            )) && content.iter().any(|item| matches!(
+                item,
+                AssistantContent::ToolCall(tool_call) if tool_call.function.name == Notify::NAME
+            ))
+    )
+}
+
+fn message_has_tool_result(message: &Message) -> bool {
+    matches!(
+        message,
+        Message::User { content }
+            if content.iter().any(|item| matches!(item, UserContent::ToolResult(_)))
+    )
+}
+
+fn history_has_empty_assistant_text(messages: &[Message]) -> bool {
+    messages.iter().any(|message| {
+        matches!(
+            message,
+            Message::Assistant { content, .. }
+                if content.iter().any(|item| matches!(
+                    item,
+                    AssistantContent::Text(text) if text.text.is_empty()
+                ))
+        )
+    })
+}
+
+#[tokio::test]
+#[ignore = "requires ANTHROPIC_API_KEY"]
+async fn raw_followup_empty_end_turn_normalizes_to_empty_text_choice() {
+    let model = anthropic::Client::from_env().completion_model(CLAUDE_SONNET_4_6);
+
+    let first_turn = model
+        .completion_request(TERMINAL_NOTIFY_PROMPT)
+        .preamble(TERMINAL_NOTIFY_PREAMBLE.to_string())
+        .max_tokens(1024)
+        .tool(notify_tool_definition())
+        .send()
+        .await
+        .expect("first Anthropic turn should succeed");
+
+    let tool_call = first_turn
+        .choice
+        .iter()
+        .find_map(|item| match item {
+            AssistantContent::ToolCall(tool_call) => Some(tool_call.clone()),
+            _ => None,
+        })
+        .expect("first Anthropic turn should emit a notify tool call");
+
+    let followup = model
+        .completion_request(Message::tool_result_with_call_id(
+            tool_call.id.clone(),
+            tool_call.call_id.clone(),
+            "sent: deploy finished",
+        ))
+        .preamble(TERMINAL_NOTIFY_PREAMBLE.to_string())
+        .max_tokens(1024)
+        .message(Message::Assistant {
+            id: first_turn.message_id.clone(),
+            content: first_turn.choice.clone(),
+        })
+        .send()
+        .await
+        .expect("follow-up Anthropic turn should not error on empty end_turn");
+
+    assert_eq!(
+        followup.choice.len(),
+        1,
+        "expected normalized empty follow-up choice, got {:?}",
+        followup.choice
+    );
+
+    match followup.choice.first() {
+        AssistantContent::Text(text) => assert!(
+            text.text.is_empty(),
+            "expected empty follow-up text sentinel, got {:?}",
+            text.text
+        ),
+        other => panic!("expected empty text sentinel, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires ANTHROPIC_API_KEY"]
+async fn prompt_loop_accepts_empty_terminal_turn_after_tool_result() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let agent = anthropic::Client::from_env()
+        .agent(CLAUDE_SONNET_4_6)
+        .preamble(TERMINAL_NOTIFY_PREAMBLE)
+        .max_tokens(1024)
+        .tool(Notify::new(call_count.clone()))
+        .build();
+
+    let response = agent
+        .prompt(TERMINAL_NOTIFY_PROMPT)
+        .max_turns(5)
+        .extended_details()
+        .await
+        .expect("agent prompt should not fail on an empty terminal Anthropic turn");
+
+    assert!(
+        response.output.trim().is_empty(),
+        "expected empty final output for the terminal tool prompt, got {:?}",
+        response.output
+    );
+    assert!(
+        call_count.load(Ordering::SeqCst) >= 1,
+        "notify should be called at least once"
+    );
+
+    let messages = response
+        .messages
+        .expect("extended details should include history");
+    assert!(
+        messages.iter().any(assistant_message_has_notify_tool_call),
+        "expected notify tool call in history, got {:?}",
+        messages
+    );
+    assert!(
+        messages.iter().any(message_has_tool_result),
+        "expected tool result in history, got {:?}",
+        messages
+    );
+    assert!(
+        !history_has_empty_assistant_text(&messages),
+        "history should not contain the normalized empty assistant sentinel: {:?}",
+        messages
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires ANTHROPIC_API_KEY"]
+async fn prompt_loop_preserves_pre_tool_text_when_terminal_followup_is_empty() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let agent = anthropic::Client::from_env()
+        .agent(CLAUDE_SONNET_4_6)
+        .preamble(TERMINAL_NOTIFY_WITH_ACK_PREAMBLE)
+        .max_tokens(1024)
+        .tool(Notify::new(call_count.clone()))
+        .build();
+
+    let response = agent
+        .prompt(TERMINAL_NOTIFY_PROMPT)
+        .max_turns(5)
+        .extended_details()
+        .await
+        .expect("agent prompt should preserve prior-turn text when Anthropic ends empty");
+
+    assert!(
+        response.output.trim().is_empty(),
+        "expected empty final output for the terminal tool prompt, got {:?}",
+        response.output
+    );
+    assert!(
+        call_count.load(Ordering::SeqCst) >= 1,
+        "notify should be called at least once"
+    );
+
+    let messages = response
+        .messages
+        .expect("extended details should include history");
+    assert!(
+        messages
+            .iter()
+            .any(assistant_message_has_nonempty_text_and_notify_tool_call),
+        "expected an assistant message that preserved pre-tool text alongside the notify tool call, got {:?}",
+        messages
+    );
+    assert!(
+        messages.iter().any(message_has_tool_result),
+        "expected tool result in history, got {:?}",
+        messages
+    );
+    assert!(
+        !history_has_empty_assistant_text(&messages),
+        "history should not contain the normalized empty assistant sentinel: {:?}",
+        messages
+    );
+}

--- a/rig/rig-core/tests/anthropic/mod.rs
+++ b/rig/rig-core/tests/anthropic/mod.rs
@@ -1,5 +1,6 @@
 mod agent;
 mod default_max_turns;
+mod empty_end_turn;
 mod image;
 mod models;
 mod multi_turn_streaming;


### PR DESCRIPTION
## Summary

Fix Anthropic multi-turn tool round-trips when the follow-up assistant turn is empty with `stop_reason: "end_turn"`.

Closes #1642.

## Problem

Anthropic can validly return an empty assistant response after a `tool_result` when the turn is complete. Rig was treating that provider-valid response as:

`ResponseError: Response contained no message or tool call (empty)`

That broke non-streaming multi-turn prompts and prevented the agent loop from terminating cleanly.

## What changed

- Normalize Anthropic empty `end_turn` responses into the existing empty-text sentinel instead of raising `ResponseError`
- Update the non-streaming prompt loop to treat that sentinel as "no assistant output"
- Avoid adding a bogus empty assistant message to returned conversation history
- Add regression coverage for:
  - Anthropic provider parsing of empty `end_turn` responses
  - Non-streaming prompt-loop termination after tool results
  - Ignored Anthropic live tests covering raw follow-up and agent-loop behavior
