### PR TITLE
feat(anthropic): support document citations

### DIFF
--- a/crates/rig-bedrock/src/types/assistant_content.rs
+++ b/crates/rig-bedrock/src/types/assistant_content.rs
@@ -126,7 +126,7 @@ impl TryFrom<aws_bedrock::ContentBlock> for RigAssistantContent {
     fn try_from(value: aws_bedrock::ContentBlock) -> Result<Self, Self::Error> {
         match value {
             aws_bedrock::ContentBlock::Text(text) => {
-                Ok(RigAssistantContent(AssistantContent::Text(Text { text })))
+                Ok(RigAssistantContent(AssistantContent::Text(Text::new(text))))
             }
             aws_bedrock::ContentBlock::ToolUse(call) => Ok(RigAssistantContent(
                 completion::AssistantContent::tool_call(

--- a/crates/rig-bedrock/src/types/completion_request.rs
+++ b/crates/rig-bedrock/src/types/completion_request.rs
@@ -243,9 +243,7 @@ mod tests {
             model: None,
             preamble: None,
             chat_history: OneOrMany::one(Message::User {
-                content: OneOrMany::one(UserContent::Text(Text {
-                    text: "test".to_string(),
-                })),
+                content: OneOrMany::one(UserContent::Text(Text::new("test".to_string()))),
             }),
             documents: vec![],
             tools: vec![],
@@ -508,9 +506,7 @@ mod tests {
             chat_history: OneOrMany::many(vec![
                 Message::system("History system instruction"),
                 Message::User {
-                    content: OneOrMany::one(UserContent::Text(Text {
-                        text: "test".to_string(),
-                    })),
+                    content: OneOrMany::one(UserContent::Text(Text::new("test".to_string()))),
                 },
             ])
             .expect("history should be non-empty"),
@@ -566,9 +562,7 @@ mod tests {
             chat_history: OneOrMany::many(vec![
                 Message::system("History system instruction"),
                 Message::User {
-                    content: OneOrMany::one(UserContent::Text(Text {
-                        text: "test".to_string(),
-                    })),
+                    content: OneOrMany::one(UserContent::Text(Text::new("test".to_string()))),
                 },
             ])
             .expect("history should be non-empty"),
@@ -607,9 +601,9 @@ mod tests {
         let request = CompletionRequest {
             chat_history: OneOrMany::many(vec![
                 Message::User {
-                    content: OneOrMany::one(UserContent::Text(Text {
-                        text: "user prompt".to_string(),
-                    })),
+                    content: OneOrMany::one(UserContent::Text(Text::new(
+                        "user prompt".to_string(),
+                    ))),
                 },
                 Message::Assistant {
                     id: None,
@@ -618,9 +612,7 @@ mod tests {
                     )),
                 },
                 Message::User {
-                    content: OneOrMany::one(UserContent::Text(Text {
-                        text: "follow up".to_string(),
-                    })),
+                    content: OneOrMany::one(UserContent::Text(Text::new("follow up".to_string()))),
                 },
             ])
             .expect("history should be non-empty"),

--- a/crates/rig-bedrock/src/types/tool.rs
+++ b/crates/rig-bedrock/src/types/tool.rs
@@ -37,13 +37,13 @@ impl TryFrom<aws_bedrock::ToolResultContentBlock> for RigToolResultContent {
             }
             aws_bedrock::ToolResultContentBlock::Json(document) => {
                 let json: Value = AwsDocument(document).into();
-                Ok(RigToolResultContent(ToolResultContent::Text(Text {
-                    text: json.to_string(),
-                })))
+                Ok(RigToolResultContent(ToolResultContent::Text(Text::new(
+                    json.to_string(),
+                ))))
             }
-            aws_bedrock::ToolResultContentBlock::Text(text) => {
-                Ok(RigToolResultContent(ToolResultContent::Text(Text { text })))
-            }
+            aws_bedrock::ToolResultContentBlock::Text(text) => Ok(RigToolResultContent(
+                ToolResultContent::Text(Text::new(text)),
+            )),
             _ => Err(CompletionError::ProviderError(
                 "ToolResultContentBlock contains unsupported variant".into(),
             )),
@@ -64,7 +64,7 @@ mod tests {
 
     #[test]
     fn rig_tool_text_to_aws_tool() {
-        let tool = RigToolResultContent(ToolResultContent::Text(Text { text: "42".into() }));
+        let tool = RigToolResultContent(ToolResultContent::Text(Text::new("42")));
         let aws_tool: Result<aws_bedrock::ToolResultContentBlock, _> = tool.try_into();
         assert!(aws_tool.is_ok());
         assert_eq!(

--- a/crates/rig-bedrock/src/types/user_content.rs
+++ b/crates/rig-bedrock/src/types/user_content.rs
@@ -16,7 +16,7 @@ impl TryFrom<aws_bedrock::ContentBlock> for RigUserContent {
     fn try_from(value: aws_bedrock::ContentBlock) -> Result<Self, Self::Error> {
         match value {
             aws_bedrock::ContentBlock::Text(text) => {
-                Ok(RigUserContent(UserContent::Text(Text { text })))
+                Ok(RigUserContent(UserContent::Text(Text::new(text))))
             }
             aws_bedrock::ContentBlock::ToolResult(tool_result) => {
                 let tool_result_contents = tool_result

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -412,7 +412,7 @@ fn is_empty_assistant_turn(choice: &OneOrMany<AssistantContent>) -> bool {
     choice.len() == 1
         && matches!(
             choice.first(),
-            AssistantContent::Text(text) if text.text.is_empty()
+            AssistantContent::Text(text) if text.text.is_empty() && text.additional_params.is_none()
         )
 }
 
@@ -1327,6 +1327,46 @@ mod tests {
             response,
             "According to the document, the grass is green and the sky is blue."
         );
+    }
+
+    #[tokio::test]
+    async fn prompt_request_preserves_metadata_only_text_turn_in_history() {
+        let metadata = json!({
+            "citations": [{
+                "type": "web_search_result_location",
+                "cited_text": "Claude Shannon was born in 1916.",
+                "url": "https://example.com/shannon",
+                "title": null,
+                "encrypted_index": "encrypted-reference"
+            }]
+        });
+        let model =
+            MockCompletionModel::new([MockTurn::from_content(AssistantContent::Text(Text {
+                text: String::new(),
+                additional_params: Some(metadata.clone()),
+            }))]);
+        let agent = AgentBuilder::new(model).build();
+
+        let response = agent
+            .prompt("answer with cited metadata")
+            .extended_details()
+            .await
+            .expect("metadata-only text turn should succeed");
+
+        assert!(response.output.is_empty());
+        let history = response
+            .messages
+            .expect("extended response should include history");
+        assert!(history.iter().any(|message| matches!(
+            message,
+            Message::Assistant { content, .. }
+                if matches!(
+                    content.first(),
+                    AssistantContent::Text(text)
+                        if text.text.is_empty()
+                            && text.additional_params.as_ref() == Some(&metadata)
+                )
+        )));
     }
 
     // ----- Conversation memory integration tests -----

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -416,6 +416,16 @@ fn is_empty_assistant_turn(choice: &OneOrMany<AssistantContent>) -> bool {
         )
 }
 
+fn assistant_text_from_choice(choice: &OneOrMany<AssistantContent>) -> String {
+    choice
+        .iter()
+        .filter_map(|content| match content {
+            AssistantContent::Text(text) => Some(text.text.as_str()),
+            _ => None,
+        })
+        .collect()
+}
+
 impl<M, P> PromptRequest<Extended, M, P>
 where
     M: CompletionModel,
@@ -582,10 +592,11 @@ where
                 ));
             }
 
-            let (tool_calls, texts): (Vec<_>, Vec<_>) = resp
+            let tool_calls = resp
                 .choice
                 .iter()
-                .partition(|choice| matches!(choice, AssistantContent::ToolCall(_)));
+                .filter(|choice| matches!(choice, AssistantContent::ToolCall(_)))
+                .collect::<Vec<_>>();
 
             // Some providers normalize textless terminal turns into a single empty text item
             // because the generic completion response cannot represent an empty choice. Treat
@@ -598,17 +609,7 @@ where
             }
 
             if tool_calls.is_empty() {
-                let merged_texts = texts
-                    .into_iter()
-                    .filter_map(|content| {
-                        if let AssistantContent::Text(text) = content {
-                            Some(text.text.clone())
-                        } else {
-                            None
-                        }
-                    })
-                    .collect::<Vec<_>>()
-                    .join("\n");
+                let merged_texts = assistant_text_from_choice(&resp.choice);
 
                 if self.max_turns > 1 {
                     tracing::info!("Depth reached: {}/{}", current_max_turns, self.max_turns);
@@ -1012,7 +1013,7 @@ mod tests {
             AssistantContent, CompletionError, CompletionRequest, Message, Prompt, PromptError,
             TypedPrompt, Usage,
         },
-        message::UserContent,
+        message::{Text, UserContent},
         test_utils::{
             AppendFailingMemory, CountingMemory, FailingMemory, MockCompletionModel, MockTurn,
         },
@@ -1305,6 +1306,27 @@ mod tests {
         let requests = agent.model.requests();
         assert_eq!(requests.len(), 2);
         validate_follow_up_tool_history(&requests[1]);
+    }
+
+    #[tokio::test]
+    async fn prompt_request_concatenates_text_blocks_without_inserted_newlines() {
+        let model = MockCompletionModel::new([MockTurn::from_contents([
+            AssistantContent::Text(Text::new("According to the document, ")),
+            AssistantContent::Text(Text::new("the grass is green")),
+            AssistantContent::Text(Text::new(" and the sky is blue.")),
+        ])
+        .expect("mock response should contain text blocks")]);
+        let agent = AgentBuilder::new(model).build();
+
+        let response = agent
+            .prompt("answer with cited spans")
+            .await
+            .expect("prompt should succeed");
+
+        assert_eq!(
+            response,
+            "According to the document, the grass is green and the sky is blue."
+        );
     }
 
     // ----- Conversation memory integration tests -----

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -912,7 +912,7 @@ pub async fn stream_to_stdout<R>(
     while let Some(content) = stream.next().await {
         match content {
             Ok(MultiTurnStreamItem::StreamAssistantItem(StreamedAssistantContent::Text(
-                Text { text },
+                Text { text, .. },
             ))) => {
                 print!("{text}");
                 std::io::Write::flush(&mut std::io::stdout())?;

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -62,6 +62,8 @@ pub enum MultiTurnStreamItem<R> {
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct FinalResponse {
+    /// Structured assistant content for the final turn.
+    content: OneOrMany<AssistantContent>,
     /// Concatenated assistant text for the final turn.
     /// This is empty only when the turn completed without emitting any text.
     response: String,
@@ -75,17 +77,41 @@ pub struct FinalResponse {
 
 impl FinalResponse {
     pub fn empty() -> Self {
+        Self::new(
+            OneOrMany::one(AssistantContent::text("")),
+            crate::completion::Usage::new(),
+            None,
+        )
+    }
+
+    pub fn new(
+        content: OneOrMany<AssistantContent>,
+        aggregated_usage: crate::completion::Usage,
+        history: Option<Vec<Message>>,
+    ) -> Self {
+        let response = assistant_text_from_choice(&content);
         Self {
-            response: String::new(),
-            aggregated_usage: crate::completion::Usage::new(),
+            content,
+            response,
+            aggregated_usage,
             completion_calls: Vec::new(),
-            history: None,
+            history,
         }
     }
 
     /// Returns the concatenated assistant text for the final turn.
     pub fn response(&self) -> &str {
         &self.response
+    }
+
+    /// Returns the structured assistant content for the final turn.
+    pub fn content(&self) -> &OneOrMany<AssistantContent> {
+        &self.content
+    }
+
+    /// Returns the structured assistant content for the final turn.
+    pub fn assistant_content(&self) -> &OneOrMany<AssistantContent> {
+        &self.content
     }
 
     pub fn usage(&self) -> crate::completion::Usage {
@@ -112,40 +138,30 @@ impl<R> MultiTurnStreamItem<R> {
         Self::StreamAssistantItem(item)
     }
 
-    pub fn final_response(response: &str, aggregated_usage: crate::completion::Usage) -> Self {
-        Self::FinalResponse(FinalResponse {
-            response: response.to_string(),
-            aggregated_usage,
-            completion_calls: Vec::new(),
-            history: None,
-        })
+    pub fn final_response(
+        content: OneOrMany<AssistantContent>,
+        aggregated_usage: crate::completion::Usage,
+    ) -> Self {
+        Self::FinalResponse(FinalResponse::new(content, aggregated_usage, None))
     }
 
     pub fn final_response_with_history(
-        response: &str,
+        content: OneOrMany<AssistantContent>,
         aggregated_usage: crate::completion::Usage,
         history: Option<Vec<Message>>,
     ) -> Self {
-        Self::FinalResponse(FinalResponse {
-            response: response.to_string(),
-            aggregated_usage,
-            completion_calls: Vec::new(),
-            history,
-        })
+        Self::FinalResponse(FinalResponse::new(content, aggregated_usage, history))
     }
 
     pub(crate) fn final_response_with_completion_calls(
-        response: &str,
+        content: OneOrMany<AssistantContent>,
         aggregated_usage: crate::completion::Usage,
         completion_calls: Vec<CompletionCall>,
         history: Option<Vec<Message>>,
     ) -> Self {
-        Self::FinalResponse(FinalResponse {
-            response: response.to_string(),
-            aggregated_usage,
-            completion_calls,
-            history,
-        })
+        let mut response = FinalResponse::new(content, aggregated_usage, history);
+        response.completion_calls = completion_calls;
+        Self::FinalResponse(response)
     }
 }
 
@@ -224,6 +240,27 @@ fn assistant_text_from_choice(choice: &OneOrMany<AssistantContent>) -> String {
             _ => None,
         })
         .collect()
+}
+
+fn assistant_text_items_from_choice(choice: &OneOrMany<AssistantContent>) -> Vec<AssistantContent> {
+    choice
+        .iter()
+        .filter_map(|content| match content {
+            AssistantContent::Text(text) => (!text.text.is_empty()
+                || text.additional_params.is_some())
+            .then(|| AssistantContent::Text(text.clone())),
+            _ => None,
+        })
+        .collect()
+}
+
+fn is_empty_assistant_choice(choice: &OneOrMany<AssistantContent>) -> bool {
+    choice.len() == 1
+        && matches!(
+            choice.first(),
+            AssistantContent::Text(text)
+                if text.text.is_empty() && text.additional_params.is_none()
+        )
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -795,18 +832,15 @@ where
                     accumulated_reasoning.push(assembled);
                 }
 
-                let turn_text_response = assistant_text_from_choice(&stream.choice);
+                let final_turn_content = stream.choice.clone();
+                let turn_text_response = assistant_text_from_choice(&final_turn_content);
                 tracing::Span::current().record("gen_ai.completion", &turn_text_response);
 
                 // Add text, reasoning, and tool calls to chat history.
                 // OpenAI Responses API requires reasoning items to precede function_call items.
                 if !tool_calls.is_empty() || !accumulated_reasoning.is_empty() {
-                    let mut content_items: Vec<rig::message::AssistantContent> = vec![];
-
-                    // Text before tool calls so the model sees its own prior output
-                    if !turn_text_response.is_empty() {
-                        content_items.push(rig::message::AssistantContent::text(&turn_text_response));
-                    }
+                    // Text before tool calls so the model sees its own prior output.
+                    let mut content_items = assistant_text_items_from_choice(&final_turn_content);
 
                     // Reasoning must come before tool calls (OpenAI requirement)
                     for reasoning in accumulated_reasoning.drain(..) {
@@ -829,8 +863,11 @@ where
 
                 if !saw_tool_call_this_turn {
                     // Add user message and assistant response to history before finishing
-                    if !turn_text_response.is_empty() {
-                        new_messages.push(Message::assistant(&turn_text_response));
+                    if !is_empty_assistant_choice(&final_turn_content) {
+                        new_messages.push(Message::Assistant {
+                            id: stream.message_id.clone(),
+                            content: final_turn_content.clone(),
+                        });
                     } else {
                         tracing::warn!(
                             agent_name = agent_name.as_deref().unwrap_or(UNKNOWN_AGENT_NAME),
@@ -861,7 +898,7 @@ where
                         None
                     };
                     yield Ok(MultiTurnStreamItem::final_response_with_completion_calls(
-                        &turn_text_response,
+                        final_turn_content,
                         aggregated_usage,
                         completion_calls,
                         final_messages,
@@ -1253,7 +1290,7 @@ mod tests {
     fn final_response_serializes_completion_calls_with_missing_usage() {
         let item: MultiTurnStreamItem<MockResponse> =
             MultiTurnStreamItem::final_response_with_completion_calls(
-                "done",
+                OneOrMany::one(AssistantContent::text("done")),
                 usage(3, 4),
                 vec![
                     CompletionCall::new(0, None),
@@ -1292,6 +1329,48 @@ mod tests {
             MockStreamEvent::text(" world"),
             MockStreamEvent::final_response_with_total_tokens(3),
         ]])
+    }
+
+    fn citation_metadata() -> serde_json::Value {
+        serde_json::json!({
+            "citations": [{
+                "type": "web_search_result_location",
+                "cited_text": "Claude Shannon was born in 1916.",
+                "url": "https://example.com/shannon",
+                "title": "Claude Shannon",
+                "encrypted_index": "encrypted-reference"
+            }]
+        })
+    }
+
+    fn streaming_cited_text_then_final_model() -> MockCompletionModel {
+        MockCompletionModel::from_stream_turns([[
+            MockStreamEvent::text_start(Some(citation_metadata())),
+            MockStreamEvent::text("cited "),
+            MockStreamEvent::text_start(None),
+            MockStreamEvent::text("answer"),
+            MockStreamEvent::final_response_with_total_tokens(3),
+        ]])
+    }
+
+    fn streaming_cited_text_then_tool_model() -> MockCompletionModel {
+        MockCompletionModel::from_stream_turns([
+            vec![
+                MockStreamEvent::text_start(Some(citation_metadata())),
+                MockStreamEvent::text("I need a tool. "),
+                MockStreamEvent::tool_call(
+                    "tool_call_1",
+                    "missing_tool",
+                    serde_json::json!({"input": "value"}),
+                )
+                .with_call_id("call_1"),
+                MockStreamEvent::final_response_with_total_tokens(4),
+            ],
+            vec![
+                MockStreamEvent::text("done"),
+                MockStreamEvent::final_response_with_total_tokens(6),
+            ],
+        ])
     }
 
     fn streaming_final_only_model() -> MockCompletionModel {
@@ -1393,6 +1472,13 @@ mod tests {
                 HookAction::terminate("stop on tool call delta")
             }
         }
+    }
+
+    fn text_metadata(content: &OneOrMany<AssistantContent>) -> Option<&serde_json::Value> {
+        content.iter().find_map(|item| match item {
+            AssistantContent::Text(text) => text.additional_params.as_ref(),
+            _ => None,
+        })
     }
 
     #[tokio::test]
@@ -1835,6 +1921,114 @@ mod tests {
 
         assert_eq!(streamed_text, "hello world");
         assert_eq!(final_response_text.as_deref(), Some("hello world"));
+    }
+
+    #[tokio::test]
+    async fn final_response_preserves_structured_text_metadata() {
+        let agent = AgentBuilder::new(streaming_cited_text_then_final_model()).build();
+
+        let mut stream = agent.stream_prompt("answer with citations").await;
+        let mut final_response = None;
+
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(MultiTurnStreamItem::FinalResponse(res)) => {
+                    final_response = Some(res);
+                    break;
+                }
+                Ok(_) => {}
+                Err(err) => panic!("unexpected streaming error: {err:?}"),
+            }
+        }
+
+        let final_response = final_response.expect("expected final response");
+        assert_eq!(final_response.response(), "cited answer");
+        let metadata = text_metadata(final_response.content())
+            .expect("expected text metadata in final content");
+        assert_eq!(
+            metadata["citations"][0]["encrypted_index"],
+            "encrypted-reference"
+        );
+    }
+
+    #[tokio::test]
+    async fn final_response_history_preserves_structured_text_metadata() {
+        let agent = AgentBuilder::new(streaming_cited_text_then_final_model()).build();
+
+        let empty_history: &[Message] = &[];
+        let mut stream = agent
+            .stream_prompt("answer with citations")
+            .with_history(empty_history)
+            .await;
+        let mut final_response = None;
+
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(MultiTurnStreamItem::FinalResponse(res)) => {
+                    final_response = Some(res);
+                    break;
+                }
+                Ok(_) => {}
+                Err(err) => panic!("unexpected streaming error: {err:?}"),
+            }
+        }
+
+        let final_response = final_response.expect("expected final response");
+        let history = final_response
+            .history()
+            .expect("with_history should include final history");
+        let assistant_content = history
+            .iter()
+            .find_map(|message| match message {
+                Message::Assistant { content, .. } => Some(content),
+                _ => None,
+            })
+            .expect("expected assistant message in history");
+        let metadata =
+            text_metadata(assistant_content).expect("expected text metadata in assistant history");
+        assert_eq!(
+            metadata["citations"][0]["encrypted_index"],
+            "encrypted-reference"
+        );
+    }
+
+    #[tokio::test]
+    async fn tool_follow_up_history_preserves_structured_text_metadata() {
+        let model = streaming_cited_text_then_tool_model();
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model).build();
+        let empty_history: &[Message] = &[];
+
+        let mut stream = agent
+            .stream_prompt("use a tool with citations")
+            .with_history(empty_history)
+            .multi_turn(3)
+            .await;
+
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(MultiTurnStreamItem::FinalResponse(_)) => break,
+                Ok(_) => {}
+                Err(err) => panic!("unexpected streaming error: {err:?}"),
+            }
+        }
+
+        let requests = recorded.requests();
+        assert_eq!(requests.len(), 2);
+        let follow_up_history = requests[1].chat_history.iter().collect::<Vec<_>>();
+        let assistant_content = follow_up_history
+            .iter()
+            .find_map(|message| match message {
+                Message::Assistant { content, .. } => Some(content),
+                _ => None,
+            })
+            .expect("expected assistant message in follow-up history");
+        let metadata = text_metadata(assistant_content)
+            .expect("expected citation metadata in follow-up assistant history");
+        assert_eq!(
+            metadata["citations"][0]["encrypted_index"],
+            "encrypted-reference"
+        );
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/completion/message.rs
+++ b/crates/rig-core/src/completion/message.rs
@@ -308,13 +308,29 @@ impl ToolFunction {
 // ================================================================
 
 /// Basic text content.
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+///
+/// `additional_params` carries provider-specific fields that arrive on text
+/// content blocks (e.g. Anthropic returns citation metadata on assistant text
+/// blocks). It is flattened during serialization so the inner JSON keys appear
+/// at the same level as `text`, matching the wire format of provider APIs.
+#[derive(Default, Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct Text {
     /// Text content.
     pub text: String,
+    /// Provider-specific text fields.
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
+    pub additional_params: Option<serde_json::Value>,
 }
 
 impl Text {
+    /// Construct a new text block with no provider-specific fields.
+    pub fn new(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            additional_params: None,
+        }
+    }
+
     /// Returns the inner text string.
     pub fn text(&self) -> &str {
         &self.text
@@ -323,7 +339,7 @@ impl Text {
 
 impl std::fmt::Display for Text {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Self { text } = self;
+        let Self { text, .. } = self;
         write!(f, "{text}")
     }
 }
@@ -586,7 +602,7 @@ impl Message {
         match self {
             Message::User { content } => {
                 for item in content.iter() {
-                    if let UserContent::Text(Text { text }) = item {
+                    if let UserContent::Text(Text { text, .. }) = item {
                         return Some(text.clone());
                     }
                 }
@@ -902,9 +918,7 @@ impl ToolResultContent {
                 let mut results: Vec<ToolResultContent> = Vec::new();
 
                 if let Some(response) = json.get("response") {
-                    results.push(ToolResultContent::Text(Text {
-                        text: response.to_string(),
-                    }));
+                    results.push(ToolResultContent::Text(Text::new(response.to_string())));
                 }
 
                 if let Some(parts) = json.get("parts").and_then(|p| p.as_array()) {
@@ -1147,7 +1161,10 @@ impl std::str::FromStr for ImageDetail {
 
 impl From<String> for Text {
     fn from(text: String) -> Self {
-        Text { text }
+        Text {
+            text,
+            additional_params: None,
+        }
     }
 }
 

--- a/crates/rig-core/src/integrations/cli_chatbot.rs
+++ b/crates/rig-core/src/integrations/cli_chatbot.rs
@@ -88,7 +88,7 @@ where
 
             match chunk {
                 Ok(MultiTurnStreamItem::StreamAssistantItem(StreamedAssistantContent::Text(
-                    Text { text },
+                    Text { text, .. },
                 ))) => {
                     print!("{}", text);
                     acc.push_str(&text);

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -273,6 +273,10 @@ pub enum Role {
 pub enum Content {
     Text {
         text: String,
+        /// Citations returned by Claude pointing back into the source documents.
+        /// Empty (and skipped during serialization) on request-side blocks.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        citations: Vec<Citation>,
         #[serde(skip_serializing_if = "Option::is_none")]
         cache_control: Option<CacheControl>,
     },
@@ -297,6 +301,19 @@ pub enum Content {
     },
     Document {
         source: DocumentSource,
+        /// Optional document title, passed to the model but not citable.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        title: Option<String>,
+        /// Optional document context (e.g. metadata), passed to the model but
+        /// not citable. Useful for storing additional information about the
+        /// document that should not appear in citation `cited_text`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        context: Option<String>,
+        /// Configuration for enabling citations on this document. When `enabled`
+        /// is true, Claude returns citation metadata on response text blocks
+        /// pointing back into this document's content.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        citations: Option<CitationsConfig>,
         #[serde(skip_serializing_if = "Option::is_none")]
         cache_control: Option<CacheControl>,
     },
@@ -316,8 +333,165 @@ impl FromStr for Content {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Content::Text {
             text: s.to_owned(),
+            citations: Vec::new(),
             cache_control: None,
         })
+    }
+}
+
+/// Configuration for enabling citations on a document content block.
+///
+/// When enabled, Claude returns citation metadata on response text blocks,
+/// allowing applications to track where each piece of information in the
+/// response came from. See the [Anthropic citations documentation][docs] for
+/// details on the request/response shapes.
+///
+/// Citations must be enabled on **all or none** of the documents in a request —
+/// the API returns an error if the setting is mixed.
+///
+/// [docs]: https://docs.anthropic.com/en/docs/build-with-claude/citations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CitationsConfig {
+    /// Whether citation tracking is enabled for this document.
+    pub enabled: bool,
+}
+
+/// A citation returned by Claude pointing back to a span of source text in one
+/// of the user-supplied documents.
+///
+/// The variant determines the locator shape, which depends on the source
+/// document type:
+///
+/// - [`Citation::CharLocation`] — for plain text documents; character indices
+///   are 0-indexed with an exclusive end.
+/// - [`Citation::PageLocation`] — for PDF documents; page numbers are 1-indexed
+///   with an exclusive end.
+/// - [`Citation::ContentBlockLocation`] — for custom-content documents; block
+///   indices are 0-indexed with an exclusive end.
+///
+/// See the [Anthropic citations documentation][docs] for the exact wire format.
+///
+/// [docs]: https://docs.anthropic.com/en/docs/build-with-claude/citations
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Citation {
+    /// A citation locating a character span in a plain text document.
+    CharLocation {
+        /// The exact text being cited. Not counted toward output tokens.
+        cited_text: String,
+        /// 0-indexed position of the source document in the request's document list.
+        document_index: usize,
+        /// Optional title of the source document, echoed back from the request.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        document_title: Option<String>,
+        /// 0-indexed character offset where the cited span begins.
+        start_char_index: usize,
+        /// Character offset where the cited span ends (exclusive).
+        end_char_index: usize,
+    },
+    /// A citation locating a page range in a PDF document.
+    PageLocation {
+        /// The exact text being cited. Not counted toward output tokens.
+        cited_text: String,
+        /// 0-indexed position of the source document in the request's document list.
+        document_index: usize,
+        /// Optional title of the source document, echoed back from the request.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        document_title: Option<String>,
+        /// 1-indexed page number where the cited span begins.
+        start_page_number: u32,
+        /// 1-indexed page number where the cited span ends (exclusive).
+        end_page_number: u32,
+    },
+    /// A citation locating a block range in a custom-content document.
+    ContentBlockLocation {
+        /// The exact text being cited. Not counted toward output tokens.
+        cited_text: String,
+        /// 0-indexed position of the source document in the request's document list.
+        document_index: usize,
+        /// Optional title of the source document, echoed back from the request.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        document_title: Option<String>,
+        /// 0-indexed content block index where the cited span begins.
+        start_block_index: usize,
+        /// Content block index where the cited span ends (exclusive).
+        end_block_index: usize,
+    },
+}
+
+/// Decoded Anthropic document fields lifted out of [`message::Document::additional_params`]:
+/// optional `title`, optional `context`, and optional [`CitationsConfig`].
+type AnthropicDocParams = (Option<String>, Option<String>, Option<CitationsConfig>);
+
+/// Extract Anthropic-specific document fields (`title`, `context`, `citations`)
+/// from the generic [`message::Document::additional_params`] JSON blob.
+///
+/// Returns `Ok((None, None, None))` if `additional_params` is empty. Returns
+/// an error only if the `citations` field is present but is not a valid
+/// [`CitationsConfig`] — invalid shapes are reported instead of being silently
+/// dropped, so users notice typos.
+fn extract_anthropic_doc_params(
+    additional_params: Option<serde_json::Value>,
+) -> Result<AnthropicDocParams, MessageError> {
+    let Some(value) = additional_params else {
+        return Ok((None, None, None));
+    };
+    let title = value
+        .get("title")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let context = value
+        .get("context")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let citations = value
+        .get("citations")
+        .cloned()
+        .map(serde_json::from_value::<CitationsConfig>)
+        .transpose()
+        .map_err(|e| {
+            MessageError::ConversionError(format!(
+                "Document `additional_params.citations` is not a valid CitationsConfig: {e}",
+            ))
+        })?;
+    Ok((title, context, citations))
+}
+
+/// Extract Anthropic citations attached to a generic [`message::Text`] block.
+///
+/// Citations are returned by Claude on assistant text blocks when the request
+/// enabled them via [`CitationsConfig`]. Internally they are stored as JSON in
+/// [`message::Text::additional_params`] so they survive conversion through the
+/// generic [`message::AssistantContent`] surface.
+///
+/// Returns `Ok(vec![])` when no citations are attached. Returns an error if a
+/// `citations` field is present but not a valid `Vec<Citation>` — for example,
+/// when Anthropic adds a new location type this crate does not yet model.
+///
+/// # Example
+///
+/// ```no_run
+/// use rig::completion::message::{self, AssistantContent};
+/// use rig::providers::anthropic::completion::anthropic_citations;
+///
+/// fn print_citations(content: &AssistantContent) {
+///     if let AssistantContent::Text(text) = content
+///         && let Ok(citations) = anthropic_citations(text)
+///         && !citations.is_empty()
+///     {
+///         println!("{citations:?}");
+///     }
+/// }
+/// # let _ = message::Text::new("");
+/// ```
+pub fn anthropic_citations(text: &message::Text) -> Result<Vec<Citation>, serde_json::Error> {
+    match text
+        .additional_params
+        .as_ref()
+        .and_then(|v| v.get("citations"))
+    {
+        Some(c) => serde_json::from_value::<Vec<Citation>>(c.clone()),
+        None => Ok(Vec::new()),
     }
 }
 
@@ -430,6 +604,7 @@ impl From<String> for Content {
     fn from(text: String) -> Self {
         Content::Text {
             text,
+            citations: Vec::new(),
             cache_control: None,
         }
     }
@@ -509,8 +684,9 @@ impl TryFrom<message::AssistantContent> for Content {
     type Error = MessageError;
     fn try_from(text: message::AssistantContent) -> Result<Self, Self::Error> {
         match text {
-            message::AssistantContent::Text(message::Text { text }) => Ok(Content::Text {
+            message::AssistantContent::Text(message::Text { text, .. }) => Ok(Content::Text {
                 text,
+                citations: Vec::new(),
                 cache_control: None,
             }),
             message::AssistantContent::Image(_) => Err(MessageError::ConversionError(
@@ -535,8 +711,9 @@ fn anthropic_content_from_assistant_content(
     content: message::AssistantContent,
 ) -> Result<Vec<Content>, MessageError> {
     match content {
-        message::AssistantContent::Text(message::Text { text }) => Ok(vec![Content::Text {
+        message::AssistantContent::Text(message::Text { text, .. }) => Ok(vec![Content::Text {
             text,
+            citations: Vec::new(),
             cache_control: None,
         }]),
         message::AssistantContent::Image(_) => Err(MessageError::ConversionError(
@@ -591,8 +768,9 @@ impl TryFrom<message::Message> for Message {
             message::Message::User { content } => Message {
                 role: Role::User,
                 content: content.try_map(|content| match content {
-                    message::UserContent::Text(message::Text { text }) => Ok(Content::Text {
+                    message::UserContent::Text(message::Text { text, .. }) => Ok(Content::Text {
                         text,
+                        citations: Vec::new(),
                         cache_control: None,
                     }),
                     message::UserContent::ToolResult(message::ToolResult {
@@ -600,7 +778,7 @@ impl TryFrom<message::Message> for Message {
                     }) => Ok(Content::ToolResult {
                         tool_use_id: id,
                         content: content.try_map(|content| match content {
-                            message::ToolResultContent::Text(message::Text { text }) => {
+                            message::ToolResultContent::Text(message::Text { text, .. }) => {
                                 Ok(ToolResultContent::Text { text })
                             }
                             message::ToolResultContent::Image(image) => {
@@ -658,11 +836,19 @@ impl TryFrom<message::Message> for Message {
                         })
                     }
                     message::UserContent::Document(message::Document {
-                        data, media_type, ..
+                        data,
+                        media_type,
+                        additional_params,
                     }) => {
+                        let (title, context, citations) =
+                            extract_anthropic_doc_params(additional_params)?;
+
                         if let DocumentSourceKind::FileId(file_id) = data {
                             return Ok(Content::Document {
                                 source: DocumentSource::File { file_id },
+                                title,
+                                context,
+                                citations,
                                 cache_control: None,
                             });
                         }
@@ -712,6 +898,9 @@ impl TryFrom<message::Message> for Message {
 
                         Ok(Content::Document {
                             source,
+                            title,
+                            context,
+                            citations,
                             cache_control: None,
                         })
                     }
@@ -728,6 +917,7 @@ impl TryFrom<message::Message> for Message {
                 role: Role::User,
                 content: OneOrMany::one(Content::Text {
                     text: content,
+                    citations: Vec::new(),
                     cache_control: None,
                 }),
             },
@@ -761,7 +951,20 @@ impl TryFrom<Content> for message::AssistantContent {
 
     fn try_from(content: Content) -> Result<Self, Self::Error> {
         Ok(match content {
-            Content::Text { text, .. } => message::AssistantContent::text(text),
+            Content::Text {
+                text, citations, ..
+            } => {
+                // Preserve citation metadata on the generic text block via
+                // `additional_params` so callers going through the generic
+                // `AssistantContent` surface can still recover them (see
+                // [`anthropic_citations`]).
+                let additional_params =
+                    (!citations.is_empty()).then(|| serde_json::json!({ "citations": citations }));
+                message::AssistantContent::Text(message::Text {
+                    text,
+                    additional_params,
+                })
+            }
             Content::ToolUse { id, name, input } => {
                 message::AssistantContent::tool_call(id, name, input)
             }
@@ -786,7 +989,7 @@ impl TryFrom<Content> for message::AssistantContent {
 impl From<ToolResultContent> for message::ToolResultContent {
     fn from(content: ToolResultContent) -> Self {
         match content {
-            ToolResultContent::Text { text } => message::ToolResultContent::text(text),
+            ToolResultContent::Text { text, .. } => message::ToolResultContent::text(text),
             ToolResultContent::Image { source } => match source {
                 ImageSource::Base64 { data, media_type } => {
                     message::ToolResultContent::image_base64(data, Some(media_type.into()), None)
@@ -1626,6 +1829,7 @@ mod tests {
             content.first(),
             Content::Text {
                 text: "\n\nHello there, how may I assist you today?".to_owned(),
+                citations: Vec::new(),
                 cache_control: None,
             }
         );
@@ -1782,7 +1986,7 @@ mod tests {
                 }
 
                 match iter.next().unwrap() {
-                    message::UserContent::Text(message::Text { text }) => {
+                    message::UserContent::Text(message::Text { text, .. }) => {
                         assert_eq!(text, "What is in this image?");
                     }
                     _ => panic!("Expected text content"),
@@ -1814,7 +2018,7 @@ mod tests {
                 };
                 assert_eq!(id, "toolu_01A09q90qw90lq917835lq9");
                 match content.first() {
-                    message::ToolResultContent::Text(message::Text { text }) => {
+                    message::ToolResultContent::Text(message::Text { text, .. }) => {
                         assert_eq!(text, "15 degrees");
                     }
                     _ => panic!("Expected text content"),
@@ -1895,6 +2099,7 @@ mod tests {
         // Test Content::Text with cache_control
         let content = Content::Text {
             text: "Test message".to_string(),
+            citations: Vec::new(),
             cache_control: Some(CacheControl::ephemeral()),
         };
         let json_content = serde_json::to_string(&content).unwrap();
@@ -1910,6 +2115,7 @@ mod tests {
                 role: Role::User,
                 content: OneOrMany::one(Content::Text {
                     text: "First message".to_string(),
+                    citations: Vec::new(),
                     cache_control: None,
                 }),
             },
@@ -1917,6 +2123,7 @@ mod tests {
                 role: Role::Assistant,
                 content: OneOrMany::one(Content::Text {
                     text: "Response".to_string(),
+                    citations: Vec::new(),
                     cache_control: None,
                 }),
             },
@@ -1954,6 +2161,9 @@ mod tests {
                 data: "Hello, world!".to_string(),
                 media_type: PlainTextMediaType::Plain,
             },
+            title: None,
+            context: None,
+            citations: None,
             cache_control: None,
         };
 
@@ -1982,6 +2192,7 @@ mod tests {
             Content::Document {
                 source,
                 cache_control,
+                ..
             } => {
                 assert_eq!(
                     source,
@@ -2003,6 +2214,9 @@ mod tests {
                 data: "base64data".to_string(),
                 media_type: DocumentFormat::PDF,
             },
+            title: None,
+            context: None,
+            citations: None,
             cache_control: None,
         };
 
@@ -2047,6 +2261,9 @@ mod tests {
             source: DocumentSource::File {
                 file_id: "file_abc".to_string(),
             },
+            title: None,
+            context: None,
+            citations: None,
             cache_control: None,
         };
 
@@ -2121,6 +2338,9 @@ mod tests {
                 source: DocumentSource::File {
                     file_id: "file_abc".to_string(),
                 },
+                title: None,
+                context: None,
+                citations: None,
                 cache_control: None,
             }),
         };
@@ -2183,6 +2403,9 @@ mod tests {
                     data: "Some plain text content".to_string(),
                     media_type: PlainTextMediaType::Plain,
                 },
+                title: None,
+                context: None,
+                citations: None,
                 cache_control: None,
             }),
         };
@@ -2298,6 +2521,9 @@ mod tests {
                 data: "cached text".to_string(),
                 media_type: PlainTextMediaType::Plain,
             },
+            title: None,
+            context: None,
+            citations: None,
             cache_control: Some(CacheControl::ephemeral()),
         };
 
@@ -2537,5 +2763,182 @@ mod tests {
         assert_eq!(image_content["source"]["type"], "base64");
         assert_eq!(image_content["source"]["media_type"], "image/png");
         assert_eq!(image_content["source"]["data"], "iVBORw0KGgo...");
+    }
+
+    // -------------------------------------------------------------------
+    // Citations (#1767)
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn document_serializes_citations_and_metadata() {
+        let doc = Content::Document {
+            source: DocumentSource::Text {
+                data: "hello".into(),
+                media_type: PlainTextMediaType::Plain,
+            },
+            title: Some("My Doc".into()),
+            context: None,
+            citations: Some(CitationsConfig { enabled: true }),
+            cache_control: None,
+        };
+        let value = serde_json::to_value(&doc).unwrap();
+        assert_eq!(value["citations"]["enabled"], true);
+        assert_eq!(value["title"], "My Doc");
+        assert!(
+            value.get("context").is_none(),
+            "context should be skipped when None"
+        );
+    }
+
+    #[test]
+    fn text_serializes_without_citations_when_empty() {
+        let content = Content::Text {
+            text: "hello".into(),
+            citations: Vec::new(),
+            cache_control: None,
+        };
+        let value = serde_json::to_value(&content).unwrap();
+        assert!(
+            value.get("citations").is_none(),
+            "empty citations vec must be skipped"
+        );
+    }
+
+    #[test]
+    fn text_deserializes_char_location_citation() {
+        let value = json!({
+            "type": "text",
+            "text": "the grass is green",
+            "citations": [{
+                "type": "char_location",
+                "cited_text": "The grass is green.",
+                "document_index": 0,
+                "document_title": "Example",
+                "start_char_index": 0,
+                "end_char_index": 20
+            }]
+        });
+        let parsed: Content = serde_json::from_value(value).unwrap();
+        let Content::Text { citations, .. } = parsed else {
+            panic!("expected Content::Text");
+        };
+        assert_eq!(citations.len(), 1);
+        let Citation::CharLocation {
+            start_char_index,
+            end_char_index,
+            ..
+        } = &citations[0]
+        else {
+            panic!("expected CharLocation");
+        };
+        assert_eq!(*start_char_index, 0);
+        assert_eq!(*end_char_index, 20);
+    }
+
+    #[test]
+    fn page_location_citation_roundtrips() {
+        let citation = Citation::PageLocation {
+            cited_text: "Water is essential for life.".into(),
+            document_index: 1,
+            document_title: Some("PDF Doc".into()),
+            start_page_number: 5,
+            end_page_number: 6,
+        };
+        let value = serde_json::to_value(&citation).unwrap();
+        assert_eq!(value["type"], "page_location");
+        assert_eq!(value["start_page_number"], 5);
+        let back: Citation = serde_json::from_value(value).unwrap();
+        assert_eq!(back, citation);
+    }
+
+    #[test]
+    fn content_block_location_citation_roundtrips() {
+        let citation = Citation::ContentBlockLocation {
+            cited_text: "These are important findings.".into(),
+            document_index: 2,
+            document_title: None,
+            start_block_index: 0,
+            end_block_index: 1,
+        };
+        let value = serde_json::to_value(&citation).unwrap();
+        assert_eq!(value["type"], "content_block_location");
+        assert!(value.get("document_title").is_none());
+        let back: Citation = serde_json::from_value(value).unwrap();
+        assert_eq!(back, citation);
+    }
+
+    #[test]
+    fn anthropic_citations_extracts_from_additional_params() {
+        let text = message::Text {
+            text: "the grass is green".into(),
+            additional_params: Some(json!({
+                "citations": [{
+                    "type": "char_location",
+                    "cited_text": "The grass is green.",
+                    "document_index": 0,
+                    "start_char_index": 0,
+                    "end_char_index": 20
+                }]
+            })),
+        };
+        let citations = anthropic_citations(&text).unwrap();
+        assert_eq!(citations.len(), 1);
+    }
+
+    #[test]
+    fn anthropic_citations_returns_empty_when_absent() {
+        let text = message::Text::new("hello".to_string());
+        assert!(anthropic_citations(&text).unwrap().is_empty());
+    }
+
+    #[test]
+    fn content_text_with_citations_survives_assistant_conversion() {
+        let content = Content::Text {
+            text: "the grass is green".into(),
+            citations: vec![Citation::CharLocation {
+                cited_text: "The grass is green.".into(),
+                document_index: 0,
+                document_title: None,
+                start_char_index: 0,
+                end_char_index: 20,
+            }],
+            cache_control: None,
+        };
+        let assistant: message::AssistantContent = content.try_into().unwrap();
+        let message::AssistantContent::Text(text) = assistant else {
+            panic!("expected text variant");
+        };
+        let recovered = anthropic_citations(&text).unwrap();
+        assert_eq!(recovered.len(), 1);
+    }
+
+    #[test]
+    fn document_additional_params_forward_to_anthropic_document() {
+        let doc = message::UserContent::Document(message::Document {
+            data: message::DocumentSourceKind::String("Hello world.".into()),
+            media_type: Some(message::DocumentMediaType::TXT),
+            additional_params: Some(json!({
+                "title": "Doc1",
+                "context": "ctx",
+                "citations": { "enabled": true }
+            })),
+        });
+        let msg = message::Message::User {
+            content: OneOrMany::one(doc),
+        };
+        let converted: Message = msg.try_into().unwrap();
+        let block = converted.content.first();
+        let Content::Document {
+            title,
+            context,
+            citations,
+            ..
+        } = block
+        else {
+            panic!("expected Content::Document");
+        };
+        assert_eq!(title.as_deref(), Some("Doc1"));
+        assert_eq!(context.as_deref(), Some("ctx"));
+        assert_eq!(citations, Some(CitationsConfig { enabled: true }));
     }
 }

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -439,7 +439,7 @@ pub enum Citation {
         /// URL of the cited source.
         url: String,
         /// Title of the cited source.
-        title: String,
+        title: Option<String>,
         /// Encrypted reference that must be preserved for multi-turn
         /// conversations.
         encrypted_index: String,
@@ -494,7 +494,7 @@ struct SearchResultLocationCitationFields {
 struct WebSearchResultLocationCitationFields {
     cited_text: String,
     url: String,
-    title: String,
+    title: Option<String>,
     encrypted_index: String,
 }
 
@@ -3167,9 +3167,38 @@ mod tests {
                 encrypted_index,
                 ..
             } if url == "https://example.com/shannon"
-                && title == "Claude Shannon"
+                && title.as_deref() == Some("Claude Shannon")
                 && encrypted_index == "encrypted-reference"
         ));
+    }
+
+    #[test]
+    fn text_deserializes_web_search_result_location_citation_with_null_title() {
+        let value = json!({
+            "type": "text",
+            "text": "Claude Shannon worked at Bell Labs.",
+            "citations": [{
+                "type": "web_search_result_location",
+                "cited_text": "Claude Shannon was a mathematician.",
+                "url": "https://example.com/shannon",
+                "title": null,
+                "encrypted_index": "encrypted-reference"
+            }]
+        });
+
+        let parsed: Content = serde_json::from_value(value).unwrap();
+        let Content::Text { citations, .. } = parsed else {
+            panic!("expected Content::Text");
+        };
+
+        let Citation::WebSearchResultLocation { title, .. } = &citations[0] else {
+            panic!("expected WebSearchResultLocation");
+        };
+        assert_eq!(title, &None);
+
+        let serialized = serde_json::to_value(&citations[0]).unwrap();
+        assert!(serialized.get("title").is_some());
+        assert!(serialized["title"].is_null());
     }
 
     #[test]

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -355,11 +355,9 @@ pub struct CitationsConfig {
     pub enabled: bool,
 }
 
-/// A citation returned by Claude pointing back to a span of source text in one
-/// of the user-supplied documents.
+/// A citation returned by Claude pointing back to source text.
 ///
-/// The variant determines the locator shape, which depends on the source
-/// document type:
+/// The variant determines the locator shape, which depends on the source type:
 ///
 /// - [`Citation::CharLocation`] — for plain text documents; character indices
 ///   are 0-indexed with an exclusive end.
@@ -367,12 +365,17 @@ pub struct CitationsConfig {
 ///   with an exclusive end.
 /// - [`Citation::ContentBlockLocation`] — for custom-content documents; block
 ///   indices are 0-indexed with an exclusive end.
+/// - [`Citation::SearchResultLocation`] — for user-provided search-result
+///   content blocks.
+/// - [`Citation::WebSearchResultLocation`] — for Anthropic's server-side web
+///   search tool results.
+/// - [`Citation::Unknown`] — a forward-compatible fallback preserving raw
+///   citation JSON for citation types this crate does not yet model.
 ///
 /// See the [Anthropic citations documentation][docs] for the exact wire format.
 ///
 /// [docs]: https://docs.anthropic.com/en/docs/build-with-claude/citations
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Citation {
     /// A citation locating a character span in a plain text document.
     CharLocation {
@@ -381,7 +384,6 @@ pub enum Citation {
         /// 0-indexed position of the source document in the request's document list.
         document_index: usize,
         /// Optional title of the source document, echoed back from the request.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
         document_title: Option<String>,
         /// 0-indexed character offset where the cited span begins.
         start_char_index: usize,
@@ -395,7 +397,6 @@ pub enum Citation {
         /// 0-indexed position of the source document in the request's document list.
         document_index: usize,
         /// Optional title of the source document, echoed back from the request.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
         document_title: Option<String>,
         /// 1-indexed page number where the cited span begins.
         start_page_number: u32,
@@ -409,13 +410,273 @@ pub enum Citation {
         /// 0-indexed position of the source document in the request's document list.
         document_index: usize,
         /// Optional title of the source document, echoed back from the request.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
         document_title: Option<String>,
         /// 0-indexed content block index where the cited span begins.
         start_block_index: usize,
         /// Content block index where the cited span ends (exclusive).
         end_block_index: usize,
     },
+    /// A citation locating a block range in a user-provided search result.
+    SearchResultLocation {
+        /// The exact text being cited. Not counted toward output tokens.
+        cited_text: String,
+        /// Source URL or identifier from the original search result.
+        source: String,
+        /// Title from the original search result.
+        title: Option<String>,
+        /// 0-indexed position of the cited search result across all search
+        /// result blocks in the request.
+        search_result_index: usize,
+        /// 0-indexed content block index where the cited span begins.
+        start_block_index: usize,
+        /// Content block index where the cited span ends (exclusive).
+        end_block_index: usize,
+    },
+    /// A citation emitted by Anthropic's server-side web search tool.
+    WebSearchResultLocation {
+        /// The exact text being cited. Not counted toward output tokens.
+        cited_text: String,
+        /// URL of the cited source.
+        url: String,
+        /// Title of the cited source.
+        title: String,
+        /// Encrypted reference that must be preserved for multi-turn
+        /// conversations.
+        encrypted_index: String,
+    },
+    /// A forward-compatible raw citation payload for citation types this crate
+    /// does not yet model.
+    Unknown(serde_json::Value),
+}
+
+#[derive(Deserialize)]
+struct CharLocationCitationFields {
+    cited_text: String,
+    document_index: usize,
+    #[serde(default)]
+    document_title: Option<String>,
+    start_char_index: usize,
+    end_char_index: usize,
+}
+
+#[derive(Deserialize)]
+struct PageLocationCitationFields {
+    cited_text: String,
+    document_index: usize,
+    #[serde(default)]
+    document_title: Option<String>,
+    start_page_number: u32,
+    end_page_number: u32,
+}
+
+#[derive(Deserialize)]
+struct ContentBlockLocationCitationFields {
+    cited_text: String,
+    document_index: usize,
+    #[serde(default)]
+    document_title: Option<String>,
+    start_block_index: usize,
+    end_block_index: usize,
+}
+
+#[derive(Deserialize)]
+struct SearchResultLocationCitationFields {
+    cited_text: String,
+    source: String,
+    #[serde(default)]
+    title: Option<String>,
+    search_result_index: usize,
+    start_block_index: usize,
+    end_block_index: usize,
+}
+
+#[derive(Deserialize)]
+struct WebSearchResultLocationCitationFields {
+    cited_text: String,
+    url: String,
+    title: String,
+    encrypted_index: String,
+}
+
+impl Serialize for Citation {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut value = serde_json::Map::new();
+        match self {
+            Citation::CharLocation {
+                cited_text,
+                document_index,
+                document_title,
+                start_char_index,
+                end_char_index,
+            } => {
+                value.insert("type".into(), serde_json::json!("char_location"));
+                value.insert("cited_text".into(), serde_json::json!(cited_text));
+                value.insert("document_index".into(), serde_json::json!(document_index));
+                if let Some(document_title) = document_title {
+                    value.insert("document_title".into(), serde_json::json!(document_title));
+                }
+                value.insert(
+                    "start_char_index".into(),
+                    serde_json::json!(start_char_index),
+                );
+                value.insert("end_char_index".into(), serde_json::json!(end_char_index));
+            }
+            Citation::PageLocation {
+                cited_text,
+                document_index,
+                document_title,
+                start_page_number,
+                end_page_number,
+            } => {
+                value.insert("type".into(), serde_json::json!("page_location"));
+                value.insert("cited_text".into(), serde_json::json!(cited_text));
+                value.insert("document_index".into(), serde_json::json!(document_index));
+                if let Some(document_title) = document_title {
+                    value.insert("document_title".into(), serde_json::json!(document_title));
+                }
+                value.insert(
+                    "start_page_number".into(),
+                    serde_json::json!(start_page_number),
+                );
+                value.insert("end_page_number".into(), serde_json::json!(end_page_number));
+            }
+            Citation::ContentBlockLocation {
+                cited_text,
+                document_index,
+                document_title,
+                start_block_index,
+                end_block_index,
+            } => {
+                value.insert("type".into(), serde_json::json!("content_block_location"));
+                value.insert("cited_text".into(), serde_json::json!(cited_text));
+                value.insert("document_index".into(), serde_json::json!(document_index));
+                if let Some(document_title) = document_title {
+                    value.insert("document_title".into(), serde_json::json!(document_title));
+                }
+                value.insert(
+                    "start_block_index".into(),
+                    serde_json::json!(start_block_index),
+                );
+                value.insert("end_block_index".into(), serde_json::json!(end_block_index));
+            }
+            Citation::SearchResultLocation {
+                cited_text,
+                source,
+                title,
+                search_result_index,
+                start_block_index,
+                end_block_index,
+            } => {
+                value.insert("type".into(), serde_json::json!("search_result_location"));
+                value.insert("cited_text".into(), serde_json::json!(cited_text));
+                value.insert("source".into(), serde_json::json!(source));
+                if let Some(title) = title {
+                    value.insert("title".into(), serde_json::json!(title));
+                }
+                value.insert(
+                    "search_result_index".into(),
+                    serde_json::json!(search_result_index),
+                );
+                value.insert(
+                    "start_block_index".into(),
+                    serde_json::json!(start_block_index),
+                );
+                value.insert("end_block_index".into(), serde_json::json!(end_block_index));
+            }
+            Citation::WebSearchResultLocation {
+                cited_text,
+                url,
+                title,
+                encrypted_index,
+            } => {
+                value.insert(
+                    "type".into(),
+                    serde_json::json!("web_search_result_location"),
+                );
+                value.insert("cited_text".into(), serde_json::json!(cited_text));
+                value.insert("url".into(), serde_json::json!(url));
+                value.insert("title".into(), serde_json::json!(title));
+                value.insert("encrypted_index".into(), serde_json::json!(encrypted_index));
+            }
+            Citation::Unknown(raw) => return raw.serialize(serializer),
+        }
+
+        serde_json::Value::Object(value).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Citation {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        let Some(citation_type) = value.get("type").and_then(serde_json::Value::as_str) else {
+            return Ok(Citation::Unknown(value));
+        };
+
+        match citation_type {
+            "char_location" => {
+                let fields: CharLocationCitationFields =
+                    serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+                Ok(Citation::CharLocation {
+                    cited_text: fields.cited_text,
+                    document_index: fields.document_index,
+                    document_title: fields.document_title,
+                    start_char_index: fields.start_char_index,
+                    end_char_index: fields.end_char_index,
+                })
+            }
+            "page_location" => {
+                let fields: PageLocationCitationFields =
+                    serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+                Ok(Citation::PageLocation {
+                    cited_text: fields.cited_text,
+                    document_index: fields.document_index,
+                    document_title: fields.document_title,
+                    start_page_number: fields.start_page_number,
+                    end_page_number: fields.end_page_number,
+                })
+            }
+            "content_block_location" => {
+                let fields: ContentBlockLocationCitationFields =
+                    serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+                Ok(Citation::ContentBlockLocation {
+                    cited_text: fields.cited_text,
+                    document_index: fields.document_index,
+                    document_title: fields.document_title,
+                    start_block_index: fields.start_block_index,
+                    end_block_index: fields.end_block_index,
+                })
+            }
+            "search_result_location" => {
+                let fields: SearchResultLocationCitationFields =
+                    serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+                Ok(Citation::SearchResultLocation {
+                    cited_text: fields.cited_text,
+                    source: fields.source,
+                    title: fields.title,
+                    search_result_index: fields.search_result_index,
+                    start_block_index: fields.start_block_index,
+                    end_block_index: fields.end_block_index,
+                })
+            }
+            "web_search_result_location" => {
+                let fields: WebSearchResultLocationCitationFields =
+                    serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+                Ok(Citation::WebSearchResultLocation {
+                    cited_text: fields.cited_text,
+                    url: fields.url,
+                    title: fields.title,
+                    encrypted_index: fields.encrypted_index,
+                })
+            }
+            _ => Ok(Citation::Unknown(value)),
+        }
+    }
 }
 
 /// Decoded Anthropic document fields lifted out of [`message::Document::additional_params`]:
@@ -2846,6 +3107,96 @@ mod tests {
     }
 
     #[test]
+    fn text_deserializes_search_result_location_citation() {
+        let value = json!({
+            "type": "text",
+            "text": "API keys are required.",
+            "citations": [{
+                "type": "search_result_location",
+                "cited_text": "All API requests must include an API key.",
+                "source": "https://docs.example.com/api-reference",
+                "title": "API Reference",
+                "search_result_index": 0,
+                "start_block_index": 0,
+                "end_block_index": 1
+            }]
+        });
+
+        let parsed: Content = serde_json::from_value(value).unwrap();
+        let Content::Text { citations, .. } = parsed else {
+            panic!("expected Content::Text");
+        };
+
+        assert!(matches!(
+            &citations[0],
+            Citation::SearchResultLocation {
+                source,
+                title: Some(title),
+                search_result_index: 0,
+                start_block_index: 0,
+                end_block_index: 1,
+                ..
+            } if source == "https://docs.example.com/api-reference" && title == "API Reference"
+        ));
+    }
+
+    #[test]
+    fn text_deserializes_web_search_result_location_citation() {
+        let value = json!({
+            "type": "text",
+            "text": "Claude Shannon worked at Bell Labs.",
+            "citations": [{
+                "type": "web_search_result_location",
+                "cited_text": "Claude Shannon was a mathematician.",
+                "url": "https://example.com/shannon",
+                "title": "Claude Shannon",
+                "encrypted_index": "encrypted-reference"
+            }]
+        });
+
+        let parsed: Content = serde_json::from_value(value).unwrap();
+        let Content::Text { citations, .. } = parsed else {
+            panic!("expected Content::Text");
+        };
+
+        assert!(matches!(
+            &citations[0],
+            Citation::WebSearchResultLocation {
+                url,
+                title,
+                encrypted_index,
+                ..
+            } if url == "https://example.com/shannon"
+                && title == "Claude Shannon"
+                && encrypted_index == "encrypted-reference"
+        ));
+    }
+
+    #[test]
+    fn text_deserializes_unknown_citation_without_failing() {
+        let value = json!({
+            "type": "text",
+            "text": "future citation",
+            "citations": [{
+                "type": "future_location",
+                "cited_text": "future text",
+                "new_field": "kept"
+            }]
+        });
+
+        let parsed: Content = serde_json::from_value(value).unwrap();
+        let Content::Text { citations, .. } = parsed else {
+            panic!("expected Content::Text");
+        };
+
+        assert!(matches!(
+            &citations[0],
+            Citation::Unknown(raw)
+                if raw["type"] == "future_location" && raw["new_field"] == "kept"
+        ));
+    }
+
+    #[test]
     fn page_location_citation_roundtrips() {
         let citation = Citation::PageLocation {
             cited_text: "Water is essential for life.".into(),
@@ -3001,12 +3352,12 @@ mod tests {
     }
 
     #[test]
-    fn assistant_text_invalid_citations_are_rejected_for_anthropic_request_conversion() {
+    fn assistant_text_invalid_known_citations_are_rejected_for_anthropic_request_conversion() {
         let text = message::AssistantContent::Text(message::Text {
             text: "bad citation".into(),
             additional_params: Some(json!({
                 "citations": [{
-                    "type": "unknown_location",
+                    "type": "char_location",
                     "cited_text": "bad"
                 }]
             })),

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -724,9 +724,9 @@ fn extract_anthropic_doc_params(
 /// [`message::Text::additional_params`] so they survive conversion through the
 /// generic [`message::AssistantContent`] surface.
 ///
-/// Returns `Ok(vec![])` when no citations are attached. Returns an error if a
-/// `citations` field is present but not a valid `Vec<Citation>` — for example,
-/// when Anthropic adds a new location type this crate does not yet model.
+/// Returns `Ok(vec![])` when no citations are attached. Unknown citation types
+/// are preserved as [`Citation::Unknown`]. Returns an error if the `citations`
+/// field is malformed or if a known citation type has an invalid shape.
 ///
 /// # Example
 ///

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -85,13 +85,12 @@ impl ProviderResponseExt for CompletionResponse {
             .iter()
             .filter_map(|x| {
                 if let Content::Text { text, .. } = x {
-                    Some(text.to_owned())
+                    Some(text.as_str())
                 } else {
                     None
                 }
             })
-            .collect::<Vec<String>>()
-            .join("\n");
+            .collect::<String>();
 
         if res.is_empty() { None } else { Some(res) }
     }
@@ -495,6 +494,23 @@ pub fn anthropic_citations(text: &message::Text) -> Result<Vec<Citation>, serde_
     }
 }
 
+fn extract_anthropic_text_citations(text: &message::Text) -> Result<Vec<Citation>, MessageError> {
+    anthropic_citations(text).map_err(|err| {
+        MessageError::ConversionError(format!(
+            "Text `additional_params.citations` is not valid Anthropic citations: {err}"
+        ))
+    })
+}
+
+fn anthropic_text_content_from_message_text(text: message::Text) -> Result<Content, MessageError> {
+    let citations = extract_anthropic_text_citations(&text)?;
+    Ok(Content::Text {
+        text: text.text,
+        citations,
+        cache_control: None,
+    })
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ToolResultContent {
@@ -684,11 +700,7 @@ impl TryFrom<message::AssistantContent> for Content {
     type Error = MessageError;
     fn try_from(text: message::AssistantContent) -> Result<Self, Self::Error> {
         match text {
-            message::AssistantContent::Text(message::Text { text, .. }) => Ok(Content::Text {
-                text,
-                citations: Vec::new(),
-                cache_control: None,
-            }),
+            message::AssistantContent::Text(text) => anthropic_text_content_from_message_text(text),
             message::AssistantContent::Image(_) => Err(MessageError::ConversionError(
                 "Anthropic currently doesn't support images.".to_string(),
             )),
@@ -711,11 +723,9 @@ fn anthropic_content_from_assistant_content(
     content: message::AssistantContent,
 ) -> Result<Vec<Content>, MessageError> {
     match content {
-        message::AssistantContent::Text(message::Text { text, .. }) => Ok(vec![Content::Text {
-            text,
-            citations: Vec::new(),
-            cache_control: None,
-        }]),
+        message::AssistantContent::Text(text) => {
+            Ok(vec![anthropic_text_content_from_message_text(text)?])
+        }
         message::AssistantContent::Image(_) => Err(MessageError::ConversionError(
             "Anthropic currently doesn't support images.".to_string(),
         )),
@@ -2910,6 +2920,104 @@ mod tests {
         };
         let recovered = anthropic_citations(&text).unwrap();
         assert_eq!(recovered.len(), 1);
+    }
+
+    #[test]
+    fn provider_text_response_concatenates_text_blocks_without_inserted_newlines() {
+        let response = CompletionResponse {
+            content: vec![
+                Content::Text {
+                    text: "According to the document, ".into(),
+                    citations: Vec::new(),
+                    cache_control: None,
+                },
+                Content::Text {
+                    text: "the grass is green".into(),
+                    citations: Vec::new(),
+                    cache_control: None,
+                },
+                Content::Text {
+                    text: " and the sky is blue.".into(),
+                    citations: Vec::new(),
+                    cache_control: None,
+                },
+            ],
+            id: "msg_1".into(),
+            model: "claude-test".into(),
+            role: "assistant".into(),
+            stop_reason: Some("end_turn".into()),
+            stop_sequence: None,
+            usage: Usage {
+                input_tokens: 1,
+                cache_read_input_tokens: None,
+                cache_creation_input_tokens: None,
+                output_tokens: 1,
+            },
+        };
+
+        assert_eq!(
+            response.get_text_response().as_deref(),
+            Some("According to the document, the grass is green and the sky is blue.")
+        );
+    }
+
+    #[test]
+    fn assistant_text_citations_survive_anthropic_request_conversion() {
+        let assistant = message::Message::Assistant {
+            id: None,
+            content: OneOrMany::one(message::AssistantContent::Text(message::Text {
+                text: "the grass is green".into(),
+                additional_params: Some(json!({
+                    "citations": [{
+                        "type": "char_location",
+                        "cited_text": "The grass is green.",
+                        "document_index": 0,
+                        "start_char_index": 0,
+                        "end_char_index": 20
+                    }]
+                })),
+            })),
+        };
+
+        let converted: Message = assistant.try_into().unwrap();
+        let Content::Text {
+            citations, text, ..
+        } = converted.content.first()
+        else {
+            panic!("expected assistant text content");
+        };
+
+        assert_eq!(text, "the grass is green");
+        assert_eq!(
+            citations,
+            vec![Citation::CharLocation {
+                cited_text: "The grass is green.".into(),
+                document_index: 0,
+                document_title: None,
+                start_char_index: 0,
+                end_char_index: 20,
+            }]
+        );
+    }
+
+    #[test]
+    fn assistant_text_invalid_citations_are_rejected_for_anthropic_request_conversion() {
+        let text = message::AssistantContent::Text(message::Text {
+            text: "bad citation".into(),
+            additional_params: Some(json!({
+                "citations": [{
+                    "type": "unknown_location",
+                    "cited_text": "bad"
+                }]
+            })),
+        });
+
+        let result = Content::try_from(text);
+
+        assert!(
+            result.is_err(),
+            "invalid Anthropic citation metadata should not be silently dropped"
+        );
     }
 
     #[test]

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -34,6 +34,7 @@ pub const ANTHROPIC_VERSION_2023_01_01: &str = "2023-01-01";
 pub const ANTHROPIC_VERSION_2023_06_01: &str = "2023-06-01";
 pub const ANTHROPIC_VERSION_LATEST: &str = ANTHROPIC_VERSION_2023_06_01;
 const EMPTY_RESPONSE_ERROR: &str = "Response contained no message or tool call (empty)";
+pub(crate) const ANTHROPIC_RAW_CONTENT_KEY: &str = "anthropic_content";
 
 pub trait AnthropicCompatibleProvider: Provider {
     const PROVIDER_NAME: &'static str;
@@ -288,6 +289,16 @@ pub enum Content {
         id: String,
         name: String,
         input: serde_json::Value,
+    },
+    ServerToolUse {
+        id: String,
+        name: String,
+        #[serde(default)]
+        input: serde_json::Value,
+    },
+    WebSearchToolResult {
+        tool_use_id: String,
+        content: serde_json::Value,
     },
     ToolResult {
         tool_use_id: String,
@@ -764,12 +775,85 @@ fn extract_anthropic_text_citations(text: &message::Text) -> Result<Vec<Citation
 }
 
 fn anthropic_text_content_from_message_text(text: message::Text) -> Result<Content, MessageError> {
+    if let Some(raw_content) = extract_anthropic_raw_content(&text)? {
+        if !text.text.is_empty() {
+            return Err(MessageError::ConversionError(format!(
+                "Text `{ANTHROPIC_RAW_CONTENT_KEY}` metadata cannot be combined with non-empty text"
+            )));
+        }
+
+        return Ok(raw_content);
+    }
+
     let citations = extract_anthropic_text_citations(&text)?;
     Ok(Content::Text {
         text: text.text,
         citations,
         cache_control: None,
     })
+}
+
+fn extract_anthropic_raw_content(text: &message::Text) -> Result<Option<Content>, MessageError> {
+    let Some(raw_content) = text
+        .additional_params
+        .as_ref()
+        .and_then(|value| value.get(ANTHROPIC_RAW_CONTENT_KEY))
+    else {
+        return Ok(None);
+    };
+
+    let content = serde_json::from_value::<Content>(raw_content.clone()).map_err(|err| {
+        MessageError::ConversionError(format!(
+            "Text `{ANTHROPIC_RAW_CONTENT_KEY}` metadata is not valid Anthropic content: {err}"
+        ))
+    })?;
+
+    match content {
+        Content::ServerToolUse { .. } | Content::WebSearchToolResult { .. } => Ok(Some(content)),
+        _ => Err(MessageError::ConversionError(format!(
+            "Text `{ANTHROPIC_RAW_CONTENT_KEY}` metadata only supports Anthropic server_tool_use and web_search_tool_result blocks"
+        ))),
+    }
+}
+
+fn anthropic_raw_content_to_message_text(content: Content) -> Result<message::Text, MessageError> {
+    let raw_content = serde_json::to_value(content).map_err(|err| {
+        MessageError::ConversionError(format!("Failed to preserve Anthropic content block: {err}"))
+    })?;
+
+    Ok(message::Text {
+        text: String::new(),
+        additional_params: Some(serde_json::json!({
+            ANTHROPIC_RAW_CONTENT_KEY: raw_content
+        })),
+    })
+}
+
+fn anthropic_document_additional_params(
+    title: Option<String>,
+    context: Option<String>,
+    citations: Option<CitationsConfig>,
+) -> Result<Option<serde_json::Value>, MessageError> {
+    let mut params = serde_json::Map::new();
+
+    if let Some(title) = title {
+        params.insert("title".to_string(), serde_json::Value::String(title));
+    }
+    if let Some(context) = context {
+        params.insert("context".to_string(), serde_json::Value::String(context));
+    }
+    if let Some(citations) = citations {
+        params.insert(
+            "citations".to_string(),
+            serde_json::to_value(citations).map_err(|err| {
+                MessageError::ConversionError(format!(
+                    "Failed to preserve Anthropic document citations metadata: {err}"
+                ))
+            })?,
+        );
+    }
+
+    Ok((!params.is_empty()).then_some(serde_json::Value::Object(params)))
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
@@ -1239,6 +1323,9 @@ impl TryFrom<Content> for message::AssistantContent {
             Content::ToolUse { id, name, input } => {
                 message::AssistantContent::tool_call(id, name, input)
             }
+            raw @ (Content::ServerToolUse { .. } | Content::WebSearchToolResult { .. }) => {
+                message::AssistantContent::Text(anthropic_raw_content_to_message_text(raw)?)
+            }
             Content::Thinking {
                 thinking,
                 signature,
@@ -1306,28 +1393,50 @@ impl TryFrom<Message> for message::Message {
                                 })
                             }
                         },
-                        Content::Document { source, .. } => match source {
-                            DocumentSource::Base64 { data, media_type } => {
-                                let rig_media_type = match media_type {
-                                    DocumentFormat::PDF => message::DocumentMediaType::PDF,
-                                };
-                                message::UserContent::document(data, Some(rig_media_type))
+                        Content::Document {
+                            source,
+                            title,
+                            context,
+                            citations,
+                            ..
+                        } => {
+                            let additional_params =
+                                anthropic_document_additional_params(title, context, citations)?;
+
+                            match source {
+                                DocumentSource::Base64 { data, media_type } => {
+                                    let rig_media_type = match media_type {
+                                        DocumentFormat::PDF => message::DocumentMediaType::PDF,
+                                    };
+                                    message::UserContent::Document(message::Document {
+                                        data: DocumentSourceKind::String(data),
+                                        media_type: Some(rig_media_type),
+                                        additional_params,
+                                    })
+                                }
+                                DocumentSource::Text { data, .. } => {
+                                    message::UserContent::Document(message::Document {
+                                        data: DocumentSourceKind::String(data),
+                                        media_type: Some(message::DocumentMediaType::TXT),
+                                        additional_params,
+                                    })
+                                }
+                                DocumentSource::Url { url } => {
+                                    message::UserContent::Document(message::Document {
+                                        data: DocumentSourceKind::Url(url),
+                                        media_type: None,
+                                        additional_params,
+                                    })
+                                }
+                                DocumentSource::File { file_id } => {
+                                    message::UserContent::Document(message::Document {
+                                        data: DocumentSourceKind::FileId(file_id),
+                                        media_type: None,
+                                        additional_params,
+                                    })
+                                }
                             }
-                            DocumentSource::Text { data, .. } => message::UserContent::document(
-                                data,
-                                Some(message::DocumentMediaType::TXT),
-                            ),
-                            DocumentSource::Url { url } => {
-                                message::UserContent::document_url(url, None)
-                            }
-                            DocumentSource::File { file_id } => {
-                                message::UserContent::Document(message::Document {
-                                    data: DocumentSourceKind::FileId(file_id),
-                                    media_type: None,
-                                    additional_params: None,
-                                })
-                            }
-                        },
+                        }
                         _ => {
                             return Err(MessageError::ConversionError(
                                 "Unsupported content type for User role".to_owned(),
@@ -3202,6 +3311,174 @@ mod tests {
     }
 
     #[test]
+    fn web_search_response_preserves_raw_blocks_and_citations() {
+        let value = json!({
+            "id": "msg_web_search",
+            "model": CLAUDE_SONNET_4_6,
+            "role": "assistant",
+            "stop_reason": "end_turn",
+            "stop_sequence": null,
+            "usage": {
+                "input_tokens": 10,
+                "output_tokens": 20
+            },
+            "content": [
+                {
+                    "type": "server_tool_use",
+                    "id": "srvtoolu_01",
+                    "name": "web_search",
+                    "input": {
+                        "query": "claude shannon birth date"
+                    }
+                },
+                {
+                    "type": "web_search_tool_result",
+                    "tool_use_id": "srvtoolu_01",
+                    "content": [
+                        {
+                            "type": "web_search_result",
+                            "url": "https://example.com/shannon",
+                            "title": "Claude Shannon",
+                            "encrypted_content": "encrypted-content",
+                            "page_age": "April 30, 2025"
+                        }
+                    ]
+                },
+                {
+                    "type": "text",
+                    "text": "Claude Shannon was born on April 30, 1916.",
+                    "citations": [{
+                        "type": "web_search_result_location",
+                        "cited_text": "Claude Shannon was born on April 30, 1916.",
+                        "url": "https://example.com/shannon",
+                        "title": "Claude Shannon",
+                        "encrypted_index": "encrypted-index"
+                    }]
+                }
+            ]
+        });
+
+        let response: CompletionResponse = serde_json::from_value(value).unwrap();
+        let converted: completion::CompletionResponse<CompletionResponse> =
+            response.try_into().unwrap();
+        assert_eq!(converted.choice.len(), 3);
+        assert_eq!(
+            converted.raw_response.get_text_response().as_deref(),
+            Some("Claude Shannon was born on April 30, 1916.")
+        );
+
+        let items = converted.choice.iter().collect::<Vec<_>>();
+        let message::AssistantContent::Text(server_tool_use) = items[0] else {
+            panic!("expected raw server_tool_use metadata");
+        };
+        assert_eq!(server_tool_use.text, "");
+        assert_eq!(
+            server_tool_use.additional_params.as_ref().unwrap()[ANTHROPIC_RAW_CONTENT_KEY]["type"],
+            "server_tool_use"
+        );
+
+        let message::AssistantContent::Text(web_search_result) = items[1] else {
+            panic!("expected raw web_search_tool_result metadata");
+        };
+        assert_eq!(
+            web_search_result.additional_params.as_ref().unwrap()[ANTHROPIC_RAW_CONTENT_KEY]["content"]
+                [0]["encrypted_content"],
+            "encrypted-content"
+        );
+
+        let message::AssistantContent::Text(answer) = items[2] else {
+            panic!("expected text answer");
+        };
+        let citations = anthropic_citations(answer).unwrap();
+        assert!(matches!(
+            citations.first(),
+            Some(Citation::WebSearchResultLocation {
+                encrypted_index,
+                ..
+            }) if encrypted_index == "encrypted-index"
+        ));
+
+        let round_trip: Message = message::Message::Assistant {
+            id: converted.message_id.clone(),
+            content: converted.choice,
+        }
+        .try_into()
+        .unwrap();
+
+        let round_trip_items = round_trip.content.iter().collect::<Vec<_>>();
+        assert!(matches!(
+            round_trip_items.first(),
+            Some(Content::ServerToolUse { id, name, input })
+                if id == "srvtoolu_01"
+                    && name == "web_search"
+                    && input["query"] == "claude shannon birth date"
+        ));
+        assert!(matches!(
+            round_trip_items.get(1),
+            Some(Content::WebSearchToolResult {
+                tool_use_id,
+                content
+            }) if tool_use_id == "srvtoolu_01"
+                && content[0]["encrypted_content"] == "encrypted-content"
+        ));
+    }
+
+    #[test]
+    fn web_search_tool_result_error_object_is_preserved_raw() {
+        let value = json!({
+            "id": "msg_web_search_error",
+            "model": CLAUDE_SONNET_4_6,
+            "role": "assistant",
+            "stop_reason": "end_turn",
+            "stop_sequence": null,
+            "usage": {
+                "input_tokens": 10,
+                "output_tokens": 2
+            },
+            "content": [{
+                "type": "web_search_tool_result",
+                "tool_use_id": "srvtoolu_01",
+                "content": {
+                    "type": "web_search_tool_result_error",
+                    "error_code": "max_uses_exceeded"
+                }
+            }]
+        });
+
+        let response: CompletionResponse = serde_json::from_value(value).unwrap();
+        let converted: completion::CompletionResponse<CompletionResponse> =
+            response.try_into().unwrap();
+        let message::AssistantContent::Text(web_search_result) = converted.choice.first() else {
+            panic!("expected raw web_search_tool_result metadata");
+        };
+
+        let raw_content =
+            &web_search_result.additional_params.as_ref().unwrap()[ANTHROPIC_RAW_CONTENT_KEY];
+        assert_eq!(raw_content["type"], "web_search_tool_result");
+        assert_eq!(raw_content["content"]["error_code"], "max_uses_exceeded");
+        assert_eq!(
+            raw_content["content"]["type"],
+            "web_search_tool_result_error"
+        );
+
+        let round_trip: Message = message::Message::Assistant {
+            id: converted.message_id,
+            content: converted.choice,
+        }
+        .try_into()
+        .unwrap();
+
+        assert!(matches!(
+            round_trip.content.first(),
+            Content::WebSearchToolResult {
+                tool_use_id,
+                content
+            } if tool_use_id == "srvtoolu_01"
+                && content["error_code"] == "max_uses_exceeded"
+        ));
+    }
+
+    #[test]
     fn text_deserializes_unknown_citation_without_failing() {
         let value = json!({
             "type": "text",
@@ -3428,5 +3705,149 @@ mod tests {
         assert_eq!(title.as_deref(), Some("Doc1"));
         assert_eq!(context.as_deref(), Some("ctx"));
         assert_eq!(citations, Some(CitationsConfig { enabled: true }));
+    }
+
+    fn assert_reverse_document_metadata(
+        source: DocumentSource,
+        expected_data: DocumentSourceKind,
+        expected_media_type: Option<message::DocumentMediaType>,
+    ) -> message::Message {
+        let provider_message = Message {
+            role: Role::User,
+            content: OneOrMany::one(Content::Document {
+                source,
+                title: Some("Doc1".into()),
+                context: Some("ctx".into()),
+                citations: Some(CitationsConfig { enabled: true }),
+                cache_control: None,
+            }),
+        };
+
+        let generic: message::Message = provider_message.try_into().unwrap();
+        let message::Message::User { content } = &generic else {
+            panic!("expected generic user message");
+        };
+        let message::UserContent::Document(document) = content.first() else {
+            panic!("expected generic document");
+        };
+
+        assert_eq!(document.data, expected_data);
+        assert_eq!(document.media_type, expected_media_type);
+        let additional_params = document
+            .additional_params
+            .as_ref()
+            .expect("expected Anthropic document metadata");
+        assert_eq!(additional_params["title"], "Doc1");
+        assert_eq!(additional_params["context"], "ctx");
+        assert_eq!(additional_params["citations"]["enabled"], true);
+
+        generic
+    }
+
+    #[test]
+    fn anthropic_document_metadata_survives_reverse_conversion_for_all_sources() {
+        assert_reverse_document_metadata(
+            DocumentSource::Text {
+                data: "Hello world.".into(),
+                media_type: PlainTextMediaType::Plain,
+            },
+            DocumentSourceKind::String("Hello world.".into()),
+            Some(message::DocumentMediaType::TXT),
+        );
+        assert_reverse_document_metadata(
+            DocumentSource::Base64 {
+                data: "base64-pdf".into(),
+                media_type: DocumentFormat::PDF,
+            },
+            DocumentSourceKind::String("base64-pdf".into()),
+            Some(message::DocumentMediaType::PDF),
+        );
+        assert_reverse_document_metadata(
+            DocumentSource::Url {
+                url: "https://example.com/doc.pdf".into(),
+            },
+            DocumentSourceKind::Url("https://example.com/doc.pdf".into()),
+            None,
+        );
+        assert_reverse_document_metadata(
+            DocumentSource::File {
+                file_id: "file_abc".into(),
+            },
+            DocumentSourceKind::FileId("file_abc".into()),
+            None,
+        );
+    }
+
+    #[test]
+    fn anthropic_document_metadata_survives_reverse_round_trip() {
+        let provider_message = Message {
+            role: Role::User,
+            content: OneOrMany::one(Content::Document {
+                source: DocumentSource::Text {
+                    data: "Hello world.".into(),
+                    media_type: PlainTextMediaType::Plain,
+                },
+                title: Some("Doc1".into()),
+                context: Some("ctx".into()),
+                citations: Some(CitationsConfig { enabled: true }),
+                cache_control: None,
+            }),
+        };
+
+        let generic: message::Message = provider_message.try_into().unwrap();
+        let message::Message::User { content } = &generic else {
+            panic!("expected generic user message");
+        };
+        let message::UserContent::Document(document) = content.first() else {
+            panic!("expected generic document");
+        };
+        let additional_params = document
+            .additional_params
+            .as_ref()
+            .expect("expected Anthropic document metadata");
+        assert_eq!(additional_params["title"], "Doc1");
+        assert_eq!(additional_params["context"], "ctx");
+        assert_eq!(additional_params["citations"]["enabled"], true);
+
+        let round_trip: Message = generic.try_into().unwrap();
+        let Content::Document {
+            title,
+            context,
+            citations,
+            ..
+        } = round_trip.content.first()
+        else {
+            panic!("expected Anthropic document");
+        };
+        assert_eq!(title.as_deref(), Some("Doc1"));
+        assert_eq!(context.as_deref(), Some("ctx"));
+        assert_eq!(citations, Some(CitationsConfig { enabled: true }));
+    }
+
+    #[test]
+    fn anthropic_document_empty_metadata_stays_none_on_reverse_conversion() {
+        let provider_message = Message {
+            role: Role::User,
+            content: OneOrMany::one(Content::Document {
+                source: DocumentSource::Text {
+                    data: "Hello world.".into(),
+                    media_type: PlainTextMediaType::Plain,
+                },
+                title: None,
+                context: None,
+                citations: None,
+                cache_control: None,
+            }),
+        };
+
+        let generic: message::Message = provider_message.try_into().unwrap();
+        let message::Message::User { content } = &generic else {
+            panic!("expected generic user message");
+        };
+        let message::UserContent::Document(document) = content.first() else {
+            panic!("expected generic document");
+        };
+
+        assert_eq!(document.additional_params, None);
     }
 }

--- a/crates/rig-core/src/providers/anthropic/streaming.rs
+++ b/crates/rig-core/src/providers/anthropic/streaming.rs
@@ -62,10 +62,26 @@ pub struct MessageStart {
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ContentDelta {
-    TextDelta { text: String },
-    InputJsonDelta { partial_json: String },
-    ThinkingDelta { thinking: String },
-    SignatureDelta { signature: String },
+    TextDelta {
+        text: String,
+    },
+    InputJsonDelta {
+        partial_json: String,
+    },
+    ThinkingDelta {
+        thinking: String,
+    },
+    SignatureDelta {
+        signature: String,
+    },
+    CitationsDelta {
+        citation: super::completion::Citation,
+    },
+    /// Forward-compatibility fallback. Any delta type Anthropic adds in the
+    /// future that this crate does not yet model deserializes here so the
+    /// surrounding [`StreamingEvent`] still parses.
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Deserialize)]
@@ -434,6 +450,13 @@ fn handle_event(
                 // Don't yield signature chunks, they will be included in the final Reasoning
                 None
             }
+            // Citations are emitted by Anthropic when the request enabled them
+            // on a document block. They are not exposed as a streaming event in
+            // this consumer because the surrounding `RawStreamingChoice` API has
+            // no citation channel; the final, non-streaming response carries
+            // them on the assembled text block instead.
+            ContentDelta::CitationsDelta { .. } => None,
+            ContentDelta::Unknown => None,
         },
         StreamingEvent::ContentBlockStart { content_block, .. } => match content_block {
             Content::ToolUse { id, name, .. } => {
@@ -841,5 +864,50 @@ mod tests {
 
         // Tool call state should be taken
         assert!(tool_call_state.is_none());
+    }
+
+    #[test]
+    fn test_citations_delta_streaming_event_deserialization() {
+        let json = r#"{
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {
+                "type": "citations_delta",
+                "citation": {
+                    "type": "char_location",
+                    "cited_text": "The grass is green.",
+                    "document_index": 0,
+                    "document_title": "Example",
+                    "start_char_index": 0,
+                    "end_char_index": 20
+                }
+            }
+        }"#;
+
+        let event: StreamingEvent = serde_json::from_str(json).unwrap();
+        let StreamingEvent::ContentBlockDelta { index, delta } = event else {
+            panic!("expected ContentBlockDelta");
+        };
+        assert_eq!(index, 0);
+        let ContentDelta::CitationsDelta { citation } = delta else {
+            panic!("expected CitationsDelta");
+        };
+        let crate::providers::anthropic::completion::Citation::CharLocation {
+            start_char_index,
+            end_char_index,
+            ..
+        } = citation
+        else {
+            panic!("expected CharLocation");
+        };
+        assert_eq!(start_char_index, 0);
+        assert_eq!(end_char_index, 20);
+    }
+
+    #[test]
+    fn test_unknown_content_delta_falls_back() {
+        let json = r#"{"type": "something_new_from_anthropic", "field": "x"}"#;
+        let delta: ContentDelta = serde_json::from_str(json).unwrap();
+        matches!(delta, ContentDelta::Unknown);
     }
 }

--- a/crates/rig-core/src/providers/anthropic/streaming.rs
+++ b/crates/rig-core/src/providers/anthropic/streaming.rs
@@ -1030,6 +1030,39 @@ mod tests {
     }
 
     #[test]
+    fn test_web_search_result_citations_delta_allows_null_title() {
+        let json = r#"{
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {
+                "type": "citations_delta",
+                "citation": {
+                    "type": "web_search_result_location",
+                    "cited_text": "Claude Shannon was a mathematician.",
+                    "url": "https://example.com/shannon",
+                    "title": null,
+                    "encrypted_index": "encrypted-reference"
+                }
+            }
+        }"#;
+
+        let event: StreamingEvent = serde_json::from_str(json).unwrap();
+        let StreamingEvent::ContentBlockDelta { delta, .. } = event else {
+            panic!("expected ContentBlockDelta");
+        };
+        let ContentDelta::CitationsDelta { citation } = delta else {
+            panic!("expected CitationsDelta");
+        };
+        assert!(matches!(
+            citation,
+            crate::providers::anthropic::completion::Citation::WebSearchResultLocation {
+                title: None,
+                ..
+            }
+        ));
+    }
+
+    #[test]
     fn test_handle_citations_delta_event_preserves_metadata() {
         let event = StreamingEvent::ContentBlockDelta {
             index: 0,

--- a/crates/rig-core/src/providers/anthropic/streaming.rs
+++ b/crates/rig-core/src/providers/anthropic/streaming.rs
@@ -466,6 +466,13 @@ fn handle_event(
                 });
                 Some(Ok(RawStreamingChoice::TextStart { additional_params }))
             }
+            raw @ (Content::ServerToolUse { .. } | Content::WebSearchToolResult { .. }) => {
+                Some(Ok(RawStreamingChoice::TextStart {
+                    additional_params: Some(json!({
+                        super::completion::ANTHROPIC_RAW_CONTENT_KEY: raw
+                    })),
+                }))
+            }
             Content::ToolUse { id, name, .. } => {
                 let internal_call_id = nanoid::nanoid!();
                 *current_tool_call = Some(ToolCallState {
@@ -1059,6 +1066,201 @@ mod tests {
                 title: None,
                 ..
             }
+        ));
+    }
+
+    #[test]
+    fn test_web_search_content_block_start_events_deserialize() {
+        let server_tool_use = r#"{
+            "type": "content_block_start",
+            "index": 1,
+            "content_block": {
+                "type": "server_tool_use",
+                "id": "srvtoolu_01",
+                "name": "web_search",
+                "input": {
+                    "query": "claude shannon birth date"
+                }
+            }
+        }"#;
+        let event: StreamingEvent = serde_json::from_str(server_tool_use).unwrap();
+        assert!(matches!(
+            event,
+            StreamingEvent::ContentBlockStart {
+                content_block: Content::ServerToolUse {
+                    ref id,
+                    ref name,
+                    ref input
+                },
+                ..
+            } if id == "srvtoolu_01"
+                && name == "web_search"
+                && input["query"] == "claude shannon birth date"
+        ));
+
+        let web_search_tool_result = r#"{
+            "type": "content_block_start",
+            "index": 2,
+            "content_block": {
+                "type": "web_search_tool_result",
+                "tool_use_id": "srvtoolu_01",
+                "content": [{
+                    "type": "web_search_result",
+                    "url": "https://example.com/shannon",
+                    "title": "Claude Shannon",
+                    "encrypted_content": "encrypted-content"
+                }]
+            }
+        }"#;
+        let event: StreamingEvent = serde_json::from_str(web_search_tool_result).unwrap();
+        assert!(matches!(
+            event,
+            StreamingEvent::ContentBlockStart {
+                content_block: Content::WebSearchToolResult {
+                    ref tool_use_id,
+                    ref content
+                },
+                ..
+            } if tool_use_id == "srvtoolu_01"
+                && content[0]["encrypted_content"] == "encrypted-content"
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_streaming_web_search_blocks_are_preserved_on_final_choice() {
+        let raw_stream = stream! {
+            let mut tool_call_state = None;
+            let mut thinking_state = None;
+
+            yield handle_event(
+                &StreamingEvent::ContentBlockStart {
+                    index: 0,
+                    content_block: Content::ServerToolUse {
+                        id: "srvtoolu_01".to_string(),
+                        name: "web_search".to_string(),
+                        input: serde_json::json!({
+                            "query": "claude shannon birth date"
+                        }),
+                    },
+                },
+                &mut tool_call_state,
+                &mut thinking_state,
+            )
+            .expect("server_tool_use block should produce raw metadata");
+
+            yield handle_event(
+                &StreamingEvent::ContentBlockStart {
+                    index: 1,
+                    content_block: Content::WebSearchToolResult {
+                        tool_use_id: "srvtoolu_01".to_string(),
+                        content: serde_json::json!([{
+                            "type": "web_search_result",
+                            "url": "https://example.com/shannon",
+                            "title": "Claude Shannon",
+                            "encrypted_content": "encrypted-content"
+                        }]),
+                    },
+                },
+                &mut tool_call_state,
+                &mut thinking_state,
+            )
+            .expect("web_search_tool_result block should produce raw metadata");
+
+            yield handle_event(
+                &StreamingEvent::ContentBlockStart {
+                    index: 2,
+                    content_block: Content::Text {
+                        text: String::new(),
+                        citations: Vec::new(),
+                        cache_control: None,
+                    },
+                },
+                &mut tool_call_state,
+                &mut thinking_state,
+            )
+            .expect("text block start should produce a raw choice");
+
+            yield handle_event(
+                &StreamingEvent::ContentBlockDelta {
+                    index: 2,
+                    delta: ContentDelta::TextDelta {
+                        text: "Claude Shannon was born on April 30, 1916.".to_string(),
+                    },
+                },
+                &mut tool_call_state,
+                &mut thinking_state,
+            )
+            .expect("text delta should produce a raw choice");
+
+            yield handle_event(
+                &StreamingEvent::ContentBlockDelta {
+                    index: 2,
+                    delta: ContentDelta::CitationsDelta {
+                        citation: crate::providers::anthropic::completion::Citation::WebSearchResultLocation {
+                            cited_text: "Claude Shannon was born on April 30, 1916.".to_string(),
+                            url: "https://example.com/shannon".to_string(),
+                            title: Some("Claude Shannon".to_string()),
+                            encrypted_index: "encrypted-index".to_string(),
+                        },
+                    },
+                },
+                &mut tool_call_state,
+                &mut thinking_state,
+            )
+            .expect("citation delta should produce a raw choice");
+
+            yield Ok(RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
+                usage: PartialUsage::default(),
+            }));
+        };
+
+        let mut stream =
+            crate::streaming::StreamingCompletionResponse::stream(to_stream_result(raw_stream));
+        while stream.next().await.is_some() {}
+
+        let choice_items: Vec<crate::message::AssistantContent> =
+            stream.choice.clone().into_iter().collect();
+        assert_eq!(choice_items.len(), 3);
+        assert!(
+            choice_items
+                .iter()
+                .all(|item| !matches!(item, crate::message::AssistantContent::ToolCall(_))),
+            "provider-owned web-search blocks must not become Rig client tool calls"
+        );
+
+        let Some(crate::message::AssistantContent::Text(server_tool_use)) = choice_items.first()
+        else {
+            panic!("expected raw server_tool_use metadata");
+        };
+        assert_eq!(
+            server_tool_use.additional_params.as_ref().unwrap()
+                [crate::providers::anthropic::completion::ANTHROPIC_RAW_CONTENT_KEY]["type"],
+            "server_tool_use"
+        );
+
+        let Some(crate::message::AssistantContent::Text(web_search_result)) = choice_items.get(1)
+        else {
+            panic!("expected raw web_search_tool_result metadata");
+        };
+        assert_eq!(
+            web_search_result.additional_params.as_ref().unwrap()
+                [crate::providers::anthropic::completion::ANTHROPIC_RAW_CONTENT_KEY]["content"][0]
+                ["encrypted_content"],
+            "encrypted-content"
+        );
+
+        let Some(crate::message::AssistantContent::Text(answer)) = choice_items.get(2) else {
+            panic!("expected answer text");
+        };
+        assert_eq!(answer.text, "Claude Shannon was born on April 30, 1916.");
+        let citations = crate::providers::anthropic::completion::anthropic_citations(answer)
+            .expect("expected preserved citations");
+        assert!(matches!(
+            citations.first(),
+            Some(crate::providers::anthropic::completion::Citation::WebSearchResultLocation {
+                encrypted_index,
+                ..
+            }) if encrypted_index == "encrypted-index"
         ));
     }
 

--- a/crates/rig-core/src/providers/anthropic/streaming.rs
+++ b/crates/rig-core/src/providers/anthropic/streaming.rs
@@ -20,6 +20,7 @@ use crate::streaming::{
 };
 use crate::telemetry::SpanCombinator;
 use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
+use std::collections::HashMap;
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -122,6 +123,13 @@ struct ToolCallState {
     name: String,
     id: String,
     internal_call_id: String,
+    input_json: String,
+}
+
+struct ServerToolUseState {
+    name: String,
+    id: String,
+    initial_input: Value,
     input_json: String,
 }
 
@@ -311,6 +319,7 @@ where
         // Use our SSE decoder to directly handle Server-Sent Events format
         let stream: StreamingResult<StreamingCompletionResponse> = Box::pin(stream! {
             let mut current_tool_call: Option<ToolCallState> = None;
+            let mut server_tool_uses: HashMap<usize, ServerToolUseState> = HashMap::new();
             let mut current_thinking: Option<ThinkingState> = None;
             let mut sse_stream = Box::pin(stream);
             let mut input_tokens = 0;
@@ -354,7 +363,12 @@ where
                                     _ => {}
                                 }
 
-                                if let Some(result) = handle_event(&event, &mut current_tool_call, &mut current_thinking) {
+                                if let Some(result) = handle_event(
+                                    &event,
+                                    &mut current_tool_call,
+                                    &mut server_tool_uses,
+                                    &mut current_thinking,
+                                ) {
                                     if let Ok(RawStreamingChoice::Message(ref text)) = result {
                                         text_content += text;
                                     }
@@ -408,10 +422,11 @@ fn extract_tools_from_additional_params(
 fn handle_event(
     event: &StreamingEvent,
     current_tool_call: &mut Option<ToolCallState>,
+    server_tool_uses: &mut HashMap<usize, ServerToolUseState>,
     current_thinking: &mut Option<ThinkingState>,
 ) -> Option<Result<RawStreamingChoice<StreamingCompletionResponse>, CompletionError>> {
     match event {
-        StreamingEvent::ContentBlockDelta { delta, .. } => match delta {
+        StreamingEvent::ContentBlockDelta { index, delta } => match delta {
             ContentDelta::TextDelta { text } => {
                 if current_tool_call.is_none() {
                     return Some(Ok(RawStreamingChoice::Message(text.clone())));
@@ -419,6 +434,11 @@ fn handle_event(
                 None
             }
             ContentDelta::InputJsonDelta { partial_json } => {
+                if let Some(server_tool_use) = server_tool_uses.get_mut(index) {
+                    server_tool_use.input_json.push_str(partial_json);
+                    return None;
+                }
+
                 if let Some(tool_call) = current_tool_call {
                     tool_call.input_json.push_str(partial_json);
                     // Emit the delta so UI can show progress
@@ -457,7 +477,10 @@ fn handle_event(
             }
             ContentDelta::Unknown => None,
         },
-        StreamingEvent::ContentBlockStart { content_block, .. } => match content_block {
+        StreamingEvent::ContentBlockStart {
+            index,
+            content_block,
+        } => match content_block {
             Content::Text { citations, .. } => {
                 let additional_params = (!citations.is_empty()).then(|| {
                     json!({
@@ -466,13 +489,23 @@ fn handle_event(
                 });
                 Some(Ok(RawStreamingChoice::TextStart { additional_params }))
             }
-            raw @ (Content::ServerToolUse { .. } | Content::WebSearchToolResult { .. }) => {
-                Some(Ok(RawStreamingChoice::TextStart {
-                    additional_params: Some(json!({
-                        super::completion::ANTHROPIC_RAW_CONTENT_KEY: raw
-                    })),
-                }))
+            Content::ServerToolUse { id, name, input } => {
+                server_tool_uses.insert(
+                    *index,
+                    ServerToolUseState {
+                        name: name.clone(),
+                        id: id.clone(),
+                        initial_input: input.clone(),
+                        input_json: String::new(),
+                    },
+                );
+                None
             }
+            raw @ Content::WebSearchToolResult { .. } => Some(Ok(RawStreamingChoice::TextStart {
+                additional_params: Some(json!({
+                    super::completion::ANTHROPIC_RAW_CONTENT_KEY: raw
+                })),
+            })),
             Content::ToolUse { id, name, .. } => {
                 let internal_call_id = nanoid::nanoid!();
                 *current_tool_call = Some(ToolCallState {
@@ -498,7 +531,7 @@ fn handle_event(
             // Handle other content types - they don't need special handling
             _ => None,
         },
-        StreamingEvent::ContentBlockStop { .. } => {
+        StreamingEvent::ContentBlockStop { index } => {
             if let Some(thinking_state) = Option::take(current_thinking)
                 && !thinking_state.thinking.is_empty()
             {
@@ -514,6 +547,31 @@ fn handle_event(
                         text: thinking_state.thinking,
                         signature,
                     },
+                }));
+            }
+
+            if let Some(server_tool_use) = server_tool_uses.remove(index) {
+                let input = if server_tool_use.input_json.is_empty() {
+                    if server_tool_use.initial_input.is_null() {
+                        json!({})
+                    } else {
+                        server_tool_use.initial_input
+                    }
+                } else {
+                    match serde_json::from_str(&server_tool_use.input_json) {
+                        Ok(json_value) => json_value,
+                        Err(e) => return Some(Err(CompletionError::from(e))),
+                    }
+                };
+
+                return Some(Ok(RawStreamingChoice::TextStart {
+                    additional_params: Some(json!({
+                        super::completion::ANTHROPIC_RAW_CONTENT_KEY: Content::ServerToolUse {
+                            id: server_tool_use.id,
+                            name: server_tool_use.name,
+                            input,
+                        }
+                    })),
                 }));
             }
 
@@ -568,6 +626,20 @@ mod tests {
         > + 'static,
     ) -> crate::streaming::StreamingResult<StreamingCompletionResponse> {
         Box::pin(stream)
+    }
+
+    fn handle_event(
+        event: &StreamingEvent,
+        current_tool_call: &mut Option<ToolCallState>,
+        current_thinking: &mut Option<ThinkingState>,
+    ) -> Option<Result<RawStreamingChoice<StreamingCompletionResponse>, CompletionError>> {
+        let mut server_tool_uses = HashMap::new();
+        super::handle_event(
+            event,
+            current_tool_call,
+            &mut server_tool_uses,
+            current_thinking,
+        )
     }
 
     #[test]
@@ -1130,25 +1202,52 @@ mod tests {
     async fn test_streaming_web_search_blocks_are_preserved_on_final_choice() {
         let raw_stream = stream! {
             let mut tool_call_state = None;
+            let mut server_tool_uses = HashMap::new();
             let mut thinking_state = None;
 
-            yield handle_event(
+            let server_tool_use_start = super::handle_event(
                 &StreamingEvent::ContentBlockStart {
                     index: 0,
                     content_block: Content::ServerToolUse {
                         id: "srvtoolu_01".to_string(),
                         name: "web_search".to_string(),
-                        input: serde_json::json!({
-                            "query": "claude shannon birth date"
-                        }),
+                        input: serde_json::Value::Null,
                     },
                 },
                 &mut tool_call_state,
+                &mut server_tool_uses,
+                &mut thinking_state,
+            );
+            assert!(
+                server_tool_use_start.is_none(),
+                "server_tool_use start should be accumulated until its input JSON is complete"
+            );
+
+            let server_tool_use_delta = super::handle_event(
+                &StreamingEvent::ContentBlockDelta {
+                    index: 0,
+                    delta: ContentDelta::InputJsonDelta {
+                        partial_json: r#"{"query":"claude shannon birth date"}"#.to_string(),
+                    },
+                },
+                &mut tool_call_state,
+                &mut server_tool_uses,
+                &mut thinking_state,
+            );
+            assert!(
+                server_tool_use_delta.is_none(),
+                "server_tool_use input JSON should not be emitted as a Rig tool-call delta"
+            );
+
+            yield super::handle_event(
+                &StreamingEvent::ContentBlockStop { index: 0 },
+                &mut tool_call_state,
+                &mut server_tool_uses,
                 &mut thinking_state,
             )
-            .expect("server_tool_use block should produce raw metadata");
+            .expect("server_tool_use stop should produce completed raw metadata");
 
-            yield handle_event(
+            yield super::handle_event(
                 &StreamingEvent::ContentBlockStart {
                     index: 1,
                     content_block: Content::WebSearchToolResult {
@@ -1162,11 +1261,12 @@ mod tests {
                     },
                 },
                 &mut tool_call_state,
+                &mut server_tool_uses,
                 &mut thinking_state,
             )
             .expect("web_search_tool_result block should produce raw metadata");
 
-            yield handle_event(
+            yield super::handle_event(
                 &StreamingEvent::ContentBlockStart {
                     index: 2,
                     content_block: Content::Text {
@@ -1176,11 +1276,12 @@ mod tests {
                     },
                 },
                 &mut tool_call_state,
+                &mut server_tool_uses,
                 &mut thinking_state,
             )
             .expect("text block start should produce a raw choice");
 
-            yield handle_event(
+            yield super::handle_event(
                 &StreamingEvent::ContentBlockDelta {
                     index: 2,
                     delta: ContentDelta::TextDelta {
@@ -1188,11 +1289,12 @@ mod tests {
                     },
                 },
                 &mut tool_call_state,
+                &mut server_tool_uses,
                 &mut thinking_state,
             )
             .expect("text delta should produce a raw choice");
 
-            yield handle_event(
+            yield super::handle_event(
                 &StreamingEvent::ContentBlockDelta {
                     index: 2,
                     delta: ContentDelta::CitationsDelta {
@@ -1205,6 +1307,7 @@ mod tests {
                     },
                 },
                 &mut tool_call_state,
+                &mut server_tool_uses,
                 &mut thinking_state,
             )
             .expect("citation delta should produce a raw choice");
@@ -1236,6 +1339,11 @@ mod tests {
             server_tool_use.additional_params.as_ref().unwrap()
                 [crate::providers::anthropic::completion::ANTHROPIC_RAW_CONTENT_KEY]["type"],
             "server_tool_use"
+        );
+        assert_eq!(
+            server_tool_use.additional_params.as_ref().unwrap()
+                [crate::providers::anthropic::completion::ANTHROPIC_RAW_CONTENT_KEY]["input"]["query"],
+            "claude shannon birth date"
         );
 
         let Some(crate::message::AssistantContent::Text(web_search_result)) = choice_items.get(1)

--- a/crates/rig-core/src/providers/anthropic/streaming.rs
+++ b/crates/rig-core/src/providers/anthropic/streaming.rs
@@ -450,15 +450,22 @@ fn handle_event(
                 // Don't yield signature chunks, they will be included in the final Reasoning
                 None
             }
-            // Citations are emitted by Anthropic when the request enabled them
-            // on a document block. They are not exposed as a streaming event in
-            // this consumer because the surrounding `RawStreamingChoice` API has
-            // no citation channel; the final, non-streaming response carries
-            // them on the assembled text block instead.
-            ContentDelta::CitationsDelta { .. } => None,
+            ContentDelta::CitationsDelta { citation } => {
+                Some(Ok(RawStreamingChoice::TextAdditionalParams(json!({
+                    "citations": [citation]
+                }))))
+            }
             ContentDelta::Unknown => None,
         },
         StreamingEvent::ContentBlockStart { content_block, .. } => match content_block {
+            Content::Text { citations, .. } => {
+                let additional_params = (!citations.is_empty()).then(|| {
+                    json!({
+                        "citations": citations
+                    })
+                });
+                Some(Ok(RawStreamingChoice::TextStart { additional_params }))
+            }
             Content::ToolUse { id, name, .. } => {
                 let internal_call_id = nanoid::nanoid!();
                 *current_tool_call = Some(ToolCallState {
@@ -534,6 +541,27 @@ fn handle_event(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_stream::stream;
+    use futures::StreamExt;
+
+    #[cfg(not(all(feature = "wasm", target_arch = "wasm32")))]
+    fn to_stream_result(
+        stream: impl futures::Stream<
+            Item = Result<RawStreamingChoice<StreamingCompletionResponse>, CompletionError>,
+        > + Send
+        + 'static,
+    ) -> crate::streaming::StreamingResult<StreamingCompletionResponse> {
+        Box::pin(stream)
+    }
+
+    #[cfg(all(feature = "wasm", target_arch = "wasm32"))]
+    fn to_stream_result(
+        stream: impl futures::Stream<
+            Item = Result<RawStreamingChoice<StreamingCompletionResponse>, CompletionError>,
+        > + 'static,
+    ) -> crate::streaming::StreamingResult<StreamingCompletionResponse> {
+        Box::pin(stream)
+    }
 
     #[test]
     fn test_thinking_delta_deserialization() {
@@ -711,6 +739,31 @@ mod tests {
             }
             _ => panic!("Expected Message choice"),
         }
+    }
+
+    #[test]
+    fn test_handle_text_block_start_event() {
+        let event = StreamingEvent::ContentBlockStart {
+            index: 0,
+            content_block: Content::Text {
+                text: String::new(),
+                citations: Vec::new(),
+                cache_control: None,
+            },
+        };
+
+        let mut tool_call_state = None;
+        let mut thinking_state = None;
+        let result = handle_event(&event, &mut tool_call_state, &mut thinking_state);
+
+        assert!(result.is_some());
+        let choice = result.unwrap().unwrap();
+        assert!(matches!(
+            choice,
+            RawStreamingChoice::TextStart {
+                additional_params: None
+            }
+        ));
     }
 
     #[test]
@@ -905,9 +958,186 @@ mod tests {
     }
 
     #[test]
+    fn test_search_result_citations_delta_streaming_event_deserialization() {
+        let json = r#"{
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {
+                "type": "citations_delta",
+                "citation": {
+                    "type": "search_result_location",
+                    "cited_text": "API requests require a key.",
+                    "source": "https://docs.example.com/api-reference",
+                    "title": "API Reference",
+                    "search_result_index": 0,
+                    "start_block_index": 0,
+                    "end_block_index": 1
+                }
+            }
+        }"#;
+
+        let event: StreamingEvent = serde_json::from_str(json).unwrap();
+        let StreamingEvent::ContentBlockDelta { delta, .. } = event else {
+            panic!("expected ContentBlockDelta");
+        };
+        let ContentDelta::CitationsDelta { citation } = delta else {
+            panic!("expected CitationsDelta");
+        };
+        assert!(matches!(
+            citation,
+            crate::providers::anthropic::completion::Citation::SearchResultLocation {
+                search_result_index: 0,
+                start_block_index: 0,
+                end_block_index: 1,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_web_search_result_citations_delta_streaming_event_deserialization() {
+        let json = r#"{
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {
+                "type": "citations_delta",
+                "citation": {
+                    "type": "web_search_result_location",
+                    "cited_text": "Claude Shannon was a mathematician.",
+                    "url": "https://example.com/shannon",
+                    "title": "Claude Shannon",
+                    "encrypted_index": "encrypted-reference"
+                }
+            }
+        }"#;
+
+        let event: StreamingEvent = serde_json::from_str(json).unwrap();
+        let StreamingEvent::ContentBlockDelta { delta, .. } = event else {
+            panic!("expected ContentBlockDelta");
+        };
+        let ContentDelta::CitationsDelta { citation } = delta else {
+            panic!("expected CitationsDelta");
+        };
+        assert!(matches!(
+            citation,
+            crate::providers::anthropic::completion::Citation::WebSearchResultLocation {
+                ref url,
+                ref encrypted_index,
+                ..
+            } if url == "https://example.com/shannon"
+                && encrypted_index == "encrypted-reference"
+        ));
+    }
+
+    #[test]
+    fn test_handle_citations_delta_event_preserves_metadata() {
+        let event = StreamingEvent::ContentBlockDelta {
+            index: 0,
+            delta: ContentDelta::CitationsDelta {
+                citation: crate::providers::anthropic::completion::Citation::CharLocation {
+                    cited_text: "The grass is green.".to_string(),
+                    document_index: 0,
+                    document_title: Some("Example".to_string()),
+                    start_char_index: 0,
+                    end_char_index: 20,
+                },
+            },
+        };
+
+        let mut tool_call_state = None;
+        let mut thinking_state = None;
+        let result = handle_event(&event, &mut tool_call_state, &mut thinking_state);
+
+        assert!(result.is_some());
+        let choice = result.unwrap().unwrap();
+        let RawStreamingChoice::TextAdditionalParams(additional_params) = choice else {
+            panic!("expected TextAdditionalParams choice");
+        };
+        assert_eq!(additional_params["citations"][0]["type"], "char_location");
+    }
+
+    #[tokio::test]
+    async fn test_streaming_citation_deltas_are_preserved_on_final_text() {
+        let citation = crate::providers::anthropic::completion::Citation::CharLocation {
+            cited_text: "The grass is green.".to_string(),
+            document_index: 0,
+            document_title: Some("Example".to_string()),
+            start_char_index: 0,
+            end_char_index: 20,
+        };
+
+        let raw_stream = stream! {
+            let mut tool_call_state = None;
+            let mut thinking_state = None;
+
+            yield handle_event(
+                &StreamingEvent::ContentBlockStart {
+                    index: 0,
+                    content_block: Content::Text {
+                        text: String::new(),
+                        citations: Vec::new(),
+                        cache_control: None,
+                    },
+                },
+                &mut tool_call_state,
+                &mut thinking_state,
+            )
+            .expect("text block start should produce a raw choice");
+
+            yield handle_event(
+                &StreamingEvent::ContentBlockDelta {
+                    index: 0,
+                    delta: ContentDelta::TextDelta {
+                        text: "the grass is green".to_string(),
+                    },
+                },
+                &mut tool_call_state,
+                &mut thinking_state,
+            )
+            .expect("text delta should produce a raw choice");
+
+            yield handle_event(
+                &StreamingEvent::ContentBlockDelta {
+                    index: 0,
+                    delta: ContentDelta::CitationsDelta {
+                        citation: crate::providers::anthropic::completion::Citation::CharLocation {
+                            cited_text: "The grass is green.".to_string(),
+                            document_index: 0,
+                            document_title: Some("Example".to_string()),
+                            start_char_index: 0,
+                            end_char_index: 20,
+                        },
+                    },
+                },
+                &mut tool_call_state,
+                &mut thinking_state,
+            )
+            .expect("citation delta should produce a raw choice");
+
+            yield Ok(RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
+                usage: PartialUsage::default(),
+            }));
+        };
+
+        let mut stream =
+            crate::streaming::StreamingCompletionResponse::stream(to_stream_result(raw_stream));
+        while stream.next().await.is_some() {}
+
+        let choice_items: Vec<crate::message::AssistantContent> =
+            stream.choice.clone().into_iter().collect();
+        let Some(crate::message::AssistantContent::Text(text)) = choice_items.first() else {
+            panic!("expected accumulated text item");
+        };
+
+        assert_eq!(text.text, "the grass is green");
+        let citations = crate::providers::anthropic::completion::anthropic_citations(text).unwrap();
+        assert_eq!(citations, vec![citation]);
+    }
+
+    #[test]
     fn test_unknown_content_delta_falls_back() {
         let json = r#"{"type": "something_new_from_anthropic", "field": "x"}"#;
         let delta: ContentDelta = serde_json::from_str(json).unwrap();
-        matches!(delta, ContentDelta::Unknown);
+        assert!(matches!(delta, ContentDelta::Unknown));
     }
 }

--- a/crates/rig-core/src/providers/cohere/completion.rs
+++ b/crates/rig-core/src/providers/cohere/completion.rs
@@ -377,7 +377,7 @@ impl TryFrom<message::Message> for Vec<Message> {
             message::Message::User { content } => content
                 .into_iter()
                 .map(|content| match content {
-                    message::UserContent::Text(message::Text { text }) => Ok(Message::User {
+                    message::UserContent::Text(message::Text { text, .. }) => Ok(Message::User {
                         content: OneOrMany::one(UserContent::Text { text }),
                     }),
                     message::UserContent::ToolResult(message::ToolResult {
@@ -407,7 +407,7 @@ impl TryFrom<message::Message> for Vec<Message> {
 
                 for content in content.into_iter() {
                     match content {
-                        message::AssistantContent::Text(message::Text { text }) => {
+                        message::AssistantContent::Text(message::Text { text, .. }) => {
                             text_content.push(AssistantContent::Text { text });
                         }
                         message::AssistantContent::ToolCall(message::ToolCall {
@@ -458,7 +458,7 @@ impl TryFrom<Message> for message::Message {
             Message::User { content } => Ok(message::Message::User {
                 content: content.map(|content| match content {
                     UserContent::Text { text } => {
-                        message::UserContent::Text(message::Text { text })
+                        message::UserContent::Text(message::Text::new(text))
                     }
                     UserContent::ImageUrl { image_url } => {
                         message::UserContent::image_url(image_url.url, None, None)
@@ -797,9 +797,7 @@ mod tests {
     fn test_convert_completion_message_to_message_and_back() {
         let completion_message = completion::Message::User {
             content: OneOrMany::one(completion::message::UserContent::Text(
-                completion::message::Text {
-                    text: "Hello, world!".to_string(),
-                },
+                completion::message::Text::new("Hello, world!".to_string()),
             )),
         };
 

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -804,7 +804,7 @@ pub mod gemini_api_types {
 
         fn try_from(content: message::UserContent) -> Result<Self, Self::Error> {
             match content {
-                message::UserContent::Text(message::Text { text }) => Ok(Part {
+                message::UserContent::Text(message::Text { text, .. }) => Ok(Part {
                     thought: Some(false),
                     thought_signature: None,
                     part: PartKind::Text(text),
@@ -1150,7 +1150,7 @@ pub mod gemini_api_types {
 
         fn try_from(content: message::AssistantContent) -> Result<Self, Self::Error> {
             match content {
-                message::AssistantContent::Text(message::Text { text }) => Ok(text.into()),
+                message::AssistantContent::Text(message::Text { text, .. }) => Ok(text.into()),
                 message::AssistantContent::Image(message::Image {
                     data, media_type, ..
                 }) => match media_type {
@@ -2646,9 +2646,7 @@ mod tests {
             id: "test_tool".to_string(),
             call_id: None,
             content: OneOrMany::many(vec![
-                ToolResultContent::Text(message::Text {
-                    text: r#"{"status": "success"}"#.to_string(),
-                }),
+                ToolResultContent::Text(message::Text::new(r#"{"status": "success"}"#.to_string())),
                 ToolResultContent::Image(Image {
                     data: DocumentSourceKind::Base64("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==".to_string()),
                     media_type: Some(ImageMediaType::PNG),

--- a/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
@@ -1752,10 +1752,12 @@ pub mod interactions_api_types {
 
         fn try_from(content: message::UserContent) -> Result<Self, Self::Error> {
             match content {
-                message::UserContent::Text(message::Text { text }) => Ok(Self::Text(TextContent {
-                    text,
-                    annotations: None,
-                })),
+                message::UserContent::Text(message::Text { text, .. }) => {
+                    Ok(Self::Text(TextContent {
+                        text,
+                        annotations: None,
+                    }))
+                }
                 message::UserContent::ToolResult(message::ToolResult {
                     id,
                     call_id,
@@ -1862,7 +1864,7 @@ pub mod interactions_api_types {
 
         fn try_from(content: message::AssistantContent) -> Result<Self, Self::Error> {
             match content {
-                message::AssistantContent::Text(message::Text { text }) => {
+                message::AssistantContent::Text(message::Text { text, .. }) => {
                     Ok(Self::Text(TextContent {
                         text,
                         annotations: None,

--- a/crates/rig-core/src/providers/huggingface/completion.rs
+++ b/crates/rig-core/src/providers/huggingface/completion.rs
@@ -181,7 +181,7 @@ impl FromStr for SystemContent {
 impl From<UserContent> for message::UserContent {
     fn from(value: UserContent) -> Self {
         match value {
-            UserContent::Text { text } => message::UserContent::text(text),
+            UserContent::Text { text, .. } => message::UserContent::text(text),
             UserContent::ImageUrl { image_url } => {
                 message::UserContent::image_url(image_url.url, None, None)
             }
@@ -299,9 +299,10 @@ impl TryFrom<message::Message> for Vec<Message> {
                                 name: id,
                                 arguments: None,
                                 content: content.try_map(|content| match content {
-                                    message::ToolResultContent::Text(message::Text { text }) => {
-                                        Ok(text)
-                                    }
+                                    message::ToolResultContent::Text(message::Text {
+                                        text,
+                                        ..
+                                    }) => Ok(text),
                                     _ => Err(message::MessageError::ConversionError(
                                         "Tool result content does not support non-text".into(),
                                     )),
@@ -408,7 +409,9 @@ impl TryFrom<Message> for message::Message {
                 let mut content = content
                     .into_iter()
                     .map(|content| match content {
-                        AssistantContent::Text { text } => message::AssistantContent::text(text),
+                        AssistantContent::Text { text, .. } => {
+                            message::AssistantContent::text(text)
+                        }
                     })
                     .collect::<Vec<_>>();
 
@@ -441,7 +444,7 @@ impl TryFrom<Message> for message::Message {
             // stop gap to avoid obnoxious error handling or panic occurring.
             Message::System { content, .. } => message::Message::User {
                 content: content.map(|c| match c {
-                    SystemContent::Text { text } => message::UserContent::text(text),
+                    SystemContent::Text { text, .. } => message::UserContent::text(text),
                 }),
             },
         })
@@ -514,7 +517,7 @@ impl crate::telemetry::ProviderResponseExt for CompletionResponse {
                 let text = content
                     .iter()
                     .filter_map(|x| {
-                        if let UserContent::Text { text } = x {
+                        if let UserContent::Text { text, .. } = x {
                             Some(text.clone())
                         } else {
                             None
@@ -570,7 +573,9 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                 let mut content = content
                     .iter()
                     .map(|c| match c {
-                        AssistantContent::Text { text } => message::AssistantContent::text(text),
+                        AssistantContent::Text { text, .. } => {
+                            message::AssistantContent::text(text)
+                        }
                     })
                     .collect::<Vec<_>>();
 

--- a/crates/rig-core/src/providers/llamafile.rs
+++ b/crates/rig-core/src/providers/llamafile.rs
@@ -765,9 +765,7 @@ mod tests {
             model: None,
             preamble: Some("You are a helpful assistant.".to_string()),
             chat_history: OneOrMany::one(CompletionMessage::User {
-                content: OneOrMany::one(UserContent::Text(Text {
-                    text: "Hello!".to_string(),
-                })),
+                content: OneOrMany::one(UserContent::Text(Text::new("Hello!".to_string()))),
             }),
             documents: vec![],
             tools: vec![],
@@ -802,9 +800,9 @@ mod tests {
             model: None,
             preamble: None,
             chat_history: OneOrMany::one(CompletionMessage::User {
-                content: OneOrMany::one(UserContent::Text(Text {
-                    text: "What does glarb-glarb mean?".to_string(),
-                })),
+                content: OneOrMany::one(UserContent::Text(Text::new(
+                    "What does glarb-glarb mean?".to_string(),
+                ))),
             }),
             documents: vec![
                 Document {

--- a/crates/rig-core/src/providers/mira.rs
+++ b/crates/rig-core/src/providers/mira.rs
@@ -113,13 +113,11 @@ impl TryFrom<RawMessage> for message::Message {
                 content: raw.content,
             }),
             "user" => Ok(message::Message::User {
-                content: OneOrMany::one(UserContent::Text(message::Text { text: raw.content })),
+                content: OneOrMany::one(UserContent::Text(message::Text::new(raw.content))),
             }),
             "assistant" => Ok(message::Message::Assistant {
                 id: None,
-                content: OneOrMany::one(AssistantContent::Text(message::Text {
-                    text: raw.content,
-                })),
+                content: OneOrMany::one(AssistantContent::Text(message::Text::new(raw.content))),
             }),
             _ => Err(CompletionError::ResponseError(format!(
                 "Unsupported message role: {}",
@@ -689,11 +687,11 @@ impl TryFrom<serde_json::Value> for Message {
         match role {
             "system" => Ok(Message::System { content }),
             "user" => Ok(Message::User {
-                content: OneOrMany::one(UserContent::Text(message::Text { text: content })),
+                content: OneOrMany::one(UserContent::Text(message::Text::new(content))),
             }),
             "assistant" => Ok(Message::Assistant {
                 id: None,
-                content: OneOrMany::one(AssistantContent::Text(message::Text { text: content })),
+                content: OneOrMany::one(AssistantContent::Text(message::Text::new(content))),
             }),
             _ => Err(CompletionError::ResponseError(format!(
                 "Unsupported message role: {role}"
@@ -739,9 +737,9 @@ mod tests {
             Message::Assistant { content, .. } => {
                 assert_eq!(
                     content.first(),
-                    AssistantContent::Text(message::Text {
-                        text: "Hello there, how may I assist you today?".to_string()
-                    })
+                    AssistantContent::Text(message::Text::new(
+                        "Hello there, how may I assist you today?".to_string()
+                    ))
                 );
             }
             _ => panic!("Expected assistant message"),
@@ -751,9 +749,7 @@ mod tests {
             Message::User { content } => {
                 assert_eq!(
                     content.first(),
-                    UserContent::Text(message::Text {
-                        text: "What can you help me with?".to_string()
-                    })
+                    UserContent::Text(message::Text::new("What can you help me with?".to_string()))
                 );
             }
             _ => panic!("Expected user message"),
@@ -764,9 +760,9 @@ mod tests {
             Message::Assistant { content, .. } => {
                 assert_eq!(
                     content.first(),
-                    AssistantContent::Text(message::Text {
-                        text: "Hello there, how may I assist you today?".to_string()
-                    })
+                    AssistantContent::Text(message::Text::new(
+                        "Hello there, how may I assist you today?".to_string()
+                    ))
                 );
             }
             _ => panic!("Expected assistant message"),

--- a/crates/rig-core/src/providers/mistral/completion.rs
+++ b/crates/rig-core/src/providers/mistral/completion.rs
@@ -140,7 +140,7 @@ impl TryFrom<message::Message> for Vec<Message> {
                                 tool_call_id: call_id_key,
                             });
                         }
-                        message::UserContent::Text(message::Text { text }) => {
+                        message::UserContent::Text(message::Text { text, .. }) => {
                             other_messages.push(Message::User { content: text });
                         }
                         _ => {}

--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -1013,6 +1013,7 @@ impl TryFrom<crate::message::Message> for Vec<Message> {
                             match content {
                                 crate::message::UserContent::Text(crate::message::Text {
                                     text,
+                                    ..
                                 }) => texts.push(text),
                                 crate::message::UserContent::Image(crate::message::Image {
                                     data: DocumentSourceKind::Base64(data),
@@ -1098,9 +1099,9 @@ impl From<Message> for crate::completion::Message {
     fn from(msg: Message) -> Self {
         match msg {
             Message::User { content, .. } => crate::completion::Message::User {
-                content: OneOrMany::one(crate::completion::message::UserContent::Text(Text {
-                    text: content,
-                })),
+                content: OneOrMany::one(crate::completion::message::UserContent::Text(Text::new(
+                    content,
+                ))),
             },
             Message::Assistant {
                 content,
@@ -1108,9 +1109,9 @@ impl From<Message> for crate::completion::Message {
                 ..
             } => {
                 let mut assistant_contents =
-                    vec![crate::completion::message::AssistantContent::Text(Text {
-                        text: content,
-                    })];
+                    vec![crate::completion::message::AssistantContent::Text(
+                        Text::new(content),
+                    )];
                 for tc in tool_calls {
                     assistant_contents.push(
                         crate::completion::message::AssistantContent::tool_call(
@@ -1122,18 +1123,18 @@ impl From<Message> for crate::completion::Message {
                 }
                 let content =
                     OneOrMany::from_iter_optional(assistant_contents).unwrap_or_else(|| {
-                        OneOrMany::one(crate::completion::message::AssistantContent::Text(Text {
-                            text: String::new(),
-                        }))
+                        OneOrMany::one(crate::completion::message::AssistantContent::Text(
+                            Text::new(String::new()),
+                        ))
                     });
 
                 crate::completion::Message::Assistant { id: None, content }
             }
             // System and ToolResult are converted to User message as needed.
             Message::System { content, .. } => crate::completion::Message::User {
-                content: OneOrMany::one(crate::completion::message::UserContent::Text(Text {
-                    text: content,
-                })),
+                content: OneOrMany::one(crate::completion::message::UserContent::Text(Text::new(
+                    content,
+                ))),
             },
             Message::ToolResult { name, content } => crate::completion::Message::User {
                 content: OneOrMany::one(message::UserContent::tool_result(
@@ -1469,9 +1470,9 @@ mod tests {
             id: None,
             content: crate::OneOrMany::many(vec![
                 crate::message::AssistantContent::Reasoning(reasoning_content),
-                crate::message::AssistantContent::Text(crate::message::Text {
-                    text: "The answer is X".to_string(),
-                }),
+                crate::message::AssistantContent::Text(crate::message::Text::new(
+                    "The answer is X".to_string(),
+                )),
             ])
             .unwrap(),
         };
@@ -1594,9 +1595,7 @@ mod tests {
             model: None,
             preamble: Some("You are a helpful assistant.".to_string()),
             chat_history: OneOrMany::one(CompletionMessage::User {
-                content: OneOrMany::one(UserContent::Text(Text {
-                    text: "What is 2 + 2?".to_string(),
-                })),
+                content: OneOrMany::one(UserContent::Text(Text::new("What is 2 + 2?".to_string()))),
             }),
             documents: vec![],
             tools: vec![],
@@ -1662,9 +1661,7 @@ mod tests {
             model: None,
             preamble: Some("You are a helpful assistant.".to_string()),
             chat_history: OneOrMany::one(CompletionMessage::User {
-                content: OneOrMany::one(UserContent::Text(Text {
-                    text: "What is 2 + 2?".to_string(),
-                })),
+                content: OneOrMany::one(UserContent::Text(Text::new("What is 2 + 2?".to_string()))),
             }),
             documents: vec![],
             tools: vec![],
@@ -1730,9 +1727,7 @@ mod tests {
             model: None,
             preamble: Some("You are a helpful assistant.".to_string()),
             chat_history: OneOrMany::one(CompletionMessage::User {
-                content: OneOrMany::one(UserContent::Text(Text {
-                    text: "What is 2 + 2?".to_string(),
-                })),
+                content: OneOrMany::one(UserContent::Text(Text::new("What is 2 + 2?".to_string()))),
             }),
             documents: vec![],
             tools: vec![],
@@ -1798,9 +1793,7 @@ mod tests {
             model: None,
             preamble: Some("You are a helpful assistant.".to_string()),
             chat_history: OneOrMany::one(CompletionMessage::User {
-                content: OneOrMany::one(UserContent::Text(Text {
-                    text: "What is 2 + 2?".to_string(),
-                })),
+                content: OneOrMany::one(UserContent::Text(Text::new("What is 2 + 2?".to_string()))),
             }),
             documents: vec![],
             tools: vec![],
@@ -1866,9 +1859,7 @@ mod tests {
             model: None,
             preamble: Some("You are a helpful assistant.".to_string()),
             chat_history: OneOrMany::one(CompletionMessage::User {
-                content: OneOrMany::one(UserContent::Text(Text {
-                    text: "What is 2 + 2?".to_string(),
-                })),
+                content: OneOrMany::one(UserContent::Text(Text::new("What is 2 + 2?".to_string()))),
             }),
             documents: vec![],
             tools: vec![],
@@ -1901,9 +1892,7 @@ mod tests {
             model: None,
             preamble: Some("You are a helpful assistant.".to_string()),
             chat_history: OneOrMany::one(CompletionMessage::User {
-                content: OneOrMany::one(UserContent::Text(Text {
-                    text: "Hello!".to_string(),
-                })),
+                content: OneOrMany::one(UserContent::Text(Text::new("Hello!".to_string()))),
             }),
             documents: vec![],
             tools: vec![],
@@ -1966,9 +1955,9 @@ mod tests {
             model: Some("llama3.1".to_string()),
             preamble: None,
             chat_history: OneOrMany::one(CompletionMessage::User {
-                content: OneOrMany::one(UserContent::Text(Text {
-                    text: "How old is Ollama?".to_string(),
-                })),
+                content: OneOrMany::one(UserContent::Text(Text::new(
+                    "How old is Ollama?".to_string(),
+                ))),
             }),
             documents: vec![],
             tools: vec![],
@@ -2011,9 +2000,7 @@ mod tests {
             model: Some("llama3.1".to_string()),
             preamble: None,
             chat_history: OneOrMany::one(CompletionMessage::User {
-                content: OneOrMany::one(UserContent::Text(Text {
-                    text: "Hello!".to_string(),
-                })),
+                content: OneOrMany::one(UserContent::Text(Text::new("Hello!".to_string()))),
             }),
             documents: vec![],
             tools: vec![],

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -34,7 +34,7 @@ where
     S: Serializer,
 {
     if content.len() == 1
-        && let UserContent::Text { text } = content.first_ref()
+        && let UserContent::Text { text, .. } = content.first_ref()
     {
         return serializer.serialize_str(text);
     }
@@ -227,7 +227,7 @@ pub enum AssistantContent {
 impl From<AssistantContent> for completion::AssistantContent {
     fn from(value: AssistantContent) -> Self {
         match value {
-            AssistantContent::Text { text } => completion::AssistantContent::text(text),
+            AssistantContent::Text { text, .. } => completion::AssistantContent::text(text),
             AssistantContent::Refusal { refusal } => completion::AssistantContent::text(refusal),
         }
     }
@@ -457,7 +457,7 @@ impl TryFrom<message::ToolResult> for Message {
             .into_iter()
             .map(|content| {
                 match content {
-                message::ToolResultContent::Text(message::Text { text }) => Ok(text),
+                message::ToolResultContent::Text(message::Text { text, .. }) => Ok(text),
                 message::ToolResultContent::Image(_) => Err(message::MessageError::ConversionError(
                     "OpenAI does not support images in tool results. Tool results must be text."
                         .into(),
@@ -479,7 +479,7 @@ impl TryFrom<message::UserContent> for UserContent {
 
     fn try_from(value: message::UserContent) -> Result<Self, Self::Error> {
         match value {
-            message::UserContent::Text(message::Text { text }) => Ok(UserContent::Text { text }),
+            message::UserContent::Text(message::Text { text, .. }) => Ok(UserContent::Text { text }),
             message::UserContent::Image(message::Image {
                 data,
                 detail,
@@ -759,7 +759,7 @@ impl TryFrom<Message> for message::Message {
                 }
 
                 assistant_content.extend(content.into_iter().map(|content| match content {
-                    AssistantContent::Text { text } => message::AssistantContent::text(text),
+                    AssistantContent::Text { text, .. } => message::AssistantContent::text(text),
                     AssistantContent::Refusal { refusal } => {
                         message::AssistantContent::text(refusal)
                     }
@@ -805,7 +805,7 @@ impl TryFrom<Message> for message::Message {
 impl From<UserContent> for message::UserContent {
     fn from(content: UserContent) -> Self {
         match content {
-            UserContent::Text { text } => message::UserContent::text(text),
+            UserContent::Text { text, .. } => message::UserContent::text(text),
             UserContent::Image { image_url } => {
                 message::UserContent::image_url(image_url.url, None, Some(image_url.detail))
             }
@@ -922,7 +922,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                     .iter()
                     .filter_map(|c| {
                         let s = match c {
-                            AssistantContent::Text { text } => text,
+                            AssistantContent::Text { text, .. } => text,
                             AssistantContent::Refusal { refusal } => refusal,
                         };
                         if s.is_empty() {
@@ -1038,7 +1038,7 @@ fn assistant_message_text_response(message: &Message) -> Option<String> {
     let mut segments = content
         .iter()
         .filter_map(|content| match content {
-            AssistantContent::Text { text } => (!text.is_empty()).then(|| text.clone()),
+            AssistantContent::Text { text, .. } => (!text.is_empty()).then(|| text.clone()),
             AssistantContent::Refusal { refusal } => (!refusal.is_empty()).then(|| refusal.clone()),
         })
         .collect::<Vec<_>>();
@@ -1366,7 +1366,7 @@ impl crate::telemetry::ProviderRequestExt for CompletionRequest {
             return None;
         };
 
-        let UserContent::Text { text } = content.first() else {
+        let UserContent::Text { text, .. } = content.first() else {
             return None;
         };
 

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -290,7 +290,7 @@ impl TryFrom<crate::completion::Message> for Vec<InputItem> {
 
                 for user_content in content {
                     match user_content {
-                        crate::message::UserContent::Text(Text { text }) => {
+                        crate::message::UserContent::Text(Text { text, .. }) => {
                             items.push(InputItem {
                                 role: Some(Role::User),
                                 input: InputContent::Message(Message::User {
@@ -309,6 +309,7 @@ impl TryFrom<crate::completion::Message> for Vec<InputItem> {
                             for tool_result_content in tool_content {
                                 let crate::completion::message::ToolResultContent::Text(Text {
                                     text,
+                                    ..
                                 }) = tool_result_content
                                 else {
                                     return Err(CompletionError::ProviderError(
@@ -443,13 +444,13 @@ impl TryFrom<crate::completion::Message> for Vec<InputItem> {
 
                 for assistant_content in content {
                     match assistant_content {
-                        crate::message::AssistantContent::Text(Text { text }) => {
+                        crate::message::AssistantContent::Text(Text { text, .. }) => {
                             let id = id.as_ref().unwrap_or(&String::default()).clone();
                             other_items.push(InputItem {
                                 role: Some(Role::Assistant),
                                 input: InputContent::Message(Message::Assistant {
                                     content: OneOrMany::one(AssistantContentType::Text(
-                                        AssistantContent::OutputText(Text { text }),
+                                        AssistantContent::OutputText(Text::new(text)),
                                     )),
                                     id,
                                     name: None,
@@ -1607,10 +1608,10 @@ impl From<AssistantContent> for completion::AssistantContent {
     fn from(value: AssistantContent) -> Self {
         match value {
             AssistantContent::Refusal { refusal } => {
-                completion::AssistantContent::Text(Text { text: refusal })
+                completion::AssistantContent::Text(Text::new(refusal))
             }
-            AssistantContent::OutputText(Text { text }) => {
-                completion::AssistantContent::Text(Text { text })
+            AssistantContent::OutputText(Text { text, .. }) => {
+                completion::AssistantContent::Text(Text::new(text))
             }
         }
     }
@@ -1717,6 +1718,7 @@ impl TryFrom<message::Message> for Vec<Message> {
                                     match res {
                                         completion::message::ToolResultContent::Text(Text {
                                             text,
+                                            ..
                                         }) => text,
                                         _ => return  Err(MessageError::ConversionError("This API only currently supports text tool results".into()))
                                     }
@@ -1732,7 +1734,7 @@ impl TryFrom<message::Message> for Vec<Message> {
                     let other_content = other_content
                         .into_iter()
                         .map(|content| match content {
-                            message::UserContent::Text(message::Text { text }) => {
+                            message::UserContent::Text(message::Text { text, .. }) => {
                                 Ok(UserContent::InputText { text })
                             }
                             message::UserContent::Image(message::Image {
@@ -1857,12 +1859,12 @@ impl TryFrom<message::Message> for Vec<Message> {
                 })?;
 
                 match content.first() {
-                    crate::message::AssistantContent::Text(Text { text }) => {
+                    crate::message::AssistantContent::Text(Text { text, .. }) => {
                         Ok(vec![Message::Assistant {
                             id: assistant_message_id.clone(),
                             status: ToolStatus::Completed,
                             content: OneOrMany::one(AssistantContentType::Text(
-                                AssistantContent::OutputText(Text { text }),
+                                AssistantContent::OutputText(Text::new(text)),
                             )),
                             name: None,
                         }])

--- a/crates/rig-core/src/providers/openrouter/completion.rs
+++ b/crates/rig-core/src/providers/openrouter/completion.rs
@@ -610,7 +610,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                 let mut content = content
                     .iter()
                     .map(|c| match c {
-                        openai::AssistantContent::Text { text } => {
+                        openai::AssistantContent::Text { text, .. } => {
                             completion::AssistantContent::text(text)
                         }
                         openai::AssistantContent::Refusal { refusal } => {
@@ -994,7 +994,7 @@ where
     S: Serializer,
 {
     if content.len() == 1
-        && let UserContent::Text { text } = content.first_ref()
+        && let UserContent::Text { text, .. } = content.first_ref()
     {
         return serializer.serialize_str(text);
     }
@@ -1006,7 +1006,9 @@ impl TryFrom<message::UserContent> for UserContent {
 
     fn try_from(value: message::UserContent) -> Result<Self, Self::Error> {
         match value {
-            message::UserContent::Text(message::Text { text }) => Ok(UserContent::Text { text }),
+            message::UserContent::Text(message::Text { text, .. }) => {
+                Ok(UserContent::Text { text })
+            }
 
             message::UserContent::Image(message::Image {
                 data,
@@ -1206,7 +1208,9 @@ impl TryFrom<OneOrMany<message::UserContent>> for Vec<Message> {
                             .content
                             .into_iter()
                             .map(|c| match c {
-                                message::ToolResultContent::Text(message::Text { text }) => text,
+                                message::ToolResultContent::Text(message::Text {
+                                    text, ..
+                                }) => text,
                                 message::ToolResultContent::Image(_) => {
                                     "[Image content not supported in tool results]".to_string()
                                 }
@@ -1358,7 +1362,7 @@ impl TryFrom<openai::UserContent> for UserContent {
 
     fn try_from(value: openai::UserContent) -> Result<Self, Self::Error> {
         Ok(match value {
-            openai::UserContent::Text { text } => UserContent::Text { text },
+            openai::UserContent::Text { text, .. } => UserContent::Text { text },
             openai::UserContent::Image { image_url } => UserContent::ImageUrl {
                 image_url: ImageUrl {
                     url: image_url.url,
@@ -2722,9 +2726,7 @@ mod tests {
 
     #[test]
     fn test_user_content_from_rig_text() {
-        let rig_content = message::UserContent::Text(message::Text {
-            text: "Hello".to_string(),
-        });
+        let rig_content = message::UserContent::Text(message::Text::new("Hello".to_string()));
         let openrouter_content: UserContent = rig_content.try_into().unwrap();
 
         assert_eq!(
@@ -3178,9 +3180,9 @@ mod tests {
     fn test_message_conversion_with_pdf() {
         let rig_message = message::Message::User {
             content: OneOrMany::many(vec![
-                message::UserContent::Text(message::Text {
-                    text: "Summarize this document".to_string(),
-                }),
+                message::UserContent::Text(message::Text::new(
+                    "Summarize this document".to_string(),
+                )),
                 message::UserContent::Document(message::Document {
                     data: DocumentSourceKind::Url("https://example.com/paper.pdf".to_string()),
                     media_type: Some(DocumentMediaType::PDF),
@@ -3199,7 +3201,7 @@ mod tests {
 
                 // First should be text
                 match content.first_ref() {
-                    UserContent::Text { text } => assert_eq!(text, "Summarize this document"),
+                    UserContent::Text { text, .. } => assert_eq!(text, "Summarize this document"),
                     _ => panic!("Expected Text"),
                 }
             }

--- a/crates/rig-core/src/providers/perplexity.rs
+++ b/crates/rig-core/src/providers/perplexity.rs
@@ -289,7 +289,7 @@ impl TryFrom<message::Message> for Message {
                 let collapsed_content = content
                     .into_iter()
                     .map(|content| match content {
-                        message::UserContent::Text(message::Text { text }) => Ok(text),
+                        message::UserContent::Text(message::Text { text, .. }) => Ok(text),
                         _ => Err(MessageError::ConversionError(
                             "Only text content is supported by Perplexity".to_owned(),
                         )),
@@ -308,7 +308,7 @@ impl TryFrom<message::Message> for Message {
                     .into_iter()
                     .map(|content| {
                         Ok(match content {
-                            message::AssistantContent::Text(message::Text { text }) => text,
+                            message::AssistantContent::Text(message::Text { text, .. }) => text,
                             _ => return Err(MessageError::ConversionError(
                                 "Only text assistant message content is supported by Perplexity"
                                     .to_owned(),

--- a/crates/rig-core/src/providers/xai/api.rs
+++ b/crates/rig-core/src/providers/xai/api.rs
@@ -229,7 +229,7 @@ impl TryFrom<RigMessage> for Vec<Message> {
 
                 for c in content {
                     match c {
-                        UserContent::Text(Text { text }) => text_parts.push(text),
+                        UserContent::Text(Text { text, .. }) => text_parts.push(text),
                         UserContent::Image(img) => {
                             has_images = true;
                             content_items.push(image_item(img)?);

--- a/crates/rig-core/src/streaming.rs
+++ b/crates/rig-core/src/streaming.rs
@@ -869,7 +869,7 @@ mod tests {
         ));
         assert!(matches!(
             choice_items.get(1),
-            Some(AssistantContent::Text(Text { text })) if text == "final-text"
+            Some(AssistantContent::Text(Text { text, .. })) if text == "final-text"
         ));
         assert!(matches!(
             choice_items.get(2),
@@ -886,7 +886,7 @@ mod tests {
         assert_eq!(choice_items.len(), 3);
         assert!(matches!(
             choice_items.first(),
-            Some(AssistantContent::Text(Text { text })) if text == "first"
+            Some(AssistantContent::Text(Text { text, .. })) if text == "first"
         ));
         assert!(matches!(
             choice_items.get(1),
@@ -894,7 +894,7 @@ mod tests {
         ));
         assert!(matches!(
             choice_items.get(2),
-            Some(AssistantContent::Text(Text { text })) if text == "second"
+            Some(AssistantContent::Text(Text { text, .. })) if text == "second"
         ));
     }
 }
@@ -939,9 +939,7 @@ where
 {
     /// Create a text stream item.
     pub fn text(text: &str) -> Self {
-        Self::Text(Text {
-            text: text.to_string(),
-        })
+        Self::Text(Text::new(text.to_string()))
     }
 
     /// Create a final response stream item.

--- a/crates/rig-core/src/streaming.rs
+++ b/crates/rig-core/src/streaming.rs
@@ -85,6 +85,22 @@ where
     /// A text chunk from a message response
     Message(String),
 
+    /// Start a new text content block in the accumulated final choice.
+    ///
+    /// This is an internal provider-normalization event. It is not yielded to
+    /// public stream consumers, but lets providers preserve metadata boundaries
+    /// for final aggregated assistant text blocks.
+    TextStart {
+        /// Provider-specific metadata attached to this text block.
+        additional_params: Option<serde_json::Value>,
+    },
+
+    /// Provider-specific metadata for the current text content block.
+    ///
+    /// This is not yielded to public stream consumers. The metadata is merged
+    /// into the current aggregated [`Text`] block.
+    TextAdditionalParams(serde_json::Value),
+
     /// A tool call response (in its entirety)
     ToolCall(RawStreamingToolCall),
     /// A tool call partial/delta
@@ -295,6 +311,34 @@ where
         self.text_item_index = Some(self.assistant_items.len() - 1);
     }
 
+    fn append_text_additional_params(&mut self, additional_params: serde_json::Value) {
+        if additional_params.is_null() {
+            return;
+        }
+
+        let index = if let Some(index) = self.text_item_index
+            && matches!(
+                self.assistant_items.get(index),
+                Some(AssistantContent::Text(_))
+            ) {
+            index
+        } else {
+            self.assistant_items.push(AssistantContent::text(""));
+            let index = self.assistant_items.len() - 1;
+            self.text_item_index = Some(index);
+            index
+        };
+
+        let Some(AssistantContent::Text(text)) = self.assistant_items.get_mut(index) else {
+            return;
+        };
+
+        match text.additional_params.as_mut() {
+            Some(existing) => merge_text_additional_params(existing, additional_params),
+            None => text.additional_params = Some(additional_params),
+        }
+    }
+
     /// Accumulate streaming reasoning delta text into assistant_items.
     /// Providers that only emit ReasoningDelta (not full Reasoning blocks)
     /// need this so the aggregated response includes reasoning content.
@@ -319,6 +363,32 @@ where
                 }],
             }));
         self.reasoning_item_index = Some(self.assistant_items.len() - 1);
+    }
+}
+
+fn merge_text_additional_params(existing: &mut serde_json::Value, incoming: serde_json::Value) {
+    match (existing, incoming) {
+        (serde_json::Value::Object(existing_map), serde_json::Value::Object(incoming_map)) => {
+            for (key, incoming_value) in incoming_map {
+                match existing_map.get_mut(&key) {
+                    Some(existing_value) => match (existing_value, incoming_value) {
+                        (
+                            serde_json::Value::Array(existing_array),
+                            serde_json::Value::Array(mut incoming_array),
+                        ) => existing_array.append(&mut incoming_array),
+                        (existing_value, incoming_value) => {
+                            merge_text_additional_params(existing_value, incoming_value);
+                        }
+                    },
+                    None => {
+                        existing_map.insert(key, incoming_value);
+                    }
+                }
+            }
+        }
+        (existing, incoming) => {
+            *existing = incoming;
+        }
     }
 }
 
@@ -379,6 +449,18 @@ where
                     stream.reasoning_item_index = None;
                     stream.append_text_chunk(&text);
                     Poll::Ready(Some(Ok(StreamedAssistantContent::text(&text))))
+                }
+                RawStreamingChoice::TextStart { additional_params } => {
+                    stream.reasoning_item_index = None;
+                    stream.text_item_index = None;
+                    if let Some(additional_params) = additional_params {
+                        stream.append_text_additional_params(additional_params);
+                    }
+                    stream.poll_next_unpin(cx)
+                }
+                RawStreamingChoice::TextAdditionalParams(additional_params) => {
+                    stream.append_text_additional_params(additional_params);
+                    stream.poll_next_unpin(cx)
                 }
                 RawStreamingChoice::ToolCallDelta {
                     id,
@@ -744,6 +826,42 @@ mod tests {
         StreamingCompletionResponse::stream(to_stream_result(stream))
     }
 
+    fn create_text_metadata_stream() -> StreamingCompletionResponse<MockResponse> {
+        let stream = stream! {
+            yield Ok(RawStreamingChoice::TextStart {
+                additional_params: None,
+            });
+            yield Ok(RawStreamingChoice::Message("first".to_string()));
+            yield Ok(RawStreamingChoice::TextAdditionalParams(serde_json::json!({
+                "citations": [{
+                    "type": "char_location",
+                    "cited_text": "First citation.",
+                    "document_index": 0,
+                    "start_char_index": 0,
+                    "end_char_index": 15
+                }]
+            })));
+            yield Ok(RawStreamingChoice::TextAdditionalParams(serde_json::json!({
+                "citations": [{
+                    "type": "char_location",
+                    "cited_text": "Second citation.",
+                    "document_index": 0,
+                    "start_char_index": 16,
+                    "end_char_index": 32
+                }]
+            })));
+            yield Ok(RawStreamingChoice::TextStart {
+                additional_params: Some(serde_json::json!({
+                    "block": 2
+                })),
+            });
+            yield Ok(RawStreamingChoice::Message("second".to_string()));
+            yield Ok(RawStreamingChoice::FinalResponse(MockResponse::with_total_tokens(3)));
+        };
+
+        StreamingCompletionResponse::stream(to_stream_result(stream))
+    }
+
     #[tokio::test]
     async fn test_stream_cancellation() {
         let mut stream = create_mock_stream();
@@ -896,6 +1014,41 @@ mod tests {
             choice_items.get(2),
             Some(AssistantContent::Text(Text { text, .. })) if text == "second"
         ));
+    }
+
+    #[tokio::test]
+    async fn test_stream_preserves_text_additional_params() {
+        let mut stream = create_text_metadata_stream();
+        while stream.next().await.is_some() {}
+
+        let choice_items: Vec<AssistantContent> = stream.choice.clone().into_iter().collect();
+        assert_eq!(choice_items.len(), 2);
+
+        let Some(AssistantContent::Text(Text {
+            text,
+            additional_params: Some(additional_params),
+        })) = choice_items.first()
+        else {
+            panic!("expected first text item with metadata");
+        };
+        assert_eq!(text, "first");
+        assert_eq!(
+            additional_params["citations"]
+                .as_array()
+                .expect("citations should be an array")
+                .len(),
+            2
+        );
+
+        let Some(AssistantContent::Text(Text {
+            text,
+            additional_params: Some(additional_params),
+        })) = choice_items.get(1)
+        else {
+            panic!("expected second text item with metadata");
+        };
+        assert_eq!(text, "second");
+        assert_eq!(additional_params["block"], 2);
     }
 }
 

--- a/crates/rig-core/src/test_utils/pipeline.rs
+++ b/crates/rig-core/src/test_utils/pipeline.rs
@@ -16,7 +16,7 @@ impl Prompt for MockPromptModel {
         let msg = prompt.into();
         let prompt = match msg {
             Message::User { content } => match content.first() {
-                message::UserContent::Text(message::Text { text }) => text,
+                message::UserContent::Text(message::Text { text, .. }) => text,
                 _ => {
                     return Err(PromptError::CompletionError(CompletionError::RequestError(
                         "mock prompt model only accepts text user messages".into(),

--- a/crates/rig-core/src/test_utils/streaming.rs
+++ b/crates/rig-core/src/test_utils/streaming.rs
@@ -42,6 +42,12 @@ impl GetTokenUsage for MockResponse {
 pub enum MockStreamEvent {
     /// Text chunk.
     Text(String),
+    /// Start a new text content block with optional provider metadata.
+    TextStart {
+        additional_params: Option<serde_json::Value>,
+    },
+    /// Provider-specific metadata for the current text content block.
+    TextAdditionalParams(serde_json::Value),
     /// Complete tool call event.
     ToolCall {
         id: String,
@@ -69,6 +75,16 @@ impl MockStreamEvent {
     /// Create a text chunk.
     pub fn text(text: impl Into<String>) -> Self {
         Self::Text(text.into())
+    }
+
+    /// Start a new text content block.
+    pub fn text_start(additional_params: Option<serde_json::Value>) -> Self {
+        Self::TextStart { additional_params }
+    }
+
+    /// Add provider-specific metadata to the current text content block.
+    pub fn text_additional_params(additional_params: serde_json::Value) -> Self {
+        Self::TextAdditionalParams(additional_params)
     }
 
     /// Create a complete tool call event.
@@ -149,6 +165,12 @@ impl MockStreamEvent {
     ) -> Result<RawStreamingChoice<MockResponse>, CompletionError> {
         match self {
             Self::Text(text) => Ok(RawStreamingChoice::Message(text)),
+            Self::TextStart { additional_params } => {
+                Ok(RawStreamingChoice::TextStart { additional_params })
+            }
+            Self::TextAdditionalParams(additional_params) => {
+                Ok(RawStreamingChoice::TextAdditionalParams(additional_params))
+            }
             Self::ToolCall {
                 id,
                 name,

--- a/crates/rig-gemini-grpc/src/completion.rs
+++ b/crates/rig-gemini-grpc/src/completion.rs
@@ -229,7 +229,7 @@ fn rig_user_content_to_grpc_part(
     content: message::UserContent,
 ) -> Result<proto::Part, CompletionError> {
     match content {
-        message::UserContent::Text(message::Text { text }) => Ok(proto::Part {
+        message::UserContent::Text(message::Text { text, .. }) => Ok(proto::Part {
             data: Some(proto::part::Data::Text(text)),
             thought: false,
             thought_signature: Vec::new(),
@@ -334,7 +334,7 @@ fn rig_assistant_content_to_grpc_part(
     content: message::AssistantContent,
 ) -> Result<proto::Part, CompletionError> {
     match content {
-        message::AssistantContent::Text(message::Text { text }) => Ok(proto::Part {
+        message::AssistantContent::Text(message::Text { text, .. }) => Ok(proto::Part {
             data: Some(proto::part::Data::Text(text)),
             thought: false,
             thought_signature: Vec::new(),

--- a/crates/rig-vertexai/examples/completion_vertexai.rs
+++ b/crates/rig-vertexai/examples/completion_vertexai.rs
@@ -23,7 +23,8 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let mut response_text = String::new();
     for content in response.choice.iter() {
-        if let rig_core::message::AssistantContent::Text(rig_core::message::Text { text }) = content
+        if let rig_core::message::AssistantContent::Text(rig_core::message::Text { text, .. }) =
+            content
         {
             response_text.push_str(text);
         }

--- a/crates/rig-vertexai/src/types/completion_request.rs
+++ b/crates/rig-vertexai/src/types/completion_request.rs
@@ -128,9 +128,7 @@ mod tests {
             model: None,
             preamble: None,
             chat_history: OneOrMany::one(Message::User {
-                content: OneOrMany::one(UserContent::Text(Text {
-                    text: "test".to_string(),
-                })),
+                content: OneOrMany::one(UserContent::Text(Text::new("test".to_string()))),
             }),
             documents: vec![],
             tools: vec![],
@@ -303,9 +301,7 @@ mod tests {
             chat_history: OneOrMany::many(vec![
                 Message::system("System from history"),
                 Message::User {
-                    content: OneOrMany::one(UserContent::Text(Text {
-                        text: "hello".to_string(),
-                    })),
+                    content: OneOrMany::one(UserContent::Text(Text::new("hello".to_string()))),
                 },
             ])
             .expect("history should be non-empty"),

--- a/crates/rig-vertexai/src/types/completion_response.rs
+++ b/crates/rig-vertexai/src/types/completion_response.rs
@@ -39,7 +39,7 @@ impl TryFrom<VertexGenerateContentOutput> for CompletionResponse<VertexGenerateC
                     ToolFunction::new(function_call.name.clone(), args_json),
                 )));
             } else if let Some(text) = part.text() {
-                assistant_contents.push(AssistantContent::Text(Text { text: text.clone() }));
+                assistant_contents.push(AssistantContent::Text(Text::new(text.clone())));
             }
         }
 
@@ -126,9 +126,9 @@ mod tests {
         let response = completion_response.unwrap();
         assert_eq!(
             response.choice,
-            OneOrMany::one(AssistantContent::Text(Text {
-                text: "Hello, world!".to_string()
-            }))
+            OneOrMany::one(AssistantContent::Text(Text::new(
+                "Hello, world!".to_string()
+            )))
         );
     }
 

--- a/crates/rig-vertexai/src/types/message.rs
+++ b/crates/rig-vertexai/src/types/message.rs
@@ -16,7 +16,7 @@ impl TryFrom<RigMessage> for vertexai::model::Content {
                 let parts: Result<Vec<vertexai::model::Part>, _> = content
                     .into_iter()
                     .map(|user_content| match user_content {
-                        UserContent::Text(Text { text }) => {
+                        UserContent::Text(Text { text, .. }) => {
                             Ok(vertexai::model::Part::new().set_text(text))
                         }
                         UserContent::ToolResult(tool_result) => {
@@ -26,7 +26,7 @@ impl TryFrom<RigMessage> for vertexai::model::Content {
                                 .content
                                 .iter()
                                 .map(|content| match content {
-                                    ToolResultContent::Text(Text { text }) => {
+                                    ToolResultContent::Text(Text { text, .. }) => {
                                         serde_json::Value::String(text.clone())
                                     }
                                     ToolResultContent::Image(_) => {
@@ -69,7 +69,7 @@ impl TryFrom<RigMessage> for vertexai::model::Content {
                 let parts: Result<Vec<vertexai::model::Part>, _> = content
                     .into_iter()
                     .map(|assistant_content| match assistant_content {
-                        AssistantContent::Text(Text { text }) => {
+                        AssistantContent::Text(Text { text, .. }) => {
                             Ok(vertexai::model::Part::new().set_text(text))
                         }
                         AssistantContent::ToolCall(tool_call) => {
@@ -114,9 +114,9 @@ mod tests {
     #[test]
     fn test_user_text_message_conversion() {
         let message = Message::User {
-            content: OneOrMany::one(rig_core::message::UserContent::Text(Text {
-                text: "Hello".to_string(),
-            })),
+            content: OneOrMany::one(rig_core::message::UserContent::Text(Text::new(
+                "Hello".to_string(),
+            ))),
         };
 
         let rig_message = RigMessage(message);
@@ -133,9 +133,7 @@ mod tests {
     fn test_assistant_text_message_conversion() {
         let message = Message::Assistant {
             id: None,
-            content: OneOrMany::one(AssistantContent::Text(Text {
-                text: "Hi there".to_string(),
-            })),
+            content: OneOrMany::one(AssistantContent::Text(Text::new("Hi there".to_string()))),
         };
 
         let rig_message = RigMessage(message);
@@ -186,9 +184,7 @@ mod tests {
         let tool_result = ToolResult {
             id: "add".to_string(),
             call_id: None,
-            content: OneOrMany::one(ToolResultContent::Text(Text {
-                text: "8".to_string(),
-            })),
+            content: OneOrMany::one(ToolResultContent::Text(Text::new("8".to_string()))),
         };
 
         let message = Message::User {

--- a/tests/cassettes/anthropic/plaintext_document/document_citations_followup_preserves_history.yaml
+++ b/tests/cassettes/anthropic/plaintext_document/document_citations_followup_preserves_history.yaml
@@ -1,0 +1,37 @@
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":256,"messages":[{"content":[{"citations":{"enabled":true},"source":{"data":"The Rust Programming Language\n\nRust is a systems programming language focused on three goals: safety, speed,\nand concurrency. It accomplishes these goals without a garbage collector.\n\nKey Features:\n- Zero-cost abstractions\n- Move semantics\n- Guaranteed memory safety\n- Threads without data races","media_type":"text/plain","type":"text"},"title":"Rust Goals","type":"document"},{"text":"Using citations, answer in one sentence: what three goals does Rust focus on?","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","system":[{"text":"Answer using the supplied document and preserve citation metadata.","type":"text"}],"temperature":0.0}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"content":[{"citations":[{"cited_text":"The Rust Programming Language\n\nRust is a systems programming language focused on three goals: safety, speed,\nand concurrency. ","document_index":0,"document_title":"Rust Goals","end_char_index":126,"start_char_index":0,"type":"char_location"}],"text":"Rust focuses on three goals: **safety**, **speed**, and **concurrency**.","type":"text"}],"id":"msg_REDACTED_1","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":"end_turn","stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":684,"output_tokens":38,"service_tier":"standard"}}'
+---
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":64,"messages":[{"content":[{"citations":{"enabled":true},"source":{"data":"The Rust Programming Language\n\nRust is a systems programming language focused on three goals: safety, speed,\nand concurrency. It accomplishes these goals without a garbage collector.\n\nKey Features:\n- Zero-cost abstractions\n- Move semantics\n- Guaranteed memory safety\n- Threads without data races","media_type":"text/plain","type":"text"},"title":"Rust Goals","type":"document"},{"text":"Using citations, answer in one sentence: what three goals does Rust focus on?","type":"text"}],"role":"user"},{"content":[{"citations":[{"cited_text":"The Rust Programming Language\n\nRust is a systems programming language focused on three goals: safety, speed,\nand concurrency. ","document_index":0,"document_title":"Rust Goals","end_char_index":126,"start_char_index":0,"type":"char_location"}],"text":"Rust focuses on three goals: **safety**, **speed**, and **concurrency**.","type":"text"}],"role":"assistant"},{"content":[{"text":"Reply exactly: citations follow-up ok","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","system":[{"text":"Answer using the supplied document and preserve citation metadata.","type":"text"}],"temperature":0.0}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"content":[{"text":"citations follow-up ok","type":"text"}],"id":"msg_REDACTED_2","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":"end_turn","stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":733,"output_tokens":8,"service_tier":"standard"}}'

--- a/tests/core/reasoning_stream_stats.rs
+++ b/tests/core/reasoning_stream_stats.rs
@@ -2,7 +2,7 @@ use futures::stream;
 use rig::OneOrMany;
 use rig::agent::MultiTurnStreamItem;
 use rig::completion::Usage;
-use rig::message::{ToolCall, ToolFunction, ToolResult, ToolResultContent};
+use rig::message::{AssistantContent, ToolCall, ToolFunction, ToolResult, ToolResultContent};
 use rig::streaming::{StreamedAssistantContent, StreamedUserContent};
 
 use crate::reasoning::collect_stream_stats;
@@ -40,7 +40,7 @@ async fn collect_stream_stats_tracks_only_final_turn_text() {
             StreamedAssistantContent::<()>::text("It's 72F and sunny in Tokyo."),
         )),
         Ok(MultiTurnStreamItem::final_response(
-            "It's 72F and sunny in Tokyo.",
+            OneOrMany::one(AssistantContent::text("It's 72F and sunny in Tokyo.")),
             Usage::new(),
         )),
     ];

--- a/tests/providers/anthropic/cassette/document_file_id.rs
+++ b/tests/providers/anthropic/cassette/document_file_id.rs
@@ -153,6 +153,9 @@ fn provider_file_content_as_generic_document(file_id: &str) -> RigUserContent {
             source: AnthropicDocumentSource::File {
                 file_id: file_id.to_string(),
             },
+            title: None,
+            context: None,
+            citations: None,
             cache_control: None,
         }),
     };
@@ -175,11 +178,9 @@ fn document_question(content: RigUserContent, page_number: u8) -> Message {
     Message::User {
         content: OneOrMany::many(vec![
             content,
-            RigUserContent::Text(Text {
-                text: format!(
-                    "What verifier token is printed on page {page_number}? Reply with only the exact token."
-                ),
-            }),
+            RigUserContent::Text(Text::new(format!(
+                "What verifier token is printed on page {page_number}? Reply with only the exact token."
+            ))),
         ])
         .expect("content should be non-empty"),
     }
@@ -333,7 +334,7 @@ fn assert_no_verifier_leaked_into_prompt(message: &Message) {
     };
 
     for content in content.iter() {
-        let RigUserContent::Text(Text { text }) = content else {
+        let RigUserContent::Text(Text { text, .. }) = content else {
             continue;
         };
 

--- a/tests/providers/anthropic/cassette/plaintext_document.rs
+++ b/tests/providers/anthropic/cassette/plaintext_document.rs
@@ -182,7 +182,7 @@ async fn document_citations_followup_preserves_assistant_citation_history() {
                             .iter()
                             .any(|needle| cited_text.to_lowercase().contains(needle))
                 }
-                Citation::PageLocation { .. } | Citation::ContentBlockLocation { .. } => false,
+                _ => false,
             }));
 
             let followup = model

--- a/tests/providers/anthropic/cassette/plaintext_document.rs
+++ b/tests/providers/anthropic/cassette/plaintext_document.rs
@@ -2,9 +2,13 @@
 
 use rig::OneOrMany;
 use rig::client::CompletionClient;
-use rig::completion::Prompt;
+use rig::completion::{CompletionModel, Prompt};
 use rig::message::{Document, DocumentMediaType, DocumentSourceKind, Message, UserContent};
-use rig::providers::anthropic;
+use rig::providers::anthropic::completion::Citation;
+use rig::providers::anthropic::completion::{self as anthropic_completion, CLAUDE_SONNET_4_6};
+use rig::telemetry::ProviderResponseExt;
+
+use serde_json::json;
 
 use crate::support::{assert_contains_any_case_insensitive, assert_nonempty_response};
 
@@ -25,13 +29,62 @@ Key Features:
     .to_string()
 }
 
+fn cited_rust_document() -> Document {
+    Document {
+        data: DocumentSourceKind::String(rust_document()),
+        media_type: Some(DocumentMediaType::TXT),
+        additional_params: Some(json!({
+            "title": "Rust Goals",
+            "citations": { "enabled": true }
+        })),
+    }
+}
+
+fn citation_prompt() -> Message {
+    Message::User {
+        content: OneOrMany::many(vec![
+            UserContent::Document(cited_rust_document()),
+            UserContent::text(
+                "Using citations, answer in one sentence: what three goals does Rust focus on?",
+            ),
+        ])
+        .expect("citation prompt content should be non-empty"),
+    }
+}
+
+fn assistant_text(choice: &OneOrMany<rig::message::AssistantContent>) -> String {
+    choice
+        .iter()
+        .filter_map(|content| match content {
+            rig::message::AssistantContent::Text(text) => Some(text.text.as_str()),
+            _ => None,
+        })
+        .collect()
+}
+
+fn collect_anthropic_citations(
+    choice: &OneOrMany<rig::message::AssistantContent>,
+) -> Vec<Citation> {
+    choice
+        .iter()
+        .filter_map(|content| match content {
+            rig::message::AssistantContent::Text(text) => Some(text),
+            _ => None,
+        })
+        .flat_map(|text| {
+            anthropic_completion::anthropic_citations(text)
+                .expect("citations should decode from Anthropic text metadata")
+        })
+        .collect()
+}
+
 #[tokio::test]
 async fn plaintext_document_prompt() {
     super::super::support::with_anthropic_cassette(
         "plaintext_document/plaintext_document_prompt",
         |client| async move {
             let agent = client
-                .agent(anthropic::completion::CLAUDE_SONNET_4_6)
+                .agent(CLAUDE_SONNET_4_6)
                 .preamble("You are a helpful assistant that analyzes documents.")
                 .temperature(0.5)
                 .build();
@@ -59,7 +112,7 @@ async fn plaintext_document_with_instruction() {
         "plaintext_document/plaintext_document_with_instruction",
         |client| async move {
             let agent = client
-                .agent(anthropic::completion::CLAUDE_SONNET_4_6)
+                .agent(CLAUDE_SONNET_4_6)
                 .preamble("You are a helpful assistant that analyzes documents.")
                 .temperature(0.5)
                 .build();
@@ -78,6 +131,78 @@ async fn plaintext_document_with_instruction() {
                 .expect("instruction prompt should succeed");
 
             assert_contains_any_case_insensitive(&response, &["safety", "speed", "concurrency"]);
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn document_citations_followup_preserves_assistant_citation_history() {
+    super::super::support::with_anthropic_cassette(
+        "plaintext_document/document_citations_followup_preserves_history",
+        |client| async move {
+            let model = client.completion_model(CLAUDE_SONNET_4_6);
+            let prompt = citation_prompt();
+
+            let first_turn = model
+                .completion_request(prompt.clone())
+                .preamble(
+                    "Answer using the supplied document and preserve citation metadata."
+                        .to_string(),
+                )
+                .max_tokens(256)
+                .temperature(0.0)
+                .send()
+                .await
+                .expect("first document citation turn should succeed");
+
+            let first_turn_text = assistant_text(&first_turn.choice);
+            assert_nonempty_response(&first_turn_text);
+            assert_contains_any_case_insensitive(
+                &first_turn_text,
+                &["safety", "speed", "concurrency"],
+            );
+            assert_eq!(
+                first_turn.raw_response.get_text_response().as_deref(),
+                Some(first_turn_text.as_str())
+            );
+
+            let citations = collect_anthropic_citations(&first_turn.choice);
+            assert!(!citations.is_empty(), "expected citations: {first_turn:?}");
+            assert!(citations.iter().any(|citation| match citation {
+                Citation::CharLocation {
+                    cited_text,
+                    document_index,
+                    document_title,
+                    ..
+                } => {
+                    *document_index == 0
+                        && document_title.as_deref() == Some("Rust Goals")
+                        && ["safety", "speed", "concurrency"]
+                            .iter()
+                            .any(|needle| cited_text.to_lowercase().contains(needle))
+                }
+                Citation::PageLocation { .. } | Citation::ContentBlockLocation { .. } => false,
+            }));
+
+            let followup = model
+                .completion_request("Reply exactly: citations follow-up ok")
+                .preamble(
+                    "Answer using the supplied document and preserve citation metadata."
+                        .to_string(),
+                )
+                .max_tokens(64)
+                .temperature(0.0)
+                .message(prompt)
+                .message(Message::Assistant {
+                    id: first_turn.message_id.clone(),
+                    content: first_turn.choice.clone(),
+                })
+                .send()
+                .await
+                .expect("follow-up citation history turn should succeed");
+
+            assert_contains_any_case_insensitive(&assistant_text(&followup.choice), &["ok"]);
         },
     )
     .await;

--- a/tests/providers/gemini/cassette/multi_turn_streaming.rs
+++ b/tests/providers/gemini/cassette/multi_turn_streaming.rs
@@ -116,7 +116,7 @@ where
             while let Some(content) = stream.next().await {
                 match content {
                     Ok(StreamedAssistantContent::Text(text)) => {
-                        yield Ok(Text { text: text.text });
+                        yield Ok(Text::new(text.text));
                         did_call_tool = false;
                     }
                     Ok(StreamedAssistantContent::ToolCall { tool_call, .. }) => {
@@ -140,7 +140,7 @@ where
                     Ok(StreamedAssistantContent::Reasoning(reasoning)) => {
                         let rendered = reasoning.display_text();
                         if !rendered.is_empty() {
-                            yield Ok(Text { text: rendered });
+                            yield Ok(Text::new(rendered));
                         }
                         did_call_tool = false;
                     }

--- a/tests/providers/openai/live/document_file_id.rs
+++ b/tests/providers/openai/live/document_file_id.rs
@@ -131,11 +131,9 @@ fn document_question(content: RigUserContent, page_number: u8) -> Message {
     Message::User {
         content: OneOrMany::many(vec![
             content,
-            RigUserContent::Text(Text {
-                text: format!(
-                    "What exact visible text appears on page {page_number}? Reply with only that text."
-                ),
-            }),
+            RigUserContent::Text(Text::new(format!(
+                "What exact visible text appears on page {page_number}? Reply with only that text."
+            ))),
         ])
         .expect("content should be non-empty"),
     }

--- a/tests/providers/openrouter/document_file_data.rs
+++ b/tests/providers/openrouter/document_file_data.rs
@@ -43,11 +43,9 @@ fn document_question(page_number: u8) -> RigMessage {
     RigMessage::User {
         content: OneOrMany::many(vec![
             RigUserContent::Document(verifier_document()),
-            RigUserContent::Text(Text {
-                text: format!(
-                    "What verifier token is printed on page {page_number}? Reply with only the exact token."
-                ),
-            }),
+            RigUserContent::Text(Text::new(format!(
+                "What verifier token is printed on page {page_number}? Reply with only the exact token."
+            ))),
         ])
         .expect("content should be non-empty"),
     }
@@ -160,7 +158,7 @@ fn assert_no_verifier_leaked_into_prompt(message: &RigMessage) {
     };
 
     for content in content.iter() {
-        let RigUserContent::Text(Text { text }) = content else {
+        let RigUserContent::Text(Text { text, .. }) = content else {
             continue;
         };
 


### PR DESCRIPTION
## What

Adds Anthropic document citations end-to-end:

- **Request:** `Content::Document` gains optional `title`, `context`, and typed `citations: CitationsConfig` fields. `TryFrom<message::Document>` forwards `additional_params` so users going through the generic surface can opt in.
- **Response:** `Content::Text` carries typed `citations: Vec<Citation>` with all three Anthropic location types (`char_location`, `page_location`, `content_block_location`). Conversion to `message::AssistantContent` preserves them via `message::Text.additional_params`.
- **Streaming:** new `ContentDelta::CitationsDelta` variant. Also added `#[serde(other)] Unknown` so any future delta type Anthropic adds does not break stream deserialization.
- **New public helper** `anthropic_citations(&message::Text) -> Result<Vec<Citation>, serde_json::Error>` for typed extraction from the generic `message::AssistantContent` surface.

## Why

The Messages API exposes citation metadata (RAG, document QA, auditable model output). Rig previously dropped these fields silently both on the request side (when set via `message::Document.additional_params`) and on the response side (the citation arrays returned on text blocks). This PR closes the gap without forcing other providers to model fields they don't support.

## Compatibility note

`message::Text` gains `additional_params: Option<serde_json::Value>` mirroring `Image`/`Audio`/`Video`/`Document` in the same module — `Text` was the only content type missing this. The change is non-breaking at the JSON wire level (default `None`, `#[serde(flatten, skip_serializing_if = "Option::is_none")]`) but downstream code using the struct literal `message::Text { text }` should migrate to `Text::new(text)` or add `additional_params: None`. A constructor is provided. Same generic mechanism would let future providers (logprobs, reasoning notes, ...) attach metadata to text blocks without a new abstraction per provider.

## Testing

Full workspace baseline green:

- `cargo build --workspace`
- `cargo test --workspace` — 610 tests pass; added 9 in `anthropic/completion.rs` (document serialization with citations, three location-type round-trips, helper extraction in both empty and populated paths, `AssistantContent` round-trip preserving citations, end-to-end `additional_params` forwarding on a request) and 2 in `anthropic/streaming.rs` (citations_delta event deserialization, unknown-delta fallback).
- `cargo clippy --workspace --all-targets --all-features -- -Dwarnings`
- `cargo +nightly fmt --all --check`
- `cargo +nightly doc --workspace --all-features --no-deps --document-private-items` with `RUSTDOCFLAGS="-D warnings"`

## Notes

- Streaming consumer currently drops `CitationsDelta` (returns `None` from `handle_event`); citations are accumulated per-content-block and returned with the assembled final `Content::Text`. Real-time citation streaming through `RawStreamingChoice` is out of scope here and would be a follow-up.
- Citation validation (the API requires all-or-none citations across documents in a request) is left to the server — adding client-side validation is scope creep.

## AI assistance disclosure

Implemented with a two-stage AI-assisted process:

1. **Claude Opus 4.7 (Anthropic)** wrote the implementation, tests, and documentation, following the project's idiomatic Rust style (`Result`-based error propagation, `#[derive(Default)]` on the extended `message::Text` so downstream struct-literal call-sites stay ergonomic).
2. **Kimi K2.6 (Moonshot)** ran two independent reviews:
   - **Pre-coding architectural audit** of the implementation plan — caught missing `impl From<String>`/`impl Display` updates and the real scope of ~22 call-sites that would break with the new `additional_params` field before any code was written.
   - **Final diff review** — caught compile failures in `rig-bedrock` and `rig-vertexai` not surfaced by `cargo check -p rig-core`.

I reviewed every line and take responsibility for correctness and maintainability. Full workspace baseline is green: `cargo build`, `test`, `clippy --all-targets --all-features -- -Dwarnings`, `+nightly fmt --check`, and `+nightly doc -D warnings`.

Fixes #1767