### PR TITLE
[codex] fix(gemini): record tool use prompt token telemetry

### DIFF
--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -448,6 +448,7 @@ where
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
                 gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
+                gen_ai.usage.tool_use_prompt_tokens = tracing::field::Empty,
                 gen_ai.usage.reasoning_tokens = tracing::field::Empty,
             )
         } else {
@@ -536,6 +537,7 @@ where
                 gen_ai.usage.input_tokens = tracing::field::Empty,
                 gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
                 gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
+                gen_ai.usage.tool_use_prompt_tokens = tracing::field::Empty,
                 gen_ai.usage.reasoning_tokens = tracing::field::Empty,
                 gen_ai.input.messages = tracing::field::Empty,
                 gen_ai.output.messages = tracing::field::Empty,
@@ -625,6 +627,10 @@ where
                 agent_span.record(
                     "gen_ai.usage.cache_creation.input_tokens",
                     usage.cache_creation_input_tokens,
+                );
+                agent_span.record(
+                    "gen_ai.usage.tool_use_prompt_tokens",
+                    usage.tool_use_prompt_tokens,
                 );
                 agent_span.record("gen_ai.usage.reasoning_tokens", usage.reasoning_tokens);
 

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -484,6 +484,7 @@ where
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
                 gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
+                gen_ai.usage.tool_use_prompt_tokens = tracing::field::Empty,
                 gen_ai.usage.reasoning_tokens = tracing::field::Empty,
             )
         } else {
@@ -605,6 +606,7 @@ where
                     gen_ai.usage.input_tokens = tracing::field::Empty,
                     gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
                     gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
+                    gen_ai.usage.tool_use_prompt_tokens = tracing::field::Empty,
                     gen_ai.usage.reasoning_tokens = tracing::field::Empty,
                     gen_ai.input.messages = tracing::field::Empty,
                     gen_ai.output.messages = tracing::field::Empty,
@@ -881,6 +883,7 @@ where
                     current_span.record("gen_ai.usage.output_tokens", aggregated_usage.output_tokens);
                     current_span.record("gen_ai.usage.cache_read.input_tokens", aggregated_usage.cached_input_tokens);
                     current_span.record("gen_ai.usage.cache_creation.input_tokens", aggregated_usage.cache_creation_input_tokens);
+                    current_span.record("gen_ai.usage.tool_use_prompt_tokens", aggregated_usage.tool_use_prompt_tokens);
                     current_span.record("gen_ai.usage.reasoning_tokens", aggregated_usage.reasoning_tokens);
                     tracing::info!("Agent multi-turn stream finished");
                     if let Some((memory, id)) = memory_handle.as_ref()

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -104,6 +104,7 @@ where
                 gen_ai.usage.input_tokens = tracing::field::Empty,
                 gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
                 gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
+                gen_ai.usage.tool_use_prompt_tokens = tracing::field::Empty,
                 gen_ai.usage.reasoning_tokens = tracing::field::Empty,
             )
         } else {

--- a/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
@@ -134,6 +134,7 @@ where
                 gen_ai.usage.input_tokens = tracing::field::Empty,
                 gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
                 gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
+                gen_ai.usage.tool_use_prompt_tokens = tracing::field::Empty,
                 gen_ai.usage.reasoning_tokens = tracing::field::Empty,
             )
         } else {

--- a/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
@@ -69,6 +69,7 @@ where
                 gen_ai.usage.input_tokens = tracing::field::Empty,
                 gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
                 gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
+                gen_ai.usage.tool_use_prompt_tokens = tracing::field::Empty,
                 gen_ai.usage.reasoning_tokens = tracing::field::Empty,
             )
         } else {

--- a/crates/rig-core/src/providers/gemini/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/streaming.rs
@@ -108,6 +108,7 @@ where
                 gen_ai.usage.input_tokens = tracing::field::Empty,
                 gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
                 gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
+                gen_ai.usage.tool_use_prompt_tokens = tracing::field::Empty,
                 gen_ai.usage.reasoning_tokens = tracing::field::Empty,
             )
         } else {

--- a/crates/rig-core/src/telemetry/mod.rs
+++ b/crates/rig-core/src/telemetry/mod.rs
@@ -88,6 +88,10 @@ impl SpanCombinator for tracing::Span {
                 "gen_ai.usage.cache_creation.input_tokens",
                 usage.cache_creation_input_tokens,
             );
+            self.record(
+                "gen_ai.usage.tool_use_prompt_tokens",
+                usage.tool_use_prompt_tokens,
+            );
             self.record("gen_ai.usage.reasoning_tokens", usage.reasoning_tokens);
         }
     }
@@ -133,5 +137,105 @@ impl SpanCombinator for tracing::Span {
         if let Ok(output_as_json_string) = serde_json::to_string(output) {
             self.record("gen_ai.output.messages", output_as_json_string);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::completion::{GetTokenUsage, Usage};
+    use std::sync::{Arc, Mutex};
+    use tracing::field::{Field, Visit};
+    use tracing::{Id, Subscriber};
+    use tracing_subscriber::layer::{Context, SubscriberExt};
+    use tracing_subscriber::{Layer, Registry, registry::LookupSpan};
+
+    #[derive(Clone)]
+    struct TestUsage(Usage);
+
+    impl GetTokenUsage for TestUsage {
+        fn token_usage(&self) -> Option<Usage> {
+            Some(self.0)
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct CapturedFields(Arc<Mutex<Vec<(String, u64)>>>);
+
+    impl CapturedFields {
+        fn push(&self, name: &str, value: u64) {
+            if let Ok(mut fields) = self.0.lock() {
+                fields.push((name.to_string(), value));
+            }
+        }
+
+        fn contains(&self, name: &str, value: u64) -> bool {
+            self.0.lock().is_ok_and(|fields| {
+                fields
+                    .iter()
+                    .any(|field| field == &(name.to_string(), value))
+            })
+        }
+    }
+
+    struct FieldCaptureLayer {
+        fields: CapturedFields,
+    }
+
+    impl<S> Layer<S> for FieldCaptureLayer
+    where
+        S: Subscriber,
+        S: for<'lookup> LookupSpan<'lookup>,
+    {
+        fn on_record(&self, _span: &Id, values: &tracing::span::Record<'_>, _ctx: Context<'_, S>) {
+            values.record(&mut FieldCaptureVisitor {
+                fields: self.fields.clone(),
+            });
+        }
+    }
+
+    struct FieldCaptureVisitor {
+        fields: CapturedFields,
+    }
+
+    impl Visit for FieldCaptureVisitor {
+        fn record_u64(&mut self, field: &Field, value: u64) {
+            self.fields.push(field.name(), value);
+        }
+
+        fn record_debug(&mut self, _field: &Field, _value: &dyn std::fmt::Debug) {}
+    }
+
+    #[test]
+    fn record_token_usage_records_tool_use_prompt_tokens() {
+        let fields = CapturedFields::default();
+        let subscriber = Registry::default().with(FieldCaptureLayer {
+            fields: fields.clone(),
+        });
+        let usage = TestUsage(Usage {
+            input_tokens: 1,
+            output_tokens: 2,
+            total_tokens: 15,
+            cached_input_tokens: 3,
+            cache_creation_input_tokens: 4,
+            tool_use_prompt_tokens: 12,
+            reasoning_tokens: 5,
+        });
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!(
+                "usage_recording",
+                gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.output_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
+                gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
+                gen_ai.usage.tool_use_prompt_tokens = tracing::field::Empty,
+                gen_ai.usage.reasoning_tokens = tracing::field::Empty,
+            );
+
+            span.record_token_usage(&usage);
+        });
+
+        assert!(fields.contains("gen_ai.usage.tool_use_prompt_tokens", 12));
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #1790.

- Records normalized `Usage.tool_use_prompt_tokens` as `gen_ai.usage.tool_use_prompt_tokens` in the shared telemetry span recorder.
- Declares the field on Gemini completion/streaming spans so the shared recorder can emit it for Gemini usage metadata.
- Records the aggregated tool-use prompt token count on agent prompt and streaming spans.
- Adds a focused telemetry unit test that verifies the shared recorder emits the new span field.

## Why

#1790 exposed Gemini `toolUsePromptTokenCount` through normalized usage, but telemetry spans still only recorded input, output, cache, and reasoning token counts. That meant span-based analytics consumers could miss the newly normalized token count.

## Validation

- `cargo fmt --check`
- `cargo test -p rig-core telemetry::tests::record_token_usage_records_tool_use_prompt_tokens`
- `cargo test -p rig-core gemini`
- `cargo clippy -p rig-core --all-targets --all-features`
- `cargo test -p rig-core`
- `git diff --check`
