### PR TITLE
Fail fast on unknown tool calls

### DIFF
--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -7,11 +7,14 @@ use super::{
 };
 use crate::{
     OneOrMany,
-    completion::{CompletionModel, Document, Message, PromptError, Usage},
+    completion::{CompletionModel, Document, Message, PromptError, UnknownToolCallError, Usage},
     json_utils,
     memory::ConversationMemory,
     message::{AssistantContent, ToolChoice, ToolResultContent, UserContent},
-    tool::server::ToolServerHandle,
+    tool::{
+        ToolSetError,
+        server::{ToolServerError, ToolServerHandle},
+    },
     wasm_compat::{WasmBoxedFuture, WasmCompatSend},
 };
 use futures::{StreamExt, stream};
@@ -426,6 +429,48 @@ fn assistant_text_from_choice(choice: &OneOrMany<AssistantContent>) -> String {
         .collect()
 }
 
+fn log_unknown_tool_call(error: &UnknownToolCallError) {
+    tracing::warn!(
+        tool_name = error.tool_name.as_str(),
+        tool_call_id = error.tool_call_id.as_str(),
+        call_id = ?error.call_id,
+        available_tool_names = ?error.available_tool_names,
+        "Model requested an unknown tool"
+    );
+}
+
+pub(super) async fn validate_registered_tool_call(
+    tool_server_handle: &ToolServerHandle,
+    tool_call: &crate::message::ToolCall,
+) -> Result<(), UnknownToolCallError> {
+    tool_server_handle
+        .validate_tool_call_name(
+            &tool_call.function.name,
+            &tool_call.id,
+            tool_call.call_id.clone(),
+            tool_call.function.arguments.clone(),
+        )
+        .await
+        .inspect_err(log_unknown_tool_call)
+}
+
+pub(super) async fn unknown_tool_call_error(
+    tool_server_handle: &ToolServerHandle,
+    tool_name: String,
+    tool_call: &crate::message::ToolCall,
+) -> UnknownToolCallError {
+    let error = tool_server_handle
+        .unknown_tool_call_error(
+            tool_name,
+            &tool_call.id,
+            tool_call.call_id.clone(),
+            tool_call.function.arguments.clone(),
+        )
+        .await;
+    log_unknown_tool_call(&error);
+    error
+}
+
 impl<M, P> PromptRequest<Extended, M, P>
 where
     M: CompletionModel,
@@ -697,6 +742,9 @@ where
                             tool_span.record("gen_ai.tool.name", tool_name);
                             tool_span.record("gen_ai.tool.call.id", &tool_call.id);
                             tool_span.record("gen_ai.tool.call.arguments", &args);
+                            validate_registered_tool_call(&tool_server_handle, &tool_call)
+                                .await
+                                .map_err(PromptError::UnknownToolCall)?;
                             if let Some(hook) = hook1 {
                                 let action = hook
                                     .on_tool_call(
@@ -738,6 +786,17 @@ where
                             let output = match tool_server_handle.call_tool(tool_name, &args).await
                             {
                                 Ok(res) => res,
+                                Err(ToolServerError::ToolsetError(
+                                    ToolSetError::ToolNotFoundError(name),
+                                )) => {
+                                    let error = unknown_tool_call_error(
+                                        &tool_server_handle,
+                                        name,
+                                        &tool_call,
+                                    )
+                                    .await;
+                                    return Err(PromptError::UnknownToolCall(error));
+                                }
                                 Err(e) => {
                                     tracing::warn!("Error while executing tool: {e}");
                                     e.to_string()
@@ -1021,7 +1080,8 @@ mod tests {
         },
         message::{Text, UserContent},
         test_utils::{
-            AppendFailingMemory, CountingMemory, FailingMemory, MockCompletionModel, MockTurn,
+            AppendFailingMemory, CountingMemory, FailingMemory, MockAddTool, MockCompletionModel,
+            MockTurn,
         },
     };
     use schemars::JsonSchema;
@@ -1221,7 +1281,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn prompt_request_stops_cleanly_on_empty_terminal_turn() {
+    async fn prompt_request_stops_cleanly_on_empty_terminal_turn_after_known_tool() {
         let first_call_usage = Usage {
             input_tokens: 1,
             output_tokens: 1,
@@ -1241,12 +1301,12 @@ mod tests {
             reasoning_tokens: 0,
         };
         let model = MockCompletionModel::new([
-            MockTurn::tool_call("tool_call_1", "missing_tool", json!({"input": "value"}))
+            MockTurn::tool_call("tool_call_1", "add", json!({"x": 1, "y": 2}))
                 .with_call_id("call_1")
                 .with_usage(first_call_usage),
             MockTurn::text("").with_usage(second_call_usage),
         ]);
-        let agent = AgentBuilder::new(model).build();
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
 
         let response = agent
             .prompt("do tool work")
@@ -1319,6 +1379,37 @@ mod tests {
         let requests = agent.model.requests();
         assert_eq!(requests.len(), 2);
         validate_follow_up_tool_history(&requests[1]);
+    }
+
+    #[tokio::test]
+    async fn prompt_request_rejects_unknown_tool_without_follow_up_turn() {
+        let model = MockCompletionModel::new([
+            MockTurn::tool_call("tool_call_1", "missing_tool", json!({"input": "value"}))
+                .with_call_id("call_1"),
+            MockTurn::text("should not be called"),
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model).build();
+
+        let err = agent
+            .prompt("do tool work")
+            .max_turns(3)
+            .await
+            .expect_err("unknown tool should stop the prompt");
+
+        assert!(
+            matches!(
+                err,
+                PromptError::UnknownToolCall(ref error)
+                    if error.tool_name == "missing_tool"
+                        && error.tool_call_id == "tool_call_1"
+                        && error.call_id.as_deref() == Some("call_1")
+                        && error.arguments == json!({"input": "value"})
+                        && error.available_tool_names.is_empty()
+            ),
+            "expected unknown tool-call error, got {err:?}"
+        );
+        assert_eq!(recorded.requests().len(), 1);
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -7,7 +7,7 @@ use crate::{
     memory::ConversationMemory,
     message::{AssistantContent, ToolChoice, ToolResult, ToolResultContent, UserContent},
     streaming::{StreamedAssistantContent, StreamedUserContent},
-    tool::server::ToolServerHandle,
+    tool::server::{ToolServerError, ToolServerHandle},
     wasm_compat::{WasmBoxedFuture, WasmCompatSend},
 };
 use futures::{Stream, StreamExt};
@@ -16,10 +16,10 @@ use std::{pin::Pin, sync::Arc};
 use tracing::info_span;
 use tracing_futures::Instrument;
 
-use super::{CompletionCall, ToolCallHookAction, reported_usage};
+use super::{CompletionCall, ToolCallHookAction, reported_usage, unknown_tool_call_error};
 use crate::{
     agent::Agent,
-    completion::{CompletionError, CompletionModel, PromptError},
+    completion::{CompletionError, CompletionModel, PromptError, UnknownToolCallError},
     message::{Message, Text},
     tool::ToolSetError,
 };
@@ -271,6 +271,8 @@ pub enum StreamingError {
     Prompt(#[from] Box<PromptError>),
     #[error("ToolSetError: {0}")]
     Tool(#[from] ToolSetError),
+    #[error("UnknownToolCall: {0}")]
+    UnknownToolCall(UnknownToolCallError),
 }
 
 /// Surface [`crate::memory::ConversationMemory`] failures through the existing
@@ -709,6 +711,17 @@ where
                                 let tool_result = match
                                 tool_server_handle.call_tool(&tool_call.function.name, &tool_args).await {
                                     Ok(thing) => thing,
+                                    Err(ToolServerError::ToolsetError(
+                                        ToolSetError::ToolNotFoundError(name),
+                                    )) => {
+                                        let error = unknown_tool_call_error(
+                                            &tool_server_handle,
+                                            name,
+                                            &tool_call,
+                                        )
+                                        .await;
+                                        return Err(StreamingError::UnknownToolCall(error));
+                                    }
                                     Err(e) => {
                                         tracing::warn!("Error while calling tool: {e}");
                                         e.to_string()
@@ -991,7 +1004,8 @@ mod tests {
     use crate::providers::anthropic;
     use crate::streaming::{StreamingPrompt, ToolCallDeltaContent};
     use crate::test_utils::{
-        AppendFailingMemory, FailingMemory, MockCompletionModel, MockResponse, MockStreamEvent,
+        AppendFailingMemory, FailingMemory, MockAddTool, MockCompletionModel, MockResponse,
+        MockStreamEvent,
     };
     use futures::StreamExt;
     use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
@@ -1219,8 +1233,8 @@ mod tests {
             vec![
                 MockStreamEvent::tool_call(
                     "tool_call_1",
-                    "missing_tool",
-                    serde_json::json!({"input": "value"}),
+                    "add",
+                    serde_json::json!({"x": 1, "y": 2}),
                 )
                 .with_call_id("call_1"),
                 MockStreamEvent::final_response_with_total_tokens(4),
@@ -1366,8 +1380,8 @@ mod tests {
                 MockStreamEvent::text("I need a tool. "),
                 MockStreamEvent::tool_call(
                     "tool_call_1",
-                    "missing_tool",
-                    serde_json::json!({"input": "value"}),
+                    "add",
+                    serde_json::json!({"x": 1, "y": 2}),
                 )
                 .with_call_id("call_1"),
                 MockStreamEvent::final_response_with_total_tokens(4),
@@ -1491,7 +1505,7 @@ mod tests {
     async fn stream_prompt_continues_after_tool_call_turn() {
         let model = streaming_tool_then_text_model();
         let recorded = model.clone();
-        let agent = AgentBuilder::new(model).build();
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
         let empty_history: &[Message] = &[];
 
         let mut stream = agent
@@ -1551,6 +1565,67 @@ mod tests {
         let requests = recorded.requests();
         assert_eq!(requests.len(), 2);
         assert!(validate_follow_up_tool_history(&requests[1]).is_ok());
+    }
+
+    #[tokio::test]
+    async fn stream_prompt_rejects_unknown_tool_without_tool_result_or_follow_up() {
+        let model = MockCompletionModel::from_stream_turns([
+            vec![
+                MockStreamEvent::tool_call(
+                    "tool_call_1",
+                    "missing_tool",
+                    serde_json::json!({"input": "value"}),
+                )
+                .with_call_id("call_1"),
+                MockStreamEvent::final_response_with_total_tokens(4),
+            ],
+            vec![
+                MockStreamEvent::text("should not be called"),
+                MockStreamEvent::final_response_with_total_tokens(6),
+            ],
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model).build();
+
+        let mut stream = agent.stream_prompt("do tool work").multi_turn(3).await;
+        let mut saw_tool_call = false;
+        let mut saw_tool_result = false;
+        let mut saw_final_response = false;
+        let mut error = None;
+
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(MultiTurnStreamItem::StreamAssistantItem(
+                    StreamedAssistantContent::ToolCall { .. },
+                )) => saw_tool_call = true,
+                Ok(MultiTurnStreamItem::StreamUserItem(StreamedUserContent::ToolResult {
+                    ..
+                })) => saw_tool_result = true,
+                Ok(MultiTurnStreamItem::FinalResponse(_)) => saw_final_response = true,
+                Ok(_) => {}
+                Err(err) => {
+                    error = Some(err);
+                    break;
+                }
+            }
+        }
+
+        assert!(saw_tool_call);
+        assert!(!saw_tool_result);
+        assert!(!saw_final_response);
+        assert!(
+            matches!(
+                error,
+                Some(StreamingError::UnknownToolCall(ref unknown))
+                    if unknown.tool_name == "missing_tool"
+                        && unknown.tool_call_id == "tool_call_1"
+                        && unknown.call_id.as_deref() == Some("call_1")
+                        && unknown.arguments == serde_json::json!({"input": "value"})
+                        && unknown.available_tool_names.is_empty()
+            ),
+            "expected unknown tool-call error, got {error:?}"
+        );
+        assert_eq!(recorded.requests().len(), 1);
     }
 
     #[tokio::test]
@@ -1747,8 +1822,8 @@ mod tests {
             vec![
                 MockStreamEvent::tool_call(
                     "tool_call_1",
-                    "missing_tool",
-                    serde_json::json!({"input": "value"}),
+                    "add",
+                    serde_json::json!({"x": 1, "y": 2}),
                 )
                 .with_call_id("call_1"),
                 MockStreamEvent::final_response(first_call_usage),
@@ -1758,7 +1833,7 @@ mod tests {
                 MockStreamEvent::final_response(second_call_usage),
             ],
         ]);
-        let agent = AgentBuilder::new(model).build();
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
         let empty_history: &[Message] = &[];
 
         let mut stream = agent
@@ -1859,8 +1934,8 @@ mod tests {
             vec![
                 MockStreamEvent::tool_call(
                     "tool_call_1",
-                    "missing_tool",
-                    serde_json::json!({"input": "value"}),
+                    "add",
+                    serde_json::json!({"x": 1, "y": 2}),
                 )
                 .with_call_id("call_1"),
             ],
@@ -1869,7 +1944,7 @@ mod tests {
                 MockStreamEvent::final_response(second_call_usage),
             ],
         ]);
-        let agent = AgentBuilder::new(model).build();
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
         let empty_history: &[Message] = &[];
 
         let mut stream = agent
@@ -2003,7 +2078,7 @@ mod tests {
     async fn tool_follow_up_history_preserves_structured_text_metadata() {
         let model = streaming_cited_text_then_tool_model();
         let recorded = model.clone();
-        let agent = AgentBuilder::new(model).build();
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
         let empty_history: &[Message] = &[];
 
         let mut stream = agent

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -47,8 +47,8 @@ use crate::{
 };
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::ops::{Add, AddAssign};
+use std::{collections::HashMap, fmt};
 use thiserror::Error;
 
 // Errors
@@ -96,6 +96,10 @@ pub enum PromptError {
     #[error("ToolCallError: {0}")]
     ToolError(#[from] ToolSetError),
 
+    /// The model requested a tool that is not registered for this prompt.
+    #[error("UnknownToolCall: {0}")]
+    UnknownToolCall(UnknownToolCallError),
+
     /// There was an issue while executing a tool on a tool server
     #[error("ToolServerError: {0}")]
     ToolServerError(#[from] Box<ToolServerError>),
@@ -116,6 +120,53 @@ pub enum PromptError {
         chat_history: Vec<Message>,
         reason: String,
     },
+}
+
+/// The model requested a tool that is not registered for this prompt.
+#[derive(Clone, Debug, PartialEq)]
+pub struct UnknownToolCallError {
+    /// Tool name requested by the model.
+    pub tool_name: String,
+    /// Provider/tool-call identifier for the attempted tool call.
+    pub tool_call_id: String,
+    /// Optional provider call id associated with the attempted tool call.
+    pub call_id: Option<String>,
+    /// Arguments the model supplied for the attempted tool call.
+    pub arguments: serde_json::Value,
+    /// Tool names registered with the prompt at the time of validation.
+    pub available_tool_names: Vec<String>,
+}
+
+impl UnknownToolCallError {
+    /// Create an unknown-tool error with the attempted call and available tool context.
+    pub fn new(
+        tool_name: String,
+        tool_call_id: String,
+        call_id: Option<String>,
+        arguments: serde_json::Value,
+        available_tool_names: Vec<String>,
+    ) -> Self {
+        Self {
+            tool_name,
+            tool_call_id,
+            call_id,
+            arguments,
+            available_tool_names,
+        }
+    }
+}
+
+impl fmt::Display for UnknownToolCallError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "model requested unknown tool `{}` (tool_call_id={}, call_id={:?}, available_tools=[{}])",
+            self.tool_name,
+            self.tool_call_id,
+            self.call_id,
+            self.available_tool_names.join(", ")
+        )
+    }
 }
 
 /// Surface [`crate::memory::ConversationMemory`] failures through the existing

--- a/crates/rig-core/src/tool/mod.rs
+++ b/crates/rig-core/src/tool/mod.rs
@@ -320,6 +320,11 @@ impl ToolSet {
         self.tools.contains_key(toolname)
     }
 
+    /// Return the names of all registered tools.
+    pub fn names(&self) -> Vec<String> {
+        self.tools.keys().cloned().collect()
+    }
+
     /// Add a tool to the toolset
     pub fn add_tool(&mut self, tool: impl ToolDyn + 'static) {
         self.tools

--- a/crates/rig-core/src/tool/server.rs
+++ b/crates/rig-core/src/tool/server.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use crate::{
-    completion::{CompletionError, ToolDefinition},
+    completion::{CompletionError, ToolDefinition, UnknownToolCallError},
     tool::{Tool, ToolDyn, ToolSet, ToolSetError},
     vector_store::{VectorSearchRequest, VectorStoreError, VectorStoreIndexDyn, request::Filter},
 };
@@ -134,6 +134,54 @@ impl ToolServerHandle {
         state.static_tool_names.retain(|x| *x != tool_name);
         state.toolset.delete_tool(tool_name);
         Ok(())
+    }
+
+    /// Return the names of all tools registered with the server.
+    pub async fn tool_names(&self) -> Vec<String> {
+        let state = self.0.read().await;
+        let mut names = state.toolset.names();
+        names.sort();
+        names
+    }
+
+    /// Check whether a tool is registered with the server.
+    pub async fn has_tool(&self, tool_name: &str) -> bool {
+        let state = self.0.read().await;
+        state.toolset.contains(tool_name)
+    }
+
+    /// Validate that a model-requested tool call targets a registered tool.
+    pub async fn validate_tool_call_name(
+        &self,
+        tool_name: &str,
+        tool_call_id: &str,
+        call_id: Option<String>,
+        arguments: serde_json::Value,
+    ) -> Result<(), UnknownToolCallError> {
+        if self.has_tool(tool_name).await {
+            Ok(())
+        } else {
+            Err(self
+                .unknown_tool_call_error(tool_name.to_string(), tool_call_id, call_id, arguments)
+                .await)
+        }
+    }
+
+    /// Build an unknown-tool error using the server's current registered tool names.
+    pub async fn unknown_tool_call_error(
+        &self,
+        tool_name: String,
+        tool_call_id: &str,
+        call_id: Option<String>,
+        arguments: serde_json::Value,
+    ) -> UnknownToolCallError {
+        UnknownToolCallError::new(
+            tool_name,
+            tool_call_id.to_string(),
+            call_id,
+            arguments,
+            self.tool_names().await,
+        )
     }
 
     /// Look up and execute a tool by name.


### PR DESCRIPTION
## Summary

This is PR 1 from the unknown-tool validation split. It keeps the scope provider-agnostic and only changes core behavior for model-requested tools that Rig cannot execute.

Changes include:
- Add typed `UnknownToolCallError` with tool name, provider tool-call id, optional call id, arguments, and available registered tool names.
- Add `PromptError::UnknownToolCall` and `StreamingError::UnknownToolCall`.
- Add `ToolServerHandle` lookup/validation helpers: `tool_names`, `has_tool`, `validate_tool_call_name`, and `unknown_tool_call_error`.
- Add `ToolSet::names` for registered-tool diagnostics.
- Update non-streaming prompt execution so unknown tool calls fail fast instead of becoming stringified tool output.
- Update streaming prompt execution so `ToolNotFoundError` fails as `StreamingError::UnknownToolCall` instead of producing a tool-result event.
- Preserve successful empty/textless terminal turns after a known tool call.
- Update core tests that previously used missing tools as normal continuation cases.

## Out of Scope

This PR intentionally does not include:
- `CompletionError::InvalidToolCall`
- request-contract validation against declared/allowed tools
- Gemini-specific validation
- `additional_params.tools` parsing
- provider-native tool-choice allowlist parsing
- streamed tool-call delta validation before public yield

Those are intended for follow-up PRs in the split stack.

## Validation

Passed locally:
- `cargo fmt`
- `git diff --check`
- `cargo test -p rig-core prompt_request_rejects_unknown_tool_without_follow_up_turn`
- `cargo test -p rig-core stream_prompt_rejects_unknown_tool_without_tool_result_or_follow_up`
- `cargo test -p rig-core prompt_request_stops_cleanly_on_empty_terminal_turn_after_known_tool`
- `cargo test -p rig-core stream_prompt`
- `cargo test -p rig-core --lib` (`662 passed; 8 ignored`)