### PR TITLE
Change rig_qdrant::filter module to public

### DIFF
--- a/crates/rig-qdrant/src/lib.rs
+++ b/crates/rig-qdrant/src/lib.rs
@@ -7,7 +7,7 @@
 //! The root `rig` facade re-exports this crate as `rig::qdrant` when the
 //! `qdrant` feature is enabled.
 
-mod filter;
+pub mod filter;
 
 use filter::*;
 use qdrant_client::{


### PR DESCRIPTION
The `filter` module in rig-qdrant is private, making it inaccessible. Changing it to public appears to work.