### PR TITLE
test: add smoke test for completion across all Copilot models

### DIFF
--- a/tests/providers/copilot/agent.rs
+++ b/tests/providers/copilot/agent.rs
@@ -1,6 +1,6 @@
 //! Copilot agent completion smoke test.
 
-use rig::client::CompletionClient;
+use rig::client::{CompletionClient, ModelListingClient};
 use rig::completion::Prompt;
 
 use crate::copilot::{LIVE_MODEL, live_client};
@@ -20,4 +20,54 @@ async fn completion_smoke() {
         .expect("completion should succeed");
 
     assert_nonempty_response(&response);
+}
+
+/// Command to run
+/// cargo test --test copilot -- copilot::agent::all_models_completion_smoke --ignored --nocapture
+#[tokio::test]
+#[ignore = "requires Copilot credentials or existing OAuth cache"]
+async fn all_models_completion_smoke() {
+    let client = live_client();
+
+    let models = client
+        .list_models()
+        .await
+        .expect("listing Copilot models should succeed");
+
+    println!(
+        "Found {} models; testing completion on each...",
+        models.len()
+    );
+
+    assert!(
+        !models.is_empty(),
+        "expected Copilot to return at least one model"
+    );
+
+    let mut succeeded = Vec::new();
+    let mut failed = Vec::new();
+
+    for model in models.iter() {
+        println!("Testing {:#?}...", model.id);
+        let agent = client
+            .agent(model.id.as_str())
+            .preamble(BASIC_PREAMBLE)
+            .build();
+
+        match agent.prompt(BASIC_PROMPT).await {
+            Ok(response) if !response.is_empty() => succeeded.push(model.id.clone()),
+            Ok(_) => failed.push(format!("{}: empty response", model.id)),
+            Err(e) => failed.push(format!("{}: {e}", model.id)),
+        }
+    }
+
+    println!("\n=== Completion results ({} models) ===", models.len());
+    println!("Succeeded ({}):", succeeded.len());
+    for id in &succeeded {
+        println!("  + {id}");
+    }
+    println!("Failed ({}):", failed.len());
+    for entry in &failed {
+        println!("  - {entry}");
+    }
 }


### PR DESCRIPTION
Not all Copilot models support completions, so I added this smoke test as a reference. Here's the test result:

```
=== Completion results (38 models) ===
Succeeded (32):
  + claude-opus-4.6-fast
  + claude-opus-4.6
  + claude-opus-4.7
  + claude-sonnet-4.6
  + gemini-3.1-pro-preview
  + gpt-5.2-codex
  + gpt-5.3-codex
  + gpt-5.4
  + accounts/msft/routers/f185i3v4
  + accounts/msft/routers/fmfeto88
  + accounts/msft/routers/gdjv4v2v
  + gpt-5-mini
  + gpt-4o-mini-2024-07-18
  + gpt-4o-2024-11-20
  + gpt-4o-2024-08-06
  + grok-code-fast-1
  + claude-haiku-4.5
  + gemini-3-flash-preview
  + gpt-4.1-2025-04-14
  + gpt-5.2
  + gpt-3.5-turbo-0613
  + gpt-4
  + gpt-4-0613
  + gpt-4-0125-preview
  + gpt-4o-2024-05-13
  + gpt-4-o-preview
  + gpt-4.1
  + gpt-3.5-turbo
  + gpt-4o-mini
  + gpt-4
  + gpt-4o
  + gpt-4-o-preview
Failed (6):
  - gpt-5.4-mini: CompletionError: HttpError: Invalid status code 400 Bad Request with message: {"error":{"message":"model \"gpt-5.4-mini\" is not accessible via the /chat/completions endpoint","code":"unsupported_api_for_model"}}

  - gpt-5.5: CompletionError: HttpError: Invalid status code 400 Bad Request with message: {"error":{"message":"model \"gpt-5.5\" is not accessible via the /chat/completions endpoint","code":"unsupported_api_for_model"}}

  - text-embedding-3-small: CompletionError: HttpError: Invalid status code 400 Bad Request with message: {"error":{"message":"Model is not supported for this request.","code":"model_not_supported","param":"model","type":"invalid_request_error"}}

  - text-embedding-3-small-inference: CompletionError: HttpError: Invalid status code 400 Bad Request with message: {"error":{"message":"Model is not supported for this request.","code":"model_not_supported","param":"model","type":"invalid_request_error"}}

  - gpt-41-copilot: CompletionError: HttpError: Invalid status code 400 Bad Request with message: {"error":{"message":"Model is not supported for this request.","code":"model_not_supported","param":"model","type":"invalid_request_error"}}

  - text-embedding-ada-002: CompletionError: HttpError: Invalid status code 400 Bad Request with message: {"error":{"message":"Model is not supported for this request.","code":"model_not_supported","param":"model","type":"invalid_request_error"}}

test copilot::agent::all_models_completion_smoke ... ok
```