### PR TITLE
fix(bedrock): preserve adaptive-thinking signatures in streaming reasoning

### DIFF
--- a/rig-integrations/rig-bedrock/src/streaming.rs
+++ b/rig-integrations/rig-bedrock/src/streaming.rs
@@ -56,6 +56,30 @@ struct ReasoningState {
     signature: Option<String>,
 }
 
+/// Convert an accumulated [`ReasoningState`] into a streaming reasoning chunk.
+///
+/// Adaptive-thinking blocks from Bedrock can arrive as signature-only — i.e. a
+/// `Signature` delta with no preceding non-empty `Text` delta. Dropping such
+/// blocks loses the signature on the way back to the consumer, which then
+/// fails on the next turn with `messages.N.content.0.thinking.signature:
+/// Field required` when the conversation is replayed to Bedrock. We must emit
+/// whenever either the content or the signature is present; both-empty is
+/// still skipped.
+fn finalize_reasoning(
+    state: ReasoningState,
+) -> Option<RawStreamingChoice<BedrockStreamingResponse>> {
+    if state.content.is_empty() && state.signature.is_none() {
+        return None;
+    }
+    Some(RawStreamingChoice::Reasoning {
+        id: None,
+        content: ReasoningContent::Text {
+            text: state.content,
+            signature: state.signature,
+        },
+    })
+}
+
 impl CompletionModel {
     pub(crate) async fn stream(
         &self,
@@ -168,14 +192,8 @@ impl CompletionModel {
                     },
                     aws_bedrock::ConverseStreamOutput::ContentBlockStop(_event) => {
                         if let Some(reasoning_state) = current_reasoning.take()
-                            && !reasoning_state.content.is_empty() {
-                                yield Ok(RawStreamingChoice::Reasoning {
-                                    id: None,
-                                    content: ReasoningContent::Text {
-                                        text: reasoning_state.content,
-                                        signature: reasoning_state.signature,
-                                    },
-                                })
+                            && let Some(choice) = finalize_reasoning(reasoning_state) {
+                                yield Ok(choice)
                             }
                     },
                     aws_bedrock::ConverseStreamOutput::MessageStop(message_stop_event) => {
@@ -527,5 +545,79 @@ mod tests {
 
         assert_eq!(state.content, "Reasoning content here");
         assert_eq!(state.signature, Some("sig_part1_part2".to_string()));
+    }
+
+    #[test]
+    fn finalize_reasoning_with_content_and_signature_emits_text_block() {
+        let state = ReasoningState {
+            content: "I am thinking".to_string(),
+            signature: Some("sig-abc".to_string()),
+        };
+
+        let choice = finalize_reasoning(state).expect("should emit reasoning");
+        match choice {
+            RawStreamingChoice::Reasoning { id, content } => {
+                assert!(id.is_none());
+                match content {
+                    ReasoningContent::Text { text, signature } => {
+                        assert_eq!(text, "I am thinking");
+                        assert_eq!(signature.as_deref(), Some("sig-abc"));
+                    }
+                    other => panic!("expected ReasoningContent::Text, got {:?}", other),
+                }
+            }
+            _ => panic!("expected RawStreamingChoice::Reasoning"),
+        }
+    }
+
+    #[test]
+    fn finalize_reasoning_signature_only_still_emits_block() {
+        // Adaptive-thinking on Bedrock can produce a Signature delta with no
+        // accompanying non-empty Text delta. Previously this was silently
+        // dropped, losing the signature and breaking next-turn replay.
+        let state = ReasoningState {
+            content: String::new(),
+            signature: Some("sig-only".to_string()),
+        };
+
+        let choice =
+            finalize_reasoning(state).expect("should emit reasoning for signature-only state");
+        match choice {
+            RawStreamingChoice::Reasoning { content, .. } => match content {
+                ReasoningContent::Text { text, signature } => {
+                    assert!(text.is_empty());
+                    assert_eq!(signature.as_deref(), Some("sig-only"));
+                }
+                other => panic!("expected ReasoningContent::Text, got {:?}", other),
+            },
+            _ => panic!("expected RawStreamingChoice::Reasoning"),
+        }
+    }
+
+    #[test]
+    fn finalize_reasoning_content_only_still_emits_block() {
+        let state = ReasoningState {
+            content: "thoughts without sig".to_string(),
+            signature: None,
+        };
+
+        let choice =
+            finalize_reasoning(state).expect("should emit reasoning for content-only state");
+        match choice {
+            RawStreamingChoice::Reasoning { content, .. } => match content {
+                ReasoningContent::Text { text, signature } => {
+                    assert_eq!(text, "thoughts without sig");
+                    assert!(signature.is_none());
+                }
+                other => panic!("expected ReasoningContent::Text, got {:?}", other),
+            },
+            _ => panic!("expected RawStreamingChoice::Reasoning"),
+        }
+    }
+
+    #[test]
+    fn finalize_reasoning_both_empty_emits_nothing() {
+        let state = ReasoningState::default();
+        assert!(finalize_reasoning(state).is_none());
     }
 }


### PR DESCRIPTION
Closes #1684.

## Summary

Streaming counterpart to #1675. The non-streaming `assistant_content.rs` empty-text guard fixed in that PR has an analogue in `streaming.rs`: the `ContentBlockStop` handler skips emitting `RawStreamingChoice::Reasoning` whenever `reasoning_state.content.is_empty()`, even if a `Signature` delta has populated `reasoning_state.signature`. Bedrock adaptive thinking can produce exactly that shape — `ReasoningContentBlockDelta::Signature` with no preceding non-empty `Text` delta — and the signature is silently dropped.

## Symptom

In a multi-turn streaming conversation against `eu.anthropic.claude-opus-4-7` (or any Bedrock Anthropic model with adaptive thinking enabled), the consumer never receives a `RawStreamingChoice::Reasoning { signature: Some(_), .. }` event for signature-only blocks. On the next turn, replaying that conversation back to Bedrock fails with:

```
messages.N.content.0.thinking.signature: Field required
```

— the same error that motivated #1675 on the non-streaming path.

## Fix

Extracted a `finalize_reasoning(state)` helper from the inline emission logic and relaxed the gate so a `Reasoning` chunk is emitted whenever **either** content or signature is present; both-empty is still skipped.

```rust
fn finalize_reasoning(
    state: ReasoningState,
) -> Option<RawStreamingChoice<BedrockStreamingResponse>> {
    if state.content.is_empty() && state.signature.is_none() {
        return None;
    }
    Some(RawStreamingChoice::Reasoning { ... })
}
```

The helper extraction makes the emission decision unit-testable — the original inline form had no driver for the `stream!` block. Four cases are now covered:

- content + signature → emits Text block with both
- signature only → emits Text block with empty text + signature (the bug fix)
- content only → emits Text block with content + no signature
- both empty → emits nothing (preserves prior behavior)

## Verification

Confirmed end-to-end against real Bedrock with `eu.anthropic.claude-opus-4-7` and `thinking={type: adaptive}, output_config={effort: high}`:

```
[smoke] Reasoning emitted: text_len=0, sig_prefix=Er0OClkIDRAB
[smoke] totals: reasoning_chunks=1, text_chunks=0
test streaming_emits_reasoning_signature_for_adaptive_thinking ... ok
```

`text_len=0` with a populated signature is the exact shape that pre-fix would have been dropped at the `!content.is_empty()` guard.

## Test plan

- [x] `cargo test -p rig-bedrock --lib` (70 + 4 new tests pass)
- [x] `cargo clippy -p rig-bedrock --tests -- -D warnings`
- [x] `cargo fmt -p rig-bedrock --check`
- [x] Live verification against Bedrock Opus 4.7 with adaptive thinking (output above)

## Notes

- Branch is based on `main` post-#1675, so this PR contains only the streaming-side change.
- Non-streaming Bedrock (already shipped in #1675) is unaffected — different code path.
- No public API change; `finalize_reasoning` is private to the module.
