### PR TITLE
feat(openrouter): add prompt-caching support for Anthropic models

### DIFF
--- a/crates/rig-core/src/providers/openrouter/completion.rs
+++ b/crates/rig-core/src/providers/openrouter/completion.rs
@@ -1603,6 +1603,63 @@ pub enum ToolChoiceFunctionKind {
     Function { name: String },
 }
 
+/// Apply Anthropic-style prompt-caching markers to an already-serialized
+/// OpenRouter request body (automatic mode).
+///
+/// Finds the first system message in `messages` and converts its `content`
+/// to a structured text block with `cache_control: {"type": "ephemeral"}`.
+/// This tells Anthropic (via OpenRouter) to cache the system prompt so
+/// subsequent turns that share the same prefix are billed at the cache-hit rate.
+///
+/// Non-Anthropic models routed through OpenRouter typically ignore the
+/// `cache_control` field, so enabling this is safe regardless of the model.
+pub(super) fn apply_prompt_caching(body: &mut serde_json::Value) {
+    let Some(obj) = body.as_object_mut() else {
+        return;
+    };
+    let Some(messages) = obj.get_mut("messages").and_then(|v| v.as_array_mut()) else {
+        return;
+    };
+
+    let Some(system_msg) = messages
+        .iter_mut()
+        .find(|m| m.get("role").and_then(|v| v.as_str()) == Some("system"))
+    else {
+        return;
+    };
+
+    match system_msg.get("content").cloned() {
+        Some(serde_json::Value::String(s)) => {
+            if let Some(obj) = system_msg.as_object_mut() {
+                obj.insert(
+                    "content".to_string(),
+                    serde_json::json!([{
+                        "type": "text",
+                        "text": s,
+                        "cache_control": { "type": "ephemeral" }
+                    }]),
+                );
+            }
+        }
+        Some(serde_json::Value::Array(mut arr)) => {
+            // Mark the last block as the cache boundary; all other blocks (including
+            // non-text blocks such as images) are preserved unchanged.
+            if let Some(last) = arr.last_mut()
+                && let Some(obj) = last.as_object_mut()
+            {
+                obj.insert(
+                    "cache_control".to_string(),
+                    serde_json::json!({ "type": "ephemeral" }),
+                );
+            }
+            if let Some(obj) = system_msg.as_object_mut() {
+                obj.insert("content".to_string(), serde_json::Value::Array(arr));
+            }
+        }
+        _ => {}
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub(super) struct OpenrouterCompletionRequest {
     model: String,
@@ -1730,6 +1787,13 @@ pub struct CompletionModel<T = reqwest::Client> {
     /// Enable strict mode for tool schemas.
     /// When enabled, tool schemas are sanitized to meet OpenAI's strict mode requirements.
     pub strict_tools: bool,
+    /// Enable Anthropic-style prompt caching via OpenRouter.
+    ///
+    /// When true, the outgoing JSON body is post-processed to attach
+    /// `cache_control: {"type": "ephemeral"}` to the system prompt, so
+    /// Anthropic (routed through OpenRouter) caches it at ~10% of the
+    /// normal input-token cost. Non-Anthropic backends ignore the field.
+    pub prompt_caching: bool,
 }
 
 impl<T> CompletionModel<T> {
@@ -1738,7 +1802,20 @@ impl<T> CompletionModel<T> {
             client,
             model: model.into(),
             strict_tools: false,
+            prompt_caching: false,
         }
+    }
+
+    /// Enable Anthropic-style prompt caching for Anthropic models routed
+    /// through OpenRouter.
+    ///
+    /// Adds `cache_control: {"type": "ephemeral"}` to the system-prompt
+    /// block so subsequent turns that share the same system prefix are billed
+    /// at the cache-hit rate. Non-Anthropic backends typically ignore the
+    /// field, so this is safe to enable regardless of the model.
+    pub fn with_prompt_caching(mut self) -> Self {
+        self.prompt_caching = true;
+        self
     }
 
     /// Enable strict mode for tool schemas.
@@ -1809,7 +1886,13 @@ where
             tracing::Span::current()
         };
 
-        let body = serde_json::to_vec(&request)?;
+        let body = if self.prompt_caching {
+            let mut v = serde_json::to_value(&request)?;
+            apply_prompt_caching(&mut v);
+            serde_json::to_vec(&v)?
+        } else {
+            serde_json::to_vec(&request)?
+        };
 
         let req = self
             .client
@@ -3483,5 +3566,102 @@ mod tests {
             }
             _ => panic!("Expected VideoUrl variant"),
         }
+    }
+
+    #[test]
+    fn test_apply_prompt_caching_string_system_message() {
+        let mut body = json!({
+            "model": "anthropic/claude-3.5-sonnet",
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "Hello"}
+            ]
+        });
+
+        apply_prompt_caching(&mut body);
+
+        let system_content = &body["messages"][0]["content"];
+        assert!(
+            system_content.is_array(),
+            "system content should be an array after caching"
+        );
+        let block = &system_content[0];
+        assert_eq!(block["type"], "text");
+        assert_eq!(block["text"], "You are a helpful assistant.");
+        assert_eq!(block["cache_control"]["type"], "ephemeral");
+
+        // User message should be unchanged.
+        assert_eq!(body["messages"][1]["content"], "Hello");
+    }
+
+    #[test]
+    fn test_apply_prompt_caching_array_system_message_marks_last_block() {
+        let mut body = json!({
+            "model": "anthropic/claude-3.5-sonnet",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": [
+                        {"type": "text", "text": "Part 1. "},
+                        {"type": "text", "text": "Part 2."}
+                    ]
+                }
+            ]
+        });
+
+        apply_prompt_caching(&mut body);
+
+        let system_content = &body["messages"][0]["content"];
+        assert!(system_content.is_array());
+        // Both blocks are preserved; only the last one gets cache_control.
+        assert_eq!(system_content.as_array().unwrap().len(), 2);
+        assert_eq!(system_content[0]["text"], "Part 1. ");
+        assert!(system_content[0].get("cache_control").is_none());
+        assert_eq!(system_content[1]["text"], "Part 2.");
+        assert_eq!(system_content[1]["cache_control"]["type"], "ephemeral");
+    }
+
+    #[test]
+    fn test_apply_prompt_caching_preserves_non_text_blocks() {
+        let mut body = json!({
+            "model": "anthropic/claude-3.5-sonnet",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": [
+                        {"type": "image", "source": {"type": "url", "url": "https://example.com/img.png"}},
+                        {"type": "text", "text": "Describe the image."}
+                    ]
+                }
+            ]
+        });
+
+        apply_prompt_caching(&mut body);
+
+        let system_content = &body["messages"][0]["content"];
+        assert_eq!(system_content.as_array().unwrap().len(), 2);
+        // Non-text block is preserved unchanged.
+        assert_eq!(system_content[0]["type"], "image");
+        assert!(system_content[0].get("cache_control").is_none());
+        // Text block (last) receives the cache boundary.
+        assert_eq!(system_content[1]["type"], "text");
+        assert_eq!(system_content[1]["cache_control"]["type"], "ephemeral");
+    }
+
+    #[test]
+    fn test_apply_prompt_caching_no_system_message_is_noop() {
+        let mut body = json!({
+            "model": "openai/gpt-4o",
+            "messages": [
+                {"role": "user", "content": "Hello"}
+            ]
+        });
+
+        let body_before = body.clone();
+        apply_prompt_caching(&mut body);
+        assert_eq!(
+            body, body_before,
+            "body should be unchanged when no system message exists"
+        );
     }
 }

--- a/crates/rig-core/src/providers/openrouter/streaming.rs
+++ b/crates/rig-core/src/providers/openrouter/streaming.rs
@@ -148,7 +148,13 @@ where
 
         request.additional_params = Some(params);
 
-        let body = serde_json::to_vec(&request)?;
+        let body = if self.prompt_caching {
+            let mut v = serde_json::to_value(&request)?;
+            super::completion::apply_prompt_caching(&mut v);
+            serde_json::to_vec(&v)?
+        } else {
+            serde_json::to_vec(&request)?
+        };
 
         let req = self
             .client


### PR DESCRIPTION
## Summary

Adds opt-in Anthropic-style prompt caching for Anthropic models routed through OpenRouter. When enabled, the outgoing request body is post-processed to attach `cache_control: {"type": "ephemeral"}` to the system prompt so Anthropic caches the prefix at ~10% of the normal input-token cost. Non-Anthropic backends ignore the field gracefully.

## Changes

- **`apply_prompt_caching(body: &mut Value)`** — post-processes the serialized request body: string system content is converted to a structured text block with `cache_control`; array content has `cache_control` added to the last block (non-text blocks such as images are preserved unchanged).
- **`CompletionModel`** gains `prompt_caching: bool` and `with_prompt_caching()` builder.
- Wired into both the non-streaming `completion()` path (`completion.rs`) and the streaming `stream()` path (`streaming.rs`).
- Four tests: string system message, array system message (last-block only), non-text block preservation, and no-system-message no-op.

## AI Assistance

This implementation was developed with significant AI assistance (Claude). The design and tests were reviewed and validated by the author before submission.

## Issue

Fixes #1809