### PR TITLE
Fix parsing of streamed function-call argument deltas

### DIFF
--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -1015,15 +1015,17 @@ where
                                         yield Ok(RawStreamingChoice::Message(delta.delta.clone()))
                                     }
                                     ItemChunkKind::FunctionCallArgsDelta(delta) => {
-                                        let internal_call_id = tool_call_internal_ids
-                                            .entry(delta.item_id.clone())
-                                            .or_insert_with(|| nanoid::nanoid!())
-                                            .clone();
-                                        yield Ok(RawStreamingChoice::ToolCallDelta {
-                                            id: delta.item_id.clone(),
-                                            internal_call_id,
-                                            content: streaming::ToolCallDeltaContent::Delta(delta.delta.clone())
-                                        })
+                                        if let Some(item_id) = chunk.item_id.as_ref() {
+                                            let internal_call_id = tool_call_internal_ids
+                                                .entry(item_id.clone())
+                                                .or_insert_with(|| nanoid::nanoid!())
+                                                .clone();
+                                            yield Ok(RawStreamingChoice::ToolCallDelta {
+                                                id: item_id.clone(),
+                                                internal_call_id,
+                                                content: streaming::ToolCallDeltaContent::Delta(delta.delta.clone())
+                                            })
+                                        }
                                     }
                                     _ => continue,
                                 }

--- a/crates/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -270,10 +270,16 @@ impl RawChoiceAccumulator {
 
     fn decode_item_chunk(
         &mut self,
-        item: ItemChunkKind,
+        chunk: ItemChunk,
         options: ResponsesStreamOptions,
     ) -> Vec<StreamingRawChoice> {
         let mut immediate = Vec::new();
+
+        let ItemChunk {
+            item_id: outer_item_id,
+            data: item,
+            ..
+        } = chunk;
 
         match item {
             ItemChunkKind::OutputItemAdded(StreamingItemDoneOutput {
@@ -311,16 +317,18 @@ impl RawChoiceAccumulator {
                 immediate.push(streaming::RawStreamingChoice::Message(delta.delta));
             }
             ItemChunkKind::FunctionCallArgsDelta(delta) => {
-                let internal_call_id = self
-                    .tool_call_internal_ids
-                    .entry(delta.item_id.clone())
-                    .or_insert_with(|| nanoid::nanoid!())
-                    .clone();
-                immediate.push(streaming::RawStreamingChoice::ToolCallDelta {
-                    id: delta.item_id,
-                    internal_call_id,
-                    content: streaming::ToolCallDeltaContent::Delta(delta.delta),
-                });
+                if let Some(item_id) = outer_item_id {
+                    let internal_call_id = self
+                        .tool_call_internal_ids
+                        .entry(item_id.clone())
+                        .or_insert_with(|| nanoid::nanoid!())
+                        .clone();
+                    immediate.push(streaming::RawStreamingChoice::ToolCallDelta {
+                        id: item_id,
+                        internal_call_id,
+                        content: streaming::ToolCallDeltaContent::Delta(delta.delta),
+                    });
+                }
             }
             _ => {}
         }
@@ -435,7 +443,7 @@ pub(crate) fn raw_choices_from_sse_body(
         if let Ok(chunk) = serde_json::from_str::<StreamingCompletionChunk>(data) {
             match chunk {
                 StreamingCompletionChunk::Delta(chunk) => {
-                    raw_choices.extend(accumulator.decode_item_chunk(chunk.data, options));
+                    raw_choices.extend(accumulator.decode_item_chunk(chunk, options));
                 }
                 StreamingCompletionChunk::Response(chunk) => {
                     let ResponseChunk { kind, response, .. } = *chunk;
@@ -668,7 +676,7 @@ where
 
                     match data {
                         StreamingCompletionChunk::Delta(chunk) => {
-                            for choice in accumulator.decode_item_chunk(chunk.data, options) {
+                            for choice in accumulator.decode_item_chunk(chunk, options) {
                                 yield Ok(choice);
                             }
                         }
@@ -807,8 +815,8 @@ pub struct DeltaTextChunk {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DeltaTextChunkWithItemId {
-    pub item_id: String,
-    pub content_index: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_index: Option<u64>,
     pub sequence_number: u64,
     pub delta: String,
 }
@@ -829,7 +837,8 @@ pub struct RefusalTextChunk {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ArgsTextChunk {
-    pub content_index: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_index: Option<u64>,
     pub sequence_number: u64,
     pub arguments: serde_json::Value,
 }

--- a/tests/providers/openai/cassette/streaming_tools.rs
+++ b/tests/providers/openai/cassette/streaming_tools.rs
@@ -5,8 +5,11 @@ use rig::client::CompletionClient;
 use rig::completion::CompletionModel;
 use rig::message::{AssistantContent, Message};
 use rig::providers::openai;
+use rig::providers::openai::responses_api::streaming::StreamingCompletionChunk;
 use rig::streaming::StreamingPrompt;
 use rig::tool::Tool;
+
+use serde::Deserialize;
 
 use super::super::support::with_openai_cassette;
 use crate::support::{
@@ -16,6 +19,72 @@ use crate::support::{
     assert_raw_stream_tool_call_precedes_text, assert_tool_call_precedes_later_text,
     collect_raw_stream_observation, collect_stream_final_response, collect_stream_observation,
 };
+
+#[derive(Debug, Deserialize)]
+struct CassetteInteraction {
+    then: CassetteResponse,
+}
+
+#[derive(Debug, Deserialize)]
+struct CassetteResponse {
+    body: Option<String>,
+}
+
+#[test]
+fn streaming_tools_smoke_cassette_sse_events_parse() {
+    let contents = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/cassettes/openai/streaming_tools/streaming_tools_smoke.yaml"
+    ))
+    .expect("streaming tools cassette should be readable");
+
+    let mut event_count = 0;
+    let mut function_call_delta_count = 0;
+    let mut failures = Vec::new();
+
+    for (interaction_index, document) in serde_yaml::Deserializer::from_str(&contents).enumerate() {
+        let interaction = CassetteInteraction::deserialize(document)
+            .expect("streaming tools cassette interaction should deserialize");
+        let Some(body) = interaction.then.body else {
+            continue;
+        };
+
+        for (line_index, line) in body.lines().enumerate() {
+            let Some(data) = line.trim_start().strip_prefix("data:").map(str::trim) else {
+                continue;
+            };
+
+            if data.is_empty() || data == "[DONE]" {
+                continue;
+            }
+
+            event_count += 1;
+            if data.contains(r#""type":"response.function_call_arguments.delta""#) {
+                function_call_delta_count += 1;
+            }
+
+            if let Err(error) = serde_json::from_str::<StreamingCompletionChunk>(data) {
+                failures.push(format!(
+                    "interaction {interaction_index}, body line {line_index}: {error}\n{data}"
+                ));
+            }
+        }
+    }
+
+    assert!(
+        event_count > 0,
+        "expected cassette to contain SSE data events"
+    );
+    assert!(
+        function_call_delta_count > 0,
+        "expected cassette to cover function-call argument delta events"
+    );
+    assert!(
+        failures.is_empty(),
+        "all cassette SSE data events should parse as StreamingCompletionChunk; failures:\n{}",
+        failures.join("\n\n")
+    );
+}
 
 #[tokio::test]
 async fn streaming_tools_smoke() {


### PR DESCRIPTION
Fixes https://github.com/0xPlaygrounds/rig/issues/1827, including adding a test demonstrating the issue using the existing cassette.

The real wire shape for response.function_call_arguments.delta and .done places item_id at the outer event level and may omit content_index. Rig’s parser expected those fields in the inner structs, causing these chunks to fail deserialization and be silently skipped.

The completed tool call can still arrive later via response.output_item.done, so existing end-to-end tool tests could pass while incremental ToolCallDelta events were missing.

### Changes

- Parse response.function_call_arguments.delta without requiring content_index.
- Parse response.function_call_arguments.done without requiring content_index.
- Use outer ItemChunk.item_id when emitting ToolCallDelta.
- Update the accumulator to receive the full ItemChunk.
- Add cassette coverage asserting recorded OpenAI streaming tool SSE events all parse as StreamingCompletionChunk.
- Add focused unit tests for real function-call argument wire shapes.

### Verification

```bash
cargo test -p rig --test openai \
  streaming_tools_smoke_cassette_sse_events_parse \
  -- --nocapture
```
This fails prior to the fix (second commit) like this:
```
thread 'openai::cassette::streaming_tools::streaming_tools_smoke_cassette_sse_events_parse' panicked at tests/providers/openai/cassette/streaming_tools.rs:82:5:
all cassette SSE data events should parse as StreamingCompletionChunk; failures:
interaction 0, body line 10: data did not match any variant of untagged enum StreamingCompletionChunk
{"delta":"{\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_1","output_index":0,"sequence_number":3,"type":"response.function_call_arguments.delta"}
...
interaction 0, body line 37: data did not match any variant of untagged enum StreamingCompletionChunk
{"arguments":"{\"x\":2,\"y\":5}","item_id":"fc_REDACTED_1","output_index":0,"sequence_number":12,"type":"response.function_call_arguments.done"}
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test openai::cassette::streaming_tools::streaming_tools_smoke_cassette_sse_events_parse ... FAILED
```
It passes after the second commit.