### PR TITLE
fix(openai): improve diagnostic when Chat Completions data received on Responses API stream

### DIFF
--- a/rig/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/rig/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -659,10 +659,23 @@ where
                         let Err(err) = data else {
                             continue;
                         };
-                        debug!(
-                            "Couldn't deserialize SSE data as StreamingCompletionChunk: {:?}",
-                            err
-                        );
+                        // Check if this looks like a Chat Completions-format response
+                        // (e.g., from llama.cpp or other OpenAI-compatible servers that
+                        // don't support the Responses API format).
+                        if evt.data.contains("\"choices\"") {
+                            debug!(
+                                "Received Chat Completions-format data on the Responses API \
+                                 stream. If you are using an OpenAI-compatible server \
+                                 (e.g., llama.cpp), call `.completions_api()` on the client \
+                                 to use the Chat Completions endpoint instead: {:?}",
+                                err
+                            );
+                        } else {
+                            debug!(
+                                "Couldn't deserialize SSE data as StreamingCompletionChunk: {:?}",
+                                err
+                            );
+                        }
                         continue;
                     };
 


### PR DESCRIPTION
## Problem

When using an OpenAI-compatible server (e.g., llama.cpp) with Rig, the default `openai::Client` targets the Responses API (`/v1/responses`). However, llama.cpp and most OpenAI-compatible servers only implement the Chat Completions API (`/v1/chat/completions`) and return chunks containing a `"choices"` field.

These chunks fail to deserialize as `StreamingCompletionChunk` (an untagged enum expecting either a `ResponseChunk` or `ItemChunk`), and the current debug message is:

```
Couldn't deserialize SSE data as StreamingCompletionChunk: ...
```

This gives users no indication of what went wrong or how to fix it. Issue #1662 describes exactly this: users see repeated `[DONE]`-related parse errors with no actionable guidance.

## Fix

Detect when the incoming SSE data contains a `"choices"` field (the hallmark of Chat Completions-format data) and emit a targeted diagnostic:

```
Received Chat Completions-format data on the Responses API stream.
If you are using an OpenAI-compatible server (e.g., llama.cpp),
call `.completions_api()` on the client to use the Chat Completions
endpoint instead: ...
```

This points users directly to the fix: calling `.completions_api()` on the client builder, which switches the endpoint to `/v1/chat/completions`.

## Changes

- `rig-core/src/providers/openai/responses_api/streaming.rs`: branch on `"choices"` presence in the failed SSE data to emit a more specific debug message.

No behavior change — this is purely a diagnostic improvement. The stream still skips unrecognized chunks as before.

Fixes #1662