### PR TITLE
Fix OpenAI Responses instructions handling 

### DIFF
--- a/crates/rig-core/src/agent/completion.rs
+++ b/crates/rig-core/src/agent/completion.rs
@@ -48,23 +48,18 @@ pub(crate) async fn build_completion_request<M: CompletionModel>(
             .find_map(|message| message.rag_text())
     });
 
-    // Prepend preamble as system message if present
-    let chat_history: Vec<Message> = if let Some(preamble) = preamble {
-        std::iter::once(Message::system(preamble.to_owned()))
-            .chain(chat_history.iter().cloned())
-            .collect()
-    } else {
-        chat_history.to_vec()
-    };
-
-    let completion_request = model
+    let mut completion_request = model
         .completion_request(prompt)
-        .messages(chat_history)
+        .messages(chat_history.iter().cloned())
         .temperature_opt(temperature)
         .max_tokens_opt(max_tokens)
         .additional_params_opt(additional_params.cloned())
         .output_schema_opt(output_schema.cloned())
         .documents(static_context.to_vec());
+
+    if let Some(preamble) = preamble {
+        completion_request = completion_request.preamble(preamble.to_owned());
+    }
 
     let completion_request = if let Some(tool_choice) = tool_choice {
         completion_request.tool_choice(tool_choice.clone())

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -496,10 +496,7 @@ pub trait CompletionModel: Clone + WasmCompatSend + WasmCompatSync {
 pub struct CompletionRequest {
     /// Optional model override for this request.
     pub model: Option<String>,
-    /// Legacy preamble field preserved for backwards compatibility.
-    ///
-    /// New code should prefer a leading [`Message::System`]
-    /// in `chat_history` as the canonical representation of system instructions.
+    /// Optional system instructions for this request.
     pub preamble: Option<String>,
     /// The chat history to be sent to the completion model provider.
     /// The very last message will always be the prompt (hence why there is *always* one)
@@ -698,7 +695,6 @@ impl<M: CompletionModel> CompletionRequestBuilder<M> {
 
     /// Sets the preamble for the completion request.
     pub fn preamble(mut self, preamble: String) -> Self {
-        // Legacy public API: funnel preamble into canonical system messages at build-time.
         self.preamble = Some(preamble);
         self
     }
@@ -855,12 +851,8 @@ impl<M: CompletionModel> CompletionRequestBuilder<M> {
 
     /// Builds the completion request.
     pub fn build(self) -> CompletionRequest {
-        // Build the final message list, prepending preamble if present
         let mut chat_history = self.chat_history;
         let prompt = self.prompt;
-        if let Some(preamble) = self.preamble {
-            chat_history.insert(0, Message::system(preamble));
-        }
         chat_history.push(prompt.clone());
 
         let chat_history =
@@ -872,7 +864,7 @@ impl<M: CompletionModel> CompletionRequestBuilder<M> {
 
         CompletionRequest {
             model: self.request_model,
-            preamble: None,
+            preamble: self.preamble,
             chat_history,
             documents: self.documents,
             tools: self.tools,
@@ -1005,27 +997,23 @@ mod tests {
     }
 
     #[test]
-    fn preamble_builder_funnels_to_system_message() {
+    fn preamble_builder_preserves_request_preamble() {
         let request =
             CompletionRequestBuilder::new(MockCompletionModel::default(), Message::user("Prompt"))
                 .preamble("System prompt".to_string())
                 .message(Message::user("History"))
                 .build();
 
-        assert_eq!(request.preamble, None);
+        assert_eq!(request.preamble.as_deref(), Some("System prompt"));
 
         let history = request.chat_history.into_iter().collect::<Vec<_>>();
-        assert_eq!(history.len(), 3);
-        assert!(matches!(
-            &history[0],
-            Message::System { content } if content == "System prompt"
-        ));
+        assert_eq!(history.len(), 2);
+        assert!(matches!(&history[0], Message::User { .. }));
         assert!(matches!(&history[1], Message::User { .. }));
-        assert!(matches!(&history[2], Message::User { .. }));
     }
 
     #[test]
-    fn without_preamble_removes_legacy_preamble_injection() {
+    fn without_preamble_removes_request_preamble() {
         let request =
             CompletionRequestBuilder::new(MockCompletionModel::default(), Message::user("Prompt"))
                 .preamble("System prompt".to_string())

--- a/crates/rig-core/src/providers/chatgpt/mod.rs
+++ b/crates/rig-core/src/providers/chatgpt/mod.rs
@@ -158,6 +158,8 @@ impl Provider for ChatGPTExt {
     }
 }
 
+impl responses_api::ResponsesProviderProfile for ChatGPTExt {}
+
 impl<H> Capabilities<H> for ChatGPTExt {
     type Completion = Capable<ResponsesCompletionModel<H>>;
     type Embeddings = Nothing;

--- a/crates/rig-core/src/providers/chatgpt/mod.rs
+++ b/crates/rig-core/src/providers/chatgpt/mod.rs
@@ -739,7 +739,41 @@ data: [DONE]"#;
             .expect("normalize")
             .expect("instructions");
 
-        assert_eq!(instructions, "System one\n\nSystem two");
+        assert_eq!(instructions, "System two");
+        assert_eq!(request.input.len(), 1);
+    }
+
+    #[test]
+    fn test_create_request_lifts_chat_history_system_messages_into_instructions() {
+        let client = crate::providers::chatgpt::Client::builder()
+            .oauth()
+            .build()
+            .expect("client");
+        let model = ResponsesCompletionModel::new(client, GPT_5_3_CODEX);
+
+        let request = model
+            .create_request(completion::CompletionRequest {
+                model: Some("gpt-5.4".to_string()),
+                preamble: Some("System one".to_string()),
+                chat_history: OneOrMany::many(vec![
+                    completion::Message::system("System two"),
+                    completion::Message::user("hi"),
+                ])
+                .expect("history"),
+                documents: Vec::new(),
+                tools: Vec::new(),
+                temperature: None,
+                max_tokens: None,
+                tool_choice: None,
+                additional_params: None,
+                output_schema: None,
+            })
+            .expect("request");
+
+        let instructions = request.instructions.expect("instructions");
+        assert!(instructions.contains(DEFAULT_INSTRUCTIONS));
+        assert!(instructions.contains("System two"));
+        assert!(instructions.contains("System one"));
         assert_eq!(request.input.len(), 1);
     }
 

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -683,7 +683,9 @@ where
         &self,
         completion_request: completion::CompletionRequest,
     ) -> Result<ResponsesRequest, CompletionError> {
-        ResponsesRequest::try_from((self.model.clone(), completion_request))
+        responses_api::GenericResponsesCompletionModel::new(self.client.clone(), self.model.clone())
+            .with_preamble_as_input_system_message()
+            .create_completion_request(completion_request)
     }
 
     async fn completion_chat(
@@ -1743,7 +1745,10 @@ mod tests {
             .build()
             .expect("build client");
         let model = client.completion_model("gpt-5.3-codex");
-        let request = model.completion_request("hello").build();
+        let request = model
+            .completion_request("hello")
+            .preamble("Follow Copilot compatibility.".to_string())
+            .build();
 
         let _response = model
             .completion(request)
@@ -1753,7 +1758,15 @@ mod tests {
         let requests = http_client.requests();
         assert_eq!(requests.len(), 1);
         assert!(requests[0].uri.ends_with("/responses"));
-        assert!(String::from_utf8_lossy(&requests[0].body).contains("\"model\":\"gpt-5.3-codex\""));
+        let request_json: serde_json::Value =
+            serde_json::from_slice(&requests[0].body).expect("request json");
+        assert_eq!(request_json["model"], "gpt-5.3-codex");
+        assert!(request_json.get("instructions").is_none());
+        assert_eq!(request_json["input"][0]["role"], "system");
+        assert_eq!(
+            request_json["input"][0]["content"][0]["text"],
+            "Follow Copilot compatibility."
+        );
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -172,8 +172,9 @@ impl Provider for CopilotExt {
 }
 
 impl responses_api::ResponsesProviderProfile for CopilotExt {
-    const PREAMBLE_BEHAVIOR: responses_api::ResponsesPreambleBehavior =
-        responses_api::ResponsesPreambleBehavior::InputSystemMessage;
+    fn responses_preamble_behavior(&self) -> responses_api::ResponsesPreambleBehavior {
+        responses_api::ResponsesPreambleBehavior::InputSystemMessage
+    }
 }
 
 impl<H> Capabilities<H> for CopilotExt {

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -171,6 +171,11 @@ impl Provider for CopilotExt {
     const VERIFY_PATH: &'static str = "";
 }
 
+impl responses_api::ResponsesProviderProfile for CopilotExt {
+    const PREAMBLE_BEHAVIOR: responses_api::ResponsesPreambleBehavior =
+        responses_api::ResponsesPreambleBehavior::InputSystemMessage;
+}
+
 impl<H> Capabilities<H> for CopilotExt {
     type Completion = Capable<CompletionModel<H>>;
     type Embeddings = Capable<EmbeddingModel<H>>;
@@ -684,7 +689,6 @@ where
         completion_request: completion::CompletionRequest,
     ) -> Result<ResponsesRequest, CompletionError> {
         responses_api::GenericResponsesCompletionModel::new(self.client.clone(), self.model.clone())
-            .with_preamble_as_input_system_message()
             .create_completion_request(completion_request)
     }
 

--- a/crates/rig-core/src/providers/groq.rs
+++ b/crates/rig-core/src/providers/groq.rs
@@ -750,12 +750,15 @@ mod tests {
             tool_choice: None,
             stream_options: None,
             tools: Vec::new(),
-            messages: vec![Message::User {
-                content: OneOrMany::one(UserContent::Text {
-                    text: "Hello world!".to_string(),
-                }),
-                name: None,
-            }],
+            messages: vec![
+                Message::system("You are concise."),
+                Message::User {
+                    content: OneOrMany::one(UserContent::Text {
+                        text: "Hello world!".to_string(),
+                    }),
+                    name: None,
+                },
+            ],
             stream: false,
             additional_params: Some(additional_params),
         };
@@ -767,6 +770,10 @@ mod tests {
             serde_json::json!({
                 "model": "openai/gpt-120b-oss",
                 "messages": [
+                    {
+                        "role": "system",
+                        "content": "You are concise."
+                    },
                     {
                         "role": "user",
                         "content": "Hello world!"

--- a/crates/rig-core/src/providers/openai/client.rs
+++ b/crates/rig-core/src/providers/openai/client.rs
@@ -21,10 +21,14 @@ const OPENAI_API_BASE_URL: &str = "https://api.openai.com/v1";
 // OpenAI Responses API Extension
 // ================================================================
 #[derive(Debug, Default, Clone, Copy)]
-pub struct OpenAIResponsesExt;
+pub struct OpenAIResponsesExt {
+    responses_preamble_behavior: super::responses_api::ResponsesPreambleBehavior,
+}
 
 #[derive(Debug, Default, Clone, Copy)]
-pub struct OpenAIResponsesExtBuilder;
+pub struct OpenAIResponsesExtBuilder {
+    responses_preamble_behavior: super::responses_api::ResponsesPreambleBehavior,
+}
 
 // ================================================================
 // OpenAI Completions API Extension
@@ -47,12 +51,33 @@ pub type CompletionsClient<H = reqwest::Client> = client::Client<OpenAICompletio
 pub type CompletionsClientBuilder<H = crate::markers::Missing> =
     client::ClientBuilder<OpenAICompletionsExtBuilder, OpenAIApiKey, H>;
 
+impl<ApiKey, H> client::ClientBuilder<OpenAIResponsesExtBuilder, ApiKey, H> {
+    /// Set how OpenAI Responses requests map Rig preambles.
+    ///
+    /// The default is [`super::responses_api::ResponsesPreambleBehavior::Instructions`],
+    /// which matches OpenAI's official Responses API. Use
+    /// [`super::responses_api::ResponsesPreambleBehavior::InputSystemMessage`] only
+    /// when targeting an OpenAI-compatible backend that rejects top-level
+    /// `instructions`.
+    pub fn responses_preamble_behavior(
+        mut self,
+        behavior: super::responses_api::ResponsesPreambleBehavior,
+    ) -> Self {
+        self.ext_mut().responses_preamble_behavior = behavior;
+        self
+    }
+}
+
 impl Provider for OpenAIResponsesExt {
     type Builder = OpenAIResponsesExtBuilder;
     const VERIFY_PATH: &'static str = "/models";
 }
 
-impl super::responses_api::ResponsesProviderProfile for OpenAIResponsesExt {}
+impl super::responses_api::ResponsesProviderProfile for OpenAIResponsesExt {
+    fn responses_preamble_behavior(&self) -> super::responses_api::ResponsesPreambleBehavior {
+        self.responses_preamble_behavior
+    }
+}
 
 impl Provider for OpenAICompletionsExt {
     type Builder = OpenAICompletionsExtBuilder;
@@ -95,12 +120,14 @@ impl ProviderBuilder for OpenAIResponsesExtBuilder {
     const BASE_URL: &'static str = OPENAI_API_BASE_URL;
 
     fn build<H>(
-        _builder: &client::ClientBuilder<Self, Self::ApiKey, H>,
+        builder: &client::ClientBuilder<Self, Self::ApiKey, H>,
     ) -> http_client::Result<Self::Extension<H>>
     where
         H: HttpClientExt,
     {
-        Ok(OpenAIResponsesExt)
+        Ok(OpenAIResponsesExt {
+            responses_preamble_behavior: builder.ext().responses_preamble_behavior,
+        })
     }
 }
 
@@ -203,7 +230,7 @@ where
     /// Create a Responses API client from this Completions API client.
     /// Useful for switching to the newer Responses API.
     pub fn responses_api(self) -> Client<H> {
-        self.with_ext(OpenAIResponsesExt)
+        self.with_ext(OpenAIResponsesExt::default())
     }
 }
 
@@ -268,7 +295,9 @@ pub(crate) enum ApiResponse<T> {
 #[cfg(test)]
 mod tests {
     use crate::client::{CompletionClient, EmbeddingsClient};
+    use crate::completion;
     use crate::message::ImageDetail;
+    use crate::providers::openai::responses_api::ResponsesProviderProfile;
     use crate::providers::openai::{
         AssistantContent, Function, ImageUrl, Message, ToolCall, ToolType, UserContent,
     };
@@ -628,6 +657,47 @@ mod tests {
             .api_key("dummy-key")
             .build()
             .expect("Client::builder() failed");
+    }
+
+    #[test]
+    fn test_responses_preamble_behavior_builder_sets_compat_mode() {
+        let client = crate::providers::openai::Client::builder()
+            .api_key("dummy-key")
+            .base_url("https://some-provider.example/v1")
+            .responses_preamble_behavior(
+                crate::providers::openai::ResponsesPreambleBehavior::InputSystemMessage,
+            )
+            .build()
+            .expect("Client::builder() failed");
+
+        assert_eq!(
+            client.ext().responses_preamble_behavior(),
+            crate::providers::openai::ResponsesPreambleBehavior::InputSystemMessage
+        );
+
+        let model = client.completion_model("compatible-model");
+        let request = model
+            .create_completion_request(completion::CompletionRequest {
+                model: None,
+                preamble: Some("Use compatible system input.".to_string()),
+                chat_history: OneOrMany::one(completion::Message::user("hello")),
+                documents: Vec::new(),
+                tools: Vec::new(),
+                temperature: None,
+                max_tokens: None,
+                tool_choice: None,
+                additional_params: None,
+                output_schema: None,
+            })
+            .expect("request");
+
+        assert_eq!(request.instructions, None);
+        let input = serde_json::to_value(&request.input).expect("input");
+        assert_eq!(input[0]["role"], "system");
+        assert_eq!(
+            input[0]["content"][0]["text"],
+            "Use compatible system input."
+        );
     }
 
     #[test]

--- a/crates/rig-core/src/providers/openai/client.rs
+++ b/crates/rig-core/src/providers/openai/client.rs
@@ -34,7 +34,9 @@ pub struct OpenAIResponsesExtBuilder {
 // OpenAI Completions API Extension
 // ================================================================
 #[derive(Debug, Default, Clone, Copy)]
-pub struct OpenAICompletionsExt;
+pub struct OpenAICompletionsExt {
+    responses_preamble_behavior: super::responses_api::ResponsesPreambleBehavior,
+}
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct OpenAICompletionsExtBuilder;
@@ -146,7 +148,7 @@ impl ProviderBuilder for OpenAICompletionsExtBuilder {
     where
         H: HttpClientExt,
     {
-        Ok(OpenAICompletionsExt)
+        Ok(OpenAICompletionsExt::default())
     }
 }
 
@@ -175,7 +177,10 @@ where
     /// Create a Completions API client from this Responses API client.
     /// Useful for switching to the traditional Chat Completions API.
     pub fn completions_api(self) -> CompletionsClient<H> {
-        self.with_ext(OpenAICompletionsExt)
+        let responses_preamble_behavior = self.ext().responses_preamble_behavior;
+        self.with_ext(OpenAICompletionsExt {
+            responses_preamble_behavior,
+        })
     }
 }
 
@@ -230,7 +235,10 @@ where
     /// Create a Responses API client from this Completions API client.
     /// Useful for switching to the newer Responses API.
     pub fn responses_api(self) -> Client<H> {
-        self.with_ext(OpenAIResponsesExt::default())
+        let responses_preamble_behavior = self.ext().responses_preamble_behavior;
+        self.with_ext(OpenAIResponsesExt {
+            responses_preamble_behavior,
+        })
     }
 }
 
@@ -698,6 +706,26 @@ mod tests {
             input[0]["content"][0]["text"],
             "Use compatible system input."
         );
+    }
+
+    #[test]
+    fn test_responses_preamble_behavior_survives_completions_round_trip() {
+        let client = crate::providers::openai::Client::builder()
+            .api_key("dummy-key")
+            .base_url("https://some-provider.example/v1")
+            .responses_preamble_behavior(
+                crate::providers::openai::ResponsesPreambleBehavior::InputSystemMessage,
+            )
+            .build()
+            .expect("Client::builder() failed");
+
+        let client = client.completions_api().responses_api();
+
+        assert_eq!(
+            client.ext().responses_preamble_behavior(),
+            crate::providers::openai::ResponsesPreambleBehavior::InputSystemMessage
+        );
+        assert_eq!(client.base_url(), "https://some-provider.example/v1");
     }
 
     #[test]

--- a/crates/rig-core/src/providers/openai/client.rs
+++ b/crates/rig-core/src/providers/openai/client.rs
@@ -52,6 +52,8 @@ impl Provider for OpenAIResponsesExt {
     const VERIFY_PATH: &'static str = "/models";
 }
 
+impl super::responses_api::ResponsesProviderProfile for OpenAIResponsesExt {}
+
 impl Provider for OpenAICompletionsExt {
     type Builder = OpenAICompletionsExtBuilder;
     const VERIFY_PATH: &'static str = "/models";

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -41,6 +41,20 @@ where
     content.serialize(serializer)
 }
 
+/// Serializes system content as a plain string when there's a single text item.
+fn serialize_system_content<S>(
+    content: &OneOrMany<SystemContent>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    if content.len() == 1 {
+        return serializer.serialize_str(&content.first_ref().text);
+    }
+    content.serialize(serializer)
+}
+
 /// `gpt-5.5` completion model
 pub const GPT_5_5: &str = "gpt-5.5";
 
@@ -137,7 +151,10 @@ impl From<ApiErrorResponse> for CompletionError {
 pub enum Message {
     #[serde(alias = "developer")]
     System {
-        #[serde(deserialize_with = "string_or_one_or_many")]
+        #[serde(
+            deserialize_with = "string_or_one_or_many",
+            serialize_with = "serialize_system_content"
+        )]
         content: OneOrMany<SystemContent>,
         #[serde(skip_serializing_if = "Option::is_none")]
         name: Option<String>,

--- a/crates/rig-core/src/providers/openai/mod.rs
+++ b/crates/rig-core/src/providers/openai/mod.rs
@@ -33,6 +33,7 @@ pub use client::*;
 pub use completion::*;
 pub use embedding::*;
 pub use model_listing::*;
+pub use responses_api::ResponsesPreambleBehavior;
 
 /// Recursively ensures all object schemas in a JSON schema respect OpenAI structured output restrictions.
 /// Nested arrays, schema $defs, object properties and enums should be handled through this method

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -113,12 +113,13 @@ impl CompletionRequest {
 #[doc(hidden)]
 pub trait ResponsesProviderProfile {
     /// Controls how Rig maps [`crate::completion::CompletionRequest::preamble`].
-    const PREAMBLE_BEHAVIOR: ResponsesPreambleBehavior = ResponsesPreambleBehavior::Instructions;
+    fn responses_preamble_behavior(&self) -> ResponsesPreambleBehavior {
+        ResponsesPreambleBehavior::Instructions
+    }
 }
 
 /// Controls how Rig maps [`crate::completion::CompletionRequest::preamble`] into
 /// an OpenAI Responses request.
-#[doc(hidden)]
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum ResponsesPreambleBehavior {
     /// Use OpenAI's canonical top-level `instructions` field.
@@ -994,20 +995,22 @@ where
 {
     /// Creates a new [`ResponsesCompletionModel`].
     pub fn new(client: crate::client::Client<Ext, H>, model: impl Into<String>) -> Self {
+        let preamble_behavior = client.ext().responses_preamble_behavior();
         Self {
             client,
             model: model.into(),
             tools: Vec::new(),
-            preamble_behavior: Ext::PREAMBLE_BEHAVIOR,
+            preamble_behavior,
         }
     }
 
     pub fn with_model(client: crate::client::Client<Ext, H>, model: &str) -> Self {
+        let preamble_behavior = client.ext().responses_preamble_behavior();
         Self {
             client,
             model: model.to_string(),
             tools: Vec::new(),
-            preamble_behavior: Ext::PREAMBLE_BEHAVIOR,
+            preamble_behavior,
         }
     }
 

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -109,6 +109,42 @@ impl CompletionRequest {
     }
 }
 
+/// Controls how Rig maps [`crate::completion::CompletionRequest::preamble`] into
+/// an OpenAI Responses request.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ResponsesPreambleBehavior {
+    /// Use OpenAI's canonical top-level `instructions` field.
+    #[default]
+    Instructions,
+    /// Move `instructions` into the first input item as a system message.
+    ///
+    /// This is for Responses-compatible providers that reject top-level
+    /// `instructions`.
+    InputSystemMessage,
+}
+
+pub(crate) fn move_instructions_into_input_system_message(
+    request: &mut CompletionRequest,
+) -> Result<(), CompletionError> {
+    let Some(instructions) = request.instructions.take() else {
+        return Ok(());
+    };
+
+    if instructions.trim().is_empty() {
+        return Ok(());
+    }
+
+    let mut input = vec![InputItem::system_message(instructions)];
+    input.extend(request.input.clone());
+    request.input = OneOrMany::many(input).map_err(|_| {
+        CompletionError::RequestError(
+            "OpenAI Responses request input must contain at least one item".into(),
+        )
+    })?;
+
+    Ok(())
+}
+
 /// An input item for [`CompletionRequest`].
 #[derive(Debug, Deserialize, Clone)]
 pub struct InputItem {
@@ -814,14 +850,7 @@ impl TryFrom<(String, crate::completion::CompletionRequest)> for CompletionReque
             }
             partial_history.extend(req.chat_history);
 
-            // Initialize full history with preamble (or empty if non-existent)
-            // Some "Responses API compatible" providers don't support `instructions` field
-            // so we need to add a system message until further notice
-            let mut full_history: Vec<InputItem> = if let Some(content) = req.preamble {
-                vec![InputItem::system_message(content)]
-            } else {
-                Vec::new()
-            };
+            let mut full_history = Vec::new();
 
             for history_item in partial_history {
                 full_history.extend(<Vec<InputItem>>::try_from(history_item)?);
@@ -918,7 +947,7 @@ impl TryFrom<(String, crate::completion::CompletionRequest)> for CompletionReque
         Ok(Self {
             input,
             model,
-            instructions: None, // is currently None due to lack of support in compliant providers
+            instructions: req.preamble,
             max_output_tokens: req.max_tokens,
             stream,
             tool_choice,
@@ -939,6 +968,7 @@ pub struct GenericResponsesCompletionModel<Ext = super::OpenAIResponsesExt, H = 
     pub model: String,
     /// Model-level default tools that are always added to outgoing requests.
     pub tools: Vec<ResponsesToolDefinition>,
+    preamble_behavior: ResponsesPreambleBehavior,
 }
 
 /// The completion model struct for OpenAI's Responses API.
@@ -960,6 +990,7 @@ where
             client,
             model: model.into(),
             tools: Vec::new(),
+            preamble_behavior: ResponsesPreambleBehavior::default(),
         }
     }
 
@@ -968,7 +999,17 @@ where
             client,
             model: model.to_string(),
             tools: Vec::new(),
+            preamble_behavior: ResponsesPreambleBehavior::default(),
         }
+    }
+
+    /// Uses an input system message instead of top-level `instructions`.
+    ///
+    /// OpenAI itself supports `instructions`; this is only for compatibility
+    /// providers that reject that field.
+    pub fn with_preamble_as_input_system_message(mut self) -> Self {
+        self.preamble_behavior = ResponsesPreambleBehavior::InputSystemMessage;
+        self
     }
 
     /// Adds a default tool to all requests from this model.
@@ -994,6 +1035,9 @@ where
     ) -> Result<CompletionRequest, CompletionError> {
         let mut req = CompletionRequest::try_from((self.model.clone(), completion_request))?;
         req.tools.extend(self.tools.clone());
+        if self.preamble_behavior == ResponsesPreambleBehavior::InputSystemMessage {
+            move_instructions_into_input_system_message(&mut req)?;
+        }
 
         Ok(req)
     }
@@ -2012,6 +2056,81 @@ mod tests {
             .expect("provider-specific service tier should serialize"),
             json!("provider_experimental")
         );
+    }
+
+    fn user_request_with_preamble(preamble: Option<&str>) -> completion::CompletionRequest {
+        completion::CompletionRequest {
+            model: None,
+            preamble: preamble.map(ToString::to_string),
+            chat_history: OneOrMany::one(completion::Message::user("hello")),
+            documents: Vec::new(),
+            tools: Vec::new(),
+            temperature: None,
+            max_tokens: None,
+            tool_choice: None,
+            additional_params: None,
+            output_schema: None,
+        }
+    }
+
+    #[test]
+    fn openai_responses_preamble_serializes_to_top_level_instructions() {
+        let request = CompletionRequest::try_from((
+            "gpt-5.4".to_string(),
+            user_request_with_preamble(Some("Follow the policy.")),
+        ))
+        .expect("request");
+
+        assert_eq!(request.instructions.as_deref(), Some("Follow the policy."));
+        let input = serde_json::to_value(&request.input).expect("serialize input");
+        let input = input.as_array().expect("input array");
+        assert_eq!(input.len(), 1);
+        assert_eq!(input[0]["role"], "user");
+    }
+
+    #[test]
+    fn openai_responses_chat_history_system_messages_remain_input_items() {
+        let request = completion::CompletionRequest {
+            chat_history: OneOrMany::many(vec![
+                completion::Message::system("History system."),
+                completion::Message::user("hello"),
+            ])
+            .expect("history"),
+            ..user_request_with_preamble(Some("Top-level instructions."))
+        };
+
+        let request =
+            CompletionRequest::try_from(("gpt-5.4".to_string(), request)).expect("request");
+
+        assert_eq!(
+            request.instructions.as_deref(),
+            Some("Top-level instructions.")
+        );
+        let input = serde_json::to_value(&request.input).expect("serialize input");
+        let input = input.as_array().expect("input array");
+        assert_eq!(input.len(), 2);
+        assert_eq!(input[0]["role"], "system");
+        assert_eq!(input[0]["content"][0]["text"], "History system.");
+        assert_eq!(input[1]["role"], "user");
+    }
+
+    #[test]
+    fn compatibility_normalizer_moves_instructions_to_input_system_message() {
+        let mut request = CompletionRequest::try_from((
+            "gpt-5.4".to_string(),
+            user_request_with_preamble(Some("Compat instructions.")),
+        ))
+        .expect("request");
+
+        move_instructions_into_input_system_message(&mut request).expect("normalize");
+
+        assert_eq!(request.instructions, None);
+        let input = serde_json::to_value(&request.input).expect("serialize input");
+        let input = input.as_array().expect("input array");
+        assert_eq!(input.len(), 2);
+        assert_eq!(input[0]["role"], "system");
+        assert_eq!(input[0]["content"][0]["text"], "Compat instructions.");
+        assert_eq!(input[1]["role"], "user");
     }
 
     #[test]

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -1981,6 +1981,8 @@ impl FromStr for UserContent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::client::CompletionClient as _;
+    use crate::completion::{Completion as _, CompletionModel as _};
     use crate::message;
     use serde_json::json;
 
@@ -2085,6 +2087,56 @@ mod tests {
         .expect("request");
 
         assert_eq!(request.instructions.as_deref(), Some("Follow the policy."));
+        let input = serde_json::to_value(&request.input).expect("serialize input");
+        let input = input.as_array().expect("input array");
+        assert_eq!(input.len(), 1);
+        assert_eq!(input[0]["role"], "user");
+    }
+
+    #[test]
+    fn openai_responses_builder_preamble_serializes_to_top_level_instructions() {
+        let client = crate::providers::openai::Client::new("dummy-key").expect("client");
+        let model = client.completion_model("gpt-5.4");
+        let user_request = model
+            .completion_request(completion::Message::user("hello"))
+            .preamble("Builder instructions.".to_string())
+            .build();
+
+        let request = model
+            .create_completion_request(user_request)
+            .expect("request");
+
+        assert_eq!(
+            request.instructions.as_deref(),
+            Some("Builder instructions.")
+        );
+        let input = serde_json::to_value(&request.input).expect("serialize input");
+        let input = input.as_array().expect("input array");
+        assert_eq!(input.len(), 1);
+        assert_eq!(input[0]["role"], "user");
+    }
+
+    #[tokio::test]
+    async fn openai_responses_agent_preamble_serializes_to_top_level_instructions() {
+        let client = crate::providers::openai::Client::new("dummy-key").expect("client");
+        let model = client.completion_model("gpt-5.4");
+        let agent = crate::agent::AgentBuilder::new(model.clone())
+            .preamble("Agent instructions.")
+            .build();
+
+        let user_request = agent
+            .completion(
+                completion::Message::user("hello"),
+                Vec::<completion::Message>::new(),
+            )
+            .await
+            .expect("completion request")
+            .build();
+        let request = model
+            .create_completion_request(user_request)
+            .expect("request");
+
+        assert_eq!(request.instructions.as_deref(), Some("Agent instructions."));
         let input = serde_json::to_value(&request.input).expect("serialize input");
         let input = input.as_array().expect("input array");
         assert_eq!(input.len(), 1);

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -109,8 +109,16 @@ impl CompletionRequest {
     }
 }
 
+/// Provider-specific OpenAI Responses request behavior.
+#[doc(hidden)]
+pub trait ResponsesProviderProfile {
+    /// Controls how Rig maps [`crate::completion::CompletionRequest::preamble`].
+    const PREAMBLE_BEHAVIOR: ResponsesPreambleBehavior = ResponsesPreambleBehavior::Instructions;
+}
+
 /// Controls how Rig maps [`crate::completion::CompletionRequest::preamble`] into
 /// an OpenAI Responses request.
+#[doc(hidden)]
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum ResponsesPreambleBehavior {
     /// Use OpenAI's canonical top-level `instructions` field.
@@ -981,7 +989,7 @@ pub type ResponsesCompletionModel<H = reqwest::Client> =
 impl<Ext, H> GenericResponsesCompletionModel<Ext, H>
 where
     crate::client::Client<Ext, H>: HttpClientExt + Clone + std::fmt::Debug + 'static,
-    Ext: crate::client::Provider + Clone + 'static,
+    Ext: crate::client::Provider + ResponsesProviderProfile + Clone + 'static,
     H: Clone + Default + std::fmt::Debug + 'static,
 {
     /// Creates a new [`ResponsesCompletionModel`].
@@ -990,7 +998,7 @@ where
             client,
             model: model.into(),
             tools: Vec::new(),
-            preamble_behavior: ResponsesPreambleBehavior::default(),
+            preamble_behavior: Ext::PREAMBLE_BEHAVIOR,
         }
     }
 
@@ -999,17 +1007,8 @@ where
             client,
             model: model.to_string(),
             tools: Vec::new(),
-            preamble_behavior: ResponsesPreambleBehavior::default(),
+            preamble_behavior: Ext::PREAMBLE_BEHAVIOR,
         }
-    }
-
-    /// Uses an input system message instead of top-level `instructions`.
-    ///
-    /// OpenAI itself supports `instructions`; this is only for compatibility
-    /// providers that reject that field.
-    pub fn with_preamble_as_input_system_message(mut self) -> Self {
-        self.preamble_behavior = ResponsesPreambleBehavior::InputSystemMessage;
-        self
     }
 
     /// Adds a default tool to all requests from this model.
@@ -1437,6 +1436,7 @@ where
     crate::client::Client<Ext, H>:
         HttpClientExt + Clone + WasmCompatSend + WasmCompatSync + 'static,
     Ext: crate::client::Provider
+        + ResponsesProviderProfile
         + crate::client::DebugExt
         + Clone
         + WasmCompatSend

--- a/crates/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -858,7 +858,7 @@ impl<Ext, H> GenericResponsesCompletionModel<Ext, H>
 where
     crate::client::Client<Ext, H>:
         HttpClientExt + Clone + std::fmt::Debug + WasmCompatSend + 'static,
-    Ext: crate::client::Provider + Clone + 'static,
+    Ext: crate::client::Provider + super::ResponsesProviderProfile + Clone + 'static,
     H: Clone + Default + std::fmt::Debug + WasmCompatSend + 'static,
 {
     pub(crate) async fn stream(

--- a/tests/common/support.rs
+++ b/tests/common/support.rs
@@ -15,6 +15,11 @@ use serde_json::json;
 
 pub(crate) const BASIC_PREAMBLE: &str = "You are a concise assistant. Answer directly.";
 pub(crate) const BASIC_PROMPT: &str = "In one or two sentences, explain what Rust programming language is and why memory safety matters.";
+pub(crate) const INSTRUCTIONS_EXPECTED_MARKER: &str = "cedar-harbor-4192";
+pub(crate) const INSTRUCTIONS_PREAMBLE: &str = "This is an instruction routing test. Reply with exactly the text `cedar-harbor-4192` \
+    and no other text.";
+pub(crate) const INSTRUCTIONS_CONFLICT_PROMPT: &str =
+    "Reply with the exact text required by the instruction-routing test.";
 pub(crate) const RAW_TEXT_RESPONSE_PREAMBLE: &str =
     "Return exactly the requested text as plain text with no bullets, quotes, or extra commentary.";
 pub(crate) const RAW_TEXT_RESPONSE_PROMPT: &str =

--- a/tests/providers/azure/instructions.rs
+++ b/tests/providers/azure/instructions.rs
@@ -1,0 +1,31 @@
+//! Live instruction-routing checks for Azure OpenAI Chat Completions.
+
+use rig::client::{CompletionClient, ProviderClient};
+use rig::completion::Prompt;
+use rig::providers::azure;
+
+use crate::support::{
+    INSTRUCTIONS_CONFLICT_PROMPT, INSTRUCTIONS_EXPECTED_MARKER, INSTRUCTIONS_PREAMBLE,
+    assert_contains_any_case_insensitive,
+};
+
+fn completion_deployment() -> String {
+    std::env::var("AZURE_COMPLETION_DEPLOYMENT")
+        .or_else(|_| std::env::var("AZURE_OPENAI_DEPLOYMENT"))
+        .unwrap_or_else(|_| azure::GPT_4O.to_string())
+}
+
+#[tokio::test]
+#[ignore = "requires AZURE_API_KEY or AZURE_TOKEN, AZURE_API_VERSION, AZURE_ENDPOINT, and a chat deployment"]
+async fn chat_completions_preamble_is_honored() {
+    let response = azure::Client::from_env()
+        .expect("client should build")
+        .agent(completion_deployment())
+        .preamble(INSTRUCTIONS_PREAMBLE)
+        .build()
+        .prompt(INSTRUCTIONS_CONFLICT_PROMPT)
+        .await
+        .expect("Azure OpenAI completion should succeed");
+
+    assert_contains_any_case_insensitive(&response, &[INSTRUCTIONS_EXPECTED_MARKER]);
+}

--- a/tests/providers/azure/mod.rs
+++ b/tests/providers/azure/mod.rs
@@ -1,1 +1,2 @@
+mod instructions;
 mod transcription;

--- a/tests/providers/chatgpt/instructions.rs
+++ b/tests/providers/chatgpt/instructions.rs
@@ -1,0 +1,24 @@
+//! Live instruction-routing checks for the ChatGPT subscription provider.
+
+use rig::client::CompletionClient;
+use rig::completion::Prompt;
+
+use crate::chatgpt::{LIVE_MODEL, live_client};
+use crate::support::{
+    INSTRUCTIONS_CONFLICT_PROMPT, INSTRUCTIONS_EXPECTED_MARKER, INSTRUCTIONS_PREAMBLE,
+    assert_contains_any_case_insensitive,
+};
+
+#[tokio::test]
+#[ignore = "requires ChatGPT credentials or existing OAuth cache"]
+async fn preamble_and_system_normalization_are_honored() {
+    let response = live_client()
+        .agent(LIVE_MODEL)
+        .preamble(INSTRUCTIONS_PREAMBLE)
+        .build()
+        .prompt(INSTRUCTIONS_CONFLICT_PROMPT)
+        .await
+        .expect("ChatGPT completion should succeed");
+
+    assert_contains_any_case_insensitive(&response, &[INSTRUCTIONS_EXPECTED_MARKER]);
+}

--- a/tests/providers/chatgpt/mod.rs
+++ b/tests/providers/chatgpt/mod.rs
@@ -3,6 +3,7 @@ mod auth;
 mod completion;
 mod extractor;
 mod extractor_usage;
+mod instructions;
 mod multi_extract;
 mod permission_control;
 mod reasoning_roundtrip;

--- a/tests/providers/copilot/instructions.rs
+++ b/tests/providers/copilot/instructions.rs
@@ -1,0 +1,38 @@
+//! Live instruction-routing checks for Copilot Chat and Responses routes.
+
+use rig::client::CompletionClient;
+use rig::completion::Prompt;
+
+use crate::copilot::{LIVE_MODEL, live_client, live_responses_model};
+use crate::support::{
+    INSTRUCTIONS_CONFLICT_PROMPT, INSTRUCTIONS_EXPECTED_MARKER, INSTRUCTIONS_PREAMBLE,
+    assert_contains_any_case_insensitive,
+};
+
+#[tokio::test]
+#[ignore = "requires Copilot credentials or existing OAuth cache"]
+async fn chat_route_preamble_is_honored() {
+    let response = live_client()
+        .agent(LIVE_MODEL)
+        .preamble(INSTRUCTIONS_PREAMBLE)
+        .build()
+        .prompt(INSTRUCTIONS_CONFLICT_PROMPT)
+        .await
+        .expect("Copilot chat-completions route should succeed");
+
+    assert_contains_any_case_insensitive(&response, &[INSTRUCTIONS_EXPECTED_MARKER]);
+}
+
+#[tokio::test]
+#[ignore = "requires Copilot credentials or existing OAuth cache"]
+async fn responses_route_preamble_compat_shim_is_honored() {
+    let response = live_client()
+        .agent(live_responses_model())
+        .preamble(INSTRUCTIONS_PREAMBLE)
+        .build()
+        .prompt(INSTRUCTIONS_CONFLICT_PROMPT)
+        .await
+        .expect("Copilot responses route should succeed");
+
+    assert_contains_any_case_insensitive(&response, &[INSTRUCTIONS_EXPECTED_MARKER]);
+}

--- a/tests/providers/copilot/mod.rs
+++ b/tests/providers/copilot/mod.rs
@@ -3,6 +3,7 @@ mod auth;
 mod embeddings;
 mod extractor;
 mod extractor_usage;
+mod instructions;
 mod models;
 mod multi_extract;
 mod permission_control;

--- a/tests/providers/deepseek/instructions.rs
+++ b/tests/providers/deepseek/instructions.rs
@@ -1,0 +1,25 @@
+//! Live instruction-routing checks for DeepSeek.
+
+use rig::client::{CompletionClient, ProviderClient};
+use rig::completion::Prompt;
+use rig::providers::deepseek;
+
+use crate::support::{
+    INSTRUCTIONS_CONFLICT_PROMPT, INSTRUCTIONS_EXPECTED_MARKER, INSTRUCTIONS_PREAMBLE,
+    assert_contains_any_case_insensitive,
+};
+
+#[tokio::test]
+#[ignore = "requires DEEPSEEK_API_KEY"]
+async fn preamble_is_honored() {
+    let response = deepseek::Client::from_env()
+        .expect("client should build")
+        .agent(deepseek::DEEPSEEK_V4_FLASH)
+        .preamble(INSTRUCTIONS_PREAMBLE)
+        .build()
+        .prompt(INSTRUCTIONS_CONFLICT_PROMPT)
+        .await
+        .expect("DeepSeek completion should succeed");
+
+    assert_contains_any_case_insensitive(&response, &[INSTRUCTIONS_EXPECTED_MARKER]);
+}

--- a/tests/providers/deepseek/mod.rs
+++ b/tests/providers/deepseek/mod.rs
@@ -1,6 +1,7 @@
 mod agent;
 mod extractor;
 mod extractor_usage;
+mod instructions;
 mod models;
 mod multi_extract;
 mod permission_control;

--- a/tests/providers/galadriel/instructions.rs
+++ b/tests/providers/galadriel/instructions.rs
@@ -1,0 +1,25 @@
+//! Live instruction-routing checks for Galadriel.
+
+use rig::client::{CompletionClient, ProviderClient};
+use rig::completion::Prompt;
+use rig::providers::galadriel;
+
+use crate::support::{
+    INSTRUCTIONS_CONFLICT_PROMPT, INSTRUCTIONS_EXPECTED_MARKER, INSTRUCTIONS_PREAMBLE,
+    assert_contains_any_case_insensitive,
+};
+
+#[tokio::test]
+#[ignore = "requires GALADRIEL_API_KEY"]
+async fn preamble_is_honored() {
+    let response = galadriel::Client::from_env()
+        .expect("client should build")
+        .agent(galadriel::GPT_4O)
+        .preamble(INSTRUCTIONS_PREAMBLE)
+        .build()
+        .prompt(INSTRUCTIONS_CONFLICT_PROMPT)
+        .await
+        .expect("Galadriel completion should succeed");
+
+    assert_contains_any_case_insensitive(&response, &[INSTRUCTIONS_EXPECTED_MARKER]);
+}

--- a/tests/providers/galadriel/mod.rs
+++ b/tests/providers/galadriel/mod.rs
@@ -1,2 +1,3 @@
 mod agent;
+mod instructions;
 mod streaming_tools;

--- a/tests/providers/groq/instructions.rs
+++ b/tests/providers/groq/instructions.rs
@@ -1,0 +1,113 @@
+//! Live instruction-routing checks for Groq.
+
+use rig::client::{CompletionClient, ProviderClient};
+use rig::completion::{CompletionModel, Prompt};
+use rig::message::Message;
+use rig::providers::groq;
+use rig::streaming::StreamingPrompt;
+
+use crate::support::{
+    INSTRUCTIONS_CONFLICT_PROMPT, INSTRUCTIONS_EXPECTED_MARKER, INSTRUCTIONS_PREAMBLE,
+    assert_contains_any_case_insensitive, collect_stream_final_response,
+};
+
+use super::STREAMING_REASONING_MODEL;
+
+const EXPLICIT_SYSTEM_MARKER: &str = "maple-harbor-6217";
+const COMBINED_SYSTEM_MARKER: &str = "spruce-copper-8841";
+const STREAMING_SYSTEM_MARKER: &str = "willow-stream-5039";
+const STREAMING_SYSTEM_PREAMBLE: &str =
+    "Reply with exactly the text `willow-stream-5039` and no other text.";
+
+#[tokio::test]
+#[ignore = "requires GROQ_API_KEY"]
+async fn preamble_is_honored() {
+    let response = groq::Client::from_env()
+        .expect("client should build")
+        .agent(STREAMING_REASONING_MODEL)
+        .preamble(INSTRUCTIONS_PREAMBLE)
+        .build()
+        .prompt(INSTRUCTIONS_CONFLICT_PROMPT)
+        .await
+        .expect("Groq completion should succeed");
+
+    assert_contains_any_case_insensitive(&response, &[INSTRUCTIONS_EXPECTED_MARKER]);
+}
+
+#[tokio::test]
+#[ignore = "requires GROQ_API_KEY"]
+async fn explicit_chat_history_system_message_is_honored() {
+    let model = groq::Client::from_env()
+        .expect("client should build")
+        .completion_model(STREAMING_REASONING_MODEL);
+
+    let response = model
+        .completion_request("Reply with the exact text required by the system message.")
+        .message(Message::system(format!(
+            "Reply with exactly the text `{EXPLICIT_SYSTEM_MARKER}` and no other text."
+        )))
+        .send()
+        .await
+        .expect("Groq completion should succeed");
+
+    assert_contains_any_case_insensitive(
+        &response
+            .choice
+            .iter()
+            .filter_map(|content| match content {
+                rig::message::AssistantContent::Text(text) => Some(text.text.as_str()),
+                _ => None,
+            })
+            .collect::<String>(),
+        &[EXPLICIT_SYSTEM_MARKER],
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires GROQ_API_KEY"]
+async fn preamble_and_explicit_system_message_are_both_honored() {
+    let model = groq::Client::from_env()
+        .expect("client should build")
+        .completion_model(STREAMING_REASONING_MODEL);
+
+    let response = model
+        .completion_request("Reply with the exact marker required by the system messages.")
+        .preamble(format!(
+            "This preamble must be delivered as a string system message. The final answer marker is `{COMBINED_SYSTEM_MARKER}`."
+        ))
+        .message(Message::system(format!(
+            "Reply with exactly `{COMBINED_SYSTEM_MARKER}` and no other text."
+        )))
+        .send()
+        .await
+        .expect("Groq completion should succeed");
+
+    let text = response
+        .choice
+        .iter()
+        .filter_map(|content| match content {
+            rig::message::AssistantContent::Text(text) => Some(text.text.as_str()),
+            _ => None,
+        })
+        .collect::<String>();
+    assert_contains_any_case_insensitive(&text, &[COMBINED_SYSTEM_MARKER]);
+}
+
+#[tokio::test]
+#[ignore = "requires GROQ_API_KEY"]
+async fn streaming_preamble_system_message_is_honored() {
+    let agent = groq::Client::from_env()
+        .expect("client should build")
+        .agent(STREAMING_REASONING_MODEL)
+        .preamble(STREAMING_SYSTEM_PREAMBLE)
+        .build();
+
+    let mut stream = agent
+        .stream_prompt("Reply with the exact text required by the instruction-routing test.")
+        .await;
+    let response = collect_stream_final_response(&mut stream)
+        .await
+        .expect("Groq streaming completion should succeed");
+
+    assert_contains_any_case_insensitive(&response, &[STREAMING_SYSTEM_MARKER]);
+}

--- a/tests/providers/groq/mod.rs
+++ b/tests/providers/groq/mod.rs
@@ -2,6 +2,7 @@ mod agent;
 mod context;
 mod extractor;
 mod extractor_usage;
+mod instructions;
 mod loaders;
 mod multi_extract;
 mod permission_control;

--- a/tests/providers/hyperbolic/instructions.rs
+++ b/tests/providers/hyperbolic/instructions.rs
@@ -1,0 +1,25 @@
+//! Live instruction-routing checks for Hyperbolic.
+
+use rig::client::{CompletionClient, ProviderClient};
+use rig::completion::Prompt;
+use rig::providers::hyperbolic;
+
+use crate::support::{
+    INSTRUCTIONS_CONFLICT_PROMPT, INSTRUCTIONS_EXPECTED_MARKER, INSTRUCTIONS_PREAMBLE,
+    assert_contains_any_case_insensitive,
+};
+
+#[tokio::test]
+#[ignore = "requires HYPERBOLIC_API_KEY"]
+async fn preamble_is_honored() {
+    let response = hyperbolic::Client::from_env()
+        .expect("client should build")
+        .agent(hyperbolic::LLAMA_3_1_8B)
+        .preamble(INSTRUCTIONS_PREAMBLE)
+        .build()
+        .prompt(INSTRUCTIONS_CONFLICT_PROMPT)
+        .await
+        .expect("Hyperbolic completion should succeed");
+
+    assert_contains_any_case_insensitive(&response, &[INSTRUCTIONS_EXPECTED_MARKER]);
+}

--- a/tests/providers/hyperbolic/mod.rs
+++ b/tests/providers/hyperbolic/mod.rs
@@ -3,3 +3,4 @@ mod agent;
 mod audio_generation;
 #[cfg(feature = "image")]
 mod image_generation;
+mod instructions;

--- a/tests/providers/llamacpp/instructions.rs
+++ b/tests/providers/llamacpp/instructions.rs
@@ -1,0 +1,39 @@
+//! Live instruction-routing checks for a local llama.cpp OpenAI-compatible server.
+
+use rig::client::CompletionClient;
+use rig::completion::Prompt;
+
+use crate::support::{
+    INSTRUCTIONS_CONFLICT_PROMPT, INSTRUCTIONS_EXPECTED_MARKER, INSTRUCTIONS_PREAMBLE,
+    assert_contains_any_case_insensitive,
+};
+
+use super::support;
+
+#[tokio::test]
+#[ignore = "requires a local llama.cpp OpenAI-compatible server"]
+async fn chat_completions_preamble_is_honored() {
+    let response = support::completions_client()
+        .agent(support::model_name())
+        .preamble(INSTRUCTIONS_PREAMBLE)
+        .build()
+        .prompt(INSTRUCTIONS_CONFLICT_PROMPT)
+        .await
+        .expect("llama.cpp Chat Completions-compatible completion should succeed");
+
+    assert_contains_any_case_insensitive(&response, &[INSTRUCTIONS_EXPECTED_MARKER]);
+}
+
+#[tokio::test]
+#[ignore = "requires a local llama.cpp OpenAI-compatible server with /responses support"]
+async fn responses_api_preamble_is_honored_or_reveals_need_for_compat_shim() {
+    let response = support::client()
+        .agent(support::model_name())
+        .preamble(INSTRUCTIONS_PREAMBLE)
+        .build()
+        .prompt(INSTRUCTIONS_CONFLICT_PROMPT)
+        .await
+        .expect("llama.cpp Responses-compatible completion should succeed");
+
+    assert_contains_any_case_insensitive(&response, &[INSTRUCTIONS_EXPECTED_MARKER]);
+}

--- a/tests/providers/llamacpp/mod.rs
+++ b/tests/providers/llamacpp/mod.rs
@@ -2,6 +2,7 @@ mod agent;
 mod completions_api;
 mod extractor;
 mod extractor_usage;
+mod instructions;
 mod models;
 mod multi_extract;
 mod permission_control;

--- a/tests/providers/llamafile/instructions.rs
+++ b/tests/providers/llamafile/instructions.rs
@@ -1,0 +1,29 @@
+//! Live instruction-routing checks for a local llamafile server.
+
+use rig::client::CompletionClient;
+use rig::completion::Prompt;
+
+use crate::support::{
+    INSTRUCTIONS_CONFLICT_PROMPT, INSTRUCTIONS_EXPECTED_MARKER, INSTRUCTIONS_PREAMBLE,
+    assert_contains_any_case_insensitive,
+};
+
+use super::support;
+
+#[tokio::test]
+#[ignore = "requires a local llamafile server at http://localhost:8080"]
+async fn preamble_is_honored() {
+    if support::skip_if_server_unavailable() {
+        return;
+    }
+
+    let response = support::client()
+        .agent(support::model_name())
+        .preamble(INSTRUCTIONS_PREAMBLE)
+        .build()
+        .prompt(INSTRUCTIONS_CONFLICT_PROMPT)
+        .await
+        .expect("llamafile completion should succeed");
+
+    assert_contains_any_case_insensitive(&response, &[INSTRUCTIONS_EXPECTED_MARKER]);
+}

--- a/tests/providers/llamafile/mod.rs
+++ b/tests/providers/llamafile/mod.rs
@@ -3,6 +3,7 @@ mod context;
 mod embeddings;
 mod extractor;
 mod extractor_usage;
+mod instructions;
 mod loaders;
 mod multi_extract;
 mod permission_control;

--- a/tests/providers/minimax/instructions.rs
+++ b/tests/providers/minimax/instructions.rs
@@ -1,0 +1,25 @@
+//! Live instruction-routing checks for MiniMax OpenAI-compatible completions.
+
+use rig::client::{CompletionClient, ProviderClient};
+use rig::completion::Prompt;
+use rig::providers::minimax;
+
+use crate::support::{
+    INSTRUCTIONS_CONFLICT_PROMPT, INSTRUCTIONS_EXPECTED_MARKER, INSTRUCTIONS_PREAMBLE,
+    assert_contains_any_case_insensitive,
+};
+
+#[tokio::test]
+#[ignore = "requires MINIMAX_API_KEY"]
+async fn openai_compatible_preamble_is_honored() {
+    let response = minimax::Client::from_env()
+        .expect("client should build")
+        .agent(minimax::MINIMAX_M2_7)
+        .preamble(INSTRUCTIONS_PREAMBLE)
+        .build()
+        .prompt(INSTRUCTIONS_CONFLICT_PROMPT)
+        .await
+        .expect("MiniMax OpenAI-compatible completion should succeed");
+
+    assert_contains_any_case_insensitive(&response, &[INSTRUCTIONS_EXPECTED_MARKER]);
+}

--- a/tests/providers/minimax/mod.rs
+++ b/tests/providers/minimax/mod.rs
@@ -1,2 +1,3 @@
 mod anthropic;
+mod instructions;
 mod openai;

--- a/tests/providers/mira/instructions.rs
+++ b/tests/providers/mira/instructions.rs
@@ -1,0 +1,25 @@
+//! Live instruction-routing checks for Mira.
+
+use rig::client::{CompletionClient, ProviderClient};
+use rig::completion::Prompt;
+use rig::providers::{mira, openai};
+
+use crate::support::{
+    INSTRUCTIONS_CONFLICT_PROMPT, INSTRUCTIONS_EXPECTED_MARKER, INSTRUCTIONS_PREAMBLE,
+    assert_contains_any_case_insensitive,
+};
+
+#[tokio::test]
+#[ignore = "requires MIRA_API_KEY"]
+async fn preamble_is_honored() {
+    let response = mira::Client::from_env()
+        .expect("client should build")
+        .agent(openai::GPT_4O)
+        .preamble(INSTRUCTIONS_PREAMBLE)
+        .build()
+        .prompt(INSTRUCTIONS_CONFLICT_PROMPT)
+        .await
+        .expect("Mira completion should succeed");
+
+    assert_contains_any_case_insensitive(&response, &[INSTRUCTIONS_EXPECTED_MARKER]);
+}

--- a/tests/providers/mira/mod.rs
+++ b/tests/providers/mira/mod.rs
@@ -1,3 +1,4 @@
 mod agent;
+mod instructions;
 mod models;
 mod tools;

--- a/tests/providers/moonshot/instructions.rs
+++ b/tests/providers/moonshot/instructions.rs
@@ -1,0 +1,25 @@
+//! Live instruction-routing checks for Moonshot OpenAI-compatible completions.
+
+use rig::client::{CompletionClient, ProviderClient};
+use rig::completion::Prompt;
+use rig::providers::moonshot;
+
+use crate::support::{
+    INSTRUCTIONS_CONFLICT_PROMPT, INSTRUCTIONS_EXPECTED_MARKER, INSTRUCTIONS_PREAMBLE,
+    assert_contains_any_case_insensitive,
+};
+
+#[tokio::test]
+#[ignore = "requires MOONSHOT_API_KEY"]
+async fn openai_compatible_preamble_is_honored() {
+    let response = moonshot::Client::from_env()
+        .expect("client should build")
+        .agent(moonshot::KIMI_K2_5)
+        .preamble(INSTRUCTIONS_PREAMBLE)
+        .build()
+        .prompt(INSTRUCTIONS_CONFLICT_PROMPT)
+        .await
+        .expect("Moonshot OpenAI-compatible completion should succeed");
+
+    assert_contains_any_case_insensitive(&response, &[INSTRUCTIONS_EXPECTED_MARKER]);
+}

--- a/tests/providers/moonshot/mod.rs
+++ b/tests/providers/moonshot/mod.rs
@@ -1,5 +1,6 @@
 mod agent;
 mod anthropic;
 mod context;
+mod instructions;
 mod reasoning_history;
 mod tools;

--- a/tests/providers/openai/instructions.rs
+++ b/tests/providers/openai/instructions.rs
@@ -1,0 +1,41 @@
+//! Live instruction-routing checks for OpenAI Responses and Chat Completions.
+
+use rig::client::{CompletionClient, ProviderClient};
+use rig::completion::Prompt;
+use rig::providers::openai;
+
+use crate::support::{
+    INSTRUCTIONS_CONFLICT_PROMPT, INSTRUCTIONS_EXPECTED_MARKER, INSTRUCTIONS_PREAMBLE,
+    assert_contains_any_case_insensitive,
+};
+
+#[tokio::test]
+#[ignore = "requires OPENAI_API_KEY"]
+async fn responses_api_preamble_is_honored_as_instructions() {
+    let response = openai::Client::from_env()
+        .expect("client should build")
+        .agent(openai::GPT_4O)
+        .preamble(INSTRUCTIONS_PREAMBLE)
+        .build()
+        .prompt(INSTRUCTIONS_CONFLICT_PROMPT)
+        .await
+        .expect("OpenAI Responses completion should succeed");
+
+    assert_contains_any_case_insensitive(&response, &[INSTRUCTIONS_EXPECTED_MARKER]);
+}
+
+#[tokio::test]
+#[ignore = "requires OPENAI_API_KEY"]
+async fn chat_completions_api_preamble_is_honored_as_system_message() {
+    let response = openai::Client::from_env()
+        .expect("client should build")
+        .completions_api()
+        .agent(openai::GPT_4O)
+        .preamble(INSTRUCTIONS_PREAMBLE)
+        .build()
+        .prompt(INSTRUCTIONS_CONFLICT_PROMPT)
+        .await
+        .expect("OpenAI Chat Completions completion should succeed");
+
+    assert_contains_any_case_insensitive(&response, &[INSTRUCTIONS_EXPECTED_MARKER]);
+}

--- a/tests/providers/openai/mod.rs
+++ b/tests/providers/openai/mod.rs
@@ -9,6 +9,7 @@ mod extractor_usage;
 mod gpt_5_5;
 #[cfg(feature = "image")]
 mod image_generation;
+mod instructions;
 mod models;
 mod multi_extract;
 mod permission_control;

--- a/tests/providers/openrouter/instructions.rs
+++ b/tests/providers/openrouter/instructions.rs
@@ -1,0 +1,57 @@
+//! Live instruction-routing checks for OpenRouter native and OpenAI-compatible Responses paths.
+
+use rig::client::{CompletionClient, ProviderClient};
+use rig::completion::Prompt;
+use rig::providers::{openai, openrouter};
+
+use crate::support::{
+    INSTRUCTIONS_CONFLICT_PROMPT, INSTRUCTIONS_EXPECTED_MARKER, INSTRUCTIONS_PREAMBLE,
+    assert_contains_any_case_insensitive,
+};
+
+use super::DEFAULT_MODEL;
+
+const OPENROUTER_BASE_URL: &str = "https://openrouter.ai/api/v1";
+const DEFAULT_OPENAI_COMPAT_MODEL: &str = "google/gemini-3-flash-preview";
+
+fn openai_compatible_model() -> String {
+    std::env::var("OPENROUTER_OPENAI_COMPAT_MODEL")
+        .unwrap_or_else(|_| DEFAULT_OPENAI_COMPAT_MODEL.to_string())
+}
+
+fn openrouter_api_key() -> String {
+    std::env::var("OPENROUTER_API_KEY").expect("OPENROUTER_API_KEY must be set")
+}
+
+#[tokio::test]
+#[ignore = "requires OPENROUTER_API_KEY"]
+async fn native_provider_preamble_is_honored() {
+    let response = openrouter::Client::from_env()
+        .expect("client should build")
+        .agent(DEFAULT_MODEL)
+        .preamble(INSTRUCTIONS_PREAMBLE)
+        .build()
+        .prompt(INSTRUCTIONS_CONFLICT_PROMPT)
+        .await
+        .expect("OpenRouter native completion should succeed");
+
+    assert_contains_any_case_insensitive(&response, &[INSTRUCTIONS_EXPECTED_MARKER]);
+}
+
+#[tokio::test]
+#[ignore = "requires OPENROUTER_API_KEY"]
+async fn openai_responses_compat_preamble_is_honored_or_reveals_need_for_compat_shim() {
+    let response = openai::Client::builder()
+        .api_key(openrouter_api_key())
+        .base_url(OPENROUTER_BASE_URL)
+        .build()
+        .expect("OpenRouter OpenAI-compatible client should build")
+        .agent(openai_compatible_model())
+        .preamble(INSTRUCTIONS_PREAMBLE)
+        .build()
+        .prompt(INSTRUCTIONS_CONFLICT_PROMPT)
+        .await
+        .expect("OpenRouter via OpenAI Responses completion should succeed");
+
+    assert_contains_any_case_insensitive(&response, &[INSTRUCTIONS_EXPECTED_MARKER]);
+}

--- a/tests/providers/openrouter/mod.rs
+++ b/tests/providers/openrouter/mod.rs
@@ -3,6 +3,7 @@ mod document_file_data;
 mod extractor;
 mod extractor_usage;
 mod file_id;
+mod instructions;
 mod models;
 mod multi_extract;
 mod multimodal;

--- a/tests/providers/perplexity/instructions.rs
+++ b/tests/providers/perplexity/instructions.rs
@@ -1,0 +1,25 @@
+//! Live instruction-routing checks for Perplexity.
+
+use rig::client::{CompletionClient, ProviderClient};
+use rig::completion::Prompt;
+use rig::providers::perplexity;
+
+use crate::support::{
+    INSTRUCTIONS_CONFLICT_PROMPT, INSTRUCTIONS_EXPECTED_MARKER, INSTRUCTIONS_PREAMBLE,
+    assert_contains_any_case_insensitive,
+};
+
+#[tokio::test]
+#[ignore = "requires PERPLEXITY_API_KEY"]
+async fn preamble_is_honored() {
+    let response = perplexity::Client::from_env()
+        .expect("client should build")
+        .agent(perplexity::SONAR)
+        .preamble(INSTRUCTIONS_PREAMBLE)
+        .build()
+        .prompt(INSTRUCTIONS_CONFLICT_PROMPT)
+        .await
+        .expect("Perplexity completion should succeed");
+
+    assert_contains_any_case_insensitive(&response, &[INSTRUCTIONS_EXPECTED_MARKER]);
+}

--- a/tests/providers/perplexity/mod.rs
+++ b/tests/providers/perplexity/mod.rs
@@ -1,1 +1,2 @@
 mod agent;
+mod instructions;

--- a/tests/providers/together/instructions.rs
+++ b/tests/providers/together/instructions.rs
@@ -1,0 +1,25 @@
+//! Live instruction-routing checks for Together.
+
+use rig::client::{CompletionClient, ProviderClient};
+use rig::completion::Prompt;
+use rig::providers::together;
+
+use crate::support::{
+    INSTRUCTIONS_CONFLICT_PROMPT, INSTRUCTIONS_EXPECTED_MARKER, INSTRUCTIONS_PREAMBLE,
+    assert_contains_any_case_insensitive,
+};
+
+#[tokio::test]
+#[ignore = "requires TOGETHER_API_KEY"]
+async fn preamble_is_honored() {
+    let response = together::Client::from_env()
+        .expect("client should build")
+        .agent(together::LLAMA_3_1_8B_INSTRUCT_TURBO)
+        .preamble(INSTRUCTIONS_PREAMBLE)
+        .build()
+        .prompt(INSTRUCTIONS_CONFLICT_PROMPT)
+        .await
+        .expect("Together completion should succeed");
+
+    assert_contains_any_case_insensitive(&response, &[INSTRUCTIONS_EXPECTED_MARKER]);
+}

--- a/tests/providers/together/mod.rs
+++ b/tests/providers/together/mod.rs
@@ -1,6 +1,7 @@
 mod agent;
 mod context;
 mod embeddings;
+mod instructions;
 mod streaming;
 mod streaming_tools;
 mod tools;

--- a/tests/providers/xai/instructions.rs
+++ b/tests/providers/xai/instructions.rs
@@ -1,0 +1,25 @@
+//! Live instruction-routing checks for xAI Responses.
+
+use rig::client::{CompletionClient, ProviderClient};
+use rig::completion::Prompt;
+use rig::providers::xai;
+
+use crate::support::{
+    INSTRUCTIONS_CONFLICT_PROMPT, INSTRUCTIONS_EXPECTED_MARKER, INSTRUCTIONS_PREAMBLE,
+    assert_contains_any_case_insensitive,
+};
+
+#[tokio::test]
+#[ignore = "requires XAI_API_KEY"]
+async fn responses_preamble_system_message_is_honored() {
+    let response = xai::Client::from_env()
+        .expect("client should build")
+        .agent(xai::completion::GROK_3_MINI)
+        .preamble(INSTRUCTIONS_PREAMBLE)
+        .build()
+        .prompt(INSTRUCTIONS_CONFLICT_PROMPT)
+        .await
+        .expect("xAI Responses completion should succeed");
+
+    assert_contains_any_case_insensitive(&response, &[INSTRUCTIONS_EXPECTED_MARKER]);
+}

--- a/tests/providers/xai/mod.rs
+++ b/tests/providers/xai/mod.rs
@@ -6,6 +6,7 @@ mod extractor;
 mod extractor_usage;
 #[cfg(feature = "image")]
 mod image_generation;
+mod instructions;
 mod loaders;
 mod multi_extract;
 mod permission_control;

--- a/tests/providers/xiaomimimo/instructions.rs
+++ b/tests/providers/xiaomimimo/instructions.rs
@@ -1,0 +1,25 @@
+//! Live instruction-routing checks for Xiaomi MiMo OpenAI-compatible completions.
+
+use rig::client::{CompletionClient, ProviderClient};
+use rig::completion::Prompt;
+use rig::providers::xiaomimimo;
+
+use crate::support::{
+    INSTRUCTIONS_CONFLICT_PROMPT, INSTRUCTIONS_EXPECTED_MARKER, INSTRUCTIONS_PREAMBLE,
+    assert_contains_any_case_insensitive,
+};
+
+#[tokio::test]
+#[ignore = "requires XIAOMI_MIMO_API_KEY"]
+async fn openai_compatible_preamble_is_honored() {
+    let response = xiaomimimo::Client::from_env()
+        .expect("client should build")
+        .agent(xiaomimimo::MIMO_V2_5_PRO)
+        .preamble(INSTRUCTIONS_PREAMBLE)
+        .build()
+        .prompt(INSTRUCTIONS_CONFLICT_PROMPT)
+        .await
+        .expect("Xiaomi MiMo OpenAI-compatible completion should succeed");
+
+    assert_contains_any_case_insensitive(&response, &[INSTRUCTIONS_EXPECTED_MARKER]);
+}

--- a/tests/providers/xiaomimimo/mod.rs
+++ b/tests/providers/xiaomimimo/mod.rs
@@ -1,3 +1,4 @@
 mod anthropic;
+mod instructions;
 mod models;
 mod openai;

--- a/tests/providers/zai/instructions.rs
+++ b/tests/providers/zai/instructions.rs
@@ -1,0 +1,39 @@
+//! Live instruction-routing checks for Z.AI OpenAI-compatible completions.
+
+use rig::client::CompletionClient;
+use rig::completion::Prompt;
+use rig::providers::zai;
+
+use crate::support::{
+    INSTRUCTIONS_CONFLICT_PROMPT, INSTRUCTIONS_EXPECTED_MARKER, INSTRUCTIONS_PREAMBLE,
+    assert_contains_any_case_insensitive,
+};
+use crate::zai::{coding_client, general_client};
+
+#[tokio::test]
+#[ignore = "requires ZAI_API_KEY"]
+async fn general_openai_compatible_preamble_is_honored() {
+    let response = general_client()
+        .agent(zai::GLM_4_6)
+        .preamble(INSTRUCTIONS_PREAMBLE)
+        .build()
+        .prompt(INSTRUCTIONS_CONFLICT_PROMPT)
+        .await
+        .expect("Z.AI general completion should succeed");
+
+    assert_contains_any_case_insensitive(&response, &[INSTRUCTIONS_EXPECTED_MARKER]);
+}
+
+#[tokio::test]
+#[ignore = "requires ZAI_API_KEY"]
+async fn coding_openai_compatible_preamble_is_honored() {
+    let response = coding_client()
+        .agent(zai::GLM_4_6)
+        .preamble(INSTRUCTIONS_PREAMBLE)
+        .build()
+        .prompt(INSTRUCTIONS_CONFLICT_PROMPT)
+        .await
+        .expect("Z.AI coding completion should succeed");
+
+    assert_contains_any_case_insensitive(&response, &[INSTRUCTIONS_EXPECTED_MARKER]);
+}

--- a/tests/providers/zai/mod.rs
+++ b/tests/providers/zai/mod.rs
@@ -1,6 +1,7 @@
 mod anthropic;
 mod coding;
 mod general;
+mod instructions;
 
 use rig::providers::zai;
 


### PR DESCRIPTION
Closes #1599 

## Summary

- Restores canonical OpenAI Responses behavior by sending `preamble` as top-level `instructions`
- Adds provider-profile handling for Responses-compatible backends that need preamble moved into an input system message
- Wires Copilot Responses to use the compatibility behavior automatically
- Adds `openai::Client::builder().responses_preamble_behavior(...)` for custom OpenAI-compatible `base_url` backends
- Preserves ChatGPT Subscription’s system-message-to-`instructions` normalization
- Fixes OpenAI-compatible Chat Completions system-message string serialization
- Adds focused unit tests and ignored live provider instruction-routing tests

## Testing

```bash
cargo fmt
cargo test -p rig-core providers::openai::client::tests::test_responses_preamble_behavior_builder_sets_compat_mode
cargo test -p rig-core openai::responses_api
cargo test -p rig-core copilot::tests::completion_model_routes_codex_requests_to_responses
cargo test -p rig-core chatgpt::tests::test_
cargo test -p rig-core providers::groq::tests::serialize_groq_request
cargo test -p rig --tests --no-run
cargo clippy --all-targets --all-features
```

## Notes

OpenAI keeps official Responses API semantics by default. Known provider quirks are handled by provider profiles, while custom OpenAI-compatible endpoints can opt into the compatibility request shape explicitly.