### PR TITLE
fix(cli_chatbot): added a trailing newline after streamed agent response. 

### DIFF
--- a/crates/rig-core/src/integrations/cli_chatbot.rs
+++ b/crates/rig-core/src/integrations/cli_chatbot.rs
@@ -78,6 +78,7 @@ where
 
         loop {
             let Some(chunk) = response_stream.next().await else {
+                println!();
                 break Ok(acc);
             };
 


### PR DESCRIPTION
## Summary

Fixes [issue #1711](https://github.com/0xPlaygrounds/rig/issues/1711)

This pull request makes a minor improvement to the CLI chatbot integration by adding a newline when the response stream ends, ensuring cleaner output formatting.

Before:
<img width="2840" height="438" alt="image" src="https://github.com/user-attachments/assets/e6556a85-0c02-49cf-aa22-a18b1121cc74" />

After fix:
<img width="1043" height="212" alt="image" src="https://github.com/user-attachments/assets/21e0b533-7db1-4e5f-a4e7-7e544833607a" />
