### PR TITLE
fix(telemetry): emit OTel-standard gen_ai.usage.cache_read.input_tokens across providers

### DIFF
--- a/rig/rig-core/src/providers/azure.rs
+++ b/rig/rig-core/src/providers/azure.rs
@@ -709,7 +709,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()
@@ -809,7 +809,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/chatgpt/mod.rs
+++ b/rig/rig-core/src/providers/chatgpt/mod.rs
@@ -493,7 +493,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
                 gen_ai.input.messages = tracing::field::Empty,
                 gen_ai.output.messages = tracing::field::Empty,
             )
@@ -510,7 +510,7 @@ where
                 span.record("gen_ai.usage.output_tokens", response.usage.output_tokens);
                 span.record("gen_ai.usage.input_tokens", response.usage.input_tokens);
                 span.record(
-                    "gen_ai.usage.cached_tokens",
+                    "gen_ai.usage.cache_read.input_tokens",
                     response.usage.cached_input_tokens,
                 );
                 Ok(response)
@@ -575,7 +575,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/cohere/completion.rs
+++ b/rig/rig-core/src/providers/cohere/completion.rs
@@ -643,7 +643,7 @@ where
             gen_ai.response.model = self.model,
             gen_ai.usage.output_tokens = tracing::field::Empty,
             gen_ai.usage.input_tokens = tracing::field::Empty,
-            gen_ai.usage.cached_tokens = tracing::field::Empty,
+            gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/cohere/streaming.rs
+++ b/rig/rig-core/src/providers/cohere/streaming.rs
@@ -111,7 +111,7 @@ where
                 gen_ai.response.model = self.model,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/copilot/mod.rs
+++ b/rig/rig-core/src/providers/copilot/mod.rs
@@ -681,7 +681,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()
@@ -705,7 +705,7 @@ where
                                 usage.total_tokens - usage.prompt_tokens,
                             );
                             span.record(
-                                "gen_ai.usage.cached_tokens",
+                                "gen_ai.usage.cache_read.input_tokens",
                                 usage
                                     .prompt_tokens_details
                                     .as_ref()
@@ -762,7 +762,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()
@@ -782,7 +782,7 @@ where
                     span.record("gen_ai.usage.input_tokens", usage.input_tokens);
                     span.record("gen_ai.usage.output_tokens", usage.output_tokens);
                     span.record(
-                        "gen_ai.usage.cached_tokens",
+                        "gen_ai.usage.cache_read.input_tokens",
                         usage
                             .input_tokens_details
                             .as_ref()
@@ -885,7 +885,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()
@@ -1042,7 +1042,7 @@ where
                 span.record("gen_ai.usage.input_tokens", final_usage.input_tokens);
                 span.record("gen_ai.usage.output_tokens", final_usage.output_tokens);
                 span.record(
-                    "gen_ai.usage.cached_tokens",
+                    "gen_ai.usage.cache_read.input_tokens",
                     final_usage
                         .input_tokens_details
                         .as_ref()

--- a/rig/rig-core/src/providers/copilot/mod.rs
+++ b/rig/rig-core/src/providers/copilot/mod.rs
@@ -843,7 +843,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/deepseek.rs
+++ b/rig/rig-core/src/providers/deepseek.rs
@@ -671,7 +671,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/deepseek.rs
+++ b/rig/rig-core/src/providers/deepseek.rs
@@ -558,7 +558,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()
@@ -598,7 +598,7 @@ where
                             response.usage.completion_tokens,
                         );
                         span.record(
-                            "gen_ai.usage.cached_tokens",
+                            "gen_ai.usage.cache_read.input_tokens",
                             response
                                 .usage
                                 .prompt_tokens_details

--- a/rig/rig-core/src/providers/galadriel.rs
+++ b/rig/rig-core/src/providers/galadriel.rs
@@ -553,7 +553,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()
@@ -653,7 +653,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
                 gen_ai.input.messages = serde_json::to_string(&request.messages)?,
                 gen_ai.output.messages = tracing::field::Empty,
             )

--- a/rig/rig-core/src/providers/gemini/completion.rs
+++ b/rig/rig-core/src/providers/gemini/completion.rs
@@ -102,7 +102,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/gemini/interactions_api/mod.rs
+++ b/rig/rig-core/src/providers/gemini/interactions_api/mod.rs
@@ -132,6 +132,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/gemini/interactions_api/streaming.rs
+++ b/rig/rig-core/src/providers/gemini/interactions_api/streaming.rs
@@ -62,6 +62,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/gemini/streaming.rs
+++ b/rig/rig-core/src/providers/gemini/streaming.rs
@@ -93,7 +93,7 @@ where
                 gen_ai.response.model = &request_model,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/groq.rs
+++ b/rig/rig-core/src/providers/groq.rs
@@ -464,7 +464,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/groq.rs
+++ b/rig/rig-core/src/providers/groq.rs
@@ -373,7 +373,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()
@@ -415,7 +415,7 @@ where
                                 usage.total_tokens - usage.prompt_tokens,
                             );
                             span.record(
-                                "gen_ai.usage.cached_tokens",
+                                "gen_ai.usage.cache_read.input_tokens",
                                 usage
                                     .prompt_tokens_details
                                     .as_ref()

--- a/rig/rig-core/src/providers/huggingface/completion.rs
+++ b/rig/rig-core/src/providers/huggingface/completion.rs
@@ -740,7 +740,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/huggingface/streaming.rs
+++ b/rig/rig-core/src/providers/huggingface/streaming.rs
@@ -65,7 +65,7 @@ where
             gen_ai.response.model = &request_model,
             gen_ai.usage.output_tokens = tracing::field::Empty,
             gen_ai.usage.input_tokens = tracing::field::Empty,
-            gen_ai.usage.cached_tokens = tracing::field::Empty,
+            gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/hyperbolic.rs
+++ b/rig/rig-core/src/providers/hyperbolic.rs
@@ -362,7 +362,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()
@@ -433,7 +433,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
+++ b/rig/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
@@ -384,7 +384,10 @@ where
 
     span.record("gen_ai.usage.input_tokens", usage.input_tokens);
     span.record("gen_ai.usage.output_tokens", usage.output_tokens);
-    span.record("gen_ai.usage.cached_tokens", usage.cached_input_tokens);
+    span.record(
+        "gen_ai.usage.cache_read.input_tokens",
+        usage.cached_input_tokens,
+    );
 }
 
 fn record_response_metadata(

--- a/rig/rig-core/src/providers/llamafile.rs
+++ b/rig/rig-core/src/providers/llamafile.rs
@@ -387,7 +387,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/mira.rs
+++ b/rig/rig-core/src/providers/mira.rs
@@ -347,7 +347,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()
@@ -452,7 +452,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/mistral/completion.rs
+++ b/rig/rig-core/src/providers/mistral/completion.rs
@@ -608,7 +608,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/moonshot.rs
+++ b/rig/rig-core/src/providers/moonshot.rs
@@ -511,7 +511,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()
@@ -593,7 +593,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/ollama.rs
+++ b/rig/rig-core/src/providers/ollama.rs
@@ -591,7 +591,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()
@@ -671,7 +671,7 @@ where
                 gen_ai.response.model = self.model,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/openai/completion/mod.rs
+++ b/rig/rig-core/src/providers/openai/completion/mod.rs
@@ -1323,7 +1323,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/openai/completion/streaming.rs
+++ b/rig/rig-core/src/providers/openai/completion/streaming.rs
@@ -137,7 +137,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
                 gen_ai.input.messages = request_messages,
                 gen_ai.output.messages = tracing::field::Empty,
             )

--- a/rig/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/rig/rig-core/src/providers/openai/responses_api/mod.rs
@@ -1367,7 +1367,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
                 gen_ai.input.messages = tracing::field::Empty,
                 gen_ai.output.messages = tracing::field::Empty,
             )
@@ -1406,14 +1406,12 @@ where
                 if let Some(ref usage) = response.usage {
                     span.record("gen_ai.usage.output_tokens", usage.output_tokens);
                     span.record("gen_ai.usage.input_tokens", usage.input_tokens);
-                    span.record(
-                        "gen_ai.usage.cached_tokens",
-                        usage
-                            .input_tokens_details
-                            .as_ref()
-                            .map(|d| d.cached_tokens)
-                            .unwrap_or(0),
-                    );
+                    let cached_tokens = usage
+                        .input_tokens_details
+                        .as_ref()
+                        .map(|d| d.cached_tokens)
+                        .unwrap_or(0);
+                    span.record("gen_ai.usage.cache_read.input_tokens", cached_tokens);
                 }
                 if enabled!(Level::TRACE) {
                     tracing::trace!(

--- a/rig/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/rig/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -714,14 +714,12 @@ where
 
         span.record("gen_ai.usage.input_tokens", final_usage.input_tokens);
         span.record("gen_ai.usage.output_tokens", final_usage.output_tokens);
-        span.record(
-            "gen_ai.usage.cached_tokens",
-            final_usage
-                .input_tokens_details
-                .as_ref()
-                .map(|d| d.cached_tokens)
-                .unwrap_or(0),
-        );
+        let cached_tokens = final_usage
+            .input_tokens_details
+            .as_ref()
+            .map(|d| d.cached_tokens)
+            .unwrap_or(0);
+        span.record("gen_ai.usage.cache_read.input_tokens", cached_tokens);
 
     }
     .instrument(span);
@@ -900,7 +898,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/openrouter/completion.rs
+++ b/rig/rig-core/src/providers/openrouter/completion.rs
@@ -1735,7 +1735,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/openrouter/streaming.rs
+++ b/rig/rig-core/src/providers/openrouter/streaming.rs
@@ -168,7 +168,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/perplexity.rs
+++ b/rig/rig-core/src/providers/perplexity.rs
@@ -365,7 +365,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()
@@ -451,7 +451,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/together/completion.rs
+++ b/rig/rig-core/src/providers/together/completion.rs
@@ -247,7 +247,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/together/streaming.rs
+++ b/rig/rig-core/src/providers/together/streaming.rs
@@ -58,7 +58,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/xai/completion.rs
+++ b/rig/rig-core/src/providers/xai/completion.rs
@@ -222,7 +222,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/rig/rig-core/src/providers/xai/streaming.rs
+++ b/rig/rig-core/src/providers/xai/streaming.rs
@@ -62,7 +62,7 @@ where
                 gen_ai.response.model = tracing::field::Empty,
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cached_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()


### PR DESCRIPTION
## Summary
- Rename the tracing/OTel attribute `gen_ai.usage.cached_tokens` to `gen_ai.usage.cache_read.input_tokens` across every provider that emits it.
- `gen_ai.usage.cache_read.input_tokens` is the canonical attribute name listed in the [OpenTelemetry GenAI semantic-conventions registry](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/). The previous name was non-standard and would not be picked up by OTel-aware backends.
- Every instance — span declarations and `span.record(...)` call sites, streaming and non-streaming paths — has been updated so a single provider never emits two different attribute names.

## Providers touched
openai (chat + responses_api, streaming + non-streaming), openai chat-completions-compatible shared helper, anthropic (via the existing `cached_input_tokens` plumbing), azure, chatgpt, cohere, copilot, deepseek, galadriel, gemini (completion, streaming, interactions_api), groq, huggingface, hyperbolic, llamafile, mira, mistral, moonshot, ollama, openrouter, perplexity, together, xai.

## Notes
- No provider wire-format changes. Provider response structs that happen to deserialize a JSON field named `cached_tokens` (e.g. DeepSeek's `prompt_tokens_details.cached_tokens`, OpenAI's `input_tokens_details.cached_tokens`) keep those names — those are the provider's API, not our telemetry.
- Per OTel guidance, `cache_read.input_tokens` SHOULD be included in `gen_ai.usage.input_tokens`. Existing providers already follow that convention; this PR does not change any token-accounting logic.
- This is a breaking change for any downstream dashboards/alerts that queried the old attribute name.

## Test plan
- [x] `cargo fmt -- --check`
- [x] `cargo clippy -p rig-core --all-targets --all-features` — clean
- [x] `cargo test -p rig-core --all-features --lib` — 555 passed, 0 failed, 8 ignored
- [x] `grep -rn "gen_ai.usage.cached_tokens" rig/` returns no matches