### PR TITLE
fix(openai): tolerate object-form tool-call `arguments` in streaming

### DIFF
--- a/crates/rig-core/src/json_utils.rs
+++ b/crates/rig-core/src/json_utils.rs
@@ -35,6 +35,28 @@ pub fn value_to_json_string(value: &serde_json::Value) -> String {
     }
 }
 
+/// Deserialize a field that may arrive as either a JSON-encoded string or any other
+/// JSON value, into `Option<String>`.
+///
+/// - A string is taken verbatim.
+/// - Any other JSON value is re-serialized to its compact JSON-string form (via
+///   [`value_to_json_string`]). Object key order is not preserved, which is fine
+///   because callers re-parse the string.
+/// - `null` or a missing field becomes `None`.
+///
+/// Tolerates OpenAI-compatible gateways that stream `tool_calls[].function.arguments`
+/// as an object (e.g. `{}`) instead of the spec-mandated JSON string (`"{}"`).
+pub fn deserialize_json_string_or_value<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(match value {
+        None | Some(serde_json::Value::Null) => None,
+        Some(v) => Some(value_to_json_string(&v)),
+    })
+}
+
 /// Parse tool arguments from a streamed string payload.
 /// Some providers emit an empty string for parameterless tool calls; normalize that to `{}`.
 pub fn parse_tool_arguments(arguments: &str) -> serde_json::Result<serde_json::Value> {
@@ -205,6 +227,65 @@ mod tests {
     struct DummyMaybeStringified {
         #[serde(deserialize_with = "stringified_json::deserialize_maybe_stringified")]
         data: serde_json::Value,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct ArgWrapper {
+        #[serde(default, deserialize_with = "deserialize_json_string_or_value")]
+        arguments: Option<String>,
+    }
+
+    /// Spec-compliant case: `arguments` is already a JSON-encoded string, taken verbatim.
+    #[test]
+    fn json_string_or_value_string_passthrough() {
+        let w: ArgWrapper = serde_json::from_str(r#"{"arguments":"{\"a\":1}"}"#).unwrap();
+        assert_eq!(w.arguments.as_deref(), Some(r#"{"a":1}"#));
+    }
+
+    /// Non-compliant gateway: an empty object `{}` must serialize to the string `"{}"`,
+    /// not be treated as absent (None).
+    #[test]
+    fn json_string_or_value_empty_object() {
+        let w: ArgWrapper = serde_json::from_str(r#"{"arguments":{}}"#).unwrap();
+        assert_eq!(w.arguments.as_deref(), Some("{}"));
+    }
+
+    /// Non-compliant gateway: a nested object is re-serialized to a string.
+    #[test]
+    fn json_string_or_value_nested_object() {
+        let w: ArgWrapper =
+            serde_json::from_str(r#"{"arguments":{"path":"/tmp","depth":2}}"#).unwrap();
+        // `arguments` is re-serialized from a Value; object key order is not guaranteed
+        // (depends on serde_json's `preserve_order` feature), so re-parse and compare
+        // values rather than the raw string.
+        let parsed: serde_json::Value =
+            serde_json::from_str(w.arguments.as_deref().unwrap()).unwrap();
+        assert_eq!(parsed["path"], "/tmp");
+        assert_eq!(parsed["depth"], 2);
+    }
+
+    /// Non-compliant gateway: an array is also "any other JSON value" and serializes to a
+    /// string. Array order is meaningful and preserved by serde_json, so compare the string
+    /// directly.
+    #[test]
+    fn json_string_or_value_array() {
+        let w: ArgWrapper = serde_json::from_str(r#"{"arguments":[1,2,3]}"#).unwrap();
+        assert_eq!(w.arguments.as_deref(), Some("[1,2,3]"));
+    }
+
+    /// Regression test: JSON null must collapse to None (not the string "null").
+    /// Removing `.filter(|v| !v.is_null())` from the deserializer would fail this test.
+    #[test]
+    fn json_string_or_value_null_is_none() {
+        let w: ArgWrapper = serde_json::from_str(r#"{"arguments":null}"#).unwrap();
+        assert!(w.arguments.is_none());
+    }
+
+    /// A missing field is likewise None (relies on `#[serde(default)]`).
+    #[test]
+    fn json_string_or_value_missing_is_none() {
+        let w: ArgWrapper = serde_json::from_str(r#"{}"#).unwrap();
+        assert!(w.arguments.is_none());
     }
 
     #[test]

--- a/crates/rig-core/src/providers/openai/completion/streaming.rs
+++ b/crates/rig-core/src/providers/openai/completion/streaming.rs
@@ -19,7 +19,31 @@ use crate::streaming;
 #[derive(Default, Deserialize, Debug)]
 pub(crate) struct StreamingFunction {
     pub(crate) name: Option<String>,
+    #[serde(default, deserialize_with = "de_tool_call_arguments")]
     pub(crate) arguments: Option<String>,
+}
+
+/// Deserialize `tool_calls[].function.arguments`, tolerating providers that send
+/// a JSON object/array instead of the spec-mandated JSON-encoded string.
+///
+/// The OpenAI Chat Completions spec defines `arguments` as a string (e.g.
+/// `"{\"city\":\"Paris\"}"`), and that is the only form rig produced before. Some
+/// OpenAI-compatible gateways instead emit a raw object (`"arguments": {}`), which
+/// previously failed deserialization with "invalid type: map, expected a string",
+/// causing the whole SSE chunk (and thus the tool call) to be silently dropped.
+///
+/// We now accept either: a string is taken verbatim; any other JSON value is
+/// re-serialized to its compact JSON-string form.
+fn de_tool_call_arguments<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    Ok(match value {
+        None | Some(serde_json::Value::Null) => None,
+        Some(serde_json::Value::String(s)) => Some(s),
+        Some(other) => Some(other.to_string()),
+    })
 }
 
 #[derive(Deserialize, Debug)]
@@ -235,6 +259,32 @@ mod tests {
             function.arguments.as_ref().unwrap(),
             r#"{"location":"Paris"}"#
         );
+    }
+
+    #[test]
+    fn test_streaming_function_object_arguments() {
+        // Some OpenAI-compatible gateways send `arguments` as a JSON object
+        // instead of the spec-mandated JSON-encoded string. Accept it by
+        // re-serializing to the string form rather than dropping the chunk.
+        let json = r#"{"name": "list_dir", "arguments": {}}"#;
+        let function: StreamingFunction = serde_json::from_str(json).unwrap();
+        assert_eq!(function.name, Some("list_dir".to_string()));
+        assert_eq!(function.arguments.as_ref().unwrap(), "{}");
+
+        let json = r#"{"name": "get_weather", "arguments": {"city": "London"}}"#;
+        let function: StreamingFunction = serde_json::from_str(json).unwrap();
+        assert_eq!(function.arguments.as_ref().unwrap(), r#"{"city":"London"}"#);
+    }
+
+    #[test]
+    fn test_streaming_function_null_arguments() {
+        let json = r#"{"name": "list_dir", "arguments": null}"#;
+        let function: StreamingFunction = serde_json::from_str(json).unwrap();
+        assert!(function.arguments.is_none());
+
+        let json = r#"{"name": "list_dir"}"#;
+        let function: StreamingFunction = serde_json::from_str(json).unwrap();
+        assert!(function.arguments.is_none());
     }
 
     #[test]

--- a/crates/rig-core/src/providers/openai/completion/streaming.rs
+++ b/crates/rig-core/src/providers/openai/completion/streaming.rs
@@ -19,31 +19,11 @@ use crate::streaming;
 #[derive(Default, Deserialize, Debug)]
 pub(crate) struct StreamingFunction {
     pub(crate) name: Option<String>,
-    #[serde(default, deserialize_with = "de_tool_call_arguments")]
+    #[serde(
+        default,
+        deserialize_with = "crate::json_utils::deserialize_json_string_or_value"
+    )]
     pub(crate) arguments: Option<String>,
-}
-
-/// Deserialize `tool_calls[].function.arguments`, tolerating providers that send
-/// a JSON object/array instead of the spec-mandated JSON-encoded string.
-///
-/// The OpenAI Chat Completions spec defines `arguments` as a string (e.g.
-/// `"{\"city\":\"Paris\"}"`), and that is the only form rig produced before. Some
-/// OpenAI-compatible gateways instead emit a raw object (`"arguments": {}`), which
-/// previously failed deserialization with "invalid type: map, expected a string",
-/// causing the whole SSE chunk (and thus the tool call) to be silently dropped.
-///
-/// We now accept either: a string is taken verbatim; any other JSON value is
-/// re-serialized to its compact JSON-string form.
-fn de_tool_call_arguments<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
-    Ok(match value {
-        None | Some(serde_json::Value::Null) => None,
-        Some(serde_json::Value::String(s)) => Some(s),
-        Some(other) => Some(other.to_string()),
-    })
 }
 
 #[derive(Deserialize, Debug)]


### PR DESCRIPTION
Fixes #1829 

## Problem
Some OpenAI-compatible gateways stream `tool_calls[].function.arguments` as a JSON object (e.g. `"arguments": {}`) instead of the spec-mandated JSON-encoded string (`"arguments": "{}"`).

`StreamingFunction.arguments` is typed `Option<String>`, so serde fails with `invalid type: map, expected a string`. 
In `normalize_chunk` the parse error is only logged, and the whole SSE chunk is dropped (`Ok(None)`), so the tool call never surfaces, and the turn ends with empty assistant text, and then the caller sees a blank response, with no error unless `rig` debug logs are enabled.

Minimal reproducing chunk:
```json
{"choices":[{"index":0,"delta":{"role":"assistant","content":"","tool_calls":[{"index":0,"id":"call_x","type":"function","function":{"name":"list_dir","arguments":{}}}]},"finish_reason":null}],"usage":null}
```
## Fix
Deserialize `arguments` with a tolerant helper: a string is taken verbatim; any other JSON value is re-serialized to its compact JSON-string form. `null`/missing stays `None`. 
Fully backward compatible with the spec-compliant string form.

Moves the tolerant deserializer into a shared `json_utils::deserialize_json_string_or_value` (built on the existing `value_to_json_string`) and applies it to `StreamingFunction.arguments` via `#[serde(deserialize_with = …)]`, so other providers can reuse it. 
Adds unit tests in `json_utils` covering string / object / nested / null / missing.

## Tests
Adds `test_streaming_function_object_arguments` (empty + nested object) and `test_streaming_function_null_arguments` (null / missing). 
All existing streaming tests still pass.