### PR TITLE
fix(anthropic): serialize ToolResultContent::Image with source wrapper

### DIFF
--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -325,7 +325,7 @@ impl FromStr for Content {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ToolResultContent {
     Text { text: String },
-    Image(ImageSource),
+    Image { source: ImageSource },
 }
 
 impl FromStr for ToolResultContent {
@@ -614,10 +614,12 @@ impl TryFrom<message::Message> for Message {
                                     image.media_type.ok_or(MessageError::ConversionError(
                                         "Image media type is required".to_owned(),
                                     ))?;
-                                Ok(ToolResultContent::Image(ImageSource::Base64 {
-                                    data,
-                                    media_type: media_type.try_into()?,
-                                }))
+                                Ok(ToolResultContent::Image {
+                                    source: ImageSource::Base64 {
+                                        data,
+                                        media_type: media_type.try_into()?,
+                                    },
+                                })
                             }
                         })?,
                         is_error: None,
@@ -785,7 +787,7 @@ impl From<ToolResultContent> for message::ToolResultContent {
     fn from(content: ToolResultContent) -> Self {
         match content {
             ToolResultContent::Text { text } => message::ToolResultContent::text(text),
-            ToolResultContent::Image(source) => match source {
+            ToolResultContent::Image { source } => match source {
                 ImageSource::Base64 { data, media_type } => {
                     message::ToolResultContent::image_base64(data, Some(media_type.into()), None)
                 }
@@ -2496,5 +2498,44 @@ mod tests {
             err,
             CompletionError::ResponseError(message) if message == EMPTY_RESPONSE_ERROR
         ));
+    }
+
+    #[test]
+    fn test_tool_result_content_in_message_roundtrip() {
+        let message_json = r#"{
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_01A09q90qw90lq917835lq9",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Here is the screenshot:"
+                        },
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "image/png",
+                                "data": "iVBORw0KGgo..."
+                            }
+                        }
+                    ]
+                }
+            ]
+        }"#;
+
+        let message: Message = serde_json::from_str(message_json).unwrap();
+        let serialized = serde_json::to_value(&message).unwrap();
+
+        let tool_result = &serialized["content"][0];
+        assert_eq!(tool_result["type"], "tool_result");
+
+        let image_content = &tool_result["content"][1];
+        assert_eq!(image_content["type"], "image");
+        assert_eq!(image_content["source"]["type"], "base64");
+        assert_eq!(image_content["source"]["media_type"], "image/png");
+        assert_eq!(image_content["source"]["data"], "iVBORw0KGgo...");
     }
 }


### PR DESCRIPTION
## Description

Fixes incorrect serialization of `ToolResultContent::Image` when sending tool results containing images to the Anthropic API. Any tool that returns image content (screenshots, image generation, etc.) was broken.

Fixes #1771

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- Confirmed bug with live Anthropic API using upstream `rig-core 0.37.0` → **400 Bad Request** with error: `Input tag 'base64' found using 'type' does not match any of the expected tags`
- Applied fix and re-tested with a tool-calling agent → **200 OK**, Claude correctly described the image
- Added roundtrip test: deserialize a tool_result message with image content, re-serialize, assert structure matches Anthropic's expected format

```bash
cargo test -p rig-core -- providers::anthropic  # all tests pass
cargo check --workspace                         # zero errors
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Notes

The fix changes `ToolResultContent::Image` from a tuple variant to a struct variant with a `source` field:

```rust
// Before (broken — flattens ImageSource fields, "type" collision)
Image(ImageSource),

// After (correct — matches Content::Image pattern)
Image { source: ImageSource },
```

This is technically a breaking change to the Anthropic-specific type API (anyone pattern-matching on `ToolResultContent::Image(source)` needs to change to `ToolResultContent::Image { source }`), but since the previous serialization was completely non-functional with the Anthropic API, no one could have been using it successfully.