### PR TITLE
fix: http client generic parameter

### DIFF
--- a/rig/rig-core/examples/reqwest_middleware.rs
+++ b/rig/rig-core/examples/reqwest_middleware.rs
@@ -1,14 +1,15 @@
 //! Demonstrates supplying a custom reqwest client with retry middleware.
-//! Requires `ANTHROPIC_API_KEY` and the `reqwest-middleware` feature.
+//! Requires `GEMINI_API_KEY` and the `reqwest-middleware` feature.
 //! Run it to verify the provider client can use your preconfigured HTTP stack.
 
 use anyhow::{Context, Result};
 use reqwest_middleware::ClientBuilder;
 use reqwest_retry::{RetryTransientMiddleware, policies::ExponentialBackoff};
-use rig::{client::CompletionClient, completion::Prompt, providers::anthropic};
+use rig::{client::CompletionClient, completion::Prompt, providers::gemini};
 
 fn build_http_client() -> reqwest_middleware::ClientWithMiddleware {
     let retry_policy = ExponentialBackoff::builder().build_with_max_retries(5);
+
     ClientBuilder::new(Default::default())
         .with(RetryTransientMiddleware::new_with_policy(retry_policy))
         .build()
@@ -16,15 +17,15 @@ fn build_http_client() -> reqwest_middleware::ClientWithMiddleware {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let api_key = std::env::var("ANTHROPIC_API_KEY").context("ANTHROPIC_API_KEY is not set")?;
+    let api_key = std::env::var("GEMINI_API_KEY").context("GEMINI_API_KEY is not set")?;
     let http_client = build_http_client();
-    let client = anthropic::Client::builder()
+    let client = gemini::Client::builder()
         .http_client(http_client)
         .api_key(api_key)
         .build()?;
 
     let agent = client
-        .agent(anthropic::completion::CLAUDE_SONNET_4_6)
+        .agent(gemini::completion::GEMINI_3_1_FLASH_LITE_PREVIEW)
         .preamble("You are a helpful assistant.")
         .build();
 

--- a/rig/rig-core/examples/reqwest_middleware.rs
+++ b/rig/rig-core/examples/reqwest_middleware.rs
@@ -1,15 +1,14 @@
 //! Demonstrates supplying a custom reqwest client with retry middleware.
-//! Requires `GEMINI_API_KEY` and the `reqwest-middleware` feature.
+//! Requires `ANTHROPIC_API_KEY` and the `reqwest-middleware` feature.
 //! Run it to verify the provider client can use your preconfigured HTTP stack.
 
 use anyhow::{Context, Result};
 use reqwest_middleware::ClientBuilder;
 use reqwest_retry::{RetryTransientMiddleware, policies::ExponentialBackoff};
-use rig::{client::CompletionClient, completion::Prompt, providers::gemini};
+use rig::{client::CompletionClient, completion::Prompt, providers::anthropic};
 
 fn build_http_client() -> reqwest_middleware::ClientWithMiddleware {
     let retry_policy = ExponentialBackoff::builder().build_with_max_retries(5);
-
     ClientBuilder::new(Default::default())
         .with(RetryTransientMiddleware::new_with_policy(retry_policy))
         .build()
@@ -17,15 +16,15 @@ fn build_http_client() -> reqwest_middleware::ClientWithMiddleware {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let api_key = std::env::var("GEMINI_API_KEY").context("GEMINI_API_KEY is not set")?;
+    let api_key = std::env::var("ANTHROPIC_API_KEY").context("ANTHROPIC_API_KEY is not set")?;
     let http_client = build_http_client();
-    let client = gemini::Client::builder()
+    let client = anthropic::Client::builder()
         .http_client(http_client)
         .api_key(api_key)
         .build()?;
 
     let agent = client
-        .agent(gemini::completion::GEMINI_3_1_FLASH_LITE_PREVIEW)
+        .agent(anthropic::completion::CLAUDE_SONNET_4_6)
         .preamble("You are a helpful assistant.")
         .build();
 

--- a/rig/rig-core/src/client/mod.rs
+++ b/rig/rig-core/src/client/mod.rs
@@ -300,6 +300,9 @@ pub trait ProviderBuilder: Sized + Default + Clone {
     }
 }
 
+/// `new` is pinned to `H = reqwest::Client` so the call site infers without an explicit `H`
+/// annotation. Callers who want a different backend should go through [`Client::builder`] and
+/// chain [`ClientBuilder::http_client`] before [`ClientBuilder::build`].
 impl<Ext> Client<Ext, reqwest::Client>
 where
     Ext: Provider,
@@ -384,19 +387,18 @@ where
     }
 }
 
+/// `builder()` is anchored on `Client<Ext, reqwest::Client>` purely as an inference hook so that
+/// `provider::Client::builder()` resolves without a `H` annotation. The returned builder itself
+/// has `H = Missing`, accurately reflecting that no backend has been chosen yet; the eventual
+/// `Client` produced by `build()` may end up with any HTTP backend depending on whether
+/// [`ClientBuilder::http_client`] was called.
 impl<Ext> Client<Ext, reqwest::Client>
 where
     Ext: Provider,
-    Ext::Builder: ProviderBuilder<Extension<reqwest::Client> = Ext> + Default,
+    Ext::Builder: ProviderBuilder + Default,
 {
-    pub fn builder() -> ClientBuilder<Ext::Builder, Missing, reqwest::Client> {
-        ClientBuilder {
-            api_key: Missing,
-            headers: Default::default(),
-            base_url: <Ext::Builder as ProviderBuilder>::BASE_URL.into(),
-            http_client: None,
-            ext: Default::default(),
-        }
+    pub fn builder() -> ClientBuilder<Ext::Builder, Missing, Missing> {
+        ClientBuilder::default()
     }
 }
 
@@ -517,19 +519,32 @@ where
     }
 }
 
-// ApiKey is generic because Anthropic uses custom auth header, local models like Ollama use none
+/// Type-state builder for [`Client`].
+///
+/// Each generic slot encodes a separate "has the user supplied this yet?" question:
+///
+/// - `ApiKey = Missing` means the caller has not yet called [`Self::api_key`]; transitioning to a
+///   concrete `ApiKey` type is required before [`Self::build`] is reachable.
+/// - `H = Missing` means the caller has not yet called [`Self::http_client`]; in that state
+///   `build()` substitutes the canonical `reqwest::Client` backend at construction time. Once a
+///   backend has been supplied, `H` is the concrete HTTP client type and `build()` uses it
+///   directly.
+///
+/// Keeping `Missing` as the *type-level* placeholder (rather than reusing `reqwest::Client`)
+/// means the builder's generics describe what the caller has actually provided, instead of
+/// pretending a default value is already present. It also avoids carrying an `Option<H>` whose
+/// `None` branch existed only to model the same "user hasn't picked a backend" state.
 #[derive(Clone)]
-pub struct ClientBuilder<Ext, ApiKey = Missing, H = reqwest::Client> {
+pub struct ClientBuilder<Ext, ApiKey = Missing, H = Missing> {
     base_url: String,
     api_key: ApiKey,
     headers: HeaderMap,
-    http_client: Option<H>,
+    http_client: H,
     ext: Ext,
 }
 
-impl<ExtBuilder, H> Default for ClientBuilder<ExtBuilder, Missing, H>
+impl<ExtBuilder> Default for ClientBuilder<ExtBuilder, Missing, Missing>
 where
-    H: Default,
     ExtBuilder: ProviderBuilder + Default,
 {
     fn default() -> Self {
@@ -537,7 +552,7 @@ where
             api_key: Missing,
             headers: Default::default(),
             base_url: ExtBuilder::BASE_URL.into(),
-            http_client: None,
+            http_client: Missing,
             ext: Default::default(),
         }
     }
@@ -596,10 +611,13 @@ where
         }
     }
 
-    /// Set the HTTP backend used in this client
+    /// Set the HTTP backend used in this client.
+    ///
+    /// Calling this advances the builder's `H` slot from whatever it was (typically `Missing`)
+    /// to the supplied client's type, which selects the H-generic [`Self::build`] impl below.
     pub fn http_client<U>(self, http_client: U) -> ClientBuilder<Ext, ApiKey, U> {
         ClientBuilder {
-            http_client: Some(http_client),
+            http_client,
             base_url: self.base_url,
             api_key: self.api_key,
             headers: self.headers,
@@ -637,11 +655,30 @@ impl<Ext, Key, H> ClientBuilder<Ext, Key, H> {
     }
 }
 
+/// Default-backend `build`: when the caller never called [`ClientBuilder::http_client`], the
+/// builder's `H` slot is still `Missing`, and we substitute the canonical `reqwest::Client` at
+/// build time. This is the only place in the crate that knows about that default, and it is
+/// disjoint by trait bound from the H-generic `build` below (`Missing` does not implement
+/// [`HttpClientExt`]).
+impl<ExtBuilder, Key> ClientBuilder<ExtBuilder, Key, Missing>
+where
+    ExtBuilder: ProviderBuilder<ApiKey = Key>,
+    Key: ApiKey,
+{
+    pub fn build(
+        self,
+    ) -> http_client::Result<Client<ExtBuilder::Extension<reqwest::Client>, reqwest::Client>> {
+        self.http_client(reqwest::Client::default()).build()
+    }
+}
+
+/// Concrete-backend `build`: the caller supplied an HTTP client via
+/// [`ClientBuilder::http_client`], so `H` is a real `HttpClientExt` type and we use it directly.
 impl<ExtBuilder, Key, H> ClientBuilder<ExtBuilder, Key, H>
 where
     ExtBuilder: ProviderBuilder<ApiKey = Key>,
     Key: ApiKey,
-    H: Default + HttpClientExt,
+    H: HttpClientExt,
 {
     pub fn build(mut self) -> http_client::Result<Client<ExtBuilder::Extension<H>, H>> {
         let ext_builder = self.ext.clone();
@@ -662,8 +699,6 @@ where
         {
             headers.insert(k, v);
         }
-
-        let http_client = http_client.unwrap_or_default();
 
         Ok(Client {
             http_client,

--- a/rig/rig-core/src/providers/anthropic/client.rs
+++ b/rig/rig-core/src/providers/anthropic/client.rs
@@ -63,7 +63,7 @@ impl ApiKey for AnthropicKey {
 }
 
 pub type Client<H = reqwest::Client> = client::Client<AnthropicExt, H>;
-pub type ClientBuilder<H = reqwest::Client> =
+pub type ClientBuilder<H = crate::markers::Missing> =
     client::ClientBuilder<AnthropicBuilder, AnthropicKey, H>;
 
 impl Default for AnthropicBuilder {

--- a/rig/rig-core/src/providers/azure.rs
+++ b/rig/rig-core/src/providers/azure.rs
@@ -84,7 +84,7 @@ impl Default for AzureExtBuilder {
 }
 
 pub type Client<H = reqwest::Client> = client::Client<AzureExt, H>;
-pub type ClientBuilder<H = reqwest::Client> =
+pub type ClientBuilder<H = crate::markers::Missing> =
     client::ClientBuilder<AzureExtBuilder, AzureOpenAIAuth, H>;
 
 impl Provider for AzureExt {

--- a/rig/rig-core/src/providers/chatgpt/mod.rs
+++ b/rig/rig-core/src/providers/chatgpt/mod.rs
@@ -112,7 +112,8 @@ impl Debug for ChatGPTExt {
 }
 
 pub type Client<H = reqwest::Client> = client::Client<ChatGPTExt, H>;
-pub type ClientBuilder<H = reqwest::Client> = client::ClientBuilder<ChatGPTBuilder, ChatGPTAuth, H>;
+pub type ClientBuilder<H = crate::markers::Missing> =
+    client::ClientBuilder<ChatGPTBuilder, ChatGPTAuth, H>;
 
 impl Default for ChatGPTBuilder {
     fn default() -> Self {

--- a/rig/rig-core/src/providers/cohere/client.rs
+++ b/rig/rig-core/src/providers/cohere/client.rs
@@ -25,7 +25,8 @@ pub struct CohereBuilder;
 type CohereApiKey = BearerAuth;
 
 pub type Client<H = reqwest::Client> = client::Client<CohereExt, H>;
-pub type ClientBuilder<H = reqwest::Client> = client::ClientBuilder<CohereBuilder, CohereApiKey, H>;
+pub type ClientBuilder<H = crate::markers::Missing> =
+    client::ClientBuilder<CohereBuilder, CohereApiKey, H>;
 
 impl Provider for CohereExt {
     type Builder = CohereBuilder;

--- a/rig/rig-core/src/providers/copilot/mod.rs
+++ b/rig/rig-core/src/providers/copilot/mod.rs
@@ -136,7 +136,8 @@ impl Debug for CopilotExt {
 }
 
 pub type Client<H = reqwest::Client> = client::Client<CopilotExt, H>;
-pub type ClientBuilder<H = reqwest::Client> = client::ClientBuilder<CopilotBuilder, CopilotAuth, H>;
+pub type ClientBuilder<H = crate::markers::Missing> =
+    client::ClientBuilder<CopilotBuilder, CopilotAuth, H>;
 
 impl Default for CopilotBuilder {
     fn default() -> Self {

--- a/rig/rig-core/src/providers/deepseek.rs
+++ b/rig/rig-core/src/providers/deepseek.rs
@@ -84,7 +84,8 @@ impl ProviderBuilder for DeepSeekExtBuilder {
 }
 
 pub type Client<H = reqwest::Client> = client::Client<DeepSeekExt, H>;
-pub type ClientBuilder<H = reqwest::Client> = client::ClientBuilder<DeepSeekExtBuilder, String, H>;
+pub type ClientBuilder<H = crate::markers::Missing> =
+    client::ClientBuilder<DeepSeekExtBuilder, String, H>;
 
 impl ProviderClient for Client {
     type Input = DeepSeekApiKey;

--- a/rig/rig-core/src/providers/galadriel.rs
+++ b/rig/rig-core/src/providers/galadriel.rs
@@ -93,7 +93,7 @@ impl ProviderBuilder for GaladrielBuilder {
 }
 
 pub type Client<H = reqwest::Client> = client::Client<GaladrielExt, H>;
-pub type ClientBuilder<H = reqwest::Client> =
+pub type ClientBuilder<H = crate::markers::Missing> =
     client::ClientBuilder<GaladrielBuilder, GaladrielApiKey, H>;
 
 impl<T> ClientBuilder<T> {

--- a/rig/rig-core/src/providers/gemini/client.rs
+++ b/rig/rig-core/src/providers/gemini/client.rs
@@ -2,7 +2,7 @@ use crate::client::{
     self, ApiKey, Capabilities, Capable, DebugExt, Provider, ProviderBuilder, ProviderClient,
     Transport,
 };
-use crate::http_client;
+use crate::http_client::{self};
 use crate::providers::gemini::model_listing::{GeminiInteractionsModelLister, GeminiModelLister};
 use serde::Deserialize;
 use std::fmt::Debug;
@@ -50,7 +50,8 @@ where
 /// Gemini GenerateContent client.
 pub type Client<H = reqwest::Client> = client::Client<GeminiExt, H>;
 /// Builder for the Gemini GenerateContent client.
-pub type ClientBuilder<H = reqwest::Client> = client::ClientBuilder<GeminiBuilder, GeminiApiKey, H>;
+pub type ClientBuilder<H = crate::markers::Missing> =
+    client::ClientBuilder<GeminiBuilder, GeminiApiKey, H>;
 /// Gemini Interactions API client.
 pub type InteractionsClient<H = reqwest::Client> = client::Client<GeminiInteractionsExt, H>;
 

--- a/rig/rig-core/src/providers/groq.rs
+++ b/rig/rig-core/src/providers/groq.rs
@@ -87,7 +87,7 @@ impl ProviderBuilder for GroqBuilder {
 }
 
 pub type Client<H = reqwest::Client> = client::Client<GroqExt, H>;
-pub type ClientBuilder<H = reqwest::Client> = client::ClientBuilder<GroqBuilder, String, H>;
+pub type ClientBuilder<H = crate::markers::Missing> = client::ClientBuilder<GroqBuilder, String, H>;
 
 impl ProviderClient for Client {
     type Input = String;

--- a/rig/rig-core/src/providers/huggingface/client.rs
+++ b/rig/rig-core/src/providers/huggingface/client.rs
@@ -110,7 +110,7 @@ pub struct HuggingFaceBuilder {
 type HuggingFaceApiKey = BearerAuth;
 
 pub type Client<H = reqwest::Client> = client::Client<HuggingFaceExt, H>;
-pub type ClientBuilder<H = reqwest::Client> =
+pub type ClientBuilder<H = crate::markers::Missing> =
     client::ClientBuilder<HuggingFaceBuilder, HuggingFaceApiKey, H>;
 
 impl Provider for HuggingFaceExt {

--- a/rig/rig-core/src/providers/hyperbolic.rs
+++ b/rig/rig-core/src/providers/hyperbolic.rs
@@ -75,7 +75,8 @@ impl ProviderBuilder for HyperbolicBuilder {
 }
 
 pub type Client<H = reqwest::Client> = client::Client<HyperbolicExt, H>;
-pub type ClientBuilder<H = reqwest::Client> = client::ClientBuilder<HyperbolicBuilder, String, H>;
+pub type ClientBuilder<H = crate::markers::Missing> =
+    client::ClientBuilder<HyperbolicBuilder, String, H>;
 
 impl ProviderClient for Client {
     type Input = HyperbolicApiKey;

--- a/rig/rig-core/src/providers/llamafile.rs
+++ b/rig/rig-core/src/providers/llamafile.rs
@@ -95,7 +95,8 @@ impl ProviderBuilder for LlamafileBuilder {
 }
 
 pub type Client<H = reqwest::Client> = client::Client<LlamafileExt, H>;
-pub type ClientBuilder<H = reqwest::Client> = client::ClientBuilder<LlamafileBuilder, Nothing, H>;
+pub type ClientBuilder<H = crate::markers::Missing> =
+    client::ClientBuilder<LlamafileBuilder, Nothing, H>;
 
 impl Client {
     /// Create a client pointing at the given llamafile base URL

--- a/rig/rig-core/src/providers/minimax.rs
+++ b/rig/rig-core/src/providers/minimax.rs
@@ -71,7 +71,7 @@ pub struct MiniMaxAnthropicExt;
 type MiniMaxApiKey = BearerAuth;
 
 pub type Client<H = reqwest::Client> = client::Client<MiniMaxExt, H>;
-pub type ClientBuilder<H = reqwest::Client> =
+pub type ClientBuilder<H = crate::markers::Missing> =
     client::ClientBuilder<MiniMaxBuilder, MiniMaxApiKey, H>;
 
 pub type AnthropicClient<H = reqwest::Client> = client::Client<MiniMaxAnthropicExt, H>;

--- a/rig/rig-core/src/providers/mira.rs
+++ b/rig/rig-core/src/providers/mira.rs
@@ -74,7 +74,8 @@ impl ProviderBuilder for MiraBuilder {
 }
 
 pub type Client<H = reqwest::Client> = client::Client<MiraExt, H>;
-pub type ClientBuilder<H = reqwest::Client> = client::ClientBuilder<MiraBuilder, MiraApiKey, H>;
+pub type ClientBuilder<H = crate::markers::Missing> =
+    client::ClientBuilder<MiraBuilder, MiraApiKey, H>;
 
 #[derive(Debug, Error)]
 pub enum MiraError {

--- a/rig/rig-core/src/providers/mistral/client.rs
+++ b/rig/rig-core/src/providers/mistral/client.rs
@@ -21,7 +21,8 @@ pub struct MistralBuilder;
 type MistralApiKey = BearerAuth;
 
 pub type Client<H = reqwest::Client> = client::Client<MistralExt, H>;
-pub type ClientBuilder<H = reqwest::Client> = client::ClientBuilder<MistralBuilder, String, H>;
+pub type ClientBuilder<H = crate::markers::Missing> =
+    client::ClientBuilder<MistralBuilder, String, H>;
 
 impl Provider for MistralExt {
     type Builder = MistralBuilder;

--- a/rig/rig-core/src/providers/moonshot.rs
+++ b/rig/rig-core/src/providers/moonshot.rs
@@ -149,7 +149,7 @@ impl<H> Capabilities<H> for MoonshotAnthropicExt {
 }
 
 pub type Client<H = reqwest::Client> = client::Client<MoonshotExt, H>;
-pub type ClientBuilder<H = reqwest::Client> =
+pub type ClientBuilder<H = crate::markers::Missing> =
     client::ClientBuilder<MoonshotBuilder, MoonshotApiKey, H>;
 pub type AnthropicClient<H = reqwest::Client> = client::Client<MoonshotAnthropicExt, H>;
 pub type AnthropicClientBuilder<H = reqwest::Client> =

--- a/rig/rig-core/src/providers/ollama.rs
+++ b/rig/rig-core/src/providers/ollama.rs
@@ -151,7 +151,8 @@ impl ProviderBuilder for OllamaBuilder {
 }
 
 pub type Client<H = reqwest::Client> = client::Client<OllamaExt, H>;
-pub type ClientBuilder<H = reqwest::Client> = client::ClientBuilder<OllamaBuilder, OllamaApiKey, H>;
+pub type ClientBuilder<H = crate::markers::Missing> =
+    client::ClientBuilder<OllamaBuilder, OllamaApiKey, H>;
 
 impl ProviderClient for Client {
     type Input = OllamaApiKey;

--- a/rig/rig-core/src/providers/openai/client.rs
+++ b/rig/rig-core/src/providers/openai/client.rs
@@ -39,7 +39,7 @@ type OpenAIApiKey = BearerAuth;
 
 // Responses API client (default)
 pub type Client<H = reqwest::Client> = client::Client<OpenAIResponsesExt, H>;
-pub type ClientBuilder<H = reqwest::Client> =
+pub type ClientBuilder<H = crate::markers::Missing> =
     client::ClientBuilder<OpenAIResponsesExtBuilder, OpenAIApiKey, H>;
 
 // Completions API client

--- a/rig/rig-core/src/providers/openrouter/client.rs
+++ b/rig/rig-core/src/providers/openrouter/client.rs
@@ -22,7 +22,7 @@ pub struct OpenRouterExtBuilder;
 type OpenRouterApiKey = BearerAuth;
 
 pub type Client<H = reqwest::Client> = client::Client<OpenRouterExt, H>;
-pub type ClientBuilder<H = reqwest::Client> =
+pub type ClientBuilder<H = crate::markers::Missing> =
     client::ClientBuilder<OpenRouterExtBuilder, OpenRouterApiKey, H>;
 
 impl Provider for OpenRouterExt {

--- a/rig/rig-core/src/providers/perplexity.rs
+++ b/rig/rig-core/src/providers/perplexity.rs
@@ -79,7 +79,7 @@ impl ProviderBuilder for PerplexityBuilder {
 }
 
 pub type Client<H = reqwest::Client> = client::Client<PerplexityExt, H>;
-pub type ClientBuilder<H = reqwest::Client> =
+pub type ClientBuilder<H = crate::markers::Missing> =
     client::ClientBuilder<PerplexityBuilder, PerplexityApiKey, H>;
 
 impl ProviderClient for Client {

--- a/rig/rig-core/src/providers/together/client.rs
+++ b/rig/rig-core/src/providers/together/client.rs
@@ -18,7 +18,7 @@ pub struct TogetherExtBuilder;
 type TogetherApiKey = BearerAuth;
 
 pub type Client<H = reqwest::Client> = client::Client<TogetherExt, H>;
-pub type ClientBuilder<H = reqwest::Client> =
+pub type ClientBuilder<H = crate::markers::Missing> =
     client::ClientBuilder<TogetherExtBuilder, TogetherApiKey, H>;
 
 impl Provider for TogetherExt {

--- a/rig/rig-core/src/providers/voyageai.rs
+++ b/rig/rig-core/src/providers/voyageai.rs
@@ -63,7 +63,8 @@ impl ProviderBuilder for VoyageBuilder {
 }
 
 pub type Client<H = reqwest::Client> = client::Client<VoyageExt, H>;
-pub type ClientBuilder<H = reqwest::Client> = client::ClientBuilder<VoyageBuilder, VoyageApiKey, H>;
+pub type ClientBuilder<H = crate::markers::Missing> =
+    client::ClientBuilder<VoyageBuilder, VoyageApiKey, H>;
 
 impl ProviderClient for Client {
     type Input = String;

--- a/rig/rig-core/src/providers/xai/client.rs
+++ b/rig/rig-core/src/providers/xai/client.rs
@@ -14,7 +14,8 @@ pub struct XAiExtBuilder;
 type XAiApiKey = BearerAuth;
 
 pub type Client<H = reqwest::Client> = client::Client<XAiExt, H>;
-pub type ClientBuilder<H = reqwest::Client> = client::ClientBuilder<XAiExtBuilder, XAiApiKey, H>;
+pub type ClientBuilder<H = crate::markers::Missing> =
+    client::ClientBuilder<XAiExtBuilder, XAiApiKey, H>;
 
 const XAI_BASE_URL: &str = "https://api.x.ai";
 

--- a/rig/rig-core/src/providers/xiaomimimo.rs
+++ b/rig/rig-core/src/providers/xiaomimimo.rs
@@ -65,7 +65,7 @@ pub struct XiaomiMimoAnthropicExt;
 type XiaomiMimoApiKey = BearerAuth;
 
 pub type Client<H = reqwest::Client> = client::Client<XiaomiMimoExt, H>;
-pub type ClientBuilder<H = reqwest::Client> =
+pub type ClientBuilder<H = crate::markers::Missing> =
     client::ClientBuilder<XiaomiMimoBuilder, XiaomiMimoApiKey, H>;
 
 pub type AnthropicClient<H = reqwest::Client> = client::Client<XiaomiMimoAnthropicExt, H>;

--- a/rig/rig-core/src/providers/zai.rs
+++ b/rig/rig-core/src/providers/zai.rs
@@ -70,7 +70,8 @@ pub struct ZAiAnthropicExt;
 type ZAiApiKey = BearerAuth;
 
 pub type Client<H = reqwest::Client> = client::Client<ZAiExt, H>;
-pub type ClientBuilder<H = reqwest::Client> = client::ClientBuilder<ZAiBuilder, ZAiApiKey, H>;
+pub type ClientBuilder<H = crate::markers::Missing> =
+    client::ClientBuilder<ZAiBuilder, ZAiApiKey, H>;
 
 pub type AnthropicClient<H = reqwest::Client> = client::Client<ZAiAnthropicExt, H>;
 pub type AnthropicClientBuilder<H = reqwest::Client> =


### PR DESCRIPTION
Fix for bugs in ClientBuilder HTTP generic in `rig_core::client` which were preventing the use of custom HTTP clients w/ `gemini::Client`. Mostly just using `Missing` as a placeholder type in `ClientBuilder` trait impls and provider builders.