### PR TITLE
fix(openai): tolerate OpenRouter service_tier values 

### DIFF
--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -28,7 +28,7 @@ use crate::one_or_many::string_or_one_or_many;
 
 use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
 use crate::{OneOrMany, completion, message};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::{Map, Value};
 use tracing::{Instrument, Level, enabled, info_span};
 
@@ -1181,13 +1181,54 @@ impl Reasoning {
 }
 
 /// The billing service tier that will be used. On auto by default.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[derive(Clone, Debug, Default)]
 pub enum OpenAIServiceTier {
+    /// Let OpenAI choose the service tier.
     #[default]
     Auto,
+    /// Use the default service tier.
     Default,
+    /// Use the flex service tier.
     Flex,
+    /// Use the priority service tier.
+    Priority,
+    /// Use the standard service tier returned by OpenAI-compatible providers.
+    Standard,
+    /// Preserve an unknown provider-specific service tier.
+    Other(String),
+}
+
+impl Serialize for OpenAIServiceTier {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(match self {
+            Self::Auto => "auto",
+            Self::Default => "default",
+            Self::Flex => "flex",
+            Self::Priority => "priority",
+            Self::Standard => "standard",
+            Self::Other(value) => value,
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for OpenAIServiceTier {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Ok(match value.as_str() {
+            "auto" => Self::Auto,
+            "default" => Self::Default,
+            "flex" => Self::Flex,
+            "priority" => Self::Priority,
+            "standard" => Self::Standard,
+            _ => Self::Other(value),
+        })
+    }
 }
 
 /// The amount of reasoning effort that will be used by a given model.
@@ -1894,6 +1935,84 @@ impl FromStr for UserContent {
 mod tests {
     use super::*;
     use crate::message;
+    use serde_json::json;
+
+    fn response_with_service_tier(service_tier: &str) -> Value {
+        json!({
+            "id": "resp_123",
+            "object": "response",
+            "created_at": 0,
+            "status": "completed",
+            "model": "gpt-5.4",
+            "output": [],
+            "service_tier": service_tier,
+        })
+    }
+
+    #[test]
+    fn completion_response_deserializes_standard_service_tier() {
+        let response: CompletionResponse =
+            serde_json::from_value(response_with_service_tier("standard"))
+                .expect("response should deserialize");
+
+        assert!(matches!(
+            response.additional_parameters.service_tier,
+            Some(OpenAIServiceTier::Standard)
+        ));
+    }
+
+    #[test]
+    fn completion_response_deserializes_priority_service_tier() {
+        let response: CompletionResponse =
+            serde_json::from_value(response_with_service_tier("priority"))
+                .expect("response should deserialize");
+
+        assert!(matches!(
+            response.additional_parameters.service_tier,
+            Some(OpenAIServiceTier::Priority)
+        ));
+    }
+
+    #[test]
+    fn completion_response_preserves_unknown_service_tier() {
+        let response: CompletionResponse =
+            serde_json::from_value(response_with_service_tier("provider_experimental"))
+                .expect("response should deserialize");
+
+        let Some(OpenAIServiceTier::Other(service_tier)) =
+            response.additional_parameters.service_tier
+        else {
+            panic!("expected provider-specific service tier");
+        };
+
+        assert_eq!(service_tier, "provider_experimental");
+    }
+
+    #[test]
+    fn service_tier_serializes_expected_strings() {
+        let cases = [
+            (OpenAIServiceTier::Auto, "auto"),
+            (OpenAIServiceTier::Default, "default"),
+            (OpenAIServiceTier::Flex, "flex"),
+            (OpenAIServiceTier::Priority, "priority"),
+            (OpenAIServiceTier::Standard, "standard"),
+        ];
+
+        for (service_tier, expected) in cases {
+            assert_eq!(
+                serde_json::to_value(service_tier).expect("service tier should serialize"),
+                json!(expected)
+            );
+        }
+
+        assert_eq!(
+            serde_json::to_value(OpenAIServiceTier::Other(
+                "provider_experimental".to_string()
+            ))
+            .expect("provider-specific service tier should serialize"),
+            json!("provider_experimental")
+        );
+    }
 
     #[test]
     fn file_id_document_serializes_as_input_file_content() {

--- a/tests/providers/openrouter/mod.rs
+++ b/tests/providers/openrouter/mod.rs
@@ -6,6 +6,7 @@ mod file_id;
 mod models;
 mod multi_extract;
 mod multimodal;
+mod openai_responses_compat;
 mod permission_control;
 mod provider_selection;
 mod reasoning_roundtrip;

--- a/tests/providers/openrouter/openai_responses_compat.rs
+++ b/tests/providers/openrouter/openai_responses_compat.rs
@@ -1,0 +1,94 @@
+//! OpenRouter compatibility coverage through Rig's OpenAI Responses provider.
+//!
+//! These tests exercise the issue #1729 path:
+//! `openai::Client::builder().base_url("https://openrouter.ai/api/v1")`.
+//!
+//! `cargo test -p rig --test openrouter openrouter::openai_responses_compat -- --ignored --nocapture`
+
+use rig::client::CompletionClient;
+use rig::completion::{CompletionModel, Prompt};
+use rig::providers::openai;
+use rig::providers::openai::responses_api::OpenAIServiceTier;
+use rig::streaming::StreamingPrompt;
+
+use crate::support::{assert_nonempty_response, collect_stream_final_response};
+
+const OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api/v1";
+const DEFAULT_OPENAI_COMPAT_MODEL: &str = "google/gemini-3-flash-preview";
+const OPENAI_COMPAT_MODEL_ENV: &str = "OPENROUTER_OPENAI_COMPAT_MODEL";
+
+fn openrouter_api_key() -> String {
+    std::env::var("OPENROUTER_API_KEY").expect("OPENROUTER_API_KEY must be set")
+}
+
+fn openai_compatible_model() -> String {
+    std::env::var(OPENAI_COMPAT_MODEL_ENV)
+        .unwrap_or_else(|_| DEFAULT_OPENAI_COMPAT_MODEL.to_string())
+}
+
+fn openrouter_openai_client() -> openai::Client {
+    openai::Client::builder()
+        .api_key(openrouter_api_key())
+        .base_url(OPENROUTER_BASE_URL)
+        .build()
+        .expect("OpenRouter OpenAI-compatible client should build")
+}
+
+#[tokio::test]
+#[ignore = "requires OPENROUTER_API_KEY and an OpenRouter model that returns service_tier=standard"]
+async fn openai_responses_raw_response_accepts_standard_service_tier() {
+    let model_name = openai_compatible_model();
+    let response = openrouter_openai_client()
+        .completion_model(&model_name)
+        .completion_request("Reply with exactly: openrouter responses service tier ok")
+        .preamble("Return the requested text exactly, with no extra commentary.".to_string())
+        .send()
+        .await
+        .expect("OpenRouter Responses API completion should deserialize");
+
+    let service_tier = response
+        .raw_response
+        .additional_parameters
+        .service_tier
+        .as_ref()
+        .expect("OpenRouter response should include service_tier");
+
+    assert!(
+        matches!(service_tier, OpenAIServiceTier::Standard),
+        "expected OpenRouter model {model_name} to return service_tier=standard, got {service_tier:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires OPENROUTER_API_KEY"]
+async fn openai_responses_agent_prompt_against_openrouter_completes() {
+    let agent = openrouter_openai_client()
+        .agent(openai_compatible_model())
+        .preamble("You are concise. Answer with one short sentence.")
+        .build();
+
+    let response = agent
+        .prompt("Say that OpenRouter via the OpenAI Responses provider works.")
+        .await
+        .expect("agent.prompt should not fail on OpenRouter service_tier metadata");
+
+    assert_nonempty_response(&response);
+}
+
+#[tokio::test]
+#[ignore = "requires OPENROUTER_API_KEY"]
+async fn openai_responses_stream_against_openrouter_completes() {
+    let agent = openrouter_openai_client()
+        .agent(openai_compatible_model())
+        .preamble("You are concise. Answer directly.")
+        .build();
+
+    let mut stream = agent
+        .stream_prompt("In one sentence, confirm this streaming response works.")
+        .await;
+    let response = collect_stream_final_response(&mut stream)
+        .await
+        .expect("streaming prompt should not fail on OpenRouter service_tier metadata");
+
+    assert_nonempty_response(&response);
+}


### PR DESCRIPTION
## Summary

Closes #1729.

- Accept `service_tier: "standard"` in OpenAI Responses API payloads, which OpenRouter now returns for some OpenAI-compatible model responses.
- Add support for OpenAI’s `priority` service tier.
- Preserve future or provider-specific service tier strings with `OpenAIServiceTier::Other(String)` instead of failing response deserialization.
- Add focused unit coverage for known and unknown service tier values.
- Add ignored live OpenRouter tests that exercise the reported `openai::Client` + OpenRouter `base_url` path.

## Testing

- `cargo fmt`
- `cargo test -p rig-core openai::responses_api`
- `cargo test -p rig-core --lib`
- `cargo clippy -p rig-core --all-targets --all-features`
- `cargo test -p rig --test openrouter openai_responses_compat`
- `cargo test -p rig --test openrouter`
