### PR TITLE
Expose per-completion-call usage in agent responses

### DIFF
--- a/crates/rig-core/src/agent/mod.rs
+++ b/crates/rig-core/src/agent/mod.rs
@@ -117,4 +117,6 @@ pub use prompt_request::streaming::{
     FinalResponse, MultiTurnStreamItem, StreamingError, StreamingPromptRequest, StreamingResult,
     stream_to_stdout,
 };
-pub use prompt_request::{PromptRequest, PromptResponse, TypedPromptRequest, TypedPromptResponse};
+pub use prompt_request::{
+    CompletionCallUsage, PromptRequest, PromptResponse, TypedPromptRequest, TypedPromptResponse,
+};

--- a/crates/rig-core/src/agent/mod.rs
+++ b/crates/rig-core/src/agent/mod.rs
@@ -118,5 +118,5 @@ pub use prompt_request::streaming::{
     stream_to_stdout,
 };
 pub use prompt_request::{
-    CompletionCallUsage, PromptRequest, PromptResponse, TypedPromptRequest, TypedPromptResponse,
+    CompletionCall, PromptRequest, PromptResponse, TypedPromptRequest, TypedPromptResponse,
 };

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -273,15 +273,18 @@ where
 /// Details for one completion request made by an agent run.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
-pub struct CompletionCallUsage {
+pub struct CompletionCall {
     /// Zero-based index of the completion request within this agent run.
     pub call_index: usize,
     /// Token usage reported for this completion request, when the provider supplied it.
+    ///
+    /// Rig normalizes zero-valued [`Usage`] to `None` because zero-valued usage
+    /// is the existing sentinel for missing provider usage metrics.
     #[serde(default)]
     pub usage: Option<Usage>,
 }
 
-impl CompletionCallUsage {
+impl CompletionCall {
     /// Create details for one completion request in an agent run.
     pub fn new(call_index: usize, usage: Option<Usage>) -> Self {
         Self { call_index, usage }
@@ -310,7 +313,7 @@ pub struct PromptResponse {
     /// request. If a provider does not report token usage, its entry contains
     /// `None`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub completion_call_usage: Vec<CompletionCallUsage>,
+    pub completion_calls: Vec<CompletionCall>,
     pub messages: Option<Vec<Message>>,
 }
 
@@ -325,7 +328,7 @@ impl PromptResponse {
         Self {
             output: output.into(),
             usage,
-            completion_call_usage: Vec::new(),
+            completion_calls: Vec::new(),
             messages: None,
         }
     }
@@ -335,12 +338,9 @@ impl PromptResponse {
         self
     }
 
-    /// Attach per-completion-call usage details to this response.
-    pub fn with_completion_call_usage(
-        mut self,
-        completion_call_usage: Vec<CompletionCallUsage>,
-    ) -> Self {
-        self.completion_call_usage = completion_call_usage;
+    /// Attach completion call details to this response.
+    pub fn with_completion_calls(mut self, completion_calls: Vec<CompletionCall>) -> Self {
+        self.completion_calls = completion_calls;
         self
     }
 
@@ -349,8 +349,8 @@ impl PromptResponse {
     /// Non-streaming responses include every successfully completed completion
     /// request. If a provider does not report token usage, its entry contains
     /// `None`.
-    pub fn completion_call_usage(&self) -> &[CompletionCallUsage] {
-        &self.completion_call_usage
+    pub fn completion_calls(&self) -> &[CompletionCall] {
+        &self.completion_calls
     }
 }
 
@@ -368,7 +368,7 @@ pub struct TypedPromptResponse<T> {
     /// request. If a provider does not report token usage, its entry contains
     /// `None`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub completion_call_usage: Vec<CompletionCallUsage>,
+    pub completion_calls: Vec<CompletionCall>,
 }
 
 impl<T> TypedPromptResponse<T> {
@@ -376,16 +376,13 @@ impl<T> TypedPromptResponse<T> {
         Self {
             output,
             usage,
-            completion_call_usage: Vec::new(),
+            completion_calls: Vec::new(),
         }
     }
 
-    /// Attach per-completion-call usage details to this response.
-    pub fn with_completion_call_usage(
-        mut self,
-        completion_call_usage: Vec<CompletionCallUsage>,
-    ) -> Self {
-        self.completion_call_usage = completion_call_usage;
+    /// Attach completion call details to this response.
+    pub fn with_completion_calls(mut self, completion_calls: Vec<CompletionCall>) -> Self {
+        self.completion_calls = completion_calls;
         self
     }
 
@@ -394,8 +391,8 @@ impl<T> TypedPromptResponse<T> {
     /// Non-streaming responses include every successfully completed completion
     /// request. If a provider does not report token usage, its entry contains
     /// `None`.
-    pub fn completion_call_usage(&self) -> &[CompletionCallUsage] {
-        &self.completion_call_usage
+    pub fn completion_calls(&self) -> &[CompletionCall] {
+        &self.completion_calls
     }
 }
 
@@ -478,7 +475,7 @@ where
 
         let mut current_max_turns = 0;
         let mut usage = Usage::new();
-        let mut completion_call_usage = Vec::new();
+        let mut completion_calls = Vec::new();
         let mut completion_call_index = 0;
         let current_span_id: AtomicU64 = AtomicU64::new(0);
 
@@ -576,7 +573,7 @@ where
             .instrument(chat_span.clone())
             .await?;
 
-            completion_call_usage.push(CompletionCallUsage::from_reported_usage(
+            completion_calls.push(CompletionCall::from_reported_usage(
                 completion_call_index,
                 resp.usage,
             ));
@@ -650,7 +647,7 @@ where
 
                 return Ok(PromptResponse::new(merged_texts, usage)
                     .with_messages(new_messages)
-                    .with_completion_call_usage(completion_call_usage));
+                    .with_completion_calls(completion_calls));
             }
 
             let hook = self.hook.clone();
@@ -982,7 +979,7 @@ where
 
         let parsed: T = serde_json::from_str(&response.output)?;
         Ok(TypedPromptResponse::new(parsed, response.usage)
-            .with_completion_call_usage(response.completion_call_usage))
+            .with_completion_calls(response.completion_calls))
     }
 }
 
@@ -1016,7 +1013,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{CompletionCallUsage, TypedPromptResponse};
+    use super::{CompletionCall, PromptResponse, TypedPromptResponse};
     use crate::{
         agent::AgentBuilder,
         completion::{
@@ -1045,6 +1042,17 @@ mod tests {
     #[derive(Debug, Deserialize, JsonSchema, PartialEq)]
     struct TypedAnswer {
         value: String,
+    }
+
+    fn usage(input_tokens: u64, output_tokens: u64) -> Usage {
+        Usage {
+            input_tokens,
+            output_tokens,
+            total_tokens: input_tokens + output_tokens,
+            cached_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            reasoning_tokens: 0,
+        }
     }
 
     #[test]
@@ -1078,8 +1086,50 @@ mod tests {
         assert_eq!(response.usage.total_tokens, 3);
     }
 
+    #[test]
+    fn prompt_response_serializes_completion_calls_with_missing_usage() {
+        let reported_usage = usage(3, 4);
+        let response = PromptResponse::new("ok", reported_usage).with_completion_calls(vec![
+            CompletionCall::new(0, None),
+            CompletionCall::new(1, Some(reported_usage)),
+        ]);
+
+        let value = serde_json::to_value(&response).expect("serialize prompt response");
+
+        assert_eq!(
+            value.get("completion_calls"),
+            Some(&json!([
+                {
+                    "call_index": 0,
+                    "usage": null,
+                },
+                {
+                    "call_index": 1,
+                    "usage": {
+                        "input_tokens": 3,
+                        "output_tokens": 4,
+                        "total_tokens": 7,
+                        "cached_input_tokens": 0,
+                        "cache_creation_input_tokens": 0,
+                        "reasoning_tokens": 0,
+                    }
+                }
+            ]))
+        );
+
+        let response: PromptResponse =
+            serde_json::from_value(value).expect("deserialize prompt response");
+        assert_eq!(
+            response.completion_calls(),
+            &[
+                CompletionCall::new(0, None),
+                CompletionCall::new(1, Some(reported_usage))
+            ]
+        );
+    }
+
     #[tokio::test]
-    async fn typed_prompt_response_preserves_completion_call_usage() {
+    async fn typed_prompt_response_preserves_completion_calls() {
         let call_usage = Usage {
             input_tokens: 4,
             output_tokens: 6,
@@ -1106,8 +1156,8 @@ mod tests {
         );
         assert_eq!(response.usage, call_usage);
         assert_eq!(
-            response.completion_call_usage(),
-            &[CompletionCallUsage::new(0, Some(call_usage))]
+            response.completion_calls(),
+            &[CompletionCall::new(0, Some(call_usage))]
         );
     }
 
@@ -1197,10 +1247,10 @@ mod tests {
             }
         );
         assert_eq!(
-            response.completion_call_usage(),
+            response.completion_calls(),
             &[
-                CompletionCallUsage::new(0, Some(first_call_usage)),
-                CompletionCallUsage::new(1, Some(second_call_usage))
+                CompletionCall::new(0, Some(first_call_usage)),
+                CompletionCall::new(1, Some(second_call_usage))
             ]
         );
 

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -270,7 +270,7 @@ where
     }
 }
 
-/// Details for one completion request made by an agent run.
+/// Details for one successfully completed completion request made by an agent run.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct CompletionCall {
@@ -304,14 +304,12 @@ pub(crate) fn reported_usage(usage: Usage) -> Option<Usage> {
 pub struct PromptResponse {
     pub output: String,
     pub usage: Usage,
-    /// Completion requests made by this agent run, with token usage when available.
+    /// Successfully completed completion requests made by this agent run, with token usage when available.
     ///
     /// `usage` remains the aggregate across the whole run. Use the last entry's
     /// usage, when present, to inspect the final completion request's
     /// prompt/context length.
-    /// Non-streaming responses include every successfully completed completion
-    /// request. If a provider does not report token usage, its entry contains
-    /// `None`.
+    /// If a provider does not report token usage, its entry contains `None`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub completion_calls: Vec<CompletionCall>,
     pub messages: Option<Vec<Message>>,
@@ -344,11 +342,9 @@ impl PromptResponse {
         self
     }
 
-    /// Returns completion requests made by this agent run, with token usage when available.
+    /// Returns successfully completed completion requests made by this agent run, with token usage when available.
     ///
-    /// Non-streaming responses include every successfully completed completion
-    /// request. If a provider does not report token usage, its entry contains
-    /// `None`.
+    /// If a provider does not report token usage, its entry contains `None`.
     pub fn completion_calls(&self) -> &[CompletionCall] {
         &self.completion_calls
     }
@@ -359,14 +355,12 @@ impl PromptResponse {
 pub struct TypedPromptResponse<T> {
     pub output: T,
     pub usage: Usage,
-    /// Completion requests made by this agent run, with token usage when available.
+    /// Successfully completed completion requests made by this agent run, with token usage when available.
     ///
     /// `usage` remains the aggregate across the whole run. Use the last entry's
     /// usage, when present, to inspect the final completion request's
     /// prompt/context length.
-    /// Non-streaming responses include every successfully completed completion
-    /// request. If a provider does not report token usage, its entry contains
-    /// `None`.
+    /// If a provider does not report token usage, its entry contains `None`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub completion_calls: Vec<CompletionCall>,
 }
@@ -386,11 +380,9 @@ impl<T> TypedPromptResponse<T> {
         self
     }
 
-    /// Returns completion requests made by this agent run, with token usage when available.
+    /// Returns successfully completed completion requests made by this agent run, with token usage when available.
     ///
-    /// Non-streaming responses include every successfully completed completion
-    /// request. If a provider does not report token usage, its entry contains
-    /// `None`.
+    /// If a provider does not report token usage, its entry contains `None`.
     pub fn completion_calls(&self) -> &[CompletionCall] {
         &self.completion_calls
     }
@@ -1126,6 +1118,22 @@ mod tests {
                 CompletionCall::new(1, Some(reported_usage))
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn prompt_response_records_completion_call_without_reported_usage() {
+        let model = MockCompletionModel::new([MockTurn::text("ok")]);
+        let agent = AgentBuilder::new(model).build();
+
+        let response = agent
+            .prompt("say ok")
+            .extended_details()
+            .await
+            .expect("prompt should succeed");
+
+        assert_eq!(response.output, "ok");
+        assert_eq!(response.usage, Usage::new());
+        assert_eq!(response.completion_calls(), &[CompletionCall::new(0, None)]);
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -995,13 +995,14 @@ mod tests {
         agent::AgentBuilder,
         completion::{
             AssistantContent, CompletionError, CompletionRequest, Message, Prompt, PromptError,
-            Usage,
+            TypedPrompt, Usage,
         },
         message::UserContent,
         test_utils::{
             AppendFailingMemory, CountingMemory, FailingMemory, MockCompletionModel, MockTurn,
         },
     };
+    use schemars::JsonSchema;
     use serde::{Deserialize, Serialize};
     use serde_json::json;
 
@@ -1012,6 +1013,11 @@ mod tests {
 
     #[derive(Deserialize)]
     struct DeserializeOnly {
+        value: String,
+    }
+
+    #[derive(Debug, Deserialize, JsonSchema, PartialEq)]
+    struct TypedAnswer {
         value: String,
     }
 
@@ -1044,6 +1050,39 @@ mod tests {
         assert_eq!(response.usage.input_tokens, 1);
         assert_eq!(response.usage.output_tokens, 2);
         assert_eq!(response.usage.total_tokens, 3);
+    }
+
+    #[tokio::test]
+    async fn typed_prompt_response_preserves_completion_call_usage() {
+        let call_usage = Usage {
+            input_tokens: 4,
+            output_tokens: 6,
+            total_tokens: 10,
+            cached_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            reasoning_tokens: 0,
+        };
+        let model =
+            MockCompletionModel::new([MockTurn::text(r#"{"value":"ok"}"#).with_usage(call_usage)]);
+        let agent = AgentBuilder::new(model).build();
+
+        let response = agent
+            .prompt_typed::<TypedAnswer>("return typed json")
+            .extended_details()
+            .await
+            .expect("typed prompt should succeed");
+
+        assert_eq!(
+            response.output,
+            TypedAnswer {
+                value: "ok".to_string()
+            }
+        );
+        assert_eq!(response.usage, call_usage);
+        assert_eq!(
+            response.completion_call_usage(),
+            &[CompletionCallUsage::new(0, call_usage)]
+        );
     }
 
     fn validate_follow_up_tool_history(request: &CompletionRequest) {

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -341,6 +341,7 @@ impl PromptResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct TypedPromptResponse<T> {
     pub output: T,
     pub usage: Usage,

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -299,6 +299,9 @@ pub struct PromptResponse {
     ///
     /// `usage` remains the aggregate across the whole run. Use the last entry
     /// here to inspect the final completion request's prompt/context length.
+    /// Non-streaming responses include every successfully completed completion
+    /// request; if a provider does not report token usage, its entry contains a
+    /// zero-valued [`Usage`].
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub completion_call_usage: Vec<CompletionCallUsage>,
     pub messages: Option<Vec<Message>>,
@@ -335,6 +338,10 @@ impl PromptResponse {
     }
 
     /// Returns usage reported for each completion request made by this agent run.
+    ///
+    /// Non-streaming responses include every successfully completed completion
+    /// request. A zero-valued [`Usage`] means the provider did not supply token
+    /// usage for that request.
     pub fn completion_call_usage(&self) -> &[CompletionCallUsage] {
         &self.completion_call_usage
     }
@@ -349,6 +356,9 @@ pub struct TypedPromptResponse<T> {
     ///
     /// `usage` remains the aggregate across the whole run. Use the last entry
     /// here to inspect the final completion request's prompt/context length.
+    /// Non-streaming responses include every successfully completed completion
+    /// request; if a provider does not report token usage, its entry contains a
+    /// zero-valued [`Usage`].
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub completion_call_usage: Vec<CompletionCallUsage>,
 }
@@ -372,6 +382,10 @@ impl<T> TypedPromptResponse<T> {
     }
 
     /// Returns usage reported for each completion request made by this agent run.
+    ///
+    /// Non-streaming responses include every successfully completed completion
+    /// request. A zero-valued [`Usage`] means the provider did not supply token
+    /// usage for that request.
     pub fn completion_call_usage(&self) -> &[CompletionCallUsage] {
         &self.completion_call_usage
     }

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -270,11 +270,37 @@ where
     }
 }
 
+/// Token usage reported for one completion request made by an agent run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct CompletionCallUsage {
+    /// Zero-based index of the completion request within this agent run.
+    ///
+    /// This counts every completion request, including requests that do not
+    /// report token usage.
+    pub call_index: usize,
+    /// Token usage reported for this completion request.
+    pub usage: Usage,
+}
+
+impl CompletionCallUsage {
+    /// Create usage details for one completion request in an agent run.
+    pub fn new(call_index: usize, usage: Usage) -> Self {
+        Self { call_index, usage }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct PromptResponse {
     pub output: String,
     pub usage: Usage,
+    /// Token usage values for each completion request made by this agent run.
+    ///
+    /// `usage` remains the aggregate across the whole run. Use the last entry
+    /// here to inspect the final completion request's prompt/context length.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub completion_call_usage: Vec<CompletionCallUsage>,
     pub messages: Option<Vec<Message>>,
 }
 
@@ -289,6 +315,7 @@ impl PromptResponse {
         Self {
             output: output.into(),
             usage,
+            completion_call_usage: Vec::new(),
             messages: None,
         }
     }
@@ -297,17 +324,55 @@ impl PromptResponse {
         self.messages = Some(messages);
         self
     }
+
+    /// Attach per-completion-call usage details to this response.
+    pub fn with_completion_call_usage(
+        mut self,
+        completion_call_usage: Vec<CompletionCallUsage>,
+    ) -> Self {
+        self.completion_call_usage = completion_call_usage;
+        self
+    }
+
+    /// Returns usage reported for each completion request made by this agent run.
+    pub fn completion_call_usage(&self) -> &[CompletionCallUsage] {
+        &self.completion_call_usage
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TypedPromptResponse<T> {
     pub output: T,
     pub usage: Usage,
+    /// Token usage values for each completion request made by this agent run.
+    ///
+    /// `usage` remains the aggregate across the whole run. Use the last entry
+    /// here to inspect the final completion request's prompt/context length.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub completion_call_usage: Vec<CompletionCallUsage>,
 }
 
 impl<T> TypedPromptResponse<T> {
     pub fn new(output: T, usage: Usage) -> Self {
-        Self { output, usage }
+        Self {
+            output,
+            usage,
+            completion_call_usage: Vec::new(),
+        }
+    }
+
+    /// Attach per-completion-call usage details to this response.
+    pub fn with_completion_call_usage(
+        mut self,
+        completion_call_usage: Vec<CompletionCallUsage>,
+    ) -> Self {
+        self.completion_call_usage = completion_call_usage;
+        self
+    }
+
+    /// Returns usage reported for each completion request made by this agent run.
+    pub fn completion_call_usage(&self) -> &[CompletionCallUsage] {
+        &self.completion_call_usage
     }
 }
 
@@ -390,6 +455,8 @@ where
 
         let mut current_max_turns = 0;
         let mut usage = Usage::new();
+        let mut completion_call_usage = Vec::new();
+        let mut completion_call_index = 0;
         let current_span_id: AtomicU64 = AtomicU64::new(0);
 
         // We need to do at least 2 loops for 1 roundtrip (user expects normal message)
@@ -486,6 +553,8 @@ where
             .instrument(chat_span.clone())
             .await?;
 
+            completion_call_usage.push(CompletionCallUsage::new(completion_call_index, resp.usage));
+            completion_call_index += 1;
             usage += resp.usage;
 
             if let Some(ref hook) = self.hook
@@ -553,7 +622,9 @@ where
                     );
                 }
 
-                return Ok(PromptResponse::new(merged_texts, usage).with_messages(new_messages));
+                return Ok(PromptResponse::new(merged_texts, usage)
+                    .with_messages(new_messages)
+                    .with_completion_call_usage(completion_call_usage));
             }
 
             let hook = self.hook.clone();
@@ -884,7 +955,8 @@ where
         }
 
         let parsed: T = serde_json::from_str(&response.output)?;
-        Ok(TypedPromptResponse::new(parsed, response.usage))
+        Ok(TypedPromptResponse::new(parsed, response.usage)
+            .with_completion_call_usage(response.completion_call_usage))
     }
 }
 
@@ -918,7 +990,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::TypedPromptResponse;
+    use super::{CompletionCallUsage, TypedPromptResponse};
     use crate::{
         agent::AgentBuilder,
         completion::{
@@ -1016,25 +1088,27 @@ mod tests {
 
     #[tokio::test]
     async fn prompt_request_stops_cleanly_on_empty_terminal_turn() {
+        let first_call_usage = Usage {
+            input_tokens: 1,
+            output_tokens: 1,
+            total_tokens: 2,
+            cached_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            reasoning_tokens: 0,
+        };
+        let second_call_usage = Usage {
+            input_tokens: 1,
+            output_tokens: 1,
+            total_tokens: 2,
+            cached_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            reasoning_tokens: 0,
+        };
         let model = MockCompletionModel::new([
             MockTurn::tool_call("tool_call_1", "missing_tool", json!({"input": "value"}))
                 .with_call_id("call_1")
-                .with_usage(Usage {
-                    input_tokens: 1,
-                    output_tokens: 1,
-                    total_tokens: 2,
-                    cached_input_tokens: 0,
-                    cache_creation_input_tokens: 0,
-                    reasoning_tokens: 0,
-                }),
-            MockTurn::text("").with_usage(Usage {
-                input_tokens: 1,
-                output_tokens: 1,
-                total_tokens: 2,
-                cached_input_tokens: 0,
-                cache_creation_input_tokens: 0,
-                reasoning_tokens: 0,
-            }),
+                .with_usage(first_call_usage),
+            MockTurn::text("").with_usage(second_call_usage),
         ]);
         let agent = AgentBuilder::new(model).build();
 
@@ -1056,6 +1130,13 @@ mod tests {
                 cache_creation_input_tokens: 0,
                 reasoning_tokens: 0,
             }
+        );
+        assert_eq!(
+            response.completion_call_usage(),
+            &[
+                CompletionCallUsage::new(0, first_call_usage),
+                CompletionCallUsage::new(1, second_call_usage)
+            ]
         );
 
         let history = response

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -270,24 +270,30 @@ where
     }
 }
 
-/// Token usage reported for one completion request made by an agent run.
+/// Details for one completion request made by an agent run.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct CompletionCallUsage {
     /// Zero-based index of the completion request within this agent run.
-    ///
-    /// This counts every completion request, including requests that do not
-    /// report token usage.
     pub call_index: usize,
-    /// Token usage reported for this completion request.
-    pub usage: Usage,
+    /// Token usage reported for this completion request, when the provider supplied it.
+    #[serde(default)]
+    pub usage: Option<Usage>,
 }
 
 impl CompletionCallUsage {
-    /// Create usage details for one completion request in an agent run.
-    pub fn new(call_index: usize, usage: Usage) -> Self {
+    /// Create details for one completion request in an agent run.
+    pub fn new(call_index: usize, usage: Option<Usage>) -> Self {
         Self { call_index, usage }
     }
+
+    pub(crate) fn from_reported_usage(call_index: usize, usage: Usage) -> Self {
+        Self::new(call_index, reported_usage(usage))
+    }
+}
+
+pub(crate) fn reported_usage(usage: Usage) -> Option<Usage> {
+    (usage != Usage::new()).then_some(usage)
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -295,13 +301,14 @@ impl CompletionCallUsage {
 pub struct PromptResponse {
     pub output: String,
     pub usage: Usage,
-    /// Token usage values for each completion request made by this agent run.
+    /// Completion requests made by this agent run, with token usage when available.
     ///
-    /// `usage` remains the aggregate across the whole run. Use the last entry
-    /// here to inspect the final completion request's prompt/context length.
+    /// `usage` remains the aggregate across the whole run. Use the last entry's
+    /// usage, when present, to inspect the final completion request's
+    /// prompt/context length.
     /// Non-streaming responses include every successfully completed completion
-    /// request; if a provider does not report token usage, its entry contains a
-    /// zero-valued [`Usage`].
+    /// request. If a provider does not report token usage, its entry contains
+    /// `None`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub completion_call_usage: Vec<CompletionCallUsage>,
     pub messages: Option<Vec<Message>>,
@@ -337,11 +344,11 @@ impl PromptResponse {
         self
     }
 
-    /// Returns usage reported for each completion request made by this agent run.
+    /// Returns completion requests made by this agent run, with token usage when available.
     ///
     /// Non-streaming responses include every successfully completed completion
-    /// request. A zero-valued [`Usage`] means the provider did not supply token
-    /// usage for that request.
+    /// request. If a provider does not report token usage, its entry contains
+    /// `None`.
     pub fn completion_call_usage(&self) -> &[CompletionCallUsage] {
         &self.completion_call_usage
     }
@@ -352,13 +359,14 @@ impl PromptResponse {
 pub struct TypedPromptResponse<T> {
     pub output: T,
     pub usage: Usage,
-    /// Token usage values for each completion request made by this agent run.
+    /// Completion requests made by this agent run, with token usage when available.
     ///
-    /// `usage` remains the aggregate across the whole run. Use the last entry
-    /// here to inspect the final completion request's prompt/context length.
+    /// `usage` remains the aggregate across the whole run. Use the last entry's
+    /// usage, when present, to inspect the final completion request's
+    /// prompt/context length.
     /// Non-streaming responses include every successfully completed completion
-    /// request; if a provider does not report token usage, its entry contains a
-    /// zero-valued [`Usage`].
+    /// request. If a provider does not report token usage, its entry contains
+    /// `None`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub completion_call_usage: Vec<CompletionCallUsage>,
 }
@@ -381,11 +389,11 @@ impl<T> TypedPromptResponse<T> {
         self
     }
 
-    /// Returns usage reported for each completion request made by this agent run.
+    /// Returns completion requests made by this agent run, with token usage when available.
     ///
     /// Non-streaming responses include every successfully completed completion
-    /// request. A zero-valued [`Usage`] means the provider did not supply token
-    /// usage for that request.
+    /// request. If a provider does not report token usage, its entry contains
+    /// `None`.
     pub fn completion_call_usage(&self) -> &[CompletionCallUsage] {
         &self.completion_call_usage
     }
@@ -568,7 +576,10 @@ where
             .instrument(chat_span.clone())
             .await?;
 
-            completion_call_usage.push(CompletionCallUsage::new(completion_call_index, resp.usage));
+            completion_call_usage.push(CompletionCallUsage::from_reported_usage(
+                completion_call_index,
+                resp.usage,
+            ));
             completion_call_index += 1;
             usage += resp.usage;
 
@@ -1096,7 +1107,7 @@ mod tests {
         assert_eq!(response.usage, call_usage);
         assert_eq!(
             response.completion_call_usage(),
-            &[CompletionCallUsage::new(0, call_usage)]
+            &[CompletionCallUsage::new(0, Some(call_usage))]
         );
     }
 
@@ -1188,8 +1199,8 @@ mod tests {
         assert_eq!(
             response.completion_call_usage(),
             &[
-                CompletionCallUsage::new(0, first_call_usage),
-                CompletionCallUsage::new(1, second_call_usage)
+                CompletionCallUsage::new(0, Some(first_call_usage)),
+                CompletionCallUsage::new(1, Some(second_call_usage))
             ]
         );
 

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -16,7 +16,7 @@ use std::{pin::Pin, sync::Arc};
 use tracing::info_span;
 use tracing_futures::Instrument;
 
-use super::{CompletionCallUsage, ToolCallHookAction, reported_usage};
+use super::{CompletionCall, ToolCallHookAction, reported_usage};
 use crate::{
     agent::Agent,
     completion::{CompletionError, CompletionModel, PromptError},
@@ -48,13 +48,13 @@ pub enum MultiTurnStreamItem<R> {
     ///
     /// ```rust,ignore
     /// match item {
-    ///     MultiTurnStreamItem::CompletionCallUsage(call_usage) => {
-    ///         let context_tokens = call_usage.usage.map(|usage| usage.input_tokens);
+    ///     MultiTurnStreamItem::CompletionCall(completion_call) => {
+    ///         let context_tokens = completion_call.usage.map(|usage| usage.input_tokens);
     ///     }
     ///     _ => {}
     /// }
     /// ```
-    CompletionCallUsage(CompletionCallUsage),
+    CompletionCall(CompletionCall),
     /// The final result from the stream.
     FinalResponse(FinalResponse),
 }
@@ -68,7 +68,7 @@ pub struct FinalResponse {
     aggregated_usage: crate::completion::Usage,
     /// Completion requests made by this agent stream.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    completion_call_usage: Vec<CompletionCallUsage>,
+    completion_calls: Vec<CompletionCall>,
     #[serde(skip_serializing_if = "Option::is_none")]
     history: Option<Vec<Message>>,
 }
@@ -78,7 +78,7 @@ impl FinalResponse {
         Self {
             response: String::new(),
             aggregated_usage: crate::completion::Usage::new(),
-            completion_call_usage: Vec::new(),
+            completion_calls: Vec::new(),
             history: None,
         }
     }
@@ -94,11 +94,12 @@ impl FinalResponse {
 
     /// Returns completion requests made by this agent stream, with usage when available.
     ///
-    /// Each entry is a whole-request provider usage snapshot, not incremental
-    /// usage per streamed token. Streaming providers may omit usage for some
-    /// calls; those calls have an entry with `None` usage.
-    pub fn completion_call_usage(&self) -> &[CompletionCallUsage] {
-        &self.completion_call_usage
+    /// Each entry represents one provider completion request. When present,
+    /// usage is a whole-request provider snapshot, not incremental usage per
+    /// streamed token. Streaming providers may omit usage for some calls; those
+    /// calls have an entry with `None` usage.
+    pub fn completion_calls(&self) -> &[CompletionCall] {
+        &self.completion_calls
     }
 
     pub fn history(&self) -> Option<&[Message]> {
@@ -115,7 +116,7 @@ impl<R> MultiTurnStreamItem<R> {
         Self::FinalResponse(FinalResponse {
             response: response.to_string(),
             aggregated_usage,
-            completion_call_usage: Vec::new(),
+            completion_calls: Vec::new(),
             history: None,
         })
     }
@@ -128,21 +129,21 @@ impl<R> MultiTurnStreamItem<R> {
         Self::FinalResponse(FinalResponse {
             response: response.to_string(),
             aggregated_usage,
-            completion_call_usage: Vec::new(),
+            completion_calls: Vec::new(),
             history,
         })
     }
 
-    pub(crate) fn final_response_with_completion_call_usage(
+    pub(crate) fn final_response_with_completion_calls(
         response: &str,
         aggregated_usage: crate::completion::Usage,
-        completion_call_usage: Vec<CompletionCallUsage>,
+        completion_calls: Vec<CompletionCall>,
         history: Option<Vec<Message>>,
     ) -> Self {
         Self::FinalResponse(FinalResponse {
             response: response.to_string(),
             aggregated_usage,
-            completion_call_usage,
+            completion_calls,
             history,
         })
     }
@@ -499,7 +500,7 @@ where
         let output_schema = self.output_schema;
 
         let mut aggregated_usage = crate::completion::Usage::new();
-        let mut completion_call_usage = Vec::new();
+        let mut completion_calls = Vec::new();
         let mut completion_call_index = 0;
 
         // NOTE: We use .instrument(agent_span) instead of span.enter() to avoid
@@ -596,6 +597,7 @@ where
                 let call_index = completion_call_index;
                 completion_call_index += 1;
                 let mut current_call_usage = None;
+                let mut completion_call_emitted = false;
                 let mut tool_calls = vec![];
                 let mut tool_results = vec![];
                 let mut accumulated_reasoning: Vec<rig::message::Reasoning> = vec![];
@@ -748,6 +750,14 @@ where
                             if let Some(usage) = final_resp.token_usage() {
                                 current_call_usage = reported_usage(usage);
                             }
+                            if let Some(usage) = current_call_usage {
+                                aggregated_usage += usage;
+                            }
+                            let completion_call = CompletionCall::new(call_index, current_call_usage);
+                            completion_calls.push(completion_call);
+                            completion_call_emitted = true;
+                            yield Ok(MultiTurnStreamItem::CompletionCall(completion_call));
+
                             if saw_text_this_turn {
                                 if let Some(ref hook) = self.hook &&
                                      let HookAction::Terminate { reason } = hook.on_stream_completion_response_finish(&current_prompt, &final_resp).await {
@@ -766,12 +776,11 @@ where
                     }
                 }
 
-                if let Some(usage) = current_call_usage {
-                    aggregated_usage += usage;
+                if !completion_call_emitted {
+                    let completion_call = CompletionCall::new(call_index, current_call_usage);
+                    completion_calls.push(completion_call);
+                    yield Ok(MultiTurnStreamItem::CompletionCall(completion_call));
                 }
-                let call_usage = CompletionCallUsage::new(call_index, current_call_usage);
-                completion_call_usage.push(call_usage);
-                yield Ok(MultiTurnStreamItem::CompletionCallUsage(call_usage));
 
                 // Providers like Gemini emit thinking as incremental deltas
                 // without signatures; assemble into a single block so
@@ -849,10 +858,10 @@ where
                     } else {
                         None
                     };
-                    yield Ok(MultiTurnStreamItem::final_response_with_completion_call_usage(
+                    yield Ok(MultiTurnStreamItem::final_response_with_completion_calls(
                         &turn_text_response,
                         aggregated_usage,
-                        completion_call_usage,
+                        completion_calls,
                         final_messages,
                     ));
                     break;
@@ -1188,17 +1197,16 @@ mod tests {
     }
 
     #[test]
-    fn completion_call_usage_stream_item_serializes_and_deserializes_expected_shape() {
-        let item: MultiTurnStreamItem<MockResponse> = MultiTurnStreamItem::CompletionCallUsage(
-            CompletionCallUsage::new(2, Some(usage(3, 4))),
-        );
+    fn completion_calls_stream_item_serializes_and_deserializes_expected_shape() {
+        let item: MultiTurnStreamItem<MockResponse> =
+            MultiTurnStreamItem::CompletionCall(CompletionCall::new(2, Some(usage(3, 4))));
 
-        let value = serde_json::to_value(&item).expect("serialize completion call usage event");
+        let value = serde_json::to_value(&item).expect("serialize completion call event");
 
         assert_eq!(
             value,
             serde_json::json!({
-                "type": "completionCallUsage",
+                "type": "completionCall",
                 "call_index": 2,
                 "usage": {
                     "input_tokens": 3,
@@ -1212,25 +1220,62 @@ mod tests {
         );
 
         let item: MultiTurnStreamItem<MockResponse> =
-            serde_json::from_value(value).expect("deserialize completion call usage event");
+            serde_json::from_value(value).expect("deserialize completion call event");
         match item {
-            MultiTurnStreamItem::CompletionCallUsage(call_usage) => {
-                assert_eq!(call_usage, CompletionCallUsage::new(2, Some(usage(3, 4))));
+            MultiTurnStreamItem::CompletionCall(call_usage) => {
+                assert_eq!(call_usage, CompletionCall::new(2, Some(usage(3, 4))));
             }
-            other => panic!("expected completion call usage event, got {other:?}"),
+            other => panic!("expected completion call event, got {other:?}"),
         }
 
         let item: MultiTurnStreamItem<MockResponse> =
-            MultiTurnStreamItem::CompletionCallUsage(CompletionCallUsage::new(3, None));
+            MultiTurnStreamItem::CompletionCall(CompletionCall::new(3, None));
         let value = serde_json::to_value(&item).expect("serialize missing usage event");
 
         assert_eq!(
             value,
             serde_json::json!({
-                "type": "completionCallUsage",
+                "type": "completionCall",
                 "call_index": 3,
                 "usage": null
             })
+        );
+    }
+
+    #[test]
+    fn final_response_serializes_completion_calls_with_missing_usage() {
+        let item: MultiTurnStreamItem<MockResponse> =
+            MultiTurnStreamItem::final_response_with_completion_calls(
+                "done",
+                usage(3, 4),
+                vec![
+                    CompletionCall::new(0, None),
+                    CompletionCall::new(1, Some(usage(3, 4))),
+                ],
+                None,
+            );
+
+        let value = serde_json::to_value(&item).expect("serialize final response");
+
+        assert_eq!(
+            value.get("completionCalls"),
+            Some(&serde_json::json!([
+                {
+                    "call_index": 0,
+                    "usage": null,
+                },
+                {
+                    "call_index": 1,
+                    "usage": {
+                        "input_tokens": 3,
+                        "output_tokens": 4,
+                        "total_tokens": 7,
+                        "cached_input_tokens": 0,
+                        "cache_creation_input_tokens": 0,
+                        "reasoning_tokens": 0,
+                    }
+                }
+            ]))
         );
     }
 
@@ -1246,6 +1291,19 @@ mod tests {
         MockCompletionModel::from_stream_turns([[
             MockStreamEvent::final_response_with_total_tokens(1),
         ]])
+    }
+
+    #[derive(Clone)]
+    struct TerminateOnStreamFinish;
+
+    impl PromptHook<MockCompletionModel> for TerminateOnStreamFinish {
+        async fn on_stream_completion_response_finish(
+            &self,
+            _prompt: &Message,
+            _response: &<MockCompletionModel as CompletionModel>::StreamingResponse,
+        ) -> HookAction {
+            HookAction::terminate("stop after completion call")
+        }
     }
 
     #[tokio::test]
@@ -1315,7 +1373,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stream_prompt_exposes_completion_call_usage() {
+    async fn stream_prompt_exposes_completion_calls() {
         let first_call_usage = usage(10, 2);
         let second_call_usage = usage(25, 5);
         let model = MockCompletionModel::from_stream_turns([
@@ -1341,13 +1399,13 @@ mod tests {
             .with_history(empty_history)
             .multi_turn(3)
             .await;
-        let mut completion_call_usage_events = Vec::new();
+        let mut completion_calls_events = Vec::new();
         let mut final_response = None;
 
         while let Some(item) = stream.next().await {
             match item {
-                Ok(MultiTurnStreamItem::CompletionCallUsage(call_usage)) => {
-                    completion_call_usage_events.push(call_usage);
+                Ok(MultiTurnStreamItem::CompletionCall(call_usage)) => {
+                    completion_calls_events.push(call_usage);
                 }
                 Ok(MultiTurnStreamItem::FinalResponse(response)) => {
                     final_response = Some(response);
@@ -1359,10 +1417,10 @@ mod tests {
         }
 
         assert_eq!(
-            completion_call_usage_events,
+            completion_calls_events,
             vec![
-                CompletionCallUsage::new(0, Some(first_call_usage)),
-                CompletionCallUsage::new(1, Some(second_call_usage))
+                CompletionCall::new(0, Some(first_call_usage)),
+                CompletionCall::new(1, Some(second_call_usage))
             ]
         );
 
@@ -1379,16 +1437,55 @@ mod tests {
             }
         );
         assert_eq!(
-            final_response.completion_call_usage(),
+            final_response.completion_calls(),
             &[
-                CompletionCallUsage::new(0, Some(first_call_usage)),
-                CompletionCallUsage::new(1, Some(second_call_usage))
+                CompletionCall::new(0, Some(first_call_usage)),
+                CompletionCall::new(1, Some(second_call_usage))
             ]
         );
     }
 
     #[tokio::test]
-    async fn stream_prompt_completion_call_usage_records_unreported_usage() {
+    async fn stream_prompt_emits_completion_call_before_finish_hook_termination() {
+        let call_usage = usage(10, 2);
+        let model = MockCompletionModel::from_stream_turns([[
+            MockStreamEvent::text("done"),
+            MockStreamEvent::final_response(call_usage),
+        ]]);
+        let agent = AgentBuilder::new(model).build();
+
+        let mut stream = agent
+            .stream_prompt("say done")
+            .with_hook(TerminateOnStreamFinish)
+            .await;
+        let mut completion_calls = Vec::new();
+        let mut saw_error = false;
+
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(MultiTurnStreamItem::CompletionCall(completion_call)) => {
+                    completion_calls.push(completion_call);
+                }
+                Ok(MultiTurnStreamItem::FinalResponse(response)) => {
+                    panic!("unexpected final response after hook termination: {response:?}");
+                }
+                Ok(_) => {}
+                Err(_) => {
+                    saw_error = true;
+                    break;
+                }
+            }
+        }
+
+        assert_eq!(
+            completion_calls,
+            vec![CompletionCall::new(0, Some(call_usage))]
+        );
+        assert!(saw_error);
+    }
+
+    #[tokio::test]
+    async fn stream_prompt_completion_calls_records_unreported_usage() {
         let second_call_usage = usage(25, 5);
         let model = MockCompletionModel::from_stream_turns([
             vec![
@@ -1412,13 +1509,13 @@ mod tests {
             .with_history(empty_history)
             .multi_turn(3)
             .await;
-        let mut completion_call_usage_events = Vec::new();
+        let mut completion_calls_events = Vec::new();
         let mut final_response = None;
 
         while let Some(item) = stream.next().await {
             match item {
-                Ok(MultiTurnStreamItem::CompletionCallUsage(call_usage)) => {
-                    completion_call_usage_events.push(call_usage);
+                Ok(MultiTurnStreamItem::CompletionCall(call_usage)) => {
+                    completion_calls_events.push(call_usage);
                 }
                 Ok(MultiTurnStreamItem::FinalResponse(response)) => {
                     final_response = Some(response);
@@ -1430,16 +1527,13 @@ mod tests {
         }
 
         let expected_usage = vec![
-            CompletionCallUsage::new(0, None),
-            CompletionCallUsage::new(1, Some(second_call_usage)),
+            CompletionCall::new(0, None),
+            CompletionCall::new(1, Some(second_call_usage)),
         ];
-        assert_eq!(completion_call_usage_events, expected_usage);
+        assert_eq!(completion_calls_events, expected_usage);
 
         let final_response = final_response.expect("expected final response");
-        assert_eq!(
-            final_response.completion_call_usage(),
-            expected_usage.as_slice()
-        );
+        assert_eq!(final_response.completion_calls(), expected_usage.as_slice());
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -45,15 +45,7 @@ pub enum MultiTurnStreamItem<R> {
     /// This is emitted when a provider call finishes and reports usage. It is
     /// not incremental per streamed token; it is the provider's final usage for
     /// that completion request.
-    CompletionCallUsage {
-        /// Zero-based index of the completion request within this agent stream.
-        ///
-        /// This counts every completion request, including requests that do not
-        /// report token usage.
-        call_index: usize,
-        /// Token usage reported for this completion request.
-        usage: crate::completion::Usage,
-    },
+    CompletionCallUsage(CompletionCallUsage),
     /// The final result from the stream.
     FinalResponse(FinalResponse),
 }
@@ -94,7 +86,9 @@ impl FinalResponse {
     /// Returns final usage reported for each completion request in this agent stream.
     ///
     /// Each entry is a whole-request provider usage snapshot, not incremental
-    /// usage per streamed token.
+    /// usage per streamed token. Streaming providers may omit usage for some
+    /// calls; omitted calls have no entry here, and later entries keep their
+    /// original `call_index`.
     pub fn completion_call_usage(&self) -> &[CompletionCallUsage] {
         &self.completion_call_usage
     }
@@ -746,10 +740,7 @@ where
                                 let call_usage = CompletionCallUsage::new(call_index, usage);
                                 aggregated_usage += usage;
                                 completion_call_usage.push(call_usage);
-                                yield Ok(MultiTurnStreamItem::CompletionCallUsage {
-                                    call_index: call_usage.call_index,
-                                    usage: call_usage.usage,
-                                });
+                                yield Ok(MultiTurnStreamItem::CompletionCallUsage(call_usage));
                             }
                             if saw_text_this_turn {
                                 if let Some(ref hook) = self.hook &&
@@ -1295,8 +1286,8 @@ mod tests {
 
         while let Some(item) = stream.next().await {
             match item {
-                Ok(MultiTurnStreamItem::CompletionCallUsage { call_index, usage }) => {
-                    completion_call_usage_events.push(CompletionCallUsage::new(call_index, usage));
+                Ok(MultiTurnStreamItem::CompletionCallUsage(call_usage)) => {
+                    completion_call_usage_events.push(call_usage);
                 }
                 Ok(MultiTurnStreamItem::FinalResponse(response)) => {
                     final_response = Some(response);
@@ -1367,8 +1358,8 @@ mod tests {
 
         while let Some(item) = stream.next().await {
             match item {
-                Ok(MultiTurnStreamItem::CompletionCallUsage { call_index, usage }) => {
-                    completion_call_usage_events.push(CompletionCallUsage::new(call_index, usage));
+                Ok(MultiTurnStreamItem::CompletionCallUsage(call_usage)) => {
+                    completion_call_usage_events.push(call_usage);
                 }
                 Ok(MultiTurnStreamItem::FinalResponse(response)) => {
                     final_response = Some(response);

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -16,7 +16,7 @@ use std::{pin::Pin, sync::Arc};
 use tracing::info_span;
 use tracing_futures::Instrument;
 
-use super::{CompletionCallUsage, ToolCallHookAction};
+use super::{CompletionCallUsage, ToolCallHookAction, reported_usage};
 use crate::{
     agent::Agent,
     completion::{CompletionError, CompletionModel, PromptError},
@@ -40,16 +40,16 @@ pub enum MultiTurnStreamItem<R> {
     StreamAssistantItem(StreamedAssistantContent<R>),
     /// A streamed user content item (mostly for tool results).
     StreamUserItem(StreamedUserContent),
-    /// Token usage for one completion request made by this agent stream.
+    /// Details for one completion request made by this agent stream.
     ///
-    /// This is emitted when a provider call finishes and reports usage. It is
-    /// not incremental per streamed token; it is the provider's final usage for
-    /// that completion request.
+    /// This is emitted when a provider call finishes. Usage is the provider's
+    /// final usage for that completion request when available; it is not
+    /// incremental per streamed token.
     ///
     /// ```rust,ignore
     /// match item {
     ///     MultiTurnStreamItem::CompletionCallUsage(call_usage) => {
-    ///         let context_tokens = call_usage.usage.input_tokens;
+    ///         let context_tokens = call_usage.usage.map(|usage| usage.input_tokens);
     ///     }
     ///     _ => {}
     /// }
@@ -66,7 +66,7 @@ pub struct FinalResponse {
     /// This is empty only when the turn completed without emitting any text.
     response: String,
     aggregated_usage: crate::completion::Usage,
-    /// Usage values reported by completion requests made by this agent stream.
+    /// Completion requests made by this agent stream.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     completion_call_usage: Vec<CompletionCallUsage>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -92,12 +92,11 @@ impl FinalResponse {
         self.aggregated_usage
     }
 
-    /// Returns final usage reported for each completion request in this agent stream.
+    /// Returns completion requests made by this agent stream, with usage when available.
     ///
     /// Each entry is a whole-request provider usage snapshot, not incremental
     /// usage per streamed token. Streaming providers may omit usage for some
-    /// calls; omitted calls have no entry here, and later entries keep their
-    /// original `call_index`.
+    /// calls; those calls have an entry with `None` usage.
     pub fn completion_call_usage(&self) -> &[CompletionCallUsage] {
         &self.completion_call_usage
     }
@@ -596,6 +595,7 @@ where
 
                 let call_index = completion_call_index;
                 completion_call_index += 1;
+                let mut current_call_usage = None;
                 let mut tool_calls = vec![];
                 let mut tool_results = vec![];
                 let mut accumulated_reasoning: Vec<rig::message::Reasoning> = vec![];
@@ -746,10 +746,7 @@ where
                         },
                         Ok(StreamedAssistantContent::Final(final_resp)) => {
                             if let Some(usage) = final_resp.token_usage() {
-                                let call_usage = CompletionCallUsage::new(call_index, usage);
-                                aggregated_usage += usage;
-                                completion_call_usage.push(call_usage);
-                                yield Ok(MultiTurnStreamItem::CompletionCallUsage(call_usage));
+                                current_call_usage = reported_usage(usage);
                             }
                             if saw_text_this_turn {
                                 if let Some(ref hook) = self.hook &&
@@ -768,6 +765,13 @@ where
                         }
                     }
                 }
+
+                if let Some(usage) = current_call_usage {
+                    aggregated_usage += usage;
+                }
+                let call_usage = CompletionCallUsage::new(call_index, current_call_usage);
+                completion_call_usage.push(call_usage);
+                yield Ok(MultiTurnStreamItem::CompletionCallUsage(call_usage));
 
                 // Providers like Gemini emit thinking as incremental deltas
                 // without signatures; assemble into a single block so
@@ -1185,8 +1189,9 @@ mod tests {
 
     #[test]
     fn completion_call_usage_stream_item_serializes_and_deserializes_expected_shape() {
-        let item: MultiTurnStreamItem<MockResponse> =
-            MultiTurnStreamItem::CompletionCallUsage(CompletionCallUsage::new(2, usage(3, 4)));
+        let item: MultiTurnStreamItem<MockResponse> = MultiTurnStreamItem::CompletionCallUsage(
+            CompletionCallUsage::new(2, Some(usage(3, 4))),
+        );
 
         let value = serde_json::to_value(&item).expect("serialize completion call usage event");
 
@@ -1210,10 +1215,23 @@ mod tests {
             serde_json::from_value(value).expect("deserialize completion call usage event");
         match item {
             MultiTurnStreamItem::CompletionCallUsage(call_usage) => {
-                assert_eq!(call_usage, CompletionCallUsage::new(2, usage(3, 4)));
+                assert_eq!(call_usage, CompletionCallUsage::new(2, Some(usage(3, 4))));
             }
             other => panic!("expected completion call usage event, got {other:?}"),
         }
+
+        let item: MultiTurnStreamItem<MockResponse> =
+            MultiTurnStreamItem::CompletionCallUsage(CompletionCallUsage::new(3, None));
+        let value = serde_json::to_value(&item).expect("serialize missing usage event");
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "type": "completionCallUsage",
+                "call_index": 3,
+                "usage": null
+            })
+        );
     }
 
     fn streaming_text_then_final_model() -> MockCompletionModel {
@@ -1343,8 +1361,8 @@ mod tests {
         assert_eq!(
             completion_call_usage_events,
             vec![
-                CompletionCallUsage::new(0, first_call_usage),
-                CompletionCallUsage::new(1, second_call_usage)
+                CompletionCallUsage::new(0, Some(first_call_usage)),
+                CompletionCallUsage::new(1, Some(second_call_usage))
             ]
         );
 
@@ -1363,14 +1381,14 @@ mod tests {
         assert_eq!(
             final_response.completion_call_usage(),
             &[
-                CompletionCallUsage::new(0, first_call_usage),
-                CompletionCallUsage::new(1, second_call_usage)
+                CompletionCallUsage::new(0, Some(first_call_usage)),
+                CompletionCallUsage::new(1, Some(second_call_usage))
             ]
         );
     }
 
     #[tokio::test]
-    async fn stream_prompt_completion_call_usage_indexes_skip_unreported_usage() {
+    async fn stream_prompt_completion_call_usage_records_unreported_usage() {
         let second_call_usage = usage(25, 5);
         let model = MockCompletionModel::from_stream_turns([
             vec![
@@ -1411,11 +1429,17 @@ mod tests {
             }
         }
 
-        let expected_usage = CompletionCallUsage::new(1, second_call_usage);
-        assert_eq!(completion_call_usage_events, vec![expected_usage]);
+        let expected_usage = vec![
+            CompletionCallUsage::new(0, None),
+            CompletionCallUsage::new(1, Some(second_call_usage)),
+        ];
+        assert_eq!(completion_call_usage_events, expected_usage);
 
         let final_response = final_response.expect("expected final response");
-        assert_eq!(final_response.completion_call_usage(), &[expected_usage]);
+        assert_eq!(
+            final_response.completion_call_usage(),
+            expected_usage.as_slice()
+        );
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -585,6 +585,8 @@ where
 
                 .await?;
 
+                let call_index = completion_call_index;
+                completion_call_index += 1;
                 let mut tool_calls = vec![];
                 let mut tool_results = vec![];
                 let mut accumulated_reasoning: Vec<rig::message::Reasoning> = vec![];
@@ -734,8 +736,6 @@ where
                             yield Ok(MultiTurnStreamItem::stream_item(StreamedAssistantContent::ReasoningDelta { reasoning, id }));
                         },
                         Ok(StreamedAssistantContent::Final(final_resp)) => {
-                            let call_index = completion_call_index;
-                            completion_call_index += 1;
                             if let Some(usage) = final_resp.token_usage() {
                                 let call_usage = CompletionCallUsage::new(call_index, usage);
                                 aggregated_usage += usage;
@@ -1174,6 +1174,30 @@ mod tests {
         }
     }
 
+    #[test]
+    fn completion_call_usage_stream_item_serializes_expected_shape() {
+        let item: MultiTurnStreamItem<MockResponse> =
+            MultiTurnStreamItem::CompletionCallUsage(CompletionCallUsage::new(2, usage(3, 4)));
+
+        let value = serde_json::to_value(&item).expect("serialize completion call usage event");
+
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "type": "completionCallUsage",
+                "call_index": 2,
+                "usage": {
+                    "input_tokens": 3,
+                    "output_tokens": 4,
+                    "total_tokens": 7,
+                    "cached_input_tokens": 0,
+                    "cache_creation_input_tokens": 0,
+                    "reasoning_tokens": 0,
+                }
+            })
+        );
+    }
+
     fn streaming_text_then_final_model() -> MockCompletionModel {
         MockCompletionModel::from_stream_turns([[
             MockStreamEvent::text("hello"),
@@ -1338,7 +1362,6 @@ mod tests {
                     serde_json::json!({"input": "value"}),
                 )
                 .with_call_id("call_1"),
-                MockStreamEvent::FinalResponse(MockResponse::new()),
             ],
             vec![
                 MockStreamEvent::text("done"),

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -45,6 +45,15 @@ pub enum MultiTurnStreamItem<R> {
     /// This is emitted when a provider call finishes and reports usage. It is
     /// not incremental per streamed token; it is the provider's final usage for
     /// that completion request.
+    ///
+    /// ```rust,ignore
+    /// match item {
+    ///     MultiTurnStreamItem::CompletionCallUsage(call_usage) => {
+    ///         let context_tokens = call_usage.usage.input_tokens;
+    ///     }
+    ///     _ => {}
+    /// }
+    /// ```
     CompletionCallUsage(CompletionCallUsage),
     /// The final result from the stream.
     FinalResponse(FinalResponse),
@@ -1175,7 +1184,7 @@ mod tests {
     }
 
     #[test]
-    fn completion_call_usage_stream_item_serializes_expected_shape() {
+    fn completion_call_usage_stream_item_serializes_and_deserializes_expected_shape() {
         let item: MultiTurnStreamItem<MockResponse> =
             MultiTurnStreamItem::CompletionCallUsage(CompletionCallUsage::new(2, usage(3, 4)));
 
@@ -1196,6 +1205,15 @@ mod tests {
                 }
             })
         );
+
+        let item: MultiTurnStreamItem<MockResponse> =
+            serde_json::from_value(value).expect("deserialize completion call usage event");
+        match item {
+            MultiTurnStreamItem::CompletionCallUsage(call_usage) => {
+                assert_eq!(call_usage, CompletionCallUsage::new(2, usage(3, 4)));
+            }
+            other => panic!("expected completion call usage event, got {other:?}"),
+        }
     }
 
     fn streaming_text_then_final_model() -> MockCompletionModel {

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -896,7 +896,12 @@ where
     }
 }
 
-/// Helper function to stream a completion request to stdout.
+/// Helper function to stream assistant-visible completion output to stdout.
+///
+/// This helper prints streamed assistant text and reasoning only. Streaming
+/// metadata events, such as `MultiTurnStreamItem::CompletionCall`, are not
+/// printed; metadata is returned on the `FinalResponse` via accessors such as
+/// `FinalResponse::completion_calls`.
 pub async fn stream_to_stdout<R>(
     stream: &mut StreamingResult<R>,
 ) -> Result<FinalResponse, std::io::Error> {

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -40,6 +40,17 @@ pub enum MultiTurnStreamItem<R> {
     StreamAssistantItem(StreamedAssistantContent<R>),
     /// A streamed user content item (mostly for tool results).
     StreamUserItem(StreamedUserContent),
+    /// Token usage for one model request made by this agent stream.
+    ///
+    /// This is emitted when a provider call finishes and reports usage. It is
+    /// not incremental per streamed token; it is the provider's final usage for
+    /// that model call.
+    ModelCallUsage {
+        /// Zero-based index of the model request within this agent stream.
+        call_index: usize,
+        /// Token usage reported for this model request.
+        usage: crate::completion::Usage,
+    },
     /// The final result from the stream.
     FinalResponse(FinalResponse),
 }
@@ -51,6 +62,9 @@ pub struct FinalResponse {
     /// This is empty only when the turn completed without emitting any text.
     response: String,
     aggregated_usage: crate::completion::Usage,
+    /// Usage values reported by each model request made by this agent stream.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    per_call_usage: Vec<crate::completion::Usage>,
     #[serde(skip_serializing_if = "Option::is_none")]
     history: Option<Vec<Message>>,
 }
@@ -60,6 +74,7 @@ impl FinalResponse {
         Self {
             response: String::new(),
             aggregated_usage: crate::completion::Usage::new(),
+            per_call_usage: Vec::new(),
             history: None,
         }
     }
@@ -71,6 +86,14 @@ impl FinalResponse {
 
     pub fn usage(&self) -> crate::completion::Usage {
         self.aggregated_usage
+    }
+
+    /// Returns final usage reported for each model request in this agent stream.
+    ///
+    /// Each entry is a whole-request provider usage snapshot, not incremental
+    /// usage per streamed token.
+    pub fn per_call_usage(&self) -> &[crate::completion::Usage] {
+        &self.per_call_usage
     }
 
     pub fn history(&self) -> Option<&[Message]> {
@@ -87,6 +110,7 @@ impl<R> MultiTurnStreamItem<R> {
         Self::FinalResponse(FinalResponse {
             response: response.to_string(),
             aggregated_usage,
+            per_call_usage: Vec::new(),
             history: None,
         })
     }
@@ -99,6 +123,21 @@ impl<R> MultiTurnStreamItem<R> {
         Self::FinalResponse(FinalResponse {
             response: response.to_string(),
             aggregated_usage,
+            per_call_usage: Vec::new(),
+            history,
+        })
+    }
+
+    pub(crate) fn final_response_with_usage_details(
+        response: &str,
+        aggregated_usage: crate::completion::Usage,
+        per_call_usage: Vec<crate::completion::Usage>,
+        history: Option<Vec<Message>>,
+    ) -> Self {
+        Self::FinalResponse(FinalResponse {
+            response: response.to_string(),
+            aggregated_usage,
+            per_call_usage,
             history,
         })
     }
@@ -455,6 +494,7 @@ where
         let output_schema = self.output_schema;
 
         let mut aggregated_usage = crate::completion::Usage::new();
+        let mut per_call_usage = Vec::new();
 
         // NOTE: We use .instrument(agent_span) instead of span.enter() to avoid
         // span context leaking to other concurrent tasks. Using span.enter() inside
@@ -696,7 +736,15 @@ where
                             yield Ok(MultiTurnStreamItem::stream_item(StreamedAssistantContent::ReasoningDelta { reasoning, id }));
                         },
                         Ok(StreamedAssistantContent::Final(final_resp)) => {
-                            if let Some(usage) = final_resp.token_usage() { aggregated_usage += usage; };
+                            if let Some(usage) = final_resp.token_usage() {
+                                let call_index = per_call_usage.len();
+                                aggregated_usage += usage;
+                                per_call_usage.push(usage);
+                                yield Ok(MultiTurnStreamItem::ModelCallUsage {
+                                    call_index,
+                                    usage,
+                                });
+                            }
                             if saw_text_this_turn {
                                 if let Some(ref hook) = self.hook &&
                                      let HookAction::Terminate { reason } = hook.on_stream_completion_response_finish(&current_prompt, &final_resp).await {
@@ -791,9 +839,10 @@ where
                     } else {
                         None
                     };
-                    yield Ok(MultiTurnStreamItem::final_response_with_history(
+                    yield Ok(MultiTurnStreamItem::final_response_with_usage_details(
                         &turn_text_response,
                         aggregated_usage,
+                        per_call_usage,
                         final_messages,
                     ));
                     break;
@@ -868,7 +917,7 @@ mod tests {
     use crate::agent::AgentBuilder;
     use crate::client::ProviderClient;
     use crate::client::completion::CompletionClient;
-    use crate::completion::CompletionRequest;
+    use crate::completion::{CompletionRequest, Usage};
     use crate::message::{
         AssistantContent, DocumentSourceKind, ImageMediaType, Message, ReasoningContent,
         ToolResultContent, UserContent,
@@ -1117,6 +1166,17 @@ mod tests {
         ])
     }
 
+    fn usage(input_tokens: u64, output_tokens: u64) -> Usage {
+        Usage {
+            input_tokens,
+            output_tokens,
+            total_tokens: input_tokens + output_tokens,
+            cached_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            reasoning_tokens: 0,
+        }
+    }
+
     fn streaming_text_then_final_model() -> MockCompletionModel {
         MockCompletionModel::from_stream_turns([[
             MockStreamEvent::text("hello"),
@@ -1195,6 +1255,73 @@ mod tests {
         let requests = recorded.requests();
         assert_eq!(requests.len(), 2);
         assert!(validate_follow_up_tool_history(&requests[1]).is_ok());
+    }
+
+    #[tokio::test]
+    async fn stream_prompt_exposes_per_model_call_usage() {
+        let first_call_usage = usage(10, 2);
+        let second_call_usage = usage(25, 5);
+        let model = MockCompletionModel::from_stream_turns([
+            vec![
+                MockStreamEvent::tool_call(
+                    "tool_call_1",
+                    "missing_tool",
+                    serde_json::json!({"input": "value"}),
+                )
+                .with_call_id("call_1"),
+                MockStreamEvent::final_response(first_call_usage),
+            ],
+            vec![
+                MockStreamEvent::text("done"),
+                MockStreamEvent::final_response(second_call_usage),
+            ],
+        ]);
+        let agent = AgentBuilder::new(model).build();
+        let empty_history: &[Message] = &[];
+
+        let mut stream = agent
+            .stream_prompt("do tool work")
+            .with_history(empty_history)
+            .multi_turn(3)
+            .await;
+        let mut model_call_usage_events = Vec::new();
+        let mut final_response = None;
+
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(MultiTurnStreamItem::ModelCallUsage { call_index, usage }) => {
+                    model_call_usage_events.push((call_index, usage));
+                }
+                Ok(MultiTurnStreamItem::FinalResponse(response)) => {
+                    final_response = Some(response);
+                    break;
+                }
+                Ok(_) => {}
+                Err(err) => panic!("unexpected streaming error: {err:?}"),
+            }
+        }
+
+        assert_eq!(
+            model_call_usage_events,
+            vec![(0, first_call_usage), (1, second_call_usage)]
+        );
+
+        let final_response = final_response.expect("expected final response");
+        assert_eq!(
+            final_response.usage(),
+            Usage {
+                input_tokens: 35,
+                output_tokens: 7,
+                total_tokens: 42,
+                cached_input_tokens: 0,
+                cache_creation_input_tokens: 0,
+                reasoning_tokens: 0,
+            }
+        );
+        assert_eq!(
+            final_response.per_call_usage(),
+            &[first_call_usage, second_call_usage]
+        );
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -16,7 +16,7 @@ use std::{pin::Pin, sync::Arc};
 use tracing::info_span;
 use tracing_futures::Instrument;
 
-use super::ToolCallHookAction;
+use super::{CompletionCallUsage, ToolCallHookAction};
 use crate::{
     agent::Agent,
     completion::{CompletionError, CompletionModel, PromptError},
@@ -40,15 +40,18 @@ pub enum MultiTurnStreamItem<R> {
     StreamAssistantItem(StreamedAssistantContent<R>),
     /// A streamed user content item (mostly for tool results).
     StreamUserItem(StreamedUserContent),
-    /// Token usage for one model request made by this agent stream.
+    /// Token usage for one completion request made by this agent stream.
     ///
     /// This is emitted when a provider call finishes and reports usage. It is
     /// not incremental per streamed token; it is the provider's final usage for
-    /// that model call.
-    ModelCallUsage {
-        /// Zero-based index of the model request within this agent stream.
+    /// that completion request.
+    CompletionCallUsage {
+        /// Zero-based index of the completion request within this agent stream.
+        ///
+        /// This counts every completion request, including requests that do not
+        /// report token usage.
         call_index: usize,
-        /// Token usage reported for this model request.
+        /// Token usage reported for this completion request.
         usage: crate::completion::Usage,
     },
     /// The final result from the stream.
@@ -62,9 +65,9 @@ pub struct FinalResponse {
     /// This is empty only when the turn completed without emitting any text.
     response: String,
     aggregated_usage: crate::completion::Usage,
-    /// Usage values reported by each model request made by this agent stream.
+    /// Usage values reported by completion requests made by this agent stream.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    per_call_usage: Vec<crate::completion::Usage>,
+    completion_call_usage: Vec<CompletionCallUsage>,
     #[serde(skip_serializing_if = "Option::is_none")]
     history: Option<Vec<Message>>,
 }
@@ -74,7 +77,7 @@ impl FinalResponse {
         Self {
             response: String::new(),
             aggregated_usage: crate::completion::Usage::new(),
-            per_call_usage: Vec::new(),
+            completion_call_usage: Vec::new(),
             history: None,
         }
     }
@@ -88,12 +91,12 @@ impl FinalResponse {
         self.aggregated_usage
     }
 
-    /// Returns final usage reported for each model request in this agent stream.
+    /// Returns final usage reported for each completion request in this agent stream.
     ///
     /// Each entry is a whole-request provider usage snapshot, not incremental
     /// usage per streamed token.
-    pub fn per_call_usage(&self) -> &[crate::completion::Usage] {
-        &self.per_call_usage
+    pub fn completion_call_usage(&self) -> &[CompletionCallUsage] {
+        &self.completion_call_usage
     }
 
     pub fn history(&self) -> Option<&[Message]> {
@@ -110,7 +113,7 @@ impl<R> MultiTurnStreamItem<R> {
         Self::FinalResponse(FinalResponse {
             response: response.to_string(),
             aggregated_usage,
-            per_call_usage: Vec::new(),
+            completion_call_usage: Vec::new(),
             history: None,
         })
     }
@@ -123,21 +126,21 @@ impl<R> MultiTurnStreamItem<R> {
         Self::FinalResponse(FinalResponse {
             response: response.to_string(),
             aggregated_usage,
-            per_call_usage: Vec::new(),
+            completion_call_usage: Vec::new(),
             history,
         })
     }
 
-    pub(crate) fn final_response_with_usage_details(
+    pub(crate) fn final_response_with_completion_call_usage(
         response: &str,
         aggregated_usage: crate::completion::Usage,
-        per_call_usage: Vec<crate::completion::Usage>,
+        completion_call_usage: Vec<CompletionCallUsage>,
         history: Option<Vec<Message>>,
     ) -> Self {
         Self::FinalResponse(FinalResponse {
             response: response.to_string(),
             aggregated_usage,
-            per_call_usage,
+            completion_call_usage,
             history,
         })
     }
@@ -494,7 +497,8 @@ where
         let output_schema = self.output_schema;
 
         let mut aggregated_usage = crate::completion::Usage::new();
-        let mut per_call_usage = Vec::new();
+        let mut completion_call_usage = Vec::new();
+        let mut completion_call_index = 0;
 
         // NOTE: We use .instrument(agent_span) instead of span.enter() to avoid
         // span context leaking to other concurrent tasks. Using span.enter() inside
@@ -736,13 +740,15 @@ where
                             yield Ok(MultiTurnStreamItem::stream_item(StreamedAssistantContent::ReasoningDelta { reasoning, id }));
                         },
                         Ok(StreamedAssistantContent::Final(final_resp)) => {
+                            let call_index = completion_call_index;
+                            completion_call_index += 1;
                             if let Some(usage) = final_resp.token_usage() {
-                                let call_index = per_call_usage.len();
+                                let call_usage = CompletionCallUsage::new(call_index, usage);
                                 aggregated_usage += usage;
-                                per_call_usage.push(usage);
-                                yield Ok(MultiTurnStreamItem::ModelCallUsage {
-                                    call_index,
-                                    usage,
+                                completion_call_usage.push(call_usage);
+                                yield Ok(MultiTurnStreamItem::CompletionCallUsage {
+                                    call_index: call_usage.call_index,
+                                    usage: call_usage.usage,
                                 });
                             }
                             if saw_text_this_turn {
@@ -839,10 +845,10 @@ where
                     } else {
                         None
                     };
-                    yield Ok(MultiTurnStreamItem::final_response_with_usage_details(
+                    yield Ok(MultiTurnStreamItem::final_response_with_completion_call_usage(
                         &turn_text_response,
                         aggregated_usage,
-                        per_call_usage,
+                        completion_call_usage,
                         final_messages,
                     ));
                     break;
@@ -925,7 +931,7 @@ mod tests {
     use crate::providers::anthropic;
     use crate::streaming::StreamingPrompt;
     use crate::test_utils::{
-        AppendFailingMemory, FailingMemory, MockCompletionModel, MockStreamEvent,
+        AppendFailingMemory, FailingMemory, MockCompletionModel, MockResponse, MockStreamEvent,
     };
     use futures::StreamExt;
     use std::sync::Arc;
@@ -1258,7 +1264,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stream_prompt_exposes_per_model_call_usage() {
+    async fn stream_prompt_exposes_completion_call_usage() {
         let first_call_usage = usage(10, 2);
         let second_call_usage = usage(25, 5);
         let model = MockCompletionModel::from_stream_turns([
@@ -1284,13 +1290,13 @@ mod tests {
             .with_history(empty_history)
             .multi_turn(3)
             .await;
-        let mut model_call_usage_events = Vec::new();
+        let mut completion_call_usage_events = Vec::new();
         let mut final_response = None;
 
         while let Some(item) = stream.next().await {
             match item {
-                Ok(MultiTurnStreamItem::ModelCallUsage { call_index, usage }) => {
-                    model_call_usage_events.push((call_index, usage));
+                Ok(MultiTurnStreamItem::CompletionCallUsage { call_index, usage }) => {
+                    completion_call_usage_events.push(CompletionCallUsage::new(call_index, usage));
                 }
                 Ok(MultiTurnStreamItem::FinalResponse(response)) => {
                     final_response = Some(response);
@@ -1302,8 +1308,11 @@ mod tests {
         }
 
         assert_eq!(
-            model_call_usage_events,
-            vec![(0, first_call_usage), (1, second_call_usage)]
+            completion_call_usage_events,
+            vec![
+                CompletionCallUsage::new(0, first_call_usage),
+                CompletionCallUsage::new(1, second_call_usage)
+            ]
         );
 
         let final_response = final_response.expect("expected final response");
@@ -1319,9 +1328,62 @@ mod tests {
             }
         );
         assert_eq!(
-            final_response.per_call_usage(),
-            &[first_call_usage, second_call_usage]
+            final_response.completion_call_usage(),
+            &[
+                CompletionCallUsage::new(0, first_call_usage),
+                CompletionCallUsage::new(1, second_call_usage)
+            ]
         );
+    }
+
+    #[tokio::test]
+    async fn stream_prompt_completion_call_usage_indexes_skip_unreported_usage() {
+        let second_call_usage = usage(25, 5);
+        let model = MockCompletionModel::from_stream_turns([
+            vec![
+                MockStreamEvent::tool_call(
+                    "tool_call_1",
+                    "missing_tool",
+                    serde_json::json!({"input": "value"}),
+                )
+                .with_call_id("call_1"),
+                MockStreamEvent::FinalResponse(MockResponse::new()),
+            ],
+            vec![
+                MockStreamEvent::text("done"),
+                MockStreamEvent::final_response(second_call_usage),
+            ],
+        ]);
+        let agent = AgentBuilder::new(model).build();
+        let empty_history: &[Message] = &[];
+
+        let mut stream = agent
+            .stream_prompt("do tool work")
+            .with_history(empty_history)
+            .multi_turn(3)
+            .await;
+        let mut completion_call_usage_events = Vec::new();
+        let mut final_response = None;
+
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(MultiTurnStreamItem::CompletionCallUsage { call_index, usage }) => {
+                    completion_call_usage_events.push(CompletionCallUsage::new(call_index, usage));
+                }
+                Ok(MultiTurnStreamItem::FinalResponse(response)) => {
+                    final_response = Some(response);
+                    break;
+                }
+                Ok(_) => {}
+                Err(err) => panic!("unexpected streaming error: {err:?}"),
+            }
+        }
+
+        let expected_usage = CompletionCallUsage::new(1, second_call_usage);
+        assert_eq!(completion_call_usage_events, vec![expected_usage]);
+
+        let final_response = final_response.expect("expected final response");
+        assert_eq!(final_response.completion_call_usage(), &[expected_usage]);
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -40,7 +40,7 @@ pub enum MultiTurnStreamItem<R> {
     StreamAssistantItem(StreamedAssistantContent<R>),
     /// A streamed user content item (mostly for tool results).
     StreamUserItem(StreamedUserContent),
-    /// Details for one completion request made by this agent stream.
+    /// Details for one successfully completed completion request made by this agent stream.
     ///
     /// This is emitted when a provider call finishes. Usage is the provider's
     /// final usage for that completion request when available; it is not
@@ -66,7 +66,7 @@ pub struct FinalResponse {
     /// This is empty only when the turn completed without emitting any text.
     response: String,
     aggregated_usage: crate::completion::Usage,
-    /// Completion requests made by this agent stream.
+    /// Successfully completed completion requests made by this agent stream.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     completion_calls: Vec<CompletionCall>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -92,7 +92,7 @@ impl FinalResponse {
         self.aggregated_usage
     }
 
-    /// Returns completion requests made by this agent stream, with usage when available.
+    /// Returns successfully completed completion requests made by this agent stream, with usage when available.
     ///
     /// Each entry represents one provider completion request. When present,
     /// usage is a whole-request provider snapshot, not incremental usage per

--- a/examples/openai_streaming_per_call_usage.rs
+++ b/examples/openai_streaming_per_call_usage.rs
@@ -8,7 +8,7 @@
 //!
 //! That aggregate is useful for total cost, but it does not tell you the final
 //! prompt/context size. For that, inspect the last entry from
-//! `response.completion_call_usage()` and use `input_tokens` when usage is
+//! `response.completion_calls()` and use `input_tokens` when usage is
 //! reported.
 //!
 //! Requires `OPENAI_API_KEY`.
@@ -122,19 +122,19 @@ async fn main() -> Result<()> {
             MultiTurnStreamItem::StreamUserItem(_) => {
                 println!("tool result sent back to model");
             }
-            MultiTurnStreamItem::CompletionCallUsage(call_usage) => {
+            MultiTurnStreamItem::CompletionCall(completion_call) => {
                 if printed_streamed_text {
                     println!();
                     printed_streamed_text = false;
                 }
-                match call_usage.usage {
+                match completion_call.usage {
                     Some(usage) => print_usage(
-                        &format!("completion call {} usage", call_usage.call_index),
+                        &format!("completion call {} usage", completion_call.call_index),
                         usage,
                     ),
                     None => println!(
                         "completion call {} usage: not reported",
-                        call_usage.call_index
+                        completion_call.call_index
                     ),
                 }
             }
@@ -150,8 +150,8 @@ async fn main() -> Result<()> {
     println!("\n\nfinal response: {}", response.response());
     print_usage("aggregate agent usage", response.usage());
 
-    if let Some(final_call_usage) = response.completion_call_usage().last().copied() {
-        if let Some(usage) = final_call_usage.usage {
+    if let Some(final_completion_call) = response.completion_calls().last().copied() {
+        if let Some(usage) = final_completion_call.usage {
             print_usage("final completion call usage", usage);
             println!("final prompt/context token length: {}", usage.input_tokens);
         } else {

--- a/examples/openai_streaming_per_call_usage.rs
+++ b/examples/openai_streaming_per_call_usage.rs
@@ -121,12 +121,15 @@ async fn main() -> Result<()> {
             MultiTurnStreamItem::StreamUserItem(_) => {
                 println!("tool result sent back to model");
             }
-            MultiTurnStreamItem::CompletionCallUsage { call_index, usage } => {
+            MultiTurnStreamItem::CompletionCallUsage(call_usage) => {
                 if printed_streamed_text {
                     println!();
                     printed_streamed_text = false;
                 }
-                print_usage(&format!("completion call {call_index} usage"), usage);
+                print_usage(
+                    &format!("completion call {} usage", call_usage.call_index),
+                    call_usage.usage,
+                );
             }
             MultiTurnStreamItem::FinalResponse(response) => {
                 final_response = Some(response);

--- a/examples/openai_streaming_per_call_usage.rs
+++ b/examples/openai_streaming_per_call_usage.rs
@@ -1,0 +1,146 @@
+//! Shows how to inspect per-model-call usage in an agent stream.
+//!
+//! This is useful when an agent uses tools. The final `response.usage()` is
+//! intentionally aggregated across all model calls in the agent run:
+//!
+//! - call 0: prompt + tool request
+//! - call 1: prompt + prior tool call + tool result + final answer
+//!
+//! That aggregate is useful for total cost, but it does not tell you the final
+//! prompt/context size. For that, inspect the last entry from
+//! `response.per_call_usage()` and use `input_tokens`.
+//!
+//! Requires `OPENAI_API_KEY`.
+//!
+//! For OpenAI:
+//! `cargo run --example openai_streaming_per_call_usage`
+//!
+//! For OpenAI-compatible servers, for example llama.cpp:
+//! `OPENAI_BASE_URL=http://localhost:8080/v1 OPENAI_API_KEY=local OPENAI_MODEL=local-model cargo run --example openai_streaming_per_call_usage`
+
+use anyhow::{Result, anyhow};
+use futures::StreamExt;
+use rig::agent::MultiTurnStreamItem;
+use rig::client::{CompletionClient, ProviderClient};
+use rig::completion::{ToolDefinition, Usage};
+use rig::providers::openai;
+use rig::streaming::{StreamedAssistantContent, StreamingPrompt};
+use rig::tool::Tool;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::io::{self, Write};
+
+#[derive(Debug, thiserror::Error)]
+#[error("project status lookup failed")]
+struct ProjectStatusError;
+
+#[derive(Debug, Deserialize)]
+struct ProjectStatusArgs {
+    ticket: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct ProjectStatusTool;
+
+impl Tool for ProjectStatusTool {
+    const NAME: &'static str = "lookup_project_status";
+
+    type Error = ProjectStatusError;
+    type Args = ProjectStatusArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "Look up the current status for an internal project ticket.".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "ticket": {
+                        "type": "string",
+                        "description": "The internal project ticket to look up"
+                    }
+                },
+                "required": ["ticket"]
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        Ok(format!(
+            "{} is approved for release after the final usage metrics check.",
+            args.ticket
+        ))
+    }
+}
+
+fn print_usage(label: &str, usage: Usage) {
+    println!(
+        "{label}: input_tokens={}, output_tokens={}, total_tokens={}",
+        usage.input_tokens, usage.output_tokens, usage.total_tokens
+    );
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let model = std::env::var("OPENAI_MODEL").unwrap_or_else(|_| openai::GPT_4O_MINI.to_string());
+
+    let agent = openai::CompletionsClient::from_env()?
+        .agent(model)
+        .preamble(
+            "You are a concise release assistant. The user will ask about an \
+             internal ticket. Call `lookup_project_status` exactly once before \
+             answering. After the tool result is available, answer directly and \
+             do not call another tool.",
+        )
+        .max_tokens(512)
+        .tool(ProjectStatusTool)
+        .build();
+
+    let mut stream = agent
+        .stream_prompt("Check ticket RIG-usage-42 and summarize the result in one sentence.")
+        .multi_turn(4)
+        .await;
+
+    let mut final_response = None;
+
+    while let Some(item) = stream.next().await {
+        match item? {
+            MultiTurnStreamItem::StreamAssistantItem(StreamedAssistantContent::Text(text)) => {
+                print!("{}", text.text);
+                io::stdout().flush()?;
+            }
+            MultiTurnStreamItem::StreamAssistantItem(StreamedAssistantContent::ToolCall {
+                tool_call,
+                ..
+            }) => {
+                println!("\n\nmodel requested tool: {}", tool_call.function.name);
+            }
+            MultiTurnStreamItem::StreamUserItem(_) => {
+                println!("tool result sent back to model");
+            }
+            MultiTurnStreamItem::ModelCallUsage { call_index, usage } => {
+                print_usage(&format!("model call {call_index} usage"), usage);
+            }
+            MultiTurnStreamItem::FinalResponse(response) => {
+                final_response = Some(response);
+            }
+            _ => {}
+        }
+    }
+
+    let response = final_response.ok_or_else(|| anyhow!("stream ended without final response"))?;
+
+    println!("\n\nfinal response: {}", response.response());
+    print_usage("aggregate agent usage", response.usage());
+
+    if let Some(final_call_usage) = response.per_call_usage().last().copied() {
+        print_usage("final model call usage", final_call_usage);
+        println!(
+            "final prompt/context token length: {}",
+            final_call_usage.input_tokens
+        );
+    }
+
+    Ok(())
+}

--- a/examples/openai_streaming_per_call_usage.rs
+++ b/examples/openai_streaming_per_call_usage.rs
@@ -8,7 +8,8 @@
 //!
 //! That aggregate is useful for total cost, but it does not tell you the final
 //! prompt/context size. For that, inspect the last entry from
-//! `response.completion_call_usage()` and use `input_tokens`.
+//! `response.completion_call_usage()` and use `input_tokens` when usage is
+//! reported.
 //!
 //! Requires `OPENAI_API_KEY`.
 //!
@@ -126,10 +127,16 @@ async fn main() -> Result<()> {
                     println!();
                     printed_streamed_text = false;
                 }
-                print_usage(
-                    &format!("completion call {} usage", call_usage.call_index),
-                    call_usage.usage,
-                );
+                match call_usage.usage {
+                    Some(usage) => print_usage(
+                        &format!("completion call {} usage", call_usage.call_index),
+                        usage,
+                    ),
+                    None => println!(
+                        "completion call {} usage: not reported",
+                        call_usage.call_index
+                    ),
+                }
             }
             MultiTurnStreamItem::FinalResponse(response) => {
                 final_response = Some(response);
@@ -144,11 +151,12 @@ async fn main() -> Result<()> {
     print_usage("aggregate agent usage", response.usage());
 
     if let Some(final_call_usage) = response.completion_call_usage().last().copied() {
-        print_usage("final completion call usage", final_call_usage.usage);
-        println!(
-            "final prompt/context token length: {}",
-            final_call_usage.usage.input_tokens
-        );
+        if let Some(usage) = final_call_usage.usage {
+            print_usage("final completion call usage", usage);
+            println!("final prompt/context token length: {}", usage.input_tokens);
+        } else {
+            println!("final completion call usage: not reported");
+        }
     }
 
     Ok(())

--- a/examples/openai_streaming_per_call_usage.rs
+++ b/examples/openai_streaming_per_call_usage.rs
@@ -1,14 +1,14 @@
-//! Shows how to inspect per-model-call usage in an agent stream.
+//! Shows how to inspect per-completion-call usage in an agent stream.
 //!
 //! This is useful when an agent uses tools. The final `response.usage()` is
-//! intentionally aggregated across all model calls in the agent run:
+//! intentionally aggregated across all completion calls in the agent run:
 //!
 //! - call 0: prompt + tool request
 //! - call 1: prompt + prior tool call + tool result + final answer
 //!
 //! That aggregate is useful for total cost, but it does not tell you the final
 //! prompt/context size. For that, inspect the last entry from
-//! `response.per_call_usage()` and use `input_tokens`.
+//! `response.completion_call_usage()` and use `input_tokens`.
 //!
 //! Requires `OPENAI_API_KEY`.
 //!
@@ -103,12 +103,14 @@ async fn main() -> Result<()> {
         .await;
 
     let mut final_response = None;
+    let mut printed_streamed_text = false;
 
     while let Some(item) = stream.next().await {
         match item? {
             MultiTurnStreamItem::StreamAssistantItem(StreamedAssistantContent::Text(text)) => {
                 print!("{}", text.text);
                 io::stdout().flush()?;
+                printed_streamed_text = true;
             }
             MultiTurnStreamItem::StreamAssistantItem(StreamedAssistantContent::ToolCall {
                 tool_call,
@@ -119,8 +121,12 @@ async fn main() -> Result<()> {
             MultiTurnStreamItem::StreamUserItem(_) => {
                 println!("tool result sent back to model");
             }
-            MultiTurnStreamItem::ModelCallUsage { call_index, usage } => {
-                print_usage(&format!("model call {call_index} usage"), usage);
+            MultiTurnStreamItem::CompletionCallUsage { call_index, usage } => {
+                if printed_streamed_text {
+                    println!();
+                    printed_streamed_text = false;
+                }
+                print_usage(&format!("completion call {call_index} usage"), usage);
             }
             MultiTurnStreamItem::FinalResponse(response) => {
                 final_response = Some(response);
@@ -134,11 +140,11 @@ async fn main() -> Result<()> {
     println!("\n\nfinal response: {}", response.response());
     print_usage("aggregate agent usage", response.usage());
 
-    if let Some(final_call_usage) = response.per_call_usage().last().copied() {
-        print_usage("final model call usage", final_call_usage);
+    if let Some(final_call_usage) = response.completion_call_usage().last().copied() {
+        print_usage("final completion call usage", final_call_usage.usage);
         println!(
             "final prompt/context token length: {}",
-            final_call_usage.input_tokens
+            final_call_usage.usage.input_tokens
         );
     }
 


### PR DESCRIPTION
## Summary

- Add a shared `CompletionCall` type for agent completion/model-call metadata, with `call_index` and optional `usage`.
- Emit every completed model call from agent streams via `MultiTurnStreamItem::CompletionCall(CompletionCall)`, including calls where the provider did not report usage.
- Store completion call metadata on streaming `FinalResponse`, non-streaming `PromptResponse`, and `TypedPromptResponse` while preserving the existing aggregate `usage` behavior.
- Update the OpenAI-compatible example to show the aggregate-vs-final-context distinction with the new API.

## Context

In multi-turn agent flows with tools, aggregate usage is the sum of all completion calls. That remains useful for total token cost, but it does not reveal the final prompt/context length.

The new API exposes the model calls that happened during the run, so callers can inspect the last completion call usage input tokens when the provider reports usage for that call. This gives users access to the final call context size without changing the meaning of the aggregate `response.usage()` value.

This is not incremental per-token streaming usage. It reflects final usage reported for each completion request. Some OpenAI-compatible providers only report usage at the end of a request, and some providers may omit usage entirely. Those calls are now still represented as `CompletionCall { usage: None, .. }` rather than being dropped.

`stream_to_stdout` remains a display helper for assistant text/reasoning. Streaming metadata such as `CompletionCall` is returned through the final response accessors rather than printed to stdout.

## Verification

- `cargo fmt --check`
- `cargo test -p rig-core`
- `cargo clippy -p rig-core --all-targets --all-features`
- `cargo check --example openai_streaming_per_call_usage`
- `cargo clippy --example openai_streaming_per_call_usage`