### PR TITLE
Improve GenAI token usage telemetry for Gemini and Responses API

### DIFF
--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -361,6 +361,7 @@ where
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
                 gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
+                gen_ai.usage.reasoning_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()
@@ -446,6 +447,7 @@ where
                 gen_ai.usage.input_tokens = tracing::field::Empty,
                 gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
                 gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
+                gen_ai.usage.reasoning_tokens = tracing::field::Empty,
                 gen_ai.input.messages = tracing::field::Empty,
                 gen_ai.output.messages = tracing::field::Empty,
             );
@@ -539,6 +541,7 @@ where
                     "gen_ai.usage.cache_creation.input_tokens",
                     usage.cache_creation_input_tokens,
                 );
+                agent_span.record("gen_ai.usage.reasoning_tokens", usage.reasoning_tokens);
 
                 if let Some((memory, id)) = memory_handle.as_ref()
                     && let Err(err) = memory.append(id, new_messages.clone()).await

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -402,6 +402,7 @@ where
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
                 gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
+                gen_ai.usage.reasoning_tokens = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()
@@ -520,6 +521,7 @@ where
                     gen_ai.usage.input_tokens = tracing::field::Empty,
                     gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
                     gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
+                    gen_ai.usage.reasoning_tokens = tracing::field::Empty,
                     gen_ai.input.messages = tracing::field::Empty,
                     gen_ai.output.messages = tracing::field::Empty,
                 );
@@ -773,6 +775,7 @@ where
                     current_span.record("gen_ai.usage.output_tokens", aggregated_usage.output_tokens);
                     current_span.record("gen_ai.usage.cache_read.input_tokens", aggregated_usage.cached_input_tokens);
                     current_span.record("gen_ai.usage.cache_creation.input_tokens", aggregated_usage.cache_creation_input_tokens);
+                    current_span.record("gen_ai.usage.reasoning_tokens", aggregated_usage.reasoning_tokens);
                     tracing::info!("Agent multi-turn stream finished");
                     if let Some((memory, id)) = memory_handle.as_ref()
                         && let Err(err) = memory.append(id, new_messages.clone()).await

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -34,7 +34,7 @@ use crate::providers::gemini::streaming::StreamingCompletionResponse;
 use crate::telemetry::SpanCombinator;
 use crate::{
     OneOrMany,
-    completion::{self, CompletionError, CompletionRequest},
+    completion::{self, CompletionError, CompletionRequest, GetTokenUsage},
 };
 use gemini_api_types::{
     Content, FunctionDeclaration, GenerateContentRequest, GenerateContentResponse,
@@ -503,14 +503,7 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse<Generat
         let usage = response
             .usage_metadata
             .as_ref()
-            .map(|usage| completion::Usage {
-                input_tokens: usage.prompt_token_count as u64,
-                output_tokens: usage.candidates_token_count.unwrap_or(0) as u64,
-                total_tokens: usage.total_token_count as u64,
-                cached_input_tokens: 0,
-                cache_creation_input_tokens: 0,
-                reasoning_tokens: usage.thoughts_token_count.unwrap_or_default() as u64,
-            })
+            .and_then(GetTokenUsage::token_usage)
             .unwrap_or_default();
 
         Ok(completion::CompletionResponse {
@@ -2089,7 +2082,7 @@ mod tests {
     use crate::{
         message,
         providers::gemini::completion::gemini_api_types::{
-            ContentCandidate, FinishReason, flatten_schema,
+            ContentCandidate, FinishReason, UsageMetadata, flatten_schema,
         },
     };
 
@@ -2357,6 +2350,56 @@ mod tests {
                     }) if text == "thinking text" && signature == "thought_sig_123"
                 )
         ));
+    }
+
+    #[test]
+    fn test_completion_response_usage_preserves_cached_and_reasoning_tokens() {
+        let response = GenerateContentResponse {
+            response_id: "resp_1".to_string(),
+            candidates: vec![ContentCandidate {
+                content: Some(Content {
+                    parts: vec![Part {
+                        thought: None,
+                        thought_signature: None,
+                        part: PartKind::Text("answer".to_string()),
+                        additional_params: None,
+                    }],
+                    role: Some(Role::Model),
+                }),
+                finish_reason: Some(FinishReason::Stop),
+                safety_ratings: None,
+                citation_metadata: None,
+                token_count: None,
+                avg_logprobs: None,
+                logprobs_result: None,
+                index: Some(0),
+                finish_message: None,
+            }],
+            prompt_feedback: None,
+            usage_metadata: Some(UsageMetadata {
+                prompt_token_count: 40,
+                cached_content_token_count: Some(20),
+                candidates_token_count: Some(30),
+                total_token_count: 100,
+                thoughts_token_count: Some(10),
+                prompt_tokens_details: None,
+                cache_tokens_details: None,
+                candidates_tokens_details: None,
+                tool_use_prompt_token_count: None,
+                tool_use_prompt_tokens_details: None,
+                traffic_type: None,
+            }),
+            model_version: Some("gemini-2.0-flash-001".to_string()),
+        };
+
+        let converted: crate::completion::CompletionResponse<GenerateContentResponse> =
+            response.try_into().expect("convert response");
+
+        assert_eq!(converted.usage.input_tokens, 40);
+        assert_eq!(converted.usage.cached_input_tokens, 20);
+        assert_eq!(converted.usage.output_tokens, 30);
+        assert_eq!(converted.usage.reasoning_tokens, 10);
+        assert_eq!(converted.usage.total_tokens, 100);
     }
 
     #[test]

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -103,6 +103,7 @@ where
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
                 gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
                 gen_ai.usage.reasoning_tokens = tracing::field::Empty,
             )
         } else {

--- a/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
@@ -133,6 +133,7 @@ where
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
                 gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
                 gen_ai.usage.reasoning_tokens = tracing::field::Empty,
             )
         } else {

--- a/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
@@ -63,6 +63,7 @@ where
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
                 gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
                 gen_ai.usage.reasoning_tokens = tracing::field::Empty,
             )
         } else {

--- a/crates/rig-core/src/providers/gemini/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/streaming.rs
@@ -60,7 +60,9 @@ impl GetTokenUsage for PartialUsage {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StreamGenerateContentResponse {
+    pub response_id: Option<String>,
     /// Candidate responses from the model.
+    #[serde(default)]
     pub candidates: Vec<ContentCandidate>,
     pub model_version: Option<String>,
     pub usage_metadata: Option<PartialUsage>,
@@ -100,6 +102,7 @@ where
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
                 gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
                 gen_ai.usage.reasoning_tokens = tracing::field::Empty,
             )
         } else {
@@ -147,6 +150,18 @@ where
                                 continue;
                             }
                         };
+
+                        let span = tracing::Span::current();
+                        if let Some(response_id) = data.response_id.as_deref() {
+                            span.record("gen_ai.response.id", response_id);
+                        }
+                        if let Some(model_version) = data.model_version.as_deref() {
+                            span.record("gen_ai.response.model", model_version);
+                        }
+                        if let Some(usage) = data.usage_metadata.as_ref() {
+                            span.record_token_usage(usage);
+                            final_usage = Some(usage.clone());
+                        }
 
                         // Process the response data
                         let Some(choice) = data.candidates.into_iter().next() else {
@@ -218,9 +233,6 @@ where
 
                         // Check if this is the final response
                         if choice.finish_reason.is_some() {
-                            let span = tracing::Span::current();
-                            span.record_token_usage(&data.usage_metadata);
-                            final_usage = data.usage_metadata;
                             break;
                         }
                     }
@@ -291,6 +303,36 @@ mod tests {
         } else {
             panic!("Expected text part");
         }
+    }
+
+    #[test]
+    fn test_deserialize_stream_response_with_usage_only_chunk() {
+        let json_data = json!({
+            "responseId": "response-123",
+            "modelVersion": "gemini-2.0-flash-001",
+            "usageMetadata": {
+                "promptTokenCount": 10,
+                "candidatesTokenCount": 5,
+                "totalTokenCount": 15
+            }
+        });
+
+        let response: StreamGenerateContentResponse = serde_json::from_value(json_data).unwrap();
+        assert_eq!(response.response_id.as_deref(), Some("response-123"));
+        assert_eq!(
+            response.model_version.as_deref(),
+            Some("gemini-2.0-flash-001")
+        );
+        assert!(response.candidates.is_empty());
+
+        let usage = response
+            .usage_metadata
+            .as_ref()
+            .and_then(GetTokenUsage::token_usage)
+            .unwrap();
+        assert_eq!(usage.input_tokens, 10);
+        assert_eq!(usage.output_tokens, 5);
+        assert_eq!(usage.total_tokens, 15);
     }
 
     #[test]

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -682,15 +682,18 @@ impl ResponsesUsage {
 
 impl GetTokenUsage for ResponsesUsage {
     fn token_usage(&self) -> Option<crate::completion::Usage> {
-        Some(crate::providers::internal::completion_usage(
-            self.input_tokens,
-            self.output_tokens,
-            self.total_tokens,
-            self.input_tokens_details
+        Some(crate::completion::Usage {
+            input_tokens: self.input_tokens,
+            output_tokens: self.output_tokens,
+            total_tokens: self.total_tokens,
+            cached_input_tokens: self
+                .input_tokens_details
                 .as_ref()
                 .map(|details| details.cached_tokens)
                 .unwrap_or(0),
-        ))
+            cache_creation_input_tokens: 0,
+            reasoning_tokens: self.output_tokens_details.reasoning_tokens,
+        })
     }
 }
 
@@ -1530,18 +1533,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
         let usage = response
             .usage
             .as_ref()
-            .map(|usage| completion::Usage {
-                input_tokens: usage.input_tokens,
-                output_tokens: usage.output_tokens,
-                total_tokens: usage.total_tokens,
-                cached_input_tokens: usage
-                    .input_tokens_details
-                    .as_ref()
-                    .map(|d| d.cached_tokens)
-                    .unwrap_or(0),
-                cache_creation_input_tokens: 0,
-                reasoning_tokens: usage.output_tokens_details.reasoning_tokens,
-            })
+            .and_then(GetTokenUsage::token_usage)
             .unwrap_or_default();
 
         Ok(completion::CompletionResponse {
@@ -2013,6 +2005,27 @@ mod tests {
             .expect("provider-specific service tier should serialize"),
             json!("provider_experimental")
         );
+    }
+
+    #[test]
+    fn responses_usage_token_usage_preserves_reasoning_tokens() {
+        let usage = ResponsesUsage {
+            input_tokens: 100,
+            input_tokens_details: Some(InputTokensDetails { cached_tokens: 25 }),
+            output_tokens: 50,
+            output_tokens_details: OutputTokensDetails {
+                reasoning_tokens: 15,
+            },
+            total_tokens: 150,
+        };
+
+        let token_usage = usage.token_usage().expect("usage should be present");
+
+        assert_eq!(token_usage.input_tokens, 100);
+        assert_eq!(token_usage.cached_input_tokens, 25);
+        assert_eq!(token_usage.output_tokens, 50);
+        assert_eq!(token_usage.reasoning_tokens, 15);
+        assert_eq!(token_usage.total_tokens, 150);
     }
 
     #[test]

--- a/crates/rig-core/src/telemetry/mod.rs
+++ b/crates/rig-core/src/telemetry/mod.rs
@@ -105,7 +105,7 @@ impl SpanCombinator for tracing::Span {
         }
 
         if let Some(model_name) = response.get_response_model_name() {
-            self.record("gen_ai.response.model_name", model_name);
+            self.record("gen_ai.response.model", model_name);
         }
     }
 


### PR DESCRIPTION
## Summary

- Record provider response model metadata under `gen_ai.response.model` instead of `gen_ai.response.model_name`
- Preserve reasoning token usage on agent spans for both completion and streaming flows
- Preserve OpenAI Responses API reasoning tokens through `GetTokenUsage`
- Preserve Gemini cached input tokens and reasoning tokens when converting GenerateContent responses
- Improve Gemini streaming telemetry by recording response id, response model, and usage metadata from usage-only chunks

## Behavior Changes

Gemini GenerateContent responses now populate `CompletionResponse.usage.cached_input_tokens` from `cached_content_token_count` instead of dropping it.

Gemini GenerateContent responses now use the provider `GetTokenUsage` implementation when converting into Rig completion responses, keeping token usage behavior consistent with telemetry recording.

Gemini streaming now accepts final/usage-only chunks without candidates. These chunks can still update span metadata and final usage, so streams no longer miss token usage when Gemini sends usage separately from content.

Agent-level telemetry now includes `gen_ai.usage.reasoning_tokens` when usage is available.

Shared response metadata recording now uses the GenAI field `gen_ai.response.model`.

## Testing

- Added unit coverage for Gemini cached/reasoning usage preservation
- Added unit coverage for Gemini usage-only streaming chunks
- Added unit coverage for OpenAI Responses API reasoning token preservation
