### PR TITLE
fix: default OpenAI base64 image detail

### DIFF
--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -503,9 +503,7 @@ impl TryFrom<message::UserContent> for UserContent {
                         data
                     );
 
-                    let detail = detail.ok_or(message::MessageError::ConversionError(
-                        "OpenAI image URI must have image detail".into(),
-                    ))?;
+                    let detail = detail.unwrap_or_default();
 
                     Ok(UserContent::Image {
                         image_url: ImageUrl { url, detail },
@@ -2101,6 +2099,23 @@ mod tests {
         assert_eq!(json["type"], "file");
         assert_eq!(json["file"]["file_id"], "file_abc");
         assert!(json["file"].get("file_data").is_none());
+    }
+
+    #[test]
+    fn base64_image_without_detail_defaults_to_auto() {
+        let image = message::UserContent::Image(message::Image {
+            data: DocumentSourceKind::Base64("iVBORw0KGgo=".into()),
+            media_type: Some(message::ImageMediaType::PNG),
+            detail: None,
+            additional_params: None,
+        });
+        let converted: UserContent = image.try_into().expect("conversion should succeed");
+        let UserContent::Image { image_url } = converted else {
+            panic!("expected image content");
+        };
+
+        assert_eq!(image_url.url, "data:image/png;base64,iVBORw0KGgo=");
+        assert_eq!(image_url.detail, ImageDetail::Auto);
     }
 
     // Regression guard: callers passing markdown/plain text wrapped in


### PR DESCRIPTION
## Description

Fixes #1780

OpenAI chat-completions conversion already defaulted URL-backed image detail with `unwrap_or_default()`, but base64-backed images returned a conversion error when `detail` was `None`. This changes the base64 image path to use the same `ImageDetail::Auto` default while still requiring `media_type` to build the data URI.

No new dependencies.

## Type of change

- [x] Bug fix

## Testing

- [x] `cargo fmt`
- [x] `cargo fmt --check`
- [x] `git diff --check`
- [x] `cargo test -p rig-core --lib providers::openai::completion::tests::base64_image_without_detail_defaults_to_auto`
- [x] `cargo test -p rig-core --lib providers::openai::completion::tests`
- [x] `cargo test -p rig-core --lib`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Notes

AI assistance was used to locate the inconsistent converter branch and prepare this small patch. I reviewed the final diff and verified it locally.