### PR TITLE
fix(openrouter): accept Gemini model role responses

### DIFF
--- a/crates/rig-core/src/providers/openrouter/completion.rs
+++ b/crates/rig-core/src/providers/openrouter/completion.rs
@@ -1287,6 +1287,7 @@ pub enum Message {
         #[serde(skip_serializing_if = "Option::is_none")]
         name: Option<String>,
     },
+    #[serde(alias = "model")]
     Assistant {
         #[serde(
             default,
@@ -2122,6 +2123,47 @@ mod tests {
 
         assert_eq!(converted.usage.cached_input_tokens, 0);
         assert_eq!(converted.usage.cache_creation_input_tokens, 0);
+    }
+
+    #[test]
+    fn test_completion_response_deserialization_gemini_model_role() {
+        let json = json!({
+            "id": "gen-BBBBBBBBBB-BBBBBBBBBBBBBBBBBBBB",
+            "provider": "Google",
+            "model": "google/gemini-2.5-pro-exp-03-25:free",
+            "object": "chat.completion",
+            "created": 1743780565u64,
+            "choices": [{
+                "logprobs": null,
+                "finish_reason": "stop",
+                "native_finish_reason": "STOP",
+                "index": 0,
+                "message": {
+                    "role": "model",
+                    "content": "CONTENT",
+                    "refusal": null,
+                    "reasoning": null
+                }
+            }],
+            "usage": {
+                "prompt_tokens": 669,
+                "completion_tokens": 5,
+                "total_tokens": 674
+            }
+        });
+
+        let response: CompletionResponse = serde_json::from_value(json).unwrap();
+        let converted: completion::CompletionResponse<CompletionResponse> =
+            response.try_into().unwrap();
+
+        assert_eq!(
+            converted.raw_response.model,
+            "google/gemini-2.5-pro-exp-03-25:free"
+        );
+        assert!(matches!(
+            converted.choice.first(),
+            completion::AssistantContent::Text(text) if text.text == "CONTENT"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes #380.

OpenRouter responses from some Gemini-backed models can use the Gemini-style assistant role value `model` instead of OpenAI's `assistant`. The native OpenRouter response parser only accepted `assistant`, so the whole completion response failed to deserialize before Rig could normalize the message.

This adds `model` as a deserialize-only alias for OpenRouter assistant messages and covers the `google/gemini-2.5-pro-exp-03-25:free` response shape with a regression test.

I used AI assistance to help inspect the response parsing path and identify the narrow serde boundary. I reviewed the patch and ran the tests below locally.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p rig-core providers::openrouter::completion --no-default-features`
- [x] `cargo test -p rig-core providers::openrouter --no-default-features`
- [x] `cargo clippy -p rig-core --all-targets --all-features -- -D warnings`
- [x] `cargo test -p rig-core --no-default-features`
- [x] `cargo test -p rig-core providers::openrouter --all-features`
- [x] `git diff --check`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Notes

No documentation change is needed; this only broadens response deserialization for an existing provider shape.
