### PR TITLE
feat(ollama): Enhance `think` parameter with string levels

### DIFF
--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -427,7 +427,7 @@ pub(super) struct OllamaCompletionRequest {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     tools: Vec<ToolDefinition>,
     pub stream: bool,
-    think: bool,
+    think: Think,
     #[serde(skip_serializing_if = "Option::is_none")]
     max_tokens: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -469,7 +469,7 @@ impl TryFrom<(&str, CompletionRequest)> for OllamaCompletionRequest {
                 .collect::<Vec<_>>(),
         );
 
-        let mut think = false;
+        let mut think = Think::Bool(false);
         let mut keep_alive: Option<String> = None;
 
         let options = if let Some(mut extra) = req.additional_params {
@@ -477,9 +477,24 @@ impl TryFrom<(&str, CompletionRequest)> for OllamaCompletionRequest {
             if let Some(obj) = extra.as_object_mut() {
                 // Extract `think` parameter
                 if let Some(think_val) = obj.remove("think") {
-                    think = think_val.as_bool().ok_or_else(|| {
-                        CompletionError::RequestError("`think` must be a bool".into())
-                    })?;
+                    think = match think_val {
+                        Value::Bool(think) => Think::Bool(think),
+                        Value::String(think) => Think::Level(match think.to_lowercase().as_str() {
+                            "low" => Level::Low,
+                            "medium" => Level::Medium,
+                            "high" => Level::High,
+                            _ => {
+                                return Err(CompletionError::RequestError(
+                                    "`think` must be a 'low', 'medium', 'high', or bool".into(),
+                                ));
+                            }
+                        }),
+                        _ => {
+                            return Err(CompletionError::RequestError(
+                                "`think` must be a 'low', 'medium', 'high', or bool".into(),
+                            ));
+                        }
+                    };
                 }
 
                 // Extract `keep_alive` parameter
@@ -535,6 +550,21 @@ impl<T> CompletionModel<T> {
             model: model.to_owned(),
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+enum Think {
+    Bool(bool),
+    Level(Level),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum Level {
+    Low,
+    Medium,
+    High,
 }
 
 // ---------- CompletionModel Implementation ----------
@@ -1617,6 +1647,245 @@ mod tests {
         });
 
         assert_eq!(serialized, expected);
+    }
+
+    // Test that `think` and `keep_alive` are extracted as top-level params, not in `options`
+    #[test]
+    fn test_completion_request_with_level_low_think_param() {
+        use crate::OneOrMany;
+        use crate::completion::Message as CompletionMessage;
+        use crate::message::{Text, UserContent};
+
+        // Create a CompletionRequest with "think": true, "keep_alive", and "num_ctx" in additional_params
+        let completion_request = CompletionRequest {
+            model: None,
+            preamble: Some("You are a helpful assistant.".to_string()),
+            chat_history: OneOrMany::one(CompletionMessage::User {
+                content: OneOrMany::one(UserContent::Text(Text {
+                    text: "What is 2 + 2?".to_string(),
+                })),
+            }),
+            documents: vec![],
+            tools: vec![],
+            temperature: Some(0.7),
+            max_tokens: Some(1024),
+            tool_choice: None,
+            additional_params: Some(json!({
+                "think": "low",
+                "keep_alive": "-1m",
+                "num_ctx": 4096
+            })),
+            output_schema: None,
+        };
+
+        // Convert to OllamaCompletionRequest
+        let ollama_request = OllamaCompletionRequest::try_from(("qwen3:8b", completion_request))
+            .expect("Failed to create Ollama request");
+
+        // Serialize to JSON
+        let serialized =
+            serde_json::to_value(&ollama_request).expect("Failed to serialize request");
+
+        // Assert equality with expected JSON
+        // - "tools" is skipped when empty (skip_serializing_if)
+        // - "think" should be a top-level boolean, NOT in options
+        // - "keep_alive" should be a top-level string, NOT in options
+        // - "num_ctx" should be in options (it's a model parameter)
+        let expected = json!({
+            "model": "qwen3:8b",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "You are a helpful assistant."
+                },
+                {
+                    "role": "user",
+                    "content": "What is 2 + 2?"
+                }
+            ],
+            "temperature": 0.7,
+            "stream": false,
+            "think": "low",
+            "max_tokens": 1024,
+            "keep_alive": "-1m",
+            "options": {
+                "temperature": 0.7,
+                "num_ctx": 4096
+            }
+        });
+
+        assert_eq!(serialized, expected);
+    }
+
+    // Test that `think` and `keep_alive` are extracted as top-level params, not in `options`
+    #[test]
+    fn test_completion_request_with_level_medium_think_param() {
+        use crate::OneOrMany;
+        use crate::completion::Message as CompletionMessage;
+        use crate::message::{Text, UserContent};
+
+        // Create a CompletionRequest with "think": true, "keep_alive", and "num_ctx" in additional_params
+        let completion_request = CompletionRequest {
+            model: None,
+            preamble: Some("You are a helpful assistant.".to_string()),
+            chat_history: OneOrMany::one(CompletionMessage::User {
+                content: OneOrMany::one(UserContent::Text(Text {
+                    text: "What is 2 + 2?".to_string(),
+                })),
+            }),
+            documents: vec![],
+            tools: vec![],
+            temperature: Some(0.7),
+            max_tokens: Some(1024),
+            tool_choice: None,
+            additional_params: Some(json!({
+                "think": "medium",
+                "keep_alive": "-1m",
+                "num_ctx": 4096
+            })),
+            output_schema: None,
+        };
+
+        // Convert to OllamaCompletionRequest
+        let ollama_request = OllamaCompletionRequest::try_from(("qwen3:8b", completion_request))
+            .expect("Failed to create Ollama request");
+
+        // Serialize to JSON
+        let serialized =
+            serde_json::to_value(&ollama_request).expect("Failed to serialize request");
+
+        // Assert equality with expected JSON
+        // - "tools" is skipped when empty (skip_serializing_if)
+        // - "think" should be a top-level boolean, NOT in options
+        // - "keep_alive" should be a top-level string, NOT in options
+        // - "num_ctx" should be in options (it's a model parameter)
+        let expected = json!({
+            "model": "qwen3:8b",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "You are a helpful assistant."
+                },
+                {
+                    "role": "user",
+                    "content": "What is 2 + 2?"
+                }
+            ],
+            "temperature": 0.7,
+            "stream": false,
+            "think": "medium",
+            "max_tokens": 1024,
+            "keep_alive": "-1m",
+            "options": {
+                "temperature": 0.7,
+                "num_ctx": 4096
+            }
+        });
+
+        assert_eq!(serialized, expected);
+    }
+
+    // Test that `think` and `keep_alive` are extracted as top-level params, not in `options`
+    #[test]
+    fn test_completion_request_with_level_high_think_param() {
+        use crate::OneOrMany;
+        use crate::completion::Message as CompletionMessage;
+        use crate::message::{Text, UserContent};
+
+        // Create a CompletionRequest with "think": true, "keep_alive", and "num_ctx" in additional_params
+        let completion_request = CompletionRequest {
+            model: None,
+            preamble: Some("You are a helpful assistant.".to_string()),
+            chat_history: OneOrMany::one(CompletionMessage::User {
+                content: OneOrMany::one(UserContent::Text(Text {
+                    text: "What is 2 + 2?".to_string(),
+                })),
+            }),
+            documents: vec![],
+            tools: vec![],
+            temperature: Some(0.7),
+            max_tokens: Some(1024),
+            tool_choice: None,
+            additional_params: Some(json!({
+                "think": "high",
+                "keep_alive": "-1m",
+                "num_ctx": 4096
+            })),
+            output_schema: None,
+        };
+
+        // Convert to OllamaCompletionRequest
+        let ollama_request = OllamaCompletionRequest::try_from(("qwen3:8b", completion_request))
+            .expect("Failed to create Ollama request");
+
+        // Serialize to JSON
+        let serialized =
+            serde_json::to_value(&ollama_request).expect("Failed to serialize request");
+
+        // Assert equality with expected JSON
+        // - "tools" is skipped when empty (skip_serializing_if)
+        // - "think" should be a top-level boolean, NOT in options
+        // - "keep_alive" should be a top-level string, NOT in options
+        // - "num_ctx" should be in options (it's a model parameter)
+        let expected = json!({
+            "model": "qwen3:8b",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "You are a helpful assistant."
+                },
+                {
+                    "role": "user",
+                    "content": "What is 2 + 2?"
+                }
+            ],
+            "temperature": 0.7,
+            "stream": false,
+            "think": "high",
+            "max_tokens": 1024,
+            "keep_alive": "-1m",
+            "options": {
+                "temperature": 0.7,
+                "num_ctx": 4096
+            }
+        });
+
+        assert_eq!(serialized, expected);
+    }
+
+    // Test that `think` and `keep_alive` are extracted as top-level params, not in `options`
+    #[test]
+    fn test_completion_request_with_level_invalid_think_param() {
+        use crate::OneOrMany;
+        use crate::completion::Message as CompletionMessage;
+        use crate::message::{Text, UserContent};
+
+        // Create a CompletionRequest with "think": true, "keep_alive", and "num_ctx" in additional_params
+        let completion_request = CompletionRequest {
+            model: None,
+            preamble: Some("You are a helpful assistant.".to_string()),
+            chat_history: OneOrMany::one(CompletionMessage::User {
+                content: OneOrMany::one(UserContent::Text(Text {
+                    text: "What is 2 + 2?".to_string(),
+                })),
+            }),
+            documents: vec![],
+            tools: vec![],
+            temperature: Some(0.7),
+            max_tokens: Some(1024),
+            tool_choice: None,
+            additional_params: Some(json!({
+                "think": "invalid",
+                "keep_alive": "-1m",
+                "num_ctx": 4096
+            })),
+            output_schema: None,
+        };
+
+        // Convert to OllamaCompletionRequest
+        let ollama_request = OllamaCompletionRequest::try_from(("qwen3:8b", completion_request));
+
+        assert!(ollama_request.is_err())
     }
 
     // Test that `think` defaults to false when not specified


### PR DESCRIPTION
Extends the `think` parameter in Ollama completion requests to accept string values "low", "medium", or "high", in addition to boolean. This provides more granular control over Ollama's internal thought process reporting.
documentation for thinking: https://docs.ollama.com/capabilities/thinking