### PR TITLE
docs: fix "a ancient" grammar in glarb-glarb sample text

### DIFF
--- a/crates/rig-bedrock/examples/agent_with_bedrock.rs
+++ b/crates/rig-bedrock/examples/agent_with_bedrock.rs
@@ -73,7 +73,7 @@ async fn context() -> Result<(), anyhow::Error> {
     let agent = AgentBuilder::new(model)
         .preamble("Answer the question")
         .context("Definition of a *flurbo*: A flurbo is a green alien that lives on cold planets")
-        .context("Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.")
+        .context("Definition of a *glarb-glarb*: A glarb-glarb is an ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.")
         .context("Definition of a *linglingdong*: A term used by inhabitants of the far side of the moon to describe humans.")
         .build();
 

--- a/crates/rig-bedrock/examples/rag_with_bedrock.rs
+++ b/crates/rig-bedrock/examples/rag_with_bedrock.rs
@@ -47,7 +47,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 id: "doc1".to_string(),
                 word: "glarb-glarb".to_string(),
                 definitions: vec![
-                    "1. *glarb-glarb* (noun): A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
+                    "1. *glarb-glarb* (noun): A glarb-glarb is an ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
                     "2. *glarb-glarb* (noun): A fictional creature found in the distant, swampy marshlands of the planet Glibbo in the Andromeda galaxy.".to_string()
                 ]
             },

--- a/crates/rig-mongodb/examples/vector_search_mongodb.rs
+++ b/crates/rig-mongodb/examples/vector_search_mongodb.rs
@@ -74,7 +74,7 @@ async fn main() -> Result<(), anyhow::Error> {
         },
         Word {
             id: "doc1".to_string(),
-            definition: "Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
+            definition: "Definition of a *glarb-glarb*: A glarb-glarb is an ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
         },
         Word {
             id: "doc2".to_string(),

--- a/crates/rig-neo4j/examples/vector_search_simple.rs
+++ b/crates/rig-neo4j/examples/vector_search_simple.rs
@@ -47,7 +47,7 @@ async fn main() -> Result<(), anyhow::Error> {
         })?
         .document(Word {
             id: "doc1".to_string(),
-            definition: "Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
+            definition: "Definition of a *glarb-glarb*: A glarb-glarb is an ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
         })?
         .document(Word {
             id: "doc2".to_string(),

--- a/crates/rig-postgres/examples/vector_search_postgres.rs
+++ b/crates/rig-postgres/examples/vector_search_postgres.rs
@@ -63,7 +63,7 @@ async fn main() -> Result<(), anyhow::Error> {
             id: "doc1".to_string(),
             word: "glarb-glarb".to_string(),
             definitions: vec![
-                "1. *glarb-glarb* (noun): A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
+                "1. *glarb-glarb* (noun): A glarb-glarb is an ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
                 "2. *glarb-glarb* (noun): A fictional creature found in the distant, swampy marshlands of the planet Glibbo in the Andromeda galaxy.".to_string()
             ]
         },

--- a/crates/rig-qdrant/examples/qdrant_vector_search.rs
+++ b/crates/rig-qdrant/examples/qdrant_vector_search.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<(), anyhow::Error> {
         })?
         .document(Word {
             id: "62a36d43-80b6-4fd6-990c-f75bb02287d1".to_string(),
-            definition: "Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
+            definition: "Definition of a *glarb-glarb*: A glarb-glarb is an ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
         })?
         .document(Word {
             id: "f9e17d59-32e5-440c-be02-b2759a654824".to_string(),

--- a/crates/rig-s3vectors/examples/s3vectors_vector_search.rs
+++ b/crates/rig-s3vectors/examples/s3vectors_vector_search.rs
@@ -52,7 +52,7 @@ async fn main() -> Result<(), anyhow::Error> {
         })?
         .document(Word {
             id: "62a36d43-80b6-4fd6-990c-f75bb02287d1".to_string(),
-            definition: "Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
+            definition: "Definition of a *glarb-glarb*: A glarb-glarb is an ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
         })?
         .document(Word {
             id: "f9e17d59-32e5-440c-be02-b2759a654824".to_string(),

--- a/crates/rig-sqlite/examples/vector_search_sqlite.rs
+++ b/crates/rig-sqlite/examples/vector_search_sqlite.rs
@@ -80,7 +80,7 @@ async fn main() -> Result<(), anyhow::Error> {
         },
         Document {
             id: "doc1".to_string(),
-            content: "Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
+            content: "Definition of a *glarb-glarb*: A glarb-glarb is an ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
         },
         Document {
             id: "doc2".to_string(),

--- a/examples/chain.rs
+++ b/examples/chain.rs
@@ -17,7 +17,7 @@ const QUERY: &str = "What does \"glarb-glarb\" mean?";
 fn sample_definitions() -> [&'static str; 3] {
     [
         "Definition of a *flurbo*: A flurbo is a green alien that lives on cold planets",
-        "Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.",
+        "Definition of a *glarb-glarb*: A glarb-glarb is an ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.",
         "Definition of a *linglingdong*: A term used by inhabitants of the far side of the moon to describe humans.",
     ]
 }

--- a/examples/rag.rs
+++ b/examples/rag.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 id: "doc1".to_string(),
                 word: "glarb-glarb".to_string(),
                 definitions: vec![
-                    "1. *glarb-glarb* (noun): A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
+                    "1. *glarb-glarb* (noun): A glarb-glarb is an ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
                     "2. *glarb-glarb* (noun): A fictional creature found in the distant, swampy marshlands of the planet Glibbo in the Andromeda galaxy.".to_string()
                 ]
             },

--- a/examples/rag_ollama.rs
+++ b/examples/rag_ollama.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 id: "doc1".to_string(),
                 word: "glarb-glarb".to_string(),
                 definitions: vec![
-                    "1. *glarb-glarb* (noun): A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
+                    "1. *glarb-glarb* (noun): A glarb-glarb is an ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
                     "2. *glarb-glarb* (noun): A fictional creature found in the distant, swampy marshlands of the planet Glibbo in the Andromeda galaxy.".to_string()
                 ]
             },

--- a/tests/integrations/mongodb.rs
+++ b/tests/integrations/mongodb.rs
@@ -69,7 +69,7 @@ async fn vector_search_test() {
             .json_body(json!({
                 "input": [
                     "Definition of a *flurbo*: A flurbo is a green alien that lives on cold planets",
-                    "Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.",
+                    "Definition of a *glarb-glarb*: A glarb-glarb is an ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.",
                     "Definition of a *linglingdong*: A term used by inhabitants of the far side of the moon to describe humans."
                 ],
                 "model": "text-embedding-ada-002",
@@ -449,7 +449,7 @@ async fn create_embeddings(model: openai::EmbeddingModel) -> Vec<bson::Document>
         },
         Word {
             id: "doc1".to_string(),
-            definition: "Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
+            definition: "Definition of a *glarb-glarb*: A glarb-glarb is an ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
         },
         Word {
             id: "doc2".to_string(),

--- a/tests/integrations/neo4j.rs
+++ b/tests/integrations/neo4j.rs
@@ -79,7 +79,7 @@ async fn vector_search_test() {
             .json_body(json!({
                 "input": [
                     "Definition of a *flurbo*: A flurbo is a green alien that lives on cold planets",
-                    "Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.",
+                    "Definition of a *glarb-glarb*: A glarb-glarb is an ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.",
                     "Definition of a *linglingdong*: A term used by inhabitants of the far side of the moon to describe humans."
                 ],
                 "model": "text-embedding-ada-002",
@@ -233,7 +233,7 @@ async fn vector_search_test() {
         value,
         &serde_json::json!({
             "id": "doc1",
-            "document": "Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.",
+            "document": "Definition of a *glarb-glarb*: A glarb-glarb is an ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.",
             "embedding": serde_json::Value::Null
         })
     )
@@ -247,7 +247,7 @@ async fn create_embeddings(model: openai::EmbeddingModel) -> Vec<(Word, OneOrMan
         },
         Word {
             id: "doc1".to_string(),
-            definition: "Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
+            definition: "Definition of a *glarb-glarb*: A glarb-glarb is an ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
         },
         Word {
             id: "doc2".to_string(),

--- a/tests/integrations/postgres.rs
+++ b/tests/integrations/postgres.rs
@@ -91,7 +91,7 @@ async fn vector_search_test() {
         Word {
             id: "62a36d43-80b6-4fd6-990c-f75bb02287d1".to_string(),
             name: "glarb-glarb".to_string(),
-            definition: "Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
+            definition: "Definition of a *glarb-glarb*: A glarb-glarb is an ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
         },
         Word {
             id: "f9e17d59-32e5-440c-be02-b2759a654824".to_string(),
@@ -201,7 +201,7 @@ async fn create_openai_mock_service() -> httpmock::MockServer {
                 "dimensions": 1536,
                 "input": [
                     "Definition of a *flurbo*: A flurbo is a green alien that lives on cold planets",
-                    "Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.",
+                    "Definition of a *glarb-glarb*: A glarb-glarb is an ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.",
                     "Definition of a *linglingdong*: A term used by inhabitants of the far side of the moon to describe humans."
                 ],
                 "model": "text-embedding-3-small",

--- a/tests/integrations/qdrant.rs
+++ b/tests/integrations/qdrant.rs
@@ -97,7 +97,7 @@ async fn vector_search_test() {
             .json_body(json!({
                 "input": [
                     "Definition of a *flurbo*: A flurbo is a green alien that lives on cold planets",
-                    "Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.",
+                    "Definition of a *glarb-glarb*: A glarb-glarb is an ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.",
                     "Definition of a *linglingdong*: A term used by inhabitants of the far side of the moon to describe humans."
                 ],
                 "model": "text-embedding-ada-002",
@@ -207,7 +207,7 @@ async fn create_points(model: openai::EmbeddingModel) -> Vec<PointStruct> {
         },
         Word {
             id: "62a36d43-80b6-4fd6-990c-f75bb02287d1".to_string(),
-            definition: "Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
+            definition: "Definition of a *glarb-glarb*: A glarb-glarb is an ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
         },
         Word {
             id: "f9e17d59-32e5-440c-be02-b2759a654824".to_string(),

--- a/tests/integrations/scylladb.rs
+++ b/tests/integrations/scylladb.rs
@@ -98,7 +98,7 @@ async fn vector_search_test() {
         },
         Word {
             id: "doc1".to_string(),
-            definition: "Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
+            definition: "Definition of a *glarb-glarb*: A glarb-glarb is an ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
         },
         Word {
             id: "doc2".to_string(),
@@ -230,7 +230,7 @@ async fn create_openai_mock_service() -> httpmock::MockServer {
             .json_body(json!({
                 "input": [
                     "Definition of a *flurbo*: A flurbo is a green alien that lives on cold planets",
-                    "Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.",
+                    "Definition of a *glarb-glarb*: A glarb-glarb is an ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.",
                     "Definition of a *linglingdong*: A term used by inhabitants of the far side of the moon to describe humans."
                 ],
                 "model": "text-embedding-ada-002",

--- a/tests/integrations/sqlite.rs
+++ b/tests/integrations/sqlite.rs
@@ -88,7 +88,7 @@ async fn vector_search_test() {
             .json_body(json!({
                 "input": [
                     "Definition of a *flurbo*: A flurbo is a green alien that lives on cold planets",
-                    "Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.",
+                    "Definition of a *glarb-glarb*: A glarb-glarb is an ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.",
                     "Definition of a *linglingdong*: A term used by inhabitants of the far side of the moon to describe humans."
                 ],
                 "model": "text-embedding-ada-002",
@@ -202,7 +202,7 @@ async fn insert_documents_test() {
             .json_body(json!({
                 "input": [
                     "Definition of a *flurbo*: A flurbo is a green alien that lives on cold planets",
-                    "Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.",
+                    "Definition of a *glarb-glarb*: A glarb-glarb is an ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.",
                     "Definition of a *linglingdong*: A term used by inhabitants of the far side of the moon to describe humans."
                 ],
                 "model": "text-embedding-ada-002",
@@ -280,7 +280,7 @@ async fn create_embeddings(model: openai::EmbeddingModel) -> Vec<(Word, OneOrMan
         },
         Word {
             id: "doc1".to_string(),
-            definition: "Definition of a *glarb-glarb*: A glarb-glarb is a ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
+            definition: "Definition of a *glarb-glarb*: A glarb-glarb is an ancient tool used by the ancestors of the inhabitants of planet Jiro to farm the land.".to_string(),
         },
         Word {
             id: "doc2".to_string(),


### PR DESCRIPTION
Fixes a grammar error duplicated across 17 files where the sample document text reads "A glarb-glarb is a ancient tool" — the indefinite article should be `an` before the vowel-initial word `ancient`. Applied uniformly to all 25 occurrences across `examples/`, every per-provider example, and integration test fixtures so the canonical demo string stays consistent.

### Why

This text is the canonical RAG-demo sample shown to every new user landing on rig examples; the grammar slip is the first thing they see.