### PR TITLE
Add demotion hooks for bounded conversation memory

### DIFF
--- a/crates/rig-core/CHANGELOG.md
+++ b/crates/rig-core/CHANGELOG.md
@@ -36,6 +36,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `DemotingPolicyMemory<M, P, H>` adapter lives in `rig-memory`. Includes a
   forwarding `impl<H: DemotionHook + ?Sized> DemotionHook for Arc<H>` so
   hooks can be shared across multiple adapters.
+- `MemoryError::Internal(String)` variant for in-process invariant
+  violations (e.g. poisoned mutex guards), distinct from
+  `MemoryError::Backend` which is reserved for failures of the underlying
+  conversation store. `MemoryError` is now `#[non_exhaustive]` so future
+  variants are not breaking changes.
 
 ## [0.36.0](https://github.com/0xPlaygrounds/rig/compare/rig-core-v0.35.0...rig-core-v0.36.0) - 2026-04-28
 

--- a/crates/rig-core/CHANGELOG.md
+++ b/crates/rig-core/CHANGELOG.md
@@ -42,6 +42,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   conversation store. `MemoryError` is now `#[non_exhaustive]` so future
   variants are not breaking changes.
 
+  **Note for downstream crates:** `MemoryError` was previously a plain
+  enum, so any existing `match` against it without a wildcard arm will
+  now warn (and may need a wildcard arm if it was upgraded to a hard
+  error elsewhere). Adding `_ => ...` is forward-compatible with future
+  variants.
+
 ## [0.36.0](https://github.com/0xPlaygrounds/rig/compare/rig-core-v0.35.0...rig-core-v0.36.0) - 2026-04-28
 
 ### Added

--- a/crates/rig-core/CHANGELOG.md
+++ b/crates/rig-core/CHANGELOG.md
@@ -29,6 +29,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Examples: `agent_with_memory.rs` and `agent_with_memory_streaming.rs`.
   - Named history-shaping policies (sliding window, token budget) live in the
     new companion crate `rig-memory`.
+- `rig::memory::DemotionHook` trait and `NoopDemotionHook` no-op default.
+  Side-channel for messages that a memory policy or adapter removes from
+  active history. Defined in `rig-core` so any memory backend can implement
+  it without a `rig-memory` dependency; the composing
+  `DemotingPolicyMemory<M, P, H>` adapter lives in `rig-memory`. Includes a
+  forwarding `impl<H: DemotionHook + ?Sized> DemotionHook for Arc<H>` so
+  hooks can be shared across multiple adapters.
 
 ## [0.36.0](https://github.com/0xPlaygrounds/rig/compare/rig-core-v0.35.0...rig-core-v0.36.0) - 2026-04-28
 

--- a/crates/rig-core/src/memory.rs
+++ b/crates/rig-core/src/memory.rs
@@ -142,6 +142,19 @@ impl<F> MessageFilter for F where
 /// Hooks must be cheap and non-blocking: they run inline on every load.
 /// Push expensive work onto a background task or a buffered channel inside
 /// the implementation if needed.
+///
+/// # Idempotency contract
+///
+/// Implementations **must** be idempotent on the
+/// `(conversation_id, messages)` pair. Composing adapters such as the
+/// `DemotingPolicyMemory` in `rig-memory` track in-process delivery
+/// watermarks to avoid replaying the same demotion within a single
+/// process lifetime, but those watermarks are not persisted: across
+/// process restarts (or when a new adapter is constructed over an
+/// existing backend) the hook will receive previously-delivered
+/// messages again. Hooks that append to durable storage should
+/// deduplicate by content hash, by `(conversation_id, message_id)`,
+/// or by an equivalent stable key.
 pub trait DemotionHook: WasmCompatSend + WasmCompatSync {
     /// Receive `messages` that were demoted out of the active window for
     /// `conversation_id`.

--- a/crates/rig-core/src/memory.rs
+++ b/crates/rig-core/src/memory.rs
@@ -55,6 +55,7 @@ pub type MemoryBackendError = Box<dyn std::error::Error + 'static>;
 
 /// Errors produced by a [`ConversationMemory`] backend.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum MemoryError {
     /// The backing store failed to load, append, or clear messages.
     #[error("Memory backend error: {0}")]
@@ -63,6 +64,12 @@ pub enum MemoryError {
     /// A history-shaping filter or policy rejected the loaded history.
     #[error("Memory policy error: {0}")]
     Policy(String),
+
+    /// An internal invariant was violated (e.g. a poisoned in-process lock).
+    /// Distinct from [`MemoryError::Backend`], which is reserved for failures
+    /// of the underlying conversation store.
+    #[error("Memory internal error: {0}")]
+    Internal(String),
 }
 
 impl MemoryError {
@@ -139,9 +146,10 @@ impl<F> MessageFilter for F where
 /// wires a [`ConversationMemory`] backend, a policy, and a hook together
 /// lives in the `rig-memory` companion crate.
 ///
-/// Hooks must be cheap and non-blocking: they run inline on every load.
-/// Push expensive work onto a background task or a buffered channel inside
-/// the implementation if needed.
+/// Hooks should be inexpensive: their future is awaited inline on every
+/// `load` that produces demoted messages, so a slow hook delays the agent's
+/// next turn. Offload heavy I/O (network writes, disk fsyncs, …) to a
+/// background task or a buffered channel inside the implementation.
 ///
 /// # Idempotency contract
 ///
@@ -236,7 +244,7 @@ impl InMemoryConversationMemory {
     ) -> Result<std::sync::MutexGuard<'_, HashMap<String, Vec<Message>>>, MemoryError> {
         self.inner
             .lock()
-            .map_err(|e| MemoryError::backend(std::io::Error::other(e.to_string())))
+            .map_err(|e| MemoryError::Internal(e.to_string()))
     }
 }
 

--- a/crates/rig-core/src/memory.rs
+++ b/crates/rig-core/src/memory.rs
@@ -124,6 +124,68 @@ impl<F> MessageFilter for F where
 {
 }
 
+/// A side-channel for messages that a memory policy or adapter removes from
+/// active history during [`ConversationMemory::load`].
+///
+/// Truncating policies (sliding window, token budget, …) drop older turns
+/// once their limit is exceeded. Without a hook those messages are silently
+/// lost. A [`DemotionHook`] receives the demoted messages and can persist
+/// them into a long-tail store (semantic memory, episodic recall, archival
+/// storage, …), turning truncation into demotion.
+///
+/// The trait is defined here in `rig-core` so that *any* memory backend
+/// (in-memory, vector store, file archive, …) can implement it without
+/// taking on a `rig-memory` dependency. The composing adapter that actually
+/// wires a [`ConversationMemory`] backend, a policy, and a hook together
+/// lives in the `rig-memory` companion crate.
+///
+/// Hooks must be cheap and non-blocking: they run inline on every load.
+/// Push expensive work onto a background task or a buffered channel inside
+/// the implementation if needed.
+pub trait DemotionHook: WasmCompatSend + WasmCompatSync {
+    /// Receive `messages` that were demoted out of the active window for
+    /// `conversation_id`.
+    ///
+    /// `messages` are in original conversation order. Errors are propagated
+    /// as [`MemoryError::Backend`] by the composing adapter.
+    fn on_demote<'a>(
+        &'a self,
+        conversation_id: &'a str,
+        messages: Vec<Message>,
+    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>>;
+}
+
+/// A [`DemotionHook`] that does nothing. Useful as a default when an adapter
+/// requires a hook value but the caller has no long-tail store wired up yet.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoopDemotionHook;
+
+impl DemotionHook for NoopDemotionHook {
+    fn on_demote<'a>(
+        &'a self,
+        _conversation_id: &'a str,
+        _messages: Vec<Message>,
+    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+        Box::pin(async move { Ok(()) })
+    }
+}
+
+/// Forwarding impl so callers can pass `Arc<H>` wherever a `DemotionHook`
+/// is expected (e.g. when sharing a single hook between multiple memory
+/// adapters).
+impl<H> DemotionHook for Arc<H>
+where
+    H: DemotionHook + ?Sized,
+{
+    fn on_demote<'a>(
+        &'a self,
+        conversation_id: &'a str,
+        messages: Vec<Message>,
+    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+        (**self).on_demote(conversation_id, messages)
+    }
+}
+
 /// A simple thread-safe in-memory [`ConversationMemory`] backed by a `HashMap`.
 ///
 /// Messages are stored in process memory only and lost on restart. Useful for

--- a/crates/rig-memory/CHANGELOG.md
+++ b/crates/rig-memory/CHANGELOG.md
@@ -39,10 +39,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `DemotingPolicyMemory` hands to the hook.
 - `HeuristicTokenCounter` — provider-agnostic, zero-dependency
   `TokenCounter` implementation that approximates token cost from
-  character lengths. Ships `default` / `openai` / `anthropic` / `gemini`
-  presets so `TokenWindowMemory::new(budget, HeuristicTokenCounter::default())`
+  UTF-8 byte lengths (`str::len`, O(1)). Ships `default` / `openai` /
+  `anthropic` / `gemini` presets so
+  `TokenWindowMemory::new(budget, HeuristicTokenCounter::default())`
   works out of the box without a tokenizer dependency. Also handles the
-  `Message::System` variant and tool-call argument payloads.
+  `Message::System` variant and tool-call argument payloads. The
+  configurable ratio is named `bytes_per_token` to match the
+  implementation; for ASCII text bytes and characters coincide, and
+  for non-ASCII text the counter slightly over-estimates, which is the
+  safe direction for a hard budget.
 - `PolicyMemory<M, P>` adapter — wrap any `ConversationMemory` with a
   `MemoryPolicy` and propagate policy failures to the caller as
   `MemoryError::Policy`. Hard-fail counterpart to

--- a/crates/rig-memory/CHANGELOG.md
+++ b/crates/rig-memory/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `HeuristicTokenCounter` — provider-agnostic, zero-dependency
+  `TokenCounter` implementation that approximates token cost from
+  character lengths. Ships `default` / `openai` / `anthropic` / `gemini`
+  presets so `TokenWindowMemory::new(budget, HeuristicTokenCounter::default())`
+  works out of the box without a tokenizer dependency. Also handles the
+  `Message::System` variant and tool-call argument payloads.
 - `PolicyMemory<M, P>` adapter — wrap any `ConversationMemory` with a
   `MemoryPolicy` and propagate policy failures to the caller as
   `MemoryError::Policy`. Hard-fail counterpart to

--- a/crates/rig-memory/CHANGELOG.md
+++ b/crates/rig-memory/CHANGELOG.md
@@ -15,14 +15,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   implement it without taking a `rig-memory` dependency; the composing
   adapter lives in this crate. `DemotingPolicyMemory` calls the hook
   with messages that the policy truncated out of active history,
-  turning eviction into demotion. Bridges `SlidingWindowMemory` /
+  turning eviction into demotion. It tracks per-conversation demotion
+  watermarks so repeated `load` calls do not replay the same demoted
+  messages into append-only long-tail stores. Concurrent loads on the
+  same `conversation_id` are serialised at the demotion seam via an
+  in-flight gate: only one load at a time delivers to the hook;
+  others observe the gate and return the truncated history without
+  re-firing. Watermarks are in-process only — `DemotionHook`
+  implementations must be idempotent on `(conversation_id, messages)`
+  to survive process restarts. Bridges `SlidingWindowMemory` /
   `TokenWindowMemory` to long-tail stores such as `MemvidPersistHook`
   without coupling either crate to the other.
-- `MemoryPolicy::apply_with_demoted` default method that returns
-  `(kept, demoted)`. `SlidingWindowMemory` and `TokenWindowMemory`
-  override it to return the actual demoted prefix; the default
-  implementation reports an empty demoted set so existing policies
-  continue to work unchanged.
+- `DemotingPolicyMemory::forget(conversation_id)` and
+  `tracked_conversations()` for explicit watermark-map cleanup and
+  leak diagnostics.
+- `MemoryPolicy::apply_with_demoted` is now the canonical method:
+  policies override it to report `(kept, demoted)` and the default
+  `apply` discards the demoted half. `NoopMemoryPolicy`,
+  `SlidingWindowMemory`, and `TokenWindowMemory` are migrated.
 - `HeuristicTokenCounter` — provider-agnostic, zero-dependency
   `TokenCounter` implementation that approximates token cost from
   character lengths. Ships `default` / `openai` / `anthropic` / `gemini`

--- a/crates/rig-memory/CHANGELOG.md
+++ b/crates/rig-memory/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `DemotionHook` trait + `DemotingPolicyMemory<M, P, H>` adapter and a
+  `NoopDemotionHook` no-op default. The trait itself lives in
+  `rig_core::memory` (re-exported here) so any memory backend can
+  implement it without taking a `rig-memory` dependency; the composing
+  adapter lives in this crate. `DemotingPolicyMemory` calls the hook
+  with messages that the policy truncated out of active history,
+  turning eviction into demotion. Bridges `SlidingWindowMemory` /
+  `TokenWindowMemory` to long-tail stores such as `MemvidPersistHook`
+  without coupling either crate to the other.
+- `MemoryPolicy::apply_with_demoted` default method that returns
+  `(kept, demoted)`. `SlidingWindowMemory` and `TokenWindowMemory`
+  override it to return the actual demoted prefix; the default
+  implementation reports an empty demoted set so existing policies
+  continue to work unchanged.
 - `HeuristicTokenCounter` — provider-agnostic, zero-dependency
   `TokenCounter` implementation that approximates token cost from
   character lengths. Ships `default` / `openai` / `anthropic` / `gemini`

--- a/crates/rig-memory/CHANGELOG.md
+++ b/crates/rig-memory/CHANGELOG.md
@@ -28,11 +28,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   without coupling either crate to the other.
 - `DemotingPolicyMemory::forget(conversation_id)` and
   `tracked_conversations()` for explicit watermark-map cleanup and
-  leak diagnostics.
-- `MemoryPolicy::apply_with_demoted` is now the canonical method:
-  policies override it to report `(kept, demoted)` and the default
-  `apply` discards the demoted half. `NoopMemoryPolicy`,
-  `SlidingWindowMemory`, and `TokenWindowMemory` are migrated.
+  leak diagnostics. Both are infallible: a poisoned internal lock
+  is treated as "nothing to forget / zero tracked" rather than a
+  caller-visible error.
+- `MemoryPolicy::apply_with_demoted` companion method that reports
+  `(kept, demoted)`. `apply` remains the required method; the default
+  `apply_with_demoted` returns `(apply(...)?, Vec::new())` so existing
+  policies keep compiling unchanged. `SlidingWindowMemory` and
+  `TokenWindowMemory` override it to populate the demoted prefix that
+  `DemotingPolicyMemory` hands to the hook.
 - `HeuristicTokenCounter` — provider-agnostic, zero-dependency
   `TokenCounter` implementation that approximates token cost from
   character lengths. Ships `default` / `openai` / `anthropic` / `gemini`

--- a/crates/rig-memory/src/lib.rs
+++ b/crates/rig-memory/src/lib.rs
@@ -35,7 +35,10 @@
 //!     .with_filter(SlidingWindowMemory::last_messages(20).into_filter());
 //! ```
 
-use std::sync::Arc;
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex as StdMutex},
+};
 
 /// Re-exports of the core memory abstractions so callers only need a single
 /// dependency on `rig-memory` for both the trait/backend and the policies.
@@ -53,27 +56,31 @@ use rig_core::wasm_compat::{WasmBoxedFuture, WasmCompatSend, WasmCompatSync};
 /// pure, fallible message transformers: implementors that cannot fail should
 /// always return `Ok`.
 pub trait MemoryPolicy: WasmCompatSend + WasmCompatSync {
-    /// Transform `messages` into the history that should be returned to the agent.
-    fn apply(&self, messages: Vec<Message>) -> Result<Vec<Message>, MemoryError>;
-
     /// Transform `messages` and report which messages were demoted (excluded
     /// from the returned history).
     ///
-    /// Returns `(kept, demoted)`. The default implementation calls
-    /// [`MemoryPolicy::apply`] and reports an empty `demoted` list, which is
-    /// safe but uninformative for any consumer that wants to feed evicted
-    /// turns into a long-tail store such as `MemvidPersistHook`. Truncating
-    /// policies (sliding window, token window, …) override this method to
-    /// return the actual demoted prefix.
+    /// Returns `(kept, demoted)`. Truncating policies (sliding window, token
+    /// window, …) populate `demoted` with the evicted prefix; non-truncating
+    /// policies (e.g. [`NoopMemoryPolicy`]) return an empty `demoted` list.
     ///
-    /// Implementors must guarantee that `kept ⊆ messages` in their iteration
-    /// order, otherwise [`DemotingPolicyMemory`] may return inconsistent
-    /// history. Order-preserving truncation policies satisfy this trivially.
+    /// Implementors must guarantee that `kept ⊆ messages` in their
+    /// iteration order, otherwise [`DemotingPolicyMemory`] may return
+    /// inconsistent history. Order-preserving truncation policies satisfy
+    /// this trivially.
+    ///
+    /// This is the canonical method — [`MemoryPolicy::apply`] is a thin
+    /// wrapper that discards the demoted half. Implementors only override
+    /// this method.
     fn apply_with_demoted(
         &self,
         messages: Vec<Message>,
-    ) -> Result<(Vec<Message>, Vec<Message>), MemoryError> {
-        Ok((self.apply(messages)?, Vec::new()))
+    ) -> Result<(Vec<Message>, Vec<Message>), MemoryError>;
+
+    /// Transform `messages` into the history that should be returned to the
+    /// agent. Equivalent to discarding the demoted half of
+    /// [`MemoryPolicy::apply_with_demoted`].
+    fn apply(&self, messages: Vec<Message>) -> Result<Vec<Message>, MemoryError> {
+        Ok(self.apply_with_demoted(messages)?.0)
     }
 }
 
@@ -134,8 +141,11 @@ impl<P> IntoFilter for P where P: MemoryPolicy + 'static {}
 pub struct NoopMemoryPolicy;
 
 impl MemoryPolicy for NoopMemoryPolicy {
-    fn apply(&self, messages: Vec<Message>) -> Result<Vec<Message>, MemoryError> {
-        Ok(messages)
+    fn apply_with_demoted(
+        &self,
+        messages: Vec<Message>,
+    ) -> Result<(Vec<Message>, Vec<Message>), MemoryError> {
+        Ok((messages, Vec::new()))
     }
 }
 
@@ -158,10 +168,6 @@ impl SlidingWindowMemory {
 }
 
 impl MemoryPolicy for SlidingWindowMemory {
-    fn apply(&self, messages: Vec<Message>) -> Result<Vec<Message>, MemoryError> {
-        Ok(self.apply_with_demoted(messages)?.0)
-    }
-
     fn apply_with_demoted(
         &self,
         messages: Vec<Message>,
@@ -392,10 +398,6 @@ impl std::fmt::Debug for TokenWindowMemory {
 }
 
 impl MemoryPolicy for TokenWindowMemory {
-    fn apply(&self, messages: Vec<Message>) -> Result<Vec<Message>, MemoryError> {
-        Ok(self.apply_with_demoted(messages)?.0)
-    }
-
     fn apply_with_demoted(
         &self,
         messages: Vec<Message>,
@@ -514,6 +516,22 @@ where
 /// [`MemoryPolicy::apply_with_demoted`]; policies that rely on the default
 /// implementation will still load correctly but will never demote anything.
 ///
+/// # Concurrency
+///
+/// Concurrent [`ConversationMemory::load`] calls on the same
+/// `conversation_id` are serialised at the demotion seam: only one call at
+/// a time delivers messages to the hook for a given conversation. Other
+/// concurrent loads for that conversation observe the in-flight delivery
+/// and return the truncated `kept` history immediately without firing the
+/// hook again. Pending demotions that were skipped this way are picked up
+/// by the next `load` after the in-flight delivery completes.
+///
+/// # Persistence
+///
+/// Delivery watermarks are kept in process memory only. Across process
+/// restarts, the hook will receive previously-delivered demotions again;
+/// see the [`DemotionHook`] idempotency contract.
+///
 /// # Example
 ///
 /// ```no_run
@@ -533,6 +551,18 @@ pub struct DemotingPolicyMemory<M, P, H> {
     inner: M,
     policy: P,
     hook: H,
+    state: StdMutex<HashMap<String, ConversationDemotionState>>,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct ConversationDemotionState {
+    /// Number of demoted messages already delivered to the hook within
+    /// this process lifetime. Advanced only on hook success.
+    delivered: usize,
+    /// True while a `load` is currently awaiting `hook.on_demote(...)`
+    /// for this conversation. Other concurrent loads observe this and
+    /// short-circuit without re-delivering the same messages.
+    in_flight: bool,
 }
 
 impl<M, P, H> DemotingPolicyMemory<M, P, H> {
@@ -543,6 +573,7 @@ impl<M, P, H> DemotingPolicyMemory<M, P, H> {
             inner,
             policy,
             hook,
+            state: StdMutex::new(HashMap::new()),
         }
     }
 
@@ -564,6 +595,24 @@ impl<M, P, H> DemotingPolicyMemory<M, P, H> {
     /// Consume the wrapper and return its three components.
     pub fn into_inner(self) -> (M, P, H) {
         (self.inner, self.policy, self.hook)
+    }
+
+    /// Drop the in-process delivery watermark for `conversation_id`.
+    ///
+    /// Call this when a conversation has ended to bound memory usage.
+    /// The watermark map is otherwise unbounded — entries persist for
+    /// the lifetime of the wrapper.
+    pub fn forget(&self, conversation_id: &str) -> Result<(), MemoryError> {
+        let mut guard = self.state.lock().map_err(poisoned)?;
+        guard.remove(conversation_id);
+        Ok(())
+    }
+
+    /// Number of conversations currently tracked in the watermark map.
+    /// Useful for telemetry and leak detection.
+    pub fn tracked_conversations(&self) -> Result<usize, MemoryError> {
+        let guard = self.state.lock().map_err(poisoned)?;
+        Ok(guard.len())
     }
 }
 
@@ -593,10 +642,48 @@ where
     ) -> WasmBoxedFuture<'a, Result<Vec<Message>, MemoryError>> {
         Box::pin(async move {
             let messages = self.inner.load(conversation_id).await?;
-            let (kept, demoted) = self.policy.apply_with_demoted(messages)?;
-            if !demoted.is_empty() {
-                self.hook.on_demote(conversation_id, demoted).await?;
+            let (kept, mut demoted) = self.policy.apply_with_demoted(messages)?;
+            let demoted_count = demoted.len();
+
+            // Reserve a delivery slot atomically. Decide-and-mark must
+            // happen under one short-lived lock so concurrent loads on
+            // the same conversation_id can't both observe the same
+            // delivered watermark and double-fire the hook.
+            let pending = {
+                let mut guard = self.state.lock().map_err(poisoned)?;
+                let entry = guard.entry(conversation_id.to_string()).or_default();
+                if entry.in_flight {
+                    // Another load is mid-delivery for this conversation;
+                    // skip and let the next load see whatever it leaves
+                    // behind.
+                    return Ok(kept);
+                }
+                if entry.delivered >= demoted_count {
+                    Vec::new()
+                } else {
+                    let split = entry.delivered;
+                    entry.in_flight = true;
+                    demoted.split_off(split)
+                }
+            };
+
+            if pending.is_empty() {
+                return Ok(kept);
             }
+
+            let result = self.hook.on_demote(conversation_id, pending).await;
+
+            // Reacquire briefly to advance the watermark on success and
+            // always clear the in-flight flag so a future load can retry.
+            {
+                let mut guard = self.state.lock().map_err(poisoned)?;
+                let entry = guard.entry(conversation_id.to_string()).or_default();
+                entry.in_flight = false;
+                if result.is_ok() {
+                    entry.delivered = demoted_count;
+                }
+            }
+            result?;
             Ok(kept)
         })
     }
@@ -613,8 +700,16 @@ where
         &'a self,
         conversation_id: &'a str,
     ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
-        self.inner.clear(conversation_id)
+        Box::pin(async move {
+            self.inner.clear(conversation_id).await?;
+            self.forget(conversation_id)?;
+            Ok(())
+        })
     }
+}
+
+fn poisoned<E: std::fmt::Display>(err: E) -> MemoryError {
+    MemoryError::backend(std::io::Error::other(err.to_string()))
 }
 
 #[cfg(test)]
@@ -796,7 +891,10 @@ mod tests {
     fn into_filter_returns_input_on_policy_error() {
         struct FailingPolicy;
         impl MemoryPolicy for FailingPolicy {
-            fn apply(&self, _: Vec<Message>) -> Result<Vec<Message>, MemoryError> {
+            fn apply_with_demoted(
+                &self,
+                _: Vec<Message>,
+            ) -> Result<(Vec<Message>, Vec<Message>), MemoryError> {
                 Err(MemoryError::Policy("intentional failure".into()))
             }
         }
@@ -833,7 +931,10 @@ mod tests {
     async fn policy_memory_propagates_policy_errors() {
         struct FailingPolicy;
         impl MemoryPolicy for FailingPolicy {
-            fn apply(&self, _: Vec<Message>) -> Result<Vec<Message>, MemoryError> {
+            fn apply_with_demoted(
+                &self,
+                _: Vec<Message>,
+            ) -> Result<(Vec<Message>, Vec<Message>), MemoryError> {
                 Err(MemoryError::Policy("intentional failure".into()))
             }
         }
@@ -971,6 +1072,110 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn demoting_policy_memory_does_not_replay_demotions() {
+        let hook = Arc::new(CountingHook::default());
+        let mem = DemotingPolicyMemory::new(
+            InMemoryConversationMemory::new(),
+            SlidingWindowMemory::last_messages(2),
+            hook.clone(),
+        );
+
+        mem.append(
+            "c",
+            vec![user("1"), assistant("2"), user("3"), assistant("4")],
+        )
+        .await
+        .unwrap();
+
+        mem.load("c").await.unwrap();
+        mem.load("c").await.unwrap();
+        assert_eq!(hook.calls(), 1);
+        assert_eq!(hook.last_demoted_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn demoting_policy_memory_only_reports_newly_demoted_messages() {
+        let hook = Arc::new(CountingHook::default());
+        let mem = DemotingPolicyMemory::new(
+            InMemoryConversationMemory::new(),
+            SlidingWindowMemory::last_messages(2),
+            hook.clone(),
+        );
+
+        mem.append(
+            "c",
+            vec![user("1"), assistant("2"), user("3"), assistant("4")],
+        )
+        .await
+        .unwrap();
+        mem.load("c").await.unwrap();
+
+        mem.append("c", vec![user("5")]).await.unwrap();
+        mem.load("c").await.unwrap();
+
+        assert_eq!(hook.calls(), 2);
+        assert_eq!(hook.last_demoted_count(), 1);
+    }
+
+    #[derive(Default)]
+    struct FailingHook {
+        calls: Mutex<usize>,
+    }
+
+    impl DemotionHook for FailingHook {
+        fn on_demote<'a>(
+            &'a self,
+            _conversation_id: &'a str,
+            _messages: Vec<Message>,
+        ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+            Box::pin(async move {
+                *self.calls.lock().unwrap() += 1;
+                Err(MemoryError::backend(std::io::Error::other("hook failed")))
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn demoting_policy_memory_does_not_advance_watermark_on_hook_failure() {
+        let hook = Arc::new(FailingHook::default());
+        let mem = DemotingPolicyMemory::new(
+            InMemoryConversationMemory::new(),
+            SlidingWindowMemory::last_messages(1),
+            hook.clone(),
+        );
+        mem.append("c", vec![user("1"), assistant("2")])
+            .await
+            .unwrap();
+
+        assert!(mem.load("c").await.is_err());
+        assert!(mem.load("c").await.is_err());
+        assert_eq!(*hook.calls.lock().unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn demoting_policy_memory_clear_resets_watermark() {
+        let hook = Arc::new(CountingHook::default());
+        let mem = DemotingPolicyMemory::new(
+            InMemoryConversationMemory::new(),
+            SlidingWindowMemory::last_messages(1),
+            hook.clone(),
+        );
+
+        mem.append("c", vec![user("1"), assistant("2")])
+            .await
+            .unwrap();
+        mem.load("c").await.unwrap();
+        mem.clear("c").await.unwrap();
+        mem.append("c", vec![user("3"), assistant("4")])
+            .await
+            .unwrap();
+        mem.load("c").await.unwrap();
+
+        assert_eq!(hook.calls(), 2);
+        assert_eq!(hook.last_demoted_count(), 1);
+    }
+
+    #[tokio::test]
     async fn demoting_policy_memory_skips_hook_when_nothing_evicted() {
         let hook = Arc::new(CountingHook::default());
         let mem = DemotingPolicyMemory::new(
@@ -997,5 +1202,104 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(mem.load("c").await.unwrap().len(), 1);
+    }
+
+    /// Hook that blocks until the test releases it. Used to provoke the
+    /// concurrent-load race against the in-flight gate.
+    struct GatedHook {
+        calls: Arc<std::sync::atomic::AtomicUsize>,
+        rendezvous: Arc<tokio::sync::Notify>,
+        release: Arc<tokio::sync::Notify>,
+    }
+
+    impl DemotionHook for GatedHook {
+        fn on_demote<'a>(
+            &'a self,
+            _conversation_id: &'a str,
+            _messages: Vec<Message>,
+        ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+            let calls = self.calls.clone();
+            let rendezvous = self.rendezvous.clone();
+            let release = self.release.clone();
+            Box::pin(async move {
+                calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                rendezvous.notify_one();
+                release.notified().await;
+                Ok(())
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn demoting_policy_memory_serialises_concurrent_loads() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let rendezvous = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let hook = GatedHook {
+            calls: calls.clone(),
+            rendezvous: rendezvous.clone(),
+            release: release.clone(),
+        };
+
+        let mem = Arc::new(DemotingPolicyMemory::new(
+            InMemoryConversationMemory::new(),
+            SlidingWindowMemory::last_messages(1),
+            hook,
+        ));
+
+        mem.append("c", vec![user("1"), assistant("2"), user("3")])
+            .await
+            .unwrap();
+
+        let m1 = mem.clone();
+        let first = tokio::spawn(async move { m1.load("c").await });
+
+        // Wait until the first load has entered the hook.
+        rendezvous.notified().await;
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        // Second concurrent load on the same conversation must skip the
+        // hook entirely (in-flight gate) and return the truncated view.
+        let kept = mem.load("c").await.unwrap();
+        assert_eq!(kept.len(), 1);
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "hook must not double-fire");
+
+        // Release the first load and confirm it completes successfully.
+        release.notify_one();
+        let kept_first = first.await.unwrap().unwrap();
+        assert_eq!(kept_first.len(), 1);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        // Subsequent loads observe the watermark and don't re-fire.
+        mem.load("c").await.unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn forget_drops_in_process_watermark() {
+        let hook = Arc::new(CountingHook::default());
+        let mem = DemotingPolicyMemory::new(
+            InMemoryConversationMemory::new(),
+            SlidingWindowMemory::last_messages(1),
+            hook.clone(),
+        );
+
+        mem.append("c", vec![user("1"), assistant("2")])
+            .await
+            .unwrap();
+        mem.load("c").await.unwrap();
+        assert_eq!(mem.tracked_conversations().unwrap(), 1);
+        assert_eq!(hook.calls(), 1);
+
+        // After forgetting, the next load on the same (still-populated)
+        // backend re-delivers the demotion. This is the documented
+        // contract: forget()/restart re-fire the hook, hooks must be
+        // idempotent.
+        mem.forget("c").unwrap();
+        assert_eq!(mem.tracked_conversations().unwrap(), 0);
+        mem.load("c").await.unwrap();
+        assert_eq!(hook.calls(), 2);
     }
 }

--- a/crates/rig-memory/src/lib.rs
+++ b/crates/rig-memory/src/lib.rs
@@ -17,6 +17,8 @@
 //! - [`NoopMemoryPolicy`] — identity, returns input unchanged.
 //! - [`SlidingWindowMemory`] — retains the most recent `N` messages.
 //! - [`TokenWindowMemory`] — retains messages that fit within a token budget.
+//! - [`HeuristicTokenCounter`] — provider-agnostic, zero-dependency
+//!   [`TokenCounter`] that approximates token cost from character lengths.
 //!
 //! All sliding policies drop a leading orphan tool-result message when the
 //! preceding assistant tool call has been truncated, since most providers
@@ -161,6 +163,155 @@ where
 {
     fn count(&self, message: &Message) -> usize {
         (self)(message)
+    }
+}
+
+/// A provider-agnostic [`TokenCounter`] that approximates token counts from
+/// character lengths.
+///
+/// This is intended as a zero-dependency default. It is **not** a substitute
+/// for a tokenizer and will under- or over-count by up to ~30 % on real
+/// content, but it is monotonic in message size and stable across runs, which
+/// is enough for [`TokenWindowMemory`] to enforce a budget that *trends*
+/// with provider billing.
+///
+/// # Strategy
+///
+/// For every text-bearing block (`Text`, reasoning text, tool-result text)
+/// the counter sums character lengths and divides by `chars_per_token`,
+/// rounded up. Tool calls are charged the JSON-serialised length of their
+/// `ToolFunction` payload. Each message is charged a flat
+/// `per_message_overhead` to model the per-turn role/separator tokens that
+/// providers add internally. Non-text blocks (images, audio, video,
+/// documents) are charged `per_attachment_tokens` each because their real
+/// cost is provider-specific and rarely text-derived.
+///
+/// # Presets
+///
+/// The defaults match OpenAI's published rule of thumb (~4 chars per token,
+/// ~4 tokens of per-message overhead). [`HeuristicTokenCounter::anthropic`]
+/// uses a slightly denser ratio that better fits Claude's tokenizer.
+///
+/// # Example
+///
+/// ```
+/// use rig_memory::{HeuristicTokenCounter, TokenWindowMemory};
+///
+/// let policy = TokenWindowMemory::new(2_000, HeuristicTokenCounter::default());
+/// # let _ = policy;
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct HeuristicTokenCounter {
+    chars_per_token: f32,
+    per_message_overhead: usize,
+    per_attachment_tokens: usize,
+}
+
+impl HeuristicTokenCounter {
+    /// Create a counter with explicit parameters.
+    ///
+    /// `chars_per_token` is clamped to a minimum of `1.0` so the counter
+    /// never panics or produces zero-cost messages on degenerate input.
+    pub fn new(
+        chars_per_token: f32,
+        per_message_overhead: usize,
+        per_attachment_tokens: usize,
+    ) -> Self {
+        let chars_per_token = if chars_per_token.is_finite() && chars_per_token >= 1.0 {
+            chars_per_token
+        } else {
+            1.0
+        };
+        Self {
+            chars_per_token,
+            per_message_overhead,
+            per_attachment_tokens,
+        }
+    }
+
+    /// Preset matching OpenAI's chat-completion token rule of thumb.
+    ///
+    /// Equivalent to [`HeuristicTokenCounter::default`].
+    pub fn openai() -> Self {
+        Self::new(4.0, 4, 256)
+    }
+
+    /// Preset tuned for Anthropic Claude's tokenizer.
+    pub fn anthropic() -> Self {
+        Self::new(3.5, 4, 256)
+    }
+
+    /// Preset tuned for Google Gemini.
+    pub fn gemini() -> Self {
+        Self::new(4.0, 4, 256)
+    }
+
+    fn chars_to_tokens(&self, chars: usize) -> usize {
+        // `chars_per_token` is clamped to >= 1.0 in the constructor, so the
+        // division is well-defined. We round up so a single non-empty
+        // character still costs at least one token.
+        let tokens = (chars as f32) / self.chars_per_token;
+        tokens.ceil() as usize
+    }
+
+    fn count_user(&self, content: &rig_core::message::UserContent) -> usize {
+        use rig_core::message::UserContent;
+        match content {
+            UserContent::Text(text) => self.chars_to_tokens(text.text.chars().count()),
+            UserContent::ToolResult(result) => result
+                .content
+                .iter()
+                .map(|c| match c {
+                    rig_core::message::ToolResultContent::Text(t) => {
+                        self.chars_to_tokens(t.text.chars().count())
+                    }
+                    rig_core::message::ToolResultContent::Image(_) => self.per_attachment_tokens,
+                })
+                .sum(),
+            UserContent::Image(_)
+            | UserContent::Audio(_)
+            | UserContent::Video(_)
+            | UserContent::Document(_) => self.per_attachment_tokens,
+        }
+    }
+
+    fn count_assistant(&self, content: &rig_core::message::AssistantContent) -> usize {
+        use rig_core::message::AssistantContent;
+        match content {
+            AssistantContent::Text(text) => self.chars_to_tokens(text.text.chars().count()),
+            AssistantContent::Reasoning(reasoning) => {
+                self.chars_to_tokens(reasoning.display_text().chars().count())
+            }
+            AssistantContent::ToolCall(call) => {
+                let name_chars = call.function.name.chars().count();
+                // `serde_json::Value::to_string` is the canonical compact JSON
+                // encoding and never fails, so we charge tool calls by the
+                // length of their serialised arguments without pulling in a
+                // direct `serde_json` dependency.
+                let args_chars = call.function.arguments.to_string().chars().count();
+                self.chars_to_tokens(name_chars + args_chars)
+            }
+            AssistantContent::Image(_) => self.per_attachment_tokens,
+        }
+    }
+}
+
+impl Default for HeuristicTokenCounter {
+    fn default() -> Self {
+        Self::openai()
+    }
+}
+
+impl TokenCounter for HeuristicTokenCounter {
+    fn count(&self, message: &Message) -> usize {
+        let content_tokens: usize = match message {
+            Message::User { content } => content.iter().map(|c| self.count_user(c)).sum(),
+            Message::Assistant { content, .. } => {
+                content.iter().map(|c| self.count_assistant(c)).sum()
+            }
+            Message::System { content } => self.chars_to_tokens(content.chars().count()),
+        };
+        content_tokens.saturating_add(self.per_message_overhead)
     }
 }
 
@@ -424,6 +575,58 @@ mod tests {
         let policy = TokenWindowMemory::new(5, |_: &Message| 10);
         let out = policy.apply(vec![user("anything")]).unwrap();
         assert!(out.is_empty());
+    }
+
+    #[test]
+    fn heuristic_counter_charges_overhead_per_message() {
+        let counter = HeuristicTokenCounter::default();
+        let empty = counter.count(&user(""));
+        assert!(
+            empty >= 4,
+            "default per-message overhead is at least 4 tokens"
+        );
+    }
+
+    #[test]
+    fn heuristic_counter_is_monotonic_in_text_length() {
+        let counter = HeuristicTokenCounter::default();
+        let small = counter.count(&user("hi"));
+        let big = counter.count(&user(&"x".repeat(400)));
+        assert!(big > small);
+    }
+
+    #[test]
+    fn heuristic_counter_handles_tool_calls() {
+        let counter = HeuristicTokenCounter::default();
+        let cost = counter.count(&tool_call_msg());
+        assert!(cost > 0);
+    }
+
+    #[test]
+    fn heuristic_counter_handles_system_messages() {
+        let counter = HeuristicTokenCounter::default();
+        let cost = counter.count(&Message::System {
+            content: "you are helpful".into(),
+        });
+        assert!(cost > 0);
+    }
+
+    #[test]
+    fn heuristic_counter_clamps_invalid_chars_per_token() {
+        // Zero/NaN/negative ratios fall back to 1.0 instead of panicking.
+        let counter = HeuristicTokenCounter::new(0.0, 0, 0);
+        assert!(counter.count(&user("abcd")) >= 4);
+        let nan = HeuristicTokenCounter::new(f32::NAN, 0, 0);
+        assert!(nan.count(&user("abcd")) >= 4);
+    }
+
+    #[test]
+    fn heuristic_counter_drives_token_window() {
+        let policy = TokenWindowMemory::new(100, HeuristicTokenCounter::default());
+        let msgs = vec![user(&"a".repeat(2_000)), user("short")];
+        let out = policy.apply(msgs).unwrap();
+        // The huge message must be evicted; the short one retained.
+        assert_eq!(out.len(), 1);
     }
 
     #[test]

--- a/crates/rig-memory/src/lib.rs
+++ b/crates/rig-memory/src/lib.rs
@@ -183,7 +183,7 @@ impl MemoryPolicy for SlidingWindowMemory {
         // it is preserved end-to-end through the demotion hook even though
         // the model never sees it again.
         if let Some(Message::User { content }) = window.first()
-            && matches!(content.first(), UserContent::ToolResult(_))
+            && matches!(content.first_ref(), UserContent::ToolResult(_))
         {
             demoted.push(window.remove(0));
         }
@@ -212,7 +212,7 @@ where
 }
 
 /// A provider-agnostic [`TokenCounter`] that approximates token counts from
-/// character lengths.
+/// UTF-8 byte lengths.
 ///
 /// This is intended as a zero-dependency default. It is **not** a substitute
 /// for a tokenizer and will under- or over-count by up to ~30 % on real
@@ -223,17 +223,24 @@ where
 /// # Strategy
 ///
 /// For every text-bearing block (`Text`, reasoning text, tool-result text)
-/// the counter sums character lengths and divides by `chars_per_token`,
-/// rounded up. Tool calls are charged the JSON-serialised length of their
-/// `ToolFunction` payload. Each message is charged a flat
-/// `per_message_overhead` to model the per-turn role/separator tokens that
-/// providers add internally. Non-text blocks (images, audio, video,
-/// documents) are charged `per_attachment_tokens` each because their real
-/// cost is provider-specific and rarely text-derived.
+/// the counter sums UTF-8 byte lengths (`str::len`, an O(1) call) and divides
+/// by `bytes_per_token`, rounded up. Bytes are used instead of Unicode
+/// scalars because the cost is O(1), modern BPE tokenizers operate on byte
+/// sequences, and per-message budgeting only needs the rough order of
+/// magnitude. For ASCII text bytes and characters coincide; for non-ASCII
+/// text the counter slightly over-estimates, which is the safe direction
+/// for a hard budget.
+///
+/// Tool calls are charged the JSON-serialised length of their `ToolFunction`
+/// payload. Each message is charged a flat `per_message_overhead` to model
+/// the per-turn role/separator tokens that providers add internally. Non-text
+/// blocks (images, audio, video, documents) are charged
+/// `per_attachment_tokens` each because their real cost is provider-specific
+/// and rarely text-derived.
 ///
 /// # Presets
 ///
-/// The defaults match OpenAI's published rule of thumb (~4 chars per token,
+/// The defaults match OpenAI's published rule of thumb (~4 bytes per token,
 /// ~4 tokens of per-message overhead). [`HeuristicTokenCounter::anthropic`]
 /// uses a slightly denser ratio that better fits Claude's tokenizer.
 ///
@@ -247,7 +254,7 @@ where
 /// ```
 #[derive(Debug, Clone, Copy)]
 pub struct HeuristicTokenCounter {
-    chars_per_token: f32,
+    bytes_per_token: f32,
     per_message_overhead: usize,
     per_attachment_tokens: usize,
 }
@@ -255,20 +262,20 @@ pub struct HeuristicTokenCounter {
 impl HeuristicTokenCounter {
     /// Create a counter with explicit parameters.
     ///
-    /// `chars_per_token` is clamped to a minimum of `1.0` so the counter
+    /// `bytes_per_token` is clamped to a minimum of `1.0` so the counter
     /// never panics or produces zero-cost messages on degenerate input.
     pub fn new(
-        chars_per_token: f32,
+        bytes_per_token: f32,
         per_message_overhead: usize,
         per_attachment_tokens: usize,
     ) -> Self {
-        let chars_per_token = if chars_per_token.is_finite() && chars_per_token >= 1.0 {
-            chars_per_token
+        let bytes_per_token = if bytes_per_token.is_finite() && bytes_per_token >= 1.0 {
+            bytes_per_token
         } else {
             1.0
         };
         Self {
-            chars_per_token,
+            bytes_per_token,
             per_message_overhead,
             per_attachment_tokens,
         }
@@ -291,24 +298,24 @@ impl HeuristicTokenCounter {
         Self::new(4.0, 4, 256)
     }
 
-    fn chars_to_tokens(&self, chars: usize) -> usize {
-        // `chars_per_token` is clamped to >= 1.0 in the constructor, so the
+    fn bytes_to_tokens(&self, bytes: usize) -> usize {
+        // `bytes_per_token` is clamped to >= 1.0 in the constructor, so the
         // division is well-defined. We round up so a single non-empty
-        // character still costs at least one token.
-        let tokens = (chars as f32) / self.chars_per_token;
+        // input still costs at least one token.
+        let tokens = (bytes as f32) / self.bytes_per_token;
         tokens.ceil() as usize
     }
 
     fn count_user(&self, content: &rig_core::message::UserContent) -> usize {
         use rig_core::message::UserContent;
         match content {
-            UserContent::Text(text) => self.chars_to_tokens(text.text.chars().count()),
+            UserContent::Text(text) => self.bytes_to_tokens(text.text.len()),
             UserContent::ToolResult(result) => result
                 .content
                 .iter()
                 .map(|c| match c {
                     rig_core::message::ToolResultContent::Text(t) => {
-                        self.chars_to_tokens(t.text.chars().count())
+                        self.bytes_to_tokens(t.text.len())
                     }
                     rig_core::message::ToolResultContent::Image(_) => self.per_attachment_tokens,
                 })
@@ -323,18 +330,18 @@ impl HeuristicTokenCounter {
     fn count_assistant(&self, content: &rig_core::message::AssistantContent) -> usize {
         use rig_core::message::AssistantContent;
         match content {
-            AssistantContent::Text(text) => self.chars_to_tokens(text.text.chars().count()),
+            AssistantContent::Text(text) => self.bytes_to_tokens(text.text.len()),
             AssistantContent::Reasoning(reasoning) => {
-                self.chars_to_tokens(reasoning.display_text().chars().count())
+                self.bytes_to_tokens(reasoning.display_text().len())
             }
             AssistantContent::ToolCall(call) => {
-                let name_chars = call.function.name.chars().count();
+                let name_bytes = call.function.name.len();
                 // `serde_json::Value::to_string` is the canonical compact JSON
                 // encoding and never fails, so we charge tool calls by the
                 // length of their serialised arguments without pulling in a
                 // direct `serde_json` dependency.
-                let args_chars = call.function.arguments.to_string().chars().count();
-                self.chars_to_tokens(name_chars + args_chars)
+                let args_bytes = call.function.arguments.to_string().len();
+                self.bytes_to_tokens(name_bytes + args_bytes)
             }
             AssistantContent::Image(_) => self.per_attachment_tokens,
         }
@@ -354,7 +361,7 @@ impl TokenCounter for HeuristicTokenCounter {
             Message::Assistant { content, .. } => {
                 content.iter().map(|c| self.count_assistant(c)).sum()
             }
-            Message::System { content } => self.chars_to_tokens(content.chars().count()),
+            Message::System { content } => self.bytes_to_tokens(content.len()),
         };
         content_tokens.saturating_add(self.per_message_overhead)
     }
@@ -421,7 +428,7 @@ impl MemoryPolicy for TokenWindowMemory {
         let mut window: Vec<Message> = iter.collect();
 
         if let Some(Message::User { content }) = window.first()
-            && matches!(content.first(), UserContent::ToolResult(_))
+            && matches!(content.first_ref(), UserContent::ToolResult(_))
         {
             demoted.push(window.remove(0));
         }
@@ -527,6 +534,15 @@ where
 /// and return the truncated `kept` history immediately without firing the
 /// hook again. Pending demotions that were skipped this way are picked up
 /// by the next `load` after the in-flight delivery completes.
+///
+/// **Failure visibility.** A hook error is returned only to the caller
+/// whose `load` actually drove the delivery. Concurrent callers that
+/// short-circuited on `in_flight` see `Ok(kept)` even if the in-flight
+/// delivery ultimately failed; the watermark stays unchanged so the next
+/// `load` retries. Callers that rely on the hook for durability should
+/// treat a successful `load` as best-effort with respect to demotion and
+/// surface hook failures through the hook's own observability (logs,
+/// metrics, dead-letter buffer) rather than the `load` return value.
 ///
 /// # Persistence
 ///
@@ -655,21 +671,40 @@ where
             // happen under one short-lived lock so concurrent loads on
             // the same conversation_id can't both observe the same
             // delivered watermark and double-fire the hook.
+            //
+            // Fast path: if the conversation is already tracked, mutate in
+            // place. Only allocate a new `String` key when we are about to
+            // record state for a conversation we have not seen before *and*
+            // there is actually demotion work to track.
             let pending = {
                 let mut guard = self.state.lock().map_err(poisoned)?;
-                let entry = guard.entry(conversation_id.to_string()).or_default();
-                if entry.in_flight {
-                    // Another load is mid-delivery for this conversation;
-                    // skip and let the next load see whatever it leaves
-                    // behind.
-                    return Ok(kept);
-                }
-                if entry.delivered >= demoted_count {
+                if let Some(entry) = guard.get_mut(conversation_id) {
+                    if entry.in_flight {
+                        // Another load is mid-delivery for this conversation;
+                        // skip and let the next load see whatever it leaves
+                        // behind.
+                        return Ok(kept);
+                    }
+                    if entry.delivered >= demoted_count {
+                        Vec::new()
+                    } else {
+                        let split = entry.delivered;
+                        entry.in_flight = true;
+                        demoted.split_off(split)
+                    }
+                } else if demoted_count == 0 {
+                    // First load for this conversation and nothing was
+                    // demoted: no need to allocate a tracking entry yet.
                     Vec::new()
                 } else {
-                    let split = entry.delivered;
-                    entry.in_flight = true;
-                    demoted.split_off(split)
+                    guard.insert(
+                        conversation_id.to_string(),
+                        ConversationDemotionState {
+                            delivered: 0,
+                            in_flight: true,
+                        },
+                    );
+                    std::mem::take(&mut demoted)
                 }
             };
 
@@ -884,7 +919,7 @@ mod tests {
     }
 
     #[test]
-    fn heuristic_counter_clamps_invalid_chars_per_token() {
+    fn heuristic_counter_clamps_invalid_bytes_per_token() {
         // Zero/NaN/negative ratios fall back to 1.0 instead of panicking.
         let counter = HeuristicTokenCounter::new(0.0, 0, 0);
         assert!(counter.count(&user("abcd")) >= 4);

--- a/crates/rig-memory/src/lib.rs
+++ b/crates/rig-memory/src/lib.rs
@@ -56,31 +56,28 @@ use rig_core::wasm_compat::{WasmBoxedFuture, WasmCompatSend, WasmCompatSync};
 /// pure, fallible message transformers: implementors that cannot fail should
 /// always return `Ok`.
 pub trait MemoryPolicy: WasmCompatSend + WasmCompatSync {
+    /// Transform `messages` into the history that should be returned to the
+    /// agent. This is the required method — every policy must implement it.
+    fn apply(&self, messages: Vec<Message>) -> Result<Vec<Message>, MemoryError>;
+
     /// Transform `messages` and report which messages were demoted (excluded
     /// from the returned history).
     ///
-    /// Returns `(kept, demoted)`. Truncating policies (sliding window, token
-    /// window, …) populate `demoted` with the evicted prefix; non-truncating
-    /// policies (e.g. [`NoopMemoryPolicy`]) return an empty `demoted` list.
+    /// Returns `(kept, demoted)`. The default implementation returns
+    /// `(self.apply(messages)?, Vec::new())`, which is correct for
+    /// non-truncating policies. Truncating policies (sliding window, token
+    /// window, …) override this method to populate `demoted` with the
+    /// messages they evicted.
     ///
-    /// Implementors must guarantee that `kept ⊆ messages` in their
-    /// iteration order, otherwise [`DemotingPolicyMemory`] may return
-    /// inconsistent history. Order-preserving truncation policies satisfy
-    /// this trivially.
-    ///
-    /// This is the canonical method — [`MemoryPolicy::apply`] is a thin
-    /// wrapper that discards the demoted half. Implementors only override
-    /// this method.
+    /// Implementors must guarantee that `demoted` is the prefix of the
+    /// original input not retained in `kept`, in original order. Composing
+    /// adapters such as [`DemotingPolicyMemory`] rely on this contract to
+    /// track delivery watermarks correctly.
     fn apply_with_demoted(
         &self,
         messages: Vec<Message>,
-    ) -> Result<(Vec<Message>, Vec<Message>), MemoryError>;
-
-    /// Transform `messages` into the history that should be returned to the
-    /// agent. Equivalent to discarding the demoted half of
-    /// [`MemoryPolicy::apply_with_demoted`].
-    fn apply(&self, messages: Vec<Message>) -> Result<Vec<Message>, MemoryError> {
-        Ok(self.apply_with_demoted(messages)?.0)
+    ) -> Result<(Vec<Message>, Vec<Message>), MemoryError> {
+        Ok((self.apply(messages)?, Vec::new()))
     }
 }
 
@@ -141,11 +138,8 @@ impl<P> IntoFilter for P where P: MemoryPolicy + 'static {}
 pub struct NoopMemoryPolicy;
 
 impl MemoryPolicy for NoopMemoryPolicy {
-    fn apply_with_demoted(
-        &self,
-        messages: Vec<Message>,
-    ) -> Result<(Vec<Message>, Vec<Message>), MemoryError> {
-        Ok((messages, Vec::new()))
+    fn apply(&self, messages: Vec<Message>) -> Result<Vec<Message>, MemoryError> {
+        Ok(messages)
     }
 }
 
@@ -168,6 +162,10 @@ impl SlidingWindowMemory {
 }
 
 impl MemoryPolicy for SlidingWindowMemory {
+    fn apply(&self, messages: Vec<Message>) -> Result<Vec<Message>, MemoryError> {
+        Ok(self.apply_with_demoted(messages)?.0)
+    }
+
     fn apply_with_demoted(
         &self,
         messages: Vec<Message>,
@@ -398,6 +396,10 @@ impl std::fmt::Debug for TokenWindowMemory {
 }
 
 impl MemoryPolicy for TokenWindowMemory {
+    fn apply(&self, messages: Vec<Message>) -> Result<Vec<Message>, MemoryError> {
+        Ok(self.apply_with_demoted(messages)?.0)
+    }
+
     fn apply_with_demoted(
         &self,
         messages: Vec<Message>,
@@ -602,17 +604,21 @@ impl<M, P, H> DemotingPolicyMemory<M, P, H> {
     /// Call this when a conversation has ended to bound memory usage.
     /// The watermark map is otherwise unbounded — entries persist for
     /// the lifetime of the wrapper.
-    pub fn forget(&self, conversation_id: &str) -> Result<(), MemoryError> {
-        let mut guard = self.state.lock().map_err(poisoned)?;
-        guard.remove(conversation_id);
-        Ok(())
+    ///
+    /// If the internal state lock has been poisoned by a panic in another
+    /// thread, this is a no-op (the watermark will be dropped naturally
+    /// when the wrapper itself is dropped).
+    pub fn forget(&self, conversation_id: &str) {
+        if let Ok(mut guard) = self.state.lock() {
+            guard.remove(conversation_id);
+        }
     }
 
     /// Number of conversations currently tracked in the watermark map.
-    /// Useful for telemetry and leak detection.
-    pub fn tracked_conversations(&self) -> Result<usize, MemoryError> {
-        let guard = self.state.lock().map_err(poisoned)?;
-        Ok(guard.len())
+    /// Useful for telemetry and leak detection. Returns `0` if the internal
+    /// state lock is poisoned.
+    pub fn tracked_conversations(&self) -> usize {
+        self.state.lock().map(|g| g.len()).unwrap_or(0)
     }
 }
 
@@ -675,12 +681,20 @@ where
 
             // Reacquire briefly to advance the watermark on success and
             // always clear the in-flight flag so a future load can retry.
+            //
+            // Only update if the entry still exists: a concurrent `clear`
+            // (and matching `forget`) for this `conversation_id` may have
+            // dropped the watermark entry while the hook was awaiting. In
+            // that case we must not resurrect it with a stale `delivered`
+            // count — the next load on a freshly-populated backend would
+            // then skip a real demotion.
             {
                 let mut guard = self.state.lock().map_err(poisoned)?;
-                let entry = guard.entry(conversation_id.to_string()).or_default();
-                entry.in_flight = false;
-                if result.is_ok() {
-                    entry.delivered = demoted_count;
+                if let Some(entry) = guard.get_mut(conversation_id) {
+                    entry.in_flight = false;
+                    if result.is_ok() {
+                        entry.delivered = demoted_count;
+                    }
                 }
             }
             result?;
@@ -702,14 +716,14 @@ where
     ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
         Box::pin(async move {
             self.inner.clear(conversation_id).await?;
-            self.forget(conversation_id)?;
+            self.forget(conversation_id);
             Ok(())
         })
     }
 }
 
 fn poisoned<E: std::fmt::Display>(err: E) -> MemoryError {
-    MemoryError::backend(std::io::Error::other(err.to_string()))
+    MemoryError::Internal(err.to_string())
 }
 
 #[cfg(test)]
@@ -891,10 +905,7 @@ mod tests {
     fn into_filter_returns_input_on_policy_error() {
         struct FailingPolicy;
         impl MemoryPolicy for FailingPolicy {
-            fn apply_with_demoted(
-                &self,
-                _: Vec<Message>,
-            ) -> Result<(Vec<Message>, Vec<Message>), MemoryError> {
+            fn apply(&self, _: Vec<Message>) -> Result<Vec<Message>, MemoryError> {
                 Err(MemoryError::Policy("intentional failure".into()))
             }
         }
@@ -931,10 +942,7 @@ mod tests {
     async fn policy_memory_propagates_policy_errors() {
         struct FailingPolicy;
         impl MemoryPolicy for FailingPolicy {
-            fn apply_with_demoted(
-                &self,
-                _: Vec<Message>,
-            ) -> Result<(Vec<Message>, Vec<Message>), MemoryError> {
+            fn apply(&self, _: Vec<Message>) -> Result<Vec<Message>, MemoryError> {
                 Err(MemoryError::Policy("intentional failure".into()))
             }
         }
@@ -1290,15 +1298,15 @@ mod tests {
             .await
             .unwrap();
         mem.load("c").await.unwrap();
-        assert_eq!(mem.tracked_conversations().unwrap(), 1);
+        assert_eq!(mem.tracked_conversations(), 1);
         assert_eq!(hook.calls(), 1);
 
         // After forgetting, the next load on the same (still-populated)
         // backend re-delivers the demotion. This is the documented
         // contract: forget()/restart re-fire the hook, hooks must be
         // idempotent.
-        mem.forget("c").unwrap();
-        assert_eq!(mem.tracked_conversations().unwrap(), 0);
+        mem.forget("c");
+        assert_eq!(mem.tracked_conversations(), 0);
         mem.load("c").await.unwrap();
         assert_eq!(hook.calls(), 2);
     }

--- a/crates/rig-memory/src/lib.rs
+++ b/crates/rig-memory/src/lib.rs
@@ -19,6 +19,8 @@
 //! - [`TokenWindowMemory`] — retains messages that fit within a token budget.
 //! - [`HeuristicTokenCounter`] — provider-agnostic, zero-dependency
 //!   [`TokenCounter`] that approximates token cost from character lengths.
+//! - [`DemotionHook`] + [`DemotingPolicyMemory`] — bridge truncated turns
+//!   from a [`MemoryPolicy`] into a long-tail store.
 //!
 //! All sliding policies drop a leading orphan tool-result message when the
 //! preceding assistant tool call has been truncated, since most providers
@@ -37,7 +39,9 @@ use std::sync::Arc;
 
 /// Re-exports of the core memory abstractions so callers only need a single
 /// dependency on `rig-memory` for both the trait/backend and the policies.
-pub use rig_core::memory::{ConversationMemory, InMemoryConversationMemory, MemoryError};
+pub use rig_core::memory::{
+    ConversationMemory, DemotionHook, InMemoryConversationMemory, MemoryError, NoopDemotionHook,
+};
 
 use rig_core::completion::Message;
 use rig_core::message::UserContent;
@@ -51,6 +55,26 @@ use rig_core::wasm_compat::{WasmBoxedFuture, WasmCompatSend, WasmCompatSync};
 pub trait MemoryPolicy: WasmCompatSend + WasmCompatSync {
     /// Transform `messages` into the history that should be returned to the agent.
     fn apply(&self, messages: Vec<Message>) -> Result<Vec<Message>, MemoryError>;
+
+    /// Transform `messages` and report which messages were demoted (excluded
+    /// from the returned history).
+    ///
+    /// Returns `(kept, demoted)`. The default implementation calls
+    /// [`MemoryPolicy::apply`] and reports an empty `demoted` list, which is
+    /// safe but uninformative for any consumer that wants to feed evicted
+    /// turns into a long-tail store such as `MemvidPersistHook`. Truncating
+    /// policies (sliding window, token window, …) override this method to
+    /// return the actual demoted prefix.
+    ///
+    /// Implementors must guarantee that `kept ⊆ messages` in their iteration
+    /// order, otherwise [`DemotingPolicyMemory`] may return inconsistent
+    /// history. Order-preserving truncation policies satisfy this trivially.
+    fn apply_with_demoted(
+        &self,
+        messages: Vec<Message>,
+    ) -> Result<(Vec<Message>, Vec<Message>), MemoryError> {
+        Ok((self.apply(messages)?, Vec::new()))
+    }
 }
 
 /// Adapt a [`MemoryPolicy`] into a closure suitable for
@@ -135,15 +159,32 @@ impl SlidingWindowMemory {
 
 impl MemoryPolicy for SlidingWindowMemory {
     fn apply(&self, messages: Vec<Message>) -> Result<Vec<Message>, MemoryError> {
+        Ok(self.apply_with_demoted(messages)?.0)
+    }
+
+    fn apply_with_demoted(
+        &self,
+        messages: Vec<Message>,
+    ) -> Result<(Vec<Message>, Vec<Message>), MemoryError> {
         if messages.len() <= self.max_messages {
-            return Ok(messages);
+            return Ok((messages, Vec::new()));
         }
 
         let start = messages.len() - self.max_messages;
-        let mut window: Vec<Message> = messages.into_iter().skip(start).collect();
+        let mut iter = messages.into_iter();
+        let mut demoted: Vec<Message> = (&mut iter).take(start).collect();
+        let mut window: Vec<Message> = iter.collect();
 
-        drop_leading_orphan_tool_result(&mut window);
-        Ok(window)
+        // The orphan tool-result, if any, becomes part of the demoted set so
+        // it is preserved end-to-end through the demotion hook even though
+        // the model never sees it again.
+        if let Some(Message::User { content }) = window.first()
+            && matches!(content.first(), UserContent::ToolResult(_))
+        {
+            demoted.push(window.remove(0));
+        }
+
+        Ok((window, demoted))
     }
 }
 
@@ -352,6 +393,13 @@ impl std::fmt::Debug for TokenWindowMemory {
 
 impl MemoryPolicy for TokenWindowMemory {
     fn apply(&self, messages: Vec<Message>) -> Result<Vec<Message>, MemoryError> {
+        Ok(self.apply_with_demoted(messages)?.0)
+    }
+
+    fn apply_with_demoted(
+        &self,
+        messages: Vec<Message>,
+    ) -> Result<(Vec<Message>, Vec<Message>), MemoryError> {
         let mut budget = self.max_tokens;
         let mut keep_from = messages.len();
 
@@ -364,17 +412,17 @@ impl MemoryPolicy for TokenWindowMemory {
             keep_from = idx;
         }
 
-        let mut window: Vec<Message> = messages.into_iter().skip(keep_from).collect();
-        drop_leading_orphan_tool_result(&mut window);
-        Ok(window)
-    }
-}
+        let mut iter = messages.into_iter();
+        let mut demoted: Vec<Message> = (&mut iter).take(keep_from).collect();
+        let mut window: Vec<Message> = iter.collect();
 
-fn drop_leading_orphan_tool_result(window: &mut Vec<Message>) {
-    if let Some(Message::User { content }) = window.first()
-        && matches!(content.first(), UserContent::ToolResult(_))
-    {
-        window.remove(0);
+        if let Some(Message::User { content }) = window.first()
+            && matches!(content.first(), UserContent::ToolResult(_))
+        {
+            demoted.push(window.remove(0));
+        }
+
+        Ok((window, demoted))
     }
 }
 
@@ -455,6 +503,120 @@ where
     }
 }
 
+/// A [`ConversationMemory`] adapter that wraps a backend with a
+/// [`MemoryPolicy`] **and** a [`DemotionHook`], so messages truncated by the
+/// policy flow into the hook before the active window is returned.
+///
+/// `DemotingPolicyMemory` is the bridge between the recent-turn store
+/// ([`InMemoryConversationMemory`] or any other [`ConversationMemory`]) and a
+/// long-tail store (`MemvidPersistHook`, vector RAG, archival storage, …).
+/// Compose it with any [`MemoryPolicy`] that overrides
+/// [`MemoryPolicy::apply_with_demoted`]; policies that rely on the default
+/// implementation will still load correctly but will never demote anything.
+///
+/// # Example
+///
+/// ```no_run
+/// use rig_memory::{
+///     DemotingPolicyMemory, DemotionHook, InMemoryConversationMemory,
+///     MemoryError, NoopDemotionHook, SlidingWindowMemory,
+/// };
+///
+/// let memory = DemotingPolicyMemory::new(
+///     InMemoryConversationMemory::new(),
+///     SlidingWindowMemory::last_messages(20),
+///     NoopDemotionHook,
+/// );
+/// # let _ = memory;
+/// ```
+pub struct DemotingPolicyMemory<M, P, H> {
+    inner: M,
+    policy: P,
+    hook: H,
+}
+
+impl<M, P, H> DemotingPolicyMemory<M, P, H> {
+    /// Wrap `inner` so every load runs through `policy` and demoted messages
+    /// flow into `hook`.
+    pub fn new(inner: M, policy: P, hook: H) -> Self {
+        Self {
+            inner,
+            policy,
+            hook,
+        }
+    }
+
+    /// Return a reference to the wrapped backend.
+    pub fn inner(&self) -> &M {
+        &self.inner
+    }
+
+    /// Return a reference to the wrapped policy.
+    pub fn policy(&self) -> &P {
+        &self.policy
+    }
+
+    /// Return a reference to the demotion hook.
+    pub fn hook(&self) -> &H {
+        &self.hook
+    }
+
+    /// Consume the wrapper and return its three components.
+    pub fn into_inner(self) -> (M, P, H) {
+        (self.inner, self.policy, self.hook)
+    }
+}
+
+impl<M, P, H> std::fmt::Debug for DemotingPolicyMemory<M, P, H>
+where
+    M: std::fmt::Debug,
+    P: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DemotingPolicyMemory")
+            .field("inner", &self.inner)
+            .field("policy", &self.policy)
+            .field("hook", &"<hook>")
+            .finish()
+    }
+}
+
+impl<M, P, H> ConversationMemory for DemotingPolicyMemory<M, P, H>
+where
+    M: ConversationMemory,
+    P: MemoryPolicy,
+    H: DemotionHook,
+{
+    fn load<'a>(
+        &'a self,
+        conversation_id: &'a str,
+    ) -> WasmBoxedFuture<'a, Result<Vec<Message>, MemoryError>> {
+        Box::pin(async move {
+            let messages = self.inner.load(conversation_id).await?;
+            let (kept, demoted) = self.policy.apply_with_demoted(messages)?;
+            if !demoted.is_empty() {
+                self.hook.on_demote(conversation_id, demoted).await?;
+            }
+            Ok(kept)
+        })
+    }
+
+    fn append<'a>(
+        &'a self,
+        conversation_id: &'a str,
+        messages: Vec<Message>,
+    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+        self.inner.append(conversation_id, messages)
+    }
+
+    fn clear<'a>(
+        &'a self,
+        conversation_id: &'a str,
+    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+        self.inner.clear(conversation_id)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -462,6 +624,7 @@ mod tests {
     use rig_core::message::{
         AssistantContent, ToolCall, ToolFunction, ToolResult, ToolResultContent, UserContent,
     };
+    use std::sync::Mutex;
 
     fn user(text: &str) -> Message {
         Message::user(text)
@@ -694,5 +857,145 @@ mod tests {
 
         mem.clear("c").await.unwrap();
         assert!(mem.load("c").await.unwrap().is_empty());
+    }
+
+    #[test]
+    fn sliding_window_reports_demoted_prefix() {
+        let policy = SlidingWindowMemory::last_messages(2);
+        let (kept, demoted) = policy
+            .apply_with_demoted(vec![
+                user("oldest"),
+                assistant("old"),
+                user("recent"),
+                assistant("latest"),
+            ])
+            .unwrap();
+        assert_eq!(kept.len(), 2);
+        assert_eq!(demoted.len(), 2);
+    }
+
+    #[test]
+    fn token_window_reports_demoted_prefix() {
+        let policy = TokenWindowMemory::new(2, |_: &Message| 1);
+        let (kept, demoted) = policy
+            .apply_with_demoted(vec![user("a"), assistant("b"), user("c"), assistant("d")])
+            .unwrap();
+        assert_eq!(kept.len(), 2);
+        assert_eq!(demoted.len(), 2);
+    }
+
+    #[test]
+    fn noop_policy_demotes_nothing() {
+        let (kept, demoted) = NoopMemoryPolicy
+            .apply_with_demoted(vec![user("a"), assistant("b")])
+            .unwrap();
+        assert_eq!(kept.len(), 2);
+        assert!(demoted.is_empty());
+    }
+
+    #[test]
+    fn sliding_window_demotes_orphan_tool_result_with_prefix() {
+        // Window keeps the last 2 messages, but the leading message of that
+        // window is an orphan tool result; it must be moved into `demoted`
+        // so the hook can preserve it.
+        let policy = SlidingWindowMemory::last_messages(2);
+        let (kept, demoted) = policy
+            .apply_with_demoted(vec![
+                tool_call_msg(),
+                tool_result_msg(),
+                user("after"),
+                assistant("done"),
+            ])
+            .unwrap();
+        assert_eq!(kept.len(), 2);
+        assert!(matches!(kept.first(), Some(Message::User { content })
+            if matches!(content.first(), UserContent::Text(_))));
+        assert_eq!(demoted.len(), 2);
+    }
+
+    #[derive(Default)]
+    struct CountingHook {
+        seen: Mutex<Vec<(String, Vec<Message>)>>,
+    }
+
+    impl CountingHook {
+        fn calls(&self) -> usize {
+            self.seen.lock().unwrap().len()
+        }
+        fn last_demoted_count(&self) -> usize {
+            self.seen
+                .lock()
+                .unwrap()
+                .last()
+                .map(|(_, m)| m.len())
+                .unwrap_or(0)
+        }
+    }
+
+    impl DemotionHook for CountingHook {
+        fn on_demote<'a>(
+            &'a self,
+            conversation_id: &'a str,
+            messages: Vec<Message>,
+        ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+            Box::pin(async move {
+                self.seen
+                    .lock()
+                    .unwrap()
+                    .push((conversation_id.to_string(), messages));
+                Ok(())
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn demoting_policy_memory_invokes_hook_on_truncation() {
+        let hook = Arc::new(CountingHook::default());
+        let mem = DemotingPolicyMemory::new(
+            InMemoryConversationMemory::new(),
+            SlidingWindowMemory::last_messages(2),
+            hook.clone(),
+        );
+
+        mem.append(
+            "c",
+            vec![user("1"), assistant("2"), user("3"), assistant("4")],
+        )
+        .await
+        .unwrap();
+
+        let kept = mem.load("c").await.unwrap();
+        assert_eq!(kept.len(), 2);
+        assert_eq!(hook.calls(), 1);
+        assert_eq!(hook.last_demoted_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn demoting_policy_memory_skips_hook_when_nothing_evicted() {
+        let hook = Arc::new(CountingHook::default());
+        let mem = DemotingPolicyMemory::new(
+            InMemoryConversationMemory::new(),
+            SlidingWindowMemory::last_messages(10),
+            hook.clone(),
+        );
+
+        mem.append("c", vec![user("1"), assistant("2")])
+            .await
+            .unwrap();
+        mem.load("c").await.unwrap();
+        assert_eq!(hook.calls(), 0);
+    }
+
+    #[tokio::test]
+    async fn demoting_policy_memory_with_noop_hook_behaves_like_policy_memory() {
+        let mem = DemotingPolicyMemory::new(
+            InMemoryConversationMemory::new(),
+            SlidingWindowMemory::last_messages(1),
+            NoopDemotionHook,
+        );
+        mem.append("c", vec![user("a"), assistant("b"), user("c")])
+            .await
+            .unwrap();
+        assert_eq!(mem.load("c").await.unwrap().len(), 1);
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #1702. Adds the missing seam for evicted conversation turns so bounded active history can hand off to long-lived memory without `rig-core` taking on a storage opinion.

Fixes #1739.

Three small additions:

- `HeuristicTokenCounter` — zero-dep default so `TokenWindowMemory` is usable out of the box.
- `DemotionHook` (+ `NoopDemotionHook`) in `rig-core` — trait seam for messages removed from active history.
- `DemotingPolicyMemory` in `rig-memory` — composes any `ConversationMemory`, any `MemoryPolicy`, and any demotion hook. Tracks per-conversation in-process watermarks so repeated `load` calls do not redeliver the same demoted prefix; documents the idempotency contract for hooks that need to survive restarts.

## Why

#1702 gave `rig-core` first-class conversation memory and gave `rig-memory` named windowing policies. What was missing — and what we noticed only when wiring downstream backends — was the path for turns that fall *out* of the window. They were silently dropped.

This keeps that seam minimal: `rig-core` only defines the trait, `rig-memory` owns the policy adapter, storage crates choose whether to implement the hook.

## Notes for review

- The demotion watermark is intentionally in-process only. Durable hooks must be idempotent on `(conversation_id, messages)` because restarts or freshly constructed adapters can redeliver prior demotions.
- Concurrent `load` calls for the same conversation are gated at the demotion seam so only one call delivers to the hook at a time.
- `MemoryPolicy::apply_with_demoted` is the canonical method; `apply` remains the convenience wrapper for callers that only need the kept history.

## Verification

- `cargo test -p rig-core -p rig-memory`
- `cargo clippy -p rig-core -p rig-memory --all-targets --all-features`
- `cargo doc --no-deps -p rig-core -p rig-memory`