### PR TITLE
Add provider file ID support for document inputs

### DIFF
--- a/crates/rig-core/src/completion/message.rs
+++ b/crates/rig-core/src/completion/message.rs
@@ -377,6 +377,8 @@ pub enum DocumentSourceKind {
     Url(String),
     /// A base-64 encoded string.
     Base64(String),
+    /// A provider-side uploaded file identifier.
+    FileId(String),
     /// Raw bytes
     Raw(Vec<u8>),
     /// A string (or a string literal).
@@ -397,6 +399,11 @@ impl DocumentSourceKind {
         Self::Base64(base64_string.to_string())
     }
 
+    /// Create a provider file ID-backed source.
+    pub fn file_id(file_id: &str) -> Self {
+        Self::FileId(file_id.to_string())
+    }
+
     /// Create a raw byte source.
     pub fn raw(bytes: impl Into<Vec<u8>>) -> Self {
         Self::Raw(bytes.into())
@@ -412,10 +419,10 @@ impl DocumentSourceKind {
         Self::Unknown
     }
 
-    /// Return the contained URL or base64 string, if this source stores one.
+    /// Return the contained URL, base64 string, or file ID, if this source stores one.
     pub fn try_into_inner(self) -> Option<String> {
         match self {
-            Self::Url(s) | Self::Base64(s) => Some(s),
+            Self::Url(s) | Self::Base64(s) | Self::FileId(s) => Some(s),
             _ => None,
         }
     }
@@ -426,6 +433,7 @@ impl std::fmt::Display for DocumentSourceKind {
         match self {
             Self::Url(string) => write!(f, "{string}"),
             Self::Base64(string) => write!(f, "{string}"),
+            Self::FileId(string) => write!(f, "{string}"),
             Self::String(string) => write!(f, "{string}"),
             Self::Raw(_) => write!(f, "<binary data>"),
             Self::Unknown => write!(f, "<unknown>"),

--- a/crates/rig-core/src/loaders/pdf.rs
+++ b/crates/rig-core/src/loaders/pdf.rs
@@ -506,9 +506,23 @@ mod tests {
 
     use super::PdfFileLoader;
 
+    fn fixture_path(filename: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../tests/data")
+            .join(filename)
+    }
+
+    fn fixture_glob() -> String {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../tests/data/*.pdf")
+            .to_string_lossy()
+            .into_owned()
+    }
+
     #[test]
     fn test_pdf_loader() {
-        let loader = PdfFileLoader::with_glob("tests/data/*.pdf").unwrap();
+        let glob = fixture_glob();
+        let loader = PdfFileLoader::with_glob(&glob).unwrap();
         let actual = loader
             .load_with_path()
             .ignore_errors()
@@ -530,11 +544,19 @@ mod tests {
 
         let mut expected = vec![
             (
-                PathBuf::from("tests/data/dummy.pdf"),
+                fixture_path("dummy.pdf"),
                 vec![(0, "Test\nPDF\nDocument\n".to_string())],
             ),
             (
-                PathBuf::from("tests/data/pages.pdf"),
+                fixture_path("file-id-verifiers.pdf"),
+                vec![
+                    (0, "rig-file-id-page-one-verifier-3a91\n".to_string()),
+                    (1, "rig-file-id-page-two-verifier-8c27\n".to_string()),
+                    (2, "rig-file-id-page-three-verifier-f54e\n".to_string()),
+                ],
+            ),
+            (
+                fixture_path("pages.pdf"),
                 vec![
                     (0, "Page\n1\n".to_string()),
                     (1, "Page\n2\n".to_string()),
@@ -553,7 +575,7 @@ mod tests {
     #[test]
     fn test_pdf_loader_bytes() {
         // this should never fail!
-        let bytes = std::fs::read("tests/data/dummy.pdf").unwrap();
+        let bytes = std::fs::read(fixture_path("dummy.pdf")).unwrap();
 
         let loader = PdfFileLoader::from_bytes(bytes);
 
@@ -569,7 +591,7 @@ mod tests {
         assert_eq!(actual, vec!["Test\nPDF\nDocument\n".to_string()]);
 
         // this should never fail!
-        let bytes = std::fs::read("tests/data/pages.pdf").unwrap();
+        let bytes = std::fs::read(fixture_path("pages.pdf")).unwrap();
 
         let loader = PdfFileLoader::from_bytes(bytes);
 

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -356,14 +356,11 @@ pub enum ImageSource {
 
 /// The source of a document content block.
 ///
-/// Anthropic supports multiple source types for documents. Currently implemented:
+/// Anthropic supports multiple source types for documents:
 /// - `Base64`: Base64-encoded document data (used for PDFs)
 /// - `Text`: Plain text document data
-///
-/// Future variants (not yet implemented):
-/// - URL-based PDF sources
-/// - Content block sources
-/// - File API sources
+/// - `Url`: URL reference to a document
+/// - `File`: Provider-side uploaded file reference from the Files API
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum DocumentSource {
@@ -377,6 +374,9 @@ pub enum DocumentSource {
     },
     Url {
         url: String,
+    },
+    File {
+        file_id: String,
     },
 }
 
@@ -657,6 +657,13 @@ impl TryFrom<message::Message> for Message {
                     message::UserContent::Document(message::Document {
                         data, media_type, ..
                     }) => {
+                        if let DocumentSourceKind::FileId(file_id) = data {
+                            return Ok(Content::Document {
+                                source: DocumentSource::File { file_id },
+                                cache_control: None,
+                            });
+                        }
+
                         let media_type = media_type.ok_or(MessageError::ConversionError(
                             "Document media type is required".to_string(),
                         ))?;
@@ -835,6 +842,13 @@ impl TryFrom<Message> for message::Message {
                             ),
                             DocumentSource::Url { url } => {
                                 message::UserContent::document_url(url, None)
+                            }
+                            DocumentSource::File { file_id } => {
+                                message::UserContent::Document(message::Document {
+                                    data: DocumentSourceKind::FileId(file_id),
+                                    media_type: None,
+                                    additional_params: None,
+                                })
                             }
                         },
                         _ => {
@@ -2021,6 +2035,108 @@ mod tests {
                 );
             }
             _ => panic!("Expected Document content"),
+        }
+    }
+
+    #[test]
+    fn test_file_id_document_serialization() {
+        let content = Content::Document {
+            source: DocumentSource::File {
+                file_id: "file_abc".to_string(),
+            },
+            cache_control: None,
+        };
+
+        let json = serde_json::to_value(&content).unwrap();
+        assert_eq!(json["type"], "document");
+        assert_eq!(json["source"]["type"], "file");
+        assert_eq!(json["source"]["file_id"], "file_abc");
+    }
+
+    #[test]
+    fn test_file_id_document_deserialization() {
+        let json = r#"
+        {
+            "type": "document",
+            "source": {
+                "type": "file",
+                "file_id": "file_abc"
+            }
+        }
+        "#;
+
+        let content: Content = serde_json::from_str(json).unwrap();
+        match content {
+            Content::Document { source, .. } => {
+                assert_eq!(
+                    source,
+                    DocumentSource::File {
+                        file_id: "file_abc".to_string(),
+                    }
+                );
+            }
+            _ => panic!("Expected Document content"),
+        }
+    }
+
+    #[test]
+    fn test_file_id_rig_to_anthropic_conversion() {
+        use crate::completion::message as msg;
+
+        let rig_message = msg::Message::User {
+            content: OneOrMany::one(msg::UserContent::Document(msg::Document {
+                data: DocumentSourceKind::FileId("file_abc".to_string()),
+                media_type: None,
+                additional_params: None,
+            })),
+        };
+
+        let anthropic_message: Message = rig_message.try_into().unwrap();
+        assert_eq!(anthropic_message.role, Role::User);
+
+        let mut iter = anthropic_message.content.into_iter();
+        match iter.next().unwrap() {
+            Content::Document { source, .. } => {
+                assert_eq!(
+                    source,
+                    DocumentSource::File {
+                        file_id: "file_abc".to_string(),
+                    }
+                );
+            }
+            other => panic!("Expected Document content, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_file_id_anthropic_to_rig_conversion() {
+        use crate::completion::message as msg;
+
+        let anthropic_message = Message {
+            role: Role::User,
+            content: OneOrMany::one(Content::Document {
+                source: DocumentSource::File {
+                    file_id: "file_abc".to_string(),
+                },
+                cache_control: None,
+            }),
+        };
+
+        let rig_message: msg::Message = anthropic_message.try_into().unwrap();
+        match rig_message {
+            msg::Message::User { content } => {
+                let mut iter = content.into_iter();
+                match iter.next().unwrap() {
+                    msg::UserContent::Document(msg::Document {
+                        data, media_type, ..
+                    }) => {
+                        assert_eq!(data, DocumentSourceKind::FileId("file_abc".to_string()));
+                        assert_eq!(media_type, None);
+                    }
+                    other => panic!("Expected Document content, got: {other:?}"),
+                }
+            }
+            _ => panic!("Expected User message"),
         }
     }
 

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -787,6 +787,11 @@ pub mod gemini_api_types {
                         "Raw files not supported, encode as base64 first".into(),
                     ));
                 }
+                DocumentSourceKind::FileId(_) => {
+                    return Err(message::MessageError::ConversionError(
+                        "Provider file IDs are not supported for Gemini image inputs".into(),
+                    ));
+                }
                 DocumentSourceKind::Unknown => {
                     return Err(message::MessageError::ConversionError(
                         "Can't convert an unknown document source".to_string(),
@@ -970,6 +975,12 @@ pub mod gemini_api_types {
                                     "Raw files not supported, encode as base64 first".to_string(),
                                 ));
                             }
+                            DocumentSourceKind::FileId(_) => {
+                                return Err(MessageError::ConversionError(
+                                    "Provider file IDs are not supported for Gemini documents"
+                                        .to_string(),
+                                ));
+                            }
                             DocumentSourceKind::Unknown => {
                                 return Err(MessageError::ConversionError(
                                     "Document has no body".to_string(),
@@ -1047,6 +1058,12 @@ pub mod gemini_api_types {
                                 "Raw files not supported, encode as base64 first".into(),
                             ));
                         }
+                        DocumentSourceKind::FileId(_) => {
+                            return Err(message::MessageError::ConversionError(
+                                "Provider file IDs are not supported for Gemini audio inputs"
+                                    .into(),
+                            ));
+                        }
                         DocumentSourceKind::Unknown => {
                             return Err(message::MessageError::ConversionError(
                                 "Content has no body".to_string(),
@@ -1106,6 +1123,12 @@ pub mod gemini_api_types {
                         DocumentSourceKind::Raw(_) => {
                             return Err(message::MessageError::ConversionError(
                                 "Raw file data not supported, encode as base64 first".into(),
+                            ));
+                        }
+                        DocumentSourceKind::FileId(_) => {
+                            return Err(message::MessageError::ConversionError(
+                                "Provider file IDs are not supported for Gemini video inputs"
+                                    .into(),
                             ));
                         }
                         DocumentSourceKind::Unknown => {

--- a/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
@@ -626,6 +626,9 @@ fn split_data_uri(
         message::DocumentSourceKind::Raw(_) => Err(message::MessageError::ConversionError(
             "Raw content is not supported, encode as base64 first".to_string(),
         )),
+        message::DocumentSourceKind::FileId(_) => Err(message::MessageError::ConversionError(
+            "Provider file IDs are not supported for Gemini Interactions inputs".to_string(),
+        )),
         message::DocumentSourceKind::Unknown => Err(message::MessageError::ConversionError(
             "Unknown content source".to_string(),
         )),

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -514,6 +514,9 @@ impl TryFrom<message::UserContent> for UserContent {
                 DocumentSourceKind::Raw(_) => Err(message::MessageError::ConversionError(
                     "Raw files not supported, encode as base64 first".into(),
                 )),
+                DocumentSourceKind::FileId(_) => Err(message::MessageError::ConversionError(
+                    "File IDs are not supported for images".into(),
+                )),
                 DocumentSourceKind::Unknown => Err(message::MessageError::ConversionError(
                     "Document has no body".into(),
                 )),
@@ -521,6 +524,16 @@ impl TryFrom<message::UserContent> for UserContent {
                     "Unsupported document type: {doc:?}"
                 ))),
             },
+            message::UserContent::Document(message::Document {
+                data: DocumentSourceKind::FileId(file_id),
+                ..
+            }) => Ok(UserContent::File {
+                file: FileData {
+                    file_data: None,
+                    file_id: Some(file_id),
+                    filename: None,
+                },
+            }),
             message::UserContent::Document(message::Document {
                 data,
                 media_type: Some(message::DocumentMediaType::PDF),
@@ -541,6 +554,9 @@ impl TryFrom<message::UserContent> for UserContent {
                 )),
                 DocumentSourceKind::String(_) => Err(message::MessageError::ConversionError(
                     "PDF documents must be base64-encoded, not raw strings".into(),
+                )),
+                DocumentSourceKind::FileId(_) => Err(message::MessageError::ConversionError(
+                    "File ID documents should be converted without media type constraints".into(),
                 )),
                 DocumentSourceKind::Unknown => Err(message::MessageError::ConversionError(
                     "Document has no body".into(),
@@ -572,6 +588,9 @@ impl TryFrom<message::UserContent> for UserContent {
                 )),
                 DocumentSourceKind::Raw(_) => Err(message::MessageError::ConversionError(
                     "Raw files are not supported for audio".into(),
+                )),
+                DocumentSourceKind::FileId(_) => Err(message::MessageError::ConversionError(
+                    "File IDs are not supported for audio".into(),
                 )),
                 DocumentSourceKind::Unknown => Err(message::MessageError::ConversionError(
                     "Audio has no body".into(),
@@ -811,10 +830,12 @@ impl From<UserContent> for message::UserContent {
                         additional_params: None,
                     })
                 }
-                // `DocumentSourceKind` cannot model a remote file handle today,
-                // so a `file_id`-only payload is preserved as a text breadcrumb.
                 None => match file_id {
-                    Some(id) => message::UserContent::text(format!("[file_id: {id}]")),
+                    Some(id) => message::UserContent::Document(message::Document {
+                        data: DocumentSourceKind::FileId(id),
+                        media_type: None,
+                        additional_params: None,
+                    }),
                     None => message::UserContent::text(String::new()),
                 },
             },
@@ -2066,6 +2087,21 @@ mod tests {
         assert!(json["file"].get("file_id").is_none());
     }
 
+    #[test]
+    fn file_id_document_serializes_as_file_content_part() {
+        let doc = message::UserContent::Document(message::Document {
+            data: DocumentSourceKind::FileId("file_abc".into()),
+            media_type: None,
+            additional_params: None,
+        });
+        let converted: UserContent = doc.try_into().expect("conversion should succeed");
+        let json = serde_json::to_value(&converted).expect("serialize");
+
+        assert_eq!(json["type"], "file");
+        assert_eq!(json["file"]["file_id"], "file_abc");
+        assert!(json["file"].get("file_data").is_none());
+    }
+
     // Regression guard: callers passing markdown/plain text wrapped in
     // `UserContent::Document` should keep getting flattened to `text`.
     #[test]
@@ -2143,7 +2179,7 @@ mod tests {
     }
 
     #[test]
-    fn file_variant_with_file_id_only_falls_back_to_text() {
+    fn file_variant_with_file_id_only_round_trips_to_document_file_id() {
         let wire = UserContent::File {
             file: FileData {
                 file_data: None,
@@ -2152,10 +2188,20 @@ mod tests {
             },
         };
         let rig: message::UserContent = wire.into();
-        let message::UserContent::Text(text) = rig else {
-            panic!("expected Text");
+        let message::UserContent::Document(doc) = rig else {
+            panic!("expected Document");
         };
-        assert_eq!(text.text, "[file_id: file_abc]");
+        assert_eq!(doc.media_type, None);
+        assert!(matches!(doc.data, DocumentSourceKind::FileId(ref id) if id == "file_abc"));
+
+        let converted: UserContent = message::UserContent::Document(doc)
+            .try_into()
+            .expect("conversion should succeed");
+        let json = serde_json::to_value(&converted).expect("serialize");
+
+        assert_eq!(json["type"], "file");
+        assert_eq!(json["file"]["file_id"], "file_abc");
+        assert!(json["file"].get("file_data").is_none());
     }
 
     // Guards against `OneOrMany::many` flattening at the User content site:

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -327,6 +327,21 @@ impl TryFrom<crate::completion::Message> for Vec<InputItem> {
                             }
                         }
                         crate::message::UserContent::Document(Document {
+                            data: DocumentSourceKind::FileId(file_id),
+                            ..
+                        }) => items.push(InputItem {
+                            role: Some(Role::User),
+                            input: InputContent::Message(Message::User {
+                                content: OneOrMany::one(UserContent::InputFile {
+                                    file_id: Some(file_id),
+                                    file_data: None,
+                                    file_url: None,
+                                    filename: None,
+                                }),
+                                name: None,
+                            }),
+                        }),
+                        crate::message::UserContent::Document(Document {
                             data,
                             media_type: Some(DocumentMediaType::PDF),
                             ..
@@ -353,6 +368,7 @@ impl TryFrom<crate::completion::Message> for Vec<InputItem> {
                                 role: Some(Role::User),
                                 input: InputContent::Message(Message::User {
                                     content: OneOrMany::one(UserContent::InputFile {
+                                        file_id: None,
                                         file_data,
                                         file_url,
                                         filename: Some("document.pdf".to_string()),
@@ -1613,6 +1629,8 @@ pub enum UserContent {
     },
     InputFile {
         #[serde(skip_serializing_if = "Option::is_none")]
+        file_id: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         file_url: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         file_data: Option<String>,
@@ -1718,6 +1736,15 @@ impl TryFrom<message::Message> for Vec<Message> {
                                 })
                             }
                             message::UserContent::Document(message::Document {
+                                data: DocumentSourceKind::FileId(file_id),
+                                ..
+                            }) => Ok(UserContent::InputFile {
+                                file_id: Some(file_id),
+                                file_url: None,
+                                file_data: None,
+                                filename: None,
+                            }),
+                            message::UserContent::Document(message::Document {
                                 media_type: Some(DocumentMediaType::PDF),
                                 data,
                                 ..
@@ -1743,6 +1770,7 @@ impl TryFrom<message::Message> for Vec<Message> {
                                 };
 
                                 Ok(UserContent::InputFile {
+                                    file_id: None,
                                     file_url,
                                     file_data,
                                     filename,
@@ -1859,5 +1887,55 @@ impl FromStr for UserContent {
         Ok(UserContent::InputText {
             text: s.to_string(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message;
+
+    #[test]
+    fn file_id_document_serializes_as_input_file_content() {
+        let message = message::Message::User {
+            content: OneOrMany::one(message::UserContent::Document(message::Document {
+                data: DocumentSourceKind::FileId("file_abc".to_string()),
+                media_type: None,
+                additional_params: None,
+            })),
+        };
+
+        let converted: Vec<Message> = message.try_into().expect("conversion should succeed");
+        let Message::User { content, .. } = &converted[0] else {
+            panic!("expected user message");
+        };
+
+        let json = serde_json::to_value(content.first_ref()).expect("serialize content");
+
+        assert_eq!(json["type"], "input_file");
+        assert_eq!(json["file_id"], "file_abc");
+        assert!(json.get("file_data").is_none());
+        assert!(json.get("file_url").is_none());
+    }
+
+    #[test]
+    fn file_id_document_serializes_as_input_item_content() {
+        let message = completion::Message::User {
+            content: OneOrMany::one(message::UserContent::Document(message::Document {
+                data: DocumentSourceKind::FileId("file_abc".to_string()),
+                media_type: None,
+                additional_params: None,
+            })),
+        };
+
+        let converted: Vec<InputItem> = message.try_into().expect("conversion should succeed");
+        let json = serde_json::to_value(&converted[0]).expect("serialize input item");
+
+        assert_eq!(json["type"], "message");
+        assert_eq!(json["role"], "user");
+        assert_eq!(json["content"][0]["type"], "input_file");
+        assert_eq!(json["content"][0]["file_id"], "file_abc");
+        assert!(json["content"][0].get("file_data").is_none());
+        assert!(json["content"][0].get("file_url").is_none());
     }
 }

--- a/crates/rig-core/src/providers/openrouter/completion.rs
+++ b/crates/rig-core/src/providers/openrouter/completion.rs
@@ -860,7 +860,6 @@ impl UserContent {
             file: FileContent {
                 filename,
                 file_data: Some(url.into()),
-                file_id: None,
             },
         }
     }
@@ -877,7 +876,6 @@ impl UserContent {
             file: FileContent {
                 filename,
                 file_data: Some(data_uri),
-                file_id: None,
             },
         }
     }
@@ -975,7 +973,6 @@ pub struct VideoUrlContent {
 /// which accepts either:
 /// - A publicly accessible URL to the file
 /// - A base64-encoded data URI (e.g., `data:application/pdf;base64,...`)
-/// - A provider file identifier
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct FileContent {
     /// Filename (e.g., "document.pdf")
@@ -984,9 +981,6 @@ pub struct FileContent {
     /// File data source - URL or base64-encoded data URI
     #[serde(skip_serializing_if = "Option::is_none")]
     pub file_data: Option<String>,
-    /// Identifier of a previously uploaded file.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub file_id: Option<String>,
 }
 
 /// Serializes user content as a plain string when there's a single text item,
@@ -1060,13 +1054,9 @@ impl TryFrom<message::UserContent> for UserContent {
             message::UserContent::Document(message::Document {
                 data, media_type, ..
             }) => match data {
-                DocumentSourceKind::FileId(file_id) => Ok(UserContent::File {
-                    file: FileContent {
-                        filename: None,
-                        file_data: None,
-                        file_id: Some(file_id),
-                    },
-                }),
+                DocumentSourceKind::FileId(_) => Err(message::MessageError::ConversionError(
+                    "Provider file IDs are not supported for OpenRouter document inputs".into(),
+                )),
                 DocumentSourceKind::Url(url) => {
                     let filename = media_type.as_ref().map(|mt| match mt {
                         DocumentMediaType::PDF => "document.pdf",
@@ -1081,7 +1071,6 @@ impl TryFrom<message::UserContent> for UserContent {
                         file: FileContent {
                             filename: filename.map(String::from),
                             file_data: Some(url),
-                            file_id: None,
                         },
                     })
                 }
@@ -1106,7 +1095,6 @@ impl TryFrom<message::UserContent> for UserContent {
                         file: FileContent {
                             filename: filename.map(String::from),
                             file_data: Some(data_uri),
-                            file_id: None,
                         },
                     })
                 }
@@ -1359,10 +1347,12 @@ enum ToolCallAdditionalParams {
     },
 }
 
-/// Convert OpenAI's UserContent to OpenRouter's UserContent
-impl From<openai::UserContent> for UserContent {
-    fn from(value: openai::UserContent) -> Self {
-        match value {
+/// Convert OpenAI's user content to OpenRouter's user content.
+impl TryFrom<openai::UserContent> for UserContent {
+    type Error = message::MessageError;
+
+    fn try_from(value: openai::UserContent) -> Result<Self, Self::Error> {
+        Ok(match value {
             openai::UserContent::Text { text } => UserContent::Text { text },
             openai::UserContent::Image { image_url } => UserContent::ImageUrl {
                 image_url: ImageUrl {
@@ -1376,28 +1366,26 @@ impl From<openai::UserContent> for UserContent {
                     file: FileContent {
                         filename: file.filename,
                         file_data: Some(file_data),
-                        file_id: file.file_id,
                     },
                 },
-                None => UserContent::File {
-                    file: FileContent {
-                        filename: file.filename,
-                        file_data: None,
-                        file_id: file.file_id,
-                    },
-                },
+                None => {
+                    return Err(message::MessageError::ConversionError(
+                        "OpenRouter file inputs require URL or base64 file_data; provider file IDs are not supported".into(),
+                    ));
+                }
             },
-        }
+        })
     }
 }
 
-impl From<openai::Message> for Message {
-    fn from(value: openai::Message) -> Self {
-        match value {
+impl TryFrom<openai::Message> for Message {
+    type Error = message::MessageError;
+
+    fn try_from(value: openai::Message) -> Result<Self, Self::Error> {
+        Ok(match value {
             openai::Message::System { content, name } => Self::System { content, name },
             openai::Message::User { content, name } => {
-                // Convert OpenAI UserContent to OpenRouter UserContent
-                let converted_content = content.map(UserContent::from);
+                let converted_content = content.try_map(UserContent::try_from)?;
                 Self::User {
                     content: converted_content,
                     name,
@@ -1426,7 +1414,7 @@ impl From<openai::Message> for Message {
                 tool_call_id,
                 content: content.as_text(),
             },
-        }
+        })
     }
 }
 
@@ -2611,23 +2599,6 @@ mod tests {
     }
 
     #[test]
-    fn test_user_content_file_id_serialization() {
-        let content = UserContent::File {
-            file: FileContent {
-                filename: Some("uploaded.pdf".to_string()),
-                file_data: None,
-                file_id: Some("file_abc".to_string()),
-            },
-        };
-        let json = serde_json::to_value(&content).unwrap();
-
-        assert_eq!(json["type"], "file");
-        assert_eq!(json["file"]["filename"], "uploaded.pdf");
-        assert_eq!(json["file"]["file_id"], "file_abc");
-        assert!(json["file"].get("file_data").is_none());
-    }
-
-    #[test]
     fn test_user_content_text_deserialization() {
         let json = json!({
             "type": "text",
@@ -2669,8 +2640,7 @@ mod tests {
             "type": "file",
             "file": {
                 "filename": "doc.pdf",
-                "file_data": "https://example.com/doc.pdf",
-                "file_id": "file_abc"
+                "file_data": "https://example.com/doc.pdf"
             }
         });
 
@@ -2682,7 +2652,6 @@ mod tests {
                     file.file_data,
                     Some("https://example.com/doc.pdf".to_string())
                 );
-                assert_eq!(file.file_id, Some("file_abc".to_string()));
             }
             _ => panic!("Expected File variant"),
         }
@@ -2848,16 +2817,17 @@ mod tests {
             media_type: None,
             additional_params: None,
         });
-        let openrouter_content: UserContent = rig_content.try_into().unwrap();
-        let json = serde_json::to_value(&openrouter_content).unwrap();
 
-        assert_eq!(json["type"], "file");
-        assert_eq!(json["file"]["file_id"], "file_abc");
-        assert!(json["file"].get("file_data").is_none());
+        let result: Result<UserContent, _> = rig_content.try_into();
+        assert!(matches!(
+            result,
+            Err(message::MessageError::ConversionError(message))
+                if message.contains("Provider file IDs are not supported")
+        ));
     }
 
     #[test]
-    fn test_openai_file_id_content_round_trips_through_rig_to_openrouter_file() {
+    fn test_openai_file_id_content_round_trips_through_rig_to_openrouter_error() {
         let openai_content = openai::UserContent::File {
             file: openai::FileData {
                 file_data: None,
@@ -2866,12 +2836,13 @@ mod tests {
             },
         };
         let rig_content: message::UserContent = openai_content.into();
-        let openrouter_content: UserContent = rig_content.try_into().unwrap();
-        let json = serde_json::to_value(&openrouter_content).unwrap();
 
-        assert_eq!(json["type"], "file");
-        assert_eq!(json["file"]["file_id"], "file_abc");
-        assert!(json["file"].get("file_data").is_none());
+        let result: Result<UserContent, _> = rig_content.try_into();
+        assert!(matches!(
+            result,
+            Err(message::MessageError::ConversionError(message))
+                if message.contains("Provider file IDs are not supported")
+        ));
     }
 
     #[test]
@@ -3256,7 +3227,7 @@ mod tests {
         let openai_text = openai::UserContent::Text {
             text: "Hello".to_string(),
         };
-        let converted: UserContent = openai_text.into();
+        let converted: UserContent = openai_text.try_into().unwrap();
         assert_eq!(
             converted,
             UserContent::Text {
@@ -3270,7 +3241,7 @@ mod tests {
                 detail: ImageDetail::Auto,
             },
         };
-        let converted: UserContent = openai_image.into();
+        let converted: UserContent = openai_image.try_into().unwrap();
         match converted {
             UserContent::ImageUrl { image_url } => {
                 assert_eq!(image_url.url, "https://example.com/img.png");
@@ -3285,7 +3256,7 @@ mod tests {
                 format: AudioMediaType::FLAC,
             },
         };
-        let converted: UserContent = openai_audio.into();
+        let converted: UserContent = openai_audio.try_into().unwrap();
         match converted {
             UserContent::InputAudio { input_audio } => {
                 assert_eq!(input_audio.data, "audiodata");
@@ -3296,20 +3267,36 @@ mod tests {
 
         let openai_file = openai::UserContent::File {
             file: openai::FileData {
+                file_data: Some("data:application/pdf;base64,AAAA".to_string()),
+                file_id: None,
+                filename: Some("uploaded.pdf".to_string()),
+            },
+        };
+        let converted: UserContent = openai_file.try_into().unwrap();
+        match converted {
+            UserContent::File { file } => {
+                assert_eq!(file.filename, Some("uploaded.pdf".to_string()));
+                assert_eq!(
+                    file.file_data,
+                    Some("data:application/pdf;base64,AAAA".to_string())
+                );
+            }
+            _ => panic!("Expected File"),
+        }
+
+        let openai_file_id = openai::UserContent::File {
+            file: openai::FileData {
                 file_data: None,
                 file_id: Some("file_abc".to_string()),
                 filename: Some("uploaded.pdf".to_string()),
             },
         };
-        let converted: UserContent = openai_file.into();
-        match converted {
-            UserContent::File { file } => {
-                assert_eq!(file.filename, Some("uploaded.pdf".to_string()));
-                assert!(file.file_data.is_none());
-                assert_eq!(file.file_id, Some("file_abc".to_string()));
-            }
-            _ => panic!("Expected File"),
-        }
+        let result: Result<UserContent, _> = openai_file_id.try_into();
+        assert!(matches!(
+            result,
+            Err(message::MessageError::ConversionError(message))
+                if message.contains("provider file IDs are not supported")
+        ));
     }
 
     #[test]

--- a/crates/rig-core/src/providers/openrouter/completion.rs
+++ b/crates/rig-core/src/providers/openrouter/completion.rs
@@ -1036,6 +1036,11 @@ impl TryFrom<message::UserContent> for UserContent {
                             "Raw bytes not supported, encode as base64 first".into(),
                         ));
                     }
+                    DocumentSourceKind::FileId(_) => {
+                        return Err(message::MessageError::ConversionError(
+                            "File IDs are not supported for images".into(),
+                        ));
+                    }
                     DocumentSourceKind::String(_) => {
                         return Err(message::MessageError::ConversionError(
                             "String source not supported for images".into(),
@@ -1055,6 +1060,13 @@ impl TryFrom<message::UserContent> for UserContent {
             message::UserContent::Document(message::Document {
                 data, media_type, ..
             }) => match data {
+                DocumentSourceKind::FileId(file_id) => Ok(UserContent::File {
+                    file: FileContent {
+                        filename: None,
+                        file_data: None,
+                        file_id: Some(file_id),
+                    },
+                }),
                 DocumentSourceKind::Url(url) => {
                     let filename = media_type.as_ref().map(|mt| match mt {
                         DocumentMediaType::PDF => "document.pdf",
@@ -1126,6 +1138,9 @@ impl TryFrom<message::UserContent> for UserContent {
                 DocumentSourceKind::Raw(_) => Err(message::MessageError::ConversionError(
                     "Raw bytes not supported for audio, encode as base64 first".into(),
                 )),
+                DocumentSourceKind::FileId(_) => Err(message::MessageError::ConversionError(
+                    "File IDs are not supported for audio".into(),
+                )),
                 DocumentSourceKind::String(_) => Err(message::MessageError::ConversionError(
                     "String source not supported for audio".into(),
                 )),
@@ -1152,6 +1167,11 @@ impl TryFrom<message::UserContent> for UserContent {
                     DocumentSourceKind::Raw(_) => {
                         return Err(message::MessageError::ConversionError(
                             "Raw bytes not supported for video, encode as base64 first".into(),
+                        ));
+                    }
+                    DocumentSourceKind::FileId(_) => {
+                        return Err(message::MessageError::ConversionError(
+                            "File IDs are not supported for video".into(),
                         ));
                     }
                     DocumentSourceKind::String(_) => {
@@ -2819,6 +2839,39 @@ mod tests {
             }
             _ => panic!("Expected File variant"),
         }
+    }
+
+    #[test]
+    fn test_user_content_from_rig_document_file_id() {
+        let rig_content = message::UserContent::Document(message::Document {
+            data: DocumentSourceKind::FileId("file_abc".to_string()),
+            media_type: None,
+            additional_params: None,
+        });
+        let openrouter_content: UserContent = rig_content.try_into().unwrap();
+        let json = serde_json::to_value(&openrouter_content).unwrap();
+
+        assert_eq!(json["type"], "file");
+        assert_eq!(json["file"]["file_id"], "file_abc");
+        assert!(json["file"].get("file_data").is_none());
+    }
+
+    #[test]
+    fn test_openai_file_id_content_round_trips_through_rig_to_openrouter_file() {
+        let openai_content = openai::UserContent::File {
+            file: openai::FileData {
+                file_data: None,
+                file_id: Some("file_abc".to_string()),
+                filename: None,
+            },
+        };
+        let rig_content: message::UserContent = openai_content.into();
+        let openrouter_content: UserContent = rig_content.try_into().unwrap();
+        let json = serde_json::to_value(&openrouter_content).unwrap();
+
+        assert_eq!(json["type"], "file");
+        assert_eq!(json["file"]["file_id"], "file_abc");
+        assert!(json["file"].get("file_data").is_none());
     }
 
     #[test]

--- a/tests/data/file-id-verifiers.pdf
+++ b/tests/data/file-id-verifiers.pdf
@@ -1,0 +1,66 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [4 0 R 6 0 R 8 0 R] /Count 3 >>
+endobj
+3 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+4 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents 5 0 R >>
+endobj
+5 0 obj
+<< /Length 66 >>
+stream
+BT
+/F1 18 Tf
+72 720 Td
+(rig-file-id-page-one-verifier-3a91) Tj
+ET
+endstream
+endobj
+6 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents 7 0 R >>
+endobj
+7 0 obj
+<< /Length 66 >>
+stream
+BT
+/F1 18 Tf
+72 720 Td
+(rig-file-id-page-two-verifier-8c27) Tj
+ET
+endstream
+endobj
+8 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents 9 0 R >>
+endobj
+9 0 obj
+<< /Length 68 >>
+stream
+BT
+/F1 18 Tf
+72 720 Td
+(rig-file-id-page-three-verifier-f54e) Tj
+ET
+endstream
+endobj
+xref
+0 10
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000127 00000 n 
+0000000197 00000 n 
+0000000323 00000 n 
+0000000438 00000 n 
+0000000564 00000 n 
+0000000679 00000 n 
+0000000805 00000 n 
+trailer
+<< /Size 10 /Root 1 0 R >>
+startxref
+922
+%%EOF

--- a/tests/providers/anthropic/document_file_id.rs
+++ b/tests/providers/anthropic/document_file_id.rs
@@ -1,0 +1,304 @@
+//! Live Anthropic coverage for provider file IDs in generic document messages.
+//!
+//! Run with:
+//! `cargo test -p rig --test anthropic anthropic::document_file_id -- --ignored --nocapture --test-threads=1`
+
+use futures::FutureExt;
+use rig::OneOrMany;
+use rig::client::CompletionClient;
+use rig::completion::{Chat, Prompt};
+use rig::message::{
+    Document, DocumentMediaType, DocumentSourceKind, Message, Text, UserContent as RigUserContent,
+};
+use rig::providers::anthropic;
+use rig::providers::anthropic::completion::{
+    ANTHROPIC_VERSION_2023_06_01, Content as AnthropicContent,
+    DocumentSource as AnthropicDocumentSource, Message as AnthropicMessage, Role as AnthropicRole,
+};
+use rig::streaming::StreamingPrompt;
+use serde::Deserialize;
+use std::future::Future;
+use std::panic::{AssertUnwindSafe, resume_unwind};
+
+use crate::support::{
+    PDF_FIXTURE_PATH, assert_contains_all_case_insensitive, assert_nonempty_response,
+    collect_stream_final_response,
+};
+
+const ANTHROPIC_FILES_BETA: &str = "files-api-2025-04-14";
+const DOCUMENT_PREAMBLE: &str =
+    "Answer using only the attached PDF. Keep answers short and quote exact visible text.";
+
+#[derive(Debug, Deserialize)]
+struct UploadedFile {
+    id: String,
+}
+
+fn anthropic_base_url() -> String {
+    let base_url =
+        std::env::var("ANTHROPIC_BASE_URL").unwrap_or_else(|_| "https://api.anthropic.com".into());
+    let trimmed = base_url.trim_end_matches('/');
+
+    if let Some(stripped) = trimmed.strip_suffix("/v1/messages") {
+        stripped.to_string()
+    } else if let Some(stripped) = trimmed.strip_suffix("/messages") {
+        stripped.to_string()
+    } else if let Some(stripped) = trimmed.strip_suffix("/v1") {
+        stripped.to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn anthropic_api_key() -> String {
+    std::env::var("ANTHROPIC_API_KEY")
+        .expect("ANTHROPIC_API_KEY should be set for this ignored test")
+}
+
+fn anthropic_files_client() -> anthropic::Client {
+    let mut builder = anthropic::Client::builder()
+        .api_key(anthropic_api_key())
+        .anthropic_beta(ANTHROPIC_FILES_BETA);
+
+    if let Ok(base_url) = std::env::var("ANTHROPIC_BASE_URL") {
+        builder = builder.base_url(base_url);
+    }
+
+    builder.build().expect("client should build")
+}
+
+async fn upload_pdf_for_file_id_test() -> UploadedFile {
+    let bytes = tokio::fs::read(PDF_FIXTURE_PATH)
+        .await
+        .expect("fixture PDF should be readable");
+    let file_part = reqwest::multipart::Part::bytes(bytes)
+        .file_name("rig-pages.pdf")
+        .mime_str("application/pdf")
+        .expect("fixture PDF MIME should be valid");
+    let form = reqwest::multipart::Form::new().part("file", file_part);
+
+    let response = reqwest::Client::new()
+        .post(format!("{}/v1/files", anthropic_base_url()))
+        .header("x-api-key", anthropic_api_key())
+        .header("anthropic-version", ANTHROPIC_VERSION_2023_06_01)
+        .header("anthropic-beta", ANTHROPIC_FILES_BETA)
+        .multipart(form)
+        .send()
+        .await
+        .expect("file upload request should be sent");
+
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .expect("file upload response body should be readable");
+    assert!(
+        status.is_success(),
+        "file upload failed with {status}: {body}"
+    );
+
+    serde_json::from_str(&body).expect("file upload response should deserialize")
+}
+
+async fn delete_uploaded_file(file_id: &str) {
+    let response = reqwest::Client::new()
+        .delete(format!("{}/v1/files/{file_id}", anthropic_base_url()))
+        .header("x-api-key", anthropic_api_key())
+        .header("anthropic-version", ANTHROPIC_VERSION_2023_06_01)
+        .header("anthropic-beta", ANTHROPIC_FILES_BETA)
+        .send()
+        .await;
+
+    if let Ok(response) = response
+        && !response.status().is_success()
+    {
+        eprintln!(
+            "cleanup failed for uploaded Anthropic file {file_id}: {}",
+            response.status()
+        );
+    }
+}
+
+async fn with_uploaded_pdf<F, Fut>(test_body: F)
+where
+    F: FnOnce(String) -> Fut,
+    Fut: Future<Output = ()>,
+{
+    let uploaded = upload_pdf_for_file_id_test().await;
+    let file_id = uploaded.id;
+
+    let result = AssertUnwindSafe(test_body(file_id.clone()))
+        .catch_unwind()
+        .await;
+
+    delete_uploaded_file(&file_id).await;
+
+    if let Err(payload) = result {
+        resume_unwind(payload);
+    }
+}
+
+fn file_id_document(file_id: &str) -> Document {
+    Document {
+        data: DocumentSourceKind::file_id(file_id),
+        media_type: Some(DocumentMediaType::PDF),
+        additional_params: None,
+    }
+}
+
+fn provider_file_content_as_generic_document(file_id: &str) -> RigUserContent {
+    let provider_message = AnthropicMessage {
+        role: AnthropicRole::User,
+        content: OneOrMany::one(AnthropicContent::Document {
+            source: AnthropicDocumentSource::File {
+                file_id: file_id.to_string(),
+            },
+            cache_control: None,
+        }),
+    };
+    let generic_message: Message = provider_message
+        .try_into()
+        .expect("Anthropic file source should convert into generic message");
+    let Message::User { content } = generic_message else {
+        panic!("expected generic user message");
+    };
+    let content = content
+        .into_iter()
+        .next()
+        .expect("generic user message should contain document");
+
+    assert_file_id_user_content(&content, file_id);
+    content
+}
+
+fn document_question(content: RigUserContent, page_number: u8) -> Message {
+    Message::User {
+        content: OneOrMany::many(vec![
+            content,
+            RigUserContent::Text(Text {
+                text: format!(
+                    "What exact visible text appears on page {page_number}? Reply with only that text."
+                ),
+            }),
+        ])
+        .expect("content should be non-empty"),
+    }
+}
+
+fn direct_file_id_document_question(file_id: &str, page_number: u8) -> Message {
+    document_question(
+        RigUserContent::Document(file_id_document(file_id)),
+        page_number,
+    )
+}
+
+fn assert_file_id_user_content(content: &RigUserContent, expected_file_id: &str) {
+    let RigUserContent::Document(Document { data, .. }) = content else {
+        panic!("expected generic document content, got {content:?}");
+    };
+
+    assert!(
+        matches!(data, DocumentSourceKind::FileId(file_id) if file_id == expected_file_id),
+        "expected file ID document source {expected_file_id}, got {data:?}"
+    );
+}
+
+fn assert_history_contains_file_id(history: &[Message], expected_file_id: &str) {
+    let found = history.iter().any(|message| {
+        let Message::User { content } = message else {
+            return false;
+        };
+
+        content.iter().any(|content| {
+            matches!(
+                content,
+                RigUserContent::Document(Document {
+                    data: DocumentSourceKind::FileId(file_id),
+                    ..
+                }) if file_id == expected_file_id
+            )
+        })
+    });
+
+    assert!(
+        found,
+        "expected chat history to preserve document file ID {expected_file_id}: {history:?}"
+    );
+}
+
+fn assert_anthropic_wire_file_source(message: Message, expected_file_id: &str) {
+    let anthropic_message: AnthropicMessage = message
+        .try_into()
+        .expect("generic file_id document should convert to Anthropic message");
+    let json = serde_json::to_value(&anthropic_message).expect("message should serialize");
+
+    assert_eq!(json["content"][0]["type"], "document");
+    assert_eq!(json["content"][0]["source"]["type"], "file");
+    assert_eq!(json["content"][0]["source"]["file_id"], expected_file_id);
+}
+
+fn assert_page_label(response: &str, page_number: u8) {
+    assert_nonempty_response(response);
+    assert_contains_all_case_insensitive(response, &["page", &page_number.to_string()]);
+}
+
+#[tokio::test]
+#[ignore = "requires ANTHROPIC_API_KEY"]
+async fn messages_document_file_id_roundtrip_live() {
+    with_uploaded_pdf(|file_id| async move {
+        let client = anthropic_files_client();
+        let agent = client
+            .agent(anthropic::completion::CLAUDE_SONNET_4_6)
+            .preamble(DOCUMENT_PREAMBLE)
+            .build();
+        let mut history = Vec::new();
+
+        assert_anthropic_wire_file_source(direct_file_id_document_question(&file_id, 2), &file_id);
+
+        let provider_native_content = provider_file_content_as_generic_document(&file_id);
+        let response = agent
+            .chat(document_question(provider_native_content, 2), &mut history)
+            .await
+            .expect("Messages API should read uploaded PDF by file_id");
+        assert_page_label(&response, 2);
+        assert_history_contains_file_id(&history, &file_id);
+
+        let follow_up = agent
+            .chat(
+                "Using the same PDF from the conversation history, what exact visible text appears on page 3? Reply with only that text.",
+                &mut history,
+            )
+            .await
+            .expect("Messages API should reuse file_id document from chat history");
+        assert_page_label(&follow_up, 3);
+        assert_history_contains_file_id(&history, &file_id);
+
+        let direct_response = agent
+            .prompt(direct_file_id_document_question(&file_id, 1))
+            .await
+            .expect("Messages API should read direct generic file_id document");
+        assert_page_label(&direct_response, 1);
+    })
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires ANTHROPIC_API_KEY"]
+async fn streaming_document_file_id_roundtrip_live() {
+    with_uploaded_pdf(|file_id| async move {
+        let client = anthropic_files_client();
+        let agent = client
+            .agent(anthropic::completion::CLAUDE_SONNET_4_6)
+            .preamble(DOCUMENT_PREAMBLE)
+            .build();
+
+        let mut stream = agent
+            .stream_prompt(direct_file_id_document_question(&file_id, 2))
+            .await;
+        let response = collect_stream_final_response(&mut stream)
+            .await
+            .expect("streaming Messages API should read uploaded PDF by file_id");
+        assert_page_label(&response, 2);
+    })
+    .await;
+}

--- a/tests/providers/anthropic/document_file_id.rs
+++ b/tests/providers/anthropic/document_file_id.rs
@@ -17,21 +17,34 @@ use rig::providers::anthropic::completion::{
 };
 use rig::streaming::StreamingPrompt;
 use serde::Deserialize;
+use serde_json::Value;
 use std::future::Future;
 use std::panic::{AssertUnwindSafe, resume_unwind};
 
-use crate::support::{
-    PDF_FIXTURE_PATH, assert_contains_all_case_insensitive, assert_nonempty_response,
-    collect_stream_final_response,
-};
+use crate::support::{assert_nonempty_response, collect_stream_final_response};
 
 const ANTHROPIC_FILES_BETA: &str = "files-api-2025-04-14";
 const DOCUMENT_PREAMBLE: &str =
-    "Answer using only the attached PDF. Keep answers short and quote exact visible text.";
+    "Answer using only the attached PDF. Keep answers short and return exact visible tokens.";
+const VERIFIER_FIXTURE_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/data/file-id-verifiers.pdf"
+);
+const VERIFIER_FIXTURE_FILENAME: &str = "rig-file-id-verifiers.pdf";
+const PAGE_ONE_VERIFIER: &str = "rig-file-id-page-one-verifier-3a91";
+const PAGE_TWO_VERIFIER: &str = "rig-file-id-page-two-verifier-8c27";
+const PAGE_THREE_VERIFIER: &str = "rig-file-id-page-three-verifier-f54e";
+const PAGE_VERIFIERS: [&str; 3] = [PAGE_ONE_VERIFIER, PAGE_TWO_VERIFIER, PAGE_THREE_VERIFIER];
 
 #[derive(Debug, Deserialize)]
 struct UploadedFile {
     id: String,
+    #[serde(rename = "type")]
+    file_type: String,
+    filename: String,
+    mime_type: String,
+    size_bytes: u64,
+    downloadable: bool,
 }
 
 fn anthropic_base_url() -> String {
@@ -68,13 +81,13 @@ fn anthropic_files_client() -> anthropic::Client {
 }
 
 async fn upload_pdf_for_file_id_test() -> UploadedFile {
-    let bytes = tokio::fs::read(PDF_FIXTURE_PATH)
+    let bytes = tokio::fs::read(VERIFIER_FIXTURE_PATH)
         .await
-        .expect("fixture PDF should be readable");
+        .expect("verifier fixture PDF should be readable");
     let file_part = reqwest::multipart::Part::bytes(bytes)
-        .file_name("rig-pages.pdf")
+        .file_name(VERIFIER_FIXTURE_FILENAME)
         .mime_str("application/pdf")
-        .expect("fixture PDF MIME should be valid");
+        .expect("verifier fixture PDF MIME should be valid");
     let form = reqwest::multipart::Form::new().part("file", file_part);
 
     let response = reqwest::Client::new()
@@ -97,7 +110,29 @@ async fn upload_pdf_for_file_id_test() -> UploadedFile {
         "file upload failed with {status}: {body}"
     );
 
-    serde_json::from_str(&body).expect("file upload response should deserialize")
+    let uploaded: UploadedFile =
+        serde_json::from_str(&body).expect("file upload response should deserialize");
+    assert_uploaded_file_metadata(&uploaded);
+    uploaded
+}
+
+fn assert_uploaded_file_metadata(uploaded: &UploadedFile) {
+    assert!(
+        uploaded.id.starts_with("file_"),
+        "expected Anthropic file id to start with file_, got {}",
+        uploaded.id
+    );
+    assert_eq!(uploaded.file_type, "file");
+    assert_eq!(uploaded.filename, VERIFIER_FIXTURE_FILENAME);
+    assert_eq!(uploaded.mime_type, "application/pdf");
+    assert!(
+        uploaded.size_bytes > 0,
+        "uploaded file size should be nonzero"
+    );
+    assert!(
+        !uploaded.downloadable,
+        "user-uploaded Anthropic file should not be downloadable"
+    );
 }
 
 async fn delete_uploaded_file(file_id: &str) {
@@ -177,7 +212,7 @@ fn document_question(content: RigUserContent, page_number: u8) -> Message {
             content,
             RigUserContent::Text(Text {
                 text: format!(
-                    "What exact visible text appears on page {page_number}? Reply with only that text."
+                    "What verifier token is printed on page {page_number}? Reply with only the exact token."
                 ),
             }),
         ])
@@ -193,7 +228,12 @@ fn direct_file_id_document_question(file_id: &str, page_number: u8) -> Message {
 }
 
 fn assert_file_id_user_content(content: &RigUserContent, expected_file_id: &str) {
-    let RigUserContent::Document(Document { data, .. }) = content else {
+    let RigUserContent::Document(Document {
+        data,
+        media_type,
+        additional_params,
+    }) = content
+    else {
         panic!("expected generic document content, got {content:?}");
     };
 
@@ -201,45 +241,183 @@ fn assert_file_id_user_content(content: &RigUserContent, expected_file_id: &str)
         matches!(data, DocumentSourceKind::FileId(file_id) if file_id == expected_file_id),
         "expected file ID document source {expected_file_id}, got {data:?}"
     );
-}
-
-fn assert_history_contains_file_id(history: &[Message], expected_file_id: &str) {
-    let found = history.iter().any(|message| {
-        let Message::User { content } = message else {
-            return false;
-        };
-
-        content.iter().any(|content| {
-            matches!(
-                content,
-                RigUserContent::Document(Document {
-                    data: DocumentSourceKind::FileId(file_id),
-                    ..
-                }) if file_id == expected_file_id
-            )
-        })
-    });
-
-    assert!(
-        found,
-        "expected chat history to preserve document file ID {expected_file_id}: {history:?}"
+    assert_eq!(
+        *media_type, None,
+        "provider file-id content should not invent a generic media type"
+    );
+    assert_eq!(
+        *additional_params, None,
+        "provider file-id content should not invent additional params"
     );
 }
 
-fn assert_anthropic_wire_file_source(message: Message, expected_file_id: &str) {
-    let anthropic_message: AnthropicMessage = message
-        .try_into()
-        .expect("generic file_id document should convert to Anthropic message");
-    let json = serde_json::to_value(&anthropic_message).expect("message should serialize");
+fn message_contains_file_id(message: &Message, expected_file_id: &str) -> bool {
+    let Message::User { content } = message else {
+        return false;
+    };
 
-    assert_eq!(json["content"][0]["type"], "document");
-    assert_eq!(json["content"][0]["source"]["type"], "file");
-    assert_eq!(json["content"][0]["source"]["file_id"], expected_file_id);
+    content.iter().any(|content| {
+        matches!(
+            content,
+            RigUserContent::Document(Document {
+                data: DocumentSourceKind::FileId(file_id),
+                ..
+            }) if file_id == expected_file_id
+        )
+    })
 }
 
-fn assert_page_label(response: &str, page_number: u8) {
+fn assert_history_preserves_single_file_id(history: &[Message], expected_file_id: &str) {
+    let mut file_id_message_count = 0;
+
+    for message in history {
+        let json = anthropic_wire_json(message.clone());
+        assert_no_text_file_id_fallback(&json, expected_file_id);
+
+        if message_contains_file_id(message, expected_file_id) {
+            file_id_message_count += 1;
+            assert_wire_json_has_exact_file_source(&json, expected_file_id);
+        }
+    }
+
+    assert_eq!(
+        file_id_message_count, 1,
+        "expected exactly one history message to preserve document file ID {expected_file_id}: {history:?}"
+    );
+}
+
+fn anthropic_wire_json(message: Message) -> Value {
+    let anthropic_message: AnthropicMessage = message
+        .try_into()
+        .expect("generic message should convert to Anthropic message");
+    serde_json::to_value(&anthropic_message).expect("message should serialize")
+}
+
+fn assert_anthropic_wire_file_source(message: Message, expected_file_id: &str) {
+    let json = anthropic_wire_json(message);
+
+    assert_eq!(json["role"], "user");
+    assert_wire_json_has_exact_file_source(&json, expected_file_id);
+    assert_no_text_file_id_fallback(&json, expected_file_id);
+}
+
+fn assert_wire_json_has_exact_file_source(json: &Value, expected_file_id: &str) {
+    let content = json["content"]
+        .as_array()
+        .unwrap_or_else(|| panic!("expected content array, got {json:#}"));
+    assert!(
+        !content.is_empty(),
+        "expected non-empty content array, got {json:#}"
+    );
+
+    let document_blocks = content
+        .iter()
+        .filter(|block| block["type"] == "document")
+        .collect::<Vec<_>>();
+    assert_eq!(
+        document_blocks.len(),
+        1,
+        "expected exactly one document block, got {json:#}"
+    );
+
+    let document = document_blocks[0]
+        .as_object()
+        .unwrap_or_else(|| panic!("expected document object, got {json:#}"));
+    assert_eq!(
+        document.len(),
+        2,
+        "expected document block to contain only type and source, got {json:#}"
+    );
+    let source = document_blocks[0]["source"]
+        .as_object()
+        .unwrap_or_else(|| panic!("expected document source object, got {json:#}"));
+    assert_eq!(
+        source.len(),
+        2,
+        "expected file source to contain only type and file_id, got {json:#}"
+    );
+    assert_eq!(source["type"], "file");
+    assert_eq!(source["file_id"], expected_file_id);
+}
+
+fn assert_no_text_file_id_fallback(json: &Value, expected_file_id: &str) {
+    let serialized = serde_json::to_string(json).expect("json should serialize");
+    assert!(
+        !serialized.contains("[file_id:"),
+        "file id fallback text marker leaked into Anthropic JSON: {json:#}"
+    );
+
+    let Some(content) = json["content"].as_array() else {
+        return;
+    };
+
+    for block in content {
+        if block["type"] == "text" {
+            let text = block["text"].as_str().unwrap_or_default();
+            assert!(
+                !text.contains(expected_file_id),
+                "file id appeared in a text block instead of document source: {json:#}"
+            );
+        }
+    }
+}
+
+fn assert_no_verifier_leaked_into_prompt(message: &Message) {
+    let Message::User { content } = message else {
+        return;
+    };
+
+    for content in content.iter() {
+        let RigUserContent::Text(Text { text }) = content else {
+            continue;
+        };
+
+        for verifier in PAGE_VERIFIERS {
+            assert!(
+                !text.contains(verifier),
+                "prompt text leaked verifier {verifier}: {text}"
+            );
+        }
+    }
+}
+
+fn assert_verifier_response(response: &str, expected_verifier: &str) {
     assert_nonempty_response(response);
-    assert_contains_all_case_insensitive(response, &["page", &page_number.to_string()]);
+    assert!(
+        response.contains(expected_verifier),
+        "expected response to contain verifier {expected_verifier}, got {response:?}"
+    );
+
+    for verifier in PAGE_VERIFIERS {
+        if verifier != expected_verifier {
+            assert!(
+                !response.contains(verifier),
+                "response included wrong-page verifier {verifier}; response was {response:?}"
+            );
+        }
+    }
+}
+
+fn assert_generic_message_has_file_id(message: &Message, expected_file_id: &str) {
+    assert!(
+        message_contains_file_id(message, expected_file_id),
+        "expected generic message to preserve document file ID {expected_file_id}: {message:?}"
+    );
+}
+
+#[test]
+fn document_file_id_wire_assertions_cover_roundtrip_paths() {
+    let file_id = "file_test";
+
+    let direct_message = direct_file_id_document_question(file_id, 2);
+    assert_no_verifier_leaked_into_prompt(&direct_message);
+    assert_anthropic_wire_file_source(direct_message, file_id);
+
+    let provider_native_content = provider_file_content_as_generic_document(file_id);
+    let provider_native_roundtrip_message = document_question(provider_native_content, 2);
+    assert_no_verifier_leaked_into_prompt(&provider_native_roundtrip_message);
+    assert_generic_message_has_file_id(&provider_native_roundtrip_message, file_id);
+    assert_anthropic_wire_file_source(provider_native_roundtrip_message, file_id);
 }
 
 #[tokio::test]
@@ -253,31 +431,41 @@ async fn messages_document_file_id_roundtrip_live() {
             .build();
         let mut history = Vec::new();
 
-        assert_anthropic_wire_file_source(direct_file_id_document_question(&file_id, 2), &file_id);
+        let direct_message = direct_file_id_document_question(&file_id, 2);
+        assert_no_verifier_leaked_into_prompt(&direct_message);
+        assert_anthropic_wire_file_source(direct_message, &file_id);
 
         let provider_native_content = provider_file_content_as_generic_document(&file_id);
+        let provider_native_roundtrip_message = document_question(provider_native_content, 2);
+        assert_no_verifier_leaked_into_prompt(&provider_native_roundtrip_message);
+        assert_generic_message_has_file_id(&provider_native_roundtrip_message, &file_id);
+        assert_anthropic_wire_file_source(provider_native_roundtrip_message.clone(), &file_id);
+
         let response = agent
-            .chat(document_question(provider_native_content, 2), &mut history)
+            .chat(provider_native_roundtrip_message, &mut history)
             .await
             .expect("Messages API should read uploaded PDF by file_id");
-        assert_page_label(&response, 2);
-        assert_history_contains_file_id(&history, &file_id);
+        assert_verifier_response(&response, PAGE_TWO_VERIFIER);
+        assert_history_preserves_single_file_id(&history, &file_id);
 
         let follow_up = agent
             .chat(
-                "Using the same PDF from the conversation history, what exact visible text appears on page 3? Reply with only that text.",
+                "Using the same PDF from the conversation history, what verifier token is printed on page 3? Reply with only the exact token.",
                 &mut history,
             )
             .await
             .expect("Messages API should reuse file_id document from chat history");
-        assert_page_label(&follow_up, 3);
-        assert_history_contains_file_id(&history, &file_id);
+        assert_verifier_response(&follow_up, PAGE_THREE_VERIFIER);
+        assert_history_preserves_single_file_id(&history, &file_id);
 
+        let direct_prompt = direct_file_id_document_question(&file_id, 1);
+        assert_no_verifier_leaked_into_prompt(&direct_prompt);
+        assert_anthropic_wire_file_source(direct_prompt.clone(), &file_id);
         let direct_response = agent
-            .prompt(direct_file_id_document_question(&file_id, 1))
+            .prompt(direct_prompt)
             .await
             .expect("Messages API should read direct generic file_id document");
-        assert_page_label(&direct_response, 1);
+        assert_verifier_response(&direct_response, PAGE_ONE_VERIFIER);
     })
     .await;
 }
@@ -292,13 +480,15 @@ async fn streaming_document_file_id_roundtrip_live() {
             .preamble(DOCUMENT_PREAMBLE)
             .build();
 
-        let mut stream = agent
-            .stream_prompt(direct_file_id_document_question(&file_id, 2))
-            .await;
+        let stream_prompt = direct_file_id_document_question(&file_id, 2);
+        assert_no_verifier_leaked_into_prompt(&stream_prompt);
+        assert_anthropic_wire_file_source(stream_prompt.clone(), &file_id);
+
+        let mut stream = agent.stream_prompt(stream_prompt).await;
         let response = collect_stream_final_response(&mut stream)
             .await
             .expect("streaming Messages API should read uploaded PDF by file_id");
-        assert_page_label(&response, 2);
+        assert_verifier_response(&response, PAGE_TWO_VERIFIER);
     })
     .await;
 }

--- a/tests/providers/anthropic/mod.rs
+++ b/tests/providers/anthropic/mod.rs
@@ -1,5 +1,6 @@
 mod agent;
 mod default_max_turns;
+mod document_file_id;
 mod empty_end_turn;
 mod image;
 mod models;

--- a/tests/providers/openai/document_file_id.rs
+++ b/tests/providers/openai/document_file_id.rs
@@ -1,0 +1,266 @@
+//! Live OpenAI coverage for provider file IDs in generic document messages.
+//!
+//! Run with:
+//! `cargo test -p rig --test openai openai::document_file_id -- --ignored --nocapture --test-threads=1`
+
+use futures::FutureExt;
+use rig::OneOrMany;
+use rig::client::{CompletionClient, ProviderClient};
+use rig::completion::{Chat, Prompt};
+use rig::message::{
+    Document, DocumentMediaType, DocumentSourceKind, Message, Text, UserContent as RigUserContent,
+};
+use rig::providers::openai::{self, FileData, UserContent as OpenAiUserContent};
+use serde::Deserialize;
+use std::future::Future;
+use std::panic::{AssertUnwindSafe, resume_unwind};
+
+use crate::support::{
+    PDF_FIXTURE_PATH, assert_contains_all_case_insensitive, assert_nonempty_response,
+};
+
+const DOCUMENT_PREAMBLE: &str =
+    "Answer using only the attached PDF. Keep answers short and quote exact visible text.";
+
+#[derive(Debug, Deserialize)]
+struct UploadedFile {
+    id: String,
+}
+
+fn openai_base_url() -> String {
+    std::env::var("OPENAI_BASE_URL").unwrap_or_else(|_| "https://api.openai.com/v1".to_string())
+}
+
+fn openai_api_key() -> String {
+    std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY should be set for this ignored test")
+}
+
+async fn upload_pdf_for_file_id_test() -> UploadedFile {
+    let bytes = tokio::fs::read(PDF_FIXTURE_PATH)
+        .await
+        .expect("fixture PDF should be readable");
+    let file_part = reqwest::multipart::Part::bytes(bytes)
+        .file_name("rig-pages.pdf")
+        .mime_str("application/pdf")
+        .expect("fixture PDF MIME should be valid");
+    let form = reqwest::multipart::Form::new()
+        .text("purpose", "user_data")
+        .text("expires_after[anchor]", "created_at")
+        .text("expires_after[seconds]", "3600")
+        .part("file", file_part);
+
+    let response = reqwest::Client::new()
+        .post(format!("{}/files", openai_base_url()))
+        .bearer_auth(openai_api_key())
+        .multipart(form)
+        .send()
+        .await
+        .expect("file upload request should be sent");
+
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .expect("file upload response body should be readable");
+    assert!(
+        status.is_success(),
+        "file upload failed with {status}: {body}"
+    );
+
+    serde_json::from_str(&body).expect("file upload response should deserialize")
+}
+
+async fn delete_uploaded_file(file_id: &str) {
+    let response = reqwest::Client::new()
+        .delete(format!("{}/files/{file_id}", openai_base_url()))
+        .bearer_auth(openai_api_key())
+        .send()
+        .await;
+
+    if let Ok(response) = response
+        && !response.status().is_success()
+    {
+        eprintln!(
+            "cleanup failed for uploaded OpenAI file {file_id}: {}",
+            response.status()
+        );
+    }
+}
+
+async fn with_uploaded_pdf<F, Fut>(test_body: F)
+where
+    F: FnOnce(String) -> Fut,
+    Fut: Future<Output = ()>,
+{
+    let uploaded = upload_pdf_for_file_id_test().await;
+    let file_id = uploaded.id;
+
+    let result = AssertUnwindSafe(test_body(file_id.clone()))
+        .catch_unwind()
+        .await;
+
+    delete_uploaded_file(&file_id).await;
+
+    if let Err(payload) = result {
+        resume_unwind(payload);
+    }
+}
+
+fn file_id_document(file_id: &str) -> Document {
+    Document {
+        data: DocumentSourceKind::file_id(file_id),
+        media_type: Some(DocumentMediaType::PDF),
+        additional_params: None,
+    }
+}
+
+fn provider_file_content_as_generic_document(file_id: &str) -> RigUserContent {
+    let content = OpenAiUserContent::File {
+        file: FileData {
+            file_data: None,
+            file_id: Some(file_id.to_string()),
+            filename: Some("rig-pages.pdf".to_string()),
+        },
+    };
+    let content: RigUserContent = content.into();
+    assert_file_id_user_content(&content, file_id);
+    content
+}
+
+fn document_question(content: RigUserContent, page_number: u8) -> Message {
+    Message::User {
+        content: OneOrMany::many(vec![
+            content,
+            RigUserContent::Text(Text {
+                text: format!(
+                    "What exact visible text appears on page {page_number}? Reply with only that text."
+                ),
+            }),
+        ])
+        .expect("content should be non-empty"),
+    }
+}
+
+fn direct_file_id_document_question(file_id: &str, page_number: u8) -> Message {
+    document_question(
+        RigUserContent::Document(file_id_document(file_id)),
+        page_number,
+    )
+}
+
+fn assert_file_id_user_content(content: &RigUserContent, expected_file_id: &str) {
+    let RigUserContent::Document(Document { data, .. }) = content else {
+        panic!("expected generic document content, got {content:?}");
+    };
+
+    assert!(
+        matches!(data, DocumentSourceKind::FileId(file_id) if file_id == expected_file_id),
+        "expected file ID document source {expected_file_id}, got {data:?}"
+    );
+}
+
+fn assert_history_contains_file_id(history: &[Message], expected_file_id: &str) {
+    let found = history.iter().any(|message| {
+        let Message::User { content } = message else {
+            return false;
+        };
+
+        content.iter().any(|content| {
+            matches!(
+                content,
+                RigUserContent::Document(Document {
+                    data: DocumentSourceKind::FileId(file_id),
+                    ..
+                }) if file_id == expected_file_id
+            )
+        })
+    });
+
+    assert!(
+        found,
+        "expected chat history to preserve document file ID {expected_file_id}: {history:?}"
+    );
+}
+
+fn assert_page_label(response: &str, page_number: u8) {
+    assert_nonempty_response(response);
+    assert_contains_all_case_insensitive(response, &["page", &page_number.to_string()]);
+}
+
+#[tokio::test]
+#[ignore = "requires OPENAI_API_KEY"]
+async fn responses_document_file_id_roundtrip_live() {
+    with_uploaded_pdf(|file_id| async move {
+        let client = openai::Client::from_env().expect("client should build");
+        let agent = client
+            .agent(openai::GPT_5_5)
+            .preamble(DOCUMENT_PREAMBLE)
+            .build();
+        let mut history = Vec::new();
+
+        let provider_native_content = provider_file_content_as_generic_document(&file_id);
+        let response = agent
+            .chat(document_question(provider_native_content, 2), &mut history)
+            .await
+            .expect("Responses API should read uploaded PDF by file_id");
+        assert_page_label(&response, 2);
+        assert_history_contains_file_id(&history, &file_id);
+
+        let follow_up = agent
+            .chat(
+                "Using the same PDF from the conversation history, what exact visible text appears on page 3? Reply with only that text.",
+                &mut history,
+            )
+            .await
+            .expect("Responses API should reuse file_id document from chat history");
+        assert_page_label(&follow_up, 3);
+        assert_history_contains_file_id(&history, &file_id);
+
+        let direct_response = agent
+            .prompt(direct_file_id_document_question(&file_id, 1))
+            .await
+            .expect("Responses API should read direct generic file_id document");
+        assert_page_label(&direct_response, 1);
+    })
+    .await;
+}
+
+#[tokio::test]
+#[ignore = "requires OPENAI_API_KEY"]
+async fn chat_completions_document_file_id_roundtrip_live() {
+    with_uploaded_pdf(|file_id| async move {
+        let client = openai::Client::from_env()
+            .expect("client should build")
+            .completions_api();
+        let agent = client
+            .agent(openai::GPT_5_5)
+            .preamble(DOCUMENT_PREAMBLE)
+            .build();
+        let mut history = Vec::new();
+
+        let response = agent
+            .chat(direct_file_id_document_question(&file_id, 2), &mut history)
+            .await
+            .expect("Chat Completions API should read uploaded PDF by file_id");
+        assert_page_label(&response, 2);
+        assert_history_contains_file_id(&history, &file_id);
+
+        let follow_up = agent
+            .chat(
+                "Using the same PDF from the conversation history, what exact visible text appears on page 3? Reply with only that text.",
+                &mut history,
+            )
+            .await
+            .expect("Chat Completions API should reuse file_id document from chat history");
+        assert_page_label(&follow_up, 3);
+        assert_history_contains_file_id(&history, &file_id);
+
+        let provider_native_content = provider_file_content_as_generic_document(&file_id);
+        let native_roundtrip_response = agent
+            .prompt(document_question(provider_native_content, 1))
+            .await
+            .expect("Chat Completions API should read provider-native file_id round-tripped through Rig");
+        assert_page_label(&native_roundtrip_response, 1);
+    })
+    .await;
+}

--- a/tests/providers/openai/mod.rs
+++ b/tests/providers/openai/mod.rs
@@ -3,6 +3,7 @@ mod agent;
 mod audio_generation;
 mod chat_history;
 mod completions_api;
+mod document_file_id;
 mod extractor;
 mod extractor_usage;
 mod gpt_5_5;

--- a/tests/providers/openrouter/document_file_data.rs
+++ b/tests/providers/openrouter/document_file_data.rs
@@ -1,0 +1,268 @@
+//! Live OpenRouter coverage for PDF `file_data` document messages.
+//!
+//! Run with:
+//! `cargo test -p rig --test openrouter openrouter::document_file_data -- --ignored --nocapture --test-threads=1`
+
+use base64::{Engine, prelude::BASE64_STANDARD};
+use rig::OneOrMany;
+use rig::client::{CompletionClient, ProviderClient};
+use rig::completion::{Chat, Prompt};
+use rig::message::{
+    Document, DocumentMediaType, DocumentSourceKind, Message as RigMessage, Text,
+    UserContent as RigUserContent,
+};
+use rig::providers::openrouter::{self, Message as OpenRouterMessage};
+use rig::streaming::StreamingPrompt;
+use serde_json::Value;
+
+use crate::support::{assert_nonempty_response, collect_stream_final_response};
+
+const DOCUMENT_MODEL: &str = "google/gemini-2.5-flash";
+const DOCUMENT_PREAMBLE: &str =
+    "Answer using only the attached PDF. Keep answers short and return exact visible tokens.";
+const VERIFIER_FIXTURE_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/data/file-id-verifiers.pdf"
+);
+const PAGE_ONE_VERIFIER: &str = "rig-file-id-page-one-verifier-3a91";
+const PAGE_TWO_VERIFIER: &str = "rig-file-id-page-two-verifier-8c27";
+const PAGE_THREE_VERIFIER: &str = "rig-file-id-page-three-verifier-f54e";
+const PAGE_VERIFIERS: [&str; 3] = [PAGE_ONE_VERIFIER, PAGE_TWO_VERIFIER, PAGE_THREE_VERIFIER];
+
+fn verifier_document() -> Document {
+    let bytes =
+        std::fs::read(VERIFIER_FIXTURE_PATH).expect("verifier fixture PDF should be readable");
+    Document {
+        data: DocumentSourceKind::base64(&BASE64_STANDARD.encode(bytes)),
+        media_type: Some(DocumentMediaType::PDF),
+        additional_params: None,
+    }
+}
+
+fn document_question(page_number: u8) -> RigMessage {
+    RigMessage::User {
+        content: OneOrMany::many(vec![
+            RigUserContent::Document(verifier_document()),
+            RigUserContent::Text(Text {
+                text: format!(
+                    "What verifier token is printed on page {page_number}? Reply with only the exact token."
+                ),
+            }),
+        ])
+        .expect("content should be non-empty"),
+    }
+}
+
+fn message_contains_base64_document(message: &RigMessage) -> bool {
+    let RigMessage::User { content } = message else {
+        return false;
+    };
+
+    content.iter().any(|content| {
+        matches!(
+            content,
+            RigUserContent::Document(Document {
+                data: DocumentSourceKind::Base64(_),
+                media_type: Some(DocumentMediaType::PDF),
+                ..
+            })
+        )
+    })
+}
+
+fn openrouter_wire_messages(message: RigMessage) -> Vec<Value> {
+    let messages: Vec<OpenRouterMessage> = message
+        .try_into()
+        .expect("generic message should convert to OpenRouter messages");
+    messages
+        .into_iter()
+        .map(|message| serde_json::to_value(message).expect("message should serialize"))
+        .collect()
+}
+
+fn assert_openrouter_wire_file_data(message: RigMessage) {
+    let messages = openrouter_wire_messages(message);
+    assert_eq!(messages.len(), 1, "expected one OpenRouter message");
+
+    let json = &messages[0];
+    assert_eq!(json["role"], "user");
+
+    let content = json["content"]
+        .as_array()
+        .unwrap_or_else(|| panic!("expected content array, got {json:#}"));
+    assert!(
+        !content.is_empty(),
+        "expected non-empty content array, got {json:#}"
+    );
+
+    let file_blocks = content
+        .iter()
+        .filter(|block| block["type"] == "file")
+        .collect::<Vec<_>>();
+    assert_eq!(
+        file_blocks.len(),
+        1,
+        "expected exactly one file block, got {json:#}"
+    );
+
+    let file = file_blocks[0]["file"]
+        .as_object()
+        .unwrap_or_else(|| panic!("expected file object, got {json:#}"));
+    assert_eq!(
+        file.get("filename").and_then(Value::as_str),
+        Some("document.pdf")
+    );
+    let file_data = file
+        .get("file_data")
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("expected file_data, got {json:#}"));
+    assert!(
+        file_data.starts_with("data:application/pdf;base64,"),
+        "expected PDF data URI, got {file_data:?}"
+    );
+    assert!(
+        file.get("file_id").is_none(),
+        "OpenRouter wire JSON must not contain provider file IDs: {json:#}"
+    );
+}
+
+fn assert_no_file_id_leaked_into_wire(message: RigMessage) {
+    let messages = openrouter_wire_messages(message);
+    for json in messages {
+        let serialized = serde_json::to_string(&json).expect("json should serialize");
+        assert!(
+            !serialized.contains("file_id"),
+            "provider file ID field leaked into OpenRouter JSON: {json:#}"
+        );
+    }
+}
+
+fn assert_history_preserves_single_file_data_document(history: &[RigMessage]) {
+    let mut document_message_count = 0;
+
+    for message in history {
+        assert_no_file_id_leaked_into_wire(message.clone());
+        if message_contains_base64_document(message) {
+            document_message_count += 1;
+            assert_openrouter_wire_file_data(message.clone());
+        }
+    }
+
+    assert_eq!(
+        document_message_count, 1,
+        "expected exactly one history message to preserve the PDF file_data document: {history:?}"
+    );
+}
+
+fn assert_no_verifier_leaked_into_prompt(message: &RigMessage) {
+    let RigMessage::User { content } = message else {
+        return;
+    };
+
+    for content in content.iter() {
+        let RigUserContent::Text(Text { text }) = content else {
+            continue;
+        };
+
+        for verifier in PAGE_VERIFIERS {
+            assert!(
+                !text.contains(verifier),
+                "prompt text leaked verifier {verifier}: {text}"
+            );
+        }
+    }
+}
+
+fn assert_verifier_response(response: &str, expected_verifier: &str) {
+    assert_nonempty_response(response);
+    let expected_suffix = verifier_suffix(expected_verifier);
+    assert!(
+        response.contains(expected_verifier) || response.contains(expected_suffix),
+        "expected response to contain verifier {expected_verifier} or suffix {expected_suffix}, got {response:?}"
+    );
+
+    for verifier in PAGE_VERIFIERS {
+        if verifier != expected_verifier {
+            let suffix = verifier_suffix(verifier);
+            assert!(
+                !response.contains(verifier) && !response.contains(suffix),
+                "response included wrong-page verifier {verifier} or suffix {suffix}; response was {response:?}"
+            );
+        }
+    }
+}
+
+fn verifier_suffix(verifier: &str) -> &str {
+    verifier
+        .rsplit('-')
+        .next()
+        .expect("verifier should contain a suffix")
+}
+
+#[test]
+fn document_file_data_wire_assertions_cover_pdf_prompt() {
+    let message = document_question(2);
+    assert_no_verifier_leaked_into_prompt(&message);
+    assert_openrouter_wire_file_data(message);
+}
+
+#[tokio::test]
+#[ignore = "requires OPENROUTER_API_KEY"]
+async fn document_file_data_roundtrip_live() {
+    let client = openrouter::Client::from_env().expect("client should build");
+    let agent = client
+        .agent(DOCUMENT_MODEL)
+        .preamble(DOCUMENT_PREAMBLE)
+        .build();
+    let mut history = Vec::new();
+
+    let direct_message = document_question(2);
+    assert_no_verifier_leaked_into_prompt(&direct_message);
+    assert_openrouter_wire_file_data(direct_message.clone());
+
+    let response = agent
+        .chat(direct_message, &mut history)
+        .await
+        .expect("OpenRouter should read PDF file_data document");
+    assert_verifier_response(&response, PAGE_TWO_VERIFIER);
+    assert_history_preserves_single_file_data_document(&history);
+
+    let follow_up = agent
+        .chat(
+            "Using the same PDF from the conversation history, what verifier token is printed on page 3? Reply with only the exact token.",
+            &mut history,
+        )
+        .await
+        .expect("OpenRouter should reuse PDF file_data document from chat history");
+    assert_verifier_response(&follow_up, PAGE_THREE_VERIFIER);
+    assert_history_preserves_single_file_data_document(&history);
+
+    let direct_prompt = document_question(1);
+    assert_no_verifier_leaked_into_prompt(&direct_prompt);
+    assert_openrouter_wire_file_data(direct_prompt.clone());
+    let direct_response = agent
+        .prompt(direct_prompt)
+        .await
+        .expect("OpenRouter should read direct generic PDF file_data document");
+    assert_verifier_response(&direct_response, PAGE_ONE_VERIFIER);
+}
+
+#[tokio::test]
+#[ignore = "requires OPENROUTER_API_KEY"]
+async fn streaming_document_file_data_roundtrip_live() {
+    let client = openrouter::Client::from_env().expect("client should build");
+    let agent = client
+        .agent(DOCUMENT_MODEL)
+        .preamble(DOCUMENT_PREAMBLE)
+        .build();
+
+    let stream_prompt = document_question(2);
+    assert_no_verifier_leaked_into_prompt(&stream_prompt);
+    assert_openrouter_wire_file_data(stream_prompt.clone());
+
+    let mut stream = agent.stream_prompt(stream_prompt).await;
+    let response = collect_stream_final_response(&mut stream)
+        .await
+        .expect("OpenRouter streaming should read PDF file_data document");
+    assert_verifier_response(&response, PAGE_TWO_VERIFIER);
+}

--- a/tests/providers/openrouter/file_id.rs
+++ b/tests/providers/openrouter/file_id.rs
@@ -1,0 +1,71 @@
+use rig::OneOrMany;
+use rig::message::{Document, DocumentSourceKind, Message, UserContent as RigUserContent};
+use rig::providers::openai::{FileData as OpenAiFileData, UserContent as OpenAiUserContent};
+use rig::providers::openrouter::{
+    Message as OpenRouterMessage, UserContent as OpenRouterUserContent,
+};
+
+#[test]
+fn generic_document_file_id_fails_openrouter_message_conversion() {
+    let message = Message::User {
+        content: OneOrMany::one(RigUserContent::Document(Document {
+            data: DocumentSourceKind::file_id("file_abc"),
+            media_type: None,
+            additional_params: None,
+        })),
+    };
+
+    let result: Result<Vec<OpenRouterMessage>, _> = message.try_into();
+
+    assert!(result.is_err());
+    let error = result.unwrap_err().to_string();
+    assert!(
+        error.contains("Provider file IDs are not supported for OpenRouter document inputs"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn openai_file_data_converts_to_openrouter_file_data() {
+    let openai_content = OpenAiUserContent::File {
+        file: OpenAiFileData {
+            file_data: Some("data:application/pdf;base64,AAAA".to_string()),
+            file_id: Some("file_abc".to_string()),
+            filename: Some("document.pdf".to_string()),
+        },
+    };
+
+    let converted: OpenRouterUserContent = openai_content.try_into().unwrap();
+    let json = serde_json::to_value(&converted).unwrap();
+
+    assert_eq!(json["type"], "file");
+    assert_eq!(json["file"]["filename"], "document.pdf");
+    assert_eq!(
+        json["file"]["file_data"],
+        "data:application/pdf;base64,AAAA"
+    );
+    assert!(
+        json["file"].get("file_id").is_none(),
+        "OpenRouter payload should not include provider file IDs: {json}"
+    );
+}
+
+#[test]
+fn openai_file_id_only_fails_openrouter_user_content_conversion() {
+    let openai_content = OpenAiUserContent::File {
+        file: OpenAiFileData {
+            file_data: None,
+            file_id: Some("file_abc".to_string()),
+            filename: Some("document.pdf".to_string()),
+        },
+    };
+
+    let result: Result<OpenRouterUserContent, _> = openai_content.try_into();
+
+    assert!(result.is_err());
+    let error = result.unwrap_err().to_string();
+    assert!(
+        error.contains("provider file IDs are not supported"),
+        "unexpected error: {error}"
+    );
+}

--- a/tests/providers/openrouter/mod.rs
+++ b/tests/providers/openrouter/mod.rs
@@ -1,6 +1,8 @@
 mod agent;
+mod document_file_data;
 mod extractor;
 mod extractor_usage;
+mod file_id;
 mod models;
 mod multi_extract;
 mod multimodal;


### PR DESCRIPTION
## Summary

- Add `DocumentSourceKind::FileId` so generic document messages can preserve provider-side uploaded file references.
- Wire file ID document inputs through Anthropic and OpenAI chat/responses conversions.
- Return explicit unsupported errors for providers that cannot consume provider file IDs.
- Update OpenRouter PDF handling to use `file_data` only, and add fixture/live coverage for document file inputs.

## Testing

- `cargo fmt --check`
- `cargo check --workspace --all-targets --all-features`
- `cargo test -p rig-core file_id --lib`
- `cargo test -p rig --test openrouter file_id`
- `cargo test -p rig --test anthropic document_file_id_wire_assertions_cover_roundtrip_paths`
- `cargo test -p rig --test openrouter document_file_data_wire_assertions_cover_pdf_prompt`

Ignored live provider tests were added but require API keys to run.
