### PR TITLE
fix: preserve multimodal tool results in streaming chat history

### DIFF
--- a/rig/rig-core/src/agent/prompt_request/streaming.rs
+++ b/rig/rig-core/src/agent/prompt_request/streaming.rs
@@ -159,7 +159,7 @@ fn tool_result_to_user_message(
     call_id: Option<String>,
     tool_result: String,
 ) -> Message {
-    let content = OneOrMany::one(ToolResultContent::text(tool_result));
+    let content = ToolResultContent::from_tool_output(tool_result);
     let user_content = match call_id {
         Some(call_id) => UserContent::tool_result_with_call_id(id, call_id, content),
         None => UserContent::tool_result(id, content),
@@ -794,7 +794,10 @@ mod tests {
     use crate::completion::{
         CompletionError, CompletionModel, CompletionRequest, CompletionResponse,
     };
-    use crate::message::{AssistantContent, Message, ReasoningContent, UserContent};
+    use crate::message::{
+        AssistantContent, DocumentSourceKind, ImageMediaType, Message, ReasoningContent,
+        ToolResultContent, UserContent,
+    };
     use crate::providers::anthropic;
     use crate::streaming::StreamingPrompt;
     use crate::streaming::{RawStreamingChoice, RawStreamingToolCall, StreamingCompletionResponse};
@@ -912,6 +915,58 @@ mod tests {
                 Some(ReasoningContent::Text { text, .. }) if text == "second"
             )
         ));
+    }
+
+    #[test]
+    fn tool_result_to_user_message_preserves_multimodal_tool_output() {
+        let message = tool_result_to_user_message(
+            "tool_call_1".to_string(),
+            Some("call_1".to_string()),
+            serde_json::json!({
+                "response": {
+                    "instruction": "Use the image part to answer."
+                },
+                "parts": [
+                    {
+                        "type": "image",
+                        "data": "base64data==",
+                        "mimeType": "image/png"
+                    }
+                ]
+            })
+            .to_string(),
+        );
+
+        let tool_result = match message {
+            Message::User { content } => match content.first() {
+                UserContent::ToolResult(tool_result) => tool_result,
+                other => panic!("expected tool result content, got {other:?}"),
+            },
+            other => panic!("expected user message, got {other:?}"),
+        };
+
+        assert_eq!(tool_result.id, "tool_call_1");
+        assert_eq!(tool_result.call_id.as_deref(), Some("call_1"));
+        assert_eq!(tool_result.content.len(), 2);
+
+        let mut items = tool_result.content.iter();
+        match items.next() {
+            Some(ToolResultContent::Text(text)) => {
+                assert!(text.text.contains("Use the image part to answer."));
+            }
+            other => panic!("expected structured text payload first, got {other:?}"),
+        }
+
+        match items.next() {
+            Some(ToolResultContent::Image(image)) => {
+                assert_eq!(image.media_type, Some(ImageMediaType::PNG));
+                assert!(matches!(
+                    image.data,
+                    DocumentSourceKind::Base64(ref data) if data == "base64data=="
+                ));
+            }
+            other => panic!("expected image payload second, got {other:?}"),
+        }
     }
 
     #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/rig/rig-core/tests/gemini/mod.rs
+++ b/rig/rig-core/tests/gemini/mod.rs
@@ -7,6 +7,7 @@ mod multi_turn_streaming;
 mod reasoning_roundtrip;
 mod reasoning_tool_roundtrip;
 mod streaming;
+mod streaming_multimodal_tool_results;
 mod streaming_tools;
 mod structured_output;
 mod transcription;

--- a/rig/rig-core/tests/gemini/multi_turn_streaming.rs
+++ b/rig/rig-core/tests/gemini/multi_turn_streaming.rs
@@ -155,20 +155,14 @@ where
             }
 
             for (id, call_id, tool_result) in tool_results {
-                let content = if let Some(call_id) = call_id {
-                    UserContent::tool_result_with_call_id(
-                        id,
-                        call_id,
-                        OneOrMany::one(ToolResultContent::text(tool_result)),
-                    )
+                let tool_content = ToolResultContent::from_tool_output(tool_result);
+                let user_content = if let Some(call_id) = call_id {
+                    UserContent::tool_result_with_call_id(id, call_id, tool_content)
                 } else {
-                    UserContent::tool_result(
-                        id,
-                        OneOrMany::one(ToolResultContent::text(tool_result)),
-                    )
+                    UserContent::tool_result(id, tool_content)
                 };
                 chat_history.push(Message::User {
-                    content: OneOrMany::one(content),
+                    content: OneOrMany::one(user_content),
                 });
             }
 

--- a/rig/rig-core/tests/gemini/streaming_multimodal_tool_results.rs
+++ b/rig/rig-core/tests/gemini/streaming_multimodal_tool_results.rs
@@ -18,6 +18,7 @@ use serde_json::json;
 use crate::support::assert_nonempty_response;
 
 const RED_PIXEL_PNG_BASE64: &str = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==";
+const MULTIMODAL_FUNCTION_RESPONSE_MODEL: &str = gemini::completion::GEMINI_3_FLASH_PREVIEW;
 
 fn streaming_tool_params() -> serde_json::Value {
     serde_json::to_value(AdditionalParameters::default().with_config(GenerationConfig::default()))
@@ -72,7 +73,7 @@ impl Tool for HybridImageTool {
 async fn streaming_history_preserves_hybrid_tool_result_image_parts() {
     let client = gemini::Client::from_env();
     let agent = client
-        .agent(gemini::completion::GEMINI_2_5_FLASH)
+        .agent(MULTIMODAL_FUNCTION_RESPONSE_MODEL)
         .preamble(
             "You are a precise assistant. Call `render_reference_image` exactly once before \
              answering. After the tool result arrives, do not call any more tools. Answer in one \

--- a/rig/rig-core/tests/gemini/streaming_multimodal_tool_results.rs
+++ b/rig/rig-core/tests/gemini/streaming_multimodal_tool_results.rs
@@ -1,0 +1,179 @@
+//! Gemini streaming regression for multimodal tool results in chat history.
+
+use futures::StreamExt;
+use rig::agent::MultiTurnStreamItem;
+use rig::client::{CompletionClient, ProviderClient};
+use rig::completion::ToolDefinition;
+use rig::message::{
+    AssistantContent, DocumentSourceKind, ImageMediaType, Message, ToolResultContent, UserContent,
+};
+use rig::providers::gemini;
+use rig::providers::gemini::completion::gemini_api_types::{
+    AdditionalParameters, GenerationConfig,
+};
+use rig::streaming::StreamingPrompt;
+use rig::tool::Tool;
+use serde_json::json;
+
+use crate::support::assert_nonempty_response;
+
+const RED_PIXEL_PNG_BASE64: &str = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==";
+
+fn streaming_tool_params() -> serde_json::Value {
+    serde_json::to_value(AdditionalParameters::default().with_config(GenerationConfig::default()))
+        .expect("Gemini additional params should serialize")
+}
+
+#[derive(Debug)]
+struct HybridImageTool;
+
+#[derive(Debug, thiserror::Error)]
+#[error("hybrid image tool error")]
+struct HybridImageToolError;
+
+impl Tool for HybridImageTool {
+    const NAME: &'static str = "render_reference_image";
+    type Error = HybridImageToolError;
+    type Args = serde_json::Value;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "Return a reference image the assistant must inspect before answering."
+                .to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {},
+                "required": [],
+            }),
+        }
+    }
+
+    async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
+        Ok(json!({
+            "response": {
+                "instruction": "Use the image part to answer the user's question."
+            },
+            "parts": [
+                {
+                    "type": "image",
+                    "data": RED_PIXEL_PNG_BASE64,
+                    "mimeType": "image/png"
+                }
+            ]
+        })
+        .to_string())
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires GEMINI_API_KEY"]
+async fn streaming_history_preserves_hybrid_tool_result_image_parts() {
+    let client = gemini::Client::from_env();
+    let agent = client
+        .agent(gemini::completion::GEMINI_2_5_FLASH)
+        .preamble(
+            "You are a precise assistant. Call `render_reference_image` exactly once before \
+             answering. After the tool result arrives, do not call any more tools. Answer in one \
+             short sentence.",
+        )
+        .tool(HybridImageTool)
+        .additional_params(streaming_tool_params())
+        .build();
+
+    let empty_history: &[Message] = &[];
+    let mut stream = agent
+        .stream_prompt(
+            "Use the tool once, then answer with the dominant color in the returned image.",
+        )
+        .with_history(empty_history)
+        .multi_turn(4)
+        .await;
+
+    let mut final_response = None;
+    let mut final_history = None;
+
+    while let Some(item) = stream.next().await {
+        match item.expect("streaming prompt should succeed") {
+            MultiTurnStreamItem::FinalResponse(response) => {
+                final_response = Some(response.response().to_owned());
+                final_history = response.history().map(|history| history.to_vec());
+                break;
+            }
+            MultiTurnStreamItem::StreamAssistantItem(_)
+            | MultiTurnStreamItem::StreamUserItem(_) => {}
+            _ => {}
+        }
+    }
+
+    let final_response = final_response.expect("stream should yield a final response");
+    assert_nonempty_response(&final_response);
+
+    let history = final_history.expect("final response should include updated history");
+    assert!(
+        history.iter().any(|message| matches!(
+            message,
+            Message::Assistant { content, .. }
+                if content.iter().any(|item| matches!(
+                    item,
+                    AssistantContent::ToolCall(tool_call)
+                        if tool_call.function.name == HybridImageTool::NAME
+                ))
+        )),
+        "history should retain the assistant tool call: {history:#?}"
+    );
+
+    let tool_result = history
+        .iter()
+        .find_map(|message| match message {
+            Message::User { content } => content.iter().find_map(|item| match item {
+                UserContent::ToolResult(tool_result) => Some(tool_result),
+                _ => None,
+            }),
+            _ => None,
+        })
+        .expect("history should retain the tool result user message");
+
+    assert_eq!(
+        tool_result.content.len(),
+        2,
+        "hybrid tool results should round-trip as [text, image], not a single text blob: {tool_result:#?}"
+    );
+
+    let mut saw_instruction_text = false;
+    let mut saw_image = false;
+
+    for content in tool_result.content.iter() {
+        match content {
+            ToolResultContent::Text(text) => {
+                saw_instruction_text = true;
+                assert!(
+                    text.text.contains("Use the image part"),
+                    "tool result text should contain only the structured response payload: {text:?}"
+                );
+                assert!(
+                    !text.text.contains(RED_PIXEL_PNG_BASE64),
+                    "tool result text should not inline the image base64 payload: {text:?}"
+                );
+            }
+            ToolResultContent::Image(image) => {
+                saw_image = true;
+                assert_eq!(image.media_type, Some(ImageMediaType::PNG));
+                assert!(
+                    matches!(image.data, DocumentSourceKind::Base64(ref data) if data == RED_PIXEL_PNG_BASE64),
+                    "tool result image should preserve the base64 image payload: {image:?}"
+                );
+            }
+        }
+    }
+
+    assert!(
+        saw_instruction_text,
+        "hybrid tool results should preserve the response text payload"
+    );
+    assert!(
+        saw_image,
+        "hybrid tool results should preserve the image payload as ToolResultContent::Image"
+    );
+}


### PR DESCRIPTION
Closes #1650.

## Summary

The streaming multi-turn path was storing tool results in chat history as plain text, even when the tool output was structured multimodal JSON

That meant the follow-up turn received the entire payload as a text blob instead of a parsed Text + Image tool result, which breaks multimodal tool round-tripping and can explode context size when image base64 is tokenized as text.

This change makes the streaming history path match the non-streaming path by parsing tool outputs with ToolResultContent::from_tool_output(...) before writing them into history.

What changed
update rig-core/src/agent/prompt_request/streaming.rs so streamed tool results are stored in history as parsed ToolResultContent
add a unit regression test covering multimodal tool output preservation in tool_result_to_user_message
add a live ignored Gemini regression test under rig-core/tests/gemini
update the migrated Gemini manual multi-turn streaming test helper to use the same tool output parsing behavior
Notes
The live provider regression uses gemini-3-flash-preview because Gemini 2.5 Flash rejects multimodal 