### PR TITLE
Clean up root facade features and integration docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,7 +222,6 @@ url = { workspace = true }
 
 [features]
 default = ["rig_core/default", "rustls"]
-all = ["rig_core/all"]
 test-utils = ["rig_core/test-utils"]
 bedrock = ["dep:rig-bedrock"]
 fastembed = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,7 @@ exclude-members = ["crates/rig-core", "crates/rig-derive"]
 workspace = true
 
 [dependencies]
-rig_core = { package = "rig-core", path = "crates/rig-core", version = "0.36.0", default-features = false }
+rig-core = { path = "crates/rig-core", version = "0.36.0", default-features = false }
 rig-bedrock = { path = "crates/rig-bedrock", version = "0.4.5", optional = true, default-features = false }
 rig-fastembed = { path = "crates/rig-fastembed", version = "0.4.0", optional = true, default-features = false }
 rig-gemini-grpc = { path = "crates/rig-gemini-grpc", version = "0.2.5", optional = true, default-features = false }
@@ -168,7 +168,7 @@ anyhow = { workspace = true }
 arrow-array = { workspace = true }
 assert_fs = { workspace = true }
 async-stream = { workspace = true }
-rig_core = { package = "rig-core", path = "crates/rig-core", version = "0.36.0", default-features = false, features = [
+rig-core = { path = "crates/rig-core", version = "0.36.0", default-features = false, features = [
   "test-utils",
 ] }
 tokio = { workspace = true, features = ["full"] }
@@ -221,8 +221,8 @@ tracing-opentelemetry = { workspace = true }
 url = { workspace = true }
 
 [features]
-default = ["rig_core/default", "rustls"]
-test-utils = ["rig_core/test-utils"]
+default = ["rig-core/default", "rustls"]
+test-utils = ["rig-core/test-utils"]
 bedrock = ["dep:rig-bedrock"]
 fastembed = [
   "dep:rig-fastembed",
@@ -246,23 +246,23 @@ sqlite = ["dep:rig-sqlite"]
 surrealdb = ["dep:rig-surrealdb"]
 vectorize = ["dep:rig-vectorize"]
 vertexai = ["dep:rig-vertexai"]
-audio = ["rig_core/audio"]
-image = ["rig_core/image"]
-derive = ["rig_core/derive"]
-experimental = ["rig_core/experimental"]
-discord-bot = ["rig_core/discord-bot"]
-pdf = ["rig_core/pdf"]
-epub = ["rig_core/epub"]
-rayon = ["rig_core/rayon"]
-wasm = ["rig_core/wasm"]
-rmcp = ["rig_core/rmcp"]
-socks = ["rig_core/socks"]
-reqwest = ["rig_core/reqwest"]
-websocket = ["rig_core/websocket"]
-websocket-rustls = ["rig_core/websocket-rustls"]
-websocket-native-tls = ["rig_core/websocket-native-tls"]
+audio = ["rig-core/audio"]
+image = ["rig-core/image"]
+derive = ["rig-core/derive"]
+experimental = ["rig-core/experimental"]
+discord-bot = ["rig-core/discord-bot"]
+pdf = ["rig-core/pdf"]
+epub = ["rig-core/epub"]
+rayon = ["rig-core/rayon"]
+wasm = ["rig-core/wasm"]
+rmcp = ["rig-core/rmcp"]
+socks = ["rig-core/socks"]
+reqwest = ["rig-core/reqwest"]
+websocket = ["rig-core/websocket"]
+websocket-rustls = ["rig-core/websocket-rustls"]
+websocket-native-tls = ["rig-core/websocket-native-tls"]
 rustls = [
-  "rig_core/rustls",
+  "rig-core/rustls",
   "rig-bedrock?/bedrock-rustls",
   "rig-fastembed?/hf-hub-rustls-tls",
   "rig-helixdb?/rustls",
@@ -270,15 +270,15 @@ rustls = [
   "rig-milvus?/rustls",
 ]
 native-tls = [
-  "rig_core/native-tls",
+  "rig-core/native-tls",
   "rig-fastembed?/hf-hub-native-tls",
   "rig-helixdb?/native-tls",
   "rig-lancedb?/rig-native-tls",
   "rig-milvus?/native-tls",
 ]
-reqwest-middleware = ["rig_core/reqwest-middleware"]
-reqwest-middleware-rustls = ["rig_core/reqwest-middleware-rustls"]
-reqwest-middleware-native-tls = ["rig_core/reqwest-middleware-native-tls"]
+reqwest-middleware = ["rig-core/reqwest-middleware"]
+reqwest-middleware-rustls = ["rig-core/reqwest-middleware-rustls"]
+reqwest-middleware-native-tls = ["rig-core/reqwest-middleware-native-tls"]
 
 [[example]]
 name = "rag"

--- a/README.md
+++ b/README.md
@@ -130,37 +130,31 @@ You can find more examples in each crate's `examples` directory (for example, [`
 
 ## Supported Integrations
 
-Vector stores are available as separate companion-crates:
-- MongoDB: [`rig-mongodb`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-mongodb)
-- LanceDB: [`rig-lancedb`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-lancedb)
-- Neo4j: [`rig-neo4j`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-neo4j)
-- Qdrant: [`rig-qdrant`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-qdrant)
-- SQLite: [`rig-sqlite`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-sqlite)
-- SurrealDB: [`rig-surrealdb`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-surrealdb)
-- Milvus: [`rig-milvus`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-milvus)
-- ScyllaDB: [`rig-scylladb`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-scylladb)
-- AWS S3Vectors: [`rig-s3vectors`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-s3vectors)
-- HelixDB: [`rig-helixdb`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-helixdb)
-- Cloudflare Vectorize: [`rig-vectorize`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-vectorize)
-
-The following providers are available as separate companion-crates:
-- AWS Bedrock: [`rig-bedrock`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-bedrock)
-- Fastembed: [`rig-fastembed`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-fastembed)
-- Google Gemini gRPC: [`rig-gemini-grpc`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-gemini-grpc)
-- Google Vertex: [`rig-vertexai`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-vertexai)
-
-The root `rig` facade also exposes these companion crates behind one feature per integration:
+The root `rig` facade exposes companion crates behind one feature per integration:
 
 ```toml
 rig = { version = "0.36.0", features = ["lancedb", "fastembed"] }
 ```
 
-Available facade features include `bedrock`, `fastembed`, `gemini-grpc`,
-`helixdb`, `lancedb`, `memory`, `milvus`, `mongodb`, `neo4j`, `postgres`,
-`qdrant`, `s3vectors`, `scylladb`, `sqlite`, `surrealdb`, `vectorize`, and
-`vertexai`.
-With those features enabled, use the ergonomic root modules such as
-`rig::lancedb`, `rig::mongodb`, `rig::bedrock`, and `rig::fastembed`.
+| Integration | Crate | Feature | Module path |
+| --- | --- | --- | --- |
+| AWS Bedrock | [`rig-bedrock`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-bedrock) | `bedrock` | `rig::bedrock` |
+| AWS S3Vectors | [`rig-s3vectors`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-s3vectors) | `s3vectors` | `rig::s3vectors` |
+| Cloudflare Vectorize | [`rig-vectorize`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-vectorize) | `vectorize` | `rig::vectorize` |
+| FastEmbed | [`rig-fastembed`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-fastembed) | `fastembed` | `rig::fastembed` |
+| Google Gemini gRPC | [`rig-gemini-grpc`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-gemini-grpc) | `gemini-grpc` | `rig::gemini_grpc` |
+| Google Vertex AI | [`rig-vertexai`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-vertexai) | `vertexai` | `rig::vertexai` |
+| HelixDB | [`rig-helixdb`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-helixdb) | `helixdb` | `rig::helixdb` |
+| LanceDB | [`rig-lancedb`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-lancedb) | `lancedb` | `rig::lancedb` |
+| Memory policies | [`rig-memory`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-memory) | `memory` | `rig::memory` |
+| Milvus | [`rig-milvus`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-milvus) | `milvus` | `rig::milvus` |
+| MongoDB | [`rig-mongodb`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-mongodb) | `mongodb` | `rig::mongodb` |
+| Neo4j | [`rig-neo4j`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-neo4j) | `neo4j` | `rig::neo4j` |
+| PostgreSQL | [`rig-postgres`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-postgres) | `postgres` | `rig::postgres` |
+| Qdrant | [`rig-qdrant`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-qdrant) | `qdrant` | `rig::qdrant` |
+| ScyllaDB | [`rig-scylladb`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-scylladb) | `scylladb` | `rig::scylladb` |
+| SQLite | [`rig-sqlite`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-sqlite) | `sqlite` | `rig::sqlite` |
+| SurrealDB | [`rig-surrealdb`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-surrealdb) | `surrealdb` | `rig::surrealdb` |
 
 We also have some other associated crates that have additional functionality you may find helpful when using Rig:
 - `rig-onchain-kit` - the [Rig Onchain Kit.](https://github.com/0xPlaygrounds/rig-onchain-kit) Intended to make interactions between Solana/EVM and Rig much easier to implement.

--- a/README.md
+++ b/README.md
@@ -156,6 +156,11 @@ rig = { version = "0.36.0", features = ["lancedb", "fastembed"] }
 | SQLite | [`rig-sqlite`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-sqlite) | `sqlite` | `rig::sqlite` |
 | SurrealDB | [`rig-surrealdb`](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-surrealdb) | `surrealdb` | `rig::surrealdb` |
 
+`rig::memory` is available without the `memory` feature; it contains the core
+conversation memory traits and in-memory backend re-exported from `rig-core`.
+Enabling `features = ["memory"]` adds reusable history-shaping policy types from
+the `rig-memory` companion crate to the same module.
+
 We also have some other associated crates that have additional functionality you may find helpful when using Rig:
 - `rig-onchain-kit` - the [Rig Onchain Kit.](https://github.com/0xPlaygrounds/rig-onchain-kit) Intended to make interactions between Solana/EVM and Rig much easier to implement.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <a href="https://docs.rs/rig/latest/rig/"><img src="https://img.shields.io/badge/docs-API Reference-dca282.svg" /></a> &nbsp;
 <a href="https://crates.io/crates/rig-core"><img src="https://img.shields.io/crates/v/rig-core.svg?color=dca282" /></a>
 &nbsp;
-<a href="https://crates.io/crates/rig-core"><img src="https://img.shields.io/crates/d/rig-core.svg?color=dca282" /></a>
+<a href="https://crates.io/crates/rig"><img src="https://img.shields.io/crates/d/rig-core.svg?color=dca282" /></a>
 </br>
 <a href="https://discord.gg/playgrounds"><img src="https://img.shields.io/discord/511303648119226382?color=%236d82cc&label=Discord&logo=discord&logoColor=white" /></a>
 &nbsp;

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@
 <br>
 <a href="https://docs.rig.rs"><img src="https://img.shields.io/badge/📖 docs-rig.rs-dca282.svg" /></a> &nbsp;
 <a href="https://docs.rs/rig/latest/rig/"><img src="https://img.shields.io/badge/docs-API Reference-dca282.svg" /></a> &nbsp;
-<a href="https://crates.io/crates/rig-core"><img src="https://img.shields.io/crates/v/rig-core.svg?color=dca282" /></a>
+<a href="https://crates.io/crates/rig"><img src="https://img.shields.io/crates/v/rig.svg?color=dca282" /></a>
 &nbsp;
 <a href="https://crates.io/crates/rig"><img src="https://img.shields.io/crates/d/rig-core.svg?color=dca282" /></a>
+&nbsp;
+<a href="LICENSE"><img src="https://img.shields.io/crates/l/rig.svg?color=dca282" /></a>
 </br>
 <a href="https://discord.gg/playgrounds"><img src="https://img.shields.io/discord/511303648119226382?color=%236d82cc&label=Discord&logo=discord&logoColor=white" /></a>
 &nbsp;
@@ -45,7 +47,7 @@
 
 - [Table of contents](#table-of-contents)
 - [What is Rig?](#what-is-rig)
-- [High-level features](#high-level-features)
+- [Features](#features)
 - [Who's using Rig?](#who-is-using-rig)
 - [Get Started](#get-started)
   - [Simple example](#simple-example)

--- a/crates/rig-core/Cargo.toml
+++ b/crates/rig-core/Cargo.toml
@@ -105,8 +105,7 @@ tracing-opentelemetry = { workspace = true }
 
 
 [features]
-default = ["reqwest", "rustls"]
-all = ["derive", "pdf", "rayon"]
+default = ["reqwest", "derive", "rustls"]
 audio = []
 image = []
 derive = ["dep:rig-derive"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
 //! Public facade for Rig.
 
 pub use rig_core::*;
@@ -6,10 +7,12 @@ pub mod memory {
     pub use rig_core::memory::*;
 
     #[cfg(feature = "memory")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "memory")))]
     pub use rig_memory::*;
 }
 
 #[cfg(feature = "bedrock")]
+#[cfg_attr(docsrs, doc(cfg(feature = "bedrock")))]
 pub mod bedrock {
     pub use rig_bedrock::*;
 }
@@ -19,76 +22,98 @@ pub mod bedrock {
     feature = "fastembed-hf-hub",
     feature = "fastembed-ort-download-binaries",
 ))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(
+        feature = "fastembed",
+        feature = "fastembed-hf-hub",
+        feature = "fastembed-ort-download-binaries"
+    )))
+)]
 pub mod fastembed {
     pub use rig_fastembed::*;
 }
 
 #[cfg(feature = "gemini-grpc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "gemini-grpc")))]
 pub mod gemini_grpc {
     pub use rig_gemini_grpc::*;
 }
 
 #[cfg(feature = "helixdb")]
+#[cfg_attr(docsrs, doc(cfg(feature = "helixdb")))]
 pub mod helixdb {
     pub use rig_helixdb::*;
 }
 
 #[cfg(feature = "lancedb")]
+#[cfg_attr(docsrs, doc(cfg(feature = "lancedb")))]
 pub mod lancedb {
     pub use rig_lancedb::*;
 }
 
 #[cfg(feature = "milvus")]
+#[cfg_attr(docsrs, doc(cfg(feature = "milvus")))]
 pub mod milvus {
     pub use rig_milvus::*;
 }
 
 #[cfg(feature = "mongodb")]
+#[cfg_attr(docsrs, doc(cfg(feature = "mongodb")))]
 pub mod mongodb {
     pub use rig_mongodb::*;
 }
 
 #[cfg(feature = "neo4j")]
+#[cfg_attr(docsrs, doc(cfg(feature = "neo4j")))]
 pub mod neo4j {
     pub use rig_neo4j::*;
 }
 
 #[cfg(feature = "postgres")]
+#[cfg_attr(docsrs, doc(cfg(feature = "postgres")))]
 pub mod postgres {
     pub use rig_postgres::*;
 }
 
 #[cfg(feature = "qdrant")]
+#[cfg_attr(docsrs, doc(cfg(feature = "qdrant")))]
 pub mod qdrant {
     pub use rig_qdrant::*;
 }
 
 #[cfg(feature = "s3vectors")]
+#[cfg_attr(docsrs, doc(cfg(feature = "s3vectors")))]
 pub mod s3vectors {
     pub use rig_s3vectors::*;
 }
 
 #[cfg(feature = "scylladb")]
+#[cfg_attr(docsrs, doc(cfg(feature = "scylladb")))]
 pub mod scylladb {
     pub use rig_scylladb::*;
 }
 
 #[cfg(feature = "sqlite")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sqlite")))]
 pub mod sqlite {
     pub use rig_sqlite::*;
 }
 
 #[cfg(feature = "surrealdb")]
+#[cfg_attr(docsrs, doc(cfg(feature = "surrealdb")))]
 pub mod surrealdb {
     pub use rig_surrealdb::*;
 }
 
 #[cfg(feature = "vectorize")]
+#[cfg_attr(docsrs, doc(cfg(feature = "vectorize")))]
 pub mod vectorize {
     pub use rig_vectorize::*;
 }
 
 #[cfg(feature = "vertexai")]
+#[cfg_attr(docsrs, doc(cfg(feature = "vertexai")))]
 pub mod vertexai {
     pub use rig_vertexai::*;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,40 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 //! Public facade for Rig.
+//!
+//! The `rig` crate is the user-facing entry point for Rig. It re-exports the
+//! full public API of `rig_core`, so core traits, builders, providers, tools,
+//! vector-store abstractions, and request/response types are available through
+//! `rig::...` paths.
+//!
+//! # Companion integrations
+//!
+//! Companion provider and vector-store crates are exposed as feature-gated
+//! modules on this facade. Enable only the integrations your application uses:
+//!
+//! ```toml
+//! [dependencies]
+//! rig = { version = "0.36.0", features = ["lancedb", "fastembed"] }
+//! ```
+//!
+//! This enables modules such as `rig::lancedb` and `rig::fastembed`. Other
+//! companion integrations follow the same pattern, with feature names aligned to
+//! their facade module paths wherever Rust module naming allows it.
+//!
+//! # When to use `rig-core` directly
+//!
+//! Depend on the `rig-core` package directly when you only need the core Rig
+//! implementation crate, including provider abstractions, built-in core
+//! providers, tools, memory traits, and vector-store traits, without the root
+//! facade's companion integration feature surface.
 
 pub use rig_core::*;
 
+/// Conversation memory APIs and optional memory policy helpers.
+///
+/// This module is always available and re-exports the core memory traits and
+/// in-process backend from `rig_core::memory`. Enabling the `memory` feature
+/// additionally re-exports policy types from the `rig-memory` companion crate
+/// into this same module.
 pub mod memory {
     pub use rig_core::memory::*;
 


### PR DESCRIPTION
## Summary

- Adds crate-level docs for the root `rig` facade, including when to use `rig` vs `rig-core`.
- Adds `doc(cfg(...))` annotations for feature-gated facade modules.
- Reworks the README integration section into a table mapping each integration to its companion crate, facade feature, and `rig::...` module path.
- Updates README badges to point at the root `rig` crate.
- Removes the old `all` feature and enables `derive` through `rig-core` defaults.
- Normalizes root `rig-core` dependency feature forwarding to use the canonical Cargo package name.

## Testing

- `cargo fmt --check`
- `cargo metadata --no-deps --format-version 1`
- `cargo check -p rig --no-default-features`
- `cargo check -p rig`
