### PR TITLE
feat(gemini): expose finish_reason and model_version on StreamingCompletionResponse

### DIFF
--- a/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
@@ -25,6 +25,11 @@ use serde_json::{Map, Value};
 pub struct StreamingCompletionResponse {
     pub usage: Option<InteractionUsage>,
     pub interaction: Option<Interaction>,
+    /// Resolved model identifier (e.g. `gemini-2.5-pro-preview-05-06`), extracted from
+    /// `Interaction.model`. The Interactions API has no `FinishReason` field; use
+    /// `interaction.status` for lifecycle state.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_version: Option<String>,
 }
 
 #[cfg(not(all(feature = "wasm", target_arch = "wasm32")))]
@@ -160,9 +165,11 @@ where
 
             event_source.close();
 
+            let model_version = final_interaction.as_ref().and_then(|i| i.model.clone());
             yield Ok(streaming::RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
                 usage: final_usage.or_else(|| final_interaction.as_ref().and_then(|i| i.usage.clone())),
                 interaction: final_interaction,
+                model_version,
             }));
         }
         .instrument(span);
@@ -289,6 +296,27 @@ fn content_delta_to_choice(
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn test_streaming_completion_response_has_model_version() {
+        let response = StreamingCompletionResponse {
+            usage: None,
+            interaction: None,
+            model_version: Some("gemini-2.5-pro-preview-05-06".to_string()),
+        };
+
+        assert_eq!(
+            response.model_version.as_deref(),
+            Some("gemini-2.5-pro-preview-05-06")
+        );
+
+        let json = serde_json::to_string(&response).unwrap();
+        let deserialized: StreamingCompletionResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            deserialized.model_version.as_deref(),
+            Some("gemini-2.5-pro-preview-05-06")
+        );
+    }
 
     #[test]
     fn test_content_delta_text_event() {

--- a/crates/rig-core/src/providers/gemini/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/streaming.rs
@@ -5,7 +5,7 @@ use tracing::{Level, enabled, info_span};
 use tracing_futures::Instrument;
 
 use super::completion::gemini_api_types::{
-    ContentCandidate, ModalityTokenCount, Part, PartKind, TrafficType,
+    ContentCandidate, FinishReason, ModalityTokenCount, Part, PartKind, TrafficType,
 };
 use super::completion::{
     CompletionModel, create_request_body, resolve_request_model, streaming_endpoint,
@@ -71,6 +71,10 @@ pub struct StreamGenerateContentResponse {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct StreamingCompletionResponse {
     pub usage_metadata: PartialUsage,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finish_reason: Option<FinishReason>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_version: Option<String>,
 }
 
 impl GetTokenUsage for StreamingCompletionResponse {
@@ -131,6 +135,8 @@ where
 
         let stream = stream! {
             let mut final_usage = None;
+            let mut final_finish_reason: Option<FinishReason> = None;
+            let mut final_model_version: Option<String> = None;
             while let Some(event_result) = event_source.next().await {
                 match event_result {
                     Ok(Event::Open) => {
@@ -155,8 +161,9 @@ where
                         if let Some(response_id) = data.response_id.as_deref() {
                             span.record("gen_ai.response.id", response_id);
                         }
-                        if let Some(model_version) = data.model_version.as_deref() {
-                            span.record("gen_ai.response.model", model_version);
+                        if let Some(model_version) = &data.model_version {
+                            span.record("gen_ai.response.model", model_version.as_str());
+                            final_model_version = Some(model_version.clone());
                         }
                         if let Some(usage) = data.usage_metadata.as_ref() {
                             span.record_token_usage(usage);
@@ -169,8 +176,18 @@ where
                             continue;
                         };
 
+                        // Capture before partial moves of choice fields
+                        let should_stop = choice.finish_reason.is_some();
+                        if let Some(fr) = &choice.finish_reason {
+                            final_finish_reason = Some(fr.clone());
+                        }
+
                         let Some(content) = choice.content else {
-                            tracing::debug!(finish_reason = ?choice.finish_reason, "Streaming candidate missing content");
+                            tracing::debug!(finish_reason = ?final_finish_reason, "Streaming candidate missing content");
+                            // Gemini's final chunk may carry finishReason with no content — break instead of skip
+                            if should_stop {
+                                break;
+                            }
                             continue;
                         };
 
@@ -232,7 +249,7 @@ where
                         }
 
                         // Check if this is the final response
-                        if choice.finish_reason.is_some() {
+                        if should_stop {
                             break;
                         }
                     }
@@ -251,7 +268,9 @@ where
             event_source.close();
 
             yield Ok(streaming::RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
-                usage_metadata: final_usage.unwrap_or_default()
+                usage_metadata: final_usage.unwrap_or_default(),
+                finish_reason: final_finish_reason,
+                model_version: final_model_version,
             }));
         }.instrument(span);
 
@@ -607,6 +626,31 @@ mod tests {
     }
 
     #[test]
+    fn test_streaming_completion_response_has_finish_reason_and_model_version() {
+        use super::super::completion::gemini_api_types::FinishReason;
+
+        let response = StreamingCompletionResponse {
+            usage_metadata: PartialUsage::default(),
+            finish_reason: Some(FinishReason::Stop),
+            model_version: Some("gemini-2.5-pro-preview-05-06".to_string()),
+        };
+
+        assert!(matches!(response.finish_reason, Some(FinishReason::Stop)));
+        assert_eq!(
+            response.model_version.as_deref(),
+            Some("gemini-2.5-pro-preview-05-06")
+        );
+
+        let json = serde_json::to_string(&response).unwrap();
+        let deserialized: StreamingCompletionResponse = serde_json::from_str(&json).unwrap();
+        assert!(matches!(deserialized.finish_reason, Some(FinishReason::Stop)));
+        assert_eq!(
+            deserialized.model_version.as_deref(),
+            Some("gemini-2.5-pro-preview-05-06")
+        );
+    }
+
+    #[test]
     fn test_streaming_completion_response_token_usage() {
         let response = StreamingCompletionResponse {
             usage_metadata: PartialUsage {
@@ -622,6 +666,8 @@ mod tests {
                 tool_use_prompt_tokens_details: None,
                 traffic_type: None,
             },
+            finish_reason: None,
+            model_version: None,
         };
 
         let token_usage = response.token_usage().unwrap();

--- a/crates/rig-core/src/providers/gemini/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/streaming.rs
@@ -643,7 +643,10 @@ mod tests {
 
         let json = serde_json::to_string(&response).unwrap();
         let deserialized: StreamingCompletionResponse = serde_json::from_str(&json).unwrap();
-        assert!(matches!(deserialized.finish_reason, Some(FinishReason::Stop)));
+        assert!(matches!(
+            deserialized.finish_reason,
+            Some(FinishReason::Stop)
+        ));
         assert_eq!(
             deserialized.model_version.as_deref(),
             Some("gemini-2.5-pro-preview-05-06")


### PR DESCRIPTION
## Summary

- Adds `finish_reason: Option<FinishReason>` and `model_version: Option<String>` to `gemini::streaming::StreamingCompletionResponse` — both were deserialized from the SSE stream but dropped before the `FinalResponse` was yielded to callers
- Adds `model_version: Option<String>` to `gemini::interactions_api::streaming::StreamingCompletionResponse`, extracted from `Interaction.model`
- Fixes a subtle bug: when the final Gemini chunk carries `finishReason` with no `content` (a common protocol pattern), the stream now correctly breaks instead of continuing to wait for more events
- The Interactions API has no `FinishReason` equivalent (it uses `InteractionStatus` lifecycle values); only `model_version` is added for that path, with a doc comment explaining why

## Motivation

Ryzome's PostHog LLM Analytics forwarder needs `$ai_stop_reason` (from `finish_reason`) and the resolved model string `$ai_model` (from `model_version`, which is the exact model like `gemini-2.5-pro-preview-05-06` rather than the alias the caller requested).

## Test Plan

- New unit test `test_streaming_completion_response_has_finish_reason_and_model_version` in `gemini/streaming.rs` asserts both fields populate and roundtrip through serde correctly
- New unit test `test_streaming_completion_response_has_model_version` in `interactions_api/streaming.rs` asserts `model_version` populates and roundtrips

Closes RIG-1315