### PR TITLE
feat(core): add Xiaomi MiMo

### DIFF
--- a/rig/rig-core/src/providers/mod.rs
+++ b/rig/rig-core/src/providers/mod.rs
@@ -69,4 +69,5 @@ pub mod perplexity;
 pub mod together;
 pub mod voyageai;
 pub mod xai;
+pub mod xiaomimimo;
 pub mod zai;

--- a/rig/rig-core/src/providers/xiaomimimo.rs
+++ b/rig/rig-core/src/providers/xiaomimimo.rs
@@ -335,10 +335,9 @@ where
         }
 
         let body = response.into_body().await?;
-        let api_resp: ListModelsResponse =
-            serde_json::from_slice(&body).map_err(|error| {
-                ModelListingError::parse_error_with_context("Xiaomi MiMo", path, &error, &body)
-            })?;
+        let api_resp: ListModelsResponse = serde_json::from_slice(&body).map_err(|error| {
+            ModelListingError::parse_error_with_context("Xiaomi MiMo", path, &error, &body)
+        })?;
 
         let models = api_resp.data.into_iter().map(Model::from).collect();
 

--- a/rig/rig-core/src/providers/xiaomimimo.rs
+++ b/rig/rig-core/src/providers/xiaomimimo.rs
@@ -22,13 +22,15 @@
 //! ```
 
 use crate::client::{
-    self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
-    ProviderClient,
+    self, BearerAuth, Capabilities, Capable, DebugExt, ModelLister, Nothing, Provider,
+    ProviderBuilder, ProviderClient,
 };
 use crate::http_client::{self, HttpClientExt};
+use crate::model::{Model, ModelList, ModelListingError};
 use crate::providers::anthropic::client::{
     AnthropicBuilder as AnthropicCompatBuilder, AnthropicKey, finish_anthropic_builder,
 };
+use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
 
 /// OpenAI-compatible base URL.
 pub const API_BASE_URL: &str = "https://api.xiaomimimo.com/v1";
@@ -86,7 +88,7 @@ impl<H> Capabilities<H> for XiaomiMimoExt {
     type Completion = Capable<super::openai::completion::GenericCompletionModel<XiaomiMimoExt, H>>;
     type Embeddings = Nothing;
     type Transcription = Nothing;
-    type ModelListing = Nothing;
+    type ModelListing = Capable<XiaomiMimoModelLister<H>>;
     #[cfg(feature = "image")]
     type ImageGeneration = Nothing;
     #[cfg(feature = "audio")]
@@ -264,6 +266,83 @@ impl<H> AnthropicClientBuilder<H> {
             ext.anthropic.anthropic_betas.push(anthropic_beta.into());
             ext
         })
+    }
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct ListModelsResponse {
+    data: Vec<ListModelEntry>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct ListModelEntry {
+    id: String,
+    owned_by: String,
+}
+
+impl From<ListModelEntry> for Model {
+    fn from(value: ListModelEntry) -> Self {
+        let mut model = Model::from_id(value.id);
+        model.owned_by = Some(value.owned_by);
+        model
+    }
+}
+
+/// [`ModelLister`] implementation for the Xiaomi MiMo API (`GET /models`).
+#[derive(Clone)]
+pub struct XiaomiMimoModelLister<H = reqwest::Client> {
+    client: Client<H>,
+}
+
+impl<H> ModelLister<H> for XiaomiMimoModelLister<H>
+where
+    H: HttpClientExt + WasmCompatSend + WasmCompatSync + 'static,
+{
+    type Client = Client<H>;
+
+    fn new(client: Self::Client) -> Self {
+        Self { client }
+    }
+
+    async fn list_all(&self) -> Result<ModelList, ModelListingError> {
+        let path = "/models";
+        let req = self.client.get(path)?.body(http_client::NoBody)?;
+        let response = self
+            .client
+            .send::<_, Vec<u8>>(req)
+            .await
+            .map_err(|error| match error {
+                http_client::Error::InvalidStatusCodeWithMessage(status, message) => {
+                    ModelListingError::api_error_with_context(
+                        "Xiaomi MiMo",
+                        path,
+                        status.as_u16(),
+                        message.as_bytes(),
+                    )
+                }
+                other => ModelListingError::from(other),
+            })?;
+
+        if !response.status().is_success() {
+            let status_code = response.status().as_u16();
+            let body = response.into_body().await?;
+            return Err(ModelListingError::api_error_with_context(
+                "Xiaomi MiMo",
+                path,
+                status_code,
+                &body,
+            ));
+        }
+
+        let body = response.into_body().await?;
+        let api_resp: ListModelsResponse =
+            serde_json::from_slice(&body).map_err(|error| {
+                ModelListingError::parse_error_with_context("Xiaomi MiMo", path, &error, &body)
+            })?;
+
+        let models = api_resp.data.into_iter().map(Model::from).collect();
+
+        Ok(ModelList::new(models))
     }
 }
 

--- a/rig/rig-core/src/providers/xiaomimimo.rs
+++ b/rig/rig-core/src/providers/xiaomimimo.rs
@@ -1,0 +1,326 @@
+//! Xiaomi MiMo API clients and Rig integrations.
+//!
+//! Xiaomi exposes both OpenAI-compatible and Anthropic-compatible chat APIs
+//! under a single global host.
+//!
+//! # OpenAI-compatible example
+//! ```no_run
+//! use rig::client::CompletionClient;
+//! use rig::providers::xiaomimimo;
+//!
+//! let client = xiaomimimo::Client::new("YOUR_API_KEY").expect("Failed to build client");
+//! let model = client.completion_model(xiaomimimo::MIMO_V2_5_PRO);
+//! ```
+//!
+//! # Anthropic-compatible example
+//! ```no_run
+//! use rig::client::CompletionClient;
+//! use rig::providers::xiaomimimo;
+//!
+//! let client = xiaomimimo::AnthropicClient::new("YOUR_API_KEY").expect("Failed to build client");
+//! let model = client.completion_model(xiaomimimo::MIMO_V2_5_PRO);
+//! ```
+
+use crate::client::{
+    self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
+    ProviderClient,
+};
+use crate::http_client::{self, HttpClientExt};
+use crate::providers::anthropic::client::{
+    AnthropicBuilder as AnthropicCompatBuilder, AnthropicKey, finish_anthropic_builder,
+};
+
+/// OpenAI-compatible base URL.
+pub const API_BASE_URL: &str = "https://api.xiaomimimo.com/v1";
+/// Anthropic-compatible base URL.
+pub const ANTHROPIC_API_BASE_URL: &str = "https://api.xiaomimimo.com/anthropic/v1";
+
+/// `mimo-v2-flash`
+pub const MIMO_V2_FLASH: &str = "mimo-v2-flash";
+/// `mimo-v2-omni`
+pub const MIMO_V2_OMNI: &str = "mimo-v2-omni";
+/// `mimo-v2-pro`
+pub const MIMO_V2_PRO: &str = "mimo-v2-pro";
+/// `mimo-v2.5`
+pub const MIMO_V2_5: &str = "mimo-v2.5";
+/// `mimo-v2.5-pro`
+pub const MIMO_V2_5_PRO: &str = "mimo-v2.5-pro";
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct XiaomiMimoExt;
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct XiaomiMimoBuilder;
+
+#[derive(Debug, Default, Clone)]
+pub struct XiaomiMimoAnthropicBuilder {
+    anthropic: AnthropicCompatBuilder,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct XiaomiMimoAnthropicExt;
+
+type XiaomiMimoApiKey = BearerAuth;
+
+pub type Client<H = reqwest::Client> = client::Client<XiaomiMimoExt, H>;
+pub type ClientBuilder<H = reqwest::Client> =
+    client::ClientBuilder<XiaomiMimoBuilder, XiaomiMimoApiKey, H>;
+
+pub type AnthropicClient<H = reqwest::Client> = client::Client<XiaomiMimoAnthropicExt, H>;
+pub type AnthropicClientBuilder<H = reqwest::Client> =
+    client::ClientBuilder<XiaomiMimoAnthropicBuilder, AnthropicKey, H>;
+
+impl Provider for XiaomiMimoExt {
+    type Builder = XiaomiMimoBuilder;
+
+    const VERIFY_PATH: &'static str = "/models";
+}
+
+impl Provider for XiaomiMimoAnthropicExt {
+    type Builder = XiaomiMimoAnthropicBuilder;
+
+    const VERIFY_PATH: &'static str = "/v1/models";
+}
+
+impl<H> Capabilities<H> for XiaomiMimoExt {
+    type Completion = Capable<super::openai::completion::GenericCompletionModel<XiaomiMimoExt, H>>;
+    type Embeddings = Nothing;
+    type Transcription = Nothing;
+    type ModelListing = Nothing;
+    #[cfg(feature = "image")]
+    type ImageGeneration = Nothing;
+    #[cfg(feature = "audio")]
+    type AudioGeneration = Nothing;
+}
+
+impl<H> Capabilities<H> for XiaomiMimoAnthropicExt {
+    type Completion =
+        Capable<super::anthropic::completion::GenericCompletionModel<XiaomiMimoAnthropicExt, H>>;
+    type Embeddings = Nothing;
+    type Transcription = Nothing;
+    type ModelListing = Nothing;
+    #[cfg(feature = "image")]
+    type ImageGeneration = Nothing;
+    #[cfg(feature = "audio")]
+    type AudioGeneration = Nothing;
+}
+
+impl DebugExt for XiaomiMimoExt {}
+impl DebugExt for XiaomiMimoAnthropicExt {}
+
+impl ProviderBuilder for XiaomiMimoBuilder {
+    type Extension<H>
+        = XiaomiMimoExt
+    where
+        H: HttpClientExt;
+    type ApiKey = XiaomiMimoApiKey;
+
+    const BASE_URL: &'static str = API_BASE_URL;
+
+    fn build<H>(
+        _builder: &client::ClientBuilder<Self, Self::ApiKey, H>,
+    ) -> http_client::Result<Self::Extension<H>>
+    where
+        H: HttpClientExt,
+    {
+        Ok(XiaomiMimoExt)
+    }
+}
+
+impl ProviderBuilder for XiaomiMimoAnthropicBuilder {
+    type Extension<H>
+        = XiaomiMimoAnthropicExt
+    where
+        H: HttpClientExt;
+    type ApiKey = AnthropicKey;
+
+    const BASE_URL: &'static str = ANTHROPIC_API_BASE_URL;
+
+    fn build<H>(
+        _builder: &client::ClientBuilder<Self, Self::ApiKey, H>,
+    ) -> http_client::Result<Self::Extension<H>>
+    where
+        H: HttpClientExt,
+    {
+        Ok(XiaomiMimoAnthropicExt)
+    }
+
+    fn finish<H>(
+        &self,
+        builder: client::ClientBuilder<Self, AnthropicKey, H>,
+    ) -> http_client::Result<client::ClientBuilder<Self, AnthropicKey, H>> {
+        finish_anthropic_builder(&self.anthropic, builder)
+    }
+}
+
+impl super::anthropic::completion::AnthropicCompatibleProvider for XiaomiMimoAnthropicExt {
+    const PROVIDER_NAME: &'static str = "xiaomimimo";
+
+    fn default_max_tokens(_model: &str) -> Option<u64> {
+        Some(4096)
+    }
+}
+
+impl ProviderClient for Client {
+    type Input = XiaomiMimoApiKey;
+    type Error = crate::client::ProviderClientError;
+
+    fn from_env() -> Result<Self, Self::Error> {
+        let api_key = crate::client::required_env_var("XIAOMI_MIMO_API_KEY")?;
+        let mut builder = Self::builder().api_key(api_key);
+
+        if let Some(base_url) = crate::client::optional_env_var("XIAOMI_MIMO_API_BASE")? {
+            builder = builder.base_url(base_url);
+        }
+
+        builder.build().map_err(Into::into)
+    }
+
+    fn from_val(input: Self::Input) -> Result<Self, Self::Error> {
+        Self::new(input).map_err(Into::into)
+    }
+}
+
+impl ProviderClient for AnthropicClient {
+    type Input = String;
+    type Error = crate::client::ProviderClientError;
+
+    fn from_env() -> Result<Self, Self::Error> {
+        let api_key = crate::client::required_env_var("XIAOMI_MIMO_API_KEY")?;
+        let mut builder = Self::builder().api_key(api_key);
+
+        if let Some(base_url) =
+            anthropic_base_override("XIAOMI_MIMO_ANTHROPIC_API_BASE", "XIAOMI_MIMO_API_BASE")?
+        {
+            builder = builder.base_url(base_url);
+        }
+
+        builder.build().map_err(Into::into)
+    }
+
+    fn from_val(input: Self::Input) -> Result<Self, Self::Error> {
+        Self::builder().api_key(input).build().map_err(Into::into)
+    }
+}
+
+fn anthropic_base_override(
+    primary_env: &'static str,
+    fallback_env: &'static str,
+) -> crate::client::ProviderClientResult<Option<String>> {
+    let primary = crate::client::optional_env_var(primary_env)?;
+    let fallback = crate::client::optional_env_var(fallback_env)?;
+
+    Ok(resolve_anthropic_base_override(
+        primary.as_deref(),
+        fallback.as_deref(),
+    ))
+}
+
+fn resolve_anthropic_base_override(
+    primary: Option<&str>,
+    fallback: Option<&str>,
+) -> Option<String> {
+    primary
+        .map(str::to_owned)
+        .or_else(|| fallback.and_then(normalize_anthropic_base_url))
+}
+
+fn normalize_anthropic_base_url(base_url: &str) -> Option<String> {
+    if base_url.contains("/anthropic") {
+        return Some(base_url.to_owned());
+    }
+
+    if base_url.trim_end_matches('/') == API_BASE_URL {
+        return Some(ANTHROPIC_API_BASE_URL.to_owned());
+    }
+
+    let mut url = url::Url::parse(base_url).ok()?;
+    if !matches!(url.path(), "/v1" | "/v1/") {
+        return None;
+    }
+    url.set_path("/anthropic/v1");
+    Some(url.to_string())
+}
+
+impl<H> AnthropicClientBuilder<H> {
+    pub fn anthropic_version(self, anthropic_version: &str) -> Self {
+        self.over_ext(|mut ext| {
+            ext.anthropic.anthropic_version = anthropic_version.into();
+            ext
+        })
+    }
+
+    pub fn anthropic_betas(self, anthropic_betas: &[&str]) -> Self {
+        self.over_ext(|mut ext| {
+            ext.anthropic
+                .anthropic_betas
+                .extend(anthropic_betas.iter().copied().map(String::from));
+            ext
+        })
+    }
+
+    pub fn anthropic_beta(self, anthropic_beta: &str) -> Self {
+        self.over_ext(|mut ext| {
+            ext.anthropic.anthropic_betas.push(anthropic_beta.into());
+            ext
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ANTHROPIC_API_BASE_URL, API_BASE_URL, normalize_anthropic_base_url,
+        resolve_anthropic_base_override,
+    };
+
+    #[test]
+    fn test_client_initialization() {
+        let _client =
+            crate::providers::xiaomimimo::Client::new("dummy-key").expect("Client::new()");
+        let _client_from_builder = crate::providers::xiaomimimo::Client::builder()
+            .api_key("dummy-key")
+            .build()
+            .expect("Client::builder()");
+        let _anthropic_client = crate::providers::xiaomimimo::AnthropicClient::new("dummy-key")
+            .expect("AnthropicClient::new()");
+        let _anthropic_client_from_builder =
+            crate::providers::xiaomimimo::AnthropicClient::builder()
+                .api_key("dummy-key")
+                .build()
+                .expect("AnthropicClient::builder()");
+    }
+
+    #[test]
+    fn normalize_openai_bases_to_anthropic_bases() {
+        assert_eq!(
+            normalize_anthropic_base_url(API_BASE_URL).as_deref(),
+            Some(ANTHROPIC_API_BASE_URL)
+        );
+        assert_eq!(
+            normalize_anthropic_base_url("https://proxy.example.com/v1").as_deref(),
+            Some("https://proxy.example.com/anthropic/v1")
+        );
+    }
+
+    #[test]
+    fn normalize_preserves_existing_anthropic_base() {
+        assert_eq!(
+            normalize_anthropic_base_url(ANTHROPIC_API_BASE_URL).as_deref(),
+            Some(ANTHROPIC_API_BASE_URL)
+        );
+    }
+
+    #[test]
+    fn anthropic_primary_override_wins() {
+        let override_url = resolve_anthropic_base_override(
+            Some("https://primary.example.com/anthropic/v1"),
+            Some(API_BASE_URL),
+        );
+
+        assert_eq!(
+            override_url.as_deref(),
+            Some("https://primary.example.com/anthropic/v1")
+        );
+    }
+}

--- a/rig/rig-core/tests/xiaomimimo.rs
+++ b/rig/rig-core/tests/xiaomimimo.rs
@@ -18,6 +18,8 @@
 //! backends, and running them concurrently creates avoidable rate-limit,
 //! quota, and load-related flakiness.
 //!
+//! Use XIAOMI_MIMO_API_KEY to set the api key
+//!
 //! Run a single ignored smoke test with:
 //! `cargo test -p rig-core --test xiaomimimo xiaomimimo::anthropic::anthropic_compatible_completion_smoke -- --ignored`
 

--- a/rig/rig-core/tests/xiaomimimo.rs
+++ b/rig/rig-core/tests/xiaomimimo.rs
@@ -1,0 +1,28 @@
+#![allow(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::unwrap_used,
+    clippy::unreachable
+)]
+
+//! Xiaomi MiMo integration tests.
+//!
+//! Run the provider target with:
+//! `cargo test -p rig-core --test xiaomimimo`
+//!
+//! Run all ignored provider-backed tests serially with:
+//! `cargo test -p rig-core --test xiaomimimo -- --ignored --test-threads=1`
+//!
+//! Use `--test-threads=1` because these ignored tests talk to real model
+//! backends, and running them concurrently creates avoidable rate-limit,
+//! quota, and load-related flakiness.
+//!
+//! Run a single ignored smoke test with:
+//! `cargo test -p rig-core --test xiaomimimo xiaomimimo::anthropic::anthropic_compatible_completion_smoke -- --ignored`
+
+#[path = "common/support.rs"]
+mod support;
+
+#[path = "xiaomimimo/mod.rs"]
+mod xiaomimimo;

--- a/rig/rig-core/tests/xiaomimimo/anthropic.rs
+++ b/rig/rig-core/tests/xiaomimimo/anthropic.rs
@@ -1,0 +1,22 @@
+//! Xiaomi MiMo Anthropic-compatible completion smoke test.
+
+use rig::client::{CompletionClient, ProviderClient};
+use rig::completion::Prompt;
+use rig::providers::xiaomimimo;
+
+use crate::support::{BASIC_PREAMBLE, BASIC_PROMPT, assert_nonempty_response};
+
+#[tokio::test]
+#[ignore = "requires XIAOMI_MIMO_API_KEY"]
+async fn anthropic_compatible_completion_smoke() {
+    let response = xiaomimimo::AnthropicClient::from_env()
+        .expect("client should build")
+        .agent(xiaomimimo::MIMO_V2_5_PRO)
+        .preamble(BASIC_PREAMBLE)
+        .build()
+        .prompt(BASIC_PROMPT)
+        .await
+        .expect("Xiaomi MiMo Anthropic-compatible completion should succeed");
+
+    assert_nonempty_response(&response);
+}

--- a/rig/rig-core/tests/xiaomimimo/mod.rs
+++ b/rig/rig-core/tests/xiaomimimo/mod.rs
@@ -1,0 +1,2 @@
+mod anthropic;
+mod openai;

--- a/rig/rig-core/tests/xiaomimimo/mod.rs
+++ b/rig/rig-core/tests/xiaomimimo/mod.rs
@@ -1,2 +1,3 @@
 mod anthropic;
+mod models;
 mod openai;

--- a/rig/rig-core/tests/xiaomimimo/models.rs
+++ b/rig/rig-core/tests/xiaomimimo/models.rs
@@ -12,9 +12,7 @@ async fn list_models_smoke() {
     let models = match client.list_models().await {
         Ok(models) => models,
         Err(error) => {
-            panic!(
-                "listing Xiaomi MiMo models should succeed\nDisplay: {error}\nDebug: {error:#?}"
-            )
+            panic!("listing Xiaomi MiMo models should succeed\nDisplay: {error}\nDebug: {error:#?}")
         }
     };
 
@@ -32,7 +30,13 @@ async fn list_models_smoke() {
 
     let model_ids: Vec<&str> = models.iter().map(|m| m.id.as_str()).collect();
 
-    for expected_id in [MIMO_V2_FLASH, MIMO_V2_OMNI, MIMO_V2_PRO, MIMO_V2_5, MIMO_V2_5_PRO] {
+    for expected_id in [
+        MIMO_V2_FLASH,
+        MIMO_V2_OMNI,
+        MIMO_V2_PRO,
+        MIMO_V2_5,
+        MIMO_V2_5_PRO,
+    ] {
         assert!(
             model_ids.contains(&expected_id),
             "expected model {expected_id:?} in response\nReturned model IDs: {model_ids:#?}"

--- a/rig/rig-core/tests/xiaomimimo/models.rs
+++ b/rig/rig-core/tests/xiaomimimo/models.rs
@@ -1,7 +1,9 @@
 //! Xiaomi MiMo model listing smoke test.
 
 use rig::client::{ModelListingClient, ProviderClient};
-use rig::providers::xiaomimimo;
+use rig::providers::xiaomimimo::{
+    self, MIMO_V2_5, MIMO_V2_5_PRO, MIMO_V2_FLASH, MIMO_V2_OMNI, MIMO_V2_PRO,
+};
 
 #[tokio::test]
 #[ignore = "requires XIAOMI_MIMO_API_KEY"]
@@ -27,4 +29,13 @@ async fn list_models_smoke() {
             .any(|model| model.owned_by.as_deref() == Some("xiaomi")),
         "expected at least one Xiaomi-owned model\nModel list: {models:#?}"
     );
+
+    let model_ids: Vec<&str> = models.iter().map(|m| m.id.as_str()).collect();
+
+    for expected_id in [MIMO_V2_FLASH, MIMO_V2_OMNI, MIMO_V2_PRO, MIMO_V2_5, MIMO_V2_5_PRO] {
+        assert!(
+            model_ids.contains(&expected_id),
+            "expected model {expected_id:?} in response\nReturned model IDs: {model_ids:#?}"
+        );
+    }
 }

--- a/rig/rig-core/tests/xiaomimimo/models.rs
+++ b/rig/rig-core/tests/xiaomimimo/models.rs
@@ -1,0 +1,30 @@
+//! Xiaomi MiMo model listing smoke test.
+
+use rig::client::{ModelListingClient, ProviderClient};
+use rig::providers::xiaomimimo;
+
+#[tokio::test]
+#[ignore = "requires XIAOMI_MIMO_API_KEY"]
+async fn list_models_smoke() {
+    let client = xiaomimimo::Client::from_env().expect("client should build");
+    let models = match client.list_models().await {
+        Ok(models) => models,
+        Err(error) => {
+            panic!(
+                "listing Xiaomi MiMo models should succeed\nDisplay: {error}\nDebug: {error:#?}"
+            )
+        }
+    };
+
+    assert!(
+        !models.is_empty(),
+        "expected Xiaomi MiMo to return at least one model\nModel list: {models:#?}"
+    );
+
+    assert!(
+        models
+            .iter()
+            .any(|model| model.owned_by.as_deref() == Some("xiaomi")),
+        "expected at least one Xiaomi-owned model\nModel list: {models:#?}"
+    );
+}

--- a/rig/rig-core/tests/xiaomimimo/openai.rs
+++ b/rig/rig-core/tests/xiaomimimo/openai.rs
@@ -1,0 +1,22 @@
+//! Xiaomi MiMo OpenAI-compatible completion smoke test.
+
+use rig::client::{CompletionClient, ProviderClient};
+use rig::completion::Prompt;
+use rig::providers::xiaomimimo;
+
+use crate::support::{BASIC_PREAMBLE, BASIC_PROMPT, assert_nonempty_response};
+
+#[tokio::test]
+#[ignore = "requires XIAOMI_MIMO_API_KEY"]
+async fn openai_compatible_completion_smoke() {
+    let response = xiaomimimo::Client::from_env()
+        .expect("client should build")
+        .agent(xiaomimimo::MIMO_V2_5_PRO)
+        .preamble(BASIC_PREAMBLE)
+        .build()
+        .prompt(BASIC_PROMPT)
+        .await
+        .expect("Xiaomi MiMo OpenAI-compatible completion should succeed");
+
+    assert_nonempty_response(&response);
+}


### PR DESCRIPTION
## Add xiaomimimo provider (Xiaomi MiMo)

Adds Rig support for Xiaomi's MiMo LLM API, which exposes both OpenAI-compatible and Anthropic-compatible chat endpoints under a single global host.

### What's new

  - rig::providers::xiaomimimo::Client — OpenAI-compatible client backed by https://api.xiaomimimo.com/v1
  - rig::providers::xiaomimimo::AnthropicClient — Anthropic-compatible client backed by https://api.xiaomimimo.com/anthropic/v1
  - Model listing — Client::list_models() via GET /models; AnthropicClient leaves this as Nothing since the Anthropic-compat endpoint doesn't host a models list
  - Model constants for the five chat-capable models: MIMO_V2_FLASH, MIMO_V2_OMNI, MIMO_V2_PRO, MIMO_V2_5, MIMO_V2_5_PRO (TTS-only models omitted — not reachable via the chat completion API)
  - AnthropicClientBuilder convenience methods: .anthropic_version(), .anthropic_beta(), .anthropic_betas()
  - Env vars: XIAOMI_MIMO_API_KEY (required), XIAOMI_MIMO_API_BASE (optional OpenAI base override), XIAOMI_MIMO_ANTHROPIC_API_BASE (optional Anthropic base override, falls back to XIAOMI_MIMO_API_BASE with path normalization to /anthropic/v1)

### Tests                                                                                                                                                                                                                                                                                                                                                                                                                          
   
  Three #[ignore]-gated smoke tests (require XIAOMI_MIMO_API_KEY):                                                                                                                                                                                                                                                                                                                                                               
  - openai_compatible_completion_smoke                            
  - anthropic_compatible_completion_smoke                                                                                                                                                                                                                                                                                                                                                                                        
  - list_models_smoke — verifies all five chat-model constants appear in the API response
                                                                                         
  Four unit tests run without network access: client initialization and three URL-normalization cases.