### PR TITLE
feat(core): add ToolCallHookAction::ContinueWith for tool argument mutation

### DIFF
--- a/rig/rig-core/src/agent/prompt_request/hooks.rs
+++ b/rig/rig-core/src/agent/prompt_request/hooks.rs
@@ -35,7 +35,9 @@ where
     ///
     /// # Returns
     /// - `ToolCallHookAction::Continue` - Allow tool execution to proceed
+    /// - `ToolCallHookAction::ContinueWith { args }` - Allow tool execution with replacement arguments
     /// - `ToolCallHookAction::Skip { reason }` - Reject tool execution; `reason` will be returned to the LLM as the tool result
+    /// - `ToolCallHookAction::Terminate { reason }` - Terminate the agent loop early
     fn on_tool_call(
         &self,
         _tool_name: &str,
@@ -93,9 +95,16 @@ impl<M> PromptHook<M> for () where M: CompletionModel {}
 
 /// Control flow action for tool call hooks. This is different from the regular [`HookAction`] in that tool call executions may be skipped for one or more reasons.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ToolCallHookAction {
     /// Continue tool execution as normal.
     Continue,
+    /// Continue tool execution with replacement arguments.
+    ///
+    /// The tool will be invoked with the provided `args` instead of the
+    /// original arguments from the LLM. Downstream hooks (`on_tool_result`)
+    /// and tracing spans will also see the replacement arguments.
+    ContinueWith { args: String },
     /// Skip tool execution and return the provided reason as the tool result.
     Skip { reason: String },
     /// Terminate agent loop early
@@ -106,6 +115,11 @@ impl ToolCallHookAction {
     /// Continue the agentic loop as normal
     pub fn cont() -> Self {
         Self::Continue
+    }
+
+    /// Continue tool execution with replacement arguments.
+    pub fn continue_with(args: impl Into<String>) -> Self {
+        Self::ContinueWith { args: args.into() }
     }
 
     /// Skip a given tool call (with a provided reason).
@@ -125,6 +139,7 @@ impl ToolCallHookAction {
 
 /// Control flow action for hooks.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum HookAction {
     /// Continue agentic loop execution as normal.
     Continue,
@@ -143,5 +158,40 @@ impl HookAction {
         Self::Terminate {
             reason: reason.into(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_call_hook_action_continue_with() {
+        let action = ToolCallHookAction::continue_with(r#"{"x": 10}"#);
+        assert_eq!(
+            action,
+            ToolCallHookAction::ContinueWith {
+                args: r#"{"x": 10}"#.to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn tool_call_hook_action_continue_with_from_string() {
+        let args = String::from(r#"{"path": "/sandbox/file.txt"}"#);
+        let action = ToolCallHookAction::continue_with(args.clone());
+        assert_eq!(action, ToolCallHookAction::ContinueWith { args });
+    }
+
+    #[test]
+    fn tool_call_hook_action_variants_are_distinct() {
+        assert_ne!(
+            ToolCallHookAction::cont(),
+            ToolCallHookAction::continue_with("{}")
+        );
+        assert_ne!(
+            ToolCallHookAction::continue_with("{}"),
+            ToolCallHookAction::skip("{}")
+        );
     }
 }

--- a/rig/rig-core/src/agent/prompt_request/mod.rs
+++ b/rig/rig-core/src/agent/prompt_request/mod.rs
@@ -548,8 +548,7 @@ where
                             let tool_span = tracing::Span::current();
                             tool_span.record("gen_ai.tool.name", tool_name);
                             tool_span.record("gen_ai.tool.call.id", &tool_call.id);
-                            tool_span.record("gen_ai.tool.call.arguments", &args);
-                            if let Some(hook) = hook1 {
+                            let args = if let Some(hook) = hook1 {
                                 let action = hook
                                     .on_tool_call(
                                         tool_name,
@@ -559,34 +558,41 @@ where
                                     )
                                     .await;
 
-                                if let ToolCallHookAction::Terminate { reason } = action {
-                                    return Err(PromptError::prompt_cancelled(
-                                        cloned_history_for_error,
-                                        reason,
-                                    ));
-                                }
-
-                                if let ToolCallHookAction::Skip { reason } = action {
-                                    // Tool execution rejected, return rejection message as tool result
-                                    tracing::info!(
-                                        tool_name = tool_name,
-                                        reason = reason,
-                                        "Tool call rejected"
-                                    );
-                                    if let Some(call_id) = tool_call.call_id.clone() {
-                                        return Ok(UserContent::tool_result_with_call_id(
-                                            tool_call.id.clone(),
-                                            call_id,
-                                            OneOrMany::one(reason.into()),
-                                        ));
-                                    } else {
-                                        return Ok(UserContent::tool_result(
-                                            tool_call.id.clone(),
-                                            OneOrMany::one(reason.into()),
+                                match action {
+                                    ToolCallHookAction::Terminate { reason } => {
+                                        return Err(PromptError::prompt_cancelled(
+                                            cloned_history_for_error,
+                                            reason,
                                         ));
                                     }
+                                    ToolCallHookAction::Skip { reason } => {
+                                        tracing::info!(
+                                            tool_name = tool_name,
+                                            reason = reason,
+                                            "Tool call rejected"
+                                        );
+                                        if let Some(call_id) = tool_call.call_id.clone() {
+                                            return Ok(UserContent::tool_result_with_call_id(
+                                                tool_call.id.clone(),
+                                                call_id,
+                                                OneOrMany::one(reason.into()),
+                                            ));
+                                        } else {
+                                            return Ok(UserContent::tool_result(
+                                                tool_call.id.clone(),
+                                                OneOrMany::one(reason.into()),
+                                            ));
+                                        }
+                                    }
+                                    ToolCallHookAction::ContinueWith {
+                                        args: replacement_args,
+                                    } => replacement_args,
+                                    ToolCallHookAction::Continue => args,
                                 }
-                            }
+                            } else {
+                                args
+                            };
+                            tool_span.record("gen_ai.tool.call.arguments", &args);
                             let output = match tool_server_handle.call_tool(tool_name, &args).await
                             {
                                 Ok(res) => res,

--- a/rig/rig-core/src/agent/prompt_request/streaming.rs
+++ b/rig/rig-core/src/agent/prompt_request/streaming.rs
@@ -531,29 +531,33 @@ where
                             let tc_result = async {
                                 let tool_span = tracing::Span::current();
                                 let tool_args = json_utils::value_to_json_string(&tool_call.function.arguments);
-                                if let Some(ref hook) = self.hook {
+                                let tool_args = if let Some(ref hook) = self.hook {
                                     let action = hook
                                         .on_tool_call(&tool_call.function.name, tool_call.call_id.clone(), &internal_call_id, &tool_args)
                                         .await;
 
-                                    if let ToolCallHookAction::Terminate { reason } = action {
-                                        return Err(cancelled_prompt_error(chat_history.as_deref(), new_messages.clone(), reason).await);
+                                    match action {
+                                        ToolCallHookAction::Terminate { reason } => {
+                                            return Err(cancelled_prompt_error(chat_history.as_deref(), new_messages.clone(), reason).await);
+                                        }
+                                        ToolCallHookAction::Skip { reason } => {
+                                            tracing::info!(
+                                                tool_name = tool_call.function.name.as_str(),
+                                                reason = reason,
+                                                "Tool call rejected"
+                                            );
+                                            let tool_call_msg = AssistantContent::ToolCall(tool_call.clone());
+                                            tool_calls.push(tool_call_msg);
+                                            tool_results.push((tool_call.id.clone(), tool_call.call_id.clone(), reason.clone()));
+                                            saw_tool_call_this_turn = true;
+                                            return Ok(reason);
+                                        }
+                                        ToolCallHookAction::ContinueWith { args: replacement_args } => replacement_args,
+                                        ToolCallHookAction::Continue => tool_args,
                                     }
-
-                                    if let ToolCallHookAction::Skip { reason } = action {
-                                        // Tool execution rejected, return rejection message as tool result
-                                        tracing::info!(
-                                            tool_name = tool_call.function.name.as_str(),
-                                            reason = reason,
-                                            "Tool call rejected"
-                                        );
-                                        let tool_call_msg = AssistantContent::ToolCall(tool_call.clone());
-                                        tool_calls.push(tool_call_msg);
-                                        tool_results.push((tool_call.id.clone(), tool_call.call_id.clone(), reason.clone()));
-                                        saw_tool_call_this_turn = true;
-                                        return Ok(reason);
-                                    }
-                                }
+                                } else {
+                                    tool_args
+                                };
 
                                 tool_span.record("gen_ai.tool.name", &tool_call.function.name);
                                 tool_span.record("gen_ai.tool.call.arguments", &tool_args);

--- a/rig/rig-core/tests/core/hook_continue_with.rs
+++ b/rig/rig-core/tests/core/hook_continue_with.rs
@@ -1,0 +1,545 @@
+use rig::OneOrMany;
+use rig::agent::{AgentBuilder, HookAction, PromptHook, ToolCallHookAction};
+use rig::completion::{
+    CompletionError, CompletionModel, CompletionRequest, CompletionResponse, Prompt,
+    ToolDefinition, Usage,
+};
+use rig::message::{AssistantContent, ToolCall, ToolFunction};
+use rig::streaming::{StreamingCompletionResponse, StreamingResult};
+use rig::tool::Tool;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+// ---------------------------------------------------------------------------
+// Mock model: returns add(x=1, y=2) tool call on turn 0, text on turn 1
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+struct AddToolCallModel {
+    turn: Arc<AtomicUsize>,
+}
+
+impl AddToolCallModel {
+    fn new() -> Self {
+        Self {
+            turn: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+}
+
+#[allow(refining_impl_trait)]
+impl CompletionModel for AddToolCallModel {
+    type Response = ();
+    type StreamingResponse = ();
+    type Client = ();
+
+    fn make(_: &Self::Client, _: impl Into<String>) -> Self {
+        Self::new()
+    }
+
+    async fn completion(
+        &self,
+        _request: CompletionRequest,
+    ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+        let turn = self.turn.fetch_add(1, Ordering::SeqCst);
+
+        if turn == 0 {
+            Ok(CompletionResponse {
+                choice: OneOrMany::one(AssistantContent::ToolCall(ToolCall::new(
+                    "tc_add".to_string(),
+                    ToolFunction::new("add".to_string(), json!({"x": 1, "y": 2})),
+                ))),
+                usage: Usage::new(),
+                raw_response: (),
+                message_id: None,
+            })
+        } else {
+            Ok(CompletionResponse {
+                choice: OneOrMany::one(AssistantContent::text("done")),
+                usage: Usage::new(),
+                raw_response: (),
+                message_id: None,
+            })
+        }
+    }
+
+    async fn stream(
+        &self,
+        _request: CompletionRequest,
+    ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+        let stream: StreamingResult<()> = Box::pin(futures::stream::empty());
+        Ok(StreamingCompletionResponse::stream(stream))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Adder tool
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+struct AddArgs {
+    x: i32,
+    y: i32,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("Math error")]
+struct MathError;
+
+#[derive(Deserialize, Serialize)]
+struct Adder;
+
+impl Tool for Adder {
+    const NAME: &'static str = "add";
+    type Error = MathError;
+    type Args = AddArgs;
+    type Output = i32;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: "add".to_string(),
+            description: "Add x and y".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "x": { "type": "number" },
+                    "y": { "type": "number" }
+                },
+                "required": ["x", "y"],
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        Ok(args.x + args.y)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Hooks
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+struct ArgCapture {
+    tool_call_args: Arc<Mutex<Vec<String>>>,
+    tool_result_args: Arc<Mutex<Vec<String>>>,
+    tool_results: Arc<Mutex<Vec<String>>>,
+}
+
+impl ArgCapture {
+    fn new() -> Self {
+        Self {
+            tool_call_args: Arc::new(Mutex::new(Vec::new())),
+            tool_result_args: Arc::new(Mutex::new(Vec::new())),
+            tool_results: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct PassthroughHook {
+    capture: ArgCapture,
+}
+
+impl<M: CompletionModel> PromptHook<M> for PassthroughHook {
+    async fn on_tool_call(
+        &self,
+        _tool_name: &str,
+        _tool_call_id: Option<String>,
+        _internal_call_id: &str,
+        args: &str,
+    ) -> ToolCallHookAction {
+        self.capture
+            .tool_call_args
+            .lock()
+            .unwrap()
+            .push(args.to_string());
+        ToolCallHookAction::cont()
+    }
+
+    async fn on_tool_result(
+        &self,
+        _tool_name: &str,
+        _tool_call_id: Option<String>,
+        _internal_call_id: &str,
+        args: &str,
+        result: &str,
+    ) -> HookAction {
+        self.capture
+            .tool_result_args
+            .lock()
+            .unwrap()
+            .push(args.to_string());
+        self.capture
+            .tool_results
+            .lock()
+            .unwrap()
+            .push(result.to_string());
+        HookAction::cont()
+    }
+}
+
+#[derive(Clone)]
+struct RewriteHook {
+    capture: ArgCapture,
+}
+
+impl<M: CompletionModel> PromptHook<M> for RewriteHook {
+    async fn on_tool_call(
+        &self,
+        _tool_name: &str,
+        _tool_call_id: Option<String>,
+        _internal_call_id: &str,
+        args: &str,
+    ) -> ToolCallHookAction {
+        self.capture
+            .tool_call_args
+            .lock()
+            .unwrap()
+            .push(args.to_string());
+        ToolCallHookAction::continue_with(r#"{"x":100,"y":200}"#)
+    }
+
+    async fn on_tool_result(
+        &self,
+        _tool_name: &str,
+        _tool_call_id: Option<String>,
+        _internal_call_id: &str,
+        args: &str,
+        result: &str,
+    ) -> HookAction {
+        self.capture
+            .tool_result_args
+            .lock()
+            .unwrap()
+            .push(args.to_string());
+        self.capture
+            .tool_results
+            .lock()
+            .unwrap()
+            .push(result.to_string());
+        HookAction::cont()
+    }
+}
+
+#[derive(Clone)]
+struct TerminateHook;
+
+impl<M: CompletionModel> PromptHook<M> for TerminateHook {
+    async fn on_tool_call(
+        &self,
+        _tool_name: &str,
+        _tool_call_id: Option<String>,
+        _internal_call_id: &str,
+        _args: &str,
+    ) -> ToolCallHookAction {
+        ToolCallHookAction::terminate("stopped by hook")
+    }
+}
+
+#[derive(Clone)]
+struct SkipHook {
+    capture: ArgCapture,
+}
+
+impl<M: CompletionModel> PromptHook<M> for SkipHook {
+    async fn on_tool_call(
+        &self,
+        _tool_name: &str,
+        _tool_call_id: Option<String>,
+        _internal_call_id: &str,
+        _args: &str,
+    ) -> ToolCallHookAction {
+        ToolCallHookAction::skip("tool not allowed")
+    }
+
+    async fn on_tool_result(
+        &self,
+        _tool_name: &str,
+        _tool_call_id: Option<String>,
+        _internal_call_id: &str,
+        _args: &str,
+        result: &str,
+    ) -> HookAction {
+        self.capture
+            .tool_results
+            .lock()
+            .unwrap()
+            .push(result.to_string());
+        HookAction::cont()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// P0: Regression — Continue passes original args
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn continue_passes_original_args() {
+    let agent = AgentBuilder::new(AddToolCallModel::new())
+        .tool(Adder)
+        .build();
+
+    let capture = ArgCapture::new();
+    let hook = PassthroughHook {
+        capture: capture.clone(),
+    };
+
+    let response: String = agent
+        .prompt("add 1 and 2")
+        .max_turns(3)
+        .with_hook(hook)
+        .await
+        .expect("prompt should succeed");
+
+    assert_eq!(response, "done");
+
+    let results = capture.tool_results.lock().unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0], "3");
+
+    let result_args = capture.tool_result_args.lock().unwrap();
+    assert_eq!(result_args.len(), 1);
+    assert!(
+        result_args[0].contains("1") && result_args[0].contains("2"),
+        "on_tool_result should see original args, got: {}",
+        result_args[0]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// P0: Contract — ContinueWith replacement args reach call_tool
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn continue_with_replaces_args_in_call_tool() {
+    let agent = AgentBuilder::new(AddToolCallModel::new())
+        .tool(Adder)
+        .build();
+
+    let capture = ArgCapture::new();
+    let hook = RewriteHook {
+        capture: capture.clone(),
+    };
+
+    let response: String = agent
+        .prompt("add 1 and 2")
+        .max_turns(3)
+        .with_hook(hook)
+        .await
+        .expect("prompt should succeed");
+
+    assert_eq!(response, "done");
+
+    let results = capture.tool_results.lock().unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(
+        results[0], "300",
+        "tool should compute 100+200=300, not 1+2=3"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// P0: Contract — on_tool_result receives replacement args
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn continue_with_replacement_args_reach_on_tool_result() {
+    let agent = AgentBuilder::new(AddToolCallModel::new())
+        .tool(Adder)
+        .build();
+
+    let capture = ArgCapture::new();
+    let hook = RewriteHook {
+        capture: capture.clone(),
+    };
+
+    let _response: String = agent
+        .prompt("add")
+        .max_turns(3)
+        .with_hook(hook)
+        .await
+        .expect("prompt should succeed");
+
+    let call_args = capture.tool_call_args.lock().unwrap();
+    assert_eq!(call_args.len(), 1);
+    assert!(
+        call_args[0].contains("1") && call_args[0].contains("2"),
+        "on_tool_call should see original args from LLM, got: {}",
+        call_args[0]
+    );
+
+    let result_args = capture.tool_result_args.lock().unwrap();
+    assert_eq!(result_args.len(), 1);
+    assert!(
+        result_args[0].contains("100") && result_args[0].contains("200"),
+        "on_tool_result should see replacement args, got: {}",
+        result_args[0]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// P1: Regression — Terminate still cancels the loop
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn terminate_still_cancels_loop() {
+    use rig::completion::PromptError;
+
+    let agent = AgentBuilder::new(AddToolCallModel::new())
+        .tool(Adder)
+        .build();
+
+    let result = agent
+        .prompt("add")
+        .max_turns(3)
+        .with_hook(TerminateHook)
+        .await;
+
+    match result {
+        Err(PromptError::PromptCancelled { reason, .. }) => {
+            assert_eq!(reason, "stopped by hook");
+        }
+        Ok(_) => panic!("expected PromptCancelled, got Ok"),
+        Err(other) => panic!("expected PromptCancelled, got: {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// P1: Regression — Skip returns reason as tool result, on_tool_result does NOT fire
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn skip_returns_reason_and_bypasses_on_tool_result() {
+    let agent = AgentBuilder::new(AddToolCallModel::new())
+        .tool(Adder)
+        .build();
+
+    let capture = ArgCapture::new();
+    let hook = SkipHook {
+        capture: capture.clone(),
+    };
+
+    let response: String = agent
+        .prompt("add")
+        .max_turns(3)
+        .with_hook(hook)
+        .await
+        .expect("prompt should succeed");
+
+    assert_eq!(response, "done");
+
+    let results = capture.tool_results.lock().unwrap();
+    assert!(
+        results.is_empty(),
+        "on_tool_result should NOT fire for skipped tool calls, but got: {results:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// P1: Boundary — ContinueWith with invalid JSON
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+struct InvalidJsonHook;
+
+impl<M: CompletionModel> PromptHook<M> for InvalidJsonHook {
+    async fn on_tool_call(
+        &self,
+        _tool_name: &str,
+        _tool_call_id: Option<String>,
+        _internal_call_id: &str,
+        _args: &str,
+    ) -> ToolCallHookAction {
+        ToolCallHookAction::continue_with("not valid json")
+    }
+}
+
+#[tokio::test]
+async fn continue_with_invalid_json_does_not_panic() {
+    let agent = AgentBuilder::new(AddToolCallModel::new())
+        .tool(Adder)
+        .build();
+
+    let result: String = agent
+        .prompt("add")
+        .max_turns(3)
+        .with_hook(InvalidJsonHook)
+        .await
+        .expect("should not panic, tool error becomes string result");
+
+    assert_eq!(result, "done");
+}
+
+// ---------------------------------------------------------------------------
+// P1: Error path — ContinueWith args that fail tool deserialization
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+struct WrongFieldsHook {
+    capture: ArgCapture,
+}
+
+impl<M: CompletionModel> PromptHook<M> for WrongFieldsHook {
+    async fn on_tool_call(
+        &self,
+        _tool_name: &str,
+        _tool_call_id: Option<String>,
+        _internal_call_id: &str,
+        _args: &str,
+    ) -> ToolCallHookAction {
+        ToolCallHookAction::continue_with(r#"{"z": 999}"#)
+    }
+
+    async fn on_tool_result(
+        &self,
+        _tool_name: &str,
+        _tool_call_id: Option<String>,
+        _internal_call_id: &str,
+        _args: &str,
+        result: &str,
+    ) -> HookAction {
+        self.capture
+            .tool_results
+            .lock()
+            .unwrap()
+            .push(result.to_string());
+        HookAction::cont()
+    }
+}
+
+#[tokio::test]
+async fn continue_with_wrong_fields_triggers_tool_error() {
+    let agent = AgentBuilder::new(AddToolCallModel::new())
+        .tool(Adder)
+        .build();
+
+    let capture = ArgCapture::new();
+    let hook = WrongFieldsHook {
+        capture: capture.clone(),
+    };
+
+    let response: String = agent
+        .prompt("add")
+        .max_turns(3)
+        .with_hook(hook)
+        .await
+        .expect("should succeed — tool error becomes string result");
+
+    assert_eq!(response, "done");
+
+    let results = capture.tool_results.lock().unwrap();
+    assert_eq!(
+        results.len(),
+        1,
+        "on_tool_result should still fire for tool errors"
+    );
+    assert!(
+        results[0].contains("missing field"),
+        "tool error should mention missing field, got: {}",
+        results[0]
+    );
+}

--- a/rig/rig-core/tests/core/mod.rs
+++ b/rig/rig-core/tests/core/mod.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "derive")]
 mod embed_macro;
+mod hook_continue_with;
 mod loaders;
 mod prompt_response_messages;
 mod provider_layout;

--- a/rig/rig-core/tests/openai/arg_rewrite_hook.rs
+++ b/rig/rig-core/tests/openai/arg_rewrite_hook.rs
@@ -1,0 +1,142 @@
+use anyhow::Result;
+use rig::agent::{HookAction, PromptHook, ToolCallHookAction};
+use rig::client::{CompletionClient, ProviderClient};
+use rig::completion::{CompletionModel, Prompt, ToolDefinition};
+use rig::providers;
+use rig::tool::Tool;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use crate::support::assert_nonempty_response;
+
+#[derive(Deserialize)]
+struct AddArgs {
+    x: i32,
+    y: i32,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("Math error")]
+struct MathError;
+
+#[derive(Deserialize, Serialize)]
+struct Adder;
+
+impl Tool for Adder {
+    const NAME: &'static str = "add";
+    type Error = MathError;
+    type Args = AddArgs;
+    type Output = i32;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: "add".to_string(),
+            description: "Add two numbers together. Returns x + y.".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "x": { "type": "number", "description": "First number" },
+                    "y": { "type": "number", "description": "Second number" }
+                },
+                "required": ["x", "y"],
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        Ok(args.x + args.y)
+    }
+}
+
+#[derive(Clone)]
+struct ArgRewriteHook {
+    rewritten_args: Arc<Mutex<Option<String>>>,
+    result_args: Arc<Mutex<Option<String>>>,
+}
+
+impl<M: CompletionModel> PromptHook<M> for ArgRewriteHook {
+    async fn on_tool_call(
+        &self,
+        _tool_name: &str,
+        _tool_call_id: Option<String>,
+        _internal_call_id: &str,
+        args: &str,
+    ) -> ToolCallHookAction {
+        let mut parsed: serde_json::Value =
+            serde_json::from_str(args).expect("args should be valid JSON");
+        parsed["x"] = json!(100);
+        parsed["y"] = json!(200);
+        let new_args = serde_json::to_string(&parsed).expect("should serialize");
+        *self.rewritten_args.lock().expect("lock") = Some(new_args.clone());
+        ToolCallHookAction::continue_with(new_args)
+    }
+
+    async fn on_tool_result(
+        &self,
+        _tool_name: &str,
+        _tool_call_id: Option<String>,
+        _internal_call_id: &str,
+        args: &str,
+        _result: &str,
+    ) -> HookAction {
+        *self.result_args.lock().expect("lock") = Some(args.to_string());
+        HookAction::cont()
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires OPENAI_API_KEY"]
+async fn arg_rewrite_hook_modifies_tool_args() -> Result<()> {
+    let agent = providers::openai::Client::from_env()
+        .expect("client should build")
+        .agent(providers::openai::GPT_4O_MINI)
+        .preamble("You have an add tool. Use it when asked to add numbers.")
+        .tool(Adder)
+        .build();
+
+    let rewritten_args = Arc::new(Mutex::new(None));
+    let result_args = Arc::new(Mutex::new(None));
+    let hook = ArgRewriteHook {
+        rewritten_args: rewritten_args.clone(),
+        result_args: result_args.clone(),
+    };
+
+    let response = agent
+        .prompt("What is 1 + 2? Use the add tool.")
+        .max_turns(3)
+        .with_hook(hook)
+        .await?;
+
+    assert_nonempty_response(&response);
+
+    let rewritten = rewritten_args.lock().expect("lock").clone();
+    anyhow::ensure!(
+        rewritten.is_some(),
+        "on_tool_call should have been invoked and rewritten args"
+    );
+    let rewritten = rewritten.unwrap();
+    anyhow::ensure!(
+        rewritten.contains("100") && rewritten.contains("200"),
+        "rewritten args should contain 100 and 200, got: {rewritten}"
+    );
+
+    let result_args_val = result_args.lock().expect("lock").clone();
+    anyhow::ensure!(
+        result_args_val.is_some(),
+        "on_tool_result should have been invoked"
+    );
+    let result_args_val = result_args_val.unwrap();
+    anyhow::ensure!(
+        result_args_val.contains("100") && result_args_val.contains("200"),
+        "on_tool_result should receive the rewritten args, got: {result_args_val}"
+    );
+
+    anyhow::ensure!(
+        response.contains("300"),
+        "response should contain 300 (100+200), got: {response}"
+    );
+
+    Ok(())
+}

--- a/rig/rig-core/tests/openai/mod.rs
+++ b/rig/rig-core/tests/openai/mod.rs
@@ -1,4 +1,5 @@
 mod agent;
+mod arg_rewrite_hook;
 #[cfg(feature = "audio")]
 mod audio_generation;
 mod completions_api;


### PR DESCRIPTION
## Summary

- Add `ContinueWith { args: String }` variant to `ToolCallHookAction` so prompt hooks can modify tool arguments before execution
- Both non-streaming and streaming dispatch paths shadow the original args with the replacement, ensuring `call_tool`, `on_tool_result`, and tracing spans all see the actual arguments used
- Mark `ToolCallHookAction` and `HookAction` as `#[non_exhaustive]` for future extensibility

Fixes #1680

## Motivation

Today `on_tool_call` can observe, reject (`Skip`), or abort (`Terminate`) — but it cannot modify the arguments that will be passed to the tool. This forces callers into workarounds (returning `Skip` and manually calling the tool inside the hook) that bypass rig's dispatch, lose tracing, and make `on_tool_result` inconsistent.

Use cases: argument sanitization (sandbox file paths), argument enrichment (inject defaults the LLM omitted), argument normalization (fix common LLM mistakes in tool args).

## Changes

### `hooks.rs`
- New `ContinueWith { args: String }` variant on `ToolCallHookAction`
- `continue_with()` convenience constructor
- `#[non_exhaustive]` on both `ToolCallHookAction` and `HookAction`
- Updated `on_tool_call` doc to list all four return variants
- 3 unit tests for the new constructor

### `mod.rs` (non-streaming dispatch)
- Refactored `if let` chain to exhaustive `match` on `ToolCallHookAction`
- `args` is shadowed with replacement when `ContinueWith` is returned
- Moved `tool_span.record("gen_ai.tool.call.arguments")` after the hook so it records the actual args used

### `streaming.rs` (streaming dispatch)
- Same refactor — `tool_args` is shadowed, downstream `call_tool`, `on_tool_result`, and tracing all see the replacement

### Tests
- **`tests/core/hook_continue_with.rs`** — 7 mock-based CI-runnable tests (no API key needed):
  - `continue_passes_original_args` — regression: `Continue` still works
  - `continue_with_replaces_args_in_call_tool` — contract: tool computes 100+200=300, not 1+2=3
  - `continue_with_replacement_args_reach_on_tool_result` — contract: `on_tool_result` sees replacement args
  - `terminate_still_cancels_loop` — regression: `Terminate` still works after refactor
  - `skip_returns_reason_and_bypasses_on_tool_result` — regression: `Skip` still works, `on_tool_result` does NOT fire
  - `continue_with_invalid_json_does_not_panic` — boundary: invalid JSON args → graceful tool error
  - `continue_with_wrong_fields_triggers_tool_error` — error path: missing fields → deser error becomes tool result
- **`tests/openai/arg_rewrite_hook.rs`** — integration test (requires API key) verifying end-to-end arg rewrite

## Breaking Changes

- `ToolCallHookAction` and `HookAction` are now `#[non_exhaustive]` — downstream crates with exhaustive `match` on these enums will need a wildcard arm
- New `ContinueWith` variant — not breaking by itself since the enums are now `#[non_exhaustive]`

## AI Disclosure

This PR was significantly assisted by AI (Claude). All code has been reviewed, tested, and verified by the contributor.