### PR TITLE
feat(openrouter): add transcription (STT) and audio generation (TTS) support

### DIFF
--- a/crates/rig-core/src/providers/openrouter/audio_generation.rs
+++ b/crates/rig-core/src/providers/openrouter/audio_generation.rs
@@ -61,7 +61,11 @@ where
         .into_iter()
         .collect();
 
-         if let Some(obj) = request.additional_params.as_ref().and_then(|p| p.as_object()) {
+        if let Some(obj) = request
+            .additional_params
+            .as_ref()
+            .and_then(|p| p.as_object())
+        {
             for (k, v) in obj {
                 body_map.insert(k.clone(), v.clone());
             }

--- a/crates/rig-core/src/providers/openrouter/audio_generation.rs
+++ b/crates/rig-core/src/providers/openrouter/audio_generation.rs
@@ -1,0 +1,97 @@
+use crate::audio_generation::{
+    self, AudioGenerationError, AudioGenerationRequest, AudioGenerationResponse,
+};
+use crate::http_client::{self, HttpClientExt};
+use crate::providers::openrouter::Client;
+use bytes::Bytes;
+use serde_json::json;
+
+// ================================================================
+// Model constants
+// ================================================================
+
+/// The `openai/gpt-4o-mini-tts-2025-12-15` model.
+pub const GPT_4O_MINI_TTS: &str = "openai/gpt-4o-mini-tts-2025-12-15";
+/// The `mistralai/voxtral-mini-tts-2603` model.
+pub const VOXTRAL_MINI_TTS: &str = "mistralai/voxtral-mini-tts-2603";
+/// The `hexgrad/kokoro-82m` model.
+pub const KOKORO_82M: &str = "hexgrad/kokoro-82m";
+
+// ================================================================
+// Model
+// ================================================================
+
+#[derive(Clone)]
+pub struct AudioGenerationModel<T = reqwest::Client> {
+    client: Client<T>,
+    pub model: String,
+}
+
+impl<T> AudioGenerationModel<T> {
+    pub fn new(client: Client<T>, model: impl Into<String>) -> Self {
+        Self {
+            client,
+            model: model.into(),
+        }
+    }
+}
+
+impl<T> audio_generation::AudioGenerationModel for AudioGenerationModel<T>
+where
+    T: HttpClientExt + Clone + std::fmt::Debug + Default + Send + 'static,
+{
+    type Response = Bytes;
+    type Client = Client<T>;
+
+    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
+        Self::new(client.clone(), model)
+    }
+
+    async fn audio_generation(
+        &self,
+        request: AudioGenerationRequest,
+    ) -> Result<AudioGenerationResponse<Self::Response>, AudioGenerationError> {
+        let mut body_map: serde_json::Map<String, serde_json::Value> = [
+            ("model".to_string(), json!(self.model)),
+            ("input".to_string(), json!(request.text)),
+            ("voice".to_string(), json!(request.voice)),
+            ("response_format".to_string(), json!("mp3")),
+            ("speed".to_string(), json!(request.speed)),
+        ]
+        .into_iter()
+        .collect();
+
+         if let Some(obj) = request.additional_params.as_ref().and_then(|p| p.as_object()) {
+            for (k, v) in obj {
+                body_map.insert(k.clone(), v.clone());
+            }
+        }
+
+        let body = serde_json::to_vec(&serde_json::Value::Object(body_map))?;
+
+        let req = self
+            .client
+            .post("/audio/speech")?
+            .header("Content-Type", "application/json")
+            .body(body)
+            .map_err(http_client::Error::from)?;
+
+        let response = self.client.send(req).await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = http_client::text(response).await?;
+            return Err(AudioGenerationError::ProviderError(format!(
+                "{}: {}",
+                status, text
+            )));
+        }
+
+        let audio: Vec<u8> = response.into_body().await?;
+
+        Ok(AudioGenerationResponse {
+            audio: audio.clone(),
+            response: Bytes::from(audio),
+        })
+    }
+}

--- a/crates/rig-core/src/providers/openrouter/audio_generation.rs
+++ b/crates/rig-core/src/providers/openrouter/audio_generation.rs
@@ -3,6 +3,7 @@ use crate::audio_generation::{
 };
 use crate::http_client::{self, HttpClientExt};
 use crate::providers::openrouter::Client;
+use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
 use bytes::Bytes;
 use serde_json::json;
 
@@ -38,7 +39,13 @@ impl<T> AudioGenerationModel<T> {
 
 impl<T> audio_generation::AudioGenerationModel for AudioGenerationModel<T>
 where
-    T: HttpClientExt + Clone + std::fmt::Debug + Default + Send + 'static,
+    T: HttpClientExt
+        + Clone
+        + std::fmt::Debug
+        + Default
+        + WasmCompatSend
+        + WasmCompatSync
+        + 'static,
 {
     type Response = Bytes;
     type Client = Client<T>;
@@ -61,12 +68,14 @@ where
         .into_iter()
         .collect();
 
-        if let Some(obj) = request
-            .additional_params
-            .as_ref()
-            .and_then(|p| p.as_object())
-        {
-            for (k, v) in obj {
+        if let Some(ref additional_params) = request.additional_params {
+            let params = additional_params.as_object().ok_or_else(|| {
+                AudioGenerationError::RequestError(Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "additional audio generation parameters must be a JSON object",
+                )))
+            })?;
+            for (k, v) in params {
                 body_map.insert(k.clone(), v.clone());
             }
         }

--- a/crates/rig-core/src/providers/openrouter/client.rs
+++ b/crates/rig-core/src/providers/openrouter/client.rs
@@ -1,6 +1,8 @@
+#[cfg(feature = "image")]
+use crate::client::Nothing;
 use crate::{
     client::{
-        self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
+        self, BearerAuth, Capabilities, Capable, DebugExt, Provider, ProviderBuilder,
         ProviderClient,
     },
     completion::GetTokenUsage,
@@ -34,13 +36,13 @@ impl Provider for OpenRouterExt {
 impl<H> Capabilities<H> for OpenRouterExt {
     type Completion = Capable<super::CompletionModel<H>>;
     type Embeddings = Capable<super::EmbeddingModel<H>>;
-    type Transcription = Nothing;
+    type Transcription = Capable<super::transcription::TranscriptionModel<H>>;
     type ModelListing = Capable<super::OpenRouterModelLister<H>>;
     #[cfg(feature = "image")]
     type ImageGeneration = Nothing;
 
     #[cfg(feature = "audio")]
-    type AudioGeneration = Nothing;
+    type AudioGeneration = Capable<super::audio_generation::AudioGenerationModel<H>>;
 }
 
 impl DebugExt for OpenRouterExt {}

--- a/crates/rig-core/src/providers/openrouter/mod.rs
+++ b/crates/rig-core/src/providers/openrouter/mod.rs
@@ -12,13 +12,23 @@
 //! # }
 //! ```
 
+#[cfg(feature = "audio")]
+#[cfg_attr(docsrs, doc(cfg(feature = "audio")))]
+pub mod audio_generation;
 pub mod client;
 pub mod completion;
 pub mod embedding;
 pub mod model_listing;
 pub mod streaming;
+pub mod transcription;
 
+#[cfg(feature = "audio")]
+pub use audio_generation::{AudioGenerationModel, GPT_4O_MINI_TTS, KOKORO_82M, VOXTRAL_MINI_TTS};
 pub use client::*;
 pub use completion::*;
 pub use embedding::*;
 pub use model_listing::OpenRouterModelLister;
+pub use transcription::{
+    CHIRP_3, GPT_4O_MINI_TRANSCRIBE, GPT_4O_TRANSCRIBE, TranscriptionModel, TranscriptionResponse,
+    WHISPER_1, WHISPER_LARGE_V3, WHISPER_LARGE_V3_TURBO,
+};

--- a/crates/rig-core/src/providers/openrouter/transcription.rs
+++ b/crates/rig-core/src/providers/openrouter/transcription.rs
@@ -155,7 +155,11 @@ where
             body_map.insert("temperature".to_string(), serde_json::json!(temperature));
         }
 
-         if let Some(obj) = request.additional_params.as_ref().and_then(|p| p.as_object()) {
+        if let Some(obj) = request
+            .additional_params
+            .as_ref()
+            .and_then(|p| p.as_object())
+        {
             for (k, v) in obj {
                 body_map.insert(k.clone(), v.clone());
             }

--- a/crates/rig-core/src/providers/openrouter/transcription.rs
+++ b/crates/rig-core/src/providers/openrouter/transcription.rs
@@ -56,7 +56,8 @@ pub struct TranscriptionResponse {
 
 #[derive(Debug, Deserialize)]
 pub struct TranscriptionUsage {
-    pub seconds: f64,
+    #[serde(default)]
+    pub seconds: Option<f64>,
     #[serde(default)]
     pub total_tokens: Option<usize>,
     #[serde(default)]
@@ -100,9 +101,9 @@ impl<T> TranscriptionModel<T> {
 }
 
 fn infer_format_from_filename(filename: &str) -> String {
-    filename
-        .split('.')
-        .nth(1)
+    std::path::Path::new(filename)
+        .extension()
+        .and_then(|e| e.to_str())
         .and_then(|ext| match ext.to_lowercase().as_str() {
             "wav" => Some("wav"),
             "mp3" => Some("mp3"),
@@ -132,6 +133,17 @@ where
         &self,
         request: transcription::TranscriptionRequest,
     ) -> Result<transcription::TranscriptionResponse<Self::Response>, TranscriptionError> {
+        if let Some(_prompt) = request.prompt {
+            return Err(TranscriptionError::RequestError(Box::new(
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "OpenRouter STT does not support a top-level prompt field. \
+                     Provider-specific prompt options can be passed via `additional_params`. \
+                     Example: {\"provider\": {\"options\": {\"<provider>\": {\"prompt\": \"<text>\"}}}}",
+                ),
+            )));
+        }
+
         let audio_b64 = STANDARD.encode(&request.data);
         let format = infer_format_from_filename(&request.filename);
 
@@ -155,12 +167,14 @@ where
             body_map.insert("temperature".to_string(), serde_json::json!(temperature));
         }
 
-        if let Some(obj) = request
-            .additional_params
-            .as_ref()
-            .and_then(|p| p.as_object())
-        {
-            for (k, v) in obj {
+        if let Some(ref additional_params) = request.additional_params {
+            let params = additional_params.as_object().ok_or_else(|| {
+                TranscriptionError::RequestError(Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "additional transcription parameters must be a JSON object",
+                )))
+            })?;
+            for (k, v) in params {
                 body_map.insert(k.clone(), v.clone());
             }
         }
@@ -205,6 +219,8 @@ mod tests {
         assert_eq!(infer_format_from_filename("audio.MP3"), "mp3");
         assert_eq!(infer_format_from_filename("unknown"), "wav");
         assert_eq!(infer_format_from_filename("noextension"), "wav");
+        assert_eq!(infer_format_from_filename("meeting.final.mp3"), "mp3");
+        assert_eq!(infer_format_from_filename("audio.tar.gz"), "wav");
     }
 
     #[test]
@@ -231,7 +247,7 @@ mod tests {
         let resp: TranscriptionResponse = serde_json::from_str(json).unwrap();
         assert_eq!(resp.text, "Hello world");
         let usage = resp.usage.unwrap();
-        assert_eq!(usage.seconds, 1.5);
+        assert_eq!(usage.seconds, Some(1.5));
     }
 
     #[test]

--- a/crates/rig-core/src/providers/openrouter/transcription.rs
+++ b/crates/rig-core/src/providers/openrouter/transcription.rs
@@ -1,0 +1,240 @@
+use crate::http_client::HttpClientExt;
+use crate::providers::openrouter::Client;
+use crate::transcription;
+use crate::transcription::TranscriptionError;
+use crate::wasm_compat::WasmCompatSend;
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+
+// ================================================================
+// Model constants
+// ================================================================
+
+/// The `openai/whisper-1` model.
+pub const WHISPER_1: &str = "openai/whisper-1";
+/// The `openai/whisper-large-v3-turbo` model.
+pub const WHISPER_LARGE_V3_TURBO: &str = "openai/whisper-large-v3-turbo";
+/// The `openai/whisper-large-v3` model.
+pub const WHISPER_LARGE_V3: &str = "openai/whisper-large-v3";
+/// The `openai/gpt-4o-transcribe` model.
+pub const GPT_4O_TRANSCRIBE: &str = "openai/gpt-4o-transcribe";
+/// The `openai/gpt-4o-mini-transcribe` model.
+pub const GPT_4O_MINI_TRANSCRIBE: &str = "openai/gpt-4o-mini-transcribe";
+/// The `google/chirp-3` model.
+pub const CHIRP_3: &str = "google/chirp-3";
+
+// ================================================================
+// Request/Response types
+// ================================================================
+
+#[allow(dead_code)]
+#[derive(Debug, Serialize)]
+struct InputAudio {
+    data: String,
+    format: String,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Serialize)]
+struct TranscriptionRequestInput {
+    model: String,
+    input_audio: InputAudio,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    language: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TranscriptionResponse {
+    pub text: String,
+    #[serde(default)]
+    pub usage: Option<TranscriptionUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TranscriptionUsage {
+    pub seconds: f64,
+    #[serde(default)]
+    pub total_tokens: Option<usize>,
+    #[serde(default)]
+    pub input_tokens: Option<usize>,
+    #[serde(default)]
+    pub output_tokens: Option<usize>,
+    #[serde(default)]
+    pub cost: Option<f64>,
+}
+
+impl TryFrom<TranscriptionResponse>
+    for transcription::TranscriptionResponse<TranscriptionResponse>
+{
+    type Error = TranscriptionError;
+
+    fn try_from(value: TranscriptionResponse) -> Result<Self, Self::Error> {
+        Ok(transcription::TranscriptionResponse {
+            text: value.text.clone(),
+            response: value,
+        })
+    }
+}
+
+// ================================================================
+// Model
+// ================================================================
+
+#[derive(Clone)]
+pub struct TranscriptionModel<T = reqwest::Client> {
+    client: Client<T>,
+    pub model: String,
+}
+
+impl<T> TranscriptionModel<T> {
+    pub fn new(client: Client<T>, model: impl Into<String>) -> Self {
+        Self {
+            client,
+            model: model.into(),
+        }
+    }
+}
+
+fn infer_format_from_filename(filename: &str) -> String {
+    filename
+        .split('.')
+        .nth(1)
+        .and_then(|ext| match ext.to_lowercase().as_str() {
+            "wav" => Some("wav"),
+            "mp3" => Some("mp3"),
+            "flac" => Some("flac"),
+            "m4a" => Some("m4a"),
+            "ogg" => Some("ogg"),
+            "webm" => Some("webm"),
+            "aac" => Some("aac"),
+            _ => None,
+        })
+        .unwrap_or("wav")
+        .to_string()
+}
+
+impl<T> transcription::TranscriptionModel for TranscriptionModel<T>
+where
+    T: HttpClientExt + Clone + std::fmt::Debug + Default + WasmCompatSend + 'static,
+{
+    type Response = TranscriptionResponse;
+    type Client = Client<T>;
+
+    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
+        Self::new(client.clone(), model)
+    }
+
+    async fn transcription(
+        &self,
+        request: transcription::TranscriptionRequest,
+    ) -> Result<transcription::TranscriptionResponse<Self::Response>, TranscriptionError> {
+        let audio_b64 = STANDARD.encode(&request.data);
+        let format = infer_format_from_filename(&request.filename);
+
+        let mut body_map: serde_json::Map<String, serde_json::Value> = [
+            ("model".to_string(), serde_json::json!(self.model)),
+            (
+                "input_audio".to_string(),
+                serde_json::json!({
+                    "data": audio_b64,
+                    "format": format,
+                }),
+            ),
+        ]
+        .into_iter()
+        .collect();
+
+        if let Some(language) = request.language {
+            body_map.insert("language".to_string(), serde_json::json!(language));
+        }
+        if let Some(temperature) = request.temperature {
+            body_map.insert("temperature".to_string(), serde_json::json!(temperature));
+        }
+
+         if let Some(obj) = request.additional_params.as_ref().and_then(|p| p.as_object()) {
+            for (k, v) in obj {
+                body_map.insert(k.clone(), v.clone());
+            }
+        }
+
+        let body = serde_json::to_vec(&serde_json::Value::Object(body_map))?;
+
+        let req = self
+            .client
+            .post("/audio/transcriptions")?
+            .header("Content-Type", "application/json")
+            .body(body)
+            .map_err(|e| TranscriptionError::HttpError(e.into()))?;
+
+        let response = self.client.send::<_, Bytes>(req).await?;
+        let status = response.status();
+        let body_bytes = response.into_body().await?;
+
+        if status.is_success() {
+            let resp: TranscriptionResponse = serde_json::from_slice(&body_bytes)?;
+            resp.try_into()
+        } else {
+            let text = String::from_utf8_lossy(&body_bytes).to_string();
+            Err(TranscriptionError::ProviderError(text))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_infer_format_from_filename() {
+        assert_eq!(infer_format_from_filename("audio.wav"), "wav");
+        assert_eq!(infer_format_from_filename("audio.mp3"), "mp3");
+        assert_eq!(infer_format_from_filename("audio.flac"), "flac");
+        assert_eq!(infer_format_from_filename("audio.m4a"), "m4a");
+        assert_eq!(infer_format_from_filename("audio.ogg"), "ogg");
+        assert_eq!(infer_format_from_filename("audio.webm"), "webm");
+        assert_eq!(infer_format_from_filename("audio.aac"), "aac");
+        assert_eq!(infer_format_from_filename("audio.WAV"), "wav");
+        assert_eq!(infer_format_from_filename("audio.MP3"), "mp3");
+        assert_eq!(infer_format_from_filename("unknown"), "wav");
+        assert_eq!(infer_format_from_filename("noextension"), "wav");
+    }
+
+    #[test]
+    fn test_transcription_request_serialization() {
+        let audio_b64 = STANDARD.encode(b"test audio data");
+        let req = TranscriptionRequestInput {
+            model: "openai/whisper-1".to_string(),
+            input_audio: InputAudio {
+                data: audio_b64,
+                format: "mp3".to_string(),
+            },
+            language: Some("en".to_string()),
+            temperature: None,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("\"model\":\"openai/whisper-1\""));
+        assert!(json.contains("\"input_audio\""));
+        assert!(json.contains("\"language\":\"en\""));
+    }
+
+    #[test]
+    fn test_transcription_response_deserialization() {
+        let json = r#"{"text": "Hello world", "usage": {"seconds": 1.5, "cost": 0.001}}"#;
+        let resp: TranscriptionResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.text, "Hello world");
+        let usage = resp.usage.unwrap();
+        assert_eq!(usage.seconds, 1.5);
+    }
+
+    #[test]
+    fn test_transcription_response_without_usage() {
+        let json = r#"{"text": "Hello world"}"#;
+        let resp: TranscriptionResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.text, "Hello world");
+        assert!(resp.usage.is_none());
+    }
+}

--- a/tests/providers/openrouter/audio_generation.rs
+++ b/tests/providers/openrouter/audio_generation.rs
@@ -1,0 +1,24 @@
+//! OpenRouter audio generation (TTS) smoke test.
+
+use rig::audio_generation::AudioGenerationModel;
+use rig::client::ProviderClient;
+use rig::prelude::AudioGenerationClient;
+use rig::providers::openrouter;
+
+use crate::support::{AUDIO_TEXT, assert_nonempty_bytes};
+
+#[tokio::test]
+#[ignore = "requires OPENROUTER_API_KEY"]
+async fn audio_generation_smoke() {
+    let client = openrouter::Client::from_env().expect("client should build");
+    let model = client.audio_generation_model(openrouter::GPT_4O_MINI_TTS);
+    let response = model
+        .audio_generation_request()
+        .text(AUDIO_TEXT)
+        .voice("alloy")
+        .send()
+        .await
+        .expect("audio generation should succeed");
+
+    assert_nonempty_bytes(&response.audio);
+}

--- a/tests/providers/openrouter/mod.rs
+++ b/tests/providers/openrouter/mod.rs
@@ -1,4 +1,6 @@
 mod agent;
+#[cfg(feature = "audio")]
+mod audio_generation;
 mod document_file_data;
 mod extractor;
 mod extractor_usage;
@@ -14,6 +16,7 @@ mod reasoning_tool_roundtrip;
 mod request_hook;
 mod streaming;
 mod streaming_tools;
+mod transcription;
 mod typed_prompt_tools;
 
 pub(super) const DEFAULT_MODEL: &str = "openai/gpt-4o-mini";

--- a/tests/providers/openrouter/transcription.rs
+++ b/tests/providers/openrouter/transcription.rs
@@ -1,0 +1,24 @@
+//! OpenRouter transcription (STT) smoke test.
+
+use rig::client::ProviderClient;
+use rig::prelude::TranscriptionClient;
+use rig::providers::openrouter;
+use rig::transcription::TranscriptionModel;
+
+use crate::support::{AUDIO_FIXTURE_PATH, assert_nonempty_response};
+
+#[tokio::test]
+#[ignore = "requires OPENROUTER_API_KEY"]
+async fn transcription_smoke() {
+    let client = openrouter::Client::from_env().expect("client should build");
+    let model = client.transcription_model(openrouter::WHISPER_1);
+    let response = model
+        .transcription_request()
+        .load_file(AUDIO_FIXTURE_PATH)
+        .expect("should be able to load audio fixture")
+        .send()
+        .await
+        .expect("transcription should succeed");
+
+    assert_nonempty_response(&response.text);
+}


### PR DESCRIPTION
PR to solve issue #1750 

Add  transcription.rs  and  audio_generation.rs  to the OpenRouter provider, implementing STT (speech-to-text) via
OpenRouter's  /api/v1/audio/transcriptions  endpoint and TTS via  /audio/speech . STT uses JSON with base64-encoded audio (differing from OpenAI's multipart transport) and exposes well-known Whisper, GPT-4o Transcribe, and Chirp 3 model constants. TTS defaults to MP3 output and supports provider-specific passthrough via  additional_params . Update  mod.rs with module declarations and re-exports, and change client capabilities in  client.rs  from  Nothing  to  Capable  for both transcription and audio generation (behind the  audio  feature gate).
[pr-description.md](https://github.com/user-attachments/files/27628786/pr-description.md)
