### PR TITLE
fix(core)!: make Chat append messages to caller history

### DIFF
--- a/crates/rig-core/src/agent/completion.rs
+++ b/crates/rig-core/src/agent/completion.rs
@@ -296,18 +296,21 @@ where
     P: PromptHook<M> + 'static,
 {
     #[tracing::instrument(skip(self, prompt, chat_history), fields(agent_name = self.name()))]
-    async fn chat<I, T>(
+    async fn chat(
         &self,
         prompt: impl Into<Message> + WasmCompatSend,
-        chat_history: I,
-    ) -> Result<String, PromptError>
-    where
-        I: IntoIterator<Item = T>,
-        T: Into<Message>,
-    {
-        PromptRequest::from_agent(self, prompt)
-            .with_history(chat_history)
-            .await
+        chat_history: &mut Vec<Message>,
+    ) -> Result<String, PromptError> {
+        let response = PromptRequest::from_agent(self, prompt)
+            .with_history(chat_history.clone())
+            .extended_details()
+            .await?;
+
+        if let Some(messages) = response.messages {
+            chat_history.extend(messages);
+        }
+
+        Ok(response.output)
     }
 }
 

--- a/crates/rig-core/src/agent/mod.rs
+++ b/crates/rig-core/src/agent/mod.rs
@@ -37,7 +37,7 @@
 //!
 //! // Use the agent for completions and prompts
 //! // Generate a chat completion response from a prompt and chat history
-//! let chat_response = agent.chat("Prompt", Vec::<rig_core::completion::Message>::new()).await?;
+//! let chat_response = agent.chat("Prompt", &mut Vec::<rig_core::completion::Message>::new()).await?;
 //!
 //! // Generate a prompt completion response from a simple prompt
 //! let prompt_response = agent.prompt("Prompt").await?;

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -257,14 +257,16 @@ pub trait Chat: WasmCompatSend + WasmCompatSync {
     /// is returned as a string.
     ///
     /// If the tool does not exist, or the tool call fails, then an error is returned.
-    fn chat<I, T>(
+    ///
+    /// The prompt and any assistant or tool messages produced during the turn
+    /// are appended to `chat_history`. Callers should pass the current
+    /// conversation history and should not push the user prompt themselves
+    /// before calling this method.
+    fn chat(
         &self,
         prompt: impl Into<Message> + WasmCompatSend,
-        chat_history: I,
-    ) -> impl std::future::Future<Output = Result<String, PromptError>> + WasmCompatSend
-    where
-        I: IntoIterator<Item = T> + WasmCompatSend,
-        T: Into<Message>;
+        chat_history: &mut Vec<Message>,
+    ) -> impl std::future::Future<Output = Result<String, PromptError>> + WasmCompatSend;
 }
 
 /// Trait defining a high-level typed prompt interface for structured output.

--- a/crates/rig-core/src/integrations/cli_chatbot.rs
+++ b/crates/rig-core/src/integrations/cli_chatbot.rs
@@ -30,8 +30,11 @@ pub struct ChatBot<T>(T);
 /// Trait to abstract message behavior away from cli_chat/`run` loop
 #[allow(private_interfaces)]
 trait CliChat {
-    async fn request(&mut self, prompt: &str, history: Vec<Message>)
-    -> Result<String, PromptError>;
+    async fn request(
+        &mut self,
+        prompt: &str,
+        history: &mut Vec<Message>,
+    ) -> Result<String, PromptError>;
 
     fn show_usage(&self) -> bool {
         false
@@ -49,9 +52,9 @@ where
     async fn request(
         &mut self,
         prompt: &str,
-        history: Vec<Message>,
+        history: &mut Vec<Message>,
     ) -> Result<String, PromptError> {
-        let res = self.0.chat(prompt, &history).await?;
+        let res = self.0.chat(prompt, history).await?;
         println!("{res}");
 
         Ok(res)
@@ -65,18 +68,19 @@ where
     async fn request(
         &mut self,
         prompt: &str,
-        history: Vec<Message>,
+        history: &mut Vec<Message>,
     ) -> Result<String, PromptError> {
         let mut response_stream = self
             .agent
             .stream_prompt(prompt)
-            .with_history(&history)
+            .with_history(history.clone())
             .multi_turn(self.max_turns)
             .await;
 
         let mut acc = String::new();
+        let mut messages = None;
 
-        loop {
+        let result = loop {
             let Some(chunk) = response_stream.next().await else {
                 println!();
                 break Ok(acc);
@@ -91,6 +95,7 @@ where
                 }
                 Ok(MultiTurnStreamItem::FinalResponse(final_response)) => {
                     self.usage = final_response.usage();
+                    messages = final_response.history().map(|history| history.to_vec());
                 }
                 Err(e) => {
                     break Err(PromptError::CompletionError(
@@ -99,7 +104,18 @@ where
                 }
                 _ => continue,
             }
+        };
+
+        if let Ok(response) = &result {
+            if let Some(messages) = messages {
+                history.extend(messages);
+            } else {
+                history.push(Message::user(prompt));
+                history.push(Message::assistant(response.as_str()));
+            }
         }
+
+        result
     }
 
     fn show_usage(&self) -> bool {
@@ -202,9 +218,7 @@ where
                     println!();
                     println!("========================== Response ============================");
 
-                    let response = self.0.request(input, history.clone()).await?;
-                    history.push(Message::user(input));
-                    history.push(Message::assistant(response));
+                    self.0.request(input, &mut history).await?;
 
                     println!("================================================================");
                     println!();

--- a/crates/rig-core/src/integrations/discord_bot.rs
+++ b/crates/rig-core/src/integrations/discord_bot.rs
@@ -1,9 +1,8 @@
 //! Integration for deploying your Rig agents (and more) as Discord bots.
 //! This feature is not WASM-compatible (and as such, is incompatible with the `worker` feature).
-use crate::OneOrMany;
 use crate::agent::Agent;
-use crate::completion::{AssistantContent, CompletionModel, request::Chat};
-use crate::message::{Message as RigMessage, UserContent};
+use crate::completion::{CompletionModel, request::Chat};
+use crate::message::Message as RigMessage;
 use serenity::all::{
     Command, CommandInteraction, Context, CreateCommand, CreateThread, EventHandler,
     GatewayIntents, Interaction, Message, Ready, async_trait,
@@ -159,30 +158,21 @@ where
     async fn handle_thread_message(&self, ctx: &Context, msg: &Message) {
         let thread_id = msg.channel_id.get();
 
-        // Add user message to history
-        {
-            let mut conversations = self.state.conversations.write().await;
-            if let Some(history) = conversations.get_mut(&thread_id) {
-                history.push(RigMessage::User {
-                    content: OneOrMany::one(UserContent::text(msg.content.clone())),
-                });
-            }
-        }
-
         // Show typing indicator
         let _ = msg.channel_id.broadcast_typing(&ctx.http).await;
 
-        // Get conversation history
+        // Get conversation history snapshot.
         let conversations = self.state.conversations.read().await;
-        let history = if let Some(history) = conversations.get(&thread_id) {
+        let mut history = if let Some(history) = conversations.get(&thread_id) {
             history.clone()
         } else {
             vec![]
         };
         drop(conversations);
 
-        // Generate response using the agent with conversation history
-        let response = match self.state.agent.chat(&msg.content, history).await {
+        // Generate response. `chat` appends the user prompt and generated
+        // assistant/tool messages onto the history snapshot.
+        let response = match self.state.agent.chat(&msg.content, &mut history).await {
             Ok(resp) => resp,
             Err(e) => {
                 eprintln!("Agent error: {}", e);
@@ -197,15 +187,10 @@ where
             }
         };
 
-        // Add assistant response to history
+        // Persist the round-tripped history back into the conversations map.
         {
             let mut conversations = self.state.conversations.write().await;
-            if let Some(history) = conversations.get_mut(&thread_id) {
-                history.push(RigMessage::Assistant {
-                    content: OneOrMany::one(AssistantContent::text(msg.content.clone())),
-                    id: None,
-                });
-            }
+            conversations.insert(thread_id, history);
         }
 
         // Send response (split if too long for Discord's 2000 char limit)

--- a/examples/multi_agent.rs
+++ b/examples/multi_agent.rs
@@ -48,8 +48,8 @@ impl<M: CompletionModel + 'static> Tool for TranslatorTool<M> {
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
-        let empty_history: &[Message] = &[];
-        match self.0.chat(&args.prompt, empty_history).await {
+        let mut empty_history = Vec::<Message>::new();
+        match self.0.chat(&args.prompt, &mut empty_history).await {
             Ok(response) => {
                 println!("Translated prompt: {response}");
                 Ok(response)

--- a/tests/common/reasoning.rs
+++ b/tests/common/reasoning.rs
@@ -13,7 +13,9 @@ use rig::OneOrMany;
 use rig::agent::{MultiTurnStreamItem, StreamingError};
 use rig::completion::request::ToolDefinition;
 use rig::completion::{self, CompletionModel};
-use rig::message::{AssistantContent, Message, Reasoning, ReasoningContent, UserContent};
+use rig::message::{
+    AssistantContent, Message, Reasoning, ReasoningContent, ToolResultContent, UserContent,
+};
 use rig::streaming::{StreamedAssistantContent, StreamedUserContent};
 use rig::tool::Tool;
 use rig::wasm_compat::WasmCompatSend;
@@ -577,5 +579,123 @@ pub(crate) fn assert_nonstreaming_universal(
         references_tool_output,
         "[{provider}] Response does not reference tool output: {:?}",
         &trimmed[..trimmed.len().min(200)]
+    );
+}
+
+pub(crate) fn assert_chat_history_preserves_reasoning_tool_roundtrip(
+    chat_history: &[Message],
+    result: &str,
+    provider: &str,
+) {
+    assert!(
+        chat_history.len() >= 4,
+        "[{provider}] Chat history should contain at least user prompt, assistant tool call, tool result, and final assistant response. Got: {chat_history:#?}"
+    );
+
+    let result = result.trim();
+    let mut prompt_index = None;
+    let mut reasoning_index = None;
+    let mut tool_call_index = None;
+    let mut tool_result_index = None;
+    let mut final_response_index = None;
+    let mut tool_result_text = String::new();
+
+    for (index, message) in chat_history.iter().enumerate() {
+        match message {
+            Message::User { content } => {
+                for item in content.iter() {
+                    match item {
+                        UserContent::Text(text)
+                            if text.text.contains("Tokyo")
+                                || text.text.contains("get_weather")
+                                || text.text.contains("weather") =>
+                        {
+                            prompt_index.get_or_insert(index);
+                        }
+                        UserContent::ToolResult(tool_result) => {
+                            tool_result_index.get_or_insert(index);
+                            for content in tool_result.content.iter() {
+                                if let ToolResultContent::Text(text) = content {
+                                    tool_result_text.push_str(&text.text);
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            Message::Assistant { content, .. } => {
+                let mut assistant_text = String::new();
+
+                for item in content.iter() {
+                    match item {
+                        AssistantContent::Reasoning(_) => {
+                            reasoning_index.get_or_insert(index);
+                        }
+                        AssistantContent::ToolCall(tool_call)
+                            if tool_call.function.name == WeatherTool::NAME =>
+                        {
+                            tool_call_index.get_or_insert(index);
+                        }
+                        AssistantContent::Text(text) => {
+                            assistant_text.push_str(&text.text);
+                        }
+                        _ => {}
+                    }
+                }
+
+                let assistant_text = assistant_text.trim();
+                if !assistant_text.is_empty()
+                    && (assistant_text == result
+                        || assistant_text.contains(result)
+                        || result.contains(assistant_text))
+                {
+                    final_response_index.get_or_insert(index);
+                }
+            }
+            Message::System { .. } => {}
+        }
+    }
+
+    let prompt_index = prompt_index.unwrap_or_else(|| {
+        panic!("[{provider}] Chat history is missing the original user prompt: {chat_history:#?}")
+    });
+    let _reasoning_index = reasoning_index.unwrap_or_else(|| {
+        panic!(
+            "[{provider}] Chat history is missing assistant reasoning content: {chat_history:#?}"
+        )
+    });
+    let tool_call_index = tool_call_index.unwrap_or_else(|| {
+        panic!("[{provider}] Chat history is missing the get_weather tool call: {chat_history:#?}")
+    });
+    let tool_result_index = tool_result_index.unwrap_or_else(|| {
+        panic!(
+            "[{provider}] Chat history is missing the get_weather tool result: {chat_history:#?}"
+        )
+    });
+    let final_response_index = final_response_index.unwrap_or_else(|| {
+        panic!(
+            "[{provider}] Chat history is missing the returned final assistant response {result:?}: {chat_history:#?}"
+        )
+    });
+
+    assert!(
+        prompt_index < tool_call_index,
+        "[{provider}] Tool call should appear after the user prompt: {chat_history:#?}"
+    );
+    assert!(
+        tool_call_index < tool_result_index,
+        "[{provider}] Tool result should appear after the assistant tool call: {chat_history:#?}"
+    );
+    assert!(
+        tool_result_index < final_response_index,
+        "[{provider}] Final assistant response should appear after the tool result: {chat_history:#?}"
+    );
+
+    let tool_result_lower = tool_result_text.to_ascii_lowercase();
+    assert!(
+        tool_result_lower.contains("tokyo")
+            && (tool_result_lower.contains("72") || tool_result_lower.contains("sunny")),
+        "[{provider}] Tool result content was not preserved in chat history: {tool_result_text:?}"
     );
 }

--- a/tests/core/prompt_response_messages.rs
+++ b/tests/core/prompt_response_messages.rs
@@ -4,7 +4,8 @@
 use rig::OneOrMany;
 use rig::agent::AgentBuilder;
 use rig::completion::{
-    CompletionError, CompletionModel, CompletionRequest, CompletionResponse, Message, Prompt, Usage,
+    Chat, CompletionError, CompletionModel, CompletionRequest, CompletionResponse, Message, Prompt,
+    Usage,
 };
 use rig::message::{AssistantContent, Text, ToolCall, ToolFunction, UserContent};
 use rig::streaming::{StreamingCompletionResponse, StreamingResult};
@@ -440,7 +441,102 @@ async fn extended_details_works_without_with_history() {
     assert_eq!(resp.output, "The answer is 5");
 }
 
-/// Test 10: Multiple sequential prompts each return independent message histories.
+/// Test 10: `Chat::chat` appends the prompt and response messages to the
+/// caller-owned history.
+#[tokio::test]
+async fn chat_appends_prompt_and_assistant_to_history() {
+    let agent = AgentBuilder::new(SimpleTextModel).build();
+    let mut history = Vec::<Message>::new();
+
+    let output = agent
+        .chat("hi", &mut history)
+        .await
+        .expect("chat should succeed");
+
+    assert_eq!(output, "hello from mock");
+    assert_eq!(
+        history.len(),
+        2,
+        "expected chat to append [User, Assistant], got: {history:#?}"
+    );
+
+    match &history[0] {
+        Message::User { content } => match content.first() {
+            UserContent::Text(text) => assert_eq!(text.text, "hi"),
+            other => panic!("expected text user content, got: {other:?}"),
+        },
+        other => panic!("expected User message, got: {other:?}"),
+    }
+
+    match &history[1] {
+        Message::Assistant { content, .. } => match content.first() {
+            AssistantContent::Text(text) => assert_eq!(text.text, "hello from mock"),
+            other => panic!("expected text assistant content, got: {other:?}"),
+        },
+        other => panic!("expected Assistant message, got: {other:?}"),
+    }
+
+    let _ = agent
+        .chat("again", &mut history)
+        .await
+        .expect("second chat should succeed");
+
+    assert_eq!(
+        history.len(),
+        4,
+        "expected history to grow to 4 messages, got: {history:#?}"
+    );
+}
+
+/// Test 11: `Chat::chat` appends every message produced by a tool roundtrip.
+#[tokio::test]
+async fn chat_appends_tool_roundtrip_to_history() {
+    let agent = AgentBuilder::new(ToolThenTextModel::new()).build();
+    let mut history = Vec::<Message>::new();
+
+    let output = agent
+        .chat("What is 2 + 3?", &mut history)
+        .await
+        .expect("chat should succeed");
+
+    assert_eq!(output, "The answer is 5");
+    assert_eq!(
+        history.len(),
+        4,
+        "expected chat to append [User, Assistant(tool), User(tool result), Assistant], got: {history:#?}"
+    );
+    assert!(matches!(&history[0], Message::User { .. }));
+
+    match &history[1] {
+        Message::Assistant { content, .. } => assert!(
+            content
+                .iter()
+                .any(|content| matches!(content, AssistantContent::ToolCall(_))),
+            "expected assistant tool call, got: {content:?}"
+        ),
+        other => panic!("expected Assistant with tool call, got: {other:?}"),
+    }
+
+    match &history[2] {
+        Message::User { content } => assert!(
+            content
+                .iter()
+                .any(|content| matches!(content, UserContent::ToolResult(_))),
+            "expected user tool result, got: {content:?}"
+        ),
+        other => panic!("expected User with tool result, got: {other:?}"),
+    }
+
+    match &history[3] {
+        Message::Assistant { content, .. } => match content.first() {
+            AssistantContent::Text(text) => assert_eq!(text.text, "The answer is 5"),
+            other => panic!("expected final assistant text, got: {other:?}"),
+        },
+        other => panic!("expected final Assistant, got: {other:?}"),
+    }
+}
+
+/// Test 12: Multiple sequential prompts each return independent message histories.
 #[tokio::test]
 async fn sequential_prompts_have_independent_histories() {
     let agent = AgentBuilder::new(SimpleTextModel).build();

--- a/tests/providers/anthropic/opus_4_7.rs
+++ b/tests/providers/anthropic/opus_4_7.rs
@@ -202,7 +202,7 @@ async fn messages_adaptive_thinking_tool_roundtrip_smoke() {
         .build();
 
     let result = agent
-        .chat(reasoning::TOOL_USER_PROMPT, Vec::<Message>::new())
+        .chat(reasoning::TOOL_USER_PROMPT, &mut Vec::<Message>::new())
         .await
         .expect("adaptive thinking tool chat should succeed");
 

--- a/tests/providers/anthropic/reasoning_tool_roundtrip.rs
+++ b/tests/providers/anthropic/reasoning_tool_roundtrip.rs
@@ -66,7 +66,7 @@ async fn nonstreaming() {
         .build();
 
     let result = agent
-        .chat(reasoning::TOOL_USER_PROMPT, Vec::<Message>::new())
+        .chat(reasoning::TOOL_USER_PROMPT, &mut Vec::<Message>::new())
         .await
         .expect("[anthropic] Non-streaming chat failed - likely 400 from dropped reasoning");
 

--- a/tests/providers/copilot/reasoning_tool_roundtrip.rs
+++ b/tests/providers/copilot/reasoning_tool_roundtrip.rs
@@ -56,7 +56,7 @@ async fn nonstreaming() {
         .build();
 
     let result = agent
-        .chat(reasoning::TOOL_USER_PROMPT, Vec::<Message>::new())
+        .chat(reasoning::TOOL_USER_PROMPT, &mut Vec::<Message>::new())
         .await
         .expect("[copilot] Non-streaming chat failed");
 

--- a/tests/providers/deepseek/reasoning_tool_roundtrip.rs
+++ b/tests/providers/deepseek/reasoning_tool_roundtrip.rs
@@ -60,7 +60,7 @@ async fn nonstreaming() {
         .build();
 
     let result = agent
-        .chat(reasoning::TOOL_USER_PROMPT, Vec::<Message>::new())
+        .chat(reasoning::TOOL_USER_PROMPT, &mut Vec::<Message>::new())
         .await
         .expect("[deepseek] Non-streaming chat failed - likely 400 from dropped reasoning");
 

--- a/tests/providers/gemini/chat_history.rs
+++ b/tests/providers/gemini/chat_history.rs
@@ -1,0 +1,44 @@
+//! Gemini high-level Chat history regression tests.
+//!
+//! Run only this case with:
+//! `cargo test -p rig --test gemini gemini::chat_history::chat_appends_reasoning_tool_turns_to_caller_history -- --ignored --nocapture`
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+
+use rig::client::{CompletionClient, ProviderClient};
+use rig::completion::{Chat, Message};
+use rig::providers::gemini;
+
+use crate::reasoning::{self, WeatherTool};
+
+#[tokio::test]
+#[ignore = "requires GEMINI_API_KEY"]
+async fn chat_appends_reasoning_tool_turns_to_caller_history() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let client = gemini::Client::from_env().expect("client should build");
+    let agent = client
+        .agent(gemini::completion::GEMINI_2_5_FLASH)
+        .preamble(reasoning::TOOL_SYSTEM_PROMPT)
+        .max_tokens(4096)
+        .tool(WeatherTool::new(call_count.clone()))
+        .additional_params(serde_json::json!({
+            "generationConfig": {
+                "thinkingConfig": { "thinkingBudget": 4096, "includeThoughts": true }
+            }
+        }))
+        .build();
+    let mut chat_history = Vec::<Message>::new();
+
+    let result = agent
+        .chat(reasoning::TOOL_USER_PROMPT, &mut chat_history)
+        .await
+        .expect("[gemini] Chat failed before it could update caller-owned history");
+
+    reasoning::assert_nonstreaming_universal(&result, &call_count, "gemini");
+    reasoning::assert_chat_history_preserves_reasoning_tool_roundtrip(
+        &chat_history,
+        &result,
+        "gemini",
+    );
+}

--- a/tests/providers/gemini/chat_history.rs
+++ b/tests/providers/gemini/chat_history.rs
@@ -2,15 +2,109 @@
 //!
 //! Run only this case with:
 //! `cargo test -p rig --test gemini gemini::chat_history::chat_appends_reasoning_tool_turns_to_caller_history -- --ignored --nocapture`
+//! `cargo test -p rig --test gemini gemini::chat_history::five_turn_chat_history_stress_preserves_context_and_tools -- --ignored --nocapture`
 
 use std::sync::Arc;
-use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rig::client::{CompletionClient, ProviderClient};
-use rig::completion::{Chat, Message};
+use rig::completion::{Chat, Message, ToolDefinition};
+use rig::message::{AssistantContent, UserContent};
 use rig::providers::gemini;
+use rig::tool::Tool;
+use serde::Deserialize;
+use serde_json::json;
 
 use crate::reasoning::{self, WeatherTool};
+
+const STRESS_EXPECTED_FINAL: &str = "NOVA-200-142-LIME";
+
+#[derive(Debug, thiserror::Error)]
+#[error("stress calculator error")]
+struct StressCalculatorError;
+
+#[derive(Deserialize)]
+struct StressMathArgs {
+    x: i32,
+    y: i32,
+}
+
+struct StressAdd {
+    call_count: Arc<AtomicUsize>,
+}
+
+impl StressAdd {
+    fn new(call_count: Arc<AtomicUsize>) -> Self {
+        Self { call_count }
+    }
+}
+
+impl Tool for StressAdd {
+    const NAME: &'static str = "stress_add";
+    type Error = StressCalculatorError;
+    type Args = StressMathArgs;
+    type Output = i32;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "Add x and y. This tool must be used for stress-test addition turns."
+                .to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "x": { "type": "number", "description": "Left operand" },
+                    "y": { "type": "number", "description": "Right operand" }
+                },
+                "required": ["x", "y"]
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        self.call_count.fetch_add(1, Ordering::SeqCst);
+        Ok(args.x + args.y)
+    }
+}
+
+struct StressSubtract {
+    call_count: Arc<AtomicUsize>,
+}
+
+impl StressSubtract {
+    fn new(call_count: Arc<AtomicUsize>) -> Self {
+        Self { call_count }
+    }
+}
+
+impl Tool for StressSubtract {
+    const NAME: &'static str = "stress_subtract";
+    type Error = StressCalculatorError;
+    type Args = StressMathArgs;
+    type Output = i32;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: Self::NAME.to_string(),
+            description:
+                "Subtract y from x. This tool must be used for stress-test subtraction turns."
+                    .to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "x": { "type": "number", "description": "Value to subtract from" },
+                    "y": { "type": "number", "description": "Value to subtract" }
+                },
+                "required": ["x", "y"]
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        self.call_count.fetch_add(1, Ordering::SeqCst);
+        Ok(args.x - args.y)
+    }
+}
 
 #[tokio::test]
 #[ignore = "requires GEMINI_API_KEY"]
@@ -41,4 +135,168 @@ async fn chat_appends_reasoning_tool_turns_to_caller_history() {
         &result,
         "gemini",
     );
+}
+
+#[tokio::test]
+#[ignore = "requires GEMINI_API_KEY"]
+async fn five_turn_chat_history_stress_preserves_context_and_tools() {
+    let add_count = Arc::new(AtomicUsize::new(0));
+    let subtract_count = Arc::new(AtomicUsize::new(0));
+    let client = gemini::Client::from_env().expect("client should build");
+    let agent = client
+        .agent(gemini::completion::GEMINI_2_5_FLASH)
+        .preamble(
+            "You are running a deterministic Rig integration test. Preserve facts across turns. \
+             When a prompt says to use a tool, call exactly that tool before answering. \
+             Keep replies concise. When asked for the final code, return only the code with no \
+             markdown, quotes, or commentary.",
+        )
+        .temperature(0.0)
+        .max_tokens(4096)
+        .tool(StressAdd::new(add_count.clone()))
+        .tool(StressSubtract::new(subtract_count.clone()))
+        .additional_params(serde_json::json!({
+            "generationConfig": {
+                "thinkingConfig": { "thinkingBudget": 1024, "includeThoughts": true }
+            }
+        }))
+        .build();
+
+    let mut chat_history = Vec::<Message>::new();
+
+    let turn1 = agent
+        .chat(
+            "Turn 1 of 5. Remember that the alpha token is NOVA. Reply exactly ACK-ALPHA.",
+            &mut chat_history,
+        )
+        .await
+        .expect("[gemini] turn 1 should succeed");
+    assert_response_contains("turn 1", &turn1, "ACK-ALPHA");
+
+    let turn2 = agent
+        .chat(
+            "Turn 2 of 5. Use the stress_add tool to compute 123 + 77. \
+             Remember the tool result as SUM. Reply exactly SUM=<tool result>.",
+            &mut chat_history,
+        )
+        .await
+        .expect("[gemini] turn 2 should succeed");
+    assert_response_contains("turn 2", &turn2, "200");
+
+    let turn3 = agent
+        .chat(
+            "Turn 3 of 5. Use the stress_subtract tool to compute the remembered SUM minus 58. \
+             If you need concrete tool arguments, use x=200 and y=58. \
+             Remember the tool result as DELTA. Reply exactly DELTA=<tool result>.",
+            &mut chat_history,
+        )
+        .await
+        .expect("[gemini] turn 3 should succeed");
+    assert_response_contains("turn 3", &turn3, "142");
+
+    let turn4 = agent
+        .chat(
+            "Turn 4 of 5. Remember that the suffix token is LIME. \
+             Also remember that the final code format is <ALPHA>-<SUM>-<DELTA>-<SUFFIX>. \
+             Reply exactly ACK-SUFFIX.",
+            &mut chat_history,
+        )
+        .await
+        .expect("[gemini] turn 4 should succeed");
+    assert_response_contains("turn 4", &turn4, "ACK-SUFFIX");
+
+    let final_result = agent
+        .chat(
+            "Turn 5 of 5. Using only facts stored in the previous turns, produce the final code. \
+             Reply with the code only.",
+            &mut chat_history,
+        )
+        .await
+        .expect("[gemini] turn 5 should succeed");
+
+    assert_eq!(
+        final_result.trim(),
+        STRESS_EXPECTED_FINAL,
+        "[gemini] final stress result mismatch. Full chat history: {chat_history:#?}"
+    );
+    assert_eq!(
+        add_count.load(Ordering::SeqCst),
+        1,
+        "[gemini] stress_add should be called exactly once"
+    );
+    assert_eq!(
+        subtract_count.load(Ordering::SeqCst),
+        1,
+        "[gemini] stress_subtract should be called exactly once"
+    );
+
+    assert_eq!(
+        count_text_user_turns(&chat_history),
+        5,
+        "[gemini] expected five caller chat turns in history: {chat_history:#?}"
+    );
+    assert!(
+        chat_history.len() >= 14,
+        "[gemini] expected five chat turns plus two tool roundtrips in history, got {}: {chat_history:#?}",
+        chat_history.len()
+    );
+    assert!(
+        count_assistant_tool_calls(&chat_history, StressAdd::NAME) >= 1,
+        "[gemini] chat history is missing stress_add tool call: {chat_history:#?}"
+    );
+    assert!(
+        count_assistant_tool_calls(&chat_history, StressSubtract::NAME) >= 1,
+        "[gemini] chat history is missing stress_subtract tool call: {chat_history:#?}"
+    );
+    assert!(
+        count_user_tool_results(&chat_history) >= 2,
+        "[gemini] chat history should contain both tool results: {chat_history:#?}"
+    );
+}
+
+fn assert_response_contains(turn: &str, response: &str, expected: &str) {
+    assert!(
+        response.contains(expected),
+        "[gemini] {turn} response should contain {expected:?}, got {response:?}"
+    );
+}
+
+fn count_text_user_turns(chat_history: &[Message]) -> usize {
+    chat_history
+        .iter()
+        .filter(|message| match message {
+            Message::User { content } => content.iter().any(|content| match content {
+                UserContent::Text(text) => text.text.contains("Turn "),
+                _ => false,
+            }),
+            _ => false,
+        })
+        .count()
+}
+
+fn count_assistant_tool_calls(chat_history: &[Message], tool_name: &str) -> usize {
+    chat_history
+        .iter()
+        .filter_map(|message| match message {
+            Message::Assistant { content, .. } => Some(content),
+            _ => None,
+        })
+        .flat_map(|content| content.iter())
+        .filter(|content| match content {
+            AssistantContent::ToolCall(tool_call) => tool_call.function.name == tool_name,
+            _ => false,
+        })
+        .count()
+}
+
+fn count_user_tool_results(chat_history: &[Message]) -> usize {
+    chat_history
+        .iter()
+        .filter_map(|message| match message {
+            Message::User { content } => Some(content),
+            _ => None,
+        })
+        .flat_map(|content| content.iter())
+        .filter(|content| matches!(content, UserContent::ToolResult(_)))
+        .count()
 }

--- a/tests/providers/gemini/mod.rs
+++ b/tests/providers/gemini/mod.rs
@@ -1,4 +1,5 @@
 mod agent;
+mod chat_history;
 mod embeddings;
 mod extractor;
 mod interactions_api;

--- a/tests/providers/gemini/reasoning_tool_roundtrip.rs
+++ b/tests/providers/gemini/reasoning_tool_roundtrip.rs
@@ -57,7 +57,7 @@ async fn nonstreaming() {
         .build();
 
     let result = agent
-        .chat(reasoning::TOOL_USER_PROMPT, Vec::<Message>::new())
+        .chat(reasoning::TOOL_USER_PROMPT, &mut Vec::<Message>::new())
         .await
         .expect("[gemini] Non-streaming chat failed - likely 400 from dropped reasoning");
 

--- a/tests/providers/openai/chat_history.rs
+++ b/tests/providers/openai/chat_history.rs
@@ -1,0 +1,42 @@
+//! OpenAI high-level Chat history regression tests.
+//!
+//! Run only this case with:
+//! `cargo test -p rig --test openai openai::chat_history::chat_appends_reasoning_tool_turns_to_caller_history -- --ignored --nocapture`
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+
+use rig::client::{CompletionClient, ProviderClient};
+use rig::completion::{Chat, Message};
+use rig::providers::openai;
+
+use crate::reasoning::{self, WeatherTool};
+
+#[tokio::test]
+#[ignore = "requires OPENAI_API_KEY"]
+async fn chat_appends_reasoning_tool_turns_to_caller_history() {
+    let call_count = Arc::new(AtomicUsize::new(0));
+    let client = openai::Client::from_env().expect("client should build");
+    let agent = client
+        .agent(openai::GPT_5_2)
+        .preamble(reasoning::TOOL_SYSTEM_PROMPT)
+        .max_tokens(4096)
+        .tool(WeatherTool::new(call_count.clone()))
+        .additional_params(serde_json::json!({
+            "reasoning": { "effort": "high" }
+        }))
+        .build();
+    let mut chat_history = Vec::<Message>::new();
+
+    let result = agent
+        .chat(reasoning::TOOL_USER_PROMPT, &mut chat_history)
+        .await
+        .expect("[openai] Chat failed before it could update caller-owned history");
+
+    reasoning::assert_nonstreaming_universal(&result, &call_count, "openai");
+    reasoning::assert_chat_history_preserves_reasoning_tool_roundtrip(
+        &chat_history,
+        &result,
+        "openai",
+    );
+}

--- a/tests/providers/openai/gpt_5_5.rs
+++ b/tests/providers/openai/gpt_5_5.rs
@@ -230,7 +230,7 @@ async fn responses_reasoning_tool_roundtrip_smoke() {
         .build();
 
     let result = agent
-        .chat(reasoning::TOOL_USER_PROMPT, Vec::<Message>::new())
+        .chat(reasoning::TOOL_USER_PROMPT, &mut Vec::<Message>::new())
         .await
         .expect("reasoning tool chat should succeed");
 

--- a/tests/providers/openai/mod.rs
+++ b/tests/providers/openai/mod.rs
@@ -1,6 +1,7 @@
 mod agent;
 #[cfg(feature = "audio")]
 mod audio_generation;
+mod chat_history;
 mod completions_api;
 mod extractor;
 mod extractor_usage;

--- a/tests/providers/openai/reasoning_tool_roundtrip.rs
+++ b/tests/providers/openai/reasoning_tool_roundtrip.rs
@@ -61,7 +61,7 @@ async fn nonstreaming() {
         .build();
 
     let result = agent
-        .chat(reasoning::TOOL_USER_PROMPT, Vec::<Message>::new())
+        .chat(reasoning::TOOL_USER_PROMPT, &mut Vec::<Message>::new())
         .await
         .expect("[openai] Non-streaming chat failed - likely 400 from dropped reasoning");
 

--- a/tests/providers/openrouter/reasoning_tool_roundtrip.rs
+++ b/tests/providers/openrouter/reasoning_tool_roundtrip.rs
@@ -55,7 +55,7 @@ async fn nonstreaming() {
         .build();
 
     let result = agent
-        .chat(reasoning::TOOL_USER_PROMPT, Vec::<Message>::new())
+        .chat(reasoning::TOOL_USER_PROMPT, &mut Vec::<Message>::new())
         .await
         .expect("[openrouter] Non-streaming chat failed - likely 400 from dropped reasoning");
 

--- a/tests/providers/xai/reasoning_tool_roundtrip.rs
+++ b/tests/providers/xai/reasoning_tool_roundtrip.rs
@@ -47,7 +47,7 @@ async fn nonstreaming() {
         .build();
 
     let result = agent
-        .chat(reasoning::TOOL_USER_PROMPT, Vec::<Message>::new())
+        .chat(reasoning::TOOL_USER_PROMPT, &mut Vec::<Message>::new())
         .await
         .expect("[xai] Non-streaming chat failed - likely 400 from dropped reasoning");
 


### PR DESCRIPTION
## Summary

Closes #1556.

`Chat::chat` previously accepted chat history as input, but returned only the final assistant `String`. The agent loop already accumulated the full message delta internally, including the user prompt, assistant reasoning, tool calls, tool results, and final assistant response, but the high-level `Chat` trait discarded that data.

This changes `Chat::chat` to take `&mut Vec<Message>` and append the generated turn messages back into caller-owned history.

## API contract

```rust
let mut history = Vec::<Message>::new();

let response = agent.chat(prompt, &mut history).await?;
```

After the call, `history` contains the previous conversation plus the prompt and all messages produced during the turn.

Callers should not pre-push the user prompt before calling `chat`; `chat` now owns appending the prompt and response messages.

## Changes

- Updated `Chat::chat` to take `chat_history: &mut Vec<Message>`.
- Updated `Agent::chat` to call `.extended_details()` and append `PromptResponse::messages` to caller history.
- Updated first-party call sites, examples, CLI chatbot, Discord bot, and provider tests for the new contract.
- Added core regressions for simple prompt/assistant history appending and full tool-roundtrip history appending.
- Added ignored live provider regressions for Gemini and OpenAI.
- Added an extended Gemini live stress test with 5 sequential chat turns, tool calls, shared history, and exact final-result validation.
