### PR TITLE
fix: OpenAI text extraction 

### DIFF
--- a/rig/rig-core/src/providers/openai/completion/mod.rs
+++ b/rig/rig-core/src/providers/openai/completion/mod.rs
@@ -820,7 +820,10 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                     .collect::<Vec<_>>();
 
                 if let Some(reasoning) = reasoning {
-                    content.push(completion::AssistantContent::text(reasoning));
+                    // llama.cpp exposes hidden reasoning on a separate non-standard field.
+                    // Keep it structured here so the non-streaming path matches streaming
+                    // behavior and does not pollute plain-text response surfaces.
+                    content.push(completion::AssistantContent::reasoning(reasoning));
                 }
 
                 content.extend(
@@ -1905,12 +1908,13 @@ mod tests {
 
         assert_eq!(response.choice.len(), 1);
 
-        let completion::message::AssistantContent::Text(text) = response.choice.first() else {
-            panic!("expected assistant content to be text");
+        let completion::message::AssistantContent::Reasoning(reasoning) = response.choice.first()
+        else {
+            panic!("expected assistant content to be reasoning");
         };
         assert_eq!(
-            text.text,
-            "Now I understand the structure better. I need to: ..."
+            reasoning.first_text(),
+            Some("Now I understand the structure better. I need to: ...")
         );
     }
 }

--- a/rig/rig-core/src/providers/openai/completion/mod.rs
+++ b/rig/rig-core/src/providers/openai/completion/mod.rs
@@ -670,9 +670,6 @@ impl TryFrom<Message> for message::Message {
                     .into_iter()
                     .map(|content| match content {
                         AssistantContent::Text { text } => message::AssistantContent::text(text),
-
-                        // TODO: Currently, refusals are converted into text, but should be
-                        //  investigated for generalization.
                         AssistantContent::Refusal { refusal } => {
                             message::AssistantContent::text(refusal)
                         }
@@ -893,19 +890,51 @@ impl ProviderResponseExt for CompletionResponse {
     }
 
     fn get_text_response(&self) -> Option<String> {
-        let Message::User { ref content, .. } = self.choices.last()?.message.clone() else {
-            return None;
-        };
+        let response = self
+            .choices
+            .iter()
+            .filter_map(|choice| assistant_message_text_response(&choice.message))
+            .collect::<Vec<_>>()
+            .join("\n");
 
-        let UserContent::Text { text } = content.first() else {
-            return None;
-        };
-
-        Some(text)
+        if response.is_empty() {
+            None
+        } else {
+            Some(response)
+        }
     }
 
     fn get_usage(&self) -> Option<Self::Usage> {
         self.usage.clone()
+    }
+}
+
+fn assistant_message_text_response(message: &Message) -> Option<String> {
+    let Message::Assistant {
+        content, refusal, ..
+    } = message
+    else {
+        return None;
+    };
+
+    let mut segments = content
+        .iter()
+        .filter_map(|content| match content {
+            AssistantContent::Text { text } => (!text.is_empty()).then(|| text.clone()),
+            AssistantContent::Refusal { refusal } => (!refusal.is_empty()).then(|| refusal.clone()),
+        })
+        .collect::<Vec<_>>();
+
+    if segments.is_empty()
+        && let Some(refusal) = refusal.as_ref().filter(|refusal| !refusal.is_empty())
+    {
+        segments.push(refusal.clone());
+    }
+
+    if segments.is_empty() {
+        None
+    } else {
+        Some(segments.join("\n"))
     }
 }
 
@@ -1364,6 +1393,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::telemetry::ProviderResponseExt;
 
     #[test]
     fn test_openai_request_uses_request_model_override() {
@@ -1472,6 +1502,73 @@ mod tests {
             }
             _ => panic!("expected assistant message"),
         }
+    }
+
+    #[test]
+    fn provider_response_text_response_reads_assistant_multipart_output() {
+        let response = CompletionResponse {
+            id: "resp_123".to_owned(),
+            object: "chat.completion".to_owned(),
+            created: 0,
+            model: GPT_4O.to_owned(),
+            system_fingerprint: None,
+            choices: vec![Choice {
+                index: 0,
+                message: Message::Assistant {
+                    content: vec![
+                        AssistantContent::Text {
+                            text: "first".to_owned(),
+                        },
+                        AssistantContent::Refusal {
+                            refusal: "second".to_owned(),
+                        },
+                        AssistantContent::Text {
+                            text: "third".to_owned(),
+                        },
+                    ],
+                    reasoning: Some("hidden".to_owned()),
+                    refusal: None,
+                    audio: None,
+                    name: None,
+                    tool_calls: vec![],
+                },
+                logprobs: None,
+                finish_reason: "stop".to_owned(),
+            }],
+            usage: None,
+        };
+
+        assert_eq!(
+            response.get_text_response(),
+            Some("first\nsecond\nthird".to_owned())
+        );
+    }
+
+    #[test]
+    fn provider_response_text_response_falls_back_to_assistant_refusal_field() {
+        let response = CompletionResponse {
+            id: "resp_123".to_owned(),
+            object: "chat.completion".to_owned(),
+            created: 0,
+            model: GPT_4O.to_owned(),
+            system_fingerprint: None,
+            choices: vec![Choice {
+                index: 0,
+                message: Message::Assistant {
+                    content: vec![],
+                    reasoning: None,
+                    refusal: Some("blocked".to_owned()),
+                    audio: None,
+                    name: None,
+                    tool_calls: vec![],
+                },
+                logprobs: None,
+                finish_reason: "stop".to_owned(),
+            }],
+            usage: None,
+        };
+
+        assert_eq!(response.get_text_response(), Some("blocked".to_owned()));
     }
 
     #[test]

--- a/rig/rig-core/tests/common/support.rs
+++ b/rig/rig-core/tests/common/support.rs
@@ -4,7 +4,7 @@
 use futures::StreamExt;
 use rig::{
     agent::{MultiTurnStreamItem, StreamingError, StreamingResult},
-    completion::{GetTokenUsage, ToolDefinition},
+    completion::{AssistantContent, GetTokenUsage, ToolDefinition},
     embeddings::Embedding,
     streaming::{StreamedAssistantContent, StreamedUserContent, StreamingCompletionResponse},
     tool::Tool,
@@ -15,6 +15,10 @@ use serde_json::json;
 
 pub(crate) const BASIC_PREAMBLE: &str = "You are a concise assistant. Answer directly.";
 pub(crate) const BASIC_PROMPT: &str = "In one or two sentences, explain what Rust programming language is and why memory safety matters.";
+pub(crate) const RAW_TEXT_RESPONSE_PREAMBLE: &str =
+    "Return exactly the requested text as plain text with no bullets, quotes, or extra commentary.";
+pub(crate) const RAW_TEXT_RESPONSE_PROMPT: &str =
+    "Reply with exactly two short lines and nothing else. First line: cedar. Second line: maple.";
 
 pub(crate) const CONTEXT_DOCS: [&str; 3] = [
     "Definition of a *flurbo*: A flurbo is a green alien that lives on cold planets.",
@@ -257,6 +261,23 @@ pub(crate) fn assert_nonempty_response(response: &str) {
         !trimmed.is_empty(),
         "Response was empty or whitespace-only."
     );
+}
+
+pub(crate) fn assistant_text_response(choice: &rig::OneOrMany<AssistantContent>) -> Option<String> {
+    let response = choice
+        .iter()
+        .filter_map(|content| match content {
+            AssistantContent::Text(text) => Some(text.text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    if response.is_empty() {
+        None
+    } else {
+        Some(response)
+    }
 }
 
 pub(crate) fn assert_contains_any_case_insensitive(response: &str, expected: &[&str]) {

--- a/rig/rig-core/tests/llamacpp/completions_api.rs
+++ b/rig/rig-core/tests/llamacpp/completions_api.rs
@@ -1,9 +1,14 @@
 //! Migrated from `examples/openai_agent_completions_api.rs` against a local llama.cpp server.
 
 use rig::client::CompletionClient;
+use rig::completion::CompletionModel;
 use rig::completion::Prompt;
+use rig::telemetry::ProviderResponseExt;
 
-use crate::support::assert_nonempty_response;
+use crate::support::{
+    RAW_TEXT_RESPONSE_PREAMBLE, RAW_TEXT_RESPONSE_PROMPT, assert_contains_all_case_insensitive,
+    assert_nonempty_response, assistant_text_response,
+};
 
 use super::support;
 
@@ -23,4 +28,29 @@ async fn completions_api_agent_prompt() {
         .expect("completions api prompt should succeed");
 
     assert_nonempty_response(&response);
+}
+
+#[tokio::test]
+#[ignore = "requires a local llama.cpp OpenAI-compatible server"]
+async fn completions_api_raw_response_text_matches_normalized_choice_text() {
+    let client = support::completions_client();
+    let response = client
+        .completion_model(support::model_name())
+        .completion_request(RAW_TEXT_RESPONSE_PROMPT)
+        .preamble(RAW_TEXT_RESPONSE_PREAMBLE.to_string())
+        .send()
+        .await
+        .expect("raw completions api request should succeed");
+
+    let normalized_text = assistant_text_response(&response.choice)
+        .expect("normalized completions api response should contain assistant text");
+    let raw_text = response
+        .raw_response
+        .get_text_response()
+        .expect("raw completions api response should contain assistant text");
+
+    assert_nonempty_response(&normalized_text);
+    assert_nonempty_response(&raw_text);
+    assert_contains_all_case_insensitive(&raw_text, &["cedar", "maple"]);
+    assert_eq!(raw_text.trim(), normalized_text.trim());
 }

--- a/rig/rig-core/tests/openai/completions_api.rs
+++ b/rig/rig-core/tests/openai/completions_api.rs
@@ -7,16 +7,19 @@ use rig::completion::Prompt;
 use rig::message::{AssistantContent, Message, ToolChoice};
 use rig::providers::openai;
 use rig::streaming::StreamingPrompt;
+use rig::telemetry::ProviderResponseExt;
 use rig::tool::Tool;
 
 use crate::support::{
     ALPHA_SIGNAL_OUTPUT, AlphaSignal, BETA_SIGNAL_OUTPUT, BetaSignal, ORDERED_TOOL_STREAM_PREAMBLE,
-    ORDERED_TOOL_STREAM_PROMPT, REQUIRED_ZERO_ARG_TOOL_PROMPT, TWO_TOOL_STREAM_PREAMBLE,
-    TWO_TOOL_STREAM_PROMPT, assert_nonempty_response,
+    ORDERED_TOOL_STREAM_PROMPT, RAW_TEXT_RESPONSE_PREAMBLE, RAW_TEXT_RESPONSE_PROMPT,
+    REQUIRED_ZERO_ARG_TOOL_PROMPT, TWO_TOOL_STREAM_PREAMBLE, TWO_TOOL_STREAM_PROMPT,
+    assert_contains_all_case_insensitive, assert_nonempty_response,
     assert_raw_stream_contains_distinct_tool_calls_before_text, assert_raw_stream_text_contains,
     assert_raw_stream_tool_call_precedes_text, assert_stream_contains_zero_arg_tool_call_named,
     assert_tool_call_precedes_later_text, assert_two_tool_roundtrip_contract,
-    collect_raw_stream_observation, collect_stream_observation, zero_arg_tool_definition,
+    assistant_text_response, collect_raw_stream_observation, collect_stream_observation,
+    zero_arg_tool_definition,
 };
 
 #[tokio::test]
@@ -35,6 +38,31 @@ async fn completions_api_agent_prompt() {
         .expect("completions api prompt should succeed");
 
     assert_nonempty_response(&response);
+}
+
+#[tokio::test]
+#[ignore = "requires OPENAI_API_KEY"]
+async fn completions_api_raw_response_text_matches_normalized_choice_text() {
+    let client = openai::Client::from_env().completions_api();
+    let response = client
+        .completion_model(openai::GPT_4O)
+        .completion_request(RAW_TEXT_RESPONSE_PROMPT)
+        .preamble(RAW_TEXT_RESPONSE_PREAMBLE.to_string())
+        .send()
+        .await
+        .expect("raw completions api request should succeed");
+
+    let normalized_text = assistant_text_response(&response.choice)
+        .expect("normalized completions api response should contain assistant text");
+    let raw_text = response
+        .raw_response
+        .get_text_response()
+        .expect("raw completions api response should contain assistant text");
+
+    assert_nonempty_response(&normalized_text);
+    assert_nonempty_response(&raw_text);
+    assert_contains_all_case_insensitive(&raw_text, &["cedar", "maple"]);
+    assert_eq!(raw_text.trim(), normalized_text.trim());
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fixes #1602.

## Summary
- update OpenAI chat completions `get_text_response()` to read assistant messages instead of user messages
- aggregate all assistant text/refusal segments instead of returning only the first text item
- return `None` only when the assistant response has no textual content
- map llama.cpp `reasoning_content` to `completion::AssistantContent::Reasoning(...)` in the non-streaming conversion path so hidden reasoning does not leak into plain-text response surfaces and matches the streaming path
- add ignored live-provider coverage for the raw completions API path in both `rig-core/tests/openai` and `rig-core/tests/llamacpp`
