### PR TITLE
fix(agent): batch multiple tool results into single User message for Anthropic

### DIFF
--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -754,8 +754,20 @@ where
                     }
                 }
 
-                for (id, call_id, tool_result) in tool_results {
-                    new_messages.push(tool_result_to_user_message(id, call_id, tool_result));
+                // Combine all tool results into a single User message (required by Anthropic)
+                let tool_result_contents: Vec<UserContent> = tool_results
+                    .into_iter()
+                    .map(|(id, call_id, tool_result)| {
+                        let content = ToolResultContent::from_tool_output(tool_result);
+                        match call_id {
+                            Some(call_id) => UserContent::tool_result_with_call_id(id, call_id, content),
+                            None => UserContent::tool_result(id, content),
+                        }
+                    })
+                    .collect();
+
+                if let Some(content) = OneOrMany::from_iter_optional(tool_result_contents) {
+                    new_messages.push(Message::User { content });
                 }
 
                 if !saw_tool_call_this_turn {


### PR DESCRIPTION
## Summary

Anthropic requires that all `tool_result` messages from the same assistant turn be grouped into a single `User` message. The streaming path in `agent::prompt_request::streaming` was emitting each tool result as a separate `Message::User`, which broke multi-turn tool use with Anthropic models.

## Fix

In `crates/rig-core/src/agent/prompt_request/streaming.rs`, the `for` loop that iterates over `tool_results` and calls `tool_result_to_user_message()` for each is replaced with logic that:
1. Collects all tool results into a `Vec<UserContent>`
2. Wraps them in a `OneOrMany`
3. Emits a single `Message::User { content }`

This matches the behavior of the non-streaming path and satisfies Anthropics API requirement.

## Testing

- Manually verified with multi-turn tool use against Anthropic Claude models
- The change only affects the streaming path; the non-streaming path already behaves correctly

?? Generated with [Claude Code](https://claude.com/claude-code)