### PR TITLE
[codex] Reject undeclared Gemini tool calls

### DIFF
--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -446,13 +446,25 @@ pub(super) async fn validate_registered_tool_call(
     tool_server_handle: &ToolServerHandle,
     tool_call: &crate::message::ToolCall,
 ) -> Result<(), UnknownToolCallError> {
+    validate_registered_tool_name(
+        tool_server_handle,
+        &tool_call.function.name,
+        &tool_call.id,
+        tool_call.call_id.clone(),
+        tool_call.function.arguments.clone(),
+    )
+    .await
+}
+
+pub(super) async fn validate_registered_tool_name(
+    tool_server_handle: &ToolServerHandle,
+    tool_name: &str,
+    tool_call_id: &str,
+    call_id: Option<String>,
+    arguments: serde_json::Value,
+) -> Result<(), UnknownToolCallError> {
     tool_server_handle
-        .validate_tool_call_name(
-            &tool_call.function.name,
-            &tool_call.id,
-            tool_call.call_id.clone(),
-            tool_call.function.arguments.clone(),
-        )
+        .validate_tool_call_name(tool_name, tool_call_id, call_id, arguments)
         .await
         .inspect_err(log_unknown_tool_call)
 }

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -740,11 +740,15 @@ where
                                 )) => {
                                     tracing::warn!(
                                         tool_name = name.as_str(),
+                                        tool_call_id = tool_call.id.as_str(),
+                                        call_id = ?tool_call.call_id,
                                         "Model requested an unknown tool"
                                     );
-                                    return Err(PromptError::ToolError(
-                                        ToolSetError::ToolNotFoundError(name),
-                                    ));
+                                    return Err(PromptError::UnknownToolCall {
+                                        tool_name: name,
+                                        tool_call_id: tool_call.id.clone(),
+                                        call_id: tool_call.call_id.clone(),
+                                    });
                                 }
                                 Err(e) => {
                                     tracing::warn!("Error while executing tool: {e}");
@@ -1342,8 +1346,13 @@ mod tests {
         assert!(
             matches!(
                 err,
-                PromptError::ToolError(crate::tool::ToolSetError::ToolNotFoundError(ref name))
-                    if name == "missing_tool"
+                PromptError::UnknownToolCall {
+                    ref tool_name,
+                    ref tool_call_id,
+                    ref call_id,
+                } if tool_name == "missing_tool"
+                    && tool_call_id == "tool_call_1"
+                    && call_id.as_deref() == Some("call_1")
             ),
             "expected missing tool error, got {err:?}"
         );

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -11,7 +11,10 @@ use crate::{
     json_utils,
     memory::ConversationMemory,
     message::{AssistantContent, ToolChoice, ToolResultContent, UserContent},
-    tool::server::ToolServerHandle,
+    tool::{
+        ToolSetError,
+        server::{ToolServerError, ToolServerHandle},
+    },
     wasm_compat::{WasmBoxedFuture, WasmCompatSend},
 };
 use futures::{StreamExt, stream};
@@ -732,6 +735,17 @@ where
                             let output = match tool_server_handle.call_tool(tool_name, &args).await
                             {
                                 Ok(res) => res,
+                                Err(ToolServerError::ToolsetError(
+                                    ToolSetError::ToolNotFoundError(name),
+                                )) => {
+                                    tracing::warn!(
+                                        tool_name = name.as_str(),
+                                        "Model requested an unknown tool"
+                                    );
+                                    return Err(PromptError::ToolError(
+                                        ToolSetError::ToolNotFoundError(name),
+                                    ));
+                                }
                                 Err(e) => {
                                     tracing::warn!("Error while executing tool: {e}");
                                     e.to_string()
@@ -1015,7 +1029,8 @@ mod tests {
         },
         message::{Text, UserContent},
         test_utils::{
-            AppendFailingMemory, CountingMemory, FailingMemory, MockCompletionModel, MockTurn,
+            AppendFailingMemory, CountingMemory, FailingMemory, MockAddTool, MockCompletionModel,
+            MockTurn,
         },
     };
     use schemars::JsonSchema;
@@ -1211,7 +1226,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn prompt_request_stops_cleanly_on_empty_terminal_turn() {
+    async fn prompt_request_stops_cleanly_on_empty_terminal_turn_after_known_tool() {
         let first_call_usage = Usage {
             input_tokens: 1,
             output_tokens: 1,
@@ -1229,12 +1244,12 @@ mod tests {
             reasoning_tokens: 0,
         };
         let model = MockCompletionModel::new([
-            MockTurn::tool_call("tool_call_1", "missing_tool", json!({"input": "value"}))
+            MockTurn::tool_call("tool_call_1", "add", json!({"x": 1, "y": 2}))
                 .with_call_id("call_1")
                 .with_usage(first_call_usage),
             MockTurn::text("").with_usage(second_call_usage),
         ]);
-        let agent = AgentBuilder::new(model).build();
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
 
         let response = agent
             .prompt("do tool work")
@@ -1306,6 +1321,33 @@ mod tests {
         let requests = agent.model.requests();
         assert_eq!(requests.len(), 2);
         validate_follow_up_tool_history(&requests[1]);
+    }
+
+    #[tokio::test]
+    async fn prompt_request_unknown_tool_returns_error_without_follow_up_turn() {
+        let model = MockCompletionModel::new([
+            MockTurn::tool_call("tool_call_1", "missing_tool", json!({"input": "value"}))
+                .with_call_id("call_1"),
+            MockTurn::text("should not be called"),
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model).build();
+
+        let err = agent
+            .prompt("do tool work")
+            .max_turns(3)
+            .await
+            .expect_err("unknown tool should stop the prompt");
+
+        assert!(
+            matches!(
+                err,
+                PromptError::ToolError(crate::tool::ToolSetError::ToolNotFoundError(ref name))
+                    if name == "missing_tool"
+            ),
+            "expected missing tool error, got {err:?}"
+        );
+        assert_eq!(recorded.requests().len(), 1);
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -7,7 +7,10 @@ use super::{
 };
 use crate::{
     OneOrMany,
-    completion::{CompletionModel, Document, Message, PromptError, UnknownToolCallError, Usage},
+    completion::{
+        CompletionModel, Document, Message, PromptError, ToolCallNameValidator,
+        UnknownToolCallError, Usage,
+    },
     json_utils,
     memory::ConversationMemory,
     message::{AssistantContent, ToolChoice, ToolResultContent, UserContent},
@@ -429,6 +432,61 @@ fn assistant_text_from_choice(choice: &OneOrMany<AssistantContent>) -> String {
         .collect()
 }
 
+fn log_unknown_tool_call(error: &UnknownToolCallError) {
+    tracing::warn!(
+        tool_name = error.tool_name.as_str(),
+        tool_call_id = error.tool_call_id.as_str(),
+        call_id = ?error.call_id,
+        available_tool_names = ?error.available_tool_names,
+        "Model requested an unknown tool"
+    );
+}
+
+pub(super) async fn validate_registered_tool_call(
+    tool_server_handle: &ToolServerHandle,
+    tool_call: &crate::message::ToolCall,
+) -> Result<(), UnknownToolCallError> {
+    tool_server_handle
+        .validate_tool_call_name(
+            &tool_call.function.name,
+            &tool_call.id,
+            tool_call.call_id.clone(),
+            tool_call.function.arguments.clone(),
+        )
+        .await
+        .inspect_err(log_unknown_tool_call)
+}
+
+pub(super) async fn unknown_tool_call_error(
+    tool_server_handle: &ToolServerHandle,
+    tool_name: String,
+    tool_call: &crate::message::ToolCall,
+) -> UnknownToolCallError {
+    let error = tool_server_handle
+        .unknown_tool_call_error(
+            tool_name,
+            &tool_call.id,
+            tool_call.call_id.clone(),
+            tool_call.function.arguments.clone(),
+        )
+        .await;
+    log_unknown_tool_call(&error);
+    error
+}
+
+fn validate_response_tool_calls(
+    tool_call_validator: &ToolCallNameValidator,
+    choice: &OneOrMany<AssistantContent>,
+) -> Result<(), crate::completion::CompletionError> {
+    for content in choice.iter() {
+        if let AssistantContent::ToolCall(tool_call) = content {
+            tool_call_validator.validate_tool_call(tool_call)?;
+        }
+    }
+
+    Ok(())
+}
+
 impl<M, P> PromptRequest<Extended, M, P>
 where
     M: CompletionModel,
@@ -559,7 +617,7 @@ where
             let history_for_request =
                 build_history_for_request(chat_history.as_deref(), history_for_current_turn);
 
-            let resp = build_completion_request(
+            let completion_request = build_completion_request(
                 &self.model,
                 prompt.clone(),
                 &history_for_request,
@@ -574,9 +632,14 @@ where
                 self.output_schema.as_ref(),
             )
             .await?
-            .send()
-            .instrument(chat_span.clone())
-            .await?;
+            .build();
+            let tool_call_validator =
+                ToolCallNameValidator::from_completion_request("rig", &completion_request);
+            let resp = self
+                .model
+                .completion(completion_request)
+                .instrument(chat_span.clone())
+                .await?;
 
             completion_calls.push(CompletionCall::from_reported_usage(
                 completion_call_index,
@@ -584,6 +647,8 @@ where
             ));
             completion_call_index += 1;
             usage += resp.usage;
+
+            validate_response_tool_calls(&tool_call_validator, &resp.choice)?;
 
             if let Some(ref hook) = self.hook
                 && let HookAction::Terminate { reason } =
@@ -694,25 +759,9 @@ where
                             tool_span.record("gen_ai.tool.name", tool_name);
                             tool_span.record("gen_ai.tool.call.id", &tool_call.id);
                             tool_span.record("gen_ai.tool.call.arguments", &args);
-                            if !tool_server_handle.has_tool(tool_name).await {
-                                let available_tool_names = tool_server_handle.tool_names().await;
-                                tracing::warn!(
-                                    tool_name = tool_name,
-                                    tool_call_id = tool_call.id.as_str(),
-                                    call_id = ?tool_call.call_id,
-                                    available_tool_names = ?available_tool_names,
-                                    "Model requested an unknown tool"
-                                );
-                                return Err(PromptError::UnknownToolCall(
-                                    UnknownToolCallError::new(
-                                        tool_name.to_string(),
-                                        tool_call.id.clone(),
-                                        tool_call.call_id.clone(),
-                                        tool_call.function.arguments.clone(),
-                                        available_tool_names,
-                                    ),
-                                ));
-                            }
+                            validate_registered_tool_call(&tool_server_handle, &tool_call)
+                                .await
+                                .map_err(PromptError::UnknownToolCall)?;
                             if let Some(hook) = hook1 {
                                 let action = hook
                                     .on_tool_call(
@@ -757,21 +806,13 @@ where
                                 Err(ToolServerError::ToolsetError(
                                     ToolSetError::ToolNotFoundError(name),
                                 )) => {
-                                    tracing::warn!(
-                                        tool_name = name.as_str(),
-                                        tool_call_id = tool_call.id.as_str(),
-                                        call_id = ?tool_call.call_id,
-                                        "Model requested an unknown tool"
-                                    );
-                                    return Err(PromptError::UnknownToolCall(
-                                        UnknownToolCallError::new(
-                                            name,
-                                            tool_call.id.clone(),
-                                            tool_call.call_id.clone(),
-                                            tool_call.function.arguments.clone(),
-                                            tool_server_handle.tool_names().await,
-                                        ),
-                                    ));
+                                    let error = unknown_tool_call_error(
+                                        &tool_server_handle,
+                                        name,
+                                        &tool_call,
+                                    )
+                                    .await;
+                                    return Err(PromptError::UnknownToolCall(error));
                                 }
                                 Err(e) => {
                                     tracing::warn!("Error while executing tool: {e}");
@@ -1052,12 +1093,12 @@ mod tests {
         agent::AgentBuilder,
         completion::{
             AssistantContent, CompletionError, CompletionRequest, Message, Prompt, PromptError,
-            TypedPrompt, Usage,
+            ToolCallValidationReason, TypedPrompt, Usage,
         },
-        message::{Text, UserContent},
+        message::{Text, ToolChoice, UserContent},
         test_utils::{
             AppendFailingMemory, CountingMemory, FailingMemory, MockAddTool, MockCompletionModel,
-            MockTurn,
+            MockSubtractTool, MockTurn,
         },
     };
     use schemars::JsonSchema;
@@ -1358,7 +1399,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn prompt_request_unknown_tool_returns_error_without_follow_up_turn() {
+    async fn prompt_request_rejects_undeclared_tool_call_without_follow_up_turn() {
         let model = MockCompletionModel::new([
             MockTurn::tool_call("tool_call_1", "missing_tool", json!({"input": "value"}))
                 .with_call_id("call_1"),
@@ -1371,19 +1412,57 @@ mod tests {
             .prompt("do tool work")
             .max_turns(3)
             .await
-            .expect_err("unknown tool should stop the prompt");
+            .expect_err("undeclared tool call should stop the prompt");
 
         assert!(
             matches!(
                 err,
-                PromptError::UnknownToolCall(ref error)
-                    if error.tool_name == "missing_tool"
-                        && error.tool_call_id == "tool_call_1"
-                        && error.call_id.as_deref() == Some("call_1")
-                        && error.arguments == json!({"input": "value"})
-                        && error.available_tool_names.is_empty()
+                PromptError::CompletionError(CompletionError::InvalidToolCall(ref error))
+                    if error.provider == "rig"
+                        && error.tool_name == "missing_tool"
+                        && error.declared_tool_names.is_empty()
+                        && error.allowed_tool_names.is_none()
+                        && error.reason == ToolCallValidationReason::Undeclared
             ),
-            "expected missing tool error, got {err:?}"
+            "expected invalid tool call error, got {err:?}"
+        );
+        assert_eq!(recorded.requests().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn prompt_request_rejects_registered_but_disallowed_tool_without_dispatch() {
+        let model = MockCompletionModel::new([
+            MockTurn::tool_call("tool_call_1", "subtract", json!({"x": 4, "y": 2}))
+                .with_call_id("call_1"),
+            MockTurn::text("should not be called"),
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model)
+            .tool(MockAddTool)
+            .tool(MockSubtractTool)
+            .tool_choice(ToolChoice::Specific {
+                function_names: vec!["add".to_string()],
+            })
+            .build();
+
+        let err = agent
+            .prompt("do tool work")
+            .max_turns(3)
+            .await
+            .expect_err("disallowed tool should stop the prompt");
+
+        assert!(
+            matches!(
+                err,
+                PromptError::CompletionError(CompletionError::InvalidToolCall(ref invalid))
+                    if invalid.provider == "rig"
+                        && invalid.tool_name == "subtract"
+                        && invalid.declared_tool_names
+                            == vec!["add".to_string(), "subtract".to_string()]
+                        && invalid.allowed_tool_names == Some(vec!["add".to_string()])
+                        && invalid.reason == ToolCallValidationReason::Disallowed
+            ),
+            "expected invalid tool-call error, got {err:?}"
         );
         assert_eq!(recorded.requests().len(), 1);
     }

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -1100,6 +1100,7 @@ mod tests {
             AppendFailingMemory, CountingMemory, FailingMemory, MockAddTool, MockCompletionModel,
             MockSubtractTool, MockTurn,
         },
+        tool::{ToolSet, server::ToolServer},
     };
     use schemars::JsonSchema;
     use serde::{Deserialize, Serialize};
@@ -1465,6 +1466,50 @@ mod tests {
             "expected invalid tool-call error, got {err:?}"
         );
         assert_eq!(recorded.requests().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn prompt_request_accepts_provider_extra_function_declared_in_params() {
+        let model = MockCompletionModel::new([
+            MockTurn::tool_call("tool_call_1", "add", json!({"x": 2, "y": 3}))
+                .with_call_id("call_1"),
+            MockTurn::text("done"),
+        ]);
+        let recorded = model.clone();
+        let tool_server_handle = ToolServer::new()
+            .add_tools(ToolSet::from_tools(vec![MockAddTool]))
+            .run();
+        let agent = AgentBuilder::new(model)
+            .additional_params(json!({
+                "tools": [
+                    {
+                        "type": "function",
+                        "name": "add",
+                        "description": "Add numbers",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "x": { "type": "number" },
+                                "y": { "type": "number" }
+                            },
+                            "required": ["x", "y"]
+                        }
+                    }
+                ]
+            }))
+            .tool_server_handle(tool_server_handle)
+            .build();
+
+        let response = agent
+            .prompt("do tool work")
+            .max_turns(3)
+            .await
+            .expect("provider-extra function should be accepted and dispatched");
+
+        assert_eq!(response, "done");
+        let requests = recorded.requests();
+        assert_eq!(requests.len(), 2);
+        assert!(requests[0].tools.is_empty());
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -7,7 +7,7 @@ use super::{
 };
 use crate::{
     OneOrMany,
-    completion::{CompletionModel, Document, Message, PromptError, Usage},
+    completion::{CompletionModel, Document, Message, PromptError, UnknownToolCallError, Usage},
     json_utils,
     memory::ConversationMemory,
     message::{AssistantContent, ToolChoice, ToolResultContent, UserContent},
@@ -694,6 +694,25 @@ where
                             tool_span.record("gen_ai.tool.name", tool_name);
                             tool_span.record("gen_ai.tool.call.id", &tool_call.id);
                             tool_span.record("gen_ai.tool.call.arguments", &args);
+                            if !tool_server_handle.has_tool(tool_name).await {
+                                let available_tool_names = tool_server_handle.tool_names().await;
+                                tracing::warn!(
+                                    tool_name = tool_name,
+                                    tool_call_id = tool_call.id.as_str(),
+                                    call_id = ?tool_call.call_id,
+                                    available_tool_names = ?available_tool_names,
+                                    "Model requested an unknown tool"
+                                );
+                                return Err(PromptError::UnknownToolCall(
+                                    UnknownToolCallError::new(
+                                        tool_name.to_string(),
+                                        tool_call.id.clone(),
+                                        tool_call.call_id.clone(),
+                                        tool_call.function.arguments.clone(),
+                                        available_tool_names,
+                                    ),
+                                ));
+                            }
                             if let Some(hook) = hook1 {
                                 let action = hook
                                     .on_tool_call(
@@ -744,11 +763,15 @@ where
                                         call_id = ?tool_call.call_id,
                                         "Model requested an unknown tool"
                                     );
-                                    return Err(PromptError::UnknownToolCall {
-                                        tool_name: name,
-                                        tool_call_id: tool_call.id.clone(),
-                                        call_id: tool_call.call_id.clone(),
-                                    });
+                                    return Err(PromptError::UnknownToolCall(
+                                        UnknownToolCallError::new(
+                                            name,
+                                            tool_call.id.clone(),
+                                            tool_call.call_id.clone(),
+                                            tool_call.function.arguments.clone(),
+                                            tool_server_handle.tool_names().await,
+                                        ),
+                                    ));
                                 }
                                 Err(e) => {
                                     tracing::warn!("Error while executing tool: {e}");
@@ -1353,13 +1376,12 @@ mod tests {
         assert!(
             matches!(
                 err,
-                PromptError::UnknownToolCall {
-                    ref tool_name,
-                    ref tool_call_id,
-                    ref call_id,
-                } if tool_name == "missing_tool"
-                    && tool_call_id == "tool_call_1"
-                    && call_id.as_deref() == Some("call_1")
+                PromptError::UnknownToolCall(ref error)
+                    if error.tool_name == "missing_tool"
+                        && error.tool_call_id == "tool_call_1"
+                        && error.call_id.as_deref() == Some("call_1")
+                        && error.arguments == json!({"input": "value"})
+                        && error.available_tool_names.is_empty()
             ),
             "expected missing tool error, got {err:?}"
         );

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -779,6 +779,13 @@ where
                             }
                         },
                         Ok(StreamedAssistantContent::ToolCallDelta { id, internal_call_id, content }) => {
+                            if let rig::streaming::ToolCallDeltaContent::Name(name) = &content
+                                && let Err(error) = tool_call_validator.validate(name)
+                            {
+                                yield Err(StreamingError::Completion(error));
+                                break 'outer;
+                            }
+
                             if let Some(ref hook) = self.hook {
                                 let (name, delta) = match &content {
                                     rig::streaming::ToolCallDeltaContent::Name(n) => {
@@ -1021,6 +1028,7 @@ mod tests {
         AppendFailingMemory, FailingMemory, MockAddTool, MockCompletionModel, MockResponse,
         MockStreamEvent, MockSubtractTool,
     };
+    use crate::tool::{ToolSet, server::ToolServer};
     use futures::StreamExt;
     use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
     use std::sync::{Arc, Mutex};
@@ -1363,6 +1371,22 @@ mod tests {
             MockStreamEvent::text(" world"),
             MockStreamEvent::final_response_with_total_tokens(3),
         ]])
+    }
+
+    fn calculator_provider_params() -> serde_json::Value {
+        serde_json::json!({
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "calculator",
+                    "description": "Calculate a result",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {}
+                    }
+                }
+            ]
+        })
     }
 
     fn citation_metadata() -> serde_json::Value {
@@ -1711,6 +1735,123 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn stream_prompt_rejects_disallowed_tool_name_delta_before_yield() {
+        let model = MockCompletionModel::from_stream_turns([[
+            MockStreamEvent::tool_call_name_delta("tool_call_1", "internal_1", "subtract"),
+            MockStreamEvent::final_response_with_total_tokens(4),
+        ]]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model)
+            .tool(MockAddTool)
+            .tool(MockSubtractTool)
+            .tool_choice(ToolChoice::Specific {
+                function_names: vec!["add".to_string()],
+            })
+            .build();
+
+        let mut stream = agent.stream_prompt("do tool work").multi_turn(3).await;
+        let mut saw_tool_delta = false;
+        let mut saw_final_response = false;
+        let mut error = None;
+
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(MultiTurnStreamItem::StreamAssistantItem(
+                    StreamedAssistantContent::ToolCallDelta { .. },
+                )) => saw_tool_delta = true,
+                Ok(MultiTurnStreamItem::FinalResponse(_)) => saw_final_response = true,
+                Ok(_) => {}
+                Err(err) => {
+                    error = Some(err);
+                    break;
+                }
+            }
+        }
+
+        assert!(!saw_tool_delta);
+        assert!(!saw_final_response);
+        assert!(
+            matches!(
+                error,
+                Some(StreamingError::Completion(CompletionError::InvalidToolCall(ref invalid)))
+                    if invalid.provider == "rig"
+                        && invalid.tool_name == "subtract"
+                        && invalid.reason == ToolCallValidationReason::Disallowed
+            ),
+            "expected invalid tool-call delta error, got {error:?}"
+        );
+        assert_eq!(recorded.requests().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn stream_prompt_accepts_provider_extra_function_declared_in_params() {
+        let model = MockCompletionModel::from_stream_turns([
+            vec![
+                MockStreamEvent::tool_call(
+                    "tool_call_1",
+                    "add",
+                    serde_json::json!({"x": 2, "y": 3}),
+                )
+                .with_call_id("call_1"),
+                MockStreamEvent::final_response_with_total_tokens(4),
+            ],
+            vec![
+                MockStreamEvent::text("done"),
+                MockStreamEvent::final_response_with_total_tokens(6),
+            ],
+        ]);
+        let recorded = model.clone();
+        let tool_server_handle = ToolServer::new()
+            .add_tools(ToolSet::from_tools(vec![MockAddTool]))
+            .run();
+        let agent = AgentBuilder::new(model)
+            .additional_params(serde_json::json!({
+                "tools": [
+                    {
+                        "type": "function",
+                        "name": "add",
+                        "description": "Add numbers",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "x": { "type": "number" },
+                                "y": { "type": "number" }
+                            },
+                            "required": ["x", "y"]
+                        }
+                    }
+                ]
+            }))
+            .tool_server_handle(tool_server_handle)
+            .build();
+
+        let mut stream = agent.stream_prompt("do tool work").multi_turn(3).await;
+        let mut saw_tool_call = false;
+        let mut saw_tool_result = false;
+        let mut final_response = None;
+
+        while let Some(item) = stream.next().await {
+            match item.expect("stream should succeed") {
+                MultiTurnStreamItem::StreamAssistantItem(StreamedAssistantContent::ToolCall {
+                    ..
+                }) => saw_tool_call = true,
+                MultiTurnStreamItem::StreamUserItem(StreamedUserContent::ToolResult { .. }) => {
+                    saw_tool_result = true
+                }
+                MultiTurnStreamItem::FinalResponse(response) => final_response = Some(response),
+                _ => {}
+            }
+        }
+
+        assert!(saw_tool_call);
+        assert!(saw_tool_result);
+        assert!(matches!(final_response, Some(ref response) if response.response() == "done"));
+        let requests = recorded.requests();
+        assert_eq!(requests.len(), 2);
+        assert!(requests[0].tools.is_empty());
+    }
+
+    #[tokio::test]
     async fn stream_prompt_emits_tool_call_deltas_without_hook() {
         let model = MockCompletionModel::from_stream_turns([[
             MockStreamEvent::tool_call_name_delta("tool_1", "internal_1", "calculator"),
@@ -1718,7 +1859,9 @@ mod tests {
             MockStreamEvent::tool_call_arguments_delta("tool_1", "internal_1", "1}"),
             MockStreamEvent::final_response_with_total_tokens(3),
         ]]);
-        let agent = AgentBuilder::new(model).build();
+        let agent = AgentBuilder::new(model)
+            .additional_params(calculator_provider_params())
+            .build();
 
         let mut stream = agent.stream_prompt("stream a tool call").await;
         let mut deltas = Vec::new();
@@ -1771,7 +1914,9 @@ mod tests {
             MockStreamEvent::final_response_with_total_tokens(3),
         ]]);
         let hook = RecordingToolCallDeltaHook::default();
-        let agent = AgentBuilder::new(model).build();
+        let agent = AgentBuilder::new(model)
+            .additional_params(calculator_provider_params())
+            .build();
 
         let mut stream = agent
             .stream_prompt("stream a tool call")
@@ -1849,7 +1994,9 @@ mod tests {
             MockStreamEvent::final_response_with_total_tokens(3),
         ]]);
         let hook = TerminatingToolCallDeltaHook::default();
-        let agent = AgentBuilder::new(model).build();
+        let agent = AgentBuilder::new(model)
+            .additional_params(calculator_provider_params())
+            .build();
 
         let mut stream = agent
             .stream_prompt("stream a tool call")

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -16,10 +16,15 @@ use std::{pin::Pin, sync::Arc};
 use tracing::info_span;
 use tracing_futures::Instrument;
 
-use super::{CompletionCall, ToolCallHookAction, reported_usage};
+use super::{
+    CompletionCall, ToolCallHookAction, reported_usage, unknown_tool_call_error,
+    validate_registered_tool_call,
+};
 use crate::{
     agent::Agent,
-    completion::{CompletionError, CompletionModel, PromptError, UnknownToolCallError},
+    completion::{
+        CompletionError, CompletionModel, PromptError, ToolCallNameValidator, UnknownToolCallError,
+    },
     message::{Message, Text},
     tool::ToolSetError,
 };
@@ -612,25 +617,28 @@ where
                     gen_ai.output.messages = tracing::field::Empty,
                 );
 
-                let mut stream = tracing::Instrument::instrument(
-                    build_completion_request(
-                        &model,
-                        current_prompt.clone(),
-                        &history_snapshot,
-                        preamble.as_deref(),
-                        &static_context,
-                        temperature,
-                        max_tokens,
-                        additional_params.as_ref(),
-                        tool_choice.as_ref(),
-                        &tool_server_handle,
-                        &dynamic_context,
-                        output_schema.as_ref(),
-                    )
-                    .await?
-                    .stream(), chat_stream_span
+                let completion_request = build_completion_request(
+                    &model,
+                    current_prompt.clone(),
+                    &history_snapshot,
+                    preamble.as_deref(),
+                    &static_context,
+                    temperature,
+                    max_tokens,
+                    additional_params.as_ref(),
+                    tool_choice.as_ref(),
+                    &tool_server_handle,
+                    &dynamic_context,
+                    output_schema.as_ref(),
                 )
-
+                .await?
+                .build();
+                let tool_call_validator =
+                    ToolCallNameValidator::from_completion_request("rig", &completion_request);
+                let mut stream = tracing::Instrument::instrument(
+                    model.stream(completion_request),
+                    chat_stream_span
+                )
                 .await?;
 
                 let call_index = completion_call_index;
@@ -664,22 +672,12 @@ where
                         },
                         Ok(StreamedAssistantContent::ToolCall { tool_call, internal_call_id }) => {
                             let tool_args = json_utils::value_to_json_string(&tool_call.function.arguments);
-                            if !tool_server_handle.has_tool(&tool_call.function.name).await {
-                                let available_tool_names = tool_server_handle.tool_names().await;
-                                tracing::warn!(
-                                    tool_name = tool_call.function.name.as_str(),
-                                    tool_call_id = tool_call.id.as_str(),
-                                    call_id = ?tool_call.call_id,
-                                    available_tool_names = ?available_tool_names,
-                                    "Model requested an unknown tool"
-                                );
-                                yield Err(StreamingError::UnknownToolCall(UnknownToolCallError::new(
-                                    tool_call.function.name.clone(),
-                                    tool_call.id.clone(),
-                                    tool_call.call_id.clone(),
-                                    tool_call.function.arguments.clone(),
-                                    available_tool_names,
-                                )));
+                            if let Err(error) = tool_call_validator.validate_tool_call(&tool_call) {
+                                yield Err(StreamingError::Completion(error));
+                                break 'outer;
+                            }
+                            if let Err(error) = validate_registered_tool_call(&tool_server_handle, &tool_call).await {
+                                yield Err(StreamingError::UnknownToolCall(error));
                                 break 'outer;
                             }
 
@@ -731,21 +729,13 @@ where
                                     Err(ToolServerError::ToolsetError(
                                         ToolSetError::ToolNotFoundError(name),
                                     )) => {
-                                        tracing::warn!(
-                                            tool_name = name.as_str(),
-                                            tool_call_id = tool_call.id.as_str(),
-                                            call_id = ?tool_call.call_id,
-                                            "Model requested an unknown tool"
-                                        );
-                                        return Err(StreamingError::UnknownToolCall(
-                                            UnknownToolCallError::new(
-                                                name,
-                                                tool_call.id.clone(),
-                                                tool_call.call_id.clone(),
-                                                tool_call.function.arguments.clone(),
-                                                tool_server_handle.tool_names().await,
-                                            ),
-                                        ));
+                                        let error = unknown_tool_call_error(
+                                            &tool_server_handle,
+                                            name,
+                                            &tool_call,
+                                        )
+                                        .await;
+                                        return Err(StreamingError::UnknownToolCall(error));
                                     }
                                     Err(e) => {
                                         tracing::warn!("Error while calling tool: {e}");
@@ -1020,16 +1010,16 @@ mod tests {
     use crate::agent::AgentBuilder;
     use crate::client::ProviderClient;
     use crate::client::completion::CompletionClient;
-    use crate::completion::{CompletionRequest, Usage};
+    use crate::completion::{CompletionRequest, ToolCallValidationReason, Usage};
     use crate::message::{
         AssistantContent, DocumentSourceKind, ImageMediaType, Message, ReasoningContent,
-        ToolResultContent, UserContent,
+        ToolChoice, ToolResultContent, UserContent,
     };
     use crate::providers::anthropic;
     use crate::streaming::{StreamingPrompt, ToolCallDeltaContent};
     use crate::test_utils::{
         AppendFailingMemory, FailingMemory, MockAddTool, MockCompletionModel, MockResponse,
-        MockStreamEvent,
+        MockStreamEvent, MockSubtractTool,
     };
     use futures::StreamExt;
     use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
@@ -1592,7 +1582,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stream_prompt_unknown_tool_errors_without_tool_result_or_follow_up_turn() {
+    async fn stream_prompt_rejects_undeclared_tool_call_without_tool_result_or_follow_up_turn() {
         let model = MockCompletionModel::from_stream_turns([
             vec![
                 MockStreamEvent::tool_call(
@@ -1640,14 +1630,82 @@ mod tests {
         assert!(
             matches!(
                 error,
-                Some(StreamingError::UnknownToolCall(ref error))
-                    if error.tool_name == "missing_tool"
-                        && error.tool_call_id == "tool_call_1"
-                        && error.call_id.as_deref() == Some("call_1")
-                        && error.arguments == serde_json::json!({"input": "value"})
-                        && error.available_tool_names.is_empty()
+                Some(StreamingError::Completion(CompletionError::InvalidToolCall(ref error)))
+                    if error.provider == "rig"
+                        && error.tool_name == "missing_tool"
+                        && error.declared_tool_names.is_empty()
+                        && error.allowed_tool_names.is_none()
+                        && error.reason == ToolCallValidationReason::Undeclared
             ),
-            "expected missing tool error, got {error:?}"
+            "expected invalid tool call error, got {error:?}"
+        );
+        assert_eq!(recorded.requests().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn stream_prompt_rejects_registered_but_disallowed_tool_before_yield_or_dispatch() {
+        let model = MockCompletionModel::from_stream_turns([
+            vec![
+                MockStreamEvent::tool_call(
+                    "tool_call_1",
+                    "subtract",
+                    serde_json::json!({"x": 4, "y": 2}),
+                )
+                .with_call_id("call_1"),
+                MockStreamEvent::final_response_with_total_tokens(4),
+            ],
+            vec![
+                MockStreamEvent::text("should not be called"),
+                MockStreamEvent::final_response_with_total_tokens(6),
+            ],
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model)
+            .tool(MockAddTool)
+            .tool(MockSubtractTool)
+            .tool_choice(ToolChoice::Specific {
+                function_names: vec!["add".to_string()],
+            })
+            .build();
+
+        let mut stream = agent.stream_prompt("do tool work").multi_turn(3).await;
+        let mut saw_tool_call = false;
+        let mut saw_tool_result = false;
+        let mut saw_final_response = false;
+        let mut error = None;
+
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(MultiTurnStreamItem::StreamAssistantItem(
+                    StreamedAssistantContent::ToolCall { .. },
+                )) => saw_tool_call = true,
+                Ok(MultiTurnStreamItem::StreamUserItem(StreamedUserContent::ToolResult {
+                    ..
+                })) => saw_tool_result = true,
+                Ok(MultiTurnStreamItem::FinalResponse(_)) => saw_final_response = true,
+                Ok(_) => {}
+                Err(err) => {
+                    error = Some(err);
+                    break;
+                }
+            }
+        }
+
+        assert!(!saw_tool_call);
+        assert!(!saw_tool_result);
+        assert!(!saw_final_response);
+        assert!(
+            matches!(
+                error,
+                Some(StreamingError::Completion(CompletionError::InvalidToolCall(ref invalid)))
+                    if invalid.provider == "rig"
+                        && invalid.tool_name == "subtract"
+                        && invalid.declared_tool_names
+                            == vec!["add".to_string(), "subtract".to_string()]
+                        && invalid.allowed_tool_names == Some(vec!["add".to_string()])
+                        && invalid.reason == ToolCallValidationReason::Disallowed
+            ),
+            "expected invalid tool-call error, got {error:?}"
         );
         assert_eq!(recorded.requests().len(), 1);
     }

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -271,6 +271,14 @@ pub enum StreamingError {
     Prompt(#[from] Box<PromptError>),
     #[error("ToolSetError: {0}")]
     Tool(#[from] ToolSetError),
+    #[error(
+        "UnknownToolCall: model requested unknown tool `{tool_name}` (tool_call_id={tool_call_id}, call_id={call_id:?})"
+    )]
+    UnknownToolCall {
+        tool_name: String,
+        tool_call_id: String,
+        call_id: Option<String>,
+    },
 }
 
 /// Surface [`crate::memory::ConversationMemory`] failures through the existing
@@ -712,11 +720,15 @@ where
                                     )) => {
                                         tracing::warn!(
                                             tool_name = name.as_str(),
+                                            tool_call_id = tool_call.id.as_str(),
+                                            call_id = ?tool_call.call_id,
                                             "Model requested an unknown tool"
                                         );
-                                        return Err(StreamingError::Tool(
-                                            ToolSetError::ToolNotFoundError(name),
-                                        ));
+                                        return Err(StreamingError::UnknownToolCall {
+                                            tool_name: name,
+                                            tool_call_id: tool_call.id.clone(),
+                                            call_id: tool_call.call_id.clone(),
+                                        });
                                     }
                                     Err(e) => {
                                         tracing::warn!("Error while calling tool: {e}");
@@ -1608,8 +1620,13 @@ mod tests {
         assert!(
             matches!(
                 error,
-                Some(StreamingError::Tool(crate::tool::ToolSetError::ToolNotFoundError(ref name)))
-                    if name == "missing_tool"
+                Some(StreamingError::UnknownToolCall {
+                    ref tool_name,
+                    ref tool_call_id,
+                    ref call_id,
+                }) if tool_name == "missing_tool"
+                    && tool_call_id == "tool_call_1"
+                    && call_id.as_deref() == Some("call_1")
             ),
             "expected missing tool error, got {error:?}"
         );

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -7,7 +7,7 @@ use crate::{
     memory::ConversationMemory,
     message::{AssistantContent, ToolChoice, ToolResult, ToolResultContent, UserContent},
     streaming::{StreamedAssistantContent, StreamedUserContent},
-    tool::server::ToolServerHandle,
+    tool::server::{ToolServerError, ToolServerHandle},
     wasm_compat::{WasmBoxedFuture, WasmCompatSend},
 };
 use futures::{Stream, StreamExt};
@@ -707,6 +707,17 @@ where
                                 let tool_result = match
                                 tool_server_handle.call_tool(&tool_call.function.name, &tool_args).await {
                                     Ok(thing) => thing,
+                                    Err(ToolServerError::ToolsetError(
+                                        ToolSetError::ToolNotFoundError(name),
+                                    )) => {
+                                        tracing::warn!(
+                                            tool_name = name.as_str(),
+                                            "Model requested an unknown tool"
+                                        );
+                                        return Err(StreamingError::Tool(
+                                            ToolSetError::ToolNotFoundError(name),
+                                        ));
+                                    }
                                     Err(e) => {
                                         tracing::warn!("Error while calling tool: {e}");
                                         e.to_string()
@@ -988,7 +999,8 @@ mod tests {
     use crate::providers::anthropic;
     use crate::streaming::{StreamingPrompt, ToolCallDeltaContent};
     use crate::test_utils::{
-        AppendFailingMemory, FailingMemory, MockCompletionModel, MockResponse, MockStreamEvent,
+        AppendFailingMemory, FailingMemory, MockAddTool, MockCompletionModel, MockResponse,
+        MockStreamEvent,
     };
     use futures::StreamExt;
     use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
@@ -1216,8 +1228,8 @@ mod tests {
             vec![
                 MockStreamEvent::tool_call(
                     "tool_call_1",
-                    "missing_tool",
-                    serde_json::json!({"input": "value"}),
+                    "add",
+                    serde_json::json!({"x": 1, "y": 2}),
                 )
                 .with_call_id("call_1"),
                 MockStreamEvent::final_response_with_total_tokens(4),
@@ -1360,8 +1372,8 @@ mod tests {
                 MockStreamEvent::text("I need a tool. "),
                 MockStreamEvent::tool_call(
                     "tool_call_1",
-                    "missing_tool",
-                    serde_json::json!({"input": "value"}),
+                    "add",
+                    serde_json::json!({"x": 1, "y": 2}),
                 )
                 .with_call_id("call_1"),
                 MockStreamEvent::final_response_with_total_tokens(4),
@@ -1485,7 +1497,7 @@ mod tests {
     async fn stream_prompt_continues_after_tool_call_turn() {
         let model = streaming_tool_then_text_model();
         let recorded = model.clone();
-        let agent = AgentBuilder::new(model).build();
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
         let empty_history: &[Message] = &[];
 
         let mut stream = agent
@@ -1545,6 +1557,63 @@ mod tests {
         let requests = recorded.requests();
         assert_eq!(requests.len(), 2);
         assert!(validate_follow_up_tool_history(&requests[1]).is_ok());
+    }
+
+    #[tokio::test]
+    async fn stream_prompt_unknown_tool_errors_without_tool_result_or_follow_up_turn() {
+        let model = MockCompletionModel::from_stream_turns([
+            vec![
+                MockStreamEvent::tool_call(
+                    "tool_call_1",
+                    "missing_tool",
+                    serde_json::json!({"input": "value"}),
+                )
+                .with_call_id("call_1"),
+                MockStreamEvent::final_response_with_total_tokens(4),
+            ],
+            vec![
+                MockStreamEvent::text("should not be called"),
+                MockStreamEvent::final_response_with_total_tokens(6),
+            ],
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model).build();
+
+        let mut stream = agent.stream_prompt("do tool work").multi_turn(3).await;
+        let mut saw_tool_call = false;
+        let mut saw_tool_result = false;
+        let mut saw_final_response = false;
+        let mut error = None;
+
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(MultiTurnStreamItem::StreamAssistantItem(
+                    StreamedAssistantContent::ToolCall { .. },
+                )) => saw_tool_call = true,
+                Ok(MultiTurnStreamItem::StreamUserItem(StreamedUserContent::ToolResult {
+                    ..
+                })) => saw_tool_result = true,
+                Ok(MultiTurnStreamItem::FinalResponse(_)) => saw_final_response = true,
+                Ok(_) => {}
+                Err(err) => {
+                    error = Some(err);
+                    break;
+                }
+            }
+        }
+
+        assert!(saw_tool_call);
+        assert!(!saw_tool_result);
+        assert!(!saw_final_response);
+        assert!(
+            matches!(
+                error,
+                Some(StreamingError::Tool(crate::tool::ToolSetError::ToolNotFoundError(ref name)))
+                    if name == "missing_tool"
+            ),
+            "expected missing tool error, got {error:?}"
+        );
+        assert_eq!(recorded.requests().len(), 1);
     }
 
     #[tokio::test]
@@ -1741,8 +1810,8 @@ mod tests {
             vec![
                 MockStreamEvent::tool_call(
                     "tool_call_1",
-                    "missing_tool",
-                    serde_json::json!({"input": "value"}),
+                    "add",
+                    serde_json::json!({"x": 1, "y": 2}),
                 )
                 .with_call_id("call_1"),
                 MockStreamEvent::final_response(first_call_usage),
@@ -1752,7 +1821,7 @@ mod tests {
                 MockStreamEvent::final_response(second_call_usage),
             ],
         ]);
-        let agent = AgentBuilder::new(model).build();
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
         let empty_history: &[Message] = &[];
 
         let mut stream = agent
@@ -1852,8 +1921,8 @@ mod tests {
             vec![
                 MockStreamEvent::tool_call(
                     "tool_call_1",
-                    "missing_tool",
-                    serde_json::json!({"input": "value"}),
+                    "add",
+                    serde_json::json!({"x": 1, "y": 2}),
                 )
                 .with_call_id("call_1"),
             ],
@@ -1862,7 +1931,7 @@ mod tests {
                 MockStreamEvent::final_response(second_call_usage),
             ],
         ]);
-        let agent = AgentBuilder::new(model).build();
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
         let empty_history: &[Message] = &[];
 
         let mut stream = agent
@@ -1996,7 +2065,7 @@ mod tests {
     async fn tool_follow_up_history_preserves_structured_text_metadata() {
         let model = streaming_cited_text_then_tool_model();
         let recorded = model.clone();
-        let agent = AgentBuilder::new(model).build();
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
         let empty_history: &[Message] = &[];
 
         let mut stream = agent

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -19,7 +19,7 @@ use tracing_futures::Instrument;
 use super::{CompletionCall, ToolCallHookAction, reported_usage};
 use crate::{
     agent::Agent,
-    completion::{CompletionError, CompletionModel, PromptError},
+    completion::{CompletionError, CompletionModel, PromptError, UnknownToolCallError},
     message::{Message, Text},
     tool::ToolSetError,
 };
@@ -271,14 +271,8 @@ pub enum StreamingError {
     Prompt(#[from] Box<PromptError>),
     #[error("ToolSetError: {0}")]
     Tool(#[from] ToolSetError),
-    #[error(
-        "UnknownToolCall: model requested unknown tool `{tool_name}` (tool_call_id={tool_call_id}, call_id={call_id:?})"
-    )]
-    UnknownToolCall {
-        tool_name: String,
-        tool_call_id: String,
-        call_id: Option<String>,
-    },
+    #[error("UnknownToolCall: {0}")]
+    UnknownToolCall(UnknownToolCallError),
 }
 
 /// Surface [`crate::memory::ConversationMemory`] failures through the existing
@@ -669,6 +663,26 @@ where
                             yield Ok(MultiTurnStreamItem::stream_item(StreamedAssistantContent::Text(text)));
                         },
                         Ok(StreamedAssistantContent::ToolCall { tool_call, internal_call_id }) => {
+                            let tool_args = json_utils::value_to_json_string(&tool_call.function.arguments);
+                            if !tool_server_handle.has_tool(&tool_call.function.name).await {
+                                let available_tool_names = tool_server_handle.tool_names().await;
+                                tracing::warn!(
+                                    tool_name = tool_call.function.name.as_str(),
+                                    tool_call_id = tool_call.id.as_str(),
+                                    call_id = ?tool_call.call_id,
+                                    available_tool_names = ?available_tool_names,
+                                    "Model requested an unknown tool"
+                                );
+                                yield Err(StreamingError::UnknownToolCall(UnknownToolCallError::new(
+                                    tool_call.function.name.clone(),
+                                    tool_call.id.clone(),
+                                    tool_call.call_id.clone(),
+                                    tool_call.function.arguments.clone(),
+                                    available_tool_names,
+                                )));
+                                break 'outer;
+                            }
+
                             let tool_span = info_span!(
                                 parent: tracing::Span::current(),
                                 "execute_tool",
@@ -684,7 +698,6 @@ where
 
                             let tc_result = async {
                                 let tool_span = tracing::Span::current();
-                                let tool_args = json_utils::value_to_json_string(&tool_call.function.arguments);
                                 if let Some(ref hook) = self.hook {
                                     let action = hook
                                         .on_tool_call(&tool_call.function.name, tool_call.call_id.clone(), &internal_call_id, &tool_args)
@@ -724,11 +737,15 @@ where
                                             call_id = ?tool_call.call_id,
                                             "Model requested an unknown tool"
                                         );
-                                        return Err(StreamingError::UnknownToolCall {
-                                            tool_name: name,
-                                            tool_call_id: tool_call.id.clone(),
-                                            call_id: tool_call.call_id.clone(),
-                                        });
+                                        return Err(StreamingError::UnknownToolCall(
+                                            UnknownToolCallError::new(
+                                                name,
+                                                tool_call.id.clone(),
+                                                tool_call.call_id.clone(),
+                                                tool_call.function.arguments.clone(),
+                                                tool_server_handle.tool_names().await,
+                                            ),
+                                        ));
                                     }
                                     Err(e) => {
                                         tracing::warn!("Error while calling tool: {e}");
@@ -1617,19 +1634,18 @@ mod tests {
             }
         }
 
-        assert!(saw_tool_call);
+        assert!(!saw_tool_call);
         assert!(!saw_tool_result);
         assert!(!saw_final_response);
         assert!(
             matches!(
                 error,
-                Some(StreamingError::UnknownToolCall {
-                    ref tool_name,
-                    ref tool_call_id,
-                    ref call_id,
-                }) if tool_name == "missing_tool"
-                    && tool_call_id == "tool_call_1"
-                    && call_id.as_deref() == Some("call_1")
+                Some(StreamingError::UnknownToolCall(ref error))
+                    if error.tool_name == "missing_tool"
+                        && error.tool_call_id == "tool_call_1"
+                        && error.call_id.as_deref() == Some("call_1")
+                        && error.arguments == serde_json::json!({"input": "value"})
+                        && error.available_tool_names.is_empty()
             ),
             "expected missing tool error, got {error:?}"
         );

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -18,7 +18,7 @@ use tracing_futures::Instrument;
 
 use super::{
     CompletionCall, ToolCallHookAction, reported_usage, unknown_tool_call_error,
-    validate_registered_tool_call,
+    validate_registered_tool_call, validate_registered_tool_name,
 };
 use crate::{
     agent::Agent,
@@ -779,11 +779,23 @@ where
                             }
                         },
                         Ok(StreamedAssistantContent::ToolCallDelta { id, internal_call_id, content }) => {
-                            if let rig::streaming::ToolCallDeltaContent::Name(name) = &content
-                                && let Err(error) = tool_call_validator.validate(name)
-                            {
-                                yield Err(StreamingError::Completion(error));
-                                break 'outer;
+                            if let rig::streaming::ToolCallDeltaContent::Name(name) = &content {
+                                if let Err(error) = tool_call_validator.validate(name) {
+                                    yield Err(StreamingError::Completion(error));
+                                    break 'outer;
+                                }
+                                if let Err(error) = validate_registered_tool_name(
+                                    &tool_server_handle,
+                                    name,
+                                    &id,
+                                    None,
+                                    serde_json::Value::Null,
+                                )
+                                .await
+                                {
+                                    yield Err(StreamingError::UnknownToolCall(error));
+                                    break 'outer;
+                                }
                             }
 
                             if let Some(ref hook) = self.hook {
@@ -1373,22 +1385,6 @@ mod tests {
         ]])
     }
 
-    fn calculator_provider_params() -> serde_json::Value {
-        serde_json::json!({
-            "tools": [
-                {
-                    "type": "function",
-                    "name": "calculator",
-                    "description": "Calculate a result",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {}
-                    }
-                }
-            ]
-        })
-    }
-
     fn citation_metadata() -> serde_json::Value {
         serde_json::json!({
             "citations": [{
@@ -1784,6 +1780,75 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn stream_prompt_rejects_unregistered_tool_name_delta_before_yield_or_hook() {
+        let model = MockCompletionModel::from_stream_turns([[
+            MockStreamEvent::tool_call_name_delta("tool_call_1", "internal_1", "add"),
+            MockStreamEvent::final_response_with_total_tokens(4),
+        ]]);
+        let recorded = model.clone();
+        let hook = RecordingToolCallDeltaHook::default();
+        let agent = AgentBuilder::new(model)
+            .additional_params(serde_json::json!({
+                "tools": [
+                    {
+                        "type": "function",
+                        "name": "add",
+                        "description": "Add numbers",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "x": { "type": "number" },
+                                "y": { "type": "number" }
+                            },
+                            "required": ["x", "y"]
+                        }
+                    }
+                ]
+            }))
+            .build();
+
+        let mut stream = agent
+            .stream_prompt("do tool work")
+            .with_hook(hook.clone())
+            .multi_turn(3)
+            .await;
+        let mut saw_tool_delta = false;
+        let mut saw_final_response = false;
+        let mut error = None;
+
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(MultiTurnStreamItem::StreamAssistantItem(
+                    StreamedAssistantContent::ToolCallDelta { .. },
+                )) => saw_tool_delta = true,
+                Ok(MultiTurnStreamItem::FinalResponse(_)) => saw_final_response = true,
+                Ok(_) => {}
+                Err(err) => {
+                    error = Some(err);
+                    break;
+                }
+            }
+        }
+
+        assert!(!saw_tool_delta);
+        assert!(!saw_final_response);
+        assert!(hook.observed().is_empty());
+        assert!(
+            matches!(
+                error,
+                Some(StreamingError::UnknownToolCall(ref unknown))
+                    if unknown.tool_name == "add"
+                        && unknown.tool_call_id == "tool_call_1"
+                        && unknown.call_id.is_none()
+                        && unknown.arguments.is_null()
+                        && unknown.available_tool_names.is_empty()
+            ),
+            "expected unknown tool-call delta error, got {error:?}"
+        );
+        assert_eq!(recorded.requests().len(), 1);
+    }
+
+    #[tokio::test]
     async fn stream_prompt_accepts_provider_extra_function_declared_in_params() {
         let model = MockCompletionModel::from_stream_turns([
             vec![
@@ -1854,14 +1919,12 @@ mod tests {
     #[tokio::test]
     async fn stream_prompt_emits_tool_call_deltas_without_hook() {
         let model = MockCompletionModel::from_stream_turns([[
-            MockStreamEvent::tool_call_name_delta("tool_1", "internal_1", "calculator"),
+            MockStreamEvent::tool_call_name_delta("tool_1", "internal_1", "add"),
             MockStreamEvent::tool_call_arguments_delta("tool_1", "internal_1", "{\"x\":"),
             MockStreamEvent::tool_call_arguments_delta("tool_1", "internal_1", "1}"),
             MockStreamEvent::final_response_with_total_tokens(3),
         ]]);
-        let agent = AgentBuilder::new(model)
-            .additional_params(calculator_provider_params())
-            .build();
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
 
         let mut stream = agent.stream_prompt("stream a tool call").await;
         let mut deltas = Vec::new();
@@ -1889,7 +1952,7 @@ mod tests {
                 (
                     "tool_1".to_string(),
                     "internal_1".to_string(),
-                    ToolCallDeltaContent::Name("calculator".to_string())
+                    ToolCallDeltaContent::Name("add".to_string())
                 ),
                 (
                     "tool_1".to_string(),
@@ -1908,15 +1971,13 @@ mod tests {
     #[tokio::test]
     async fn stream_prompt_emits_tool_call_deltas_after_hook_continue() {
         let model = MockCompletionModel::from_stream_turns([[
-            MockStreamEvent::tool_call_name_delta("tool_1", "internal_1", "calculator"),
+            MockStreamEvent::tool_call_name_delta("tool_1", "internal_1", "add"),
             MockStreamEvent::tool_call_arguments_delta("tool_1", "internal_1", "{\"x\":"),
             MockStreamEvent::tool_call_arguments_delta("tool_1", "internal_1", "1}"),
             MockStreamEvent::final_response_with_total_tokens(3),
         ]]);
         let hook = RecordingToolCallDeltaHook::default();
-        let agent = AgentBuilder::new(model)
-            .additional_params(calculator_provider_params())
-            .build();
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
 
         let mut stream = agent
             .stream_prompt("stream a tool call")
@@ -1947,7 +2008,7 @@ mod tests {
                 (
                     "tool_1".to_string(),
                     "internal_1".to_string(),
-                    Some("calculator".to_string()),
+                    Some("add".to_string()),
                     String::new()
                 ),
                 (
@@ -1970,7 +2031,7 @@ mod tests {
                 (
                     "tool_1".to_string(),
                     "internal_1".to_string(),
-                    ToolCallDeltaContent::Name("calculator".to_string())
+                    ToolCallDeltaContent::Name("add".to_string())
                 ),
                 (
                     "tool_1".to_string(),
@@ -1989,14 +2050,12 @@ mod tests {
     #[tokio::test]
     async fn stream_prompt_tool_call_deltas_hook_termination_prevents_delta_emit() {
         let model = MockCompletionModel::from_stream_turns([[
-            MockStreamEvent::tool_call_name_delta("tool_1", "internal_1", "calculator"),
+            MockStreamEvent::tool_call_name_delta("tool_1", "internal_1", "add"),
             MockStreamEvent::tool_call_arguments_delta("tool_1", "internal_1", "{\"x\":"),
             MockStreamEvent::final_response_with_total_tokens(3),
         ]]);
         let hook = TerminatingToolCallDeltaHook::default();
-        let agent = AgentBuilder::new(model)
-            .additional_params(calculator_provider_params())
-            .build();
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
 
         let mut stream = agent
             .stream_prompt("stream a tool call")
@@ -2029,7 +2088,7 @@ mod tests {
             vec![(
                 "tool_1".to_string(),
                 "internal_1".to_string(),
-                Some("calculator".to_string()),
+                Some("add".to_string()),
                 String::new()
             )]
         );

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -127,11 +127,21 @@ impl ToolCallNameValidator {
 
     /// Create a validator from the generic completion request contract sent to a provider.
     pub fn from_completion_request(provider: &'static str, request: &CompletionRequest) -> Self {
-        let declared_tool_names = request.tools.iter().map(|tool| tool.name.clone()).chain(
-            provider_declared_function_names(request.additional_params.as_ref()),
-        );
+        let declared_tool_names =
+            dedupe_tool_names(request.tools.iter().map(|tool| tool.name.clone()).chain(
+                provider_declared_function_names(request.additional_params.as_ref()),
+            ));
+        let allowed_tool_names =
+            allowed_tool_names_from_tool_choice(request.tool_choice.as_ref(), &declared_tool_names)
+                .or_else(|| {
+                    provider_allowed_tool_names(
+                        provider,
+                        request.additional_params.as_ref(),
+                        &declared_tool_names,
+                    )
+                });
 
-        Self::from_declared_tool_names(provider, declared_tool_names, request.tool_choice.as_ref())
+        Self::new(provider, declared_tool_names, allowed_tool_names)
     }
 
     /// Create a validator from explicit declared tool names and a generic tool-choice policy.
@@ -141,14 +151,8 @@ impl ToolCallNameValidator {
         tool_choice: Option<&ToolChoice>,
     ) -> Self {
         let declared_tool_names = dedupe_tool_names(declared_tool_names);
-        let allowed_tool_names = match tool_choice {
-            None | Some(ToolChoice::Auto) => None,
-            Some(ToolChoice::Required) => Some(declared_tool_names.clone()),
-            Some(ToolChoice::Specific { function_names }) => {
-                Some(dedupe_tool_names(function_names.iter().cloned()))
-            }
-            Some(ToolChoice::None) => Some(Vec::new()),
-        };
+        let allowed_tool_names =
+            allowed_tool_names_from_tool_choice(tool_choice, &declared_tool_names);
 
         Self::new(provider, declared_tool_names, allowed_tool_names)
     }
@@ -215,6 +219,20 @@ fn dedupe_tool_names(names: impl IntoIterator<Item = String>) -> Vec<String> {
     deduped
 }
 
+fn allowed_tool_names_from_tool_choice(
+    tool_choice: Option<&ToolChoice>,
+    declared_tool_names: &[String],
+) -> Option<Vec<String>> {
+    match tool_choice {
+        None | Some(ToolChoice::Auto) => None,
+        Some(ToolChoice::Required) => Some(declared_tool_names.to_vec()),
+        Some(ToolChoice::Specific { function_names }) => {
+            Some(dedupe_tool_names(function_names.iter().cloned()))
+        }
+        Some(ToolChoice::None) => Some(Vec::new()),
+    }
+}
+
 fn provider_declared_function_names(additional_params: Option<&serde_json::Value>) -> Vec<String> {
     additional_params
         .and_then(|params| params.get("tools"))
@@ -226,6 +244,23 @@ fn provider_declared_function_names(additional_params: Option<&serde_json::Value
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default()
+}
+
+fn provider_allowed_tool_names(
+    provider: &'static str,
+    additional_params: Option<&serde_json::Value>,
+    declared_tool_names: &[String],
+) -> Option<Vec<String>> {
+    let additional_params = additional_params?;
+
+    match provider {
+        "gemini" => generate_content_allowed_tool_names(additional_params, declared_tool_names)
+            .or_else(|| interactions_allowed_tool_names(additional_params, declared_tool_names)),
+        "anthropic" => anthropic_allowed_tool_names(additional_params, declared_tool_names),
+        _ => generate_content_allowed_tool_names(additional_params, declared_tool_names)
+            .or_else(|| interactions_allowed_tool_names(additional_params, declared_tool_names))
+            .or_else(|| anthropic_allowed_tool_names(additional_params, declared_tool_names)),
+    }
 }
 
 fn provider_tool_function_names(tool: &serde_json::Value) -> Vec<String> {
@@ -247,6 +282,13 @@ fn provider_tool_function_names(tool: &serde_json::Value) -> Vec<String> {
         }
     }
 
+    if tool.get("type").is_none()
+        && tool.get("input_schema").is_some()
+        && let Some(name) = tool.get("name").and_then(serde_json::Value::as_str)
+    {
+        names.push(name.to_string());
+    }
+
     for key in ["functionDeclarations", "function_declarations"] {
         if let Some(function_declarations) = tool.get(key).and_then(serde_json::Value::as_array) {
             names.extend(function_declarations.iter().filter_map(|declaration| {
@@ -259,6 +301,119 @@ fn provider_tool_function_names(tool: &serde_json::Value) -> Vec<String> {
     }
 
     names
+}
+
+fn generate_content_allowed_tool_names(
+    additional_params: &serde_json::Value,
+    declared_tool_names: &[String],
+) -> Option<Vec<String>> {
+    let function_calling_config = additional_params
+        .get("toolConfig")
+        .or_else(|| additional_params.get("tool_config"))
+        .and_then(|tool_config| {
+            tool_config
+                .get("functionCallingConfig")
+                .or_else(|| tool_config.get("function_calling_config"))
+        })?;
+
+    allowed_tool_names_from_mode_and_names(
+        function_calling_config
+            .get("mode")
+            .and_then(serde_json::Value::as_str),
+        function_calling_config
+            .get("allowedFunctionNames")
+            .or_else(|| function_calling_config.get("allowed_function_names")),
+        declared_tool_names,
+    )
+}
+
+fn interactions_allowed_tool_names(
+    additional_params: &serde_json::Value,
+    declared_tool_names: &[String],
+) -> Option<Vec<String>> {
+    let tool_choice = additional_params
+        .get("generation_config")
+        .or_else(|| additional_params.get("generationConfig"))
+        .and_then(|generation_config| {
+            generation_config
+                .get("tool_choice")
+                .or_else(|| generation_config.get("toolChoice"))
+        })?;
+
+    allowed_tool_names_from_interactions_tool_choice(tool_choice, declared_tool_names)
+}
+
+fn anthropic_allowed_tool_names(
+    additional_params: &serde_json::Value,
+    declared_tool_names: &[String],
+) -> Option<Vec<String>> {
+    let tool_choice = additional_params.get("tool_choice")?;
+
+    allowed_tool_names_from_type_tool_choice(tool_choice, declared_tool_names)
+}
+
+fn allowed_tool_names_from_interactions_tool_choice(
+    tool_choice: &serde_json::Value,
+    declared_tool_names: &[String],
+) -> Option<Vec<String>> {
+    if let Some(mode) = tool_choice.as_str() {
+        return allowed_tool_names_from_mode_and_names(mode.into(), None, declared_tool_names);
+    }
+
+    let allowed_tools = tool_choice.get("allowed_tools")?;
+
+    allowed_tool_names_from_mode_and_names(
+        allowed_tools
+            .get("mode")
+            .and_then(serde_json::Value::as_str),
+        allowed_tools.get("tools"),
+        declared_tool_names,
+    )
+}
+
+fn allowed_tool_names_from_type_tool_choice(
+    tool_choice: &serde_json::Value,
+    declared_tool_names: &[String],
+) -> Option<Vec<String>> {
+    let mode = tool_choice
+        .get("type")
+        .and_then(serde_json::Value::as_str)?;
+
+    match mode.to_ascii_lowercase().as_str() {
+        "auto" => None,
+        "any" => Some(declared_tool_names.to_vec()),
+        "none" => Some(Vec::new()),
+        "tool" => tool_choice
+            .get("name")
+            .and_then(serde_json::Value::as_str)
+            .map(|name| vec![name.to_string()]),
+        _ => None,
+    }
+}
+
+fn allowed_tool_names_from_mode_and_names(
+    mode: Option<&str>,
+    names: Option<&serde_json::Value>,
+    declared_tool_names: &[String],
+) -> Option<Vec<String>> {
+    let names = names.and_then(serde_json::Value::as_array).map(|names| {
+        dedupe_tool_names(
+            names
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .map(String::from),
+        )
+    });
+
+    match mode.map(|mode| mode.to_ascii_lowercase()) {
+        Some(mode) if mode == "none" => Some(Vec::new()),
+        Some(mode) if mode == "any" || mode == "validated" => {
+            names.or_else(|| Some(declared_tool_names.to_vec()))
+        }
+        Some(mode) if mode == "auto" => names,
+        Some(_) => names,
+        None => names,
+    }
 }
 
 /// The model requested a tool that is not registered for this prompt.
@@ -1403,6 +1558,32 @@ mod tests {
     }
 
     #[test]
+    fn tool_call_name_validator_accepts_anthropic_extra_function_tool() {
+        let mut request = validator_request(Vec::new(), None);
+        request.additional_params = Some(serde_json::json!({
+            "tools": [
+                {
+                    "name": "lookup_weather",
+                    "description": "Lookup weather",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {}
+                    }
+                }
+            ]
+        }));
+        let validator = ToolCallNameValidator::from_completion_request("anthropic", &request);
+
+        assert_eq!(
+            validator.declared_tool_names(),
+            ["lookup_weather".to_string()].as_slice()
+        );
+        validator
+            .validate("lookup_weather")
+            .expect("Anthropic extra function tool should validate");
+    }
+
+    #[test]
     fn tool_call_name_validator_ignores_provider_built_in_tools() {
         let mut request = validator_request(Vec::new(), None);
         request.additional_params = Some(serde_json::json!({
@@ -1420,6 +1601,97 @@ mod tests {
             err,
             CompletionError::InvalidToolCall(ToolCallValidationError {
                 reason: ToolCallValidationReason::Undeclared,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn tool_call_name_validator_respects_generate_content_extra_tool_config_allowlist() {
+        let mut request = validator_request(vec![test_tool("add"), test_tool("subtract")], None);
+        request.additional_params = Some(serde_json::json!({
+            "toolConfig": {
+                "functionCallingConfig": {
+                    "mode": "ANY",
+                    "allowedFunctionNames": ["add"]
+                }
+            }
+        }));
+        let validator = ToolCallNameValidator::from_completion_request("rig", &request);
+
+        validator
+            .validate("add")
+            .expect("provider-native allowed function should validate");
+        let err = validator
+            .validate("subtract")
+            .expect_err("provider-native allowlist should reject disallowed functions");
+
+        assert!(matches!(
+            err,
+            CompletionError::InvalidToolCall(ToolCallValidationError {
+                reason: ToolCallValidationReason::Disallowed,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn tool_call_name_validator_respects_interactions_extra_tool_choice_allowlist() {
+        let mut request = validator_request(vec![test_tool("add"), test_tool("subtract")], None);
+        request.additional_params = Some(serde_json::json!({
+            "generation_config": {
+                "tool_choice": {
+                    "allowed_tools": {
+                        "mode": "validated",
+                        "tools": ["add"]
+                    }
+                }
+            }
+        }));
+        let validator = ToolCallNameValidator::from_completion_request("rig", &request);
+
+        validator
+            .validate("add")
+            .expect("provider-native allowed interaction function should validate");
+        let err = validator
+            .validate("subtract")
+            .expect_err("provider-native interaction allowlist should reject disallowed functions");
+
+        assert!(matches!(
+            err,
+            CompletionError::InvalidToolCall(ToolCallValidationError {
+                reason: ToolCallValidationReason::Disallowed,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn tool_call_name_validator_respects_anthropic_extra_tool_choice() {
+        let mut request = validator_request(vec![test_tool("add"), test_tool("subtract")], None);
+        request.additional_params = Some(serde_json::json!({
+            "tool_choice": {
+                "type": "tool",
+                "name": "add"
+            }
+        }));
+        let validator = ToolCallNameValidator::from_completion_request("rig", &request);
+
+        assert_eq!(
+            validator.allowed_tool_names(),
+            Some(["add".to_string()].as_slice())
+        );
+        validator
+            .validate("add")
+            .expect("provider-native Anthropic tool choice should validate");
+        let err = validator
+            .validate("subtract")
+            .expect_err("provider-native Anthropic tool choice should reject other tools");
+
+        assert!(matches!(
+            err,
+            CompletionError::InvalidToolCall(ToolCallValidationError {
+                reason: ToolCallValidationReason::Disallowed,
                 ..
             })
         ));

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -96,6 +96,16 @@ pub enum PromptError {
     #[error("ToolCallError: {0}")]
     ToolError(#[from] ToolSetError),
 
+    /// The model requested a tool that is not registered for this prompt.
+    #[error(
+        "UnknownToolCall: model requested unknown tool `{tool_name}` (tool_call_id={tool_call_id}, call_id={call_id:?})"
+    )]
+    UnknownToolCall {
+        tool_name: String,
+        tool_call_id: String,
+        call_id: Option<String>,
+    },
+
     /// There was an issue while executing a tool on a tool server
     #[error("ToolServerError: {0}")]
     ToolServerError(#[from] Box<ToolServerError>),

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -47,9 +47,174 @@ use crate::{
 };
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::ops::{Add, AddAssign};
+use std::{collections::HashMap, fmt};
 use thiserror::Error;
+
+/// Why a provider-emitted tool call did not match the request contract.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ToolCallValidationReason {
+    /// The provider returned a tool name that was not declared in the request.
+    Undeclared,
+    /// The provider returned a declared tool name that was excluded by the request's tool-choice allowlist.
+    Disallowed,
+}
+
+impl fmt::Display for ToolCallValidationReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Undeclared => write!(f, "undeclared"),
+            Self::Disallowed => write!(f, "disallowed"),
+        }
+    }
+}
+
+/// A provider emitted a tool call that does not match the request's declared or allowed tools.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ToolCallValidationError {
+    /// Provider that emitted the invalid tool call.
+    pub provider: &'static str,
+    /// Tool name emitted by the provider.
+    pub tool_name: String,
+    /// Tool names declared in the request sent to the provider.
+    pub declared_tool_names: Vec<String>,
+    /// Optional tool names allowed by request-level tool choice settings.
+    pub allowed_tool_names: Option<Vec<String>>,
+    /// Why the emitted tool name was invalid.
+    pub reason: ToolCallValidationReason,
+}
+
+impl fmt::Display for ToolCallValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} returned {} tool call `{}`; declared tools: [{}]",
+            self.provider,
+            self.reason,
+            self.tool_name,
+            self.declared_tool_names.join(", ")
+        )?;
+
+        if let Some(allowed_tool_names) = &self.allowed_tool_names {
+            write!(f, "; allowed tools: [{}]", allowed_tool_names.join(", "))?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Validates provider-emitted tool calls against the request's declared and allowed tool names.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ToolCallNameValidator {
+    provider: &'static str,
+    declared_tool_names: Vec<String>,
+    allowed_tool_names: Option<Vec<String>>,
+}
+
+impl ToolCallNameValidator {
+    /// Create a validator from the provider name, declared tools, and optional allowed tools.
+    pub fn new(
+        provider: &'static str,
+        declared_tool_names: Vec<String>,
+        allowed_tool_names: Option<Vec<String>>,
+    ) -> Self {
+        Self {
+            provider,
+            declared_tool_names,
+            allowed_tool_names,
+        }
+    }
+
+    /// Validate a provider-emitted tool name against this request contract.
+    pub fn validate(&self, tool_name: &str) -> Result<(), CompletionError> {
+        if !self
+            .declared_tool_names
+            .iter()
+            .any(|declared| declared == tool_name)
+        {
+            return Err(CompletionError::InvalidToolCall(ToolCallValidationError {
+                provider: self.provider,
+                tool_name: tool_name.to_string(),
+                declared_tool_names: self.declared_tool_names.clone(),
+                allowed_tool_names: self.allowed_tool_names.clone(),
+                reason: ToolCallValidationReason::Undeclared,
+            }));
+        }
+
+        if let Some(allowed_tool_names) = &self.allowed_tool_names
+            && !allowed_tool_names
+                .iter()
+                .any(|allowed| allowed == tool_name)
+        {
+            return Err(CompletionError::InvalidToolCall(ToolCallValidationError {
+                provider: self.provider,
+                tool_name: tool_name.to_string(),
+                declared_tool_names: self.declared_tool_names.clone(),
+                allowed_tool_names: self.allowed_tool_names.clone(),
+                reason: ToolCallValidationReason::Disallowed,
+            }));
+        }
+
+        Ok(())
+    }
+
+    /// Tool names declared in the request sent to the provider.
+    pub fn declared_tool_names(&self) -> &[String] {
+        &self.declared_tool_names
+    }
+
+    /// Optional request-level tool-choice allowlist.
+    pub fn allowed_tool_names(&self) -> Option<&[String]> {
+        self.allowed_tool_names.as_deref()
+    }
+}
+
+/// The model requested a tool that is not registered for this prompt.
+#[derive(Clone, Debug, PartialEq)]
+pub struct UnknownToolCallError {
+    /// Tool name requested by the model.
+    pub tool_name: String,
+    /// Provider/tool-call identifier for the attempted tool call.
+    pub tool_call_id: String,
+    /// Optional provider call id associated with the attempted tool call.
+    pub call_id: Option<String>,
+    /// Arguments the model supplied for the attempted tool call.
+    pub arguments: serde_json::Value,
+    /// Tool names registered with the prompt at the time of validation.
+    pub available_tool_names: Vec<String>,
+}
+
+impl UnknownToolCallError {
+    /// Create an unknown-tool error with the attempted call and available tool context.
+    pub fn new(
+        tool_name: String,
+        tool_call_id: String,
+        call_id: Option<String>,
+        arguments: serde_json::Value,
+        available_tool_names: Vec<String>,
+    ) -> Self {
+        Self {
+            tool_name,
+            tool_call_id,
+            call_id,
+            arguments,
+            available_tool_names,
+        }
+    }
+}
+
+impl fmt::Display for UnknownToolCallError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "model requested unknown tool `{}` (tool_call_id={}, call_id={:?}, available_tools=[{}])",
+            self.tool_name,
+            self.tool_call_id,
+            self.call_id,
+            self.available_tool_names.join(", ")
+        )
+    }
+}
 
 // Errors
 #[derive(Debug, Error)]
@@ -80,6 +245,10 @@ pub enum CompletionError {
     #[error("ResponseError: {0}")]
     ResponseError(String),
 
+    /// A provider emitted a tool call outside the request's declared or allowed tool set.
+    #[error("InvalidToolCall: {0}")]
+    InvalidToolCall(ToolCallValidationError),
+
     /// Error returned by the completion model provider
     #[error("ProviderError: {0}")]
     ProviderError(String),
@@ -97,14 +266,8 @@ pub enum PromptError {
     ToolError(#[from] ToolSetError),
 
     /// The model requested a tool that is not registered for this prompt.
-    #[error(
-        "UnknownToolCall: model requested unknown tool `{tool_name}` (tool_call_id={tool_call_id}, call_id={call_id:?})"
-    )]
-    UnknownToolCall {
-        tool_name: String,
-        tool_call_id: String,
-        call_id: Option<String>,
-    },
+    #[error("UnknownToolCall: {0}")]
+    UnknownToolCall(UnknownToolCallError),
 
     /// There was an issue while executing a tool on a tool server
     #[error("ToolServerError: {0}")]

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -127,9 +127,21 @@ impl ToolCallNameValidator {
 
     /// Create a validator from the generic completion request contract sent to a provider.
     pub fn from_completion_request(provider: &'static str, request: &CompletionRequest) -> Self {
-        let declared_tool_names =
-            dedupe_tool_names(request.tools.iter().map(|tool| tool.name.clone()));
-        let allowed_tool_names = match &request.tool_choice {
+        let declared_tool_names = request.tools.iter().map(|tool| tool.name.clone()).chain(
+            provider_declared_function_names(request.additional_params.as_ref()),
+        );
+
+        Self::from_declared_tool_names(provider, declared_tool_names, request.tool_choice.as_ref())
+    }
+
+    /// Create a validator from explicit declared tool names and a generic tool-choice policy.
+    pub fn from_declared_tool_names(
+        provider: &'static str,
+        declared_tool_names: impl IntoIterator<Item = String>,
+        tool_choice: Option<&ToolChoice>,
+    ) -> Self {
+        let declared_tool_names = dedupe_tool_names(declared_tool_names);
+        let allowed_tool_names = match tool_choice {
             None | Some(ToolChoice::Auto) => None,
             Some(ToolChoice::Required) => Some(declared_tool_names.clone()),
             Some(ToolChoice::Specific { function_names }) => {
@@ -201,6 +213,52 @@ fn dedupe_tool_names(names: impl IntoIterator<Item = String>) -> Vec<String> {
         }
     }
     deduped
+}
+
+fn provider_declared_function_names(additional_params: Option<&serde_json::Value>) -> Vec<String> {
+    additional_params
+        .and_then(|params| params.get("tools"))
+        .and_then(serde_json::Value::as_array)
+        .map(|tools| {
+            tools
+                .iter()
+                .flat_map(provider_tool_function_names)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
+}
+
+fn provider_tool_function_names(tool: &serde_json::Value) -> Vec<String> {
+    let Some(tool) = tool.as_object() else {
+        return Vec::new();
+    };
+
+    let mut names = Vec::new();
+
+    if tool.get("type").and_then(serde_json::Value::as_str) == Some("function") {
+        if let Some(name) = tool.get("name").and_then(serde_json::Value::as_str) {
+            names.push(name.to_string());
+        }
+
+        if let Some(function) = tool.get("function").and_then(serde_json::Value::as_object)
+            && let Some(name) = function.get("name").and_then(serde_json::Value::as_str)
+        {
+            names.push(name.to_string());
+        }
+    }
+
+    for key in ["functionDeclarations", "function_declarations"] {
+        if let Some(function_declarations) = tool.get(key).and_then(serde_json::Value::as_array) {
+            names.extend(function_declarations.iter().filter_map(|declaration| {
+                declaration
+                    .get("name")
+                    .and_then(serde_json::Value::as_str)
+                    .map(String::from)
+            }));
+        }
+    }
+
+    names
 }
 
 /// The model requested a tool that is not registered for this prompt.
@@ -1285,6 +1343,143 @@ mod tests {
             validator.allowed_tool_names(),
             Some(["add".to_string(), "subtract".to_string()].as_slice())
         );
+    }
+
+    #[test]
+    fn tool_call_name_validator_accepts_generate_content_extra_function_declaration() {
+        let mut request = validator_request(vec![test_tool("add")], None);
+        request.additional_params = Some(serde_json::json!({
+            "tools": [
+                {
+                    "functionDeclarations": [
+                        {
+                            "name": "lookup_weather",
+                            "description": "Lookup weather",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {}
+                            }
+                        }
+                    ]
+                }
+            ]
+        }));
+        let validator = ToolCallNameValidator::from_completion_request("test", &request);
+
+        assert_eq!(
+            validator.declared_tool_names(),
+            ["add".to_string(), "lookup_weather".to_string()].as_slice()
+        );
+        validator
+            .validate("lookup_weather")
+            .expect("extra provider function declaration should validate");
+    }
+
+    #[test]
+    fn tool_call_name_validator_accepts_interactions_extra_function_tool() {
+        let mut request = validator_request(Vec::new(), None);
+        request.additional_params = Some(serde_json::json!({
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "lookup_weather",
+                    "description": "Lookup weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {}
+                    }
+                }
+            ]
+        }));
+        let validator = ToolCallNameValidator::from_completion_request("test", &request);
+
+        assert_eq!(
+            validator.declared_tool_names(),
+            ["lookup_weather".to_string()].as_slice()
+        );
+        validator
+            .validate("lookup_weather")
+            .expect("extra provider function tool should validate");
+    }
+
+    #[test]
+    fn tool_call_name_validator_ignores_provider_built_in_tools() {
+        let mut request = validator_request(Vec::new(), None);
+        request.additional_params = Some(serde_json::json!({
+            "tools": [
+                { "type": "google_search" },
+                { "codeExecution": {} }
+            ]
+        }));
+        let validator = ToolCallNameValidator::from_completion_request("test", &request);
+        let err = validator
+            .validate("google_search")
+            .expect_err("provider built-ins should not become executable Rig tool names");
+
+        assert!(matches!(
+            err,
+            CompletionError::InvalidToolCall(ToolCallValidationError {
+                reason: ToolCallValidationReason::Undeclared,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn tool_call_name_validator_specific_choice_still_rejects_extra_function() {
+        let mut request = validator_request(
+            vec![test_tool("add")],
+            Some(ToolChoice::Specific {
+                function_names: vec!["add".to_string()],
+            }),
+        );
+        request.additional_params = Some(serde_json::json!({
+            "tools": [
+                {
+                    "functionDeclarations": [
+                        { "name": "lookup_weather", "description": "Lookup weather" }
+                    ]
+                }
+            ]
+        }));
+        let validator = ToolCallNameValidator::from_completion_request("test", &request);
+        let err = validator
+            .validate("lookup_weather")
+            .expect_err("specific tool choice should reject unlisted extra functions");
+
+        assert!(matches!(
+            err,
+            CompletionError::InvalidToolCall(ToolCallValidationError {
+                reason: ToolCallValidationReason::Disallowed,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn tool_call_name_validator_none_choice_rejects_extra_function() {
+        let mut request = validator_request(Vec::new(), Some(ToolChoice::None));
+        request.additional_params = Some(serde_json::json!({
+            "tools": [
+                {
+                    "functionDeclarations": [
+                        { "name": "lookup_weather", "description": "Lookup weather" }
+                    ]
+                }
+            ]
+        }));
+        let validator = ToolCallNameValidator::from_completion_request("test", &request);
+        let err = validator
+            .validate("lookup_weather")
+            .expect_err("tool_choice none should reject extra provider functions");
+
+        assert!(matches!(
+            err,
+            CompletionError::InvalidToolCall(ToolCallValidationError {
+                reason: ToolCallValidationReason::Disallowed,
+                ..
+            })
+        ));
     }
 
     #[test]

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -125,6 +125,22 @@ impl ToolCallNameValidator {
         }
     }
 
+    /// Create a validator from the generic completion request contract sent to a provider.
+    pub fn from_completion_request(provider: &'static str, request: &CompletionRequest) -> Self {
+        let declared_tool_names =
+            dedupe_tool_names(request.tools.iter().map(|tool| tool.name.clone()));
+        let allowed_tool_names = match &request.tool_choice {
+            None | Some(ToolChoice::Auto) => None,
+            Some(ToolChoice::Required) => Some(declared_tool_names.clone()),
+            Some(ToolChoice::Specific { function_names }) => {
+                Some(dedupe_tool_names(function_names.iter().cloned()))
+            }
+            Some(ToolChoice::None) => Some(Vec::new()),
+        };
+
+        Self::new(provider, declared_tool_names, allowed_tool_names)
+    }
+
     /// Validate a provider-emitted tool name against this request contract.
     pub fn validate(&self, tool_name: &str) -> Result<(), CompletionError> {
         if !self
@@ -158,6 +174,14 @@ impl ToolCallNameValidator {
         Ok(())
     }
 
+    /// Validate a provider-emitted tool call against this request contract.
+    pub fn validate_tool_call(
+        &self,
+        tool_call: &crate::message::ToolCall,
+    ) -> Result<(), CompletionError> {
+        self.validate(&tool_call.function.name)
+    }
+
     /// Tool names declared in the request sent to the provider.
     pub fn declared_tool_names(&self) -> &[String] {
         &self.declared_tool_names
@@ -167,6 +191,16 @@ impl ToolCallNameValidator {
     pub fn allowed_tool_names(&self) -> Option<&[String]> {
         self.allowed_tool_names.as_deref()
     }
+}
+
+fn dedupe_tool_names(names: impl IntoIterator<Item = String>) -> Vec<String> {
+    let mut deduped = Vec::new();
+    for name in names {
+        if !deduped.iter().any(|existing| existing == &name) {
+            deduped.push(name);
+        }
+    }
+    deduped
 }
 
 /// The model requested a tool that is not registered for this prompt.
@@ -1093,6 +1127,165 @@ mod tests {
 
     use super::*;
     use crate::test_utils::MockCompletionModel;
+
+    fn test_tool(name: &str) -> ToolDefinition {
+        ToolDefinition {
+            name: name.to_string(),
+            description: format!("{name} tool"),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {}
+            }),
+        }
+    }
+
+    fn validator_request(
+        tools: Vec<ToolDefinition>,
+        tool_choice: Option<ToolChoice>,
+    ) -> CompletionRequest {
+        CompletionRequest {
+            model: None,
+            preamble: None,
+            chat_history: OneOrMany::one(Message::user("use a tool")),
+            documents: Vec::new(),
+            tools,
+            temperature: None,
+            max_tokens: None,
+            tool_choice,
+            additional_params: None,
+            output_schema: None,
+        }
+    }
+
+    #[test]
+    fn tool_call_name_validator_accepts_declared_tool() {
+        let request = validator_request(vec![test_tool("add")], None);
+        let validator = ToolCallNameValidator::from_completion_request("test", &request);
+
+        validator
+            .validate("add")
+            .expect("declared tool should validate");
+    }
+
+    #[test]
+    fn tool_call_name_validator_rejects_undeclared_tool() {
+        let request = validator_request(vec![test_tool("add")], None);
+        let validator = ToolCallNameValidator::from_completion_request("test", &request);
+        let err = validator
+            .validate("subtract")
+            .expect_err("undeclared tool should be rejected");
+
+        assert!(matches!(
+            err,
+            CompletionError::InvalidToolCall(ToolCallValidationError {
+                provider: "test",
+                ref tool_name,
+                ref declared_tool_names,
+                allowed_tool_names: None,
+                reason: ToolCallValidationReason::Undeclared,
+            }) if tool_name == "subtract" && declared_tool_names == &vec!["add".to_string()]
+        ));
+    }
+
+    #[test]
+    fn tool_call_name_validator_rejects_declared_but_disallowed_tool() {
+        let request = validator_request(
+            vec![test_tool("add"), test_tool("subtract")],
+            Some(ToolChoice::Specific {
+                function_names: vec!["add".to_string()],
+            }),
+        );
+        let validator = ToolCallNameValidator::from_completion_request("test", &request);
+        let err = validator
+            .validate("subtract")
+            .expect_err("disallowed tool should be rejected");
+
+        assert!(matches!(
+            err,
+            CompletionError::InvalidToolCall(ToolCallValidationError {
+                provider: "test",
+                ref tool_name,
+                ref declared_tool_names,
+                ref allowed_tool_names,
+                reason: ToolCallValidationReason::Disallowed,
+            }) if tool_name == "subtract"
+                && declared_tool_names == &vec!["add".to_string(), "subtract".to_string()]
+                && allowed_tool_names.as_ref() == Some(&vec!["add".to_string()])
+        ));
+    }
+
+    #[test]
+    fn tool_call_name_validator_specific_choice_sets_allowlist() {
+        let request = validator_request(
+            vec![test_tool("add"), test_tool("subtract")],
+            Some(ToolChoice::Specific {
+                function_names: vec!["add".to_string(), "add".to_string()],
+            }),
+        );
+        let validator = ToolCallNameValidator::from_completion_request("test", &request);
+
+        assert_eq!(
+            validator.allowed_tool_names(),
+            Some(["add".to_string()].as_slice())
+        );
+        validator
+            .validate("add")
+            .expect("specific allowed tool should validate");
+    }
+
+    #[test]
+    fn tool_call_name_validator_none_choice_disallows_declared_tools() {
+        let request = validator_request(vec![test_tool("add")], Some(ToolChoice::None));
+        let validator = ToolCallNameValidator::from_completion_request("test", &request);
+        let err = validator
+            .validate("add")
+            .expect_err("tool_choice none should reject declared tool calls");
+
+        assert!(matches!(
+            err,
+            CompletionError::InvalidToolCall(ToolCallValidationError {
+                reason: ToolCallValidationReason::Disallowed,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn tool_call_name_validator_required_choice_allows_declared_tools() {
+        let request = validator_request(
+            vec![test_tool("add"), test_tool("subtract")],
+            Some(ToolChoice::Required),
+        );
+        let validator = ToolCallNameValidator::from_completion_request("test", &request);
+
+        assert_eq!(
+            validator.allowed_tool_names(),
+            Some(["add".to_string(), "subtract".to_string()].as_slice())
+        );
+        validator
+            .validate("subtract")
+            .expect("required choice should allow declared tools");
+    }
+
+    #[test]
+    fn tool_call_name_validator_deduplicates_names_in_order() {
+        let request = validator_request(
+            vec![test_tool("subtract"), test_tool("add"), test_tool("add")],
+            Some(ToolChoice::Specific {
+                function_names: vec!["add".to_string(), "subtract".to_string(), "add".to_string()],
+            }),
+        );
+        let validator = ToolCallNameValidator::from_completion_request("test", &request);
+
+        assert_eq!(
+            validator.declared_tool_names(),
+            ["subtract".to_string(), "add".to_string()].as_slice()
+        );
+        assert_eq!(
+            validator.allowed_tool_names(),
+            Some(["add".to_string(), "subtract".to_string()].as_slice())
+        );
+    }
 
     #[test]
     fn test_document_display_without_metadata() {

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -34,7 +34,7 @@ use crate::providers::gemini::streaming::StreamingCompletionResponse;
 use crate::telemetry::SpanCombinator;
 use crate::{
     OneOrMany,
-    completion::{self, CompletionError, CompletionRequest, GetTokenUsage},
+    completion::{self, CompletionError, CompletionRequest, GetTokenUsage, ToolCallNameValidator},
 };
 use gemini_api_types::{
     Content, FunctionDeclaration, GenerateContentRequest, GenerateContentResponse,
@@ -111,7 +111,7 @@ where
         };
 
         let request = create_request_body(completion_request)?;
-        let function_call_validator = FunctionCallNameValidator::from_request(&request);
+        let function_call_validator = function_call_validator_from_request(&request);
 
         if enabled!(Level::TRACE) {
             tracing::trace!(
@@ -412,81 +412,14 @@ impl TryFrom<Vec<completion::ToolDefinition>> for Tool {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct FunctionCallNameValidator {
-    declared_function_names: Vec<String>,
-    allowed_function_names: Option<Vec<String>>,
-}
-
-impl FunctionCallNameValidator {
-    pub(crate) fn new(
-        declared_function_names: Vec<String>,
-        allowed_function_names: Option<Vec<String>>,
-    ) -> Self {
-        Self {
-            declared_function_names,
-            allowed_function_names,
-        }
-    }
-
-    pub(crate) fn from_request(request: &GenerateContentRequest) -> Self {
-        Self::new(
-            declared_function_names_from_request(request),
-            allowed_function_names_from_request(request),
-        )
-    }
-
-    fn validate(&self, function_name: &str) -> Result<(), CompletionError> {
-        if !self
-            .declared_function_names
-            .iter()
-            .any(|declared| declared == function_name)
-        {
-            self.log_rejected(function_name, "undeclared");
-
-            return Err(CompletionError::ResponseError(format!(
-                "Gemini returned function call `{function_name}`, but it was not declared in the request. Declared functions: [{}]",
-                self.declared_function_names.join(", ")
-            )));
-        }
-
-        if let Some(allowed_function_names) = &self.allowed_function_names
-            && !allowed_function_names
-                .iter()
-                .any(|allowed| allowed == function_name)
-        {
-            self.log_rejected(function_name, "not_allowed");
-
-            return Err(CompletionError::ResponseError(format!(
-                "Gemini returned function call `{function_name}`, but it was not allowed by toolConfig.functionCallingConfig.allowedFunctionNames. Allowed functions: [{}]",
-                allowed_function_names.join(", ")
-            )));
-        }
-
-        tracing::trace!(
-            target: "rig::completions",
-            provider = "gemini",
-            raw_function_name = function_name,
-            declared_function_names = ?self.declared_function_names,
-            allowed_function_names = ?self.allowed_function_names,
-            validation = "accepted",
-            "Gemini function call matched an allowed function"
-        );
-
-        Ok(())
-    }
-
-    fn log_rejected(&self, function_name: &str, validation: &'static str) {
-        tracing::warn!(
-            target: "rig::completions",
-            provider = "gemini",
-            raw_function_name = function_name,
-            declared_function_names = ?self.declared_function_names,
-            allowed_function_names = ?self.allowed_function_names,
-            validation,
-            "Gemini returned a function call outside the request contract"
-        );
-    }
+pub(crate) fn function_call_validator_from_request(
+    request: &GenerateContentRequest,
+) -> ToolCallNameValidator {
+    ToolCallNameValidator::new(
+        "gemini",
+        declared_function_names_from_request(request),
+        allowed_function_names_from_request(request),
+    )
 }
 
 fn declared_function_names_from_request(request: &GenerateContentRequest) -> Vec<String> {
@@ -534,14 +467,42 @@ fn allowed_function_names_from_request(request: &GenerateContentRequest) -> Opti
 
 pub(crate) fn validate_function_call_name(
     function_name: &str,
-    validator: &FunctionCallNameValidator,
+    validator: &ToolCallNameValidator,
 ) -> Result<(), CompletionError> {
-    validator.validate(function_name)
+    match validator.validate(function_name) {
+        Ok(()) => {
+            tracing::trace!(
+                target: "rig::completions",
+                provider = "gemini",
+                raw_function_name = function_name,
+                declared_function_names = ?validator.declared_tool_names(),
+                allowed_function_names = ?validator.allowed_tool_names(),
+                validation = "accepted",
+                "Gemini function call matched an allowed function"
+            );
+            Ok(())
+        }
+        Err(error) => {
+            if let CompletionError::InvalidToolCall(invalid_tool_call) = &error {
+                tracing::warn!(
+                    target: "rig::completions",
+                    provider = "gemini",
+                    raw_function_name = function_name,
+                    declared_function_names = ?invalid_tool_call.declared_tool_names,
+                    allowed_function_names = ?invalid_tool_call.allowed_tool_names,
+                    validation = %invalid_tool_call.reason,
+                    "Gemini returned a function call outside the request contract"
+                );
+            }
+
+            Err(error)
+        }
+    }
 }
 
 pub(crate) fn completion_response_from_generate_content_response(
     response: GenerateContentResponse,
-    function_call_validator: &FunctionCallNameValidator,
+    function_call_validator: &ToolCallNameValidator,
 ) -> Result<completion::CompletionResponse<GenerateContentResponse>, CompletionError> {
     completion_response_from_generate_content_response_impl(response, Some(function_call_validator))
 }
@@ -554,7 +515,7 @@ fn completion_response_from_generate_content_response_unvalidated(
 
 fn completion_response_from_generate_content_response_impl(
     response: GenerateContentResponse,
-    function_call_validator: Option<&FunctionCallNameValidator>,
+    function_call_validator: Option<&ToolCallNameValidator>,
 ) -> Result<completion::CompletionResponse<GenerateContentResponse>, CompletionError> {
     let candidate = response.candidates.first().ok_or_else(|| {
         CompletionError::ResponseError("No response candidates in response".into())
@@ -2600,7 +2561,7 @@ mod tests {
 
     #[test]
     fn test_completion_response_accepts_declared_function_call_name() {
-        let validator = FunctionCallNameValidator::new(vec!["JavaScript".to_string()], None);
+        let validator = ToolCallNameValidator::new("gemini", vec!["JavaScript".to_string()], None);
         let response = function_call_response("JavaScript");
 
         let converted = completion_response_from_generate_content_response(response, &validator)
@@ -2616,7 +2577,7 @@ mod tests {
 
     #[test]
     fn test_completion_response_rejects_undeclared_default_api_function_call() {
-        let validator = FunctionCallNameValidator::new(vec!["JavaScript".to_string()], None);
+        let validator = ToolCallNameValidator::new("gemini", vec!["JavaScript".to_string()], None);
         let response = function_call_response("default_api");
 
         let err = completion_response_from_generate_content_response(response, &validator)
@@ -2625,8 +2586,12 @@ mod tests {
         assert!(
             matches!(
                 err,
-                CompletionError::ResponseError(ref message)
-                    if message.contains("default_api") && message.contains("JavaScript")
+                CompletionError::InvalidToolCall(ref invalid)
+                    if invalid.provider == "gemini"
+                        && invalid.tool_name == "default_api"
+                        && invalid.declared_tool_names == vec!["JavaScript".to_string()]
+                        && invalid.allowed_tool_names.is_none()
+                        && invalid.reason == crate::completion::ToolCallValidationReason::Undeclared
             ),
             "expected response error describing rejected function call, got {err:?}"
         );
@@ -2634,7 +2599,8 @@ mod tests {
 
     #[test]
     fn test_completion_response_rejects_declared_but_disallowed_function_call() {
-        let validator = FunctionCallNameValidator::new(
+        let validator = ToolCallNameValidator::new(
+            "gemini",
             vec!["JavaScript".to_string(), "OtherTool".to_string()],
             Some(vec!["JavaScript".to_string()]),
         );
@@ -2646,10 +2612,13 @@ mod tests {
         assert!(
             matches!(
                 err,
-                CompletionError::ResponseError(ref message)
-                    if message.contains("OtherTool")
-                        && message.contains("allowed")
-                        && message.contains("JavaScript")
+                CompletionError::InvalidToolCall(ref invalid)
+                    if invalid.provider == "gemini"
+                        && invalid.tool_name == "OtherTool"
+                        && invalid.declared_tool_names
+                            == vec!["JavaScript".to_string(), "OtherTool".to_string()]
+                        && invalid.allowed_tool_names == Some(vec!["JavaScript".to_string()])
+                        && invalid.reason == crate::completion::ToolCallValidationReason::Disallowed
             ),
             "expected response error describing rejected function call, got {err:?}"
         );
@@ -2675,7 +2644,7 @@ mod tests {
             system_instruction: None,
             additional_params: None,
         };
-        let validator = FunctionCallNameValidator::from_request(&request);
+        let validator = function_call_validator_from_request(&request);
 
         validate_function_call_name("JavaScript", &validator)
             .expect("allowed function should validate");
@@ -2685,8 +2654,11 @@ mod tests {
         assert!(
             matches!(
                 err,
-                CompletionError::ResponseError(ref message)
-                    if message.contains("OtherTool") && message.contains("allowed")
+                CompletionError::InvalidToolCall(ref invalid)
+                    if invalid.provider == "gemini"
+                        && invalid.tool_name == "OtherTool"
+                        && invalid.allowed_tool_names == Some(vec!["JavaScript".to_string()])
+                        && invalid.reason == crate::completion::ToolCallValidationReason::Disallowed
             ),
             "expected response error describing disallowed function, got {err:?}"
         );

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -110,8 +110,9 @@ where
             tracing::Span::current()
         };
 
+        let function_call_validator =
+            ToolCallNameValidator::from_completion_request("gemini", &completion_request);
         let request = create_request_body(completion_request)?;
-        let function_call_validator = function_call_validator_from_request(&request);
 
         if enabled!(Level::TRACE) {
             tracing::trace!(
@@ -409,59 +410,6 @@ impl TryFrom<Vec<completion::ToolDefinition>> for Tool {
             function_declarations,
             code_execution: None,
         })
-    }
-}
-
-pub(crate) fn function_call_validator_from_request(
-    request: &GenerateContentRequest,
-) -> ToolCallNameValidator {
-    ToolCallNameValidator::new(
-        "gemini",
-        declared_function_names_from_request(request),
-        allowed_function_names_from_request(request),
-    )
-}
-
-fn declared_function_names_from_request(request: &GenerateContentRequest) -> Vec<String> {
-    let mut names = Vec::new();
-
-    let Some(tools) = &request.tools else {
-        return names;
-    };
-
-    for tool in tools {
-        for key in ["functionDeclarations", "function_declarations"] {
-            let Some(function_declarations) = tool.get(key).and_then(Value::as_array) else {
-                continue;
-            };
-
-            for declaration in function_declarations {
-                let Some(name) = declaration.get("name").and_then(Value::as_str) else {
-                    continue;
-                };
-
-                if !names.iter().any(|declared| declared == name) {
-                    names.push(name.to_string());
-                }
-            }
-        }
-    }
-
-    names
-}
-
-fn allowed_function_names_from_request(request: &GenerateContentRequest) -> Option<Vec<String>> {
-    let function_calling_config = request
-        .tool_config
-        .as_ref()
-        .and_then(|tool_config| tool_config.function_calling_config.as_ref())?;
-
-    match function_calling_config {
-        FunctionCallingMode::Any {
-            allowed_function_names,
-        } => allowed_function_names.clone(),
-        FunctionCallingMode::None => Some(Vec::new()),
-        FunctionCallingMode::Auto => None,
     }
 }
 
@@ -2625,26 +2573,33 @@ mod tests {
     }
 
     #[test]
-    fn test_function_call_validator_from_request_respects_allowed_function_names() {
-        let request = GenerateContentRequest {
-            contents: vec![],
-            tools: Some(vec![json!({
-                "functionDeclarations": [
-                    { "name": "JavaScript" },
-                    { "name": "OtherTool" }
-                ]
-            })]),
-            tool_config: Some(ToolConfig {
-                function_calling_config: Some(FunctionCallingMode::Any {
-                    allowed_function_names: Some(vec!["JavaScript".to_string()]),
-                }),
+    fn test_completion_request_validator_respects_allowed_function_names() {
+        let request = CompletionRequest {
+            model: None,
+            preamble: None,
+            chat_history: OneOrMany::one(message::Message::user("use a tool")),
+            documents: vec![],
+            tools: vec![
+                completion::ToolDefinition {
+                    name: "JavaScript".to_string(),
+                    description: "JavaScript runtime".to_string(),
+                    parameters: json!({"type": "object"}),
+                },
+                completion::ToolDefinition {
+                    name: "OtherTool".to_string(),
+                    description: "Other tool".to_string(),
+                    parameters: json!({"type": "object"}),
+                },
+            ],
+            temperature: None,
+            max_tokens: None,
+            tool_choice: Some(message::ToolChoice::Specific {
+                function_names: vec!["JavaScript".to_string()],
             }),
-            generation_config: None,
-            safety_settings: None,
-            system_instruction: None,
             additional_params: None,
+            output_schema: None,
         };
-        let validator = function_call_validator_from_request(&request);
+        let validator = ToolCallNameValidator::from_completion_request("gemini", &request);
 
         validate_function_call_name("JavaScript", &validator)
             .expect("allowed function should validate");

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -111,6 +111,7 @@ where
         };
 
         let request = create_request_body(completion_request)?;
+        let declared_function_names = declared_function_names_from_request(&request);
 
         if enabled!(Level::TRACE) {
             tracing::trace!(
@@ -163,7 +164,10 @@ where
                     );
                 }
 
-                response.try_into()
+                completion_response_from_generate_content_response(
+                    response,
+                    Some(&declared_function_names),
+                )
             } else {
                 let text = String::from_utf8_lossy(
                     &response
@@ -408,111 +412,189 @@ impl TryFrom<Vec<completion::ToolDefinition>> for Tool {
     }
 }
 
+pub(crate) fn declared_function_names_from_request(
+    request: &GenerateContentRequest,
+) -> Vec<String> {
+    let mut names = Vec::new();
+
+    let Some(tools) = &request.tools else {
+        return names;
+    };
+
+    for tool in tools {
+        for key in ["functionDeclarations", "function_declarations"] {
+            let Some(function_declarations) = tool.get(key).and_then(Value::as_array) else {
+                continue;
+            };
+
+            for declaration in function_declarations {
+                let Some(name) = declaration.get("name").and_then(Value::as_str) else {
+                    continue;
+                };
+
+                if !names.iter().any(|declared| declared == name) {
+                    names.push(name.to_string());
+                }
+            }
+        }
+    }
+
+    names
+}
+
+pub(crate) fn validate_function_call_name(
+    function_name: &str,
+    declared_function_names: &[String],
+) -> Result<(), CompletionError> {
+    if declared_function_names
+        .iter()
+        .any(|declared| declared == function_name)
+    {
+        tracing::trace!(
+            target: "rig::completions",
+            provider = "gemini",
+            raw_function_name = function_name,
+            declared_function_names = ?declared_function_names,
+            validation = "accepted",
+            "Gemini function call matched a declared function"
+        );
+        return Ok(());
+    }
+
+    tracing::warn!(
+        target: "rig::completions",
+        provider = "gemini",
+        raw_function_name = function_name,
+        declared_function_names = ?declared_function_names,
+        validation = "rejected",
+        "Gemini returned a function call for an undeclared function"
+    );
+
+    Err(CompletionError::ResponseError(format!(
+        "Gemini returned function call `{function_name}`, but it was not declared in the request. Declared functions: [{}]",
+        declared_function_names.join(", ")
+    )))
+}
+
+pub(crate) fn completion_response_from_generate_content_response(
+    response: GenerateContentResponse,
+    declared_function_names: Option<&[String]>,
+) -> Result<completion::CompletionResponse<GenerateContentResponse>, CompletionError> {
+    let candidate = response.candidates.first().ok_or_else(|| {
+        CompletionError::ResponseError("No response candidates in response".into())
+    })?;
+
+    let content = candidate
+        .content
+        .as_ref()
+        .ok_or_else(|| {
+            let reason = candidate
+                .finish_reason
+                .as_ref()
+                .map(|r| format!("finish_reason={r:?}"))
+                .unwrap_or_else(|| "finish_reason=<unknown>".to_string());
+            let message = candidate
+                .finish_message
+                .as_deref()
+                .unwrap_or("no finish message provided");
+            CompletionError::ResponseError(format!(
+                "Gemini candidate missing content ({reason}, finish_message={message})"
+            ))
+        })?
+        .parts
+        .iter()
+        .map(
+            |Part {
+                 thought,
+                 thought_signature,
+                 part,
+                 ..
+             }| {
+                Ok(match part {
+                    PartKind::Text(text) => {
+                        if let Some(thought) = thought
+                            && *thought
+                        {
+                            completion::AssistantContent::Reasoning(Reasoning::new_with_signature(
+                                text,
+                                thought_signature.clone(),
+                            ))
+                        } else {
+                            completion::AssistantContent::text(text)
+                        }
+                    }
+                    PartKind::InlineData(inline_data) => {
+                        let mime_type = message::MediaType::from_mime_type(&inline_data.mime_type);
+
+                        match mime_type {
+                            Some(message::MediaType::Image(media_type)) => {
+                                message::AssistantContent::image_base64(
+                                    &inline_data.data,
+                                    Some(media_type),
+                                    Some(message::ImageDetail::default()),
+                                )
+                            }
+                            _ => {
+                                return Err(CompletionError::ResponseError(format!(
+                                    "Unsupported media type {mime_type:?}"
+                                )));
+                            }
+                        }
+                    }
+                    PartKind::FunctionCall(function_call) => {
+                        if let Some(declared_function_names) = declared_function_names {
+                            validate_function_call_name(
+                                &function_call.name,
+                                declared_function_names,
+                            )?;
+                        }
+
+                        completion::AssistantContent::ToolCall(
+                            message::ToolCall::new(
+                                function_call.name.clone(),
+                                message::ToolFunction::new(
+                                    function_call.name.clone(),
+                                    function_call.args.clone(),
+                                ),
+                            )
+                            .with_signature(thought_signature.clone()),
+                        )
+                    }
+                    _ => {
+                        return Err(CompletionError::ResponseError(
+                            "Response did not contain a message or tool call".into(),
+                        ));
+                    }
+                })
+            },
+        )
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let choice = OneOrMany::many(content).map_err(|_| {
+        CompletionError::ResponseError(
+            "Response contained no message or tool call (empty)".to_owned(),
+        )
+    })?;
+
+    let usage = response
+        .usage_metadata
+        .as_ref()
+        .and_then(GetTokenUsage::token_usage)
+        .unwrap_or_default();
+
+    Ok(completion::CompletionResponse {
+        choice,
+        usage,
+        raw_response: response,
+        message_id: None,
+    })
+}
+
 impl TryFrom<GenerateContentResponse> for completion::CompletionResponse<GenerateContentResponse> {
     type Error = CompletionError;
 
     fn try_from(response: GenerateContentResponse) -> Result<Self, Self::Error> {
-        let candidate = response.candidates.first().ok_or_else(|| {
-            CompletionError::ResponseError("No response candidates in response".into())
-        })?;
-
-        let content = candidate
-            .content
-            .as_ref()
-            .ok_or_else(|| {
-                let reason = candidate
-                    .finish_reason
-                    .as_ref()
-                    .map(|r| format!("finish_reason={r:?}"))
-                    .unwrap_or_else(|| "finish_reason=<unknown>".to_string());
-                let message = candidate
-                    .finish_message
-                    .as_deref()
-                    .unwrap_or("no finish message provided");
-                CompletionError::ResponseError(format!(
-                    "Gemini candidate missing content ({reason}, finish_message={message})"
-                ))
-            })?
-            .parts
-            .iter()
-            .map(
-                |Part {
-                     thought,
-                     thought_signature,
-                     part,
-                     ..
-                 }| {
-                    Ok(match part {
-                        PartKind::Text(text) => {
-                            if let Some(thought) = thought
-                                && *thought
-                            {
-                                completion::AssistantContent::Reasoning(
-                                    Reasoning::new_with_signature(text, thought_signature.clone()),
-                                )
-                            } else {
-                                completion::AssistantContent::text(text)
-                            }
-                        }
-                        PartKind::InlineData(inline_data) => {
-                            let mime_type =
-                                message::MediaType::from_mime_type(&inline_data.mime_type);
-
-                            match mime_type {
-                                Some(message::MediaType::Image(media_type)) => {
-                                    message::AssistantContent::image_base64(
-                                        &inline_data.data,
-                                        Some(media_type),
-                                        Some(message::ImageDetail::default()),
-                                    )
-                                }
-                                _ => {
-                                    return Err(CompletionError::ResponseError(format!(
-                                        "Unsupported media type {mime_type:?}"
-                                    )));
-                                }
-                            }
-                        }
-                        PartKind::FunctionCall(function_call) => {
-                            completion::AssistantContent::ToolCall(
-                                message::ToolCall::new(
-                                    function_call.name.clone(),
-                                    message::ToolFunction::new(
-                                        function_call.name.clone(),
-                                        function_call.args.clone(),
-                                    ),
-                                )
-                                .with_signature(thought_signature.clone()),
-                            )
-                        }
-                        _ => {
-                            return Err(CompletionError::ResponseError(
-                                "Response did not contain a message or tool call".into(),
-                            ));
-                        }
-                    })
-                },
-            )
-            .collect::<Result<Vec<_>, _>>()?;
-
-        let choice = OneOrMany::many(content).map_err(|_| {
-            CompletionError::ResponseError(
-                "Response contained no message or tool call (empty)".to_owned(),
-            )
-        })?;
-
-        let usage = response
-            .usage_metadata
-            .as_ref()
-            .and_then(GetTokenUsage::token_usage)
-            .unwrap_or_default();
-
-        Ok(completion::CompletionResponse {
-            choice,
-            usage,
-            raw_response: response,
-            message_id: None,
-        })
+        completion_response_from_generate_content_response(response, None)
     }
 }
 
@@ -2090,6 +2172,37 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    fn function_call_response(name: &str) -> GenerateContentResponse {
+        GenerateContentResponse {
+            response_id: "resp_1".to_string(),
+            candidates: vec![ContentCandidate {
+                content: Some(Content {
+                    parts: vec![Part {
+                        thought: None,
+                        thought_signature: None,
+                        part: PartKind::FunctionCall(gemini_api_types::FunctionCall {
+                            name: name.to_string(),
+                            args: json!({"code": "return 2 + 2;"}),
+                        }),
+                        additional_params: None,
+                    }],
+                    role: Some(Role::Model),
+                }),
+                finish_reason: Some(FinishReason::Stop),
+                safety_ratings: None,
+                citation_metadata: None,
+                token_count: None,
+                avg_logprobs: None,
+                logprobs_result: None,
+                index: Some(0),
+                finish_message: None,
+            }],
+            prompt_feedback: None,
+            usage_metadata: None,
+            model_version: None,
+        }
+    }
+
     #[test]
     fn test_resolve_request_model_uses_override() {
         let request = CompletionRequest {
@@ -2401,6 +2514,41 @@ mod tests {
         assert_eq!(converted.usage.output_tokens, 30);
         assert_eq!(converted.usage.reasoning_tokens, 10);
         assert_eq!(converted.usage.total_tokens, 100);
+    }
+
+    #[test]
+    fn test_completion_response_accepts_declared_function_call_name() {
+        let declared = vec!["JavaScript".to_string()];
+        let response = function_call_response("JavaScript");
+
+        let converted =
+            completion_response_from_generate_content_response(response, Some(&declared))
+                .expect("declared function call should convert");
+
+        assert!(matches!(
+            converted.choice.first(),
+            message::AssistantContent::ToolCall(tool_call)
+                if tool_call.function.name == "JavaScript"
+                    && tool_call.id == "JavaScript"
+        ));
+    }
+
+    #[test]
+    fn test_completion_response_rejects_undeclared_default_api_function_call() {
+        let declared = vec!["JavaScript".to_string()];
+        let response = function_call_response("default_api");
+
+        let err = completion_response_from_generate_content_response(response, Some(&declared))
+            .expect_err("undeclared Gemini function call should be rejected");
+
+        assert!(
+            matches!(
+                err,
+                CompletionError::ResponseError(ref message)
+                    if message.contains("default_api") && message.contains("JavaScript")
+            ),
+            "expected response error describing rejected function call, got {err:?}"
+        );
     }
 
     #[test]

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -111,7 +111,7 @@ where
         };
 
         let request = create_request_body(completion_request)?;
-        let declared_function_names = declared_function_names_from_request(&request);
+        let function_call_validator = FunctionCallNameValidator::from_request(&request);
 
         if enabled!(Level::TRACE) {
             tracing::trace!(
@@ -166,7 +166,7 @@ where
 
                 completion_response_from_generate_content_response(
                     response,
-                    Some(&declared_function_names),
+                    &function_call_validator,
                 )
             } else {
                 let text = String::from_utf8_lossy(
@@ -412,9 +412,84 @@ impl TryFrom<Vec<completion::ToolDefinition>> for Tool {
     }
 }
 
-pub(crate) fn declared_function_names_from_request(
-    request: &GenerateContentRequest,
-) -> Vec<String> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FunctionCallNameValidator {
+    declared_function_names: Vec<String>,
+    allowed_function_names: Option<Vec<String>>,
+}
+
+impl FunctionCallNameValidator {
+    pub(crate) fn new(
+        declared_function_names: Vec<String>,
+        allowed_function_names: Option<Vec<String>>,
+    ) -> Self {
+        Self {
+            declared_function_names,
+            allowed_function_names,
+        }
+    }
+
+    pub(crate) fn from_request(request: &GenerateContentRequest) -> Self {
+        Self::new(
+            declared_function_names_from_request(request),
+            allowed_function_names_from_request(request),
+        )
+    }
+
+    fn validate(&self, function_name: &str) -> Result<(), CompletionError> {
+        if !self
+            .declared_function_names
+            .iter()
+            .any(|declared| declared == function_name)
+        {
+            self.log_rejected(function_name, "undeclared");
+
+            return Err(CompletionError::ResponseError(format!(
+                "Gemini returned function call `{function_name}`, but it was not declared in the request. Declared functions: [{}]",
+                self.declared_function_names.join(", ")
+            )));
+        }
+
+        if let Some(allowed_function_names) = &self.allowed_function_names
+            && !allowed_function_names
+                .iter()
+                .any(|allowed| allowed == function_name)
+        {
+            self.log_rejected(function_name, "not_allowed");
+
+            return Err(CompletionError::ResponseError(format!(
+                "Gemini returned function call `{function_name}`, but it was not allowed by toolConfig.functionCallingConfig.allowedFunctionNames. Allowed functions: [{}]",
+                allowed_function_names.join(", ")
+            )));
+        }
+
+        tracing::trace!(
+            target: "rig::completions",
+            provider = "gemini",
+            raw_function_name = function_name,
+            declared_function_names = ?self.declared_function_names,
+            allowed_function_names = ?self.allowed_function_names,
+            validation = "accepted",
+            "Gemini function call matched an allowed function"
+        );
+
+        Ok(())
+    }
+
+    fn log_rejected(&self, function_name: &str, validation: &'static str) {
+        tracing::warn!(
+            target: "rig::completions",
+            provider = "gemini",
+            raw_function_name = function_name,
+            declared_function_names = ?self.declared_function_names,
+            allowed_function_names = ?self.allowed_function_names,
+            validation,
+            "Gemini returned a function call outside the request contract"
+        );
+    }
+}
+
+fn declared_function_names_from_request(request: &GenerateContentRequest) -> Vec<String> {
     let mut names = Vec::new();
 
     let Some(tools) = &request.tools else {
@@ -442,43 +517,44 @@ pub(crate) fn declared_function_names_from_request(
     names
 }
 
+fn allowed_function_names_from_request(request: &GenerateContentRequest) -> Option<Vec<String>> {
+    let function_calling_config = request
+        .tool_config
+        .as_ref()
+        .and_then(|tool_config| tool_config.function_calling_config.as_ref())?;
+
+    match function_calling_config {
+        FunctionCallingMode::Any {
+            allowed_function_names,
+        } => allowed_function_names.clone(),
+        FunctionCallingMode::None => Some(Vec::new()),
+        FunctionCallingMode::Auto => None,
+    }
+}
+
 pub(crate) fn validate_function_call_name(
     function_name: &str,
-    declared_function_names: &[String],
+    validator: &FunctionCallNameValidator,
 ) -> Result<(), CompletionError> {
-    if declared_function_names
-        .iter()
-        .any(|declared| declared == function_name)
-    {
-        tracing::trace!(
-            target: "rig::completions",
-            provider = "gemini",
-            raw_function_name = function_name,
-            declared_function_names = ?declared_function_names,
-            validation = "accepted",
-            "Gemini function call matched a declared function"
-        );
-        return Ok(());
-    }
-
-    tracing::warn!(
-        target: "rig::completions",
-        provider = "gemini",
-        raw_function_name = function_name,
-        declared_function_names = ?declared_function_names,
-        validation = "rejected",
-        "Gemini returned a function call for an undeclared function"
-    );
-
-    Err(CompletionError::ResponseError(format!(
-        "Gemini returned function call `{function_name}`, but it was not declared in the request. Declared functions: [{}]",
-        declared_function_names.join(", ")
-    )))
+    validator.validate(function_name)
 }
 
 pub(crate) fn completion_response_from_generate_content_response(
     response: GenerateContentResponse,
-    declared_function_names: Option<&[String]>,
+    function_call_validator: &FunctionCallNameValidator,
+) -> Result<completion::CompletionResponse<GenerateContentResponse>, CompletionError> {
+    completion_response_from_generate_content_response_impl(response, Some(function_call_validator))
+}
+
+fn completion_response_from_generate_content_response_unvalidated(
+    response: GenerateContentResponse,
+) -> Result<completion::CompletionResponse<GenerateContentResponse>, CompletionError> {
+    completion_response_from_generate_content_response_impl(response, None)
+}
+
+fn completion_response_from_generate_content_response_impl(
+    response: GenerateContentResponse,
+    function_call_validator: Option<&FunctionCallNameValidator>,
 ) -> Result<completion::CompletionResponse<GenerateContentResponse>, CompletionError> {
     let candidate = response.candidates.first().ok_or_else(|| {
         CompletionError::ResponseError("No response candidates in response".into())
@@ -542,10 +618,10 @@ pub(crate) fn completion_response_from_generate_content_response(
                         }
                     }
                     PartKind::FunctionCall(function_call) => {
-                        if let Some(declared_function_names) = declared_function_names {
+                        if let Some(function_call_validator) = function_call_validator {
                             validate_function_call_name(
                                 &function_call.name,
-                                declared_function_names,
+                                function_call_validator,
                             )?;
                         }
 
@@ -594,7 +670,10 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse<Generat
     type Error = CompletionError;
 
     fn try_from(response: GenerateContentResponse) -> Result<Self, Self::Error> {
-        completion_response_from_generate_content_response(response, None)
+        // `TryFrom` has no access to the original request, so it cannot enforce
+        // request-scoped Gemini function-call validation. Provider request paths
+        // should use `completion_response_from_generate_content_response`.
+        completion_response_from_generate_content_response_unvalidated(response)
     }
 }
 
@@ -2518,12 +2597,11 @@ mod tests {
 
     #[test]
     fn test_completion_response_accepts_declared_function_call_name() {
-        let declared = vec!["JavaScript".to_string()];
+        let validator = FunctionCallNameValidator::new(vec!["JavaScript".to_string()], None);
         let response = function_call_response("JavaScript");
 
-        let converted =
-            completion_response_from_generate_content_response(response, Some(&declared))
-                .expect("declared function call should convert");
+        let converted = completion_response_from_generate_content_response(response, &validator)
+            .expect("declared function call should convert");
 
         assert!(matches!(
             converted.choice.first(),
@@ -2535,10 +2613,10 @@ mod tests {
 
     #[test]
     fn test_completion_response_rejects_undeclared_default_api_function_call() {
-        let declared = vec!["JavaScript".to_string()];
+        let validator = FunctionCallNameValidator::new(vec!["JavaScript".to_string()], None);
         let response = function_call_response("default_api");
 
-        let err = completion_response_from_generate_content_response(response, Some(&declared))
+        let err = completion_response_from_generate_content_response(response, &validator)
             .expect_err("undeclared Gemini function call should be rejected");
 
         assert!(
@@ -2548,6 +2626,66 @@ mod tests {
                     if message.contains("default_api") && message.contains("JavaScript")
             ),
             "expected response error describing rejected function call, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_completion_response_rejects_declared_but_disallowed_function_call() {
+        let validator = FunctionCallNameValidator::new(
+            vec!["JavaScript".to_string(), "OtherTool".to_string()],
+            Some(vec!["JavaScript".to_string()]),
+        );
+        let response = function_call_response("OtherTool");
+
+        let err = completion_response_from_generate_content_response(response, &validator)
+            .expect_err("disallowed Gemini function call should be rejected");
+
+        assert!(
+            matches!(
+                err,
+                CompletionError::ResponseError(ref message)
+                    if message.contains("OtherTool")
+                        && message.contains("allowed")
+                        && message.contains("JavaScript")
+            ),
+            "expected response error describing rejected function call, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_function_call_validator_from_request_respects_allowed_function_names() {
+        let request = GenerateContentRequest {
+            contents: vec![],
+            tools: Some(vec![json!({
+                "functionDeclarations": [
+                    { "name": "JavaScript" },
+                    { "name": "OtherTool" }
+                ]
+            })]),
+            tool_config: Some(ToolConfig {
+                function_calling_config: Some(FunctionCallingMode::Any {
+                    allowed_function_names: Some(vec!["JavaScript".to_string()]),
+                }),
+            }),
+            generation_config: None,
+            safety_settings: None,
+            system_instruction: None,
+            additional_params: None,
+        };
+        let validator = FunctionCallNameValidator::from_request(&request);
+
+        validate_function_call_name("JavaScript", &validator)
+            .expect("allowed function should validate");
+        let err = validate_function_call_name("OtherTool", &validator)
+            .expect_err("declared but disallowed function should be rejected");
+
+        assert!(
+            matches!(
+                err,
+                CompletionError::ResponseError(ref message)
+                    if message.contains("OtherTool") && message.contains("allowed")
+            ),
+            "expected response error describing disallowed function, got {err:?}"
         );
     }
 

--- a/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
@@ -2,7 +2,9 @@
 //! From <https://ai.google.dev/api/interactions-api>
 
 use crate::OneOrMany;
-use crate::completion::{self, CompletionError, CompletionRequest, GetTokenUsage};
+use crate::completion::{
+    self, CompletionError, CompletionRequest, GetTokenUsage, ToolCallNameValidator,
+};
 use crate::http_client::HttpClientExt;
 use crate::message::{self, MimeType, Reasoning};
 use crate::telemetry::SpanCombinator;
@@ -140,6 +142,8 @@ where
             tracing::Span::current()
         };
 
+        let function_call_validator =
+            ToolCallNameValidator::from_completion_request("gemini", &completion_request);
         let request = self.create_completion_request(completion_request, Some(false))?;
 
         if enabled!(Level::TRACE) {
@@ -190,7 +194,7 @@ where
                     );
                 }
 
-                response.try_into()
+                completion_response_from_interaction(response, &function_call_validator)
             } else {
                 let text = String::from_utf8_lossy(
                     &response
@@ -471,51 +475,68 @@ impl TryFrom<Interaction> for completion::CompletionResponse<Interaction> {
     type Error = CompletionError;
 
     fn try_from(response: Interaction) -> Result<Self, Self::Error> {
-        if response.outputs.is_empty() {
-            let status = response.status.as_ref().map(|status| format!("{status:?}"));
-            let message = match status {
-                Some(status) => format!(
-                    "Interaction contained no outputs (status: {status}). Use get_interaction for background tasks."
-                ),
-                None => "Interaction contained no outputs".to_string(),
-            };
-            return Err(CompletionError::ResponseError(message));
-        }
+        completion_response_from_interaction_impl(response, None)
+    }
+}
 
-        let content = response
-            .outputs
-            .iter()
-            .cloned()
-            .filter_map(|output| match assistant_content_from_output(output) {
+fn completion_response_from_interaction(
+    response: Interaction,
+    function_call_validator: &ToolCallNameValidator,
+) -> Result<completion::CompletionResponse<Interaction>, CompletionError> {
+    completion_response_from_interaction_impl(response, Some(function_call_validator))
+}
+
+fn completion_response_from_interaction_impl(
+    response: Interaction,
+    function_call_validator: Option<&ToolCallNameValidator>,
+) -> Result<completion::CompletionResponse<Interaction>, CompletionError> {
+    if response.outputs.is_empty() {
+        let status = response.status.as_ref().map(|status| format!("{status:?}"));
+        let message = match status {
+            Some(status) => format!(
+                "Interaction contained no outputs (status: {status}). Use get_interaction for background tasks."
+            ),
+            None => "Interaction contained no outputs".to_string(),
+        };
+        return Err(CompletionError::ResponseError(message));
+    }
+
+    let content = response
+        .outputs
+        .iter()
+        .cloned()
+        .filter_map(
+            |output| match assistant_content_from_output(output, function_call_validator) {
                 Ok(Some(content)) => Some(Ok(content)),
                 Ok(None) => None,
                 Err(err) => Some(Err(err)),
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+            },
+        )
+        .collect::<Result<Vec<_>, _>>()?;
 
-        let choice = OneOrMany::many(content).map_err(|_| {
-            CompletionError::ResponseError(
-                "Response contained no message or tool call (empty)".to_owned(),
-            )
-        })?;
+    let choice = OneOrMany::many(content).map_err(|_| {
+        CompletionError::ResponseError(
+            "Response contained no message or tool call (empty)".to_owned(),
+        )
+    })?;
 
-        let usage = response
-            .usage
-            .as_ref()
-            .and_then(|usage| usage.token_usage())
-            .unwrap_or_default();
+    let usage = response
+        .usage
+        .as_ref()
+        .and_then(|usage| usage.token_usage())
+        .unwrap_or_default();
 
-        Ok(completion::CompletionResponse {
-            choice,
-            usage,
-            raw_response: response,
-            message_id: None,
-        })
-    }
+    Ok(completion::CompletionResponse {
+        choice,
+        usage,
+        raw_response: response,
+        message_id: None,
+    })
 }
 
 fn assistant_content_from_output(
     output: Content,
+    function_call_validator: Option<&ToolCallNameValidator>,
 ) -> Result<Option<completion::AssistantContent>, CompletionError> {
     match output {
         Content::Text(TextContent { text, .. }) => {
@@ -530,6 +551,9 @@ fn assistant_content_from_output(
             let Some(name) = name else {
                 return Ok(None);
             };
+            if let Some(function_call_validator) = function_call_validator {
+                super::completion::validate_function_call_name(&name, function_call_validator)?;
+            }
             let call_id = id.unwrap_or_else(|| name.clone());
             Ok(Some(completion::AssistantContent::tool_call_with_call_id(
                 name.clone(),
@@ -2538,6 +2562,31 @@ mod tests {
         assert_eq!(response.usage.input_tokens, 5);
         assert_eq!(response.usage.output_tokens, 7);
         assert_eq!(response.usage.total_tokens, 12);
+    }
+
+    #[test]
+    fn test_response_function_call_validation_rejects_undeclared_name() {
+        let interaction = Interaction {
+            id: "interaction-1".to_string(),
+            outputs: vec![Content::FunctionCall(FunctionCallContent {
+                name: Some("default_api".to_string()),
+                arguments: Some(json!({"location": "Paris"})),
+                id: Some("call-123".to_string()),
+            })],
+            ..Default::default()
+        };
+        let validator = ToolCallNameValidator::new("gemini", vec!["get_weather".to_string()], None);
+
+        let err = completion_response_from_interaction(interaction, &validator)
+            .expect_err("undeclared function call should be rejected");
+
+        assert!(matches!(
+            err,
+            CompletionError::InvalidToolCall(ref invalid)
+                if invalid.provider == "gemini"
+                    && invalid.tool_name == "default_api"
+                    && invalid.declared_tool_names == vec!["get_weather".to_string()]
+        ));
     }
 
     #[test]

--- a/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
@@ -12,7 +12,7 @@ use super::interactions_api_types::{
     InteractionSseEvent, InteractionUsage, TextContent, TextDelta, ThoughtSummaryContent,
     ThoughtSummaryDelta,
 };
-use crate::completion::{CompletionError, CompletionRequest, GetTokenUsage};
+use crate::completion::{CompletionError, CompletionRequest, GetTokenUsage, ToolCallNameValidator};
 use crate::http_client::HttpClientExt;
 use crate::http_client::Request;
 use crate::http_client::sse::{Event, GenericEventSource};
@@ -75,6 +75,8 @@ where
             tracing::Span::current()
         };
 
+        let function_call_validator =
+            ToolCallNameValidator::from_completion_request("gemini", &completion_request);
         let request = create_request_body(self.model.clone(), completion_request, Some(true))?;
 
         if enabled!(Level::TRACE) {
@@ -98,6 +100,7 @@ where
         let stream = stream! {
             let mut final_interaction: Option<Interaction> = None;
             let mut final_usage: Option<InteractionUsage> = None;
+            let mut fatal_error = false;
 
             while let Some(event_result) = event_source.next().await {
                 match event_result {
@@ -123,13 +126,25 @@ where
 
                         match data {
                             InteractionSseEvent::ContentDelta { delta, .. } => {
-                                if let Some(choice) = content_delta_to_choice(delta) {
-                                    yield Ok(choice);
+                                match content_delta_to_choice(delta, &function_call_validator) {
+                                    Ok(Some(choice)) => yield Ok(choice),
+                                    Ok(None) => {}
+                                    Err(error) => {
+                                        fatal_error = true;
+                                        yield Err(error);
+                                        break;
+                                    }
                                 }
                             }
                             InteractionSseEvent::ContentStart { content, .. } => {
-                                if let Some(choice) = content_start_to_choice(content) {
-                                    yield Ok(choice);
+                                match content_start_to_choice(content, &function_call_validator) {
+                                    Ok(Some(choice)) => yield Ok(choice),
+                                    Ok(None) => {}
+                                    Err(error) => {
+                                        fatal_error = true;
+                                        yield Err(error);
+                                        break;
+                                    }
                                 }
                             }
                             InteractionSseEvent::InteractionComplete { interaction, .. } => {
@@ -146,6 +161,7 @@ where
                                 final_interaction = Some(interaction);
                             }
                             InteractionSseEvent::Error { error, .. } => {
+                                fatal_error = true;
                                 yield Err(CompletionError::ProviderError(error.message));
                                 break;
                             }
@@ -157,6 +173,7 @@ where
                     }
                     Err(error) => {
                         tracing::error!(?error, "SSE error");
+                        fatal_error = true;
                         yield Err(CompletionError::ProviderError(error.to_string()));
                         break;
                     }
@@ -165,12 +182,14 @@ where
 
             event_source.close();
 
-            let model_version = final_interaction.as_ref().and_then(|i| i.model.clone());
-            yield Ok(streaming::RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
-                usage: final_usage.or_else(|| final_interaction.as_ref().and_then(|i| i.usage.clone())),
-                interaction: final_interaction,
-                model_version,
-            }));
+            if !fatal_error {
+                let model_version = final_interaction.as_ref().and_then(|i| i.model.clone());
+                yield Ok(streaming::RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
+                    usage: final_usage.or_else(|| final_interaction.as_ref().and_then(|i| i.usage.clone())),
+                    interaction: final_interaction,
+                    model_version,
+                }));
+            }
         }
         .instrument(span);
 
@@ -226,13 +245,14 @@ where
 
 fn content_start_to_choice(
     content: Content,
-) -> Option<streaming::RawStreamingChoice<StreamingCompletionResponse>> {
+    function_call_validator: &ToolCallNameValidator,
+) -> Result<Option<streaming::RawStreamingChoice<StreamingCompletionResponse>>, CompletionError> {
     match content {
         Content::Text(TextContent { text, .. }) => {
             if text.is_empty() {
-                None
+                Ok(None)
             } else {
-                Some(streaming::RawStreamingChoice::Message(text))
+                Ok(Some(streaming::RawStreamingChoice::Message(text)))
             }
         }
         Content::FunctionCall(FunctionCallContent {
@@ -240,55 +260,68 @@ fn content_start_to_choice(
             arguments,
             id,
         }) => {
-            let name = name?;
+            let Some(name) = name else {
+                return Ok(None);
+            };
+            crate::providers::gemini::completion::validate_function_call_name(
+                &name,
+                function_call_validator,
+            )?;
             let call_id = id.unwrap_or_else(|| name.clone());
-            Some(streaming::RawStreamingChoice::ToolCall(
+            Ok(Some(streaming::RawStreamingChoice::ToolCall(
                 streaming::RawStreamingToolCall::new(
                     name.clone(),
                     name,
                     arguments.unwrap_or(Value::Object(Map::new())),
                 )
                 .with_call_id(call_id),
-            ))
+            )))
         }
-        _ => None,
+        _ => Ok(None),
     }
 }
 
 fn content_delta_to_choice(
     delta: ContentDelta,
-) -> Option<streaming::RawStreamingChoice<StreamingCompletionResponse>> {
+    function_call_validator: &ToolCallNameValidator,
+) -> Result<Option<streaming::RawStreamingChoice<StreamingCompletionResponse>>, CompletionError> {
     match delta {
         ContentDelta::Text(TextDelta {
             text: Some(text), ..
-        }) => Some(streaming::RawStreamingChoice::Message(text)),
+        }) => Ok(Some(streaming::RawStreamingChoice::Message(text))),
         ContentDelta::FunctionCall(FunctionCallDelta {
             name,
             arguments,
             id,
         }) => {
-            let name = name?;
+            let Some(name) = name else {
+                return Ok(None);
+            };
+            crate::providers::gemini::completion::validate_function_call_name(
+                &name,
+                function_call_validator,
+            )?;
             let call_id = id.unwrap_or_else(|| name.clone());
-            Some(streaming::RawStreamingChoice::ToolCall(
+            Ok(Some(streaming::RawStreamingChoice::ToolCall(
                 streaming::RawStreamingToolCall::new(
                     name.clone(),
                     name,
                     arguments.unwrap_or(Value::Object(Map::new())),
                 )
                 .with_call_id(call_id),
-            ))
+            )))
         }
         ContentDelta::ThoughtSummary(ThoughtSummaryDelta { content }) => {
             let text = match content {
                 ThoughtSummaryContent::Text(text) => text.text,
-                _ => return None,
+                _ => return Ok(None),
             };
-            Some(streaming::RawStreamingChoice::ReasoningDelta {
+            Ok(Some(streaming::RawStreamingChoice::ReasoningDelta {
                 id: None,
                 reasoning: text,
-            })
+            }))
         }
-        _ => None,
+        _ => Ok(None),
     }
 }
 
@@ -296,6 +329,14 @@ fn content_delta_to_choice(
 mod tests {
     use super::*;
     use serde_json::json;
+
+    fn test_validator(function_names: &[&str]) -> ToolCallNameValidator {
+        ToolCallNameValidator::new(
+            "gemini",
+            function_names.iter().map(|name| name.to_string()).collect(),
+            None,
+        )
+    }
 
     #[test]
     fn test_streaming_completion_response_has_model_version() {
@@ -334,7 +375,10 @@ mod tests {
             panic!("expected content delta");
         };
 
-        let choice = content_delta_to_choice(delta).expect("choice should exist");
+        let validator = test_validator(&[]);
+        let choice = content_delta_to_choice(delta, &validator)
+            .expect("content delta should convert")
+            .expect("choice should exist");
         match choice {
             crate::streaming::RawStreamingChoice::Message(text) => {
                 assert_eq!(text, "Hello");
@@ -361,7 +405,10 @@ mod tests {
             panic!("expected content delta");
         };
 
-        let choice = content_delta_to_choice(delta).expect("choice should exist");
+        let validator = test_validator(&["get_weather"]);
+        let choice = content_delta_to_choice(delta, &validator)
+            .expect("content delta should convert")
+            .expect("choice should exist");
         match choice {
             crate::streaming::RawStreamingChoice::ToolCall(call) => {
                 assert_eq!(call.name, "get_weather");
@@ -369,5 +416,36 @@ mod tests {
             }
             other => panic!("unexpected choice: {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_content_delta_function_call_rejects_undeclared_name() {
+        let event_json = json!({
+            "event_type": "content.delta",
+            "index": 0,
+            "delta": {
+                "type": "function_call",
+                "name": "default_api",
+                "arguments": {"location": "Paris"},
+                "id": "call-1"
+            }
+        });
+
+        let event: InteractionSseEvent = serde_json::from_value(event_json).unwrap();
+        let InteractionSseEvent::ContentDelta { delta, .. } = event else {
+            panic!("expected content delta");
+        };
+
+        let validator = test_validator(&["get_weather"]);
+        let err = content_delta_to_choice(delta, &validator)
+            .expect_err("undeclared function call should be rejected");
+
+        assert!(matches!(
+            err,
+            CompletionError::InvalidToolCall(ref invalid)
+                if invalid.provider == "gemini"
+                    && invalid.tool_name == "default_api"
+                    && invalid.declared_tool_names == vec!["get_weather".to_string()]
+        ));
     }
 }

--- a/crates/rig-core/src/providers/gemini/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/streaming.rs
@@ -8,8 +8,8 @@ use super::completion::gemini_api_types::{
     ContentCandidate, FinishReason, ModalityTokenCount, Part, PartKind, TrafficType,
 };
 use super::completion::{
-    CompletionModel, create_request_body, function_call_validator_from_request,
-    resolve_request_model, streaming_endpoint, validate_function_call_name,
+    CompletionModel, create_request_body, resolve_request_model, streaming_endpoint,
+    validate_function_call_name,
 };
 use crate::completion::message::ReasoningContent;
 use crate::completion::{CompletionError, CompletionRequest, GetTokenUsage};
@@ -114,8 +114,12 @@ where
         } else {
             tracing::Span::current()
         };
+        let function_call_validator =
+            crate::completion::ToolCallNameValidator::from_completion_request(
+                "gemini",
+                &completion_request,
+            );
         let request = create_request_body(completion_request)?;
-        let function_call_validator = function_call_validator_from_request(&request);
 
         if enabled!(Level::TRACE) {
             tracing::trace!(

--- a/crates/rig-core/src/providers/gemini/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/streaming.rs
@@ -8,8 +8,8 @@ use super::completion::gemini_api_types::{
     ContentCandidate, FinishReason, ModalityTokenCount, Part, PartKind, TrafficType,
 };
 use super::completion::{
-    CompletionModel, create_request_body, declared_function_names_from_request,
-    resolve_request_model, streaming_endpoint, validate_function_call_name,
+    CompletionModel, FunctionCallNameValidator, create_request_body, resolve_request_model,
+    streaming_endpoint, validate_function_call_name,
 };
 use crate::completion::message::ReasoningContent;
 use crate::completion::{CompletionError, CompletionRequest, GetTokenUsage};
@@ -114,7 +114,7 @@ where
             tracing::Span::current()
         };
         let request = create_request_body(completion_request)?;
-        let declared_function_names = declared_function_names_from_request(&request);
+        let function_call_validator = FunctionCallNameValidator::from_request(&request);
 
         if enabled!(Level::TRACE) {
             tracing::trace!(
@@ -199,7 +199,7 @@ where
                         }
 
                         for part in content.parts {
-                            match raw_streaming_choice_from_part(part, &declared_function_names) {
+                            match raw_streaming_choice_from_part(part, &function_call_validator) {
                                 Ok(Some(choice)) => yield Ok(choice),
                                 Ok(None) => {}
                                 Err(error) => {
@@ -247,7 +247,7 @@ where
 
 pub(crate) fn raw_streaming_choice_from_part(
     part: Part,
-    declared_function_names: &[String],
+    function_call_validator: &FunctionCallNameValidator,
 ) -> Result<Option<streaming::RawStreamingChoice<StreamingCompletionResponse>>, CompletionError> {
     match part {
         Part {
@@ -293,7 +293,7 @@ pub(crate) fn raw_streaming_choice_from_part(
             thought_signature,
             ..
         } => {
-            validate_function_call_name(&function_call.name, declared_function_names)?;
+            validate_function_call_name(&function_call.name, function_call_validator)?;
 
             Ok(Some(streaming::RawStreamingChoice::ToolCall(
                 streaming::RawStreamingToolCall::new(
@@ -506,8 +506,8 @@ mod tests {
 
     #[test]
     fn test_streaming_part_accepts_declared_function_call_name() {
-        let declared = vec!["JavaScript".to_string()];
-        let choice = raw_streaming_choice_from_part(function_call_part("JavaScript"), &declared)
+        let validator = FunctionCallNameValidator::new(vec!["JavaScript".to_string()], None);
+        let choice = raw_streaming_choice_from_part(function_call_part("JavaScript"), &validator)
             .expect("declared function call should convert")
             .expect("declared function call should emit a streaming choice");
 
@@ -522,8 +522,8 @@ mod tests {
 
     #[test]
     fn test_streaming_part_rejects_undeclared_default_api_function_call() {
-        let declared = vec!["JavaScript".to_string()];
-        let err = raw_streaming_choice_from_part(function_call_part("default_api"), &declared)
+        let validator = FunctionCallNameValidator::new(vec!["JavaScript".to_string()], None);
+        let err = raw_streaming_choice_from_part(function_call_part("default_api"), &validator)
             .expect_err("undeclared Gemini function call should be rejected");
 
         assert!(
@@ -531,6 +531,27 @@ mod tests {
                 err,
                 CompletionError::ResponseError(ref message)
                     if message.contains("default_api") && message.contains("JavaScript")
+            ),
+            "expected response error describing rejected function call, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_streaming_part_rejects_declared_but_disallowed_function_call() {
+        let validator = FunctionCallNameValidator::new(
+            vec!["JavaScript".to_string(), "OtherTool".to_string()],
+            Some(vec!["JavaScript".to_string()]),
+        );
+        let err = raw_streaming_choice_from_part(function_call_part("OtherTool"), &validator)
+            .expect_err("disallowed Gemini function call should be rejected");
+
+        assert!(
+            matches!(
+                err,
+                CompletionError::ResponseError(ref message)
+                    if message.contains("OtherTool")
+                        && message.contains("allowed")
+                        && message.contains("JavaScript")
             ),
             "expected response error describing rejected function call, got {err:?}"
         );

--- a/crates/rig-core/src/providers/gemini/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/streaming.rs
@@ -8,7 +8,8 @@ use super::completion::gemini_api_types::{
     ContentCandidate, FinishReason, ModalityTokenCount, Part, PartKind, TrafficType,
 };
 use super::completion::{
-    CompletionModel, create_request_body, resolve_request_model, streaming_endpoint,
+    CompletionModel, create_request_body, declared_function_names_from_request,
+    resolve_request_model, streaming_endpoint, validate_function_call_name,
 };
 use crate::completion::message::ReasoningContent;
 use crate::completion::{CompletionError, CompletionRequest, GetTokenUsage};
@@ -113,6 +114,7 @@ where
             tracing::Span::current()
         };
         let request = create_request_body(completion_request)?;
+        let declared_function_names = declared_function_names_from_request(&request);
 
         if enabled!(Level::TRACE) {
             tracing::trace!(
@@ -137,7 +139,8 @@ where
             let mut final_usage = None;
             let mut final_finish_reason: Option<FinishReason> = None;
             let mut final_model_version: Option<String> = None;
-            while let Some(event_result) = event_source.next().await {
+            let mut fatal_error = false;
+            'events: while let Some(event_result) = event_source.next().await {
                 match event_result {
                     Ok(Event::Open) => {
                         tracing::debug!("SSE connection opened");
@@ -196,54 +199,13 @@ where
                         }
 
                         for part in content.parts {
-                            match part {
-                                Part {
-                                    part: PartKind::Text(text),
-                                    thought: Some(true),
-                                    thought_signature,
-                                    ..
-                                } => {
-                                    if !text.is_empty() {
-                                        if thought_signature.is_some() {
-                                            // Signature arrives on the final chunk of a
-                                            // thinking block; emit a full Reasoning so the
-                                            // core accumulator captures the signature for
-                                            // Gemini 3+ roundtrip.
-                                            yield Ok(streaming::RawStreamingChoice::Reasoning {
-                                                id: None,
-                                                content: ReasoningContent::Text {
-                                                    text,
-                                                    signature: thought_signature,
-                                                },
-                                            });
-                                        } else {
-                                            yield Ok(streaming::RawStreamingChoice::ReasoningDelta {
-                                                id: None,
-                                                reasoning: text,
-                                            });
-                                        }
-                                    }
-                                },
-                                Part {
-                                    part: PartKind::Text(text),
-                                    ..
-                                } => {
-                                    if !text.is_empty() {
-                                        yield Ok(streaming::RawStreamingChoice::Message(text));
-                                    }
-                                },
-                                Part {
-                                    part: PartKind::FunctionCall(function_call),
-                                    thought_signature,
-                                    ..
-                                } => {
-                                    yield Ok(streaming::RawStreamingChoice::ToolCall(
-                                        streaming::RawStreamingToolCall::new(function_call.name.clone(), function_call.name.clone(), function_call.args.clone())
-                                            .with_signature(thought_signature)
-                                    ));
-                                },
-                                part => {
-                                    tracing::warn!(?part, "Unsupported response type with streaming");
+                            match raw_streaming_choice_from_part(part, &declared_function_names) {
+                                Ok(Some(choice)) => yield Ok(choice),
+                                Ok(None) => {}
+                                Err(error) => {
+                                    fatal_error = true;
+                                    yield Err(error);
+                                    break 'events;
                                 }
                             }
                         }
@@ -258,6 +220,7 @@ where
                     }
                     Err(error) => {
                         tracing::error!(?error, "SSE error");
+                        fatal_error = true;
                         yield Err(CompletionError::ProviderError(error.to_string()));
                         break;
                     }
@@ -267,11 +230,13 @@ where
             // Ensure event source is closed when stream ends
             event_source.close();
 
-            yield Ok(streaming::RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
-                usage_metadata: final_usage.unwrap_or_default(),
-                finish_reason: final_finish_reason,
-                model_version: final_model_version,
-            }));
+            if !fatal_error {
+                yield Ok(streaming::RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
+                    usage_metadata: final_usage.unwrap_or_default(),
+                    finish_reason: final_finish_reason,
+                    model_version: final_model_version,
+                }));
+            }
         }.instrument(span);
 
         Ok(streaming::StreamingCompletionResponse::stream(Box::pin(
@@ -280,10 +245,90 @@ where
     }
 }
 
+pub(crate) fn raw_streaming_choice_from_part(
+    part: Part,
+    declared_function_names: &[String],
+) -> Result<Option<streaming::RawStreamingChoice<StreamingCompletionResponse>>, CompletionError> {
+    match part {
+        Part {
+            part: PartKind::Text(text),
+            thought: Some(true),
+            thought_signature,
+            ..
+        } => {
+            if text.is_empty() {
+                return Ok(None);
+            }
+
+            if thought_signature.is_some() {
+                // Signature arrives on the final chunk of a thinking block; emit a full
+                // Reasoning so the core accumulator captures the signature for Gemini 3+
+                // roundtrip.
+                Ok(Some(streaming::RawStreamingChoice::Reasoning {
+                    id: None,
+                    content: ReasoningContent::Text {
+                        text,
+                        signature: thought_signature,
+                    },
+                }))
+            } else {
+                Ok(Some(streaming::RawStreamingChoice::ReasoningDelta {
+                    id: None,
+                    reasoning: text,
+                }))
+            }
+        }
+        Part {
+            part: PartKind::Text(text),
+            ..
+        } => {
+            if text.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(streaming::RawStreamingChoice::Message(text)))
+            }
+        }
+        Part {
+            part: PartKind::FunctionCall(function_call),
+            thought_signature,
+            ..
+        } => {
+            validate_function_call_name(&function_call.name, declared_function_names)?;
+
+            Ok(Some(streaming::RawStreamingChoice::ToolCall(
+                streaming::RawStreamingToolCall::new(
+                    function_call.name.clone(),
+                    function_call.name,
+                    function_call.args,
+                )
+                .with_signature(thought_signature),
+            )))
+        }
+        part => {
+            tracing::warn!(?part, "Unsupported response type with streaming");
+            Ok(None)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
+
+    fn function_call_part(name: &str) -> Part {
+        Part {
+            thought: None,
+            thought_signature: Some("sig_123".to_string()),
+            part: PartKind::FunctionCall(
+                crate::providers::gemini::completion::gemini_api_types::FunctionCall {
+                    name: name.to_string(),
+                    args: json!({"code": "return 2 + 2;"}),
+                },
+            ),
+            additional_params: None,
+        }
+    }
 
     #[test]
     fn test_deserialize_stream_response_with_single_text_part() {
@@ -457,6 +502,38 @@ mod tests {
         } else {
             panic!("Expected function call at index 1");
         }
+    }
+
+    #[test]
+    fn test_streaming_part_accepts_declared_function_call_name() {
+        let declared = vec!["JavaScript".to_string()];
+        let choice = raw_streaming_choice_from_part(function_call_part("JavaScript"), &declared)
+            .expect("declared function call should convert")
+            .expect("declared function call should emit a streaming choice");
+
+        assert!(matches!(
+            choice,
+            streaming::RawStreamingChoice::ToolCall(tool_call)
+                if tool_call.name == "JavaScript"
+                    && tool_call.id == "JavaScript"
+                    && tool_call.signature.as_deref() == Some("sig_123")
+        ));
+    }
+
+    #[test]
+    fn test_streaming_part_rejects_undeclared_default_api_function_call() {
+        let declared = vec!["JavaScript".to_string()];
+        let err = raw_streaming_choice_from_part(function_call_part("default_api"), &declared)
+            .expect_err("undeclared Gemini function call should be rejected");
+
+        assert!(
+            matches!(
+                err,
+                CompletionError::ResponseError(ref message)
+                    if message.contains("default_api") && message.contains("JavaScript")
+            ),
+            "expected response error describing rejected function call, got {err:?}"
+        );
     }
 
     #[test]

--- a/crates/rig-core/src/providers/gemini/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/streaming.rs
@@ -8,8 +8,8 @@ use super::completion::gemini_api_types::{
     ContentCandidate, FinishReason, ModalityTokenCount, Part, PartKind, TrafficType,
 };
 use super::completion::{
-    CompletionModel, FunctionCallNameValidator, create_request_body, resolve_request_model,
-    streaming_endpoint, validate_function_call_name,
+    CompletionModel, create_request_body, function_call_validator_from_request,
+    resolve_request_model, streaming_endpoint, validate_function_call_name,
 };
 use crate::completion::message::ReasoningContent;
 use crate::completion::{CompletionError, CompletionRequest, GetTokenUsage};
@@ -115,7 +115,7 @@ where
             tracing::Span::current()
         };
         let request = create_request_body(completion_request)?;
-        let function_call_validator = FunctionCallNameValidator::from_request(&request);
+        let function_call_validator = function_call_validator_from_request(&request);
 
         if enabled!(Level::TRACE) {
             tracing::trace!(
@@ -248,7 +248,7 @@ where
 
 pub(crate) fn raw_streaming_choice_from_part(
     part: Part,
-    function_call_validator: &FunctionCallNameValidator,
+    function_call_validator: &crate::completion::ToolCallNameValidator,
 ) -> Result<Option<streaming::RawStreamingChoice<StreamingCompletionResponse>>, CompletionError> {
     match part {
         Part {
@@ -511,7 +511,11 @@ mod tests {
 
     #[test]
     fn test_streaming_part_accepts_declared_function_call_name() {
-        let validator = FunctionCallNameValidator::new(vec!["JavaScript".to_string()], None);
+        let validator = crate::completion::ToolCallNameValidator::new(
+            "gemini",
+            vec!["JavaScript".to_string()],
+            None,
+        );
         let choice = raw_streaming_choice_from_part(function_call_part("JavaScript"), &validator)
             .expect("declared function call should convert")
             .expect("declared function call should emit a streaming choice");
@@ -527,15 +531,23 @@ mod tests {
 
     #[test]
     fn test_streaming_part_rejects_undeclared_default_api_function_call() {
-        let validator = FunctionCallNameValidator::new(vec!["JavaScript".to_string()], None);
+        let validator = crate::completion::ToolCallNameValidator::new(
+            "gemini",
+            vec!["JavaScript".to_string()],
+            None,
+        );
         let err = raw_streaming_choice_from_part(function_call_part("default_api"), &validator)
             .expect_err("undeclared Gemini function call should be rejected");
 
         assert!(
             matches!(
                 err,
-                CompletionError::ResponseError(ref message)
-                    if message.contains("default_api") && message.contains("JavaScript")
+                CompletionError::InvalidToolCall(ref invalid)
+                    if invalid.provider == "gemini"
+                        && invalid.tool_name == "default_api"
+                        && invalid.declared_tool_names == vec!["JavaScript".to_string()]
+                        && invalid.allowed_tool_names.is_none()
+                        && invalid.reason == crate::completion::ToolCallValidationReason::Undeclared
             ),
             "expected response error describing rejected function call, got {err:?}"
         );
@@ -543,7 +555,8 @@ mod tests {
 
     #[test]
     fn test_streaming_part_rejects_declared_but_disallowed_function_call() {
-        let validator = FunctionCallNameValidator::new(
+        let validator = crate::completion::ToolCallNameValidator::new(
+            "gemini",
             vec!["JavaScript".to_string(), "OtherTool".to_string()],
             Some(vec!["JavaScript".to_string()]),
         );
@@ -553,10 +566,13 @@ mod tests {
         assert!(
             matches!(
                 err,
-                CompletionError::ResponseError(ref message)
-                    if message.contains("OtherTool")
-                        && message.contains("allowed")
-                        && message.contains("JavaScript")
+                CompletionError::InvalidToolCall(ref invalid)
+                    if invalid.provider == "gemini"
+                        && invalid.tool_name == "OtherTool"
+                        && invalid.declared_tool_names
+                            == vec!["JavaScript".to_string(), "OtherTool".to_string()]
+                        && invalid.allowed_tool_names == Some(vec!["JavaScript".to_string()])
+                        && invalid.reason == crate::completion::ToolCallValidationReason::Disallowed
             ),
             "expected response error describing rejected function call, got {err:?}"
         );

--- a/crates/rig-core/src/tool/mod.rs
+++ b/crates/rig-core/src/tool/mod.rs
@@ -320,6 +320,11 @@ impl ToolSet {
         self.tools.contains_key(toolname)
     }
 
+    /// Return the names of all registered tools.
+    pub fn names(&self) -> Vec<String> {
+        self.tools.keys().cloned().collect()
+    }
+
     /// Add a tool to the toolset
     pub fn add_tool(&mut self, tool: impl ToolDyn + 'static) {
         self.tools

--- a/crates/rig-core/src/tool/server.rs
+++ b/crates/rig-core/src/tool/server.rs
@@ -136,6 +136,20 @@ impl ToolServerHandle {
         Ok(())
     }
 
+    /// Return the names of all tools registered with the server.
+    pub async fn tool_names(&self) -> Vec<String> {
+        let state = self.0.read().await;
+        let mut names = state.toolset.names();
+        names.sort();
+        names
+    }
+
+    /// Check whether a tool is registered with the server.
+    pub async fn has_tool(&self, tool_name: &str) -> bool {
+        let state = self.0.read().await;
+        state.toolset.contains(tool_name)
+    }
+
     /// Look up and execute a tool by name.
     ///
     /// The tool handle is cloned under a brief read lock so that

--- a/crates/rig-core/src/tool/server.rs
+++ b/crates/rig-core/src/tool/server.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use crate::{
-    completion::{CompletionError, ToolDefinition},
+    completion::{CompletionError, ToolDefinition, UnknownToolCallError},
     tool::{Tool, ToolDyn, ToolSet, ToolSetError},
     vector_store::{VectorSearchRequest, VectorStoreError, VectorStoreIndexDyn, request::Filter},
 };
@@ -148,6 +148,40 @@ impl ToolServerHandle {
     pub async fn has_tool(&self, tool_name: &str) -> bool {
         let state = self.0.read().await;
         state.toolset.contains(tool_name)
+    }
+
+    /// Validate that a model-requested tool call targets a registered tool.
+    pub async fn validate_tool_call_name(
+        &self,
+        tool_name: &str,
+        tool_call_id: &str,
+        call_id: Option<String>,
+        arguments: serde_json::Value,
+    ) -> Result<(), UnknownToolCallError> {
+        if self.has_tool(tool_name).await {
+            Ok(())
+        } else {
+            Err(self
+                .unknown_tool_call_error(tool_name.to_string(), tool_call_id, call_id, arguments)
+                .await)
+        }
+    }
+
+    /// Build an unknown-tool error using the server's current registered tool names.
+    pub async fn unknown_tool_call_error(
+        &self,
+        tool_name: String,
+        tool_call_id: &str,
+        call_id: Option<String>,
+        arguments: serde_json::Value,
+    ) -> UnknownToolCallError {
+        UnknownToolCallError::new(
+            tool_name,
+            tool_call_id.to_string(),
+            call_id,
+            arguments,
+            self.tool_names().await,
+        )
     }
 
     /// Look up and execute a tool by name.

--- a/tests/core/prompt_response_messages.rs
+++ b/tests/core/prompt_response_messages.rs
@@ -4,7 +4,7 @@
 use rig::agent::AgentBuilder;
 use rig::completion::{Chat, Message, Prompt, Usage};
 use rig::message::{AssistantContent, UserContent};
-use rig::test_utils::{MockCompletionModel, MockTurn};
+use rig::test_utils::{MockAddTool, MockCompletionModel, MockTurn};
 
 // ---------------------------------------------------------------------------
 // Mock model infrastructure
@@ -29,20 +29,16 @@ fn simple_text_model(turns: usize) -> MockCompletionModel {
 
 fn tool_then_text_model() -> MockCompletionModel {
     MockCompletionModel::new([
-        MockTurn::tool_call(
-            "tc_1",
-            "calculator",
-            serde_json::json!({"op": "add", "a": 2, "b": 3}),
-        )
-        .with_usage(Usage {
-            input_tokens: 15,
-            output_tokens: 8,
-            total_tokens: 23,
-            cached_input_tokens: 0,
-            cache_creation_input_tokens: 0,
-            reasoning_tokens: 0,
-        })
-        .with_message_id("msg_tool"),
+        MockTurn::tool_call("tc_1", "add", serde_json::json!({"x": 2, "y": 3}))
+            .with_usage(Usage {
+                input_tokens: 15,
+                output_tokens: 8,
+                total_tokens: 23,
+                cached_input_tokens: 0,
+                cache_creation_input_tokens: 0,
+                reasoning_tokens: 0,
+            })
+            .with_message_id("msg_tool"),
         MockTurn::text("The answer is 5")
             .with_usage(Usage {
                 input_tokens: 20,
@@ -57,7 +53,7 @@ fn tool_then_text_model() -> MockCompletionModel {
 }
 
 fn always_tool_call_turn() -> MockTurn {
-    MockTurn::tool_call("tc_loop", "infinite_tool", serde_json::json!({"x": 1}))
+    MockTurn::tool_call("tc_loop", "add", serde_json::json!({"x": 1, "y": 1}))
 }
 
 // ---------------------------------------------------------------------------
@@ -173,7 +169,9 @@ async fn standard_with_history_works() {
 /// full conversation: User → Assistant(tool_call) → User(tool_result) → Assistant(text).
 #[tokio::test]
 async fn multi_turn_messages_include_tool_calls() {
-    let agent = AgentBuilder::new(tool_then_text_model()).build();
+    let agent = AgentBuilder::new(tool_then_text_model())
+        .tool(MockAddTool)
+        .build();
 
     let resp = agent
         .prompt("What is 2 + 3?")
@@ -188,8 +186,8 @@ async fn multi_turn_messages_include_tool_calls() {
 
     // Expected sequence:
     // [0] User: "What is 2 + 3?"
-    // [1] Assistant: ToolCall(calculator)
-    // [2] User: ToolResult (error since calculator tool isn't registered, but that's fine)
+    // [1] Assistant: ToolCall(add)
+    // [2] User: ToolResult
     // [3] Assistant: "The answer is 5"
     assert_eq!(messages.len(), 4, "expected 4 messages, got: {messages:#?}");
 
@@ -278,6 +276,7 @@ async fn max_turns_error_still_contains_history() {
     let agent = AgentBuilder::new(MockCompletionModel::new(
         (0..10).map(|_| always_tool_call_turn()),
     ))
+    .tool(MockAddTool)
     .build();
 
     let result = agent
@@ -308,7 +307,9 @@ async fn max_turns_error_still_contains_history() {
 /// be populated (this is the core feature: no need for &mut borrow).
 #[tokio::test]
 async fn extended_details_works_without_with_history() {
-    let agent = AgentBuilder::new(tool_then_text_model()).build();
+    let agent = AgentBuilder::new(tool_then_text_model())
+        .tool(MockAddTool)
+        .build();
 
     // Note: NO .with_history() call — this is the new use case
     let resp = agent
@@ -377,7 +378,9 @@ async fn chat_appends_prompt_and_assistant_to_history() {
 /// Test 11: `Chat::chat` appends every message produced by a tool roundtrip.
 #[tokio::test]
 async fn chat_appends_tool_roundtrip_to_history() {
-    let agent = AgentBuilder::new(tool_then_text_model()).build();
+    let agent = AgentBuilder::new(tool_then_text_model())
+        .tool(MockAddTool)
+        .build();
     let mut history = Vec::<Message>::new();
 
     let output = agent


### PR DESCRIPTION
## Summary

Fixes malformed and unknown tool-call handling so provider-emitted tool calls must match the tools Rig actually declared and allowed for the current request before they can enter the agent tool loop.

Changes include:
- Add typed invalid-tool-call reporting via `CompletionError::InvalidToolCall`.
- Add a generic `ToolCallNameValidator::from_completion_request(...)` built from `CompletionRequest.tools`, provider-declared function tools in `CompletionRequest.additional_params.tools`, generic `CompletionRequest.tool_choice`, and recognized provider-native tool-choice allowlists.
- Support provider-extra function declarations in the generic validator, including Gemini GenerateContent `functionDeclarations`, Gemini Interactions-style `{ "type": "function", "name": ... }`, OpenAI/xAI-style `{ "type": "function", "function": { "name": ... } }`, and Anthropic raw `{ "name": ..., "description": ..., "input_schema": ... }` tools.
- Ignore provider built-ins such as Google Search and code execution when deriving executable Rig tool names.
- Derive provider-native allowlists for Gemini GenerateContent `toolConfig.functionCallingConfig`, Gemini Interactions `generation_config.tool_choice.allowed_tools`, and Anthropic `tool_choice`.
- Validate normalized tool calls in the core non-streaming and streaming agent loops before dispatch, and before streaming callers observe a completed tool-call event.
- Validate streamed tool-call name deltas before hooks or public yield, including registry validation, so undeclared/disallowed/unregistered names do not leak as half-open tool operations.
- Treat registered-but-not-declared and declared-but-disallowed tools as request-contract violations instead of relying only on the registered tool server.
- Keep unknown registered-tool dispatch failures as hard prompt/streaming errors instead of stringifying `ToolNotFoundError` into a successful tool result.
- Share unknown-tool registry validation/logging through `ToolServerHandle` helpers to reduce drift between streaming and non-streaming paths.
- Update Gemini GenerateContent to use request-contract validation before converting function calls.
- Add the same Gemini validation coverage to the Interactions API, including streaming conversion.
- Preserve the textless-terminal-turn behavior for valid flows while preventing invalid tool calls from reaching the empty-final-response path.
- Update tests that previously encoded missing-tool continuation and add regressions for undeclared, disallowed, provider-extra, Anthropic raw tool, provider-native allowlist, streamed name-delta, and `default_api`-style tool-call failures.

## Root Cause

Rig previously accepted provider-emitted tool names without a generic validation boundary against the actual per-request tool contract. Gemini-specific paths could convert malformed names such as `default_api` into Rig tool calls, and core prompt execution could convert unknown-tool dispatch failures into normal tool-result strings. That allowed malformed provider output to poison multi-turn history and potentially end as an empty final response.

Follow-up review found two additional request-contract gaps: provider-specific tools supplied through `additional_params.tools` were intended to be supported but were invisible to generic validation, and streamed tool-call name deltas could still be observed before registry validation. The validator now includes supported provider-extra function declarations and provider-native allowlists, while the streaming loop validates name deltas before hooks or public yield.

## Validation

Passed locally:
- `cargo fmt`
- `git diff --check`
- `cargo test -p rig-core --lib` (`685 passed; 8 ignored`)
- `cargo test --test core prompt_response_messages` (`13 passed`)
- `cargo check -p rig-core --all-features`
- `cargo clippy --all-targets --all-features`

GitHub CI:
- `Lint & Test` for `19de7355` is running. At last check, `fmt`, `clippy`, `doc`, and wasm check jobs were green; the main test job was still in progress.

Previously observed unrelated failure:
- `cargo test -p rig-core --all-features` failed only in EPUB loader tests that expect one loaded document but get zero. This PR does not touch EPUB loader code.