### PR TITLE
docs: add ilert to Who is using Rig list

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Below is a non-exhaustive list of companies and people who are using Rig:
 - [deepwiki-rs](https://github.com/sopaco/deepwiki-rs) - Turn code into clarity. Generate accurate technical docs and AI-ready context in minutes—perfectly structured for human teams and intelligent agents.
 - [Cortex Memory](https://github.com/sopaco/cortex-mem) - The production-ready memory system for intelligent agents. A complete solution for memory management, from extraction and vector search to automated optimization, with a REST API, MCP, CLI, and insights dashboard out-of-the-box.
 - [Ironclaw](https://github.com/nearai/ironclaw) - A secure personal AI assistant
+- [ilert](https://www.ilert.com/) - Incident management & alerting platform. Uses Rig as the multi-provider abstraction in its agentic LLM proxy powering ilert AI.
 
 For a full list, check out our [ECOSYSTEM.md file.](https://www.github.com/0xPlaygrounds/rig/tree/main/ECOSYSTEM.md)
 


### PR DESCRIPTION
Closes #1688.

Adds ilert to the "Who is using Rig?" section.
