### PR TITLE
fix(rig-core): Expose tools added via ToolServerHandle::append_toolset

### DIFF
--- a/crates/rig-core/src/tool/server.rs
+++ b/crates/rig-core/src/tool/server.rs
@@ -121,9 +121,14 @@ impl ToolServerHandle {
         Ok(())
     }
 
-    /// Merge an entire toolset into the server.
+    /// Merge an entire toolset into the server. Tool names from `toolset`
+    /// are appended to the static-tool list, so the tools become visible
+    /// to the LLM via [`Self::get_tool_defs`].
     pub async fn append_toolset(&self, toolset: ToolSet) -> Result<(), ToolServerError> {
         let mut state = self.0.write().await;
+        state
+            .static_tool_names
+            .extend(toolset.tools.keys().cloned());
         state.toolset.add_tools(toolset);
         Ok(())
     }

--- a/crates/rig-core/src/tool/server.rs
+++ b/crates/rig-core/src/tool/server.rs
@@ -297,6 +297,36 @@ mod tests {
     }
 
     #[tokio::test]
+    pub async fn test_toolserver_append_toolset_matches_add_tool() {
+        let mut via_add_tool = {
+            let handle = ToolServer::new().run();
+            handle.add_tool(MockAddTool).await.unwrap();
+            handle.add_tool(MockSubtractTool).await.unwrap();
+            handle.get_tool_defs(None).await.unwrap()
+        };
+        via_add_tool.sort_by(|a, b| a.name.cmp(&b.name));
+
+        let mut via_append_toolset = {
+            let handle = ToolServer::new().run();
+            let mut toolset = ToolSet::default();
+            toolset.add_tool(MockAddTool);
+            toolset.add_tool(MockSubtractTool);
+            handle.append_toolset(toolset).await.unwrap();
+            handle.get_tool_defs(None).await.unwrap()
+        };
+        via_append_toolset.sort_by(|a, b| a.name.cmp(&b.name));
+
+        assert_eq!(via_add_tool.len(), via_append_toolset.len());
+        assert!(
+            via_add_tool
+                .iter()
+                .zip(via_append_toolset.iter())
+                .all(|(a, b)| a.name == b.name),
+            "append_toolset must surface the same LLM-visible tools as add_tool",
+        );
+    }
+
+    #[tokio::test]
     pub async fn test_toolserver_dynamic_tools() {
         // Create a toolset with both tools
         let mut toolset = ToolSet::default();


### PR DESCRIPTION
Tools added via ToolServerHandle::append_toolset were merged into the internal ToolSet but absent from static_tool_names, so they wouldnt' be returned by `get_tool_defs` and the LLM would never see them.

Fixes #1836 