### PR TITLE
fix(gemini): Token usage correctness for posthog llm analytics

### DIFF
--- a/crates/rig-bedrock/src/streaming.rs
+++ b/crates/rig-bedrock/src/streaming.rs
@@ -38,6 +38,7 @@ impl GetTokenUsage for BedrockStreamingResponse {
             total_tokens: u.total_tokens as u64,
             cached_input_tokens: u.cache_read_input_tokens.unwrap_or_default() as u64,
             cache_creation_input_tokens: u.cache_write_input_tokens.unwrap_or_default() as u64,
+            reasoning_tokens: 0,
         })
     }
 }

--- a/crates/rig-bedrock/src/types/assistant_content.rs
+++ b/crates/rig-bedrock/src/types/assistant_content.rs
@@ -25,6 +25,7 @@ fn normalize_usage(usage: &TokenUsage) -> completion::Usage {
         total_tokens: usage.total_tokens as u64,
         cached_input_tokens: usage.cache_read_input_tokens.unwrap_or_default() as u64,
         cache_creation_input_tokens: usage.cache_write_input_tokens.unwrap_or_default() as u64,
+        reasoning_tokens: 0,
     }
 }
 

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -950,6 +950,7 @@ mod tests {
                 total_tokens: 3,
                 cached_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning_tokens: 0,
             },
         );
 
@@ -960,7 +961,7 @@ mod tests {
     #[test]
     fn typed_prompt_response_deserializes_with_deserialize_only_output() {
         let response: TypedPromptResponse<DeserializeOnly> = serde_json::from_str(
-            r#"{"output":{"value":"ok"},"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3,"cached_input_tokens":0,"cache_creation_input_tokens":0}}"#,
+            r#"{"output":{"value":"ok"},"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3,"cached_input_tokens":0,"cache_creation_input_tokens":0,"reasoning_tokens":0}}"#,
         )
         .expect("deserialize typed prompt response");
 
@@ -1021,6 +1022,7 @@ mod tests {
                     total_tokens: 2,
                     cached_input_tokens: 0,
                     cache_creation_input_tokens: 0,
+                    reasoning_tokens: 0,
                 }),
             MockTurn::text("").with_usage(Usage {
                 input_tokens: 1,
@@ -1028,6 +1030,7 @@ mod tests {
                 total_tokens: 2,
                 cached_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning_tokens: 0,
             }),
         ]);
         let agent = AgentBuilder::new(model).build();
@@ -1048,6 +1051,7 @@ mod tests {
                 total_tokens: 4,
                 cached_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning_tokens: 0,
             }
         );
 

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -403,6 +403,9 @@ pub struct Usage {
     pub cached_input_tokens: u64,
     /// The number of input tokens written to a provider-managed cache
     pub cache_creation_input_tokens: u64,
+    /// The number of tokens spent on internal reasoning / "thoughts" by reasoning-capable
+    /// models (e.g. Gemini thinking, Anthropic extended thinking, OpenAI o-series).
+    pub reasoning_tokens: u64,
 }
 
 impl Usage {
@@ -414,6 +417,7 @@ impl Usage {
             total_tokens: 0,
             cached_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning_tokens: 0,
         }
     }
 }
@@ -435,6 +439,7 @@ impl Add for Usage {
             cached_input_tokens: self.cached_input_tokens + other.cached_input_tokens,
             cache_creation_input_tokens: self.cache_creation_input_tokens
                 + other.cache_creation_input_tokens,
+            reasoning_tokens: self.reasoning_tokens + other.reasoning_tokens,
         }
     }
 }
@@ -446,6 +451,7 @@ impl AddAssign for Usage {
         self.total_tokens += other.total_tokens;
         self.cached_input_tokens += other.cached_input_tokens;
         self.cache_creation_input_tokens += other.cache_creation_input_tokens;
+        self.reasoning_tokens += other.reasoning_tokens;
     }
 }
 

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -242,6 +242,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                 + response.usage.output_tokens,
             cached_input_tokens: response.usage.cache_read_input_tokens.unwrap_or(0),
             cache_creation_input_tokens: response.usage.cache_creation_input_tokens.unwrap_or(0),
+            reasoning_tokens: 0,
         };
 
         Ok(completion::CompletionResponse {

--- a/crates/rig-core/src/providers/cohere/completion.rs
+++ b/crates/rig-core/src/providers/cohere/completion.rs
@@ -189,6 +189,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                     total_tokens: (input_tokens + output_tokens) as u64,
                     cached_input_tokens: 0,
                     cache_creation_input_tokens: 0,
+                    reasoning_tokens: 0,
                 }
             })
             .unwrap_or_default();

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -586,6 +586,7 @@ impl TryFrom<ChatCompletionResponse> for completion::CompletionResponse<ChatComp
                     .map(|d| d.cached_tokens as u64)
                     .unwrap_or(0),
                 cache_creation_input_tokens: 0,
+                reasoning_tokens: 0,
             })
             .unwrap_or_default();
 

--- a/crates/rig-core/src/providers/deepseek.rs
+++ b/crates/rig-core/src/providers/deepseek.rs
@@ -445,6 +445,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                 .map(|c| c as u64)
                 .unwrap_or(0),
             cache_creation_input_tokens: 0,
+            reasoning_tokens: 0,
         };
 
         Ok(completion::CompletionResponse {

--- a/crates/rig-core/src/providers/galadriel.rs
+++ b/crates/rig-core/src/providers/galadriel.rs
@@ -273,6 +273,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                 total_tokens: usage.total_tokens as u64,
                 cached_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning_tokens: 0,
             })
             .unwrap_or_default();
 

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -103,6 +103,7 @@ where
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
                 gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
+                gen_ai.usage.reasoning_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()
@@ -508,6 +509,7 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse<Generat
                 total_tokens: usage.total_token_count as u64,
                 cached_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning_tokens: usage.thoughts_token_count.unwrap_or_default() as u64,
             })
             .unwrap_or_default();
 
@@ -589,7 +591,7 @@ pub mod gemini_api_types {
         }
 
         fn get_response_model_name(&self) -> Option<String> {
-            None
+            self.model_version.clone()
         }
 
         fn get_output_messages(&self) -> Vec<Self::OutputMessage> {
@@ -1333,6 +1335,44 @@ pub mod gemini_api_types {
         pub total_token_count: i32,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub thoughts_token_count: Option<i32>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub prompt_tokens_details: Option<Vec<ModalityTokenCount>>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub cache_tokens_details: Option<Vec<ModalityTokenCount>>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub candidates_tokens_details: Option<Vec<ModalityTokenCount>>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub tool_use_prompt_token_count: Option<i32>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub tool_use_prompt_tokens_details: Option<Vec<ModalityTokenCount>>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub traffic_type: Option<TrafficType>,
+    }
+
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct ModalityTokenCount {
+        pub modality: Modality,
+        pub token_count: i32,
+    }
+
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+    pub enum Modality {
+        ModalityUnspecified,
+        Text,
+        Image,
+        Video,
+        Audio,
+        Document,
+    }
+
+    #[derive(Clone, Debug, Deserialize, Serialize)]
+    #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+    pub enum TrafficType {
+        TrafficTypeUnspecified,
+        OnDemand,
+        ProvisionedThroughput,
     }
 
     impl std::fmt::Display for UsageMetadata {
@@ -1359,11 +1399,11 @@ pub mod gemini_api_types {
             let mut usage = crate::completion::Usage::new();
 
             usage.input_tokens = self.prompt_token_count as u64;
-            usage.output_tokens = (self.cached_content_token_count.unwrap_or_default()
-                + self.candidates_token_count.unwrap_or_default()
-                + self.thoughts_token_count.unwrap_or_default())
-                as u64;
-            usage.total_tokens = usage.input_tokens + usage.output_tokens;
+            usage.output_tokens = self.candidates_token_count.unwrap_or_default() as u64;
+            usage.cached_input_tokens =
+                self.cached_content_token_count.unwrap_or_default() as u64;
+            usage.reasoning_tokens = self.thoughts_token_count.unwrap_or_default() as u64;
+            usage.total_tokens = self.total_token_count as u64;
 
             Some(usage)
         }

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -1400,8 +1400,7 @@ pub mod gemini_api_types {
 
             usage.input_tokens = self.prompt_token_count as u64;
             usage.output_tokens = self.candidates_token_count.unwrap_or_default() as u64;
-            usage.cached_input_tokens =
-                self.cached_content_token_count.unwrap_or_default() as u64;
+            usage.cached_input_tokens = self.cached_content_token_count.unwrap_or_default() as u64;
             usage.reasoning_tokens = self.thoughts_token_count.unwrap_or_default() as u64;
             usage.total_tokens = self.total_token_count as u64;
 

--- a/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
@@ -133,6 +133,7 @@ where
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
                 gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
+                gen_ai.usage.reasoning_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
@@ -63,6 +63,7 @@ where
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
                 gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
+                gen_ai.usage.reasoning_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()

--- a/crates/rig-core/src/providers/gemini/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/streaming.rs
@@ -4,7 +4,9 @@ use serde::{Deserialize, Serialize};
 use tracing::{Level, enabled, info_span};
 use tracing_futures::Instrument;
 
-use super::completion::gemini_api_types::{ContentCandidate, ModalityTokenCount, Part, PartKind, TrafficType};
+use super::completion::gemini_api_types::{
+    ContentCandidate, ModalityTokenCount, Part, PartKind, TrafficType,
+};
 use super::completion::{
     CompletionModel, create_request_body, resolve_request_model, streaming_endpoint,
 };

--- a/crates/rig-core/src/providers/gemini/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/streaming.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{Level, enabled, info_span};
 use tracing_futures::Instrument;
 
-use super::completion::gemini_api_types::{ContentCandidate, Part, PartKind};
+use super::completion::gemini_api_types::{ContentCandidate, ModalityTokenCount, Part, PartKind, TrafficType};
 use super::completion::{
     CompletionModel, create_request_body, resolve_request_model, streaming_endpoint,
 };
@@ -27,6 +27,18 @@ pub struct PartialUsage {
     pub thoughts_token_count: Option<i32>,
     #[serde(default)]
     pub prompt_token_count: i32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_tokens_details: Option<Vec<ModalityTokenCount>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_tokens_details: Option<Vec<ModalityTokenCount>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub candidates_tokens_details: Option<Vec<ModalityTokenCount>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_use_prompt_token_count: Option<i32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_use_prompt_tokens_details: Option<Vec<ModalityTokenCount>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub traffic_type: Option<TrafficType>,
 }
 
 impl GetTokenUsage for PartialUsage {
@@ -34,10 +46,10 @@ impl GetTokenUsage for PartialUsage {
         let mut usage = crate::completion::Usage::new();
 
         usage.input_tokens = self.prompt_token_count as u64;
-        usage.output_tokens = (self.cached_content_token_count.unwrap_or_default()
-            + self.candidates_token_count.unwrap_or_default()
-            + self.thoughts_token_count.unwrap_or_default()) as u64;
-        usage.total_tokens = usage.input_tokens + usage.output_tokens;
+        usage.output_tokens = self.candidates_token_count.unwrap_or_default() as u64;
+        usage.cached_input_tokens = self.cached_content_token_count.unwrap_or_default() as u64;
+        usage.reasoning_tokens = self.thoughts_token_count.unwrap_or_default() as u64;
+        usage.total_tokens = self.total_token_count as u64;
 
         Some(usage)
     }
@@ -59,15 +71,7 @@ pub struct StreamingCompletionResponse {
 
 impl GetTokenUsage for StreamingCompletionResponse {
     fn token_usage(&self) -> Option<crate::completion::Usage> {
-        let mut usage = crate::completion::Usage::new();
-        usage.total_tokens = self.usage_metadata.total_token_count as u64;
-        usage.output_tokens = self
-            .usage_metadata
-            .candidates_token_count
-            .map(|x| x as u64)
-            .unwrap_or(0);
-        usage.input_tokens = self.usage_metadata.prompt_token_count as u64;
-        Some(usage)
+        self.usage_metadata.token_usage()
     }
 }
 
@@ -94,6 +98,7 @@ where
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
                 gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
+                gen_ai.usage.reasoning_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()
@@ -517,11 +522,19 @@ mod tests {
             candidates_token_count: Some(30),
             thoughts_token_count: Some(10),
             prompt_token_count: 40,
+            prompt_tokens_details: None,
+            cache_tokens_details: None,
+            candidates_tokens_details: None,
+            tool_use_prompt_token_count: None,
+            tool_use_prompt_tokens_details: None,
+            traffic_type: None,
         };
 
         let token_usage = usage.token_usage().unwrap();
         assert_eq!(token_usage.input_tokens, 40);
-        assert_eq!(token_usage.output_tokens, 60); // 20 + 30 + 10
+        assert_eq!(token_usage.cached_input_tokens, 20);
+        assert_eq!(token_usage.output_tokens, 30);
+        assert_eq!(token_usage.reasoning_tokens, 10);
         assert_eq!(token_usage.total_tokens, 100);
     }
 
@@ -533,11 +546,19 @@ mod tests {
             candidates_token_count: Some(30),
             thoughts_token_count: None,
             prompt_token_count: 20,
+            prompt_tokens_details: None,
+            cache_tokens_details: None,
+            candidates_tokens_details: None,
+            tool_use_prompt_token_count: None,
+            tool_use_prompt_tokens_details: None,
+            traffic_type: None,
         };
 
         let token_usage = usage.token_usage().unwrap();
         assert_eq!(token_usage.input_tokens, 20);
-        assert_eq!(token_usage.output_tokens, 30); // Only candidates_token_count
+        assert_eq!(token_usage.cached_input_tokens, 0);
+        assert_eq!(token_usage.output_tokens, 30);
+        assert_eq!(token_usage.reasoning_tokens, 0);
         assert_eq!(token_usage.total_tokens, 50);
     }
 
@@ -550,12 +571,70 @@ mod tests {
                 candidates_token_count: Some(75),
                 thoughts_token_count: None,
                 prompt_token_count: 75,
+                prompt_tokens_details: None,
+                cache_tokens_details: None,
+                candidates_tokens_details: None,
+                tool_use_prompt_token_count: None,
+                tool_use_prompt_tokens_details: None,
+                traffic_type: None,
             },
         };
 
         let token_usage = response.token_usage().unwrap();
         assert_eq!(token_usage.input_tokens, 75);
         assert_eq!(token_usage.output_tokens, 75);
+        assert_eq!(token_usage.reasoning_tokens, 0);
+        assert_eq!(token_usage.cached_input_tokens, 0);
         assert_eq!(token_usage.total_tokens, 150);
+    }
+
+    #[test]
+    fn test_partial_usage_serde_roundtrip_with_all_optional_fields() {
+        let json_data = serde_json::json!({
+            "promptTokenCount": 100,
+            "cachedContentTokenCount": 25,
+            "candidatesTokenCount": 50,
+            "thoughtsTokenCount": 15,
+            "totalTokenCount": 190,
+            "promptTokensDetails": [
+                { "modality": "TEXT", "tokenCount": 80 },
+                { "modality": "IMAGE", "tokenCount": 20 }
+            ],
+            "cacheTokensDetails": [
+                { "modality": "TEXT", "tokenCount": 25 }
+            ],
+            "candidatesTokensDetails": [
+                { "modality": "TEXT", "tokenCount": 50 }
+            ],
+            "toolUsePromptTokenCount": 12,
+            "toolUsePromptTokensDetails": [
+                { "modality": "TEXT", "tokenCount": 12 }
+            ],
+            "trafficType": "PROVISIONED_THROUGHPUT"
+        });
+
+        let usage: PartialUsage = serde_json::from_value(json_data).unwrap();
+        assert_eq!(usage.prompt_token_count, 100);
+        assert_eq!(usage.cached_content_token_count, Some(25));
+        assert_eq!(usage.candidates_token_count, Some(50));
+        assert_eq!(usage.thoughts_token_count, Some(15));
+        assert_eq!(usage.total_token_count, 190);
+        assert!(usage.prompt_tokens_details.is_some());
+        assert_eq!(usage.prompt_tokens_details.as_ref().unwrap().len(), 2);
+        assert!(usage.cache_tokens_details.is_some());
+        assert!(usage.candidates_tokens_details.is_some());
+        assert_eq!(usage.tool_use_prompt_token_count, Some(12));
+        assert!(usage.tool_use_prompt_tokens_details.is_some());
+        assert!(matches!(
+            usage.traffic_type,
+            Some(TrafficType::ProvisionedThroughput)
+        ));
+
+        let token_usage = usage.token_usage().unwrap();
+        assert_eq!(token_usage.input_tokens, 100);
+        assert_eq!(token_usage.cached_input_tokens, 25);
+        assert_eq!(token_usage.output_tokens, 50);
+        assert_eq!(token_usage.reasoning_tokens, 15);
+        assert_eq!(token_usage.total_tokens, 190);
     }
 }

--- a/crates/rig-core/src/providers/huggingface/completion.rs
+++ b/crates/rig-core/src/providers/huggingface/completion.rs
@@ -605,6 +605,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             total_tokens: response.usage.total_tokens as u64,
             cached_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning_tokens: 0,
         };
 
         Ok(completion::CompletionResponse {

--- a/crates/rig-core/src/providers/hyperbolic.rs
+++ b/crates/rig-core/src/providers/hyperbolic.rs
@@ -237,6 +237,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                 total_tokens: usage.total_tokens as u64,
                 cached_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning_tokens: 0,
             })
             .unwrap_or_default();
 

--- a/crates/rig-core/src/providers/internal/mod.rs
+++ b/crates/rig-core/src/providers/internal/mod.rs
@@ -15,5 +15,6 @@ pub(crate) fn completion_usage(
         total_tokens,
         cached_input_tokens,
         cache_creation_input_tokens: 0,
+        reasoning_tokens: 0,
     }
 }

--- a/crates/rig-core/src/providers/mira.rs
+++ b/crates/rig-core/src/providers/mira.rs
@@ -524,6 +524,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                         total_tokens: usage.total_tokens as u64,
                         cached_input_tokens: 0,
                         cache_creation_input_tokens: 0,
+                        reasoning_tokens: 0,
                     })
                     .unwrap_or_default();
 

--- a/crates/rig-core/src/providers/mistral/completion.rs
+++ b/crates/rig-core/src/providers/mistral/completion.rs
@@ -541,6 +541,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                 total_tokens: usage.total_tokens as u64,
                 cached_input_tokens: usage.cached_tokens(),
                 cache_creation_input_tokens: 0,
+                reasoning_tokens: 0,
             })
             .unwrap_or_default();
 

--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -406,6 +406,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                         total_tokens: prompt_tokens + completion_tokens,
                         cached_input_tokens: 0,
                         cache_creation_input_tokens: 0,
+                        reasoning_tokens: 0,
                     },
                     raw_response,
                     message_id: None,

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -980,6 +980,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                     .map(|d| d.cached_tokens as u64)
                     .unwrap_or(0),
                 cache_creation_input_tokens: 0,
+                reasoning_tokens: 0,
             })
             .unwrap_or_default();
 

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -1540,6 +1540,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                     .map(|d| d.cached_tokens)
                     .unwrap_or(0),
                 cache_creation_input_tokens: 0,
+                reasoning_tokens: usage.output_tokens_details.reasoning_tokens,
             })
             .unwrap_or_default();
 

--- a/crates/rig-core/src/providers/openrouter/completion.rs
+++ b/crates/rig-core/src/providers/openrouter/completion.rs
@@ -722,6 +722,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                 total_tokens: usage.total_tokens as u64,
                 cached_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning_tokens: 0,
             })
             .unwrap_or_default();
 

--- a/crates/rig-core/src/providers/perplexity.rs
+++ b/crates/rig-core/src/providers/perplexity.rs
@@ -195,6 +195,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                     total_tokens: response.usage.total_tokens as u64,
                     cached_input_tokens: 0,
                     cache_creation_input_tokens: 0,
+                    reasoning_tokens: 0,
                 },
                 raw_response: response,
                 message_id: None,

--- a/crates/rig-core/src/providers/xai/completion.rs
+++ b/crates/rig-core/src/providers/xai/completion.rs
@@ -162,6 +162,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                     .map(|x| x.cached_tokens)
                     .unwrap_or_default(),
                 cache_creation_input_tokens: 0,
+                reasoning_tokens: 0,
             })
             .unwrap_or_default();
 

--- a/crates/rig-core/src/telemetry/mod.rs
+++ b/crates/rig-core/src/telemetry/mod.rs
@@ -88,6 +88,7 @@ impl SpanCombinator for tracing::Span {
                 "gen_ai.usage.cache_creation.input_tokens",
                 usage.cache_creation_input_tokens,
             );
+            self.record("gen_ai.usage.reasoning_tokens", usage.reasoning_tokens);
         }
     }
 

--- a/crates/rig-gemini-grpc/src/completion.rs
+++ b/crates/rig-gemini-grpc/src/completion.rs
@@ -467,6 +467,7 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse<Generat
                 total_tokens: usage.total_token_count as u64,
                 cached_input_tokens: usage.cached_content_token_count as u64,
                 cache_creation_input_tokens: 0,
+                reasoning_tokens: 0,
             })
             .unwrap_or_default();
 

--- a/crates/rig-gemini-grpc/src/lib.rs
+++ b/crates/rig-gemini-grpc/src/lib.rs
@@ -47,6 +47,7 @@ impl rig_core::completion::GetTokenUsage for proto::GenerateContentResponse {
                 total_tokens: u.total_token_count as u64,
                 cached_input_tokens: u.cached_content_token_count as u64,
                 cache_creation_input_tokens: 0,
+                reasoning_tokens: 0,
             })
     }
 }

--- a/crates/rig-vertexai/src/types/completion_response.rs
+++ b/crates/rig-vertexai/src/types/completion_response.rs
@@ -62,6 +62,7 @@ impl TryFrom<VertexGenerateContentOutput> for CompletionResponse<VertexGenerateC
                 total_tokens: usage.total_token_count as u64,
                 cached_input_tokens: 0, // unreported at time of writing
                 cache_creation_input_tokens: 0,
+                reasoning_tokens: 0,
             })
             .unwrap_or_default();
 

--- a/tests/core/prompt_response_messages.rs
+++ b/tests/core/prompt_response_messages.rs
@@ -18,6 +18,7 @@ fn simple_text_turn() -> MockTurn {
             total_tokens: 15,
             cached_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning_tokens: 0,
         })
         .with_message_id("msg_mock_1")
 }
@@ -39,6 +40,7 @@ fn tool_then_text_model() -> MockCompletionModel {
             total_tokens: 23,
             cached_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning_tokens: 0,
         })
         .with_message_id("msg_tool"),
         MockTurn::text("The answer is 5")
@@ -48,6 +50,7 @@ fn tool_then_text_model() -> MockCompletionModel {
                 total_tokens: 24,
                 cached_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                reasoning_tokens: 0,
             })
             .with_message_id("msg_text"),
     ])


### PR DESCRIPTION
## Description

Three bugs and several gaps in rig's Gemini provider were preventing downstream
consumers (PostHog LLM analytics in particular) from getting correct
token-usage values:

- `cached_content_token_count` was being summed into `output_tokens` instead
  of being exposed as cached input — `$ai_cache_read_input_tokens` read 0
  and `$ai_output_tokens` was overstated.
- `thoughts_token_count` was also folded into `output_tokens` and lost, so
  reasoning tokens couldn't be reported anywhere.
- The streaming final-usage path dropped `thoughts_token_count` entirely and
  never populated cached input.
- Several Gemini `usage_metadata` fields documented in the API spec
  (modality details, tool-use prompt counts, traffic type) were missing
  from rig's structs.
- `GenerateContentResponse::get_response_model_name` returned `None` even
  though `model_version` was present on the struct.

This PR fixes those and exposes a normalized `reasoning_tokens` field on
`completion::Usage` so reasoning-capable providers (Gemini thinking,
OpenAI o-series, Anthropic extended thinking) can report it cleanly.

Fixes RIG-1309

## Type of change

- [x] Bug fix
- [x] New feature (additive `reasoning_tokens` field, new optional Gemini fields)

## What changed

- `completion::Usage` gains `reasoning_tokens: u64` with `Add`/`AddAssign`
  coverage.
- `SpanCombinator::record_token_usage` records
  `gen_ai.usage.reasoning_tokens`; all four Gemini `info_span!` sites
  reserve the slot.
- Three `GetTokenUsage` impls in `providers/gemini/{completion,streaming}.rs`
  now map `cached_content_token_count` → `cached_input_tokens` and
  `thoughts_token_count` → `reasoning_tokens`, using Gemini's authoritative
  `total_token_count`.
- `UsageMetadata` and `PartialUsage` gain optional `prompt_tokens_details`,
  `cache_tokens_details`, `candidates_tokens_details`,
  `tool_use_prompt_token_count`, `tool_use_prompt_tokens_details`,
  `traffic_type`, plus shared `ModalityTokenCount`, `Modality`,
  `TrafficType` types.
- `GenerateContentResponse::get_response_model_name` now returns
  `self.model_version.clone()`.
- OpenAI Responses API now plumbs its real
  `output_tokens_details.reasoning_tokens` through (bonus).
- Other providers set `reasoning_tokens: 0` (no reasoning data exposed).

## Testing

- [x] `cargo test -p rig-core providers::gemini` — passes
- [x] `cargo check -p rig-core --all-features` — clean
- [x] `cargo clippy -p rig-core --all-features -- -D warnings` — clean
- [x] Updated streaming usage tests to encode the corrected mapping
- [x] New serde round-trip test for `PartialUsage` with all optional
      fields populated, including `trafficType: PROVISIONED_THROUGHPUT`

Live smoke tests against `gemini-2.0-flash-001` (with and without thinking
enabled) recommended before merge to confirm `reasoning_tokens > 0` flows
through the streaming terminal chunk.

## Notes

`prompt_token_count` from Gemini already includes the cached portion, so
`input_tokens` and `cached_input_tokens` overlap by design. This matches
the PostHog convention where `$ai_input_tokens` is gross and
`$ai_cache_read_input_tokens` is a subset hit.

`StreamingCompletionResponse::token_usage` now delegates to
`self.usage_metadata.token_usage()` to eliminate divergence between the
two paths.

Follow-ups intentionally out of scope: Gemini `count_tokens` preflight,
same correctness pass for Anthropic extended thinking, a separate
`rig-posthog` adapter crate, OTLP-to-PostHog integration.