### PR TITLE
fix(qdrant): re-export QdrantFilter from crate root

### DIFF
--- a/crates/rig-qdrant/README.md
+++ b/crates/rig-qdrant/README.md
@@ -15,3 +15,19 @@ The root `rig` facade also exposes this crate behind the `qdrant` feature.
 
 See [`examples/qdrant_vector_search.rs`](./examples/qdrant_vector_search.rs)
 for an end-to-end example using a Qdrant collection with a Rig embedding model.
+
+Filtered searches use the crate-level `QdrantFilter` type:
+
+```rust
+use rig_core::vector_store::request::{SearchFilter, VectorSearchRequest};
+use rig_qdrant::QdrantFilter;
+
+let req = VectorSearchRequest::<QdrantFilter>::builder()
+    .query("What is a linglingdong?")
+    .samples(1)
+    .filter(QdrantFilter::eq(
+        "id",
+        serde_json::json!("f9e17d59-32e5-440c-be02-b2759a654824"),
+    ))
+    .build();
+```

--- a/crates/rig-qdrant/examples/qdrant_vector_search.rs
+++ b/crates/rig-qdrant/examples/qdrant_vector_search.rs
@@ -16,10 +16,10 @@ use rig_core::{
     client::ProviderClient,
     embeddings::EmbeddingsBuilder,
     providers::openai::{self, Client},
-    vector_store::{InsertDocuments, VectorStoreIndex},
+    vector_store::{InsertDocuments, VectorStoreIndex, request::SearchFilter},
 };
 use rig_core::{client::EmbeddingsClient, vector_store::request::VectorSearchRequest};
-use rig_qdrant::QdrantVectorStore;
+use rig_qdrant::{QdrantFilter, QdrantVectorStore};
 
 #[derive(Embed, serde::Deserialize, serde::Serialize, Debug)]
 struct Word {
@@ -85,6 +85,19 @@ async fn main() -> Result<(), anyhow::Error> {
     let results = vector_store.top_n::<Word>(req).await?;
 
     println!("Results: {results:?}");
+
+    let filtered_req = VectorSearchRequest::<QdrantFilter>::builder()
+        .query(query)
+        .samples(1)
+        .filter(QdrantFilter::eq(
+            "id",
+            serde_json::json!("f9e17d59-32e5-440c-be02-b2759a654824"),
+        ))
+        .build();
+
+    let filtered_results = vector_store.top_n::<Word>(filtered_req).await?;
+
+    println!("Filtered results: {filtered_results:?}");
 
     Ok(())
 }

--- a/crates/rig-qdrant/src/filter.rs
+++ b/crates/rig-qdrant/src/filter.rs
@@ -6,6 +6,10 @@ use rig_core::vector_store::request::{FilterError, SearchFilter};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
+/// Qdrant-compatible metadata filter for vector search requests.
+///
+/// Use this as the filter type for [`rig_core::vector_store::request::VectorSearchRequest`]
+/// when querying [`crate::QdrantVectorStore`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QdrantFilter(serde_json::Value);
 

--- a/crates/rig-qdrant/src/lib.rs
+++ b/crates/rig-qdrant/src/lib.rs
@@ -2,14 +2,14 @@
 //!
 //! This crate provides [`QdrantVectorStore`], a Rig vector store index backed
 //! by Qdrant collections. It supports dense vector search and Qdrant filter
-//! expressions.
+//! expressions through [`QdrantFilter`].
 //!
 //! The root `rig` facade re-exports this crate as `rig::qdrant` when the
 //! `qdrant` feature is enabled.
 
 mod filter;
 
-use filter::*;
+pub use filter::QdrantFilter;
 use qdrant_client::{
     Payload, Qdrant,
     qdrant::{

--- a/crates/rig-qdrant/tests/filter_export.rs
+++ b/crates/rig-qdrant/tests/filter_export.rs
@@ -1,0 +1,13 @@
+use rig_core::vector_store::request::{SearchFilter, VectorSearchRequest};
+use rig_qdrant::QdrantFilter;
+
+#[test]
+fn qdrant_filter_is_available_from_crate_root() {
+    let request = VectorSearchRequest::<QdrantFilter>::builder()
+        .query("search text")
+        .samples(3)
+        .filter(QdrantFilter::eq("document_id", serde_json::json!("doc-1")))
+        .build();
+
+    assert!(request.filter().is_some());
+}


### PR DESCRIPTION
## Summary

Expose `QdrantFilter` as a crate-root public type while keeping the internal `filter` module private.

This lets users construct filtered Qdrant vector search requests with the same pattern used by other vector-store companion crates:
