### PR TITLE
fix(openai): send PDF Documents as file parts in chat completions

### DIFF
--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -246,6 +246,14 @@ pub enum UserContent {
     Audio {
         input_audio: InputAudio,
     },
+    /// File content part for documents such as PDFs.
+    ///
+    /// Maps to OpenAI's `{"type":"file","file":{...}}` content type. Either
+    /// `file_data` (a base64 data URI like `data:application/pdf;base64,...`)
+    /// or `file_id` (a previously uploaded file reference) must be set.
+    File {
+        file: FileData,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
@@ -259,6 +267,25 @@ pub struct ImageUrl {
 pub struct InputAudio {
     pub data: String,
     pub format: AudioMediaType,
+}
+
+/// File payload for [`UserContent::File`].
+///
+/// At least one of `file_data` or `file_id` must be set for the content part
+/// to be accepted by OpenAI's chat completions API. `filename` is optional
+/// but recommended.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+pub struct FileData {
+    /// Inline file data as a base64 data URI, e.g.
+    /// `data:application/pdf;base64,JVBERi0xLjQK...`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file_data: Option<String>,
+    /// Identifier of a previously uploaded file (OpenAI Files API).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file_id: Option<String>,
+    /// Display name of the file. Recommended for inline `file_data`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filename: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
@@ -493,6 +520,31 @@ impl TryFrom<message::UserContent> for UserContent {
                 doc => Err(message::MessageError::ConversionError(format!(
                     "Unsupported document type: {doc:?}"
                 ))),
+            },
+            message::UserContent::Document(message::Document {
+                data,
+                media_type: Some(message::DocumentMediaType::PDF),
+                ..
+            }) => match data {
+                DocumentSourceKind::Base64(b64) => Ok(UserContent::File {
+                    file: FileData {
+                        file_data: Some(format!("data:application/pdf;base64,{b64}")),
+                        file_id: None,
+                        filename: Some("document.pdf".to_string()),
+                    },
+                }),
+                DocumentSourceKind::Url(_) => Err(message::MessageError::ConversionError(
+                    "OpenAI chat completions does not accept URL files; use the Responses API or pass base64-encoded bytes".into(),
+                )),
+                DocumentSourceKind::Raw(_) => Err(message::MessageError::ConversionError(
+                    "Raw files not supported, encode as base64 first".into(),
+                )),
+                DocumentSourceKind::String(_) => Err(message::MessageError::ConversionError(
+                    "PDF documents must be base64-encoded, not raw strings".into(),
+                )),
+                DocumentSourceKind::Unknown => Err(message::MessageError::ConversionError(
+                    "Document has no body".into(),
+                )),
             },
             message::UserContent::Document(message::Document { data, .. }) => {
                 if let DocumentSourceKind::Base64(text) | DocumentSourceKind::String(text) = data {
@@ -743,6 +795,29 @@ impl From<UserContent> for message::UserContent {
             UserContent::Audio { input_audio } => {
                 message::UserContent::audio(input_audio.data, Some(input_audio.format))
             }
+            UserContent::File {
+                file: FileData {
+                    file_data, file_id, ..
+                },
+            } => match file_data {
+                Some(data_url) => {
+                    let kind = match data_url.strip_prefix("data:application/pdf;base64,") {
+                        Some(b64) => DocumentSourceKind::Base64(b64.to_string()),
+                        None => DocumentSourceKind::String(data_url),
+                    };
+                    message::UserContent::Document(message::Document {
+                        data: kind,
+                        media_type: Some(message::DocumentMediaType::PDF),
+                        additional_params: None,
+                    })
+                }
+                // `DocumentSourceKind` cannot model a remote file handle today,
+                // so a `file_id`-only payload is preserved as a text breadcrumb.
+                None => match file_id {
+                    Some(id) => message::UserContent::text(format!("[file_id: {id}]")),
+                    None => message::UserContent::text(String::new()),
+                },
+            },
         }
     }
 }
@@ -1970,5 +2045,142 @@ mod tests {
             reasoning.first_text(),
             Some("Now I understand the structure better. I need to: ...")
         );
+    }
+
+    #[test]
+    fn pdf_base64_document_serializes_as_file_content_part() {
+        let doc = message::UserContent::Document(message::Document {
+            data: DocumentSourceKind::Base64("JVBERi0xLjQK".into()),
+            media_type: Some(message::DocumentMediaType::PDF),
+            additional_params: None,
+        });
+        let converted: UserContent = doc.try_into().expect("conversion should succeed");
+        let json = serde_json::to_value(&converted).expect("serialize");
+
+        assert_eq!(json["type"], "file");
+        assert_eq!(
+            json["file"]["file_data"],
+            "data:application/pdf;base64,JVBERi0xLjQK"
+        );
+        assert_eq!(json["file"]["filename"], "document.pdf");
+        assert!(json["file"].get("file_id").is_none());
+    }
+
+    // Regression guard: callers passing markdown/plain text wrapped in
+    // `UserContent::Document` should keep getting flattened to `text`.
+    #[test]
+    fn non_pdf_document_still_serializes_as_text() {
+        let doc = message::UserContent::Document(message::Document {
+            data: DocumentSourceKind::String("# Markdown".into()),
+            media_type: None,
+            additional_params: None,
+        });
+        let converted: UserContent = doc.try_into().expect("conversion should succeed");
+        let json = serde_json::to_value(&converted).expect("serialize");
+
+        assert_eq!(json["type"], "text");
+        assert_eq!(json["text"], "# Markdown");
+    }
+
+    #[test]
+    fn pdf_url_document_returns_conversion_error() {
+        let doc = message::UserContent::Document(message::Document {
+            data: DocumentSourceKind::Url("https://example.com/x.pdf".into()),
+            media_type: Some(message::DocumentMediaType::PDF),
+            additional_params: None,
+        });
+        let res: Result<UserContent, _> = doc.try_into();
+        assert!(matches!(
+            res,
+            Err(message::MessageError::ConversionError(_))
+        ));
+    }
+
+    #[test]
+    fn pdf_raw_document_returns_conversion_error() {
+        let doc = message::UserContent::Document(message::Document {
+            data: DocumentSourceKind::Raw(b"%PDF-1.4\n".to_vec()),
+            media_type: Some(message::DocumentMediaType::PDF),
+            additional_params: None,
+        });
+        let res: Result<UserContent, _> = doc.try_into();
+        assert!(matches!(
+            res,
+            Err(message::MessageError::ConversionError(_))
+        ));
+    }
+
+    #[test]
+    fn file_user_content_deserializes_from_wire_json() {
+        let raw = r#"{"type":"file","file":{"file_data":"data:application/pdf;base64,AAAA","filename":"x.pdf"}}"#;
+        let parsed: UserContent = serde_json::from_str(raw).expect("deserialize");
+        let UserContent::File { file } = parsed else {
+            panic!("expected File variant");
+        };
+        assert_eq!(
+            file.file_data.as_deref(),
+            Some("data:application/pdf;base64,AAAA")
+        );
+        assert_eq!(file.filename.as_deref(), Some("x.pdf"));
+        assert!(file.file_id.is_none());
+    }
+
+    #[test]
+    fn file_variant_round_trips_back_to_pdf_document() {
+        let wire = UserContent::File {
+            file: FileData {
+                file_data: Some("data:application/pdf;base64,QUJD".to_string()),
+                file_id: None,
+                filename: Some("document.pdf".to_string()),
+            },
+        };
+        let rig: message::UserContent = wire.into();
+        let message::UserContent::Document(doc) = rig else {
+            panic!("expected Document");
+        };
+        assert_eq!(doc.media_type, Some(message::DocumentMediaType::PDF));
+        assert!(matches!(doc.data, DocumentSourceKind::Base64(ref b) if b == "QUJD"));
+    }
+
+    #[test]
+    fn file_variant_with_file_id_only_falls_back_to_text() {
+        let wire = UserContent::File {
+            file: FileData {
+                file_data: None,
+                file_id: Some("file_abc".to_string()),
+                filename: None,
+            },
+        };
+        let rig: message::UserContent = wire.into();
+        let message::UserContent::Text(text) = rig else {
+            panic!("expected Text");
+        };
+        assert_eq!(text.text, "[file_id: file_abc]");
+    }
+
+    // Guards against `OneOrMany::many` flattening at the User content site:
+    // a mixed text + PDF message must produce one User message with both parts.
+    #[test]
+    fn mixed_text_and_pdf_user_message_produces_two_content_parts() {
+        let user = message::Message::User {
+            content: OneOrMany::many(vec![
+                message::UserContent::text("What is in this PDF?"),
+                message::UserContent::Document(message::Document {
+                    data: DocumentSourceKind::Base64("JVBERi0K".into()),
+                    media_type: Some(message::DocumentMediaType::PDF),
+                    additional_params: None,
+                }),
+            ])
+            .expect("non-empty content"),
+        };
+        let converted: Vec<Message> = user.try_into().expect("conversion should succeed");
+        assert_eq!(converted.len(), 1);
+        let Message::User { content, .. } = &converted[0] else {
+            panic!("expected user message");
+        };
+        let parts: Vec<&UserContent> = content.iter().collect();
+        assert_eq!(parts.len(), 2);
+        assert!(matches!(parts[0], UserContent::Text { .. }));
+        assert!(matches!(parts[1], UserContent::File { .. }));
     }
 }

--- a/crates/rig-core/src/providers/openrouter/completion.rs
+++ b/crates/rig-core/src/providers/openrouter/completion.rs
@@ -857,6 +857,7 @@ impl UserContent {
             file: FileContent {
                 filename,
                 file_data: Some(url.into()),
+                file_id: None,
             },
         }
     }
@@ -873,6 +874,7 @@ impl UserContent {
             file: FileContent {
                 filename,
                 file_data: Some(data_uri),
+                file_id: None,
             },
         }
     }
@@ -970,6 +972,7 @@ pub struct VideoUrlContent {
 /// which accepts either:
 /// - A publicly accessible URL to the file
 /// - A base64-encoded data URI (e.g., `data:application/pdf;base64,...`)
+/// - A provider file identifier
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct FileContent {
     /// Filename (e.g., "document.pdf")
@@ -978,6 +981,9 @@ pub struct FileContent {
     /// File data source - URL or base64-encoded data URI
     #[serde(skip_serializing_if = "Option::is_none")]
     pub file_data: Option<String>,
+    /// Identifier of a previously uploaded file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file_id: Option<String>,
 }
 
 /// Serializes user content as a plain string when there's a single text item,
@@ -1060,6 +1066,7 @@ impl TryFrom<message::UserContent> for UserContent {
                         file: FileContent {
                             filename: filename.map(String::from),
                             file_data: Some(url),
+                            file_id: None,
                         },
                     })
                 }
@@ -1084,6 +1091,7 @@ impl TryFrom<message::UserContent> for UserContent {
                         file: FileContent {
                             filename: filename.map(String::from),
                             file_data: Some(data_uri),
+                            file_id: None,
                         },
                     })
                 }
@@ -1340,6 +1348,22 @@ impl From<openai::UserContent> for UserContent {
                 },
             },
             openai::UserContent::Audio { input_audio } => UserContent::InputAudio { input_audio },
+            openai::UserContent::File { file } => match file.file_data {
+                Some(file_data) => UserContent::File {
+                    file: FileContent {
+                        filename: file.filename,
+                        file_data: Some(file_data),
+                        file_id: file.file_id,
+                    },
+                },
+                None => UserContent::File {
+                    file: FileContent {
+                        filename: file.filename,
+                        file_data: None,
+                        file_id: file.file_id,
+                    },
+                },
+            },
         }
     }
 }
@@ -2443,6 +2467,23 @@ mod tests {
     }
 
     #[test]
+    fn test_user_content_file_id_serialization() {
+        let content = UserContent::File {
+            file: FileContent {
+                filename: Some("uploaded.pdf".to_string()),
+                file_data: None,
+                file_id: Some("file_abc".to_string()),
+            },
+        };
+        let json = serde_json::to_value(&content).unwrap();
+
+        assert_eq!(json["type"], "file");
+        assert_eq!(json["file"]["filename"], "uploaded.pdf");
+        assert_eq!(json["file"]["file_id"], "file_abc");
+        assert!(json["file"].get("file_data").is_none());
+    }
+
+    #[test]
     fn test_user_content_text_deserialization() {
         let json = json!({
             "type": "text",
@@ -2484,7 +2525,8 @@ mod tests {
             "type": "file",
             "file": {
                 "filename": "doc.pdf",
-                "file_data": "https://example.com/doc.pdf"
+                "file_data": "https://example.com/doc.pdf",
+                "file_id": "file_abc"
             }
         });
 
@@ -2496,6 +2538,7 @@ mod tests {
                     file.file_data,
                     Some("https://example.com/doc.pdf".to_string())
                 );
+                assert_eq!(file.file_id, Some("file_abc".to_string()));
             }
             _ => panic!("Expected File variant"),
         }
@@ -3072,6 +3115,23 @@ mod tests {
                 assert_eq!(input_audio.format, AudioMediaType::FLAC);
             }
             _ => panic!("Expected InputAudio"),
+        }
+
+        let openai_file = openai::UserContent::File {
+            file: openai::FileData {
+                file_data: None,
+                file_id: Some("file_abc".to_string()),
+                filename: Some("uploaded.pdf".to_string()),
+            },
+        };
+        let converted: UserContent = openai_file.into();
+        match converted {
+            UserContent::File { file } => {
+                assert_eq!(file.filename, Some("uploaded.pdf".to_string()));
+                assert!(file.file_data.is_none());
+                assert_eq!(file.file_id, Some("file_abc".to_string()));
+            }
+            _ => panic!("Expected File"),
         }
     }
 


### PR DESCRIPTION
# fix(openai): send PDF Documents as file parts in chat completions

## Description

Previously, `UserContent::Document` carrying a base64-encoded PDF was flattened into a plain `text` content part on the OpenAI Chat Completions path. The model never received the PDF and, with grounded prompts, would hallucinate plausible content matching the system prompt.

This PR adds a `File { file: FileData }` variant to the chat-completions `UserContent` enum matching OpenAI's `{"type":"file","file":{...}}` content type, and routes `UserContent::Document` with `media_type: Some(PDF)` into it. Mirrors the pattern already used by rig's Responses API provider and the OpenRouter provider (added in #1404 / commit `9cb2d9ca`). Non-PDF Documents continue to serialize as text, so existing markdown/text callers are unaffected.

The OpenRouter bridge (`From<openai::UserContent> for openrouter::UserContent`) is also extended to preserve `file_id` end to end. `openrouter::FileContent` gains a `file_id: Option<String>` field, matching the upstream OpenRouter OpenAPI schema (which accepts `file_id` on `type: "file"` content alongside `file_data`). Both `file_data` and `file_id`-only payloads now produce a valid OpenRouter `File` content part.

This unblocks PDF use both on native OpenAI chat completions and on LiteLLM-style proxies (Gemini, Anthropic, vLLM, etc.) routed through rig's OpenAI provider, since they share this serializer.

Fixes #1708
Refs #446

## Type of change

- [x] Bug fix

## Testing

8 new unit tests in `crates/rig-core/src/providers/openai/completion/mod.rs`:

OpenRouter test additions:

- New `test_user_content_file_id_serialization` pinning `file_id` on the wire
- Existing `file_deserialization` test extended to assert `file_id` deserializes
- Cross-conversion test extended to assert `openai::UserContent::File { file_id }` round-trips through to OpenRouter's `File` content with `file_id` preserved

Verification:

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace` (539 lib tests + integration binaries, all green)
- [x] Manual canary verification with a PDF containing a unique token; the model returns the canary verbatim instead of hallucinating

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (doc comments on new public items: `UserContent::File`, `FileData`, all fields; `FileContent::file_id` doc comment + struct doc updated)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Notes

Two additive public API surface changes:

1. New variant `File { file: FileData }` on the public `openai::completion::UserContent` enum (re-exported as `rig::providers::openai::UserContent`). The enum is not `#[non_exhaustive]`, so downstream code that exhaustively `match`es on it will need to add a new arm. Workspace-internal: only `openrouter/completion.rs` had such a match; patched in this PR.
2. New field `file_id: Option<String>` on the public `openrouter::completion::FileContent` struct. The struct is also not `#[non_exhaustive]`, so downstream construction-by-literal will need to add the field. Workspace-internal: 4 construction sites (`UserContent::file_url`, `UserContent::file_base64`, two arms in `TryFrom<message::UserContent>`); all patched in this PR.

Given Rig is pre-1.0 and the alternative is leaving binary PDFs silently corrupted (and `file_id` unreachable on OpenRouter), I went additive rather than retroactively adding `#[non_exhaustive]`. Happy to mark either type `#[non_exhaustive]` in a follow-up if maintainers prefer.

**Out of scope (separate RFC).** A natural follow-up is `DocumentSourceKind::FileId(String)` as a cross-provider primitive for OpenAI / Anthropic / Gemini Files APIs and Bedrock S3. The wire `FileData` and `FileContent` already carry `file_id`, so the high-level abstraction can land later without re-churning users.

