### PR TITLE
feat(gemini): expose streaming response metadata

### DIFF
--- a/crates/rig-bedrock/src/streaming.rs
+++ b/crates/rig-bedrock/src/streaming.rs
@@ -38,6 +38,7 @@ impl GetTokenUsage for BedrockStreamingResponse {
             total_tokens: u.total_tokens as u64,
             cached_input_tokens: u.cache_read_input_tokens.unwrap_or_default() as u64,
             cache_creation_input_tokens: u.cache_write_input_tokens.unwrap_or_default() as u64,
+            tool_use_prompt_tokens: 0,
             reasoning_tokens: 0,
         })
     }

--- a/crates/rig-bedrock/src/types/assistant_content.rs
+++ b/crates/rig-bedrock/src/types/assistant_content.rs
@@ -25,6 +25,7 @@ fn normalize_usage(usage: &TokenUsage) -> completion::Usage {
         total_tokens: usage.total_tokens as u64,
         cached_input_tokens: usage.cache_read_input_tokens.unwrap_or_default() as u64,
         cache_creation_input_tokens: usage.cache_write_input_tokens.unwrap_or_default() as u64,
+        tool_use_prompt_tokens: 0,
         reasoning_tokens: 0,
     }
 }

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -953,6 +953,7 @@ mod tests {
                 total_tokens: 3,
                 cached_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                tool_use_prompt_tokens: 0,
                 reasoning_tokens: 0,
             },
         );
@@ -1025,6 +1026,7 @@ mod tests {
                     total_tokens: 2,
                     cached_input_tokens: 0,
                     cache_creation_input_tokens: 0,
+                    tool_use_prompt_tokens: 0,
                     reasoning_tokens: 0,
                 }),
             MockTurn::text("").with_usage(Usage {
@@ -1033,6 +1035,7 @@ mod tests {
                 total_tokens: 2,
                 cached_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                tool_use_prompt_tokens: 0,
                 reasoning_tokens: 0,
             }),
         ]);
@@ -1054,6 +1057,7 @@ mod tests {
                 total_tokens: 4,
                 cached_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                tool_use_prompt_tokens: 0,
                 reasoning_tokens: 0,
             }
         );

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -403,6 +403,9 @@ pub struct Usage {
     pub cached_input_tokens: u64,
     /// The number of input tokens written to a provider-managed cache
     pub cache_creation_input_tokens: u64,
+    /// The number of tool-use prompt tokens used in a given request.
+    #[serde(default)]
+    pub tool_use_prompt_tokens: u64,
     /// The number of tokens spent on internal reasoning / "thoughts" by reasoning-capable
     /// models (e.g. Gemini thinking, Anthropic extended thinking, OpenAI o-series).
     pub reasoning_tokens: u64,
@@ -417,6 +420,7 @@ impl Usage {
             total_tokens: 0,
             cached_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            tool_use_prompt_tokens: 0,
             reasoning_tokens: 0,
         }
     }
@@ -439,6 +443,7 @@ impl Add for Usage {
             cached_input_tokens: self.cached_input_tokens + other.cached_input_tokens,
             cache_creation_input_tokens: self.cache_creation_input_tokens
                 + other.cache_creation_input_tokens,
+            tool_use_prompt_tokens: self.tool_use_prompt_tokens + other.tool_use_prompt_tokens,
             reasoning_tokens: self.reasoning_tokens + other.reasoning_tokens,
         }
     }
@@ -451,6 +456,7 @@ impl AddAssign for Usage {
         self.total_tokens += other.total_tokens;
         self.cached_input_tokens += other.cached_input_tokens;
         self.cache_creation_input_tokens += other.cache_creation_input_tokens;
+        self.tool_use_prompt_tokens += other.tool_use_prompt_tokens;
         self.reasoning_tokens += other.reasoning_tokens;
     }
 }

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -242,6 +242,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                 + response.usage.output_tokens,
             cached_input_tokens: response.usage.cache_read_input_tokens.unwrap_or(0),
             cache_creation_input_tokens: response.usage.cache_creation_input_tokens.unwrap_or(0),
+            tool_use_prompt_tokens: 0,
             reasoning_tokens: 0,
         };
 

--- a/crates/rig-core/src/providers/cohere/completion.rs
+++ b/crates/rig-core/src/providers/cohere/completion.rs
@@ -189,6 +189,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                     total_tokens: (input_tokens + output_tokens) as u64,
                     cached_input_tokens: 0,
                     cache_creation_input_tokens: 0,
+                    tool_use_prompt_tokens: 0,
                     reasoning_tokens: 0,
                 }
             })

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -586,6 +586,7 @@ impl TryFrom<ChatCompletionResponse> for completion::CompletionResponse<ChatComp
                     .map(|d| d.cached_tokens as u64)
                     .unwrap_or(0),
                 cache_creation_input_tokens: 0,
+                tool_use_prompt_tokens: 0,
                 reasoning_tokens: 0,
             })
             .unwrap_or_default();

--- a/crates/rig-core/src/providers/deepseek.rs
+++ b/crates/rig-core/src/providers/deepseek.rs
@@ -445,6 +445,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                 .map(|c| c as u64)
                 .unwrap_or(0),
             cache_creation_input_tokens: 0,
+            tool_use_prompt_tokens: 0,
             reasoning_tokens: 0,
         };
 

--- a/crates/rig-core/src/providers/galadriel.rs
+++ b/crates/rig-core/src/providers/galadriel.rs
@@ -273,6 +273,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                 total_tokens: usage.total_tokens as u64,
                 cached_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                tool_use_prompt_tokens: 0,
                 reasoning_tokens: 0,
             })
             .unwrap_or_default();

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -1396,6 +1396,8 @@ pub mod gemini_api_types {
             usage.output_tokens = self.candidates_token_count.unwrap_or_default() as u64;
             usage.cached_input_tokens = self.cached_content_token_count.unwrap_or_default() as u64;
             usage.reasoning_tokens = self.thoughts_token_count.unwrap_or_default() as u64;
+            usage.tool_use_prompt_tokens =
+                self.tool_use_prompt_token_count.unwrap_or_default() as u64;
             usage.total_tokens = self.total_token_count as u64;
 
             Some(usage)
@@ -2386,7 +2388,7 @@ mod tests {
                 prompt_tokens_details: None,
                 cache_tokens_details: None,
                 candidates_tokens_details: None,
-                tool_use_prompt_token_count: None,
+                tool_use_prompt_token_count: Some(12),
                 tool_use_prompt_tokens_details: None,
                 traffic_type: None,
             }),
@@ -2400,6 +2402,7 @@ mod tests {
         assert_eq!(converted.usage.cached_input_tokens, 20);
         assert_eq!(converted.usage.output_tokens, 30);
         assert_eq!(converted.usage.reasoning_tokens, 10);
+        assert_eq!(converted.usage.tool_use_prompt_tokens, 12);
         assert_eq!(converted.usage.total_tokens, 100);
     }
 

--- a/crates/rig-core/src/providers/gemini/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/streaming.rs
@@ -5,7 +5,7 @@ use tracing::{Level, enabled, info_span};
 use tracing_futures::Instrument;
 
 use super::completion::gemini_api_types::{
-    ContentCandidate, ModalityTokenCount, Part, PartKind, TrafficType,
+    ContentCandidate, FinishReason, ModalityTokenCount, Part, PartKind, TrafficType,
 };
 use super::completion::{
     CompletionModel, create_request_body, resolve_request_model, streaming_endpoint,
@@ -51,6 +51,7 @@ impl GetTokenUsage for PartialUsage {
         usage.output_tokens = self.candidates_token_count.unwrap_or_default() as u64;
         usage.cached_input_tokens = self.cached_content_token_count.unwrap_or_default() as u64;
         usage.reasoning_tokens = self.thoughts_token_count.unwrap_or_default() as u64;
+        usage.tool_use_prompt_tokens = self.tool_use_prompt_token_count.unwrap_or_default() as u64;
         usage.total_tokens = self.total_token_count as u64;
 
         Some(usage)
@@ -71,6 +72,8 @@ pub struct StreamGenerateContentResponse {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct StreamingCompletionResponse {
     pub usage_metadata: PartialUsage,
+    pub finish_reason: Option<FinishReason>,
+    pub model_version: Option<String>,
 }
 
 impl GetTokenUsage for StreamingCompletionResponse {
@@ -131,6 +134,8 @@ where
 
         let stream = stream! {
             let mut final_usage = None;
+            let mut final_finish_reason = None;
+            let mut final_model_version = None;
             while let Some(event_result) = event_source.next().await {
                 match event_result {
                     Ok(Event::Open) => {
@@ -158,6 +163,9 @@ where
                         if let Some(model_version) = data.model_version.as_deref() {
                             span.record("gen_ai.response.model", model_version);
                         }
+                        if data.model_version.is_some() {
+                            final_model_version = data.model_version.clone();
+                        }
                         if let Some(usage) = data.usage_metadata.as_ref() {
                             span.record_token_usage(usage);
                             final_usage = Some(usage.clone());
@@ -170,6 +178,10 @@ where
                         };
 
                         let Some(content) = choice.content else {
+                            if choice.finish_reason.is_some() {
+                                final_finish_reason = choice.finish_reason;
+                                break;
+                            }
                             tracing::debug!(finish_reason = ?choice.finish_reason, "Streaming candidate missing content");
                             continue;
                         };
@@ -233,6 +245,7 @@ where
 
                         // Check if this is the final response
                         if choice.finish_reason.is_some() {
+                            final_finish_reason = choice.finish_reason;
                             break;
                         }
                     }
@@ -251,7 +264,9 @@ where
             event_source.close();
 
             yield Ok(streaming::RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
-                usage_metadata: final_usage.unwrap_or_default()
+                usage_metadata: final_usage.unwrap_or_default(),
+                finish_reason: final_finish_reason,
+                model_version: final_model_version,
             }));
         }.instrument(span);
 
@@ -288,6 +303,10 @@ mod tests {
 
         let response: StreamGenerateContentResponse = serde_json::from_value(json_data).unwrap();
         assert_eq!(response.candidates.len(), 1);
+        assert!(matches!(
+            response.candidates[0].finish_reason,
+            Some(FinishReason::Stop)
+        ));
         let content = response.candidates[0]
             .content
             .as_ref()
@@ -569,7 +588,7 @@ mod tests {
             prompt_tokens_details: None,
             cache_tokens_details: None,
             candidates_tokens_details: None,
-            tool_use_prompt_token_count: None,
+            tool_use_prompt_token_count: Some(12),
             tool_use_prompt_tokens_details: None,
             traffic_type: None,
         };
@@ -579,6 +598,7 @@ mod tests {
         assert_eq!(token_usage.cached_input_tokens, 20);
         assert_eq!(token_usage.output_tokens, 30);
         assert_eq!(token_usage.reasoning_tokens, 10);
+        assert_eq!(token_usage.tool_use_prompt_tokens, 12);
         assert_eq!(token_usage.total_tokens, 100);
     }
 
@@ -622,6 +642,8 @@ mod tests {
                 tool_use_prompt_tokens_details: None,
                 traffic_type: None,
             },
+            finish_reason: Some(FinishReason::Stop),
+            model_version: Some("gemini-2.0-flash-001".to_string()),
         };
 
         let token_usage = response.token_usage().unwrap();
@@ -630,6 +652,11 @@ mod tests {
         assert_eq!(token_usage.reasoning_tokens, 0);
         assert_eq!(token_usage.cached_input_tokens, 0);
         assert_eq!(token_usage.total_tokens, 150);
+        assert!(matches!(response.finish_reason, Some(FinishReason::Stop)));
+        assert_eq!(
+            response.model_version.as_deref(),
+            Some("gemini-2.0-flash-001")
+        );
     }
 
     #[test]
@@ -679,6 +706,7 @@ mod tests {
         assert_eq!(token_usage.cached_input_tokens, 25);
         assert_eq!(token_usage.output_tokens, 50);
         assert_eq!(token_usage.reasoning_tokens, 15);
+        assert_eq!(token_usage.tool_use_prompt_tokens, 12);
         assert_eq!(token_usage.total_tokens, 190);
     }
 }

--- a/crates/rig-core/src/providers/huggingface/completion.rs
+++ b/crates/rig-core/src/providers/huggingface/completion.rs
@@ -605,6 +605,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             total_tokens: response.usage.total_tokens as u64,
             cached_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            tool_use_prompt_tokens: 0,
             reasoning_tokens: 0,
         };
 

--- a/crates/rig-core/src/providers/hyperbolic.rs
+++ b/crates/rig-core/src/providers/hyperbolic.rs
@@ -237,6 +237,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                 total_tokens: usage.total_tokens as u64,
                 cached_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                tool_use_prompt_tokens: 0,
                 reasoning_tokens: 0,
             })
             .unwrap_or_default();

--- a/crates/rig-core/src/providers/internal/mod.rs
+++ b/crates/rig-core/src/providers/internal/mod.rs
@@ -15,6 +15,7 @@ pub(crate) fn completion_usage(
         total_tokens,
         cached_input_tokens,
         cache_creation_input_tokens: 0,
+        tool_use_prompt_tokens: 0,
         reasoning_tokens: 0,
     }
 }

--- a/crates/rig-core/src/providers/mira.rs
+++ b/crates/rig-core/src/providers/mira.rs
@@ -524,6 +524,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                         total_tokens: usage.total_tokens as u64,
                         cached_input_tokens: 0,
                         cache_creation_input_tokens: 0,
+                        tool_use_prompt_tokens: 0,
                         reasoning_tokens: 0,
                     })
                     .unwrap_or_default();

--- a/crates/rig-core/src/providers/mistral/completion.rs
+++ b/crates/rig-core/src/providers/mistral/completion.rs
@@ -541,6 +541,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                 total_tokens: usage.total_tokens as u64,
                 cached_input_tokens: usage.cached_tokens(),
                 cache_creation_input_tokens: 0,
+                tool_use_prompt_tokens: 0,
                 reasoning_tokens: 0,
             })
             .unwrap_or_default();

--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -406,6 +406,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                         total_tokens: prompt_tokens + completion_tokens,
                         cached_input_tokens: 0,
                         cache_creation_input_tokens: 0,
+                        tool_use_prompt_tokens: 0,
                         reasoning_tokens: 0,
                     },
                     raw_response,

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -980,6 +980,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                     .map(|d| d.cached_tokens as u64)
                     .unwrap_or(0),
                 cache_creation_input_tokens: 0,
+                tool_use_prompt_tokens: 0,
                 reasoning_tokens: 0,
             })
             .unwrap_or_default();

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -692,6 +692,7 @@ impl GetTokenUsage for ResponsesUsage {
                 .map(|details| details.cached_tokens)
                 .unwrap_or(0),
             cache_creation_input_tokens: 0,
+            tool_use_prompt_tokens: 0,
             reasoning_tokens: self.output_tokens_details.reasoning_tokens,
         })
     }

--- a/crates/rig-core/src/providers/openrouter/completion.rs
+++ b/crates/rig-core/src/providers/openrouter/completion.rs
@@ -722,6 +722,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                 total_tokens: usage.total_tokens as u64,
                 cached_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                tool_use_prompt_tokens: 0,
                 reasoning_tokens: 0,
             })
             .unwrap_or_default();

--- a/crates/rig-core/src/providers/perplexity.rs
+++ b/crates/rig-core/src/providers/perplexity.rs
@@ -195,6 +195,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                     total_tokens: response.usage.total_tokens as u64,
                     cached_input_tokens: 0,
                     cache_creation_input_tokens: 0,
+                    tool_use_prompt_tokens: 0,
                     reasoning_tokens: 0,
                 },
                 raw_response: response,

--- a/crates/rig-core/src/providers/xai/completion.rs
+++ b/crates/rig-core/src/providers/xai/completion.rs
@@ -162,6 +162,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                     .map(|x| x.cached_tokens)
                     .unwrap_or_default(),
                 cache_creation_input_tokens: 0,
+                tool_use_prompt_tokens: 0,
                 reasoning_tokens: 0,
             })
             .unwrap_or_default();

--- a/crates/rig-gemini-grpc/src/completion.rs
+++ b/crates/rig-gemini-grpc/src/completion.rs
@@ -467,6 +467,7 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse<Generat
                 total_tokens: usage.total_token_count as u64,
                 cached_input_tokens: usage.cached_content_token_count as u64,
                 cache_creation_input_tokens: 0,
+                tool_use_prompt_tokens: 0,
                 reasoning_tokens: 0,
             })
             .unwrap_or_default();

--- a/crates/rig-gemini-grpc/src/lib.rs
+++ b/crates/rig-gemini-grpc/src/lib.rs
@@ -47,6 +47,7 @@ impl rig_core::completion::GetTokenUsage for proto::GenerateContentResponse {
                 total_tokens: u.total_token_count as u64,
                 cached_input_tokens: u.cached_content_token_count as u64,
                 cache_creation_input_tokens: 0,
+                tool_use_prompt_tokens: 0,
                 reasoning_tokens: 0,
             })
     }

--- a/crates/rig-vertexai/src/types/completion_response.rs
+++ b/crates/rig-vertexai/src/types/completion_response.rs
@@ -62,6 +62,7 @@ impl TryFrom<VertexGenerateContentOutput> for CompletionResponse<VertexGenerateC
                 total_tokens: usage.total_token_count as u64,
                 cached_input_tokens: 0, // unreported at time of writing
                 cache_creation_input_tokens: 0,
+                tool_use_prompt_tokens: 0,
                 reasoning_tokens: 0,
             })
             .unwrap_or_default();

--- a/tests/core/prompt_response_messages.rs
+++ b/tests/core/prompt_response_messages.rs
@@ -18,6 +18,7 @@ fn simple_text_turn() -> MockTurn {
             total_tokens: 15,
             cached_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            tool_use_prompt_tokens: 0,
             reasoning_tokens: 0,
         })
         .with_message_id("msg_mock_1")
@@ -40,6 +41,7 @@ fn tool_then_text_model() -> MockCompletionModel {
             total_tokens: 23,
             cached_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            tool_use_prompt_tokens: 0,
             reasoning_tokens: 0,
         })
         .with_message_id("msg_tool"),
@@ -50,6 +52,7 @@ fn tool_then_text_model() -> MockCompletionModel {
                 total_tokens: 24,
                 cached_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                tool_use_prompt_tokens: 0,
                 reasoning_tokens: 0,
             })
             .with_message_id("msg_text"),


### PR DESCRIPTION
## Summary

- Expose Gemini streaming final response metadata for `finish_reason` and `model_version`.
- Add normalized `Usage.tool_use_prompt_tokens` and populate it from Gemini `toolUsePromptTokenCount`.
- Update internal `Usage` construction sites to default the new field to `0` for providers that do not report it.

## Why

Ryzome forwards Gemini streaming metadata to PostHog LLM Analytics. Gemini already returns these fields, and Rig already deserializes some of them internally, but callers could not access the final finish reason, resolved model version, or tool-use prompt token count through the normalized usage surface.

## Validation

- `cargo fmt`
- `cargo test -p rig-core gemini`
- `cargo test -p rig-core`
- `cargo check -p rig-bedrock -p rig-vertexai -p rig-gemini-grpc`
- `cargo test -p rig --test core prompt_response_messages`