### PR TITLE
feat(anthropic): add cache_control field to ToolDefinition

### DIFF
--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -150,6 +150,11 @@ pub struct ToolDefinition {
     pub name: String,
     pub description: Option<String>,
     pub input_schema: serde_json::Value,
+    /// Cache breakpoint marker. Set on the last tool in the array to cache
+    /// the tools layer independently of the system prompt. Anthropic accepts
+    /// up to 4 `cache_control` markers per request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<CacheControl>,
 }
 
 /// TTL for a cache control breakpoint.
@@ -1883,6 +1888,7 @@ impl TryFrom<AnthropicRequestParams<'_>> for AnthropicCompletionRequest {
                 name: tool.name,
                 description: Some(tool.description),
                 input_schema: tool.parameters,
+                cache_control: None,
             })
             .map(serde_json::to_value)
             .collect::<Result<Vec<_>, _>>()?;

--- a/crates/rig-core/src/providers/anthropic/streaming.rs
+++ b/crates/rig-core/src/providers/anthropic/streaming.rs
@@ -279,6 +279,7 @@ where
                 name: tool.name,
                 description: Some(tool.description),
                 input_schema: tool.parameters,
+                cache_control: None,
             })
             .map(serde_json::to_value)
             .collect::<Result<Vec<_>, _>>()?;


### PR DESCRIPTION
## Summary

Anthropic supports caching the tools layer by setting `cache_control` on the last `ToolDefinition` in the array. `ToolDefinition` currently has no such field — this is the only cacheable layer not yet exposed in rig.

`SystemContent` and the message `Content` variants already have `cache_control`. This brings `ToolDefinition` in line with the same pattern.

## Changes

- Add `pub cache_control: Option<CacheControl>` to `ToolDefinition` with `#[serde(skip_serializing_if = "Option::is_none")]`.
- Initialize `cache_control: None` at the two `ToolDefinition` construction sites in the `TryFrom` impls (`completion.rs` and `streaming.rs`).

No behaviour change for existing callers — the field defaults to `None` and is omitted from serialization when unset.

## AI Assistance

This implementation was developed with significant AI assistance (Claude). The change and rationale were reviewed and validated by the author before submission.

## Issue

Fixes #1811