### PR TITLE
Preserve OpenAI Responses prompt cache params

### DIFF
--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -1069,6 +1069,12 @@ pub struct AdditionalParameters {
     /// The username of the user (that you want to use).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<String>,
+    /// A stable cache routing key for prompt caching.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_cache_key: Option<String>,
+    /// Prompt cache retention policy.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_cache_retention: Option<String>,
     /// Any additional metadata you'd like to add. This will additionally be returned by the response.
     #[serde(skip_serializing_if = "Map::is_empty", default)]
     pub metadata: serde_json::Map<String, serde_json::Value>,

--- a/tests/providers/openai/cassette/responses_input_item.rs
+++ b/tests/providers/openai/cassette/responses_input_item.rs
@@ -358,3 +358,39 @@ fn openai_responses_invalid_additional_params_returns_error_without_panicking() 
                 .contains("Invalid OpenAI Responses additional_params payload")
     ));
 }
+
+#[test]
+fn openai_responses_request_preserves_prompt_cache_parameters() {
+    let request = rig::completion::CompletionRequest {
+        preamble: None,
+        chat_history: OneOrMany::one(CompletionMessage::user("hello")),
+        documents: vec![],
+        tools: vec![],
+        temperature: None,
+        max_tokens: None,
+        tool_choice: None,
+        additional_params: Some(serde_json::json!({
+            "prompt_cache_key": "tenant-agent-scaffold",
+            "prompt_cache_retention": "24h"
+        })),
+        model: None,
+        output_schema: None,
+    };
+
+    let request = OpenAIResponsesRequest::try_from(("gpt-test".to_string(), request))
+        .expect("convert request");
+    let request_json = serde_json::to_value(request).expect("serialize request");
+
+    assert_eq!(
+        request_json
+            .get("prompt_cache_key")
+            .and_then(|value| value.as_str()),
+        Some("tenant-agent-scaffold")
+    );
+    assert_eq!(
+        request_json
+            .get("prompt_cache_retention")
+            .and_then(|value| value.as_str()),
+        Some("24h")
+    );
+}


### PR DESCRIPTION
Adds OpenAI Responses API support for passing prompt_cache_key and prompt_cache_retention through additional_params.

Includes a focused regression test.