### PR TITLE
fix(chatgpt): Handle ChatGPT response.completed events without output field

### DIFF
--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -1038,6 +1038,7 @@ pub struct CompletionResponse {
     /// Token usage
     pub usage: Option<ResponsesUsage>,
     /// The model output (messages, etc will go here)
+    #[serde(default)]
     pub output: Vec<Output>,
     /// Tools
     #[serde(default)]

--- a/tests/cassettes/chatgpt/streaming_tools/tool_call_completed_response_without_output.yaml
+++ b/tests/cassettes/chatgpt/streaming_tools/tool_call_completed_response_without_output.yaml
@@ -1,0 +1,35 @@
+when:
+  path: /backend-api/codex/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Call the ping tool with no arguments. Do not write any normal text before the tool call.","type":"input_text"}],"role":"user","type":"message"}],"instructions":"","model":"gpt-5.3-codex","store":false,"stream":true,"tool_choice":"required","tools":[{"description":"A zero-argument tool named ping.","name":"ping","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}]}'
+then:
+  status: 200
+  header: []
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"required","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"A zero-argument tool named ping.","name":"ping","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"required","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"A zero-argument tool named ping.","name":"ping","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"arguments":"","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"ping","status":"in_progress","type":"function_call"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"{}","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_1","output_index":0,"sequence_number":3,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.done
+    data: {"arguments":"{}","item_id":"fc_REDACTED_1","output_index":0,"sequence_number":4,"type":"response.function_call_arguments.done"}
+
+    event: response.output_item.done
+    data: {"item":{"arguments":"{}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"ping","status":"completed","type":"function_call"},"output_index":0,"sequence_number":5,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"default","status":"completed","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"required","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"A zero-argument tool named ping.","name":"ping","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":56,"input_tokens_details":{"cached_tokens":0},"output_tokens":14,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":70},"user":null},"sequence_number":6,"type":"response.completed"}
+

--- a/tests/chatgpt.rs
+++ b/tests/chatgpt.rs
@@ -6,6 +6,10 @@
     clippy::unreachable
 )]
 
+#[path = "common/cassette_safety.rs"]
+mod cassette_safety;
+#[path = "common/cassettes.rs"]
+mod cassettes;
 #[path = "common/reasoning.rs"]
 mod reasoning;
 #[path = "common/support.rs"]

--- a/tests/common/cassette_safety.rs
+++ b/tests/common/cassette_safety.rs
@@ -28,6 +28,11 @@ const PROVIDER_CASSETTE_SUITES: &[ProviderCassetteSuite] = &[
         ],
     },
     ProviderCassetteSuite {
+        provider: "chatgpt",
+        source_dir: "tests/providers/chatgpt/cassette",
+        wrapper_names: &["with_chatgpt_cassette"],
+    },
+    ProviderCassetteSuite {
         provider: "anthropic",
         source_dir: "tests/providers/anthropic/cassette",
         wrapper_names: &[

--- a/tests/common/cassettes.rs
+++ b/tests/common/cassettes.rs
@@ -105,6 +105,7 @@ impl CassettePolicy {
     fn for_scenario(provider: &str, scenario: &str, replay_matching: ReplayMatching) -> Self {
         let required_request_headers = match provider {
             "openai" => OPENAI_REQUIRED_REQUEST_HEADERS,
+            "chatgpt" => CHATGPT_REQUIRED_REQUEST_HEADERS,
             "anthropic" => ANTHROPIC_REQUIRED_REQUEST_HEADERS,
             "gemini" if scenario.starts_with("interactions_api/") => {
                 GEMINI_INTERACTIONS_REQUIRED_REQUEST_HEADERS
@@ -1348,6 +1349,7 @@ const FORBIDDEN_CASSETTE_PATTERNS: &[&str] = &[
 
 const NO_REQUIRED_REQUEST_HEADERS: &[&str] = &[];
 const OPENAI_REQUIRED_REQUEST_HEADERS: &[&str] = &["authorization"];
+const CHATGPT_REQUIRED_REQUEST_HEADERS: &[&str] = &["authorization"];
 const ANTHROPIC_REQUIRED_REQUEST_HEADERS: &[&str] = &["x-api-key"];
 const GEMINI_INTERACTIONS_REQUIRED_REQUEST_HEADERS: &[&str] = &["x-goog-api-key"];
 
@@ -1388,6 +1390,8 @@ const SENSITIVE_STRING_KEYS: &[&str] = &[
     "encrypted_content",
     "encryptedcontent",
     "obfuscation",
+    "prompt_cache_key",
+    "safety_identifier",
     "signature",
     "thoughtsignature",
 ];

--- a/tests/providers/chatgpt/cassette/streaming_tools.rs
+++ b/tests/providers/chatgpt/cassette/streaming_tools.rs
@@ -1,0 +1,54 @@
+//! ChatGPT cassette coverage for terminal responses that omit `output`.
+
+use futures::StreamExt;
+use rig::client::CompletionClient;
+use rig::completion::CompletionModel;
+use rig::message::ToolChoice;
+use rig::providers::chatgpt;
+use rig::streaming::StreamedAssistantContent;
+use serde_json::json;
+
+use super::super::support::with_chatgpt_cassette;
+use crate::support::zero_arg_tool_definition;
+
+#[tokio::test]
+async fn stream_tool_call_completed_response_without_output() {
+    with_chatgpt_cassette(
+        "streaming_tools/tool_call_completed_response_without_output",
+        |client| async move {
+            let model = client.completion_model(chatgpt::GPT_5_3_CODEX);
+            let request = model
+                .completion_request(
+                    "Call the ping tool with no arguments. Do not write any normal text before the tool call.",
+                )
+                .tool(zero_arg_tool_definition("ping"))
+                .tool_choice(ToolChoice::Required)
+                .build();
+
+            let mut stream = model.stream(request).await.expect("stream should start");
+            let mut saw_ping_tool_call = false;
+            let mut final_usage = None;
+
+            while let Some(chunk) = stream.next().await {
+                match chunk.expect("stream item should be ok") {
+                    StreamedAssistantContent::ToolCall { tool_call, .. } => {
+                        if tool_call.function.name == "ping" {
+                            assert_eq!(tool_call.function.arguments, json!({}));
+                            saw_ping_tool_call = true;
+                        }
+                    }
+                    StreamedAssistantContent::Final(response) => {
+                        final_usage = Some(response.usage);
+                    }
+                    _ => {}
+                }
+            }
+
+            assert!(saw_ping_tool_call, "stream should emit the ping tool call");
+            let usage = final_usage.expect("stream should emit terminal usage");
+            assert!(usage.input_tokens > 0, "usae should have input tokens");
+            assert!(usage.output_tokens > 0, "usae should have output tokens");
+        },
+    )
+    .await;
+}

--- a/tests/providers/chatgpt/mod.rs
+++ b/tests/providers/chatgpt/mod.rs
@@ -1,3 +1,9 @@
+mod support;
+
+mod cassette {
+    mod streaming_tools;
+}
+
 mod agent;
 mod auth;
 mod completion;

--- a/tests/providers/chatgpt/support.rs
+++ b/tests/providers/chatgpt/support.rs
@@ -1,0 +1,32 @@
+use rig::providers::chatgpt::{self, ChatGPTAuth};
+use std::future::Future;
+use std::panic::AssertUnwindSafe;
+
+use crate::cassettes::{CassetteSpec, ProviderCassette};
+use futures::FutureExt;
+
+async fn chatgpt_cassette(spec: impl Into<CassetteSpec>) -> (ProviderCassette, chatgpt::Client) {
+    let cassette =
+        ProviderCassette::start("chatgpt", spec, "https://chatgpt.com/backend-api/codex").await;
+    let client = chatgpt::Client::builder()
+        .api_key(ChatGPTAuth::AccessToken {
+            access_token: cassette.api_key("CHATGPT_ACCESS_TOKEN"),
+            account_id: Some(cassette.api_key("CHATGPT_ACCOUNT_ID")),
+        })
+        .base_url(cassette.base_url())
+        .default_instructions("")
+        .build()
+        .expect("client should build");
+
+    (cassette, client)
+}
+
+pub(super) async fn with_chatgpt_cassette<F, Fut>(spec: impl Into<CassetteSpec>, test_body: F)
+where
+    F: FnOnce(chatgpt::Client) -> Fut,
+    Fut: Future<Output = ()>,
+{
+    let (cassette, client) = chatgpt_cassette(spec).await;
+    let result = AssertUnwindSafe(test_body(client)).catch_unwind().await;
+    cassette.finish_after_test(result).await;
+}


### PR DESCRIPTION
Fixes https://github.com/0xPlaygrounds/rig/issues/1826

This fixes streaming response parsing when the ChatGPT/Codex backend emits a terminal response.completed event whose response object omits the `output` field.

The OpenAI Responses API models `output` as a list, and existing OpenAI Platform cassettes include it, often as [] or with final output items. However, ChatGPT/Codex can stream all output items through `response.output_item.*` events and then send a final `response.completed` containing usage/metadata but no `output` field. Without a serde default, deserializing that terminal event fails. In the streaming path this can cause the final response metadata/usage to be lost.

### Changes

First commit adds a ChatGPT cassette test demonstrating the bug. The test fails as follows because the accumulated usage appears to be 0, since it does not include the tokens from the silently-dropped `response.completed` event:

```
$ cargo test -p rig --test chatgpt stream_tool_call_completed_response_without_output -- --nocapture
thread 'chatgpt::cassette::streaming_tools::stream_tool_call_completed_response_without_output' panicked at tests/providers/chatgpt/cassette/streaming_tools.rs:49:13:
usage should have input tokens
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test chatgpt::cassette::streaming_tools::stream_tool_call_completed_response_without_output ... FAILED
```

The second commit fixes the issue with the one-line change in `crates/rig-core/src/providers/openai/responses_api/mod.rs`

### Cassette generation

The cassette was recorded against the ChatGPT/Codex backend with:

```bash
RIG_PROVIDER_TEST_MODE=record \
CHATGPT_ACCESS_TOKEN="..." \
CHATGPT_ACCOUNT_ID="..." \
cargo test -p rig --test chatgpt \
  stream_tool_call_completed_response_without_output \
  -- --nocapture --test-threads=1
```

This writes:

```text
tests/cassettes/chatgpt/streaming_tools/tool_call_completed_response_without_output.yaml
```

### Verification

```bash
cargo test -p rig --test chatgpt \
  stream_tool_call_completed_response_without_output \
  -- --nocapture

cargo test -p rig --test chatgpt \
  cassette_safety::cassettes_do_not_contain_obvious_secrets \
  -- --nocapture

cargo test -p rig --test chatgpt \
  cassette_safety::cassette_files_match_registered_scenarios \
  -- --nocapture
```
