### PR TITLE
fix(openrouter): skip serializing empty content in Assistant messages

### DIFF
--- a/crates/rig-core/src/providers/openrouter/completion.rs
+++ b/crates/rig-core/src/providers/openrouter/completion.rs
@@ -1259,7 +1259,11 @@ pub enum Message {
         name: Option<String>,
     },
     Assistant {
-        #[serde(default, deserialize_with = "json_utils::string_or_vec")]
+        #[serde(
+            default,
+            deserialize_with = "json_utils::string_or_vec",
+            skip_serializing_if = "Vec::is_empty"
+        )]
         content: Vec<openai::AssistantContent>,
         #[serde(skip_serializing_if = "Option::is_none")]
         refusal: Option<String>,


### PR DESCRIPTION
## Problem

When routing through OpenRouter to OpenAI models (e.g. `openai/gpt-4o-mini`), multi-turn tool calling fails on the second LLM request with a 400 error:

> messages with role 'tool' must be a response to a preceding message with 'tool_calls'

The root cause: when an assistant message contains only `tool_calls` and no text, the `content` field is serialized as an empty array (`"content": []`). The OpenAI Chat Completions API rejects this — it expects the field to be absent (or `null`) when there is no content. Because it cannot parse the assistant message, the subsequent tool result appears to have no preceding `tool_calls` message, triggering the 400.

## Fix

Add `skip_serializing_if = "Vec::is_empty"` to the `content` field on `openrouter::Message::Assistant`. This matches the existing behaviour in the `openai` provider (`providers/openai/completion/mod.rs`, same field), which already had this attribute.

## Verification

Validated against a live OpenRouter → GPT-4o-mini call performing a two-turn tool call (user asks "What is 17 + 25?", model calls `add(17, 25)`, second turn returns the result). Before the fix the call fails; after the fix it completes successfully.