### PR TITLE
feat(core)!: take &mut Vec<Message> in Chat trait so reasoning and tool calls round-trip

### DIFF
--- a/crates/rig-core/src/agent/completion.rs
+++ b/crates/rig-core/src/agent/completion.rs
@@ -292,18 +292,19 @@ where
     P: PromptHook<M> + 'static,
 {
     #[tracing::instrument(skip(self, prompt, chat_history), fields(agent_name = self.name()))]
-    async fn chat<I, T>(
+    async fn chat(
         &self,
         prompt: impl Into<Message> + WasmCompatSend,
-        chat_history: I,
-    ) -> Result<String, PromptError>
-    where
-        I: IntoIterator<Item = T>,
-        T: Into<Message>,
-    {
-        PromptRequest::from_agent(self, prompt)
-            .with_history(chat_history)
-            .await
+        chat_history: &mut Vec<Message>,
+    ) -> Result<String, PromptError> {
+        let response = PromptRequest::from_agent(self, prompt)
+            .with_history(chat_history.clone())
+            .extended_details()
+            .await?;
+        if let Some(messages) = response.messages {
+            chat_history.extend(messages);
+        }
+        Ok(response.output)
     }
 }
 

--- a/crates/rig-core/src/agent/mod.rs
+++ b/crates/rig-core/src/agent/mod.rs
@@ -37,7 +37,7 @@
 //!
 //! // Use the agent for completions and prompts
 //! // Generate a chat completion response from a prompt and chat history
-//! let chat_response = agent.chat("Prompt", Vec::<rig_core::completion::Message>::new()).await?;
+//! let chat_response = agent.chat("Prompt", &mut Vec::<rig_core::completion::Message>::new()).await?;
 //!
 //! // Generate a prompt completion response from a simple prompt
 //! let prompt_response = agent.prompt("Prompt").await?;

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -248,14 +248,16 @@ pub trait Chat: WasmCompatSend + WasmCompatSync {
     /// is returned as a string.
     ///
     /// If the tool does not exist, or the tool call fails, then an error is returned.
-    fn chat<I, T>(
+    ///
+    /// `chat_history` is taken by mutable reference: the prompt and any
+    /// assistant/tool messages produced during the turn are appended to it so
+    /// callers can persist the full conversation (including reasoning and tool
+    /// calls) without losing information.
+    fn chat(
         &self,
         prompt: impl Into<Message> + WasmCompatSend,
-        chat_history: I,
-    ) -> impl std::future::Future<Output = Result<String, PromptError>> + WasmCompatSend
-    where
-        I: IntoIterator<Item = T> + WasmCompatSend,
-        T: Into<Message>;
+        chat_history: &mut Vec<Message>,
+    ) -> impl std::future::Future<Output = Result<String, PromptError>> + WasmCompatSend;
 }
 
 /// Trait defining a high-level typed prompt interface for structured output.

--- a/crates/rig-core/src/integrations/cli_chatbot.rs
+++ b/crates/rig-core/src/integrations/cli_chatbot.rs
@@ -30,8 +30,11 @@ pub struct ChatBot<T>(T);
 /// Trait to abstract message behavior away from cli_chat/`run` loop
 #[allow(private_interfaces)]
 trait CliChat {
-    async fn request(&mut self, prompt: &str, history: Vec<Message>)
-    -> Result<String, PromptError>;
+    async fn request(
+        &mut self,
+        prompt: &str,
+        history: &mut Vec<Message>,
+    ) -> Result<String, PromptError>;
 
     fn show_usage(&self) -> bool {
         false
@@ -49,9 +52,9 @@ where
     async fn request(
         &mut self,
         prompt: &str,
-        history: Vec<Message>,
+        history: &mut Vec<Message>,
     ) -> Result<String, PromptError> {
-        let res = self.0.chat(prompt, &history).await?;
+        let res = self.0.chat(prompt, history).await?;
         println!("{res}");
 
         Ok(res)
@@ -65,21 +68,21 @@ where
     async fn request(
         &mut self,
         prompt: &str,
-        history: Vec<Message>,
+        history: &mut Vec<Message>,
     ) -> Result<String, PromptError> {
         let mut response_stream = self
             .agent
             .stream_prompt(prompt)
-            .with_history(&history)
+            .with_history(history.clone())
             .multi_turn(self.max_turns)
             .await;
 
         let mut acc = String::new();
 
-        loop {
+        let result = loop {
             let Some(chunk) = response_stream.next().await else {
                 println!();
-                break Ok(acc);
+                break Ok(acc.clone());
             };
 
             match chunk {
@@ -99,7 +102,14 @@ where
                 }
                 _ => continue,
             }
+        };
+
+        if result.is_ok() {
+            history.push(Message::user(prompt));
+            history.push(Message::assistant(acc));
         }
+
+        result
     }
 
     fn show_usage(&self) -> bool {
@@ -202,9 +212,7 @@ where
                     println!();
                     println!("========================== Response ============================");
 
-                    let response = self.0.request(input, history.clone()).await?;
-                    history.push(Message::user(input));
-                    history.push(Message::assistant(response));
+                    self.0.request(input, &mut history).await?;
 
                     println!("================================================================");
                     println!();

--- a/crates/rig-core/src/integrations/discord_bot.rs
+++ b/crates/rig-core/src/integrations/discord_bot.rs
@@ -1,9 +1,8 @@
 //! Integration for deploying your Rig agents (and more) as Discord bots.
 //! This feature is not WASM-compatible (and as such, is incompatible with the `worker` feature).
-use crate::OneOrMany;
 use crate::agent::Agent;
-use crate::completion::{AssistantContent, CompletionModel, request::Chat};
-use crate::message::{Message as RigMessage, UserContent};
+use crate::completion::{CompletionModel, request::Chat};
+use crate::message::Message as RigMessage;
 use serenity::all::{
     Command, CommandInteraction, Context, CreateCommand, CreateThread, EventHandler,
     GatewayIntents, Interaction, Message, Ready, async_trait,
@@ -159,30 +158,22 @@ where
     async fn handle_thread_message(&self, ctx: &Context, msg: &Message) {
         let thread_id = msg.channel_id.get();
 
-        // Add user message to history
-        {
-            let mut conversations = self.state.conversations.write().await;
-            if let Some(history) = conversations.get_mut(&thread_id) {
-                history.push(RigMessage::User {
-                    content: OneOrMany::one(UserContent::text(msg.content.clone())),
-                });
-            }
-        }
-
         // Show typing indicator
         let _ = msg.channel_id.broadcast_typing(&ctx.http).await;
 
-        // Get conversation history
+        // Get conversation history snapshot
         let conversations = self.state.conversations.read().await;
-        let history = if let Some(history) = conversations.get(&thread_id) {
+        let mut history = if let Some(history) = conversations.get(&thread_id) {
             history.clone()
         } else {
             vec![]
         };
         drop(conversations);
 
-        // Generate response using the agent with conversation history
-        let response = match self.state.agent.chat(&msg.content, history).await {
+        // Generate response using the agent with conversation history.
+        // `chat` appends the user prompt and any assistant/tool messages
+        // produced during the turn onto `history` for us.
+        let response = match self.state.agent.chat(&msg.content, &mut history).await {
             Ok(resp) => resp,
             Err(e) => {
                 eprintln!("Agent error: {}", e);
@@ -197,15 +188,10 @@ where
             }
         };
 
-        // Add assistant response to history
+        // Persist the round-tripped history back into the conversations map.
         {
             let mut conversations = self.state.conversations.write().await;
-            if let Some(history) = conversations.get_mut(&thread_id) {
-                history.push(RigMessage::Assistant {
-                    content: OneOrMany::one(AssistantContent::text(msg.content.clone())),
-                    id: None,
-                });
-            }
+            conversations.insert(thread_id, history);
         }
 
         // Send response (split if too long for Discord's 2000 char limit)

--- a/examples/multi_agent.rs
+++ b/examples/multi_agent.rs
@@ -48,8 +48,8 @@ impl<M: CompletionModel + 'static> Tool for TranslatorTool<M> {
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
-        let empty_history: &[Message] = &[];
-        match self.0.chat(&args.prompt, empty_history).await {
+        let mut empty_history: Vec<Message> = Vec::new();
+        match self.0.chat(&args.prompt, &mut empty_history).await {
             Ok(response) => {
                 println!("Translated prompt: {response}");
                 Ok(response)

--- a/tests/core/prompt_response_messages.rs
+++ b/tests/core/prompt_response_messages.rs
@@ -4,7 +4,8 @@
 use rig::OneOrMany;
 use rig::agent::AgentBuilder;
 use rig::completion::{
-    CompletionError, CompletionModel, CompletionRequest, CompletionResponse, Message, Prompt, Usage,
+    Chat, CompletionError, CompletionModel, CompletionRequest, CompletionResponse, Message, Prompt,
+    Usage,
 };
 use rig::message::{AssistantContent, Text, ToolCall, ToolFunction, UserContent};
 use rig::streaming::{StreamingCompletionResponse, StreamingResult};
@@ -438,6 +439,58 @@ async fn extended_details_works_without_with_history() {
     // Should have full multi-turn history
     assert_eq!(messages.len(), 4);
     assert_eq!(resp.output, "The answer is 5");
+}
+
+/// Test 10a: `Chat::chat` round-trips: it appends the prompt + assistant turn
+/// onto the caller's `&mut Vec<Message>`. This is the contract introduced by
+/// the new trait signature (issue #1556).
+#[tokio::test]
+async fn chat_appends_prompt_and_assistant_to_history() {
+    let agent = AgentBuilder::new(SimpleTextModel).build();
+
+    let mut history: Vec<Message> = Vec::new();
+
+    let output = agent
+        .chat("hi", &mut history)
+        .await
+        .expect("chat should succeed");
+
+    assert_eq!(output, "hello from mock");
+
+    // History should now contain the user prompt and the assistant reply.
+    assert_eq!(
+        history.len(),
+        2,
+        "expected chat to append [User, Assistant], got: {history:#?}"
+    );
+
+    match &history[0] {
+        Message::User { content } => match content.first() {
+            UserContent::Text(t) => assert_eq!(t.text, "hi"),
+            other => panic!("expected text user content, got: {other:?}"),
+        },
+        other => panic!("expected User message, got: {other:?}"),
+    }
+
+    match &history[1] {
+        Message::Assistant { content, .. } => match content.first() {
+            AssistantContent::Text(t) => assert_eq!(t.text, "hello from mock"),
+            other => panic!("expected text assistant content, got: {other:?}"),
+        },
+        other => panic!("expected Assistant message, got: {other:?}"),
+    }
+
+    // A second chat call extends the same history with the next turn.
+    let _ = agent
+        .chat("again", &mut history)
+        .await
+        .expect("second chat should succeed");
+
+    assert_eq!(
+        history.len(),
+        4,
+        "expected history to grow to 4 messages, got: {history:#?}"
+    );
 }
 
 /// Test 10: Multiple sequential prompts each return independent message histories.

--- a/tests/providers/anthropic/opus_4_7.rs
+++ b/tests/providers/anthropic/opus_4_7.rs
@@ -202,7 +202,7 @@ async fn messages_adaptive_thinking_tool_roundtrip_smoke() {
         .build();
 
     let result = agent
-        .chat(reasoning::TOOL_USER_PROMPT, Vec::<Message>::new())
+        .chat(reasoning::TOOL_USER_PROMPT, &mut Vec::<Message>::new())
         .await
         .expect("adaptive thinking tool chat should succeed");
 

--- a/tests/providers/anthropic/reasoning_tool_roundtrip.rs
+++ b/tests/providers/anthropic/reasoning_tool_roundtrip.rs
@@ -66,7 +66,7 @@ async fn nonstreaming() {
         .build();
 
     let result = agent
-        .chat(reasoning::TOOL_USER_PROMPT, Vec::<Message>::new())
+        .chat(reasoning::TOOL_USER_PROMPT, &mut Vec::<Message>::new())
         .await
         .expect("[anthropic] Non-streaming chat failed - likely 400 from dropped reasoning");
 

--- a/tests/providers/copilot/reasoning_tool_roundtrip.rs
+++ b/tests/providers/copilot/reasoning_tool_roundtrip.rs
@@ -56,7 +56,7 @@ async fn nonstreaming() {
         .build();
 
     let result = agent
-        .chat(reasoning::TOOL_USER_PROMPT, Vec::<Message>::new())
+        .chat(reasoning::TOOL_USER_PROMPT, &mut Vec::<Message>::new())
         .await
         .expect("[copilot] Non-streaming chat failed");
 

--- a/tests/providers/deepseek/reasoning_tool_roundtrip.rs
+++ b/tests/providers/deepseek/reasoning_tool_roundtrip.rs
@@ -60,7 +60,7 @@ async fn nonstreaming() {
         .build();
 
     let result = agent
-        .chat(reasoning::TOOL_USER_PROMPT, Vec::<Message>::new())
+        .chat(reasoning::TOOL_USER_PROMPT, &mut Vec::<Message>::new())
         .await
         .expect("[deepseek] Non-streaming chat failed - likely 400 from dropped reasoning");
 

--- a/tests/providers/gemini/reasoning_tool_roundtrip.rs
+++ b/tests/providers/gemini/reasoning_tool_roundtrip.rs
@@ -57,7 +57,7 @@ async fn nonstreaming() {
         .build();
 
     let result = agent
-        .chat(reasoning::TOOL_USER_PROMPT, Vec::<Message>::new())
+        .chat(reasoning::TOOL_USER_PROMPT, &mut Vec::<Message>::new())
         .await
         .expect("[gemini] Non-streaming chat failed - likely 400 from dropped reasoning");
 

--- a/tests/providers/openai/gpt_5_5.rs
+++ b/tests/providers/openai/gpt_5_5.rs
@@ -230,7 +230,7 @@ async fn responses_reasoning_tool_roundtrip_smoke() {
         .build();
 
     let result = agent
-        .chat(reasoning::TOOL_USER_PROMPT, Vec::<Message>::new())
+        .chat(reasoning::TOOL_USER_PROMPT, &mut Vec::<Message>::new())
         .await
         .expect("reasoning tool chat should succeed");
 

--- a/tests/providers/openai/reasoning_tool_roundtrip.rs
+++ b/tests/providers/openai/reasoning_tool_roundtrip.rs
@@ -61,7 +61,7 @@ async fn nonstreaming() {
         .build();
 
     let result = agent
-        .chat(reasoning::TOOL_USER_PROMPT, Vec::<Message>::new())
+        .chat(reasoning::TOOL_USER_PROMPT, &mut Vec::<Message>::new())
         .await
         .expect("[openai] Non-streaming chat failed - likely 400 from dropped reasoning");
 

--- a/tests/providers/openrouter/reasoning_tool_roundtrip.rs
+++ b/tests/providers/openrouter/reasoning_tool_roundtrip.rs
@@ -55,7 +55,7 @@ async fn nonstreaming() {
         .build();
 
     let result = agent
-        .chat(reasoning::TOOL_USER_PROMPT, Vec::<Message>::new())
+        .chat(reasoning::TOOL_USER_PROMPT, &mut Vec::<Message>::new())
         .await
         .expect("[openrouter] Non-streaming chat failed - likely 400 from dropped reasoning");
 

--- a/tests/providers/xai/reasoning_tool_roundtrip.rs
+++ b/tests/providers/xai/reasoning_tool_roundtrip.rs
@@ -47,7 +47,7 @@ async fn nonstreaming() {
         .build();
 
     let result = agent
-        .chat(reasoning::TOOL_USER_PROMPT, Vec::<Message>::new())
+        .chat(reasoning::TOOL_USER_PROMPT, &mut Vec::<Message>::new())
         .await
         .expect("[xai] Non-streaming chat failed - likely 400 from dropped reasoning");
 


### PR DESCRIPTION
## Summary

The `Chat` trait consumed history as `IntoIterator<Item: Into<Message>>` and returned only the final assistant `String`. Any reasoning blocks, tool calls, or tool results produced during the turn were dropped, so a chatbot built on `Chat::chat` had no way to round-trip those messages back into its persistent history. `PromptRequest::extended_details()` already builds them internally, this PR just exposes them through the trait.

The new signature takes `chat_history: &mut Vec<Message>` and appends the prompt plus every assistant and tool message produced during the turn before returning. Persisting history across turns is now just keeping the same `Vec<Message>` around.

Closes #1556

## API contract

`chat` owns the appending of the prompt. Callers must NOT pre-push the user message into `chat_history` before calling, `chat` will append it for you, along with any assistant and tool messages produced during the turn.

```rust
// before
let response = agent.chat(prompt, history).await?;

// after
let response = agent.chat(prompt, &mut history).await?;
// history now contains: [...prior turns, User(prompt), Assistant(...), (optional tool turns)]
```

## Changes

- `Chat::chat` now has the signature:
  ```rust
  fn chat(
      &self,
      prompt: impl Into<Message> + WasmCompatSend,
      chat_history: &mut Vec<Message>,
  ) -> impl Future<Output = Result<String, PromptError>> + WasmCompatSend;
  ```
- `Chat for Agent<M, P>` drives `extended_details().send()` and extends `chat_history` with `PromptResponse::messages` (which is `[prompt, ...assistant/tool turns]`, no prior history), so callers see the full turn on return with no double-append.
- `cli_chatbot`:
  - `CliChat::request` now takes `history: &mut Vec<Message>` instead of an owned `Vec` that was silently discarded.
  - `ChatImpl::request` forwards the caller's history straight into `Chat::chat`, so reasoning and tool messages reach `ChatBot::run`'s persistent buffer.
  - `AgentImpl::request` (streaming path) appends `Message::user(prompt)` and `Message::assistant(acc)` after a successful stream. The streaming path does not go through `Chat::chat`, so the contract is mirrored manually. Streaming intermediate reasoning and tool deltas are not captured here, that matches prior streaming behavior and is out of scope.
  - The outer `ChatBot::run` loop drops its hand-rolled `history.push(Message::user(input))` / `Message::assistant(response)` lines, the trait now handles both.
- `discord_bot::handle_thread_message`:
  - Drops the pre-call `history.push(User { ... })` and the post-call `history.push(Assistant { ... })`. The latter also incidentally fixed a pre-existing bug where `msg.content` was being stored as the assistant's content.
  - Now calls `agent.chat(&msg.content, &mut history)` and writes the round-tripped `history` back into `state.conversations`, so threads accumulate full reasoning and tool history.
  - Drops the now-unused `OneOrMany`, `AssistantContent`, `UserContent` imports.
- `examples/multi_agent.rs`, the `agent` module doc-comment example, and 9 provider reasoning round-trip tests updated to pass `&mut Vec<Message>`.

## Tests

New `chat_appends_prompt_and_assistant_to_history` in `tests/core/prompt_response_messages.rs`. It uses the existing `SimpleTextModel` mock and asserts:

- `agent.chat("hi", &mut history)` leaves `history.len() == 2`, `history[0]` as `Message::User("hi")`, `history[1]` as `Message::Assistant("hello from mock")`.
- A second `agent.chat("again", &mut history)` grows history to 4 entries.

This locks in the appending contract per CONTRIBUTING.md's "new functionality must be tested" requirement.

## Breaking change

`Chat` is a public trait. There is one first-party impl (`Agent<M, P>`), so the in-tree footprint is the call sites listed above. Downstream users need to:

1. Pass `&mut history` (or `&mut Vec::<Message>::new()` for an empty buffer) instead of an owned iterable.
2. Stop pre-pushing the user message before calling, `chat` does that now.

## Verification

```
cargo check -p rig-core --all-targets   # clean
cargo clippy -p rig-core --all-targets  # clean
cargo test --test core chat_appends     # 1 passed
```

## Notes

AI assistance was used while preparing this change. Every line was reviewed by hand and the trait change matches the maintainer sketch in #1556.