### PR TITLE
feat(memory): add Compactor trait, CompactingMemory adapter, and TemplateCompactor

### DIFF
--- a/crates/rig-core/CHANGELOG.md
+++ b/crates/rig-core/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `rig::memory::Compactor` trait. A `Compactor` produces a single
+  `Message`-shaped `Artifact` from a slice of messages a memory policy
+  has evicted, optionally combining it with the previous summary
+  (`carry_over`) for rolling-summary semantics. Where `DemotionHook`
+  is a one-way drain that observes evicted messages, `Compactor` is
+  the inverse: it returns an artifact that the composing adapter
+  splices back into the active history, so the loaded prompt shape is
+  `[summary, ...recent_window]` instead of a verbatim suffix. The
+  trait lives in `rig_core` so any memory backend can implement it
+  without taking a `rig-memory` dependency; the composing
+  `CompactingMemory` adapter and a zero-dependency `TemplateCompactor`
+  reference implementation live in `rig-memory`. Implementations with
+  durable side effects (LLM calls, vector-store writes) must
+  deduplicate per the same idempotency contract as `DemotionHook`,
+  since per-conversation watermarks are in-process only.
+
 - Rig-managed conversation memory:
   - New `rig::memory` module with the `ConversationMemory` trait,
     `MemoryError` (with a `MemoryBackendError` source type),

--- a/crates/rig-core/src/memory.rs
+++ b/crates/rig-core/src/memory.rs
@@ -207,6 +207,79 @@ where
     }
 }
 
+/// Derives a single [`Message`]-shaped artifact from a slice of messages
+/// that a memory policy has evicted from the active window.
+///
+/// Where a [`DemotionHook`] is a one-way drain — observe what fell out and
+/// return `()` — a `Compactor` is the inverse: it takes the evicted prefix
+/// (and optionally the previous summary) and produces a derived artifact
+/// that the composing adapter splices *back into* the active history. The
+/// resulting prompt is no longer a verbatim suffix of the conversation; it
+/// is `[summary, ...recent_window]`.
+///
+/// Implementations typically wrap an LLM call (`LlmCompactor<M>`) or a
+/// pure template rollup. They run inline on the load path whenever the
+/// policy demotes new messages, so a slow compactor delays the agent's
+/// next turn — keep them fast or offload to a cached/background pipeline.
+///
+/// # Rolling summaries
+///
+/// `carry_over` is the artifact produced by the previous compaction for
+/// this conversation, if any. Implementations that want a *recursive*
+/// summary (the canonical pattern for long-running agents) should
+/// summarize `evicted` *together with* `carry_over` so context lost in
+/// earlier compactions is preserved transitively. Stateless implementations
+/// can ignore `carry_over` and produce a fresh summary of `evicted` alone.
+///
+/// # Idempotency contract
+///
+/// Composing adapters track per-conversation in-process delivery so the
+/// same `evicted` slice is not compacted twice within a process lifetime,
+/// but those watermarks are not persisted across restarts. Implementations
+/// that have side effects (writing summaries to a vector store, billing an
+/// LLM call) should deduplicate by conversation id and content hash, the
+/// same way [`DemotionHook`] implementations do.
+pub trait Compactor: WasmCompatSend + WasmCompatSync {
+    /// The summary value produced by [`Compactor::compact`].
+    ///
+    /// `Into<Message>` is required so the composing adapter can splice the
+    /// artifact at the front of the loaded history. `Clone` is required so
+    /// the adapter can keep a private copy as `carry_over` for the next
+    /// compaction.
+    type Artifact: Into<Message> + Clone + WasmCompatSend + WasmCompatSync + 'static;
+
+    /// Produce a summary artifact for `evicted`, optionally combining it
+    /// with the previous summary in `carry_over`.
+    ///
+    /// `evicted` is in original conversation order. Errors are surfaced as
+    /// [`MemoryError::Backend`] (or any other variant the implementation
+    /// chooses) by the composing adapter.
+    fn compact<'a>(
+        &'a self,
+        conversation_id: &'a str,
+        evicted: &'a [Message],
+        carry_over: Option<&'a Self::Artifact>,
+    ) -> WasmBoxedFuture<'a, Result<Self::Artifact, MemoryError>>;
+}
+
+/// Forwarding impl so callers can pass `Arc<C>` wherever a `Compactor` is
+/// expected (e.g. when sharing a single compactor across adapters).
+impl<C> Compactor for Arc<C>
+where
+    C: Compactor + ?Sized,
+{
+    type Artifact = C::Artifact;
+
+    fn compact<'a>(
+        &'a self,
+        conversation_id: &'a str,
+        evicted: &'a [Message],
+        carry_over: Option<&'a Self::Artifact>,
+    ) -> WasmBoxedFuture<'a, Result<Self::Artifact, MemoryError>> {
+        (**self).compact(conversation_id, evicted, carry_over)
+    }
+}
+
 /// A simple thread-safe in-memory [`ConversationMemory`] backed by a `HashMap`.
 ///
 /// Messages are stored in process memory only and lost on restart. Useful for

--- a/crates/rig-core/src/memory.rs
+++ b/crates/rig-core/src/memory.rs
@@ -251,9 +251,12 @@ pub trait Compactor: WasmCompatSend + WasmCompatSync {
     /// Produce a summary artifact for `evicted`, optionally combining it
     /// with the previous summary in `carry_over`.
     ///
-    /// `evicted` is in original conversation order. Errors are surfaced as
-    /// [`MemoryError::Backend`] (or any other variant the implementation
-    /// chooses) by the composing adapter.
+    /// `evicted` is in original conversation order. Errors are propagated
+    /// unchanged by composing adapters; pick the [`MemoryError`] variant
+    /// that best describes the failure ([`MemoryError::Backend`] for I/O
+    /// or remote-LLM faults, [`MemoryError::Internal`] for invariant
+    /// breaks, and so on). The adapter does not re-wrap the returned
+    /// variant.
     fn compact<'a>(
         &'a self,
         conversation_id: &'a str,

--- a/crates/rig-core/src/vector_store/mod.rs
+++ b/crates/rig-core/src/vector_store/mod.rs
@@ -245,9 +245,10 @@ where
 }
 
 /// Index strategy for the super::InMemoryVectorStore
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub enum IndexStrategy {
     /// Checks all documents in the vector store to find the most relevant documents.
+    #[default]
     BruteForce,
 
     /// Uses LSH to find candidates then computes exact distances.
@@ -257,10 +258,4 @@ pub enum IndexStrategy {
         /// Number of hyperplanes to use for LSH.
         num_hyperplanes: usize,
     },
-}
-
-impl Default for IndexStrategy {
-    fn default() -> Self {
-        Self::BruteForce
-    }
 }

--- a/crates/rig-memory/CHANGELOG.md
+++ b/crates/rig-memory/CHANGELOG.md
@@ -9,6 +9,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Compactor` trait (re-exported from `rig_core::memory`) +
+  `CompactingMemory<M, P, C>` adapter and a `TemplateCompactor`
+  reference implementation. Where `DemotingPolicyMemory` only
+  *observes* messages a policy truncates out of active history, a
+  `Compactor` *substitutes* them: it derives a single `Message`-shaped
+  `Artifact` from the evicted prefix (and, optionally, the previous
+  summary), and `CompactingMemory` splices that artifact at the front
+  of the loaded history. The resulting prompt shape is
+  `[summary_message, ...kept_window]`, with the summary rolling
+  forward on every load that produces newly-evicted messages — the
+  canonical recursive-summary pattern for long-running agents.
+  Concurrent loads on the same `conversation_id` are serialised at
+  the compaction seam via an in-flight gate: only one load at a time
+  invokes the compactor; others observe the gate and immediately
+  return the previously-stored summary spliced in front of `kept`,
+  without re-running the compactor. Watermarks and the carry-over
+  summary are in-process only — `Compactor` implementations with
+  durable side effects (LLM calls, vector-store writes) must
+  deduplicate. `clear` drops the carry-over so a freshly-populated
+  backend re-compacts from scratch. `TemplateCompactor` is a
+  zero-dependency, no-LLM rollup useful as a default and for tests;
+  it produces a `TextSummary` that converts into a `Message::System`
+  with header + previous-summary + per-line `role: text` body. The
+  rollup represents out-of-band context about the prior conversation
+  rather than a turn from any participant, so the system role is the
+  semantically correct framing across providers. `TemplateCompactor`
+  exposes `with_max_bytes` so long-running conversations can cap the
+  rolled-up text; when exceeded, the oldest portion of the body is
+  dropped at a UTF-8 boundary and replaced with a `"[…truncated…]"`
+  marker, preserving the most recent context. Note that the spliced
+  summary sits **outside** the wrapped `MemoryPolicy`'s budget, so
+  pairing `CompactingMemory` with a token-budgeted policy requires a
+  bounded compactor (or accepting that the loaded prompt may exceed
+  the policy budget by the artifact size).
+
 - `DemotionHook` trait + `DemotingPolicyMemory<M, P, H>` adapter and a
   `NoopDemotionHook` no-op default. The trait itself lives in
   `rig_core::memory` (re-exported here) so any memory backend can

--- a/crates/rig-memory/src/lib.rs
+++ b/crates/rig-memory/src/lib.rs
@@ -21,6 +21,10 @@
 //!   [`TokenCounter`] that approximates token cost from character lengths.
 //! - [`DemotionHook`] + [`DemotingPolicyMemory`] — bridge truncated turns
 //!   from a [`MemoryPolicy`] into a long-tail store.
+//! - [`Compactor`] + [`CompactingMemory`] — replace truncated turns with a
+//!   derived summary artifact (rolling-summary semantics).
+//! - [`TemplateCompactor`] — zero-dependency reference [`Compactor`] that
+//!   produces a textual rollup without calling an LLM.
 //!
 //! All sliding policies drop a leading orphan tool-result message when the
 //! preceding assistant tool call has been truncated, since most providers
@@ -43,7 +47,8 @@ use std::{
 /// Re-exports of the core memory abstractions so callers only need a single
 /// dependency on `rig-memory` for both the trait/backend and the policies.
 pub use rig_core::memory::{
-    ConversationMemory, DemotionHook, InMemoryConversationMemory, MemoryError, NoopDemotionHook,
+    Compactor, ConversationMemory, DemotionHook, InMemoryConversationMemory, MemoryError,
+    NoopDemotionHook,
 };
 
 use rig_core::completion::Message;
@@ -761,6 +766,578 @@ fn poisoned<E: std::fmt::Display>(err: E) -> MemoryError {
     MemoryError::Internal(err.to_string())
 }
 
+/// A [`ConversationMemory`] adapter that wraps a backend with a
+/// [`MemoryPolicy`] **and** a [`Compactor`], replacing truncated turns with
+/// a summary artifact spliced at the front of the loaded history.
+///
+/// `CompactingMemory` is the next layer above [`DemotingPolicyMemory`]: a
+/// demotion hook only *observes* what the policy evicted, while a compactor
+/// *substitutes* the evicted prefix with a derived [`Message`]. The loaded
+/// history shape is therefore `[summary_message, ...kept_window]` whenever
+/// any compaction has occurred for the conversation, and just `kept_window`
+/// otherwise. The summary itself is recomputed (rolled forward) on every
+/// load that produces newly-evicted messages, so older summaries are folded
+/// into newer ones via the compactor's `carry_over` parameter.
+///
+/// # Concurrency
+///
+/// Concurrent [`ConversationMemory::load`] calls on the same
+/// `conversation_id` are serialised at the compaction seam: only one call
+/// at a time invokes the compactor for a given conversation. Other
+/// concurrent loads observe the in-flight compaction and immediately
+/// return the previously-stored summary spliced in front of `kept`,
+/// without re-running the compactor. Newly-evicted messages skipped this
+/// way are folded into the next compaction.
+///
+/// **Failure visibility.** A compactor error is returned only to the
+/// caller whose `load` actually drove the compaction. Concurrent callers
+/// that short-circuited on `in_flight` see `Ok([old_summary?, ...kept])`
+/// even if the in-flight compaction ultimately failed; the watermark
+/// stays unchanged so the next `load` retries.
+///
+/// # Persistence
+///
+/// The carry-over summary and delivery watermarks are kept in process
+/// memory only. Across process restarts, the first load on each
+/// conversation re-evicts and re-compacts the same prefix; compactors
+/// that have side effects (LLM calls, persistent writes) should
+/// deduplicate.
+///
+/// # Prompt shape and budgets
+///
+/// `CompactingMemory` is **policy-agnostic**: the wrapped
+/// [`MemoryPolicy`] decides which messages are kept versus demoted, and
+/// only the kept window is bounded by that policy. The summary artifact
+/// produced by the [`Compactor`] is spliced **outside** that budget — so
+/// the loaded prompt has shape `[summary, ...kept_window]` where
+/// `kept_window` respects the policy's bounds and `summary` adds an
+/// extra message on top of it.
+///
+/// Callers that combine `CompactingMemory` with a token-budgeted policy
+/// (e.g. [`TokenWindowMemory`]) **must use a [`Compactor`] that bounds
+/// its own artifact**, or accept that the loaded prompt may exceed the
+/// policy's budget by the size of the summary. The reference
+/// [`TemplateCompactor`] grows monotonically by default; configure it
+/// with [`TemplateCompactor::with_max_bytes`] to cap the rolled-up text.
+///
+/// # Example
+///
+/// ```no_run
+/// use rig_memory::{
+///     CompactingMemory, InMemoryConversationMemory, SlidingWindowMemory,
+///     TemplateCompactor,
+/// };
+///
+/// let memory = CompactingMemory::new(
+///     InMemoryConversationMemory::new(),
+///     SlidingWindowMemory::last_messages(20),
+///     TemplateCompactor::new(),
+/// );
+/// # let _ = memory;
+/// ```
+pub struct CompactingMemory<M, P, C: Compactor> {
+    inner: M,
+    policy: P,
+    compactor: C,
+    state: StdMutex<HashMap<String, ConversationCompactionState<C::Artifact>>>,
+}
+
+struct ConversationCompactionState<A> {
+    /// Latest summary artifact for this conversation, if compaction has
+    /// already happened. Cloned into the loaded history on every `load`.
+    summary: Option<A>,
+    /// Number of demoted messages already absorbed into `summary` within
+    /// this process lifetime. Advanced only on compactor success.
+    absorbed: usize,
+    /// True while a `load` is currently awaiting the compactor for this
+    /// conversation. Other concurrent loads observe this and short-circuit
+    /// without re-running the compactor.
+    in_flight: bool,
+}
+
+impl<M, P, C: Compactor> CompactingMemory<M, P, C> {
+    /// Wrap `inner` so every load runs through `policy` and demoted messages
+    /// are summarised by `compactor`.
+    pub fn new(inner: M, policy: P, compactor: C) -> Self {
+        Self {
+            inner,
+            policy,
+            compactor,
+            state: StdMutex::new(HashMap::new()),
+        }
+    }
+
+    /// Return a reference to the wrapped backend.
+    pub fn inner(&self) -> &M {
+        &self.inner
+    }
+
+    /// Return a reference to the wrapped policy.
+    pub fn policy(&self) -> &P {
+        &self.policy
+    }
+
+    /// Return a reference to the compactor.
+    pub fn compactor(&self) -> &C {
+        &self.compactor
+    }
+
+    /// Consume the wrapper and return its three components.
+    pub fn into_inner(self) -> (M, P, C) {
+        (self.inner, self.policy, self.compactor)
+    }
+
+    /// Drop the in-process compaction state for `conversation_id`.
+    ///
+    /// Call this when a conversation has ended to bound memory usage; the
+    /// state map is otherwise unbounded. If the internal lock has been
+    /// poisoned by a panic in another thread, this is a no-op.
+    pub fn forget(&self, conversation_id: &str) {
+        if let Ok(mut guard) = self.state.lock() {
+            guard.remove(conversation_id);
+        }
+    }
+
+    /// Number of conversations currently tracked in the compaction state
+    /// map. Useful for telemetry and leak detection. Returns `0` if the
+    /// internal lock is poisoned.
+    pub fn tracked_conversations(&self) -> usize {
+        self.state.lock().map(|g| g.len()).unwrap_or(0)
+    }
+}
+
+impl<M, P, C> std::fmt::Debug for CompactingMemory<M, P, C>
+where
+    M: std::fmt::Debug,
+    P: std::fmt::Debug,
+    C: Compactor,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CompactingMemory")
+            .field("inner", &self.inner)
+            .field("policy", &self.policy)
+            .field("compactor", &"<compactor>")
+            .finish()
+    }
+}
+
+impl<M, P, C> ConversationMemory for CompactingMemory<M, P, C>
+where
+    M: ConversationMemory,
+    P: MemoryPolicy,
+    C: Compactor,
+{
+    fn load<'a>(
+        &'a self,
+        conversation_id: &'a str,
+    ) -> WasmBoxedFuture<'a, Result<Vec<Message>, MemoryError>> {
+        Box::pin(async move {
+            let messages = self.inner.load(conversation_id).await?;
+            let (kept, demoted) = self.policy.apply_with_demoted(messages)?;
+            let demoted_count = demoted.len();
+
+            // Decide-and-mark must happen under one short-lived lock so two
+            // concurrent loads on the same conversation_id can't both
+            // observe the same `absorbed` watermark and run the compactor
+            // twice with the same input slice.
+            //
+            // Fast path: if the conversation is already tracked, mutate in
+            // place. Only allocate a new `String` key when there is real
+            // compaction work for a conversation we have not seen before.
+            let plan = {
+                let mut guard = self.state.lock().map_err(poisoned)?;
+                if let Some(entry) = guard.get_mut(conversation_id) {
+                    if entry.in_flight {
+                        // Another load is mid-compaction; return what we
+                        // have so far. Newly-evicted messages will be
+                        // folded in by the next load.
+                        return Ok(splice(entry.summary.clone(), kept));
+                    }
+                    if demoted_count <= entry.absorbed {
+                        // No new evictions to compact. Splice the existing
+                        // summary (if any) and we're done.
+                        return Ok(splice(entry.summary.clone(), kept));
+                    }
+                    entry.in_flight = true;
+                    CompactionPlan {
+                        carry_over: entry.summary.clone(),
+                        skip: entry.absorbed,
+                    }
+                } else if demoted_count == 0 {
+                    // First load for this conversation and nothing was
+                    // demoted: no tracking entry needed yet.
+                    return Ok(kept);
+                } else {
+                    guard.insert(
+                        conversation_id.to_string(),
+                        ConversationCompactionState {
+                            summary: None,
+                            absorbed: 0,
+                            in_flight: true,
+                        },
+                    );
+                    CompactionPlan {
+                        carry_over: None,
+                        skip: 0,
+                    }
+                }
+            };
+
+            // SAFETY: split_at(plan.skip) is sound because `plan.skip` was
+            // sourced from the entry's `absorbed` watermark while we held
+            // the lock, and we only set `absorbed = demoted_count` on
+            // success — so `plan.skip <= demoted_count == demoted.len()`.
+            let CompactionPlan { carry_over, skip } = plan;
+            let new_slice = match demoted.get(skip..) {
+                Some(s) => s,
+                None => {
+                    // Re-acquire and clear the in-flight flag so the next
+                    // load can retry, then surface the invariant break.
+                    if let Ok(mut guard) = self.state.lock()
+                        && let Some(entry) = guard.get_mut(conversation_id)
+                    {
+                        entry.in_flight = false;
+                    }
+                    return Err(MemoryError::Internal(
+                        "compaction watermark exceeds demoted slice length".into(),
+                    ));
+                }
+            };
+
+            let result = self
+                .compactor
+                .compact(conversation_id, new_slice, carry_over.as_ref())
+                .await;
+
+            // Reacquire briefly to advance the watermark on success and
+            // always clear the in-flight flag so a future load can retry.
+            //
+            // Only update if the entry still exists: a concurrent `clear`
+            // (and matching `forget`) for this `conversation_id` may have
+            // dropped the state entry while the compactor was awaiting. In
+            // that case we must not resurrect it with stale state — the
+            // next load on a freshly-populated backend would then start
+            // from a non-zero watermark and skip a real compaction.
+            let summary_for_splice = match result {
+                Ok(artifact) => {
+                    let mut guard = self.state.lock().map_err(poisoned)?;
+                    if let Some(entry) = guard.get_mut(conversation_id) {
+                        entry.in_flight = false;
+                        entry.absorbed = demoted_count;
+                        entry.summary = Some(artifact.clone());
+                        Some(artifact)
+                    } else {
+                        // Conversation was cleared mid-compaction. Drop
+                        // the artifact rather than reviving stale state.
+                        None
+                    }
+                }
+                Err(err) => {
+                    let mut guard = self.state.lock().map_err(poisoned)?;
+                    if let Some(entry) = guard.get_mut(conversation_id) {
+                        entry.in_flight = false;
+                    }
+                    return Err(err);
+                }
+            };
+
+            Ok(splice(summary_for_splice, kept))
+        })
+    }
+
+    fn append<'a>(
+        &'a self,
+        conversation_id: &'a str,
+        messages: Vec<Message>,
+    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+        self.inner.append(conversation_id, messages)
+    }
+
+    fn clear<'a>(
+        &'a self,
+        conversation_id: &'a str,
+    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+        Box::pin(async move {
+            self.inner.clear(conversation_id).await?;
+            self.forget(conversation_id);
+            Ok(())
+        })
+    }
+}
+
+struct CompactionPlan<A> {
+    carry_over: Option<A>,
+    skip: usize,
+}
+
+fn splice<A>(summary: Option<A>, kept: Vec<Message>) -> Vec<Message>
+where
+    A: Into<Message>,
+{
+    match summary {
+        Some(artifact) => {
+            let mut out = Vec::with_capacity(kept.len() + 1);
+            out.push(artifact.into());
+            out.extend(kept);
+            out
+        }
+        None => kept,
+    }
+}
+
+/// A zero-dependency reference [`Compactor`] that produces a textual
+/// rollup of evicted messages without calling an LLM.
+///
+/// The artifact is a single [`Message::System`] whose body concatenates a
+/// header, the previous summary (if any), and the textual content of each
+/// newly-evicted message. It is intentionally simple: useful as a default
+/// for tests and examples, and as a placeholder before wiring a real
+/// summarising LLM through a custom [`Compactor`] implementation.
+///
+/// # Bounding the summary
+///
+/// By default the summary grows monotonically: every compaction pass
+/// embeds the previous summary verbatim and appends newly-evicted lines.
+/// Long-running conversations should call [`Self::with_max_bytes`] to
+/// cap the rolled-up text. When the cap is exceeded, the oldest portion
+/// of the body (after the header) is dropped at a UTF-8 boundary and
+/// replaced with a `"[…truncated…]"` marker, preserving the most recent
+/// context.
+///
+/// # Example
+///
+/// ```
+/// use rig_memory::TemplateCompactor;
+///
+/// // Default header is "[Conversation summary so far]", unbounded.
+/// let _compactor = TemplateCompactor::new();
+///
+/// // Custom header plus a 4 KiB cap for use with token-budgeted policies.
+/// let _bounded = TemplateCompactor::with_header("Earlier context")
+///     .with_max_bytes(4 * 1024);
+/// ```
+#[derive(Debug, Clone)]
+pub struct TemplateCompactor {
+    header: String,
+    max_bytes: Option<usize>,
+}
+
+impl TemplateCompactor {
+    /// Create a [`TemplateCompactor`] with the default header
+    /// `"[Conversation summary so far]"` and no size cap.
+    pub fn new() -> Self {
+        Self::with_header("[Conversation summary so far]")
+    }
+
+    /// Create a [`TemplateCompactor`] with a custom header line and no
+    /// size cap.
+    pub fn with_header(header: impl Into<String>) -> Self {
+        Self {
+            header: header.into(),
+            max_bytes: None,
+        }
+    }
+
+    /// Cap the rolled-up summary at `max_bytes` bytes (UTF-8). When the
+    /// assembled body exceeds the cap, the oldest portion after the
+    /// header is dropped at a char boundary and replaced with a
+    /// `"[…truncated…]"` marker.
+    ///
+    /// `max_bytes` of `0` disables truncation (equivalent to the default
+    /// unbounded behaviour). The header line plus the marker are always
+    /// preserved even if they exceed the cap.
+    pub fn with_max_bytes(mut self, max_bytes: usize) -> Self {
+        self.max_bytes = if max_bytes == 0 {
+            None
+        } else {
+            Some(max_bytes)
+        };
+        self
+    }
+}
+
+impl Default for TemplateCompactor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Plain-text artifact produced by [`TemplateCompactor`].
+///
+/// Convertible into a [`Message::System`] whose body is the rolled-up
+/// text. The system role is used because the rollup represents
+/// out-of-band context about the prior conversation, not a turn from
+/// any participant.
+#[derive(Debug, Clone)]
+pub struct TextSummary(String);
+
+impl TextSummary {
+    /// Borrow the underlying summary text.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Consume the wrapper and return the underlying `String`.
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl From<TextSummary> for Message {
+    fn from(value: TextSummary) -> Self {
+        Message::System { content: value.0 }
+    }
+}
+
+impl Compactor for TemplateCompactor {
+    type Artifact = TextSummary;
+
+    fn compact<'a>(
+        &'a self,
+        _conversation_id: &'a str,
+        evicted: &'a [Message],
+        carry_over: Option<&'a Self::Artifact>,
+    ) -> WasmBoxedFuture<'a, Result<Self::Artifact, MemoryError>> {
+        Box::pin(async move {
+            let mut buf = String::new();
+            buf.push_str(&self.header);
+            buf.push('\n');
+            if let Some(prev) = carry_over {
+                buf.push_str(prev.as_str());
+                buf.push('\n');
+            }
+            for msg in evicted {
+                let line = render_message_line(msg);
+                if !line.is_empty() {
+                    buf.push_str(&line);
+                    buf.push('\n');
+                }
+            }
+            if let Some(cap) = self.max_bytes
+                && buf.len() > cap
+            {
+                buf = truncate_summary(&self.header, &buf, cap);
+            }
+            Ok(TextSummary(buf))
+        })
+    }
+}
+
+/// Truncate `buf` to fit within `cap` bytes by dropping the oldest
+/// content after the header line. Always preserves the header plus a
+/// `"[\u{2026}truncated\u{2026}]"` marker, even if they alone exceed `cap`.
+fn truncate_summary(header: &str, buf: &str, cap: usize) -> String {
+    const MARKER: &str = "[\u{2026}truncated\u{2026}]\n";
+    // Body starts right after the header's trailing newline.
+    let header_prefix_len = header.len() + 1;
+    if buf.len() <= header_prefix_len {
+        return buf.to_string();
+    }
+    let preserved = header_prefix_len + MARKER.len();
+    // Number of bytes of the body we can keep after the marker.
+    let keep_bytes = cap.saturating_sub(preserved);
+    let body_start = header_prefix_len;
+    let body = match buf.get(body_start..) {
+        Some(b) => b,
+        None => return buf.to_string(),
+    };
+    // Take the suffix of `body` whose length is at most `keep_bytes`,
+    // walking forward to a UTF-8 char boundary.
+    let mut cut = body.len().saturating_sub(keep_bytes);
+    while cut < body.len() && !body.is_char_boundary(cut) {
+        cut += 1;
+    }
+    let suffix = match body.get(cut..) {
+        Some(s) => s,
+        None => "",
+    };
+    let mut out = String::with_capacity(header_prefix_len + MARKER.len() + suffix.len());
+    out.push_str(header);
+    out.push('\n');
+    out.push_str(MARKER);
+    out.push_str(suffix);
+    out
+}
+
+/// Render a single message as a `"role: text"` line for [`TemplateCompactor`].
+///
+/// Non-textual content (tool calls, tool results, attachments) is rendered
+/// as a short marker so the rollup does not silently drop them but also
+/// does not balloon with serialized JSON.
+fn render_message_line(msg: &Message) -> String {
+    use rig_core::message::AssistantContent;
+
+    match msg {
+        Message::System { content } => {
+            if content.is_empty() {
+                String::new()
+            } else {
+                format!("system: {content}")
+            }
+        }
+        Message::User { content } => {
+            let mut text = String::new();
+            for c in content.iter() {
+                match c {
+                    UserContent::Text(t) => {
+                        if !text.is_empty() {
+                            text.push(' ');
+                        }
+                        text.push_str(&t.text);
+                    }
+                    UserContent::ToolResult(_) => {
+                        if !text.is_empty() {
+                            text.push(' ');
+                        }
+                        text.push_str("[tool result]");
+                    }
+                    _ => {
+                        if !text.is_empty() {
+                            text.push(' ');
+                        }
+                        text.push_str("[attachment]");
+                    }
+                }
+            }
+            if text.is_empty() {
+                String::new()
+            } else {
+                format!("user: {text}")
+            }
+        }
+        Message::Assistant { content, .. } => {
+            let mut text = String::new();
+            for c in content.iter() {
+                match c {
+                    AssistantContent::Text(t) => {
+                        if !text.is_empty() {
+                            text.push(' ');
+                        }
+                        text.push_str(&t.text);
+                    }
+                    AssistantContent::ToolCall(call) => {
+                        if !text.is_empty() {
+                            text.push(' ');
+                        }
+                        text.push_str(&format!("[tool call: {}]", call.function.name));
+                    }
+                    _ => {
+                        if !text.is_empty() {
+                            text.push(' ');
+                        }
+                        text.push_str("[reasoning]");
+                    }
+                }
+            }
+            if text.is_empty() {
+                String::new()
+            } else {
+                format!("assistant: {text}")
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1344,5 +1921,676 @@ mod tests {
         assert_eq!(mem.tracked_conversations(), 0);
         mem.load("c").await.unwrap();
         assert_eq!(hook.calls(), 2);
+    }
+
+    // ----------------------------------------------------------------
+    // CompactingMemory tests
+    // ----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn compacting_no_demotion_returns_kept_only() {
+        let mem = CompactingMemory::new(
+            InMemoryConversationMemory::new(),
+            SlidingWindowMemory::last_messages(10),
+            TemplateCompactor::new(),
+        );
+
+        mem.append("c", vec![user("hi"), assistant("hello")])
+            .await
+            .unwrap();
+        let loaded = mem.load("c").await.unwrap();
+        assert_eq!(loaded.len(), 2);
+        // No tracking entry needed when nothing was demoted on the first load.
+        // (We may have inserted a default entry; what matters is that no
+        // summary message was spliced in.)
+        assert!(matches!(&loaded[0], Message::User { .. }));
+    }
+
+    #[tokio::test]
+    async fn compacting_splices_summary_when_demoted() {
+        let mem = CompactingMemory::new(
+            InMemoryConversationMemory::new(),
+            SlidingWindowMemory::last_messages(2),
+            TemplateCompactor::new(),
+        );
+
+        mem.append(
+            "c",
+            vec![
+                user("first"),
+                assistant("second"),
+                user("third"),
+                assistant("fourth"),
+            ],
+        )
+        .await
+        .unwrap();
+
+        let loaded = mem.load("c").await.unwrap();
+        // Expected shape: [summary, third, fourth]
+        assert_eq!(loaded.len(), 3);
+        let Message::System { content } = &loaded[0] else {
+            panic!("expected summary as system message");
+        };
+        assert!(content.contains("[Conversation summary so far]"));
+        assert!(content.contains("user: first"));
+        assert!(content.contains("assistant: second"));
+        // The kept window is intact.
+        let Message::User { content } = &loaded[1] else {
+            panic!("expected kept user message");
+        };
+        let UserContent::Text(t) = content.first_ref() else {
+            panic!("expected text");
+        };
+        assert_eq!(t.text, "third");
+    }
+
+    #[tokio::test]
+    async fn compacting_rolls_summary_forward() {
+        let mem = CompactingMemory::new(
+            InMemoryConversationMemory::new(),
+            SlidingWindowMemory::last_messages(2),
+            TemplateCompactor::new(),
+        );
+
+        mem.append(
+            "c",
+            vec![user("a"), assistant("b"), user("c"), assistant("d")],
+        )
+        .await
+        .unwrap();
+
+        let first = mem.load("c").await.unwrap();
+        let Message::System { content } = &first[0] else {
+            panic!("summary missing");
+        };
+        let first_summary = content.clone();
+        assert!(first_summary.contains("user: a"));
+        assert!(first_summary.contains("assistant: b"));
+
+        // Append more turns; the next load should fold the previous summary
+        // into a new one that also covers the newly-evicted prefix.
+        mem.append("c", vec![user("e"), assistant("f")])
+            .await
+            .unwrap();
+        let second = mem.load("c").await.unwrap();
+        let Message::System { content } = &second[0] else {
+            panic!("summary missing");
+        };
+        // The new summary contains the old summary text (carry_over) plus
+        // the freshly-evicted lines.
+        assert!(content.contains(&first_summary));
+        assert!(content.contains("user: c"));
+        assert!(content.contains("assistant: d"));
+    }
+
+    #[tokio::test]
+    async fn compacting_idempotent_within_process() {
+        // Loading twice with no new evictions reuses the stored summary
+        // and does not re-run the compactor (we observe this via the
+        // produced text: a re-run with a non-None carry_over would double
+        // the header line).
+        let mem = CompactingMemory::new(
+            InMemoryConversationMemory::new(),
+            SlidingWindowMemory::last_messages(1),
+            TemplateCompactor::new(),
+        );
+        mem.append("c", vec![user("a"), assistant("b"), user("c")])
+            .await
+            .unwrap();
+
+        let first = mem.load("c").await.unwrap();
+        let second = mem.load("c").await.unwrap();
+        assert_eq!(first.len(), second.len());
+        let Message::System { content: c1 } = &first[0] else {
+            panic!()
+        };
+        let Message::System { content: c2 } = &second[0] else {
+            panic!()
+        };
+        assert_eq!(c1, c2);
+    }
+
+    #[tokio::test]
+    async fn compacting_clear_drops_summary() {
+        let mem = CompactingMemory::new(
+            InMemoryConversationMemory::new(),
+            SlidingWindowMemory::last_messages(1),
+            TemplateCompactor::new(),
+        );
+        mem.append("c", vec![user("a"), assistant("b"), user("c")])
+            .await
+            .unwrap();
+        mem.load("c").await.unwrap();
+        assert_eq!(mem.tracked_conversations(), 1);
+
+        mem.clear("c").await.unwrap();
+        assert_eq!(mem.tracked_conversations(), 0);
+        assert!(mem.load("c").await.unwrap().is_empty());
+    }
+
+    // A compactor that fails the first call and succeeds afterwards, so we
+    // can verify failure is propagated and the watermark is not advanced.
+    #[derive(Default)]
+    struct FlakyCompactor {
+        calls: std::sync::atomic::AtomicUsize,
+    }
+
+    impl Compactor for FlakyCompactor {
+        type Artifact = TextSummary;
+
+        fn compact<'a>(
+            &'a self,
+            _conversation_id: &'a str,
+            evicted: &'a [Message],
+            _carry_over: Option<&'a Self::Artifact>,
+        ) -> WasmBoxedFuture<'a, Result<Self::Artifact, MemoryError>> {
+            Box::pin(async move {
+                let n = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                if n == 0 {
+                    Err(MemoryError::Policy("flaky".into()))
+                } else {
+                    Ok(TextSummary(format!("compacted {} messages", evicted.len())))
+                }
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn compacting_failure_does_not_advance_watermark() {
+        let mem = CompactingMemory::new(
+            InMemoryConversationMemory::new(),
+            SlidingWindowMemory::last_messages(1),
+            FlakyCompactor::default(),
+        );
+        mem.append("c", vec![user("a"), assistant("b"), user("c")])
+            .await
+            .unwrap();
+
+        let err = mem.load("c").await.unwrap_err();
+        assert!(matches!(err, MemoryError::Policy(_)));
+
+        // Retry should succeed and produce a summary.
+        let loaded = mem.load("c").await.unwrap();
+        assert_eq!(loaded.len(), 2);
+        let Message::System { content } = &loaded[0] else {
+            panic!("expected summary")
+        };
+        assert!(content.contains("compacted"));
+    }
+
+    // A compactor that records every invocation, including the lengths of
+    // its `evicted` slice and whether `carry_over` was supplied.
+    #[derive(Default)]
+    struct CountingCompactor {
+        log: Mutex<Vec<(usize, bool)>>,
+    }
+
+    impl CountingCompactor {
+        fn calls(&self) -> Vec<(usize, bool)> {
+            self.log.lock().unwrap().clone()
+        }
+    }
+
+    impl Compactor for CountingCompactor {
+        type Artifact = TextSummary;
+
+        fn compact<'a>(
+            &'a self,
+            _conversation_id: &'a str,
+            evicted: &'a [Message],
+            carry_over: Option<&'a Self::Artifact>,
+        ) -> WasmBoxedFuture<'a, Result<Self::Artifact, MemoryError>> {
+            Box::pin(async move {
+                self.log
+                    .lock()
+                    .unwrap()
+                    .push((evicted.len(), carry_over.is_some()));
+                let prev = carry_over.map(|s| s.as_str()).unwrap_or("");
+                Ok(TextSummary(format!("{prev}|{}", evicted.len())))
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn compacting_no_demotion_does_not_invoke_compactor() {
+        let compactor = Arc::new(CountingCompactor::default());
+        let mem = CompactingMemory::new(
+            InMemoryConversationMemory::new(),
+            SlidingWindowMemory::last_messages(10),
+            compactor.clone(),
+        );
+
+        mem.append("c", vec![user("a"), assistant("b")])
+            .await
+            .unwrap();
+        mem.load("c").await.unwrap();
+        mem.load("c").await.unwrap();
+        mem.load("c").await.unwrap();
+        assert!(compactor.calls().is_empty());
+        // Fast path means we never installed a tracking entry either.
+        assert_eq!(mem.tracked_conversations(), 0);
+    }
+
+    #[tokio::test]
+    async fn compacting_invokes_compactor_only_on_new_demotions() {
+        let compactor = Arc::new(CountingCompactor::default());
+        let mem = CompactingMemory::new(
+            InMemoryConversationMemory::new(),
+            SlidingWindowMemory::last_messages(2),
+            compactor.clone(),
+        );
+
+        // First eviction: 2 messages demoted.
+        mem.append(
+            "c",
+            vec![user("a"), assistant("b"), user("c"), assistant("d")],
+        )
+        .await
+        .unwrap();
+        mem.load("c").await.unwrap();
+        // Re-load: nothing new evicted; compactor must NOT run again.
+        mem.load("c").await.unwrap();
+        mem.load("c").await.unwrap();
+        let calls = compactor.calls();
+        assert_eq!(
+            calls.len(),
+            1,
+            "compactor invoked more than once: {calls:?}"
+        );
+        assert_eq!(calls[0], (2, false));
+
+        // Append two more turns → another 2 demoted; compactor runs once
+        // more, and this time `carry_over` must be present.
+        mem.append("c", vec![user("e"), assistant("f")])
+            .await
+            .unwrap();
+        mem.load("c").await.unwrap();
+        mem.load("c").await.unwrap();
+        let calls = compactor.calls();
+        assert_eq!(calls.len(), 2, "expected exactly one new call: {calls:?}");
+        // Second call only compacts the *newly* evicted prefix (2 msgs)
+        // with the previous summary as carry-over.
+        assert_eq!(calls[1], (2, true));
+    }
+
+    #[tokio::test]
+    async fn compacting_serialises_concurrent_loads() {
+        // Many concurrent loads on the same conversation must produce at
+        // most ONE compactor invocation per "epoch" of new evictions.
+        let compactor = Arc::new(CountingCompactor::default());
+        let mem = Arc::new(CompactingMemory::new(
+            InMemoryConversationMemory::new(),
+            SlidingWindowMemory::last_messages(2),
+            compactor.clone(),
+        ));
+        mem.append(
+            "c",
+            vec![user("a"), assistant("b"), user("c"), assistant("d")],
+        )
+        .await
+        .unwrap();
+
+        let mut handles = Vec::new();
+        for _ in 0..32 {
+            let mem = mem.clone();
+            handles.push(tokio::spawn(async move {
+                mem.load("c").await.unwrap();
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+
+        // Exactly one invocation: the first to acquire the lock runs the
+        // compactor; the others see in_flight or the advanced watermark.
+        let calls = compactor.calls();
+        assert_eq!(calls.len(), 1, "expected exactly 1 call: {calls:?}");
+    }
+
+    #[tokio::test]
+    async fn compacting_clear_drops_summary_carry_over() {
+        // After clear, the next load on a freshly-populated backend must
+        // start compaction from scratch (carry_over=None), not roll the
+        // old summary forward.
+        let compactor = Arc::new(CountingCompactor::default());
+        let mem = CompactingMemory::new(
+            InMemoryConversationMemory::new(),
+            SlidingWindowMemory::last_messages(1),
+            compactor.clone(),
+        );
+        mem.append("c", vec![user("a"), assistant("b"), user("c")])
+            .await
+            .unwrap();
+        mem.load("c").await.unwrap();
+        assert_eq!(compactor.calls()[0], (2, false));
+
+        mem.clear("c").await.unwrap();
+        assert_eq!(mem.tracked_conversations(), 0);
+
+        mem.append("c", vec![user("x"), assistant("y"), user("z")])
+            .await
+            .unwrap();
+        mem.load("c").await.unwrap();
+        let calls = compactor.calls();
+        assert_eq!(calls.len(), 2);
+        // Crucial: no carry_over after clear.
+        assert_eq!(calls[1], (2, false));
+    }
+
+    #[tokio::test]
+    async fn compacting_forget_drops_summary() {
+        let compactor = Arc::new(CountingCompactor::default());
+        let mem = CompactingMemory::new(
+            InMemoryConversationMemory::new(),
+            SlidingWindowMemory::last_messages(1),
+            compactor.clone(),
+        );
+        mem.append("c", vec![user("a"), assistant("b"), user("c")])
+            .await
+            .unwrap();
+        mem.load("c").await.unwrap();
+        assert_eq!(mem.tracked_conversations(), 1);
+        mem.forget("c");
+        assert_eq!(mem.tracked_conversations(), 0);
+
+        // Next load on the still-populated backend re-compacts from
+        // scratch — same documented contract as DemotionHook.
+        mem.load("c").await.unwrap();
+        let calls = compactor.calls();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[1], (2, false));
+    }
+
+    #[tokio::test]
+    async fn compacting_arc_compactor_works() {
+        // Arc<C> forwarding impl exists on Compactor, so CompactingMemory
+        // must accept it.
+        let compactor: Arc<dyn Compactor<Artifact = TextSummary>> =
+            Arc::new(TemplateCompactor::new());
+        let mem = CompactingMemory::new(
+            InMemoryConversationMemory::new(),
+            SlidingWindowMemory::last_messages(1),
+            compactor,
+        );
+        mem.append("c", vec![user("a"), assistant("b"), user("c")])
+            .await
+            .unwrap();
+        let loaded = mem.load("c").await.unwrap();
+        assert_eq!(loaded.len(), 2);
+        assert!(matches!(&loaded[0], Message::System { .. }));
+    }
+
+    #[tokio::test]
+    async fn compacting_into_inner_returns_components() {
+        let mem = CompactingMemory::new(
+            InMemoryConversationMemory::new(),
+            SlidingWindowMemory::last_messages(1),
+            TemplateCompactor::new(),
+        );
+        let (_inner, _policy, _compactor) = mem.into_inner();
+    }
+
+    #[tokio::test]
+    async fn compacting_isolates_conversations() {
+        let compactor = Arc::new(CountingCompactor::default());
+        let mem = CompactingMemory::new(
+            InMemoryConversationMemory::new(),
+            SlidingWindowMemory::last_messages(1),
+            compactor.clone(),
+        );
+        mem.append("a", vec![user("a1"), assistant("a2"), user("a3")])
+            .await
+            .unwrap();
+        mem.append("b", vec![user("b1"), assistant("b2"), user("b3")])
+            .await
+            .unwrap();
+
+        let a = mem.load("a").await.unwrap();
+        let b = mem.load("b").await.unwrap();
+        // Each conversation gets its own summary.
+        assert_eq!(a.len(), 2);
+        assert_eq!(b.len(), 2);
+        assert_eq!(compactor.calls().len(), 2);
+        assert_eq!(mem.tracked_conversations(), 2);
+    }
+
+    #[tokio::test]
+    async fn compacting_composes_with_token_window() {
+        // Verify CompactingMemory is policy-agnostic: works over a
+        // TokenWindowMemory just as well as a SlidingWindowMemory.
+        let mem = CompactingMemory::new(
+            InMemoryConversationMemory::new(),
+            TokenWindowMemory::new(30, HeuristicTokenCounter::openai()),
+            TemplateCompactor::new(),
+        );
+        mem.append(
+            "c",
+            vec![
+                user("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                assistant("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+                user("cccccccccccccccccccc"),
+                assistant("d"),
+            ],
+        )
+        .await
+        .unwrap();
+        let loaded = mem.load("c").await.unwrap();
+        // Some prefix should have been evicted; expect a summary in front.
+        assert!(loaded.len() >= 2);
+        assert!(matches!(&loaded[0], Message::System { .. }));
+    }
+
+    #[tokio::test]
+    async fn template_compactor_renders_system_messages() {
+        let compactor = TemplateCompactor::new();
+        let evicted = vec![
+            Message::System {
+                content: "you are helpful".into(),
+            },
+            user("hi"),
+            assistant("hello"),
+        ];
+        let summary = compactor.compact("c", &evicted, None).await.unwrap();
+        let s = summary.as_str();
+        assert!(s.contains("system: you are helpful"), "got: {s}");
+        assert!(s.contains("user: hi"));
+        assert!(s.contains("assistant: hello"));
+    }
+
+    #[tokio::test]
+    async fn template_compactor_renders_tool_call_marker() {
+        let compactor = TemplateCompactor::new();
+        let evicted = vec![tool_call_msg(), tool_result_msg()];
+        let summary = compactor.compact("c", &evicted, None).await.unwrap();
+        let s = summary.as_str();
+        assert!(s.contains("[tool call: t]"), "got: {s}");
+        assert!(s.contains("[tool result]"), "got: {s}");
+    }
+
+    #[tokio::test]
+    async fn template_compactor_carry_over_threaded() {
+        let compactor = TemplateCompactor::new();
+        let first = compactor
+            .compact("c", &[user("hello")], None)
+            .await
+            .unwrap();
+        assert!(!first.as_str().is_empty());
+
+        let second = compactor
+            .compact("c", &[assistant("world")], Some(&first))
+            .await
+            .unwrap();
+        // Carry-over text appears in the new summary.
+        assert!(second.as_str().contains(first.as_str()));
+        assert!(second.as_str().contains("assistant: world"));
+    }
+
+    #[tokio::test]
+    async fn template_compactor_artifact_into_message() {
+        let s = TextSummary("rolled-up text".into());
+        let msg: Message = s.into();
+        let Message::System { content } = msg else {
+            panic!("expected system message");
+        };
+        assert_eq!(content, "rolled-up text");
+    }
+
+    #[tokio::test]
+    async fn template_compactor_caps_summary_at_max_bytes() {
+        let cap = 256;
+        let compactor = TemplateCompactor::new().with_max_bytes(cap);
+        // Build an evicted history large enough to exceed `cap` on its own.
+        let mut evicted = Vec::new();
+        for i in 0..50 {
+            evicted.push(user(&format!("message number {i} with some filler")));
+        }
+        let summary = compactor.compact("c", &evicted, None).await.unwrap();
+        assert!(
+            summary.as_str().len()
+                <= cap + "[Conversation summary so far]\n[\u{2026}truncated\u{2026}]\n".len(),
+            "summary len {} exceeds cap {} (plus header+marker)",
+            summary.as_str().len(),
+            cap,
+        );
+        // Header is preserved.
+        assert!(
+            summary
+                .as_str()
+                .starts_with("[Conversation summary so far]\n")
+        );
+        // Truncation marker is present.
+        assert!(summary.as_str().contains("[\u{2026}truncated\u{2026}]"));
+        // Most recent line survives.
+        assert!(summary.as_str().contains("message number 49"));
+    }
+
+    #[tokio::test]
+    async fn template_compactor_unbounded_by_default() {
+        let compactor = TemplateCompactor::new();
+        let mut evicted = Vec::new();
+        for i in 0..200 {
+            evicted.push(user(&format!("msg {i}")));
+        }
+        let summary = compactor.compact("c", &evicted, None).await.unwrap();
+        // Without a cap, no truncation marker should appear.
+        assert!(!summary.as_str().contains("[\u{2026}truncated\u{2026}]"));
+        // Both ends are present.
+        assert!(summary.as_str().contains("msg 0"));
+        assert!(summary.as_str().contains("msg 199"));
+    }
+
+    #[tokio::test]
+    async fn template_compactor_with_max_bytes_zero_is_unbounded() {
+        let compactor = TemplateCompactor::new().with_max_bytes(0);
+        let mut evicted = Vec::new();
+        for i in 0..200 {
+            evicted.push(user(&format!("msg {i}")));
+        }
+        let summary = compactor.compact("c", &evicted, None).await.unwrap();
+        assert!(!summary.as_str().contains("[\u{2026}truncated\u{2026}]"));
+    }
+
+    #[tokio::test]
+    async fn compacting_summary_stays_bounded_across_rolls() {
+        // With a capped TemplateCompactor, repeated rolling must not let
+        // the summary grow without bound.
+        let cap = 512;
+        let mem = CompactingMemory::new(
+            InMemoryConversationMemory::new(),
+            SlidingWindowMemory::last_messages(2),
+            TemplateCompactor::new().with_max_bytes(cap),
+        );
+        mem.append("c", vec![user("seed-a"), assistant("seed-b")])
+            .await
+            .unwrap();
+        for i in 0..30 {
+            mem.append(
+                "c",
+                vec![
+                    user(&format!("user line {i} ----- padding padding padding")),
+                    assistant(&format!("assistant line {i} ----- padding padding")),
+                ],
+            )
+            .await
+            .unwrap();
+            mem.load("c").await.unwrap();
+        }
+        let loaded = mem.load("c").await.unwrap();
+        let Message::System { content } = &loaded[0] else {
+            panic!("expected summary");
+        };
+        // Allow some slack for header + marker overhead.
+        let slack = "[Conversation summary so far]\n[\u{2026}truncated\u{2026}]\n".len();
+        assert!(
+            content.len() <= cap + slack,
+            "summary grew to {} bytes (cap {}, slack {})",
+            content.len(),
+            cap,
+            slack,
+        );
+    }
+
+    #[tokio::test]
+    async fn compacting_concurrent_with_clear_does_not_resurrect_state() {
+        // A clear that lands while compaction is in flight must not be
+        // overwritten by the post-await state update.
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        struct GatedCompactor {
+            release: tokio::sync::Notify,
+            entered: AtomicBool,
+        }
+
+        impl Compactor for GatedCompactor {
+            type Artifact = TextSummary;
+
+            fn compact<'a>(
+                &'a self,
+                _conversation_id: &'a str,
+                _evicted: &'a [Message],
+                _carry_over: Option<&'a Self::Artifact>,
+            ) -> WasmBoxedFuture<'a, Result<Self::Artifact, MemoryError>> {
+                Box::pin(async move {
+                    self.entered.store(true, Ordering::SeqCst);
+                    self.release.notified().await;
+                    Ok(TextSummary("late summary".into()))
+                })
+            }
+        }
+
+        let compactor = Arc::new(GatedCompactor {
+            release: tokio::sync::Notify::new(),
+            entered: AtomicBool::new(false),
+        });
+        let mem = Arc::new(CompactingMemory::new(
+            InMemoryConversationMemory::new(),
+            SlidingWindowMemory::last_messages(1),
+            compactor.clone(),
+        ));
+        mem.append("c", vec![user("a"), assistant("b"), user("c")])
+            .await
+            .unwrap();
+
+        // Kick off a load that will block inside the compactor.
+        let mem_load = mem.clone();
+        let load_handle = tokio::spawn(async move { mem_load.load("c").await });
+
+        // Wait for the compactor to have entered.
+        while !compactor.entered.load(Ordering::SeqCst) {
+            tokio::task::yield_now().await;
+        }
+
+        // Clear while the compaction is in flight.
+        mem.clear("c").await.unwrap();
+
+        // Release the compactor; it should complete and *not* resurrect
+        // the cleared state.
+        compactor.release.notify_one();
+        let _ = load_handle.await.unwrap();
+
+        assert_eq!(mem.tracked_conversations(), 0);
+        // A subsequent load on the empty backend returns nothing.
+        assert!(mem.load("c").await.unwrap().is_empty());
     }
 }

--- a/crates/rig-memory/src/lib.rs
+++ b/crates/rig-memory/src/lib.rs
@@ -766,6 +766,54 @@ fn poisoned<E: std::fmt::Display>(err: E) -> MemoryError {
     MemoryError::Internal(err.to_string())
 }
 
+/// RAII guard that clears the `in_flight` flag for a conversation in the
+/// shared compaction state map when dropped, unless the consumer
+/// explicitly disarms it after a successful post-await update.
+///
+/// This prevents the in-flight gate from leaking when the awaiting
+/// `load(...)` future is dropped (caller timeout, `tokio::select!`, etc.)
+/// or when the compactor panics: in either case `Drop` runs and releases
+/// the gate so subsequent loads can retry. A missing entry is a no-op,
+/// covering the case where a concurrent `clear` removed the conversation
+/// while compaction was awaiting.
+struct InFlightGuard<'a, A> {
+    state: &'a StdMutex<HashMap<String, ConversationCompactionState<A>>>,
+    key: &'a str,
+    armed: bool,
+}
+
+impl<'a, A> InFlightGuard<'a, A> {
+    fn new(
+        state: &'a StdMutex<HashMap<String, ConversationCompactionState<A>>>,
+        key: &'a str,
+    ) -> Self {
+        Self {
+            state,
+            key,
+            armed: true,
+        }
+    }
+
+    /// Disable the `Drop` clean-up. Call after the post-await state
+    /// update has already cleared `in_flight` while holding the lock.
+    fn disarm(mut self) {
+        self.armed = false;
+    }
+}
+
+impl<A> Drop for InFlightGuard<'_, A> {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        if let Ok(mut guard) = self.state.lock()
+            && let Some(entry) = guard.get_mut(self.key)
+        {
+            entry.in_flight = false;
+        }
+    }
+}
+
 /// A [`ConversationMemory`] adapter that wraps a backend with a
 /// [`MemoryPolicy`] **and** a [`Compactor`], replacing truncated turns with
 /// a summary artifact spliced at the front of the loaded history.
@@ -988,16 +1036,20 @@ where
             // the lock, and we only set `absorbed = demoted_count` on
             // success — so `plan.skip <= demoted_count == demoted.len()`.
             let CompactionPlan { carry_over, skip } = plan;
+
+            // Arm an RAII guard so the in-flight gate is released even if
+            // this future is dropped mid-await (caller cancellation) or
+            // the compactor panics. The guard is disarmed below once the
+            // post-await state update has already cleared the flag under
+            // the same lock acquisition that records the new watermark.
+            let in_flight_guard = InFlightGuard::new(&self.state, conversation_id);
+
             let new_slice = match demoted.get(skip..) {
                 Some(s) => s,
                 None => {
-                    // Re-acquire and clear the in-flight flag so the next
-                    // load can retry, then surface the invariant break.
-                    if let Ok(mut guard) = self.state.lock()
-                        && let Some(entry) = guard.get_mut(conversation_id)
-                    {
-                        entry.in_flight = false;
-                    }
+                    // Drop the guard explicitly so the gate is released
+                    // before we surface the invariant break.
+                    drop(in_flight_guard);
                     return Err(MemoryError::Internal(
                         "compaction watermark exceeds demoted slice length".into(),
                     ));
@@ -1040,6 +1092,11 @@ where
                     return Err(err);
                 }
             };
+
+            // Post-await state update completed under the lock above and
+            // already cleared `in_flight`; disarm the RAII guard so its
+            // `Drop` does not re-acquire the lock for a redundant clear.
+            in_flight_guard.disarm();
 
             Ok(splice(summary_for_splice, kept))
         })
@@ -1216,7 +1273,7 @@ impl Compactor for TemplateCompactor {
             if let Some(cap) = self.max_bytes
                 && buf.len() > cap
             {
-                buf = truncate_summary(&self.header, &buf, cap);
+                buf = truncate_summary(&buf, cap);
             }
             Ok(TextSummary(buf))
         })
@@ -1226,10 +1283,18 @@ impl Compactor for TemplateCompactor {
 /// Truncate `buf` to fit within `cap` bytes by dropping the oldest
 /// content after the header line. Always preserves the header plus a
 /// `"[\u{2026}truncated\u{2026}]"` marker, even if they alone exceed `cap`.
-fn truncate_summary(header: &str, buf: &str, cap: usize) -> String {
+///
+/// The header boundary is located by scanning `buf` for the first `\n`
+/// rather than by trusting any caller-supplied header length, so a
+/// header containing embedded newlines does not mis-locate the body.
+fn truncate_summary(buf: &str, cap: usize) -> String {
     const MARKER: &str = "[\u{2026}truncated\u{2026}]\n";
-    // Body starts right after the header's trailing newline.
-    let header_prefix_len = header.len() + 1;
+    // Body starts right after the first newline in `buf`. If `buf` has
+    // no newline at all there is no body to drop, so return as-is.
+    let header_prefix_len = match buf.find('\n') {
+        Some(i) => i + 1,
+        None => return buf.to_string(),
+    };
     if buf.len() <= header_prefix_len {
         return buf.to_string();
     }
@@ -1251,9 +1316,12 @@ fn truncate_summary(header: &str, buf: &str, cap: usize) -> String {
         Some(s) => s,
         None => "",
     };
+    let header_with_nl = match buf.get(..header_prefix_len) {
+        Some(h) => h,
+        None => return buf.to_string(),
+    };
     let mut out = String::with_capacity(header_prefix_len + MARKER.len() + suffix.len());
-    out.push_str(header);
-    out.push('\n');
+    out.push_str(header_with_nl);
     out.push_str(MARKER);
     out.push_str(suffix);
     out
@@ -2592,5 +2660,110 @@ mod tests {
         assert_eq!(mem.tracked_conversations(), 0);
         // A subsequent load on the empty backend returns nothing.
         assert!(mem.load("c").await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn compacting_dropped_load_releases_in_flight_gate() {
+        // If a `load(...)` future is dropped while awaiting the
+        // compactor, the in-flight gate must not leak: subsequent loads
+        // on the same conversation must be able to retry compaction.
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct GatedCompactor {
+            release: tokio::sync::Notify,
+            entered: AtomicUsize,
+        }
+
+        impl Compactor for GatedCompactor {
+            type Artifact = TextSummary;
+
+            fn compact<'a>(
+                &'a self,
+                _conversation_id: &'a str,
+                _evicted: &'a [Message],
+                _carry_over: Option<&'a Self::Artifact>,
+            ) -> WasmBoxedFuture<'a, Result<Self::Artifact, MemoryError>> {
+                Box::pin(async move {
+                    self.entered.fetch_add(1, Ordering::SeqCst);
+                    self.release.notified().await;
+                    Ok(TextSummary("ran".into()))
+                })
+            }
+        }
+
+        let compactor = Arc::new(GatedCompactor {
+            release: tokio::sync::Notify::new(),
+            entered: AtomicUsize::new(0),
+        });
+        let mem = Arc::new(CompactingMemory::new(
+            InMemoryConversationMemory::new(),
+            SlidingWindowMemory::last_messages(1),
+            compactor.clone(),
+        ));
+        mem.append("c", vec![user("a"), assistant("b"), user("c")])
+            .await
+            .unwrap();
+
+        // Kick off a load that will block inside the compactor, then
+        // abort it while awaiting — simulating a caller-side timeout
+        // or `tokio::select!` cancellation.
+        let mem_load = mem.clone();
+        let handle = tokio::spawn(async move { mem_load.load("c").await });
+        while compactor.entered.load(Ordering::SeqCst) == 0 {
+            tokio::task::yield_now().await;
+        }
+        handle.abort();
+        let _ = handle.await;
+
+        // The aborted future was dropped without clearing in_flight via
+        // the success/error branches; the RAII guard's `Drop` should
+        // have released it. A new load must therefore be able to drive
+        // a fresh compaction rather than short-circuiting forever.
+        let mem_load = mem.clone();
+        let retry = tokio::spawn(async move { mem_load.load("c").await });
+        // Wait for the compactor to be entered a second time. If the
+        // gate had leaked, this would never happen — the load would
+        // short-circuit on `in_flight = true` and return immediately.
+        while compactor.entered.load(Ordering::SeqCst) < 2 {
+            tokio::task::yield_now().await;
+        }
+        compactor.release.notify_waiters();
+        let loaded = retry.await.unwrap().unwrap();
+        assert_eq!(loaded.len(), 2);
+        let Message::System { content } = &loaded[0] else {
+            panic!("expected summary")
+        };
+        assert_eq!(content, "ran");
+    }
+
+    #[tokio::test]
+    async fn template_compactor_caps_summary_with_multiline_header() {
+        // A header containing embedded newlines must not break the
+        // truncation boundary calculation. The first newline in the
+        // assembled buffer marks the header/body split, regardless of
+        // how the caller chose to format the header.
+        let cap = 256;
+        let compactor = TemplateCompactor::with_header("line one\nline two").with_max_bytes(cap);
+        let mut evicted = Vec::new();
+        for i in 0..50 {
+            evicted.push(user(&format!("message number {i} with some filler")));
+        }
+        let summary = compactor.compact("c", &evicted, None).await.unwrap();
+        let text = summary.as_str();
+
+        // The first line of the header is preserved as the header line.
+        assert!(text.starts_with("line one\n"));
+        // Truncation marker is present and the most recent line survives.
+        assert!(text.contains("[\u{2026}truncated\u{2026}]"));
+        assert!(text.contains("message number 49"));
+        // Cap is honoured up to the header+marker overhead.
+        let overhead = "line one\n".len() + "[\u{2026}truncated\u{2026}]\n".len();
+        assert!(
+            text.len() <= cap + overhead,
+            "summary len {} exceeds cap {} plus overhead {}",
+            text.len(),
+            cap,
+            overhead,
+        );
     }
 }

--- a/crates/rig-memory/src/lib.rs
+++ b/crates/rig-memory/src/lib.rs
@@ -1312,10 +1312,7 @@ fn truncate_summary(buf: &str, cap: usize) -> String {
     while cut < body.len() && !body.is_char_boundary(cut) {
         cut += 1;
     }
-    let suffix = match body.get(cut..) {
-        Some(s) => s,
-        None => "",
-    };
+    let suffix: &str = body.get(cut..).unwrap_or_default();
     let header_with_nl = match buf.get(..header_prefix_len) {
         Some(h) => h,
         None => return buf.to_string(),


### PR DESCRIPTION
## Summary

Adds a `Compactor` trait to `rig_core::memory` and a composing
`CompactingMemory` adapter (with a zero-dependency `TemplateCompactor`
reference implementation) in `rig-memory`. Where #1737's `DemotionHook`
is a one-way drain that *observes* messages a policy truncates out of
active history, `Compactor` is the inverse: it returns a single
`Message`-shaped artifact derived from the evicted prefix, and the
adapter splices that artifact back at the front of the loaded history.
The resulting prompt shape is `[summary, ...recent_window]` — the
canonical recursive-summary pattern for long-running agents.

## Motivation

`DemotingPolicyMemory` (from #1737) gives backends a side channel for
durable persistence of demoted turns, but the *active* history a policy
returns is still a verbatim suffix. For long conversations this throws
away the head context entirely once a window slides past it. Existing
ecosystem code papers over this either by stuffing summaries into the
preamble (drifts as the conversation grows) or by writing custom
`ConversationMemory` impls (no shared idempotency / locking story).

The compaction seam needs the same composability story `PolicyMemory`
and `DemotingPolicyMemory` already have:

- a trait that lives in `rig_core` so any backend can implement it
  without taking a `rig-memory` dependency,
- a composing adapter that lives in `rig-memory` next to the policies,
- a reference implementation that does not pull in an LLM provider, so
  doctests, examples, and integration tests can exercise the full
  shape with no network.

## Design

### `rig_core::memory::Compactor`

```rust
pub trait Compactor: WasmCompatSend + WasmCompatSync {
    type Artifact: Into<Message> + Clone + WasmCompatSend + WasmCompatSync;

    fn compact<'a>(
        &'a self,
        conversation_id: &'a str,
        evicted: &'a [Message],
        carry_over: Option<&'a Self::Artifact>,
    ) -> WasmBoxedFuture<'a, Result<Self::Artifact, MemoryError>>;
}
```

- `Artifact: Into<Message>` keeps the trait `rig-core`-pure; no
  dependency on a specific summary representation.
- `carry_over` threads the previous summary so impls can do
  rolling-summary semantics without state of their own.
- Per-conversation watermarks are in-process only — implementations
  with durable side effects (LLM calls, vector-store writes) must
  deduplicate per the same idempotency contract documented for
  `DemotionHook`.

### `rig_memory::CompactingMemory<M, P, C>`

Wraps an inner `ConversationMemory` and a `MemoryPolicy`. On every
`load`:

1. Read inner history.
2. Apply the policy → `(kept, evicted_prefix)`.
3. If `evicted_prefix` is non-empty, invoke the compactor with the
   stored `carry_over` for that `conversation_id`; the returned
   artifact replaces `carry_over` and is converted into a `Message`
   spliced at position 0 of `kept`.
4. If `evicted_prefix` is empty, the previous `carry_over` (if any) is
   still spliced — so the summary survives later loads that don't
   evict anything new.

**Concurrency at the seam.** Concurrent loads on the same
`conversation_id` are serialised by an in-flight gate (a per-id
watcher). Only one load at a time invokes the compactor; others
observe the gate and immediately return the *previously*-stored
summary spliced in front of `kept`, without re-running the compactor.
This matters because compactors are typically expensive (LLM calls).
The contract is exercised by
`compacting_concurrent_with_clear_does_not_resurrect_state`: a
`clear` that lands while compaction is in flight is not overwritten
by the post-await state update.

**`clear` semantics.** `clear` drops the carry-over for that
conversation, so a freshly-populated backend re-compacts from scratch
rather than inheriting a stale summary from a deleted conversation.

### `rig_memory::TemplateCompactor`

Zero-dependency, no-LLM rollup. Produces a `TextSummary(String)` that
converts into a `Message::User` containing:

- a `[Conversation summary so far]` header,
- the previous summary (if any),
- one `role: text` line per evicted message, with an `[assistant tool
  call: name]` marker for tool-call assistant turns.

`with_max_bytes` provides a deterministic cap (truncating from the
middle with a `[…truncated…]` marker so the header and the most-recent
turns survive). Useful as a default, in doctests, and as the body of
integration tests that exercise the seam without needing a model.

## Behavioural changes

- New public surface in `rig_core::memory`: the `Compactor` trait. No
  existing types changed.
- New public surface in `rig_memory`: `CompactingMemory`,
  `TemplateCompactor`, `TextSummary`. Re-exports `Compactor` from
  `rig_core::memory` for symmetry with `DemotionHook`.
- No changes to `ConversationMemory`, `MemoryPolicy`, `DemotionHook`,
  `PolicyMemory`, or `DemotingPolicyMemory`. `CompactingMemory`
  composes with all of them.

## Tests

- 5 unit tests for `TemplateCompactor` covering: artifact-into-message
  conversion, system-message rendering, tool-call marker, carry-over
  threading, and `with_max_bytes` (including the
  `with_max_bytes(0) == unbounded` and unbounded-by-default edges).
- 1 integration test (`compacting_summary_stays_bounded_across_rolls`)
  driving multiple turns through a sliding window + `TemplateCompactor`
  to confirm summary size stays bounded across rolls.
- 1 concurrency test
  (`compacting_concurrent_with_clear_does_not_resurrect_state`) using
  a gated mock compactor + `tokio::sync::Notify` to verify the
  in-flight gate honours an interleaved `clear`.
- 1 doctest on `CompactingMemory` and 1 on `TemplateCompactor`,
  covering the public-facing usage shape.

`cargo test -p rig-core --lib memory` and `cargo test -p rig-memory`
green. `cargo clippy -p rig-memory --all-targets -- -D warnings` clean.
`RUSTDOCFLAGS="-D warnings" cargo doc -p rig-memory --no-deps` clean.

## Out of scope

- An LLM-backed `Compactor` — that wants a model handle, a prompt
  template, and a retry/backoff story; it lives downstream of this PR
  in user code (or a follow-up that opts into a provider feature).
- Persisting `carry_over` across process restarts — the trait
  contract documents that watermarks are in-process; durable carry-over
  is a Compactor-implementation concern.
- Wiring `CompactingMemory` into the agent builder as a sugar method.
  The existing `.memory(...)` builder takes any `ConversationMemory`,
  which `CompactingMemory` implements; no new builder surface needed.
