### PR TITLE
feat(openrouter): surface cache token accounting in Usage

### DIFF
--- a/crates/rig-core/src/providers/openrouter/client.rs
+++ b/crates/rig-core/src/providers/openrouter/client.rs
@@ -102,6 +102,24 @@ pub struct Usage {
     pub total_tokens: usize,
     #[serde(default)]
     pub cost: f64,
+    /// OpenAI-compatible prompt-token details, returned by OpenRouter when a
+    /// provider reports cache activity (Anthropic with cache_control, OpenAI
+    /// with server-side automatic caching).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_tokens_details: Option<PromptTokensDetails>,
+}
+
+/// Prompt-token breakdown reported by OpenRouter for cached requests.
+// `usize` matches the parent `Usage` struct in this module; the streaming counterpart
+// in `streaming.rs` uses `u32` to match its own parent.
+#[derive(Clone, Debug, Deserialize, Serialize, Default)]
+pub struct PromptTokensDetails {
+    /// Tokens served from cache (cache hit).
+    #[serde(default)]
+    pub cached_tokens: usize,
+    /// Tokens written to cache on this call (cache miss that populated the cache).
+    #[serde(default)]
+    pub cache_write_tokens: usize,
 }
 
 impl std::fmt::Display for Usage {
@@ -116,12 +134,20 @@ impl std::fmt::Display for Usage {
 
 impl GetTokenUsage for Usage {
     fn token_usage(&self) -> Option<crate::completion::Usage> {
-        Some(crate::providers::internal::completion_usage(
-            self.prompt_tokens as u64,
-            self.completion_tokens as u64,
-            self.total_tokens as u64,
-            0,
-        ))
+        let (cached_input, cache_creation) = self
+            .prompt_tokens_details
+            .as_ref()
+            .map(|d| (d.cached_tokens as u64, d.cache_write_tokens as u64))
+            .unwrap_or((0, 0));
+        Some(crate::completion::Usage {
+            input_tokens: self.prompt_tokens as u64,
+            output_tokens: self.completion_tokens as u64,
+            total_tokens: self.total_tokens as u64,
+            cached_input_tokens: cached_input,
+            cache_creation_input_tokens: cache_creation,
+            tool_use_prompt_tokens: 0,
+            reasoning_tokens: 0,
+        })
     }
 }
 #[cfg(test)]

--- a/crates/rig-core/src/providers/openrouter/completion.rs
+++ b/crates/rig-core/src/providers/openrouter/completion.rs
@@ -716,14 +716,21 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
         let usage = response
             .usage
             .as_ref()
-            .map(|usage| completion::Usage {
-                input_tokens: usage.prompt_tokens as u64,
-                output_tokens: (usage.total_tokens - usage.prompt_tokens) as u64,
-                total_tokens: usage.total_tokens as u64,
-                cached_input_tokens: 0,
-                cache_creation_input_tokens: 0,
-                tool_use_prompt_tokens: 0,
-                reasoning_tokens: 0,
+            .map(|usage| {
+                let (cached_input, cache_creation) = usage
+                    .prompt_tokens_details
+                    .as_ref()
+                    .map(|d| (d.cached_tokens as u64, d.cache_write_tokens as u64))
+                    .unwrap_or((0, 0));
+                completion::Usage {
+                    input_tokens: usage.prompt_tokens as u64,
+                    output_tokens: (usage.total_tokens - usage.prompt_tokens) as u64,
+                    total_tokens: usage.total_tokens as u64,
+                    cached_input_tokens: cached_input,
+                    cache_creation_input_tokens: cache_creation,
+                    tool_use_prompt_tokens: 0,
+                    reasoning_tokens: 0,
+                }
             })
             .unwrap_or_default();
 
@@ -2049,6 +2056,72 @@ mod tests {
         assert_eq!(response.model, "google/gemini-2.5-flash");
         assert_eq!(response.choices.len(), 1);
         assert_eq!(response.choices[0].finish_reason, Some("stop".to_string()));
+    }
+
+    #[test]
+    fn test_completion_response_maps_cache_token_accounting() {
+        let json = json!({
+            "id": "gen-cache-test",
+            "object": "chat.completion",
+            "created": 1,
+            "model": "anthropic/claude-3.5-sonnet",
+            "choices": [{
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": "Hi"
+                }
+            }],
+            "usage": {
+                "prompt_tokens": 500,
+                "completion_tokens": 10,
+                "total_tokens": 510,
+                "prompt_tokens_details": {
+                    "cached_tokens": 400,
+                    "cache_write_tokens": 50
+                }
+            }
+        });
+
+        let response: CompletionResponse = serde_json::from_value(json).unwrap();
+        let converted: completion::CompletionResponse<CompletionResponse> =
+            response.try_into().unwrap();
+
+        assert_eq!(converted.usage.input_tokens, 500);
+        assert_eq!(converted.usage.output_tokens, 10);
+        assert_eq!(converted.usage.cached_input_tokens, 400);
+        assert_eq!(converted.usage.cache_creation_input_tokens, 50);
+    }
+
+    #[test]
+    fn test_completion_response_cache_tokens_absent_defaults_to_zero() {
+        let json = json!({
+            "id": "gen-no-cache",
+            "object": "chat.completion",
+            "created": 1,
+            "model": "openai/gpt-4o",
+            "choices": [{
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": "Hi"
+                }
+            }],
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 10,
+                "total_tokens": 110
+            }
+        });
+
+        let response: CompletionResponse = serde_json::from_value(json).unwrap();
+        let converted: completion::CompletionResponse<CompletionResponse> =
+            response.try_into().unwrap();
+
+        assert_eq!(converted.usage.cached_input_tokens, 0);
+        assert_eq!(converted.usage.cache_creation_input_tokens, 0);
     }
 
     #[test]

--- a/crates/rig-core/src/providers/openrouter/streaming.rs
+++ b/crates/rig-core/src/providers/openrouter/streaming.rs
@@ -79,16 +79,42 @@ pub struct Usage {
     pub prompt_tokens: u32,
     pub completion_tokens: u32,
     pub total_tokens: u32,
+    /// OpenAI-compatible prompt-token details, returned by OpenRouter when a
+    /// provider reports cache activity (Anthropic with cache_control, OpenAI
+    /// with server-side automatic caching).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_tokens_details: Option<PromptTokensDetails>,
+}
+
+/// Prompt-token breakdown reported by OpenRouter for cached streaming requests.
+// `u32` matches the parent `Usage` struct in this module; the non-streaming counterpart
+// in `client.rs` uses `usize` to match its own parent.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct PromptTokensDetails {
+    /// Tokens served from cache (cache hit).
+    #[serde(default)]
+    pub cached_tokens: u32,
+    /// Tokens written to cache on this call (cache miss that populated the cache).
+    #[serde(default)]
+    pub cache_write_tokens: u32,
 }
 
 impl GetTokenUsage for Usage {
     fn token_usage(&self) -> Option<crate::completion::Usage> {
-        Some(crate::providers::internal::completion_usage(
-            self.prompt_tokens as u64,
-            self.completion_tokens as u64,
-            self.total_tokens as u64,
-            0,
-        ))
+        let (cached_input, cache_creation) = self
+            .prompt_tokens_details
+            .as_ref()
+            .map(|d| (d.cached_tokens as u64, d.cache_write_tokens as u64))
+            .unwrap_or((0, 0));
+        Some(crate::completion::Usage {
+            input_tokens: self.prompt_tokens as u64,
+            output_tokens: self.completion_tokens as u64,
+            total_tokens: self.total_tokens as u64,
+            cached_input_tokens: cached_input,
+            cache_creation_input_tokens: cache_creation,
+            tool_use_prompt_tokens: 0,
+            reasoning_tokens: 0,
+        })
     }
 }
 
@@ -370,6 +396,62 @@ mod tests {
         assert_eq!(usage.prompt_tokens, 100);
         assert_eq!(usage.completion_tokens, 50);
         assert_eq!(usage.total_tokens, 150);
+    }
+
+    #[test]
+    fn test_streaming_usage_maps_cache_token_accounting() {
+        use crate::completion::GetTokenUsage;
+
+        let json = json!({
+            "id": "gen-stream-cache",
+            "choices": [],
+            "created": 1u64,
+            "model": "anthropic/claude-3.5-sonnet",
+            "object": "chat.completion.chunk",
+            "usage": {
+                "prompt_tokens": 500,
+                "completion_tokens": 20,
+                "total_tokens": 520,
+                "prompt_tokens_details": {
+                    "cached_tokens": 400,
+                    "cache_write_tokens": 60
+                }
+            }
+        });
+
+        let chunk: StreamingCompletionChunk = serde_json::from_value(json).unwrap();
+        let usage = chunk.usage.unwrap();
+        let token_usage = usage.token_usage().unwrap();
+
+        assert_eq!(token_usage.input_tokens, 500);
+        assert_eq!(token_usage.output_tokens, 20);
+        assert_eq!(token_usage.cached_input_tokens, 400);
+        assert_eq!(token_usage.cache_creation_input_tokens, 60);
+    }
+
+    #[test]
+    fn test_streaming_usage_cache_tokens_absent_defaults_to_zero() {
+        use crate::completion::GetTokenUsage;
+
+        let json = json!({
+            "id": "gen-stream-no-cache",
+            "choices": [],
+            "created": 1u64,
+            "model": "openai/gpt-4o",
+            "object": "chat.completion.chunk",
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 10,
+                "total_tokens": 110
+            }
+        });
+
+        let chunk: StreamingCompletionChunk = serde_json::from_value(json).unwrap();
+        let usage = chunk.usage.unwrap();
+        let token_usage = usage.token_usage().unwrap();
+
+        assert_eq!(token_usage.cached_input_tokens, 0);
+        assert_eq!(token_usage.cache_creation_input_tokens, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

OpenRouter reports prompt-caching activity via `prompt_tokens_details` on the usage payload (both non-streaming and streaming). These fields were previously discarded — `cached_input_tokens` and `cache_creation_input_tokens` were hardcoded to `0` in the returned `completion::Usage`.

## Changes

- **`client.rs`** — adds `PromptTokensDetails` struct; updates `GetTokenUsage::token_usage()` to map `cached_tokens` → `cached_input_tokens` and `cache_write_tokens` → `cache_creation_input_tokens`.
- **`streaming.rs`** — same additions for the streaming `Usage` path.
- **`completion.rs`** — updates the inline `completion::Usage` construction in `TryFrom<CompletionResponse>` to pull from `prompt_tokens_details` rather than hardcoding zeros.
- Four tests covering populated and absent `prompt_tokens_details` for both the non-streaming and streaming paths.

The two `PromptTokensDetails` structs use `usize` and `u32` respectively to match their parent `Usage` struct types in each module.

## AI Assistance

This implementation was developed with significant AI assistance (Claude). The design and tests were reviewed and validated by the author before submission.

## Issue

Fixes #1807