### PR TITLE
Add ToolCallHookAction::Replace for mutating tool arguments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,7 @@ When modifying hook behavior, preserve the intended control flow:
 - `ToolCallHookAction::Continue`
 - `ToolCallHookAction::Skip`
 - `ToolCallHookAction::Terminate`
+- `ToolCallHookAction::Replace`
 
 Check both streaming and non-streaming paths.
 

--- a/crates/rig-core/src/agent/prompt_request/hooks.rs
+++ b/crates/rig-core/src/agent/prompt_request/hooks.rs
@@ -8,6 +8,8 @@ use crate::{
     wasm_compat::{WasmCompatSend, WasmCompatSync},
 };
 
+use serde_json::Value;
+
 /// Trait for per-request hooks to observe tool call events.
 pub trait PromptHook<M>: Clone + WasmCompatSend + WasmCompatSync
 where
@@ -100,6 +102,8 @@ pub enum ToolCallHookAction {
     Skip { reason: String },
     /// Terminate agent loop early
     Terminate { reason: String },
+    /// Replace the tool call arguments and continue tool execution.
+    Replace { args: Value },
 }
 
 impl ToolCallHookAction {
@@ -120,6 +124,11 @@ impl ToolCallHookAction {
         Self::Terminate {
             reason: reason.into(),
         }
+    }
+
+    /// Replace the tool call arguments and continue execution.
+    pub fn replace(args: Value) -> Self {
+        Self::Replace { args }
     }
 }
 

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -690,7 +690,7 @@ where
                     async move {
                         if let AssistantContent::ToolCall(tool_call) = choice {
                             let tool_name = &tool_call.function.name;
-                            let args =
+                            let mut args =
                                 json_utils::value_to_json_string(&tool_call.function.arguments);
                             let internal_call_id = nanoid::nanoid!();
                             let tool_span = tracing::Span::current();
@@ -707,31 +707,49 @@ where
                                     )
                                     .await;
 
-                                if let ToolCallHookAction::Terminate { reason } = action {
-                                    return Err(PromptError::prompt_cancelled(
-                                        cloned_history_for_error,
-                                        reason,
-                                    ));
-                                }
+                                match action {
+                                    ToolCallHookAction::Continue => {}
 
-                                if let ToolCallHookAction::Skip { reason } = action {
-                                    // Tool execution rejected, return rejection message as tool result
-                                    tracing::info!(
-                                        tool_name = tool_name,
-                                        reason = reason,
-                                        "Tool call rejected"
-                                    );
-                                    if let Some(call_id) = tool_call.call_id.clone() {
-                                        return Ok(UserContent::tool_result_with_call_id(
-                                            tool_call.id.clone(),
-                                            call_id,
-                                            OneOrMany::one(reason.into()),
+                                    ToolCallHookAction::Replace {
+                                        args: replacement_args,
+                                    } => {
+                                        args = json_utils::value_to_json_string(&replacement_args);
+
+                                        tool_span.record("gen_ai.tool.call.arguments", &args);
+
+                                        tracing::info!(
+                                            tool_name = tool_name,
+                                            args = args,
+                                            "Tool call arguments replaced"
+                                        );
+                                    }
+
+                                    ToolCallHookAction::Terminate { reason } => {
+                                        return Err(PromptError::prompt_cancelled(
+                                            cloned_history_for_error,
+                                            reason,
                                         ));
-                                    } else {
-                                        return Ok(UserContent::tool_result(
-                                            tool_call.id.clone(),
-                                            OneOrMany::one(reason.into()),
-                                        ));
+                                    }
+
+                                    ToolCallHookAction::Skip { reason } => {
+                                        tracing::info!(
+                                            tool_name = tool_name,
+                                            reason = reason,
+                                            "Tool call rejected"
+                                        );
+
+                                        if let Some(call_id) = tool_call.call_id.clone() {
+                                            return Ok(UserContent::tool_result_with_call_id(
+                                                tool_call.id.clone(),
+                                                call_id,
+                                                OneOrMany::one(reason.into()),
+                                            ));
+                                        } else {
+                                            return Ok(UserContent::tool_result(
+                                                tool_call.id.clone(),
+                                                OneOrMany::one(reason.into()),
+                                            ));
+                                        }
                                     }
                                 }
                             }

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -679,44 +679,60 @@ where
                             let tc_result = async {
                                 let tool_span = tracing::Span::current();
                                 let mut tool_args = json_utils::value_to_json_string(&tool_call.function.arguments);
+
                                 if let Some(ref hook) = self.hook {
                                     let action = hook
-                                        .on_tool_call(&tool_call.function.name, tool_call.call_id.clone(), &internal_call_id, &tool_args)
+                                        .on_tool_call(
+                                            &tool_call.function.name,
+                                            tool_call.call_id.clone(),
+                                            &internal_call_id,
+                                            &tool_args,
+                                        )
                                         .await;
 
-                                    match action{
+                                    match action {
                                         ToolCallHookAction::Continue => {}
 
-                                        ToolCallHookAction::Replace {args: replacement_args} =>{
+                                        ToolCallHookAction::Replace { args: replacement_args } => {
                                             tool_args = json_utils::value_to_json_string(&replacement_args);
 
-                                            tracing::error!(
+                                            tracing::info!(
                                                 tool_name = tool_call.function.name.as_str(),
                                                 args = tool_args,
-                                                "Tool call argsuments replaced"
+                                                "Tool call arguments replaced"
                                             );
                                         }
 
                                         ToolCallHookAction::Terminate { reason } => {
-                                            return Err(cancelled_prompt_error(chat_history.as_deref(), new_messages.clone(), reason).await);
+                                            return Err(cancelled_prompt_error(
+                                                chat_history.as_deref(),
+                                                new_messages.clone(),
+                                                reason,
+                                            )
+                                            .await);
                                         }
-                                        
+
                                         ToolCallHookAction::Skip { reason } => {
-                                            // Tool execution rejected, return rejection message as tool result
                                             tracing::info!(
                                                 tool_name = tool_call.function.name.as_str(),
                                                 reason = reason,
                                                 "Tool call rejected"
                                             );
+
                                             let tool_call_msg = AssistantContent::ToolCall(tool_call.clone());
                                             tool_calls.push(tool_call_msg);
-                                            tool_results.push((tool_call.id.clone(), tool_call.call_id.clone(), reason.clone()));
+                                            tool_results.push((
+                                                tool_call.id.clone(),
+                                                tool_call.call_id.clone(),
+                                                reason.clone(),
+                                            ));
                                             saw_tool_call_this_turn = true;
+
                                             return Ok(reason);
                                         }
                                     }
                                 }
-                                    
+
                                 tool_span.record("gen_ai.tool.name", &tool_call.function.name);
                                 tool_span.record("gen_ai.tool.call.arguments", &tool_args);
 

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -678,31 +678,45 @@ where
 
                             let tc_result = async {
                                 let tool_span = tracing::Span::current();
-                                let tool_args = json_utils::value_to_json_string(&tool_call.function.arguments);
+                                let mut tool_args = json_utils::value_to_json_string(&tool_call.function.arguments);
                                 if let Some(ref hook) = self.hook {
                                     let action = hook
                                         .on_tool_call(&tool_call.function.name, tool_call.call_id.clone(), &internal_call_id, &tool_args)
                                         .await;
 
-                                    if let ToolCallHookAction::Terminate { reason } = action {
-                                        return Err(cancelled_prompt_error(chat_history.as_deref(), new_messages.clone(), reason).await);
-                                    }
+                                    match action{
+                                        ToolCallHookAction::Continue => {}
 
-                                    if let ToolCallHookAction::Skip { reason } = action {
-                                        // Tool execution rejected, return rejection message as tool result
-                                        tracing::info!(
-                                            tool_name = tool_call.function.name.as_str(),
-                                            reason = reason,
-                                            "Tool call rejected"
-                                        );
-                                        let tool_call_msg = AssistantContent::ToolCall(tool_call.clone());
-                                        tool_calls.push(tool_call_msg);
-                                        tool_results.push((tool_call.id.clone(), tool_call.call_id.clone(), reason.clone()));
-                                        saw_tool_call_this_turn = true;
-                                        return Ok(reason);
+                                        ToolCallHookAction::Replace {args: replacement_args} =>{
+                                            tool_args = json_utils::value_to_json_string(&replacement_args);
+
+                                            tracing::error!(
+                                                tool_name = tool_call.function.name.as_str(),
+                                                args = tool_args,
+                                                "Tool call argsuments replaced"
+                                            );
+                                        }
+
+                                        ToolCallHookAction::Terminate { reason } => {
+                                            return Err(cancelled_prompt_error(chat_history.as_deref(), new_messages.clone(), reason).await);
+                                        }
+                                        
+                                        ToolCallHookAction::Skip { reason } => {
+                                            // Tool execution rejected, return rejection message as tool result
+                                            tracing::info!(
+                                                tool_name = tool_call.function.name.as_str(),
+                                                reason = reason,
+                                                "Tool call rejected"
+                                            );
+                                            let tool_call_msg = AssistantContent::ToolCall(tool_call.clone());
+                                            tool_calls.push(tool_call_msg);
+                                            tool_results.push((tool_call.id.clone(), tool_call.call_id.clone(), reason.clone()));
+                                            saw_tool_call_this_turn = true;
+                                            return Ok(reason);
+                                        }
                                     }
                                 }
-
+                                    
                                 tool_span.record("gen_ai.tool.name", &tool_call.function.name);
                                 tool_span.record("gen_ai.tool.call.arguments", &tool_args);
 


### PR DESCRIPTION
## Summary

This PR adds `ToolCallHookAction::Replace { args }`, allowing prompt hooks to modify tool-call arguments before the tool is executed.

This is useful for guardrails, DLP, policy checks, argument normalization, and cases where middleware needs to sanitize or adjust tool inputs instead of only allowing, skipping, or terminating the call.

## Changes

- Added `ToolCallHookAction::Replace { args: serde_json::Value }`
- Added a `ToolCallHookAction::replace(args)` helper
- Updated normal tool execution to use replaced arguments before calling the tool
- Updated streaming tool execution to use replaced arguments before calling the tool
- Passed the final tool arguments into `on_tool_result`

## Testing

Ran:

```bash
cargo fmt
cargo check
cargo test
```

Fixes #1744