### PR TITLE
feat(openrouter): add with_app_identity and with_app_categories builders for app attribution

### DIFF
--- a/crates/rig-core/src/providers/openrouter/client.rs
+++ b/crates/rig-core/src/providers/openrouter/client.rs
@@ -126,17 +126,42 @@ impl GetTokenUsage for Usage {
     }
 }
 impl<ApiKey, H> client::ClientBuilder<OpenRouterExtBuilder, ApiKey, H> {
-    /// Attach OpenRouter app-identification headers (`X-Title` and `HTTP-Referer`) to
-    /// every request made by this client. `title` appears in the dashboard activity feed;
-    /// `url` is used for per-app analytics and the public rankings page. Both are optional.
+    /// Attach OpenRouter app-identification headers (`X-OpenRouter-Title` and `HTTP-Referer`)
+    /// to every request made by this client. `title` appears in the dashboard activity feed
+    /// and rankings page; `url` is the primary app identifier required to create an app page
+    /// on OpenRouter. Invalid (non-ASCII) values are silently skipped.
     pub fn with_app_identity(mut self, title: impl AsRef<str>, url: impl AsRef<str>) -> Self {
         if let Ok(val) = HeaderValue::from_str(title.as_ref()) {
-            self.headers_mut()
-                .insert(http::header::HeaderName::from_static("x-title"), val);
+            self.headers_mut().insert(
+                http::header::HeaderName::from_static("x-openrouter-title"),
+                val,
+            );
         }
         if let Ok(val) = HeaderValue::from_str(url.as_ref()) {
             self.headers_mut()
                 .insert(http::header::HeaderName::from_static("http-referer"), val);
+        }
+        self
+    }
+
+    /// Assign this app to one or more OpenRouter marketplace categories via the
+    /// `X-OpenRouter-Categories` header. Categories must be lowercase and hyphen-separated
+    /// (e.g. `"cli-agent"`, `"ide-extension"`). Unrecognized categories are silently ignored
+    /// by OpenRouter. Invalid (non-ASCII) values are silently skipped.
+    pub fn with_app_categories<S>(mut self, categories: &[S]) -> Self
+    where
+        S: AsRef<str>,
+    {
+        let joined = categories
+            .iter()
+            .map(|c| c.as_ref())
+            .collect::<Vec<_>>()
+            .join(",");
+        if let Ok(val) = HeaderValue::from_str(&joined) {
+            self.headers_mut().insert(
+                http::header::HeaderName::from_static("x-openrouter-categories"),
+                val,
+            );
         }
         self
     }
@@ -164,14 +189,14 @@ mod tests {
 
         let headers = client.headers();
         assert_eq!(
-            headers.get("x-title").and_then(|v| v.to_str().ok()),
+            headers
+                .get("x-openrouter-title")
+                .and_then(|v| v.to_str().ok()),
             Some("My App"),
-            "X-Title header should be set"
         );
         assert_eq!(
             headers.get("http-referer").and_then(|v| v.to_str().ok()),
             Some("https://myapp.example.com"),
-            "HTTP-Referer header should be set"
         );
     }
 
@@ -183,13 +208,34 @@ mod tests {
             .expect("Client::builder() failed");
 
         let headers = client.headers();
-        assert!(
-            headers.get("x-title").is_none(),
-            "X-Title header should not be present without with_app_identity"
+        assert!(headers.get("x-openrouter-title").is_none());
+        assert!(headers.get("http-referer").is_none());
+    }
+
+    #[test]
+    fn test_with_app_categories_sets_header() {
+        let client = crate::providers::openrouter::Client::builder()
+            .with_app_categories(&["cli-agent", "ide-extension"])
+            .api_key("dummy-key")
+            .build()
+            .expect("Client::builder() failed");
+
+        assert_eq!(
+            client
+                .headers()
+                .get("x-openrouter-categories")
+                .and_then(|v| v.to_str().ok()),
+            Some("cli-agent,ide-extension"),
         );
-        assert!(
-            headers.get("http-referer").is_none(),
-            "HTTP-Referer header should not be present without with_app_identity"
-        );
+    }
+
+    #[test]
+    fn test_without_app_categories_no_header() {
+        let client = crate::providers::openrouter::Client::builder()
+            .api_key("dummy-key")
+            .build()
+            .expect("Client::builder() failed");
+
+        assert!(client.headers().get("x-openrouter-categories").is_none());
     }
 }

--- a/crates/rig-core/src/providers/openrouter/client.rs
+++ b/crates/rig-core/src/providers/openrouter/client.rs
@@ -8,6 +8,7 @@ use crate::{
     completion::GetTokenUsage,
     http_client,
 };
+use http::HeaderValue;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 
@@ -124,6 +125,23 @@ impl GetTokenUsage for Usage {
         ))
     }
 }
+impl<ApiKey, H> client::ClientBuilder<OpenRouterExtBuilder, ApiKey, H> {
+    /// Attach OpenRouter app-identification headers (`X-Title` and `HTTP-Referer`) to
+    /// every request made by this client. `title` appears in the dashboard activity feed;
+    /// `url` is used for per-app analytics and the public rankings page. Both are optional.
+    pub fn with_app_identity(mut self, title: impl AsRef<str>, url: impl AsRef<str>) -> Self {
+        if let Ok(val) = HeaderValue::from_str(title.as_ref()) {
+            self.headers_mut()
+                .insert(http::header::HeaderName::from_static("x-title"), val);
+        }
+        if let Ok(val) = HeaderValue::from_str(url.as_ref()) {
+            self.headers_mut()
+                .insert(http::header::HeaderName::from_static("http-referer"), val);
+        }
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #[test]
@@ -134,5 +152,44 @@ mod tests {
             .api_key("dummy-key")
             .build()
             .expect("Client::builder() failed");
+    }
+
+    #[test]
+    fn test_with_app_identity_sets_headers() {
+        let client = crate::providers::openrouter::Client::builder()
+            .with_app_identity("My App", "https://myapp.example.com")
+            .api_key("dummy-key")
+            .build()
+            .expect("Client::builder() failed");
+
+        let headers = client.headers();
+        assert_eq!(
+            headers.get("x-title").and_then(|v| v.to_str().ok()),
+            Some("My App"),
+            "X-Title header should be set"
+        );
+        assert_eq!(
+            headers.get("http-referer").and_then(|v| v.to_str().ok()),
+            Some("https://myapp.example.com"),
+            "HTTP-Referer header should be set"
+        );
+    }
+
+    #[test]
+    fn test_without_app_identity_no_extra_headers() {
+        let client = crate::providers::openrouter::Client::builder()
+            .api_key("dummy-key")
+            .build()
+            .expect("Client::builder() failed");
+
+        let headers = client.headers();
+        assert!(
+            headers.get("x-title").is_none(),
+            "X-Title header should not be present without with_app_identity"
+        );
+        assert!(
+            headers.get("http-referer").is_none(),
+            "HTTP-Referer header should not be present without with_app_identity"
+        );
     }
 }


### PR DESCRIPTION
## Summary

OpenRouter uses the \`X-OpenRouter-Title\`, \`HTTP-Referer\`, and \`X-OpenRouter-Categories\` request headers to identify the calling application in the dashboard activity feed, public rankings page, and marketplace categories.

## Changes

- **\`client.rs\`** — adds \`ClientBuilder::with_app_identity(title, url)\` that sets \`X-OpenRouter-Title\` and \`HTTP-Referer\` on every request. \`HTTP-Referer\` is the primary app identifier required to create an app page on OpenRouter; \`X-OpenRouter-Title\` sets the display name in the activity feed and rankings.
- **\`client.rs\`** — adds \`ClientBuilder::with_app_categories(categories)\` that sets \`X-OpenRouter-Categories\` as a comma-separated list. Categories must be lowercase and hyphen-separated (e.g. \`"cli-agent"\`, \`"ide-extension"\`); unrecognized values are silently ignored by OpenRouter.
- Invalid (non-ASCII) header values are silently skipped, matching existing header-helper behaviour in the codebase.
- Five tests: headers present after \`with_app_identity\`, headers absent without it, categories set and absent, and the existing client-init smoke test.

## AI Assistance

This implementation was developed with significant AI assistance (Claude). The design and tests were reviewed and validated by the author before submission.

## Issue

Fixes #1805