### PR TITLE
fix(ollama): buffer NDJSON streaming across HTTP chunk boundaries

### DIFF
--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -593,6 +593,38 @@ impl GetTokenUsage for StreamingCompletionResponse {
     }
 }
 
+/// Reassembles newline-delimited JSON lines from a chunked HTTP byte stream.
+///
+/// `bytes_stream` makes no promises about chunk boundaries, so a single NDJSON
+/// line can be split across multiple chunks. `NdjsonBuffer` holds the trailing
+/// fragment between calls and yields only fully terminated lines.
+#[derive(Default)]
+struct NdjsonBuffer {
+    buf: Vec<u8>,
+}
+
+impl NdjsonBuffer {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    /// Appends `chunk` to the buffer and returns any newly completed lines.
+    /// Empty lines are skipped; trailing partial data is retained for the next call.
+    fn decode(&mut self, chunk: &[u8]) -> Vec<Vec<u8>> {
+        self.buf.extend_from_slice(chunk);
+
+        let mut lines = Vec::new();
+        while let Some(pos) = self.buf.iter().position(|&b| b == b'\n') {
+            let mut line: Vec<u8> = self.buf.drain(..=pos).collect();
+            line.pop();
+            if !line.is_empty() {
+                lines.push(line);
+            }
+        }
+        lines
+    }
+}
+
 impl<T> completion::CompletionModel for CompletionModel<T>
 where
     T: HttpClientExt + Clone + Default + std::fmt::Debug + Send + 'static,
@@ -743,18 +775,15 @@ where
             let mut tool_calls_final = Vec::new();
             let mut text_response = String::new();
             let mut thinking_response = String::new();
+            let mut line_buf = NdjsonBuffer::new();
 
             while let Some(chunk) = byte_stream.next().await {
                 let bytes = chunk.map_err(|e| http_client::Error::Instance(e.into()))?;
 
-                for line in bytes.split(|&b| b == b'\n') {
-                    if line.is_empty() {
-                        continue;
-                    }
+                for line in line_buf.decode(&bytes) {
+                    tracing::debug!(target: "rig", "Received NDJSON line from Ollama: {}", String::from_utf8_lossy(&line));
 
-                    tracing::debug!(target: "rig", "Received NDJSON line from Ollama: {}", String::from_utf8_lossy(line));
-
-                    let response: CompletionResponse = serde_json::from_slice(line)?;
+                    let response: CompletionResponse = serde_json::from_slice(&line)?;
 
                     if let Message::Assistant { content, thinking, tool_calls, .. } = response.message {
                         if let Some(thinking_content) = thinking && !thinking_content.is_empty() {
@@ -2042,5 +2071,98 @@ mod tests {
             .api_key(Nothing)
             .build()
             .expect("Client::builder() failed");
+    }
+
+    #[test]
+    fn ndjson_buffer_returns_complete_lines_in_single_chunk() {
+        let mut buf = NdjsonBuffer::new();
+        let lines = buf.decode(b"{\"a\":1}\n{\"b\":2}\n");
+        assert_eq!(lines, vec![b"{\"a\":1}".to_vec(), b"{\"b\":2}".to_vec()]);
+    }
+
+    #[test]
+    fn ndjson_buffer_reassembles_line_split_across_chunks() {
+        let mut buf = NdjsonBuffer::new();
+
+        assert!(buf.decode(b"{\"model\":\"llama\",\"mes").is_empty());
+
+        let lines = buf.decode(b"sage\":\"hi\"}\n{\"done\"");
+        assert_eq!(
+            lines,
+            vec![b"{\"model\":\"llama\",\"message\":\"hi\"}".to_vec()]
+        );
+
+        let lines = buf.decode(b":true}\n");
+        assert_eq!(lines, vec![b"{\"done\":true}".to_vec()]);
+    }
+
+    #[test]
+    fn ndjson_buffer_skips_blank_lines() {
+        let mut buf = NdjsonBuffer::new();
+        let lines = buf.decode(b"\n{\"a\":1}\n\n");
+        assert_eq!(lines, vec![b"{\"a\":1}".to_vec()]);
+    }
+
+    #[test]
+    fn ndjson_buffer_retains_unterminated_trailing_data() {
+        let mut buf = NdjsonBuffer::new();
+        let lines = buf.decode(b"{\"a\":1}\n{\"b\":2");
+        assert_eq!(lines, vec![b"{\"a\":1}".to_vec()]);
+        let lines = buf.decode(b"}\n");
+        assert_eq!(lines, vec![b"{\"b\":2}".to_vec()]);
+    }
+
+    #[test]
+    fn ndjson_buffer_handles_empty_chunk() {
+        let mut buf = NdjsonBuffer::new();
+        assert!(buf.decode(b"").is_empty());
+
+        buf.decode(b"{\"a\":1");
+        assert!(buf.decode(b"").is_empty());
+
+        let lines = buf.decode(b"}\n");
+        assert_eq!(lines, vec![b"{\"a\":1}".to_vec()]);
+    }
+
+    #[test]
+    fn ndjson_buffer_handles_multi_byte_utf8_split_across_chunks() {
+        // `\n` (0x0A) cannot appear inside any UTF-8 continuation byte, so a
+        // byte-wise newline scan is always safe — but verify explicitly that a
+        // multi-byte sequence reassembles correctly when split across chunks.
+        let mut buf = NdjsonBuffer::new();
+        assert!(buf.decode(&[0xd0]).is_empty());
+        assert!(buf.decode(&[0xb8, 0xd0, 0xb7, 0xd0]).is_empty());
+        assert!(
+            buf.decode(&[
+                0xb2, 0xd0, 0xb5, 0xd1, 0x81, 0xd1, 0x82, 0xd0, 0xbd, 0xd0, 0xb8
+            ])
+            .is_empty()
+        );
+
+        let lines = buf.decode(b"\n");
+        assert_eq!(lines.len(), 1);
+        assert_eq!(std::str::from_utf8(&lines[0]).unwrap(), "известни");
+    }
+
+    #[test]
+    fn ndjson_buffer_yields_parseable_chunks_when_split_arbitrarily() {
+        let original = concat!(
+            "{\"model\":\"llama3.2\",\"message\":{\"role\":\"assistant\",\"content\":\"hi\"},\"done\":false}\n",
+            "{\"model\":\"llama3.2\",\"message\":{\"role\":\"assistant\",\"content\":\"\"},\"done\":true}\n",
+        );
+
+        let mut buf = NdjsonBuffer::new();
+        let mut received = Vec::new();
+        for byte in original.as_bytes() {
+            for line in buf.decode(std::slice::from_ref(byte)) {
+                let parsed: serde_json::Value =
+                    serde_json::from_slice(&line).expect("each drained line must be valid JSON");
+                received.push(parsed);
+            }
+        }
+
+        assert_eq!(received.len(), 2);
+        assert_eq!(received[0]["message"]["content"], "hi");
+        assert_eq!(received[1]["done"], true);
     }
 }


### PR DESCRIPTION
## Problem

Fixes #1758.

The Ollama streaming chat completion loop runs `serde_json::from_slice` on every segment produced by `bytes.split('\n')` of each HTTP body chunk:

```rust
for line in bytes.split(|&b| b == b'\n') {
    if line.is_empty() { continue; }
    let response: CompletionResponse = serde_json::from_slice(line)?;
    // ...
}
```

`bytes_stream()` makes no promises about where it cuts the body. When a single NDJSON line is split mid-token across two chunks — which happens reliably on longer assistant messages, e.g. thinking-enabled responses or messages carrying multi-KB tool-call arguments — both halves are fed to serde independently and the first half fails parsing. The stream terminates with `CompletionError::JsonError` (`EOF while parsing ...`) before the caller gets any tokens. The linked issue has a runnable reproduction that triggers the error reliably against a local Ollama server.

## Fix

Add a small private `NdjsonBuffer` to `providers/ollama.rs` that accumulates bytes across `bytes_stream` chunks and yields only newline-terminated lines, retaining any trailing partial fragment until the next chunk completes it. The streaming loop swaps `bytes.split('\n')` for `NdjsonBuffer::decode(&bytes)`; all other semantics — the per-line debug log, `serde_json::from_slice`, the `done == true` break — are preserved exactly.

Notes on the chosen shape:

- The buffer is a private struct mirroring the local convention already established by `providers/anthropic/decoders/line.rs` (struct + `Default` + `new` + `decode`).
- Promoting `anthropic::decoders::line::LineDecoder` to a shared crate-level module was considered and rejected: that would be a refactor plus public-API reshape inside a bug-fix PR, which `CONTRIBUTING.md` calls out for prior discussion. Ollama's NDJSON also doesn't need the `\r` / `\r\n` handling that motivates the SSE decoder, so the duplication is intentional and small (~20 lines).

## Tests

Seven unit tests next to the existing ollama test module:

- `ndjson_buffer_returns_complete_lines_in_single_chunk` — happy path
- `ndjson_buffer_reassembles_line_split_across_chunks` — explicit regression for the bug in #1758
- `ndjson_buffer_skips_blank_lines` — keep-alive blanks
- `ndjson_buffer_retains_unterminated_trailing_data` — partial-line preservation across two `decode` calls
- `ndjson_buffer_handles_empty_chunk` — no-op on empty input, even when buffer has unterminated state
- `ndjson_buffer_handles_multi_byte_utf8_split_across_chunks` — UTF-8 safety across chunk boundaries (mirrors anthropic `LineDecoder` coverage)
- `ndjson_buffer_yields_parseable_chunks_when_split_arbitrarily` — drives a realistic Ollama NDJSON response one byte at a time through serde so every possible boundary is exercised

End-to-end verification against a live local Ollama server (thinking + chained tool calls) is captured in #1758. Before this PR the reproduction exits with `JsonError: EOF while parsing a string at line 1 column N`; after, the stream completes cleanly.

## Verification

```bash
cargo fmt -- --check
cargo clippy -p rig-core --all-features --all-targets
cargo test -p rig-core --lib providers::ollama::
cargo test --workspace
```

All clean.

## Notes for reviewers

- No public API changes. `NdjsonBuffer` is private to `providers/ollama.rs`.
- No new trait bounds, so no WASM compatibility regressions.
- The buffer's underlying `Vec<u8>` grows to the largest line seen and does not shrink — bounded per stream, one buffer per stream, no leak across streams.
- We intentionally do not add a `flush()` method like the anthropic `LineDecoder`: Ollama always terminates its final NDJSON line with `\n`, so there is no trailing fragment to recover on a normal completion.
- Edge cases consciously not in scope: `\r` / `\r\n` line endings (Ollama does not emit these, and the old code did not handle them either), and a `max_buffer_size` guard against an unbounded malformed server response.

## AI assistance

This PR was prepared with Claude (Opus 4.7). I reviewed every line, ran the regression locally against my own Ollama instance, and verified all `cargo` checks listed above before submitting.
