### PR TITLE
Add invalid tool call recovery hooks

### DIFF
--- a/crates/rig-core/src/agent/mod.rs
+++ b/crates/rig-core/src/agent/mod.rs
@@ -112,7 +112,10 @@ mod tool;
 pub use crate::message::Text;
 pub use builder::{AgentBuilder, NoToolConfig, WithBuilderTools, WithToolServerHandle};
 pub use completion::Agent;
-pub use prompt_request::hooks::{HookAction, PromptHook, ToolCallHookAction};
+pub use prompt_request::hooks::{
+    HookAction, InvalidToolCallContext, InvalidToolCallHook, InvalidToolCallHookAction, PromptHook,
+    ToolCallHookAction,
+};
 pub use prompt_request::streaming::{
     FinalResponse, MultiTurnStreamItem, StreamingError, StreamingPromptRequest, StreamingResult,
     stream_to_stdout,

--- a/crates/rig-core/src/agent/prompt_request/hooks.rs
+++ b/crates/rig-core/src/agent/prompt_request/hooks.rs
@@ -60,9 +60,11 @@ pub enum InvalidToolCallHookAction {
     Fail,
     /// Retry the model turn with corrective feedback.
     Retry { feedback: String },
-    /// Rewrite the emitted tool name. The repaired name is revalidated before use.
+    /// Rewrite only the emitted tool name. The repaired name is revalidated
+    /// against registered tools and the current `ToolChoice` before use.
     Repair { tool_name: String },
-    /// Return a synthetic tool result for this invalid structured tool call.
+    /// Treat an invalid structured tool call as skipped by returning synthetic
+    /// feedback as its tool result. This does not execute the invalid tool.
     Skip { reason: String },
 }
 

--- a/crates/rig-core/src/agent/prompt_request/hooks.rs
+++ b/crates/rig-core/src/agent/prompt_request/hooks.rs
@@ -4,9 +4,95 @@
 
 use crate::{
     completion::CompletionModel,
-    message::Message,
+    message::{Message, ToolChoice},
     wasm_compat::{WasmCompatSend, WasmCompatSync},
 };
+
+/// Context passed to [`InvalidToolCallHook`] when the model emits a tool call
+/// that Rig would reject before normal tool-call hooks or execution.
+#[derive(Debug, Clone)]
+pub struct InvalidToolCallContext {
+    /// Tool name emitted by the model.
+    pub tool_name: String,
+    /// Provider-supplied tool call ID, when available.
+    pub tool_call_id: Option<String>,
+    /// Internal Rig call ID, when available.
+    pub internal_call_id: Option<String>,
+    /// JSON arguments emitted for the tool call, when available.
+    pub args: Option<String>,
+    /// Executable Rig tools advertised to the provider for this turn.
+    pub available_tools: Vec<String>,
+    /// Tools allowed by the active [`ToolChoice`] for this turn.
+    pub allowed_tools: Vec<String>,
+    /// Active tool choice for this turn.
+    pub tool_choice: Option<ToolChoice>,
+    /// Diagnostic chat history including the rejected model output when available.
+    pub chat_history: Vec<Message>,
+    /// Whether the rejected call came from the streaming path.
+    pub is_streaming: bool,
+}
+
+/// Trait for recovering from model-emitted tool calls that Rig rejects during
+/// validation.
+///
+/// The default behavior remains fail-fast. Attach an implementation with
+/// `.with_invalid_tool_call_hook(...)` to opt into recovery.
+pub trait InvalidToolCallHook<M>: Clone + WasmCompatSend + WasmCompatSync
+where
+    M: CompletionModel,
+{
+    /// Called when a model-emitted tool call is unknown or disallowed by the
+    /// current request's tool choice.
+    fn on_invalid_tool_call(
+        &self,
+        _context: &InvalidToolCallContext,
+    ) -> impl Future<Output = InvalidToolCallHookAction> + WasmCompatSend {
+        async { InvalidToolCallHookAction::fail() }
+    }
+}
+
+impl<M> InvalidToolCallHook<M> for () where M: CompletionModel {}
+
+/// Recovery action for invalid tool-call hooks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InvalidToolCallHookAction {
+    /// Preserve Rig's default fail-fast behavior.
+    Fail,
+    /// Retry the model turn with corrective feedback.
+    Retry { feedback: String },
+    /// Rewrite the emitted tool name. The repaired name is revalidated before use.
+    Repair { tool_name: String },
+    /// Return a synthetic tool result for this invalid structured tool call.
+    Skip { reason: String },
+}
+
+impl InvalidToolCallHookAction {
+    /// Preserve Rig's default fail-fast behavior.
+    pub fn fail() -> Self {
+        Self::Fail
+    }
+
+    /// Retry the model turn with corrective feedback.
+    pub fn retry(feedback: impl Into<String>) -> Self {
+        Self::Retry {
+            feedback: feedback.into(),
+        }
+    }
+
+    /// Repair the emitted tool name.
+    pub fn repair(tool_name: impl Into<String>) -> Self {
+        Self::Repair {
+            tool_name: tool_name.into(),
+        }
+    }
+
+    /// Skip the invalid call with a synthetic tool result.
+    pub fn skip(reason: impl Into<String>) -> Self {
+        Self::Skip {
+            reason: reason.into(),
+        }
+    }
+}
 
 /// Trait for per-request hooks to observe tool call events.
 pub trait PromptHook<M>: Clone + WasmCompatSend + WasmCompatSync

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -1095,18 +1095,19 @@ use serde::de::DeserializeOwned;
 ///     .max_turns(3)
 ///     .await?;
 /// ```
-pub struct TypedPromptRequest<T, S, M, P>
+pub struct TypedPromptRequest<T, S, M, P, I = ()>
 where
     T: JsonSchema + DeserializeOwned + WasmCompatSend,
     S: PromptType,
     M: CompletionModel,
     P: PromptHook<M>,
+    I: InvalidToolCallHook<M>,
 {
-    inner: PromptRequest<S, M, P>,
+    inner: PromptRequest<S, M, P, I>,
     _phantom: std::marker::PhantomData<T>,
 }
 
-impl<T, M, P> TypedPromptRequest<T, Standard, M, P>
+impl<T, M, P> TypedPromptRequest<T, Standard, M, P, ()>
 where
     T: JsonSchema + DeserializeOwned + WasmCompatSend,
     M: CompletionModel,
@@ -1126,19 +1127,20 @@ where
     }
 }
 
-impl<T, S, M, P> TypedPromptRequest<T, S, M, P>
+impl<T, S, M, P, I> TypedPromptRequest<T, S, M, P, I>
 where
     T: JsonSchema + DeserializeOwned + WasmCompatSend,
     S: PromptType,
     M: CompletionModel,
     P: PromptHook<M>,
+    I: InvalidToolCallHook<M>,
 {
     /// Enable returning extended details for responses (includes aggregated token usage).
     ///
     /// Note: This changes the type of the response from `.send()` to return a `TypedPromptResponse<T>` struct
     /// instead of just `T`. This is useful for tracking token usage across multiple turns
     /// of conversation.
-    pub fn extended_details(self) -> TypedPromptRequest<T, Extended, M, P> {
+    pub fn extended_details(self) -> TypedPromptRequest<T, Extended, M, P, I> {
         TypedPromptRequest {
             inner: self.inner.extended_details(),
             _phantom: std::marker::PhantomData,
@@ -1155,6 +1157,14 @@ where
         self
     }
 
+    /// Set the retry budget for invalid tool-call recovery.
+    ///
+    /// Invalid tool-call retries also consume normal multi-turn depth.
+    pub fn max_invalid_tool_call_retries(mut self, retries: usize) -> Self {
+        self.inner = self.inner.max_invalid_tool_call_retries(retries);
+        self
+    }
+
     /// Add concurrency to the prompt request.
     ///
     /// This will cause the agent to execute tools concurrently.
@@ -1164,10 +1174,10 @@ where
     }
 
     /// Add chat history to the prompt request.
-    pub fn with_history<I, H>(mut self, history: I) -> Self
+    pub fn with_history<H, U>(mut self, history: H) -> Self
     where
-        I: IntoIterator<Item = H>,
-        H: Into<Message>,
+        H: IntoIterator<Item = U>,
+        U: Into<Message>,
     {
         self.inner = self.inner.with_history(history);
         self
@@ -1193,7 +1203,7 @@ where
     /// Attach a per-request hook for tool call events.
     ///
     /// This overrides any default hook set on the agent.
-    pub fn with_hook<P2>(self, hook: P2) -> TypedPromptRequest<T, S, M, P2>
+    pub fn with_hook<P2>(self, hook: P2) -> TypedPromptRequest<T, S, M, P2, I>
     where
         P2: PromptHook<M>,
     {
@@ -1202,13 +1212,27 @@ where
             _phantom: std::marker::PhantomData,
         }
     }
+
+    /// Attach a per-request hook for invalid model-emitted tool calls.
+    ///
+    /// Without this hook, Rig preserves fail-fast validation.
+    pub fn with_invalid_tool_call_hook<I2>(self, hook: I2) -> TypedPromptRequest<T, S, M, P, I2>
+    where
+        I2: InvalidToolCallHook<M>,
+    {
+        TypedPromptRequest {
+            inner: self.inner.with_invalid_tool_call_hook(hook),
+            _phantom: std::marker::PhantomData,
+        }
+    }
 }
 
-impl<T, M, P> TypedPromptRequest<T, Standard, M, P>
+impl<T, M, P, I> TypedPromptRequest<T, Standard, M, P, I>
 where
     T: JsonSchema + DeserializeOwned + WasmCompatSend,
     M: CompletionModel,
     P: PromptHook<M>,
+    I: InvalidToolCallHook<M>,
 {
     /// Send the typed prompt request and deserialize the response.
     async fn send(self) -> Result<T, StructuredOutputError> {
@@ -1223,11 +1247,12 @@ where
     }
 }
 
-impl<T, M, P> TypedPromptRequest<T, Extended, M, P>
+impl<T, M, P, I> TypedPromptRequest<T, Extended, M, P, I>
 where
     T: JsonSchema + DeserializeOwned + WasmCompatSend,
     M: CompletionModel,
     P: PromptHook<M>,
+    I: InvalidToolCallHook<M>,
 {
     /// Send the typed prompt request with extended details and deserialize the response.
     async fn send(self) -> Result<TypedPromptResponse<T>, StructuredOutputError> {
@@ -1243,11 +1268,12 @@ where
     }
 }
 
-impl<T, M, P> IntoFuture for TypedPromptRequest<T, Standard, M, P>
+impl<T, M, P, I> IntoFuture for TypedPromptRequest<T, Standard, M, P, I>
 where
     T: JsonSchema + DeserializeOwned + WasmCompatSend + 'static,
     M: CompletionModel + 'static,
     P: PromptHook<M> + 'static,
+    I: InvalidToolCallHook<M> + 'static,
 {
     type Output = Result<T, StructuredOutputError>;
     type IntoFuture = WasmBoxedFuture<'static, Self::Output>;
@@ -1257,11 +1283,12 @@ where
     }
 }
 
-impl<T, M, P> IntoFuture for TypedPromptRequest<T, Extended, M, P>
+impl<T, M, P, I> IntoFuture for TypedPromptRequest<T, Extended, M, P, I>
 where
     T: JsonSchema + DeserializeOwned + WasmCompatSend + 'static,
     M: CompletionModel + 'static,
     P: PromptHook<M> + 'static,
+    I: InvalidToolCallHook<M> + 'static,
 {
     type Output = Result<TypedPromptResponse<T>, StructuredOutputError>;
     type IntoFuture = WasmBoxedFuture<'static, Self::Output>;
@@ -1284,7 +1311,7 @@ mod tests {
         },
         completion::{
             AssistantContent, CompletionError, CompletionModel, CompletionRequest, Message, Prompt,
-            PromptError, TypedPrompt, Usage,
+            PromptError, StructuredOutputError, TypedPrompt, Usage,
         },
         message::{Text, ToolChoice, UserContent},
         test_utils::{
@@ -1830,6 +1857,112 @@ mod tests {
                     })
             )
         }));
+    }
+
+    #[tokio::test]
+    async fn typed_prompt_default_invalid_tool_call_fails_fast() {
+        let model = MockCompletionModel::new([
+            MockTurn::tool_call("tool_call_1", "default_api", json!({"x": 2, "y": 3})),
+            MockTurn::text(r#"{"value":"should not be requested"}"#),
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
+
+        let err = agent
+            .prompt_typed::<TypedAnswer>("return typed json")
+            .with_hook(PanicOnUnknownToolHook)
+            .max_turns(3)
+            .await
+            .expect_err("typed prompt should preserve fail-fast default");
+
+        match err {
+            StructuredOutputError::PromptError(err) => match *err {
+                PromptError::UnknownToolCall { tool_name, .. } => {
+                    assert_eq!(tool_name, "default_api");
+                }
+                other => panic!("expected UnknownToolCall, got {other:?}"),
+            },
+            other => panic!("expected prompt error, got {other:?}"),
+        }
+        assert_eq!(recorded.request_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn typed_prompt_invalid_tool_call_hook_can_repair_tool_name() {
+        let model = MockCompletionModel::new([
+            MockTurn::tool_call("tool_call_1", "default_api", json!({"x": 2, "y": 3})),
+            MockTurn::text(r#"{"value":"repaired"}"#),
+        ]);
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
+
+        let response = agent
+            .prompt_typed::<TypedAnswer>("return typed json")
+            .with_invalid_tool_call_hook(RepairDefaultApiHook)
+            .max_turns(3)
+            .await
+            .expect("typed prompt should repair invalid tool call");
+
+        assert_eq!(
+            response,
+            TypedAnswer {
+                value: "repaired".to_string()
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn typed_prompt_invalid_tool_call_hook_can_retry_and_parse_response() {
+        let model = MockCompletionModel::new([
+            MockTurn::tool_call("tool_call_1", "default_api", json!({"x": 2, "y": 3})),
+            MockTurn::text(r#"{"value":"retried"}"#),
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
+
+        let response = agent
+            .prompt_typed::<TypedAnswer>("return typed json")
+            .with_invalid_tool_call_hook(RetryDefaultApiHook)
+            .max_invalid_tool_call_retries(1)
+            .max_turns(3)
+            .await
+            .expect("typed prompt should retry invalid tool call");
+
+        assert_eq!(
+            response,
+            TypedAnswer {
+                value: "retried".to_string()
+            }
+        );
+        assert_eq!(recorded.request_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn typed_prompt_invalid_tool_call_retry_budget_exhaustion_fails() {
+        let model = MockCompletionModel::new([
+            MockTurn::tool_call("tool_call_1", "default_api", json!({"x": 2, "y": 3})),
+            MockTurn::text(r#"{"value":"should not be requested"}"#),
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
+
+        let err = agent
+            .prompt_typed::<TypedAnswer>("return typed json")
+            .with_invalid_tool_call_hook(RetryDefaultApiHook)
+            .max_invalid_tool_call_retries(0)
+            .max_turns(3)
+            .await
+            .expect_err("typed prompt should fail when retry budget is exhausted");
+
+        match err {
+            StructuredOutputError::PromptError(err) => match *err {
+                PromptError::UnknownToolCall { tool_name, .. } => {
+                    assert_eq!(tool_name, "default_api");
+                }
+                other => panic!("expected UnknownToolCall, got {other:?}"),
+            },
+            other => panic!("expected prompt error, got {other:?}"),
+        }
+        assert_eq!(recorded.request_count(), 1);
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -547,7 +547,13 @@ where
                 })
             }
         }
-        InvalidToolCallHookAction::Skip { reason } => InvalidToolCallResolution::Skip(reason),
+        InvalidToolCallHookAction::Skip { reason } => {
+            if matches!(tool_choice, Some(ToolChoice::None)) {
+                InvalidToolCallResolution::Fail(err)
+            } else {
+                InvalidToolCallResolution::Skip(reason)
+            }
+        }
     }
 }
 
@@ -773,7 +779,7 @@ where
                         &executable_tool_names,
                         &allowed_tool_names,
                         self.tool_choice.as_ref(),
-                        diagnostic_history,
+                        diagnostic_history.clone(),
                         false,
                     )
                     .await
@@ -788,10 +794,7 @@ where
                                         .cloned()
                                         .collect(),
                                     allowed_tools: allowed_tool_names.iter().cloned().collect(),
-                                    chat_history: Box::new(build_full_history(
-                                        chat_history.as_deref(),
-                                        new_messages.clone(),
-                                    )),
+                                    chat_history: Box::new(diagnostic_history.clone()),
                                 });
                             }
 
@@ -1380,6 +1383,18 @@ mod tests {
     }
 
     #[derive(Clone)]
+    struct RepairToSubtractHook;
+
+    impl InvalidToolCallHook<MockCompletionModel> for RepairToSubtractHook {
+        async fn on_invalid_tool_call(
+            &self,
+            _context: &InvalidToolCallContext,
+        ) -> InvalidToolCallHookAction {
+            InvalidToolCallHookAction::repair("subtract")
+        }
+    }
+
+    #[derive(Clone)]
     struct RetryDefaultApiHook;
 
     impl InvalidToolCallHook<MockCompletionModel> for RetryDefaultApiHook {
@@ -1811,8 +1826,13 @@ mod tests {
             .expect_err("retry without budget should fail");
 
         match err {
-            PromptError::UnknownToolCall { tool_name, .. } => {
+            PromptError::UnknownToolCall {
+                tool_name,
+                chat_history,
+                ..
+            } => {
                 assert_eq!(tool_name, "default_api");
+                assert!(history_contains_tool_call(&chat_history, "default_api"));
             }
             other => panic!("expected UnknownToolCall, got {other:?}"),
         }
@@ -1857,6 +1877,139 @@ mod tests {
                     })
             )
         }));
+    }
+
+    #[tokio::test]
+    async fn skip_under_specific_tool_choice_returns_synthetic_feedback() {
+        let model = MockCompletionModel::new([
+            MockTurn::tool_call("tool_call_1", "default_api", json!({"x": 2, "y": 3})),
+            MockTurn::text("skipped"),
+        ]);
+        let agent = AgentBuilder::new(model)
+            .tool(MockAddTool)
+            .tool_choice(ToolChoice::Specific {
+                function_names: vec!["add".to_string()],
+            })
+            .build();
+
+        let response = agent
+            .prompt("add")
+            .with_invalid_tool_call_hook(SkipDefaultApiHook)
+            .max_turns(3)
+            .extended_details()
+            .await
+            .expect("skip should produce synthetic feedback under Specific");
+
+        assert_eq!(response.output, "skipped");
+        let messages = response.messages.expect("messages should be present");
+        assert!(history_contains_tool_call(&messages, "default_api"));
+        assert!(messages.iter().any(|message| {
+            matches!(
+                message,
+                Message::User { content }
+                    if content.iter().any(|content| {
+                        matches!(
+                            content,
+                            UserContent::ToolResult(result)
+                                if result.id == "tool_call_1"
+                                    && result.content.iter().any(|content| {
+                                        matches!(
+                                            content,
+                                            crate::message::ToolResultContent::Text(text)
+                                                if text.text == "default_api is not available"
+                                        )
+                                    })
+                        )
+                    })
+            )
+        }));
+    }
+
+    #[tokio::test]
+    async fn repair_to_disallowed_specific_tool_fails() {
+        let model = MockCompletionModel::new([
+            MockTurn::tool_call("tool_call_1", "default_api", json!({"x": 2, "y": 3})),
+            MockTurn::text("should not be requested"),
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model)
+            .tool(MockAddTool)
+            .tool(MockSubtractTool)
+            .tool_choice(ToolChoice::Specific {
+                function_names: vec!["add".to_string()],
+            })
+            .build();
+
+        let err = agent
+            .prompt("add")
+            .with_invalid_tool_call_hook(RepairToSubtractHook)
+            .max_turns(3)
+            .await
+            .expect_err("repair to a disallowed tool should fail");
+
+        match err {
+            PromptError::UnknownToolCall { tool_name, .. } => {
+                assert_eq!(tool_name, "subtract");
+            }
+            other => panic!("expected UnknownToolCall, got {other:?}"),
+        }
+        assert_eq!(recorded.request_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn repair_under_tool_choice_none_fails() {
+        let model = MockCompletionModel::new([
+            MockTurn::tool_call("tool_call_1", "default_api", json!({"x": 2, "y": 3})),
+            MockTurn::text("should not be requested"),
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model)
+            .tool(MockAddTool)
+            .tool_choice(ToolChoice::None)
+            .build();
+
+        let err = agent
+            .prompt("do not use tools")
+            .with_invalid_tool_call_hook(RepairDefaultApiHook)
+            .max_turns(3)
+            .await
+            .expect_err("ToolChoice::None should reject repaired tool calls");
+
+        match err {
+            PromptError::UnknownToolCall { tool_name, .. } => {
+                assert_eq!(tool_name, "add");
+            }
+            other => panic!("expected UnknownToolCall, got {other:?}"),
+        }
+        assert_eq!(recorded.request_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn skip_under_tool_choice_none_fails() {
+        let model = MockCompletionModel::new([
+            MockTurn::tool_call("tool_call_1", "default_api", json!({"x": 2, "y": 3})),
+            MockTurn::text("should not be requested"),
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model)
+            .tool(MockAddTool)
+            .tool_choice(ToolChoice::None)
+            .build();
+
+        let err = agent
+            .prompt("do not use tools")
+            .with_invalid_tool_call_hook(SkipDefaultApiHook)
+            .max_turns(3)
+            .await
+            .expect_err("ToolChoice::None should reject skipped tool calls");
+
+        match err {
+            PromptError::UnknownToolCall { tool_name, .. } => {
+                assert_eq!(tool_name, "default_api");
+            }
+            other => panic!("expected UnknownToolCall, got {other:?}"),
+        }
+        assert_eq!(recorded.request_count(), 1);
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -817,7 +817,7 @@ where
                     match resolve_invalid_tool_call::<M, I>(
                         self.invalid_tool_call_hook.as_ref(),
                         &emitted_tool_name,
-                        tool_call.call_id.clone(),
+                        Some(tool_call.id.clone()),
                         None,
                         Some(args),
                         &executable_tool_names,
@@ -1367,7 +1367,7 @@ mod tests {
     use serde::{Deserialize, Serialize};
     use serde_json::json;
     use std::sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicU32, Ordering},
     };
 
@@ -1465,6 +1465,33 @@ mod tests {
             _context: &InvalidToolCallContext,
         ) -> InvalidToolCallHookAction {
             InvalidToolCallHookAction::skip("default_api is not available")
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct RecordingInvalidToolCallHook {
+        contexts: Arc<Mutex<Vec<InvalidToolCallContext>>>,
+    }
+
+    impl RecordingInvalidToolCallHook {
+        fn observed(&self) -> Vec<InvalidToolCallContext> {
+            self.contexts
+                .lock()
+                .expect("invalid tool context records mutex was poisoned")
+                .clone()
+        }
+    }
+
+    impl InvalidToolCallHook<MockCompletionModel> for RecordingInvalidToolCallHook {
+        async fn on_invalid_tool_call(
+            &self,
+            context: &InvalidToolCallContext,
+        ) -> InvalidToolCallHookAction {
+            self.contexts
+                .lock()
+                .expect("invalid tool context records mutex was poisoned")
+                .push(context.clone());
+            InvalidToolCallHookAction::fail()
         }
     }
 
@@ -1711,6 +1738,35 @@ mod tests {
             other => panic!("expected UnknownToolCall, got {other:?}"),
         }
         assert_eq!(recorded.request_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn invalid_tool_call_context_uses_completed_tool_call_provider_id() {
+        let invalid_hook = RecordingInvalidToolCallHook::default();
+        let model = MockCompletionModel::new([
+            MockTurn::tool_call("tool_call_1", "default_api", json!({"x": 1, "y": 2}))
+                .with_call_id("provider_call_1"),
+            MockTurn::text("should not be requested"),
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
+
+        let err = agent
+            .prompt("use the tool")
+            .with_invalid_tool_call_hook(invalid_hook.clone())
+            .max_turns(3)
+            .await
+            .expect_err("invalid tool should fail");
+
+        assert!(matches!(err, PromptError::UnknownToolCall { .. }));
+        assert_eq!(recorded.request_count(), 1);
+        let contexts = invalid_hook.observed();
+        assert_eq!(contexts.len(), 1);
+        let context = &contexts[0];
+        assert_eq!(context.tool_name, "default_api");
+        assert_eq!(context.tool_call_id.as_deref(), Some("tool_call_1"));
+        assert_eq!(context.internal_call_id, None);
+        assert!(!context.is_streaming);
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -15,10 +15,13 @@ use crate::{
     wasm_compat::{WasmBoxedFuture, WasmCompatSend},
 };
 use futures::{StreamExt, stream};
-use hooks::{HookAction, PromptHook, ToolCallHookAction};
+use hooks::{
+    HookAction, InvalidToolCallContext, InvalidToolCallHook, InvalidToolCallHookAction, PromptHook,
+    ToolCallHookAction,
+};
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeMap, BTreeSet},
     future::IntoFuture,
     marker::PhantomData,
     sync::{
@@ -44,11 +47,12 @@ impl PromptType for Extended {}
 /// attempting to await (which will send the prompt request) can potentially return
 /// [`crate::completion::request::PromptError::MaxTurnsError`] if the agent decides to call tools
 /// back to back.
-pub struct PromptRequest<S, M, P>
+pub struct PromptRequest<S, M, P, I = ()>
 where
     S: PromptType,
     M: CompletionModel,
     P: PromptHook<M>,
+    I: InvalidToolCallHook<M>,
 {
     /// The prompt message to send to the model
     prompt: Message,
@@ -83,6 +87,10 @@ where
     state: PhantomData<S>,
     /// Optional per-request hook for events
     hook: Option<P>,
+    /// Optional per-request hook for invalid model-emitted tool calls.
+    invalid_tool_call_hook: Option<I>,
+    /// Maximum number of invalid tool-call retries for this request.
+    max_invalid_tool_call_retries: usize,
     /// How many tools should be executed at the same time (1 by default).
     concurrency: usize,
     /// Optional JSON Schema for structured output
@@ -93,7 +101,7 @@ where
     conversation_id: Option<String>,
 }
 
-impl<M, P> PromptRequest<Standard, M, P>
+impl<M, P> PromptRequest<Standard, M, P, ()>
 where
     M: CompletionModel,
     P: PromptHook<M>,
@@ -116,6 +124,8 @@ where
             tool_choice: agent.tool_choice.clone(),
             state: PhantomData,
             hook: agent.hook.clone(),
+            invalid_tool_call_hook: None,
+            max_invalid_tool_call_retries: 0,
             concurrency: 1,
             output_schema: agent.output_schema.clone(),
             memory: agent.memory.clone(),
@@ -124,11 +134,12 @@ where
     }
 }
 
-impl<S, M, P> PromptRequest<S, M, P>
+impl<S, M, P, I> PromptRequest<S, M, P, I>
 where
     S: PromptType,
     M: CompletionModel,
     P: PromptHook<M>,
+    I: InvalidToolCallHook<M>,
 {
     /// Enable returning extended details for responses (includes aggregated token usage
     /// and the full message history accumulated during the agent loop).
@@ -136,7 +147,7 @@ where
     /// Note: This changes the type of the response from `.send` to return a `PromptResponse` struct
     /// instead of a simple `String`. This is useful for tracking token usage across multiple turns
     /// of conversation and inspecting the full message exchange.
-    pub fn extended_details(self) -> PromptRequest<Extended, M, P> {
+    pub fn extended_details(self) -> PromptRequest<Extended, M, P, I> {
         PromptRequest {
             prompt: self.prompt,
             chat_history: self.chat_history,
@@ -153,6 +164,8 @@ where
             tool_choice: self.tool_choice,
             state: PhantomData,
             hook: self.hook,
+            invalid_tool_call_hook: self.invalid_tool_call_hook,
+            max_invalid_tool_call_retries: self.max_invalid_tool_call_retries,
             concurrency: self.concurrency,
             output_schema: self.output_schema,
             memory: self.memory,
@@ -175,9 +188,9 @@ where
     }
 
     /// Add chat history to the prompt request.
-    pub fn with_history<I, T>(mut self, history: I) -> Self
+    pub fn with_history<H, T>(mut self, history: H) -> Self
     where
-        I: IntoIterator<Item = T>,
+        H: IntoIterator<Item = T>,
         T: Into<Message>,
     {
         self.chat_history = Some(history.into_iter().map(Into::into).collect());
@@ -204,7 +217,7 @@ where
 
     /// Attach a per-request hook for tool call events.
     /// This overrides any default hook set on the agent.
-    pub fn with_hook<P2>(self, hook: P2) -> PromptRequest<S, M, P2>
+    pub fn with_hook<P2>(self, hook: P2) -> PromptRequest<S, M, P2, I>
     where
         P2: PromptHook<M>,
     {
@@ -224,21 +237,64 @@ where
             tool_choice: self.tool_choice,
             state: PhantomData,
             hook: Some(hook),
+            invalid_tool_call_hook: self.invalid_tool_call_hook,
+            max_invalid_tool_call_retries: self.max_invalid_tool_call_retries,
             concurrency: self.concurrency,
             output_schema: self.output_schema,
             memory: self.memory,
             conversation_id: self.conversation_id,
         }
     }
+
+    /// Attach a per-request hook for invalid model-emitted tool calls.
+    ///
+    /// Without this hook, Rig preserves fail-fast validation.
+    pub fn with_invalid_tool_call_hook<I2>(self, hook: I2) -> PromptRequest<S, M, P, I2>
+    where
+        I2: InvalidToolCallHook<M>,
+    {
+        PromptRequest {
+            prompt: self.prompt,
+            chat_history: self.chat_history,
+            max_turns: self.max_turns,
+            model: self.model,
+            agent_name: self.agent_name,
+            preamble: self.preamble,
+            static_context: self.static_context,
+            temperature: self.temperature,
+            max_tokens: self.max_tokens,
+            additional_params: self.additional_params,
+            tool_server_handle: self.tool_server_handle,
+            dynamic_context: self.dynamic_context,
+            tool_choice: self.tool_choice,
+            state: PhantomData,
+            hook: self.hook,
+            invalid_tool_call_hook: Some(hook),
+            max_invalid_tool_call_retries: self.max_invalid_tool_call_retries,
+            concurrency: self.concurrency,
+            output_schema: self.output_schema,
+            memory: self.memory,
+            conversation_id: self.conversation_id,
+        }
+    }
+
+    /// Set the retry budget for [`InvalidToolCallHookAction::Retry`].
+    ///
+    /// Invalid tool-call retries also consume normal multi-turn depth.
+    pub fn max_invalid_tool_call_retries(mut self, retries: usize) -> Self {
+        self.max_invalid_tool_call_retries = retries;
+        self
+    }
 }
 
 /// Due to: [RFC 2515](https://github.com/rust-lang/rust/issues/63063), we have to use a `BoxFuture`
 ///  for the `IntoFuture` implementation. In the future, we should be able to use `impl Future<...>`
 ///  directly via the associated type.
-impl<M, P> IntoFuture for PromptRequest<Standard, M, P>
+impl<M, P, I> IntoFuture for PromptRequest<Standard, M, P, I>
 where
     M: CompletionModel + 'static,
     P: PromptHook<M> + 'static,
+    I: InvalidToolCallHook<M> + 'static,
 {
     type Output = Result<String, PromptError>;
     type IntoFuture = WasmBoxedFuture<'static, Self::Output>;
@@ -248,10 +304,11 @@ where
     }
 }
 
-impl<M, P> IntoFuture for PromptRequest<Extended, M, P>
+impl<M, P, I> IntoFuture for PromptRequest<Extended, M, P, I>
 where
     M: CompletionModel + 'static,
     P: PromptHook<M> + 'static,
+    I: InvalidToolCallHook<M> + 'static,
 {
     type Output = Result<PromptResponse, PromptError>;
     type IntoFuture = WasmBoxedFuture<'static, Self::Output>;
@@ -261,10 +318,11 @@ where
     }
 }
 
-impl<M, P> PromptRequest<Standard, M, P>
+impl<M, P, I> PromptRequest<Standard, M, P, I>
 where
     M: CompletionModel,
     P: PromptHook<M>,
+    I: InvalidToolCallHook<M>,
 {
     async fn send(self) -> Result<String, PromptError> {
         self.extended_details().send().await.map(|resp| resp.output)
@@ -427,6 +485,72 @@ pub(crate) fn validate_tool_call_name(
     })
 }
 
+enum InvalidToolCallResolution {
+    Fail(PromptError),
+    Retry(String),
+    Repair(String),
+    Skip(String),
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn resolve_invalid_tool_call<M, I>(
+    hook: Option<&I>,
+    tool_name: &str,
+    tool_call_id: Option<String>,
+    internal_call_id: Option<String>,
+    args: Option<String>,
+    executable_tool_names: &BTreeSet<String>,
+    allowed_tool_names: &BTreeSet<String>,
+    tool_choice: Option<&ToolChoice>,
+    chat_history: Vec<Message>,
+    is_streaming: bool,
+) -> InvalidToolCallResolution
+where
+    M: CompletionModel,
+    I: InvalidToolCallHook<M>,
+{
+    let err = PromptError::UnknownToolCall {
+        tool_name: tool_name.to_owned(),
+        available_tools: executable_tool_names.iter().cloned().collect(),
+        allowed_tools: allowed_tool_names.iter().cloned().collect(),
+        chat_history: Box::new(chat_history.clone()),
+    };
+
+    let Some(hook) = hook else {
+        return InvalidToolCallResolution::Fail(err);
+    };
+
+    let context = InvalidToolCallContext {
+        tool_name: tool_name.to_owned(),
+        tool_call_id,
+        internal_call_id,
+        args,
+        available_tools: executable_tool_names.iter().cloned().collect(),
+        allowed_tools: allowed_tool_names.iter().cloned().collect(),
+        tool_choice: tool_choice.cloned(),
+        chat_history,
+        is_streaming,
+    };
+
+    match hook.on_invalid_tool_call(&context).await {
+        InvalidToolCallHookAction::Fail => InvalidToolCallResolution::Fail(err),
+        InvalidToolCallHookAction::Retry { feedback } => InvalidToolCallResolution::Retry(feedback),
+        InvalidToolCallHookAction::Repair { tool_name } => {
+            if allowed_tool_names.contains(&tool_name) {
+                InvalidToolCallResolution::Repair(tool_name)
+            } else {
+                InvalidToolCallResolution::Fail(PromptError::UnknownToolCall {
+                    tool_name,
+                    available_tools: executable_tool_names.iter().cloned().collect(),
+                    allowed_tools: allowed_tool_names.iter().cloned().collect(),
+                    chat_history: Box::new(context.chat_history),
+                })
+            }
+        }
+        InvalidToolCallHookAction::Skip { reason } => InvalidToolCallResolution::Skip(reason),
+    }
+}
+
 fn is_empty_assistant_turn(choice: &OneOrMany<AssistantContent>) -> bool {
     choice.len() == 1
         && matches!(
@@ -445,10 +569,11 @@ fn assistant_text_from_choice(choice: &OneOrMany<AssistantContent>) -> String {
         .collect()
 }
 
-impl<M, P> PromptRequest<Extended, M, P>
+impl<M, P, I> PromptRequest<Extended, M, P, I>
 where
     M: CompletionModel,
     P: PromptHook<M>,
+    I: InvalidToolCallHook<M>,
 {
     fn agent_name(&self) -> &str {
         self.agent_name.as_deref().unwrap_or(UNKNOWN_AGENT_NAME)
@@ -499,10 +624,11 @@ where
         let mut usage = Usage::new();
         let mut completion_calls = Vec::new();
         let mut completion_call_index = 0;
+        let mut invalid_tool_call_retries = 0;
         let current_span_id: AtomicU64 = AtomicU64::new(0);
 
         // We need to do at least 2 loops for 1 roundtrip (user expects normal message)
-        let last_prompt = loop {
+        let last_prompt = 'prompt_loop: loop {
             // Get the last message (the current prompt)
             let Some((prompt_ref, history_for_current_turn)) = new_messages.split_last() else {
                 return Err(PromptError::prompt_cancelled(
@@ -608,43 +734,121 @@ where
             completion_call_index += 1;
             usage += resp.usage;
 
-            let tool_calls = resp
-                .choice
+            let mut response_choice = resp.choice.clone();
+            let has_tool_calls = response_choice
                 .iter()
-                .filter(|choice| matches!(choice, AssistantContent::ToolCall(_)))
-                .collect::<Vec<_>>();
+                .any(|choice| matches!(choice, AssistantContent::ToolCall(_)));
 
             // Some providers normalize textless terminal turns into a single empty text item
             // because the generic completion response cannot represent an empty choice. Treat
             // that sentinel as "no assistant output" so it does not pollute returned history.
-            let assistant_response_message =
-                (!is_empty_assistant_turn(&resp.choice)).then(|| Message::Assistant {
-                    id: resp.message_id.clone(),
-                    content: resp.choice.clone(),
-                });
+            let mut skipped_tool_results = BTreeMap::new();
+            let mut invalid_tool_call_recovered = false;
+            if has_tool_calls {
+                for choice in response_choice.iter_mut() {
+                    let AssistantContent::ToolCall(tool_call) = choice else {
+                        continue;
+                    };
 
-            if !tool_calls.is_empty() {
-                let mut diagnostic_messages = new_messages.clone();
-                if let Some(message) = assistant_response_message.clone() {
-                    diagnostic_messages.push(message);
-                }
+                    if allowed_tool_names.contains(&tool_call.function.name) {
+                        continue;
+                    }
 
-                for choice in &tool_calls {
-                    if let AssistantContent::ToolCall(tool_call) = choice {
-                        validate_tool_call_name(
-                            &tool_call.function.name,
-                            &executable_tool_names,
-                            &allowed_tool_names,
-                            build_full_history(
-                                chat_history.as_deref(),
-                                diagnostic_messages.clone(),
-                            ),
-                        )?;
+                    let mut diagnostic_messages = new_messages.clone();
+                    diagnostic_messages.push(Message::Assistant {
+                        id: resp.message_id.clone(),
+                        content: resp.choice.clone(),
+                    });
+                    let diagnostic_history =
+                        build_full_history(chat_history.as_deref(), diagnostic_messages);
+                    let args = json_utils::value_to_json_string(&tool_call.function.arguments);
+                    let emitted_tool_name = tool_call.function.name.clone();
+
+                    match resolve_invalid_tool_call::<M, I>(
+                        self.invalid_tool_call_hook.as_ref(),
+                        &emitted_tool_name,
+                        tool_call.call_id.clone(),
+                        None,
+                        Some(args),
+                        &executable_tool_names,
+                        &allowed_tool_names,
+                        self.tool_choice.as_ref(),
+                        diagnostic_history,
+                        false,
+                    )
+                    .await
+                    {
+                        InvalidToolCallResolution::Fail(err) => return Err(err),
+                        InvalidToolCallResolution::Retry(feedback) => {
+                            if invalid_tool_call_retries >= self.max_invalid_tool_call_retries {
+                                return Err(PromptError::UnknownToolCall {
+                                    tool_name: emitted_tool_name,
+                                    available_tools: executable_tool_names
+                                        .iter()
+                                        .cloned()
+                                        .collect(),
+                                    allowed_tools: allowed_tool_names.iter().cloned().collect(),
+                                    chat_history: Box::new(build_full_history(
+                                        chat_history.as_deref(),
+                                        new_messages.clone(),
+                                    )),
+                                });
+                            }
+
+                            invalid_tool_call_retries += 1;
+                            new_messages.push(Message::Assistant {
+                                id: resp.message_id.clone(),
+                                content: resp.choice.clone(),
+                            });
+                            let user_content = if let Some(call_id) = tool_call.call_id.clone() {
+                                UserContent::tool_result_with_call_id(
+                                    tool_call.id.clone(),
+                                    call_id,
+                                    OneOrMany::one(feedback.into()),
+                                )
+                            } else {
+                                UserContent::tool_result(
+                                    tool_call.id.clone(),
+                                    OneOrMany::one(feedback.into()),
+                                )
+                            };
+                            new_messages.push(Message::User {
+                                content: OneOrMany::one(user_content),
+                            });
+                            continue 'prompt_loop;
+                        }
+                        InvalidToolCallResolution::Repair(repaired_name) => {
+                            tool_call.function.name = repaired_name;
+                            invalid_tool_call_recovered = true;
+                        }
+                        InvalidToolCallResolution::Skip(reason) => {
+                            let user_content = if let Some(call_id) = tool_call.call_id.clone() {
+                                UserContent::tool_result_with_call_id(
+                                    tool_call.id.clone(),
+                                    call_id,
+                                    OneOrMany::one(reason.into()),
+                                )
+                            } else {
+                                UserContent::tool_result(
+                                    tool_call.id.clone(),
+                                    OneOrMany::one(reason.into()),
+                                )
+                            };
+                            skipped_tool_results.insert(tool_call.id.clone(), user_content);
+                            invalid_tool_call_recovered = true;
+                        }
                     }
                 }
             }
 
-            if let Some(ref hook) = self.hook
+            let assistant_response_message =
+                (!is_empty_assistant_turn(&response_choice)).then(|| Message::Assistant {
+                    id: resp.message_id.clone(),
+                    content: response_choice.clone(),
+                });
+
+            if !invalid_tool_call_recovered
+                && let Some(ref hook) = self.hook
                 && let HookAction::Terminate { reason } =
                     hook.on_completion_response(&prompt, &resp).await
             {
@@ -658,8 +862,8 @@ where
                 new_messages.push(message);
             }
 
-            if tool_calls.is_empty() {
-                let merged_texts = assistant_text_from_choice(&resp.choice);
+            if !has_tool_calls {
+                let merged_texts = assistant_text_from_choice(&response_choice);
 
                 if self.max_turns > 1 {
                     tracing::info!("Depth reached: {}/{}", current_max_turns, self.max_turns);
@@ -699,17 +903,23 @@ where
 
             let hook = self.hook.clone();
             let tool_server_handle = self.tool_server_handle.clone();
+            let skipped_tool_results = Arc::new(skipped_tool_results);
 
             // For error handling in concurrent tool execution, we need to build full history
             let full_history_for_errors =
                 build_full_history(chat_history.as_deref(), new_messages.clone());
 
-            let tool_calls: Vec<AssistantContent> = tool_calls.into_iter().cloned().collect();
+            let tool_calls: Vec<AssistantContent> = response_choice
+                .iter()
+                .filter(|choice| matches!(choice, AssistantContent::ToolCall(_)))
+                .cloned()
+                .collect();
             let tool_content = stream::iter(tool_calls)
                 .map(|choice| {
                     let hook1 = hook.clone();
                     let hook2 = hook.clone();
                     let tool_server_handle = tool_server_handle.clone();
+                    let skipped_tool_results = skipped_tool_results.clone();
 
                     let tool_span = info_span!(
                         "execute_tool",
@@ -741,6 +951,9 @@ where
                             let args =
                                 json_utils::value_to_json_string(&tool_call.function.arguments);
                             let internal_call_id = nanoid::nanoid!();
+                            if let Some(result) = skipped_tool_results.get(&tool_call.id) {
+                                return Ok(result.clone());
+                            }
                             let tool_span = tracing::Span::current();
                             tool_span.record("gen_ai.tool.name", tool_name);
                             tool_span.record("gen_ai.tool.call.id", &tool_call.id);
@@ -1064,7 +1277,10 @@ mod tests {
     use crate::{
         agent::{
             AgentBuilder,
-            prompt_request::hooks::{HookAction, PromptHook, ToolCallHookAction},
+            prompt_request::hooks::{
+                HookAction, InvalidToolCallContext, InvalidToolCallHook, InvalidToolCallHookAction,
+                PromptHook, ToolCallHookAction,
+            },
         },
         completion::{
             AssistantContent, CompletionError, CompletionModel, CompletionRequest, Message, Prompt,
@@ -1099,24 +1315,69 @@ mod tests {
     struct PanicOnUnknownToolHook;
 
     impl PromptHook<MockCompletionModel> for PanicOnUnknownToolHook {
-        fn on_completion_response(
+        async fn on_completion_response(
             &self,
             _prompt: &Message,
             _response: &crate::completion::CompletionResponse<
                 <MockCompletionModel as CompletionModel>::Response,
             >,
-        ) -> impl std::future::Future<Output = HookAction> + Send {
-            async { panic!("unknown tool response should fail before response hooks run") }
+        ) -> HookAction {
+            panic!("unknown tool response should fail before response hooks run")
         }
 
-        fn on_tool_call(
+        async fn on_tool_call(
             &self,
             _tool_name: &str,
             _tool_call_id: Option<String>,
             _internal_call_id: &str,
             _args: &str,
-        ) -> impl std::future::Future<Output = ToolCallHookAction> + Send {
-            async { panic!("unknown tool call should fail before tool hooks run") }
+        ) -> ToolCallHookAction {
+            panic!("unknown tool call should fail before tool hooks run")
+        }
+    }
+
+    #[derive(Clone)]
+    struct RepairDefaultApiHook;
+
+    impl InvalidToolCallHook<MockCompletionModel> for RepairDefaultApiHook {
+        fn on_invalid_tool_call(
+            &self,
+            context: &InvalidToolCallContext,
+        ) -> impl std::future::Future<Output = InvalidToolCallHookAction> + Send {
+            let tool_name = context.tool_name.clone();
+            async move {
+                assert_eq!(tool_name, "default_api");
+                InvalidToolCallHookAction::repair("add")
+            }
+        }
+    }
+
+    #[derive(Clone)]
+    struct RetryDefaultApiHook;
+
+    impl InvalidToolCallHook<MockCompletionModel> for RetryDefaultApiHook {
+        fn on_invalid_tool_call(
+            &self,
+            context: &InvalidToolCallContext,
+        ) -> impl std::future::Future<Output = InvalidToolCallHookAction> + Send {
+            let allowed_tools = context.allowed_tools.clone();
+            async move {
+                InvalidToolCallHookAction::retry(format!(
+                    "Use one of these tools instead: {allowed_tools:?}"
+                ))
+            }
+        }
+    }
+
+    #[derive(Clone)]
+    struct SkipDefaultApiHook;
+
+    impl InvalidToolCallHook<MockCompletionModel> for SkipDefaultApiHook {
+        async fn on_invalid_tool_call(
+            &self,
+            _context: &InvalidToolCallContext,
+        ) -> InvalidToolCallHookAction {
+            InvalidToolCallHookAction::skip("default_api is not available")
         }
     }
 
@@ -1420,6 +1681,155 @@ mod tests {
             other => panic!("expected UnknownToolCall, got {other:?}"),
         }
         assert_eq!(recorded.request_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn invalid_tool_call_hook_can_repair_non_streaming_tool_name() {
+        let model = MockCompletionModel::new([
+            MockTurn::tool_call("tool_call_1", "default_api", json!({"x": 2, "y": 3})),
+            MockTurn::text("done"),
+        ]);
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
+
+        let response = agent
+            .prompt("add")
+            .with_invalid_tool_call_hook(RepairDefaultApiHook)
+            .max_turns(3)
+            .extended_details()
+            .await
+            .expect("repaired tool call should execute");
+
+        assert_eq!(response.output, "done");
+        let messages = response.messages.expect("messages should be present");
+        assert!(history_contains_tool_call(&messages, "add"));
+        assert!(!history_contains_tool_call(&messages, "default_api"));
+        assert!(messages.iter().any(|message| {
+            matches!(
+                message,
+                Message::User { content }
+                    if content.iter().any(|content| {
+                        matches!(
+                            content,
+                            UserContent::ToolResult(result)
+                                if result.content.iter().any(|content| {
+                                    matches!(
+                                        content,
+                                        crate::message::ToolResultContent::Text(text)
+                                            if text.text == "5"
+                                    )
+                                })
+                        )
+                    })
+            )
+        }));
+    }
+
+    #[tokio::test]
+    async fn invalid_tool_call_hook_retry_adds_feedback_and_retries_non_streaming() {
+        let model = MockCompletionModel::new([
+            MockTurn::tool_call("tool_call_1", "default_api", json!({"x": 2, "y": 3})),
+            MockTurn::text("retried"),
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
+
+        let response = agent
+            .prompt("add")
+            .with_invalid_tool_call_hook(RetryDefaultApiHook)
+            .max_invalid_tool_call_retries(1)
+            .max_turns(3)
+            .extended_details()
+            .await
+            .expect("retry should recover");
+
+        assert_eq!(response.output, "retried");
+        assert_eq!(recorded.request_count(), 2);
+        let messages = response.messages.expect("messages should be present");
+        assert!(messages.iter().any(|message| {
+            matches!(
+                message,
+                Message::User { content }
+                    if content.iter().any(|content| {
+                        matches!(
+                            content,
+                            UserContent::ToolResult(result)
+                                if result.content.iter().any(|content| {
+                                    matches!(
+                                        content,
+                                        crate::message::ToolResultContent::Text(text)
+                                            if text.text.contains("Use one of these tools instead")
+                                    )
+                                })
+                        )
+                    })
+            )
+        }));
+    }
+
+    #[tokio::test]
+    async fn invalid_tool_call_hook_retry_budget_exhaustion_fails() {
+        let model = MockCompletionModel::new([
+            MockTurn::tool_call("tool_call_1", "default_api", json!({"x": 2, "y": 3})),
+            MockTurn::text("should not be requested"),
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
+
+        let err = agent
+            .prompt("add")
+            .with_invalid_tool_call_hook(RetryDefaultApiHook)
+            .max_invalid_tool_call_retries(0)
+            .max_turns(3)
+            .await
+            .expect_err("retry without budget should fail");
+
+        match err {
+            PromptError::UnknownToolCall { tool_name, .. } => {
+                assert_eq!(tool_name, "default_api");
+            }
+            other => panic!("expected UnknownToolCall, got {other:?}"),
+        }
+        assert_eq!(recorded.request_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn invalid_tool_call_hook_can_skip_structured_non_streaming_call() {
+        let model = MockCompletionModel::new([
+            MockTurn::tool_call("tool_call_1", "default_api", json!({"x": 2, "y": 3})),
+            MockTurn::text("skipped"),
+        ]);
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
+
+        let response = agent
+            .prompt("add")
+            .with_invalid_tool_call_hook(SkipDefaultApiHook)
+            .max_turns(3)
+            .extended_details()
+            .await
+            .expect("skip should continue with synthetic tool result");
+
+        assert_eq!(response.output, "skipped");
+        let messages = response.messages.expect("messages should be present");
+        assert!(history_contains_tool_call(&messages, "default_api"));
+        assert!(messages.iter().any(|message| {
+            matches!(
+                message,
+                Message::User { content }
+                    if content.iter().any(|content| {
+                        matches!(
+                            content,
+                            UserContent::ToolResult(result)
+                                if result.content.iter().any(|content| {
+                                    matches!(
+                                        content,
+                                        crate::message::ToolResultContent::Text(text)
+                                            if text.text == "default_api is not available"
+                                    )
+                                })
+                        )
+                    })
+            )
+        }));
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -449,6 +449,9 @@ impl<T> TypedPromptResponse<T> {
 
 const UNKNOWN_AGENT_NAME: &str = "Unnamed Agent";
 
+pub(crate) const TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER: &str =
+    "Tool not executed because another tool call in the same assistant turn was invalid.";
+
 /// Combine input history with new messages for building completion requests.
 fn build_history_for_request(
     chat_history: Option<&[Message]>,
@@ -465,6 +468,47 @@ fn build_full_history(
 ) -> Vec<Message> {
     let input = chat_history.unwrap_or(&[]);
     input.iter().cloned().chain(new_messages).collect()
+}
+
+fn tool_result_user_content(
+    id: String,
+    call_id: Option<String>,
+    tool_result: String,
+) -> UserContent {
+    let content = ToolResultContent::from_tool_output(tool_result);
+    match call_id {
+        Some(call_id) => UserContent::tool_result_with_call_id(id, call_id, content),
+        None => UserContent::tool_result(id, content),
+    }
+}
+
+fn invalid_tool_retry_user_message(
+    assistant_content: &OneOrMany<AssistantContent>,
+    invalid_tool_call_id: &str,
+    feedback: String,
+) -> Option<Message> {
+    let retry_results = assistant_content
+        .iter()
+        .filter_map(|content| match content {
+            AssistantContent::ToolCall(tool_call) if tool_call.id == invalid_tool_call_id => {
+                Some(tool_result_user_content(
+                    tool_call.id.clone(),
+                    tool_call.call_id.clone(),
+                    feedback.clone(),
+                ))
+            }
+            AssistantContent::ToolCall(tool_call) => Some(tool_result_user_content(
+                tool_call.id.clone(),
+                tool_call.call_id.clone(),
+                TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER.to_string(),
+            )),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    Some(Message::User {
+        content: OneOrMany::from_iter_optional(retry_results)?,
+    })
 }
 
 pub(crate) fn validate_tool_call_name(
@@ -803,21 +847,17 @@ where
                                 id: resp.message_id.clone(),
                                 content: resp.choice.clone(),
                             });
-                            let user_content = if let Some(call_id) = tool_call.call_id.clone() {
-                                UserContent::tool_result_with_call_id(
-                                    tool_call.id.clone(),
-                                    call_id,
-                                    OneOrMany::one(feedback.into()),
-                                )
-                            } else {
-                                UserContent::tool_result(
-                                    tool_call.id.clone(),
-                                    OneOrMany::one(feedback.into()),
-                                )
+                            let Some(user_message) = invalid_tool_retry_user_message(
+                                &resp.choice,
+                                &tool_call.id,
+                                feedback,
+                            ) else {
+                                return Err(PromptError::prompt_cancelled(
+                                    diagnostic_history,
+                                    "invalid tool call retry produced no retry messages",
+                                ));
                             };
-                            new_messages.push(Message::User {
-                                content: OneOrMany::one(user_content),
-                            });
+                            new_messages.push(user_message);
                             continue 'prompt_loop;
                         }
                         InvalidToolCallResolution::Repair(repaired_name) => {
@@ -1314,17 +1354,22 @@ mod tests {
         },
         completion::{
             AssistantContent, CompletionError, CompletionModel, CompletionRequest, Message, Prompt,
-            PromptError, StructuredOutputError, TypedPrompt, Usage,
+            PromptError, StructuredOutputError, ToolDefinition, TypedPrompt, Usage,
         },
-        message::{Text, ToolChoice, UserContent},
+        message::{Text, ToolCall, ToolChoice, ToolFunction, UserContent},
         test_utils::{
             AppendFailingMemory, CountingMemory, FailingMemory, MockAddTool, MockCompletionModel,
-            MockSubtractTool, MockTurn,
+            MockOperationArgs, MockSubtractTool, MockToolError, MockTurn,
         },
+        tool::Tool,
     };
     use schemars::JsonSchema;
     use serde::{Deserialize, Serialize};
     use serde_json::json;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicU32, Ordering},
+    };
 
     #[derive(Serialize)]
     struct SerializeOnly {
@@ -1420,6 +1465,27 @@ mod tests {
             _context: &InvalidToolCallContext,
         ) -> InvalidToolCallHookAction {
             InvalidToolCallHookAction::skip("default_api is not available")
+        }
+    }
+
+    #[derive(Clone)]
+    struct CountingAddTool {
+        calls: Arc<AtomicU32>,
+    }
+
+    impl Tool for CountingAddTool {
+        const NAME: &'static str = "add";
+        type Error = MockToolError;
+        type Args = MockOperationArgs;
+        type Output = i32;
+
+        async fn definition(&self, _prompt: String) -> ToolDefinition {
+            MockAddTool.definition(String::new()).await
+        }
+
+        async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(0)
         }
     }
 
@@ -1806,6 +1872,95 @@ mod tests {
                     })
             )
         }));
+    }
+
+    #[tokio::test]
+    async fn invalid_tool_call_hook_retries_mixed_non_streaming_turn_without_executing_valid_call()
+    {
+        let add_calls = Arc::new(AtomicU32::new(0));
+        let mut valid_tool_call = ToolCall::new(
+            "tool_call_1".to_string(),
+            ToolFunction::new("add".to_string(), json!({"x": 2, "y": 3})),
+        );
+        valid_tool_call.call_id = Some("call_1".to_string());
+        let mut invalid_tool_call = ToolCall::new(
+            "tool_call_2".to_string(),
+            ToolFunction::new("default_api".to_string(), json!({"x": 4, "y": 5})),
+        );
+        invalid_tool_call.call_id = Some("call_2".to_string());
+        let model = MockCompletionModel::new([
+            MockTurn::from_contents([
+                AssistantContent::ToolCall(valid_tool_call),
+                AssistantContent::ToolCall(invalid_tool_call),
+            ])
+            .expect("tool-call response should be non-empty"),
+            MockTurn::text("retried"),
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model)
+            .tool(CountingAddTool {
+                calls: add_calls.clone(),
+            })
+            .build();
+
+        let response = agent
+            .prompt("add")
+            .with_invalid_tool_call_hook(RetryDefaultApiHook)
+            .max_invalid_tool_call_retries(1)
+            .max_turns(3)
+            .extended_details()
+            .await
+            .expect("retry should recover");
+
+        assert_eq!(response.output, "retried");
+        assert_eq!(add_calls.load(Ordering::SeqCst), 0);
+        let requests = recorded.requests();
+        assert_eq!(requests.len(), 2);
+        let retry_history = requests[1].chat_history.iter().cloned().collect::<Vec<_>>();
+        assert_eq!(retry_history.len(), 3);
+        assert!(matches!(
+            retry_history.get(1),
+            Some(Message::Assistant { content, .. })
+                if content.iter().any(|item| matches!(
+                    item,
+                    AssistantContent::ToolCall(tool_call)
+                        if tool_call.id == "tool_call_1"
+                            && tool_call.function.name == "add"
+                ))
+                    && content.iter().any(|item| matches!(
+                        item,
+                        AssistantContent::ToolCall(tool_call)
+                            if tool_call.id == "tool_call_2"
+                                && tool_call.function.name == "default_api"
+                    ))
+        ));
+        assert!(matches!(
+            retry_history.get(2),
+            Some(Message::User { content })
+                if content.iter().filter(|item| matches!(item, UserContent::ToolResult(_))).count() == 2
+                    && content.iter().any(|item| matches!(
+                        item,
+                        UserContent::ToolResult(result)
+                            if result.id == "tool_call_1"
+                                && result.call_id.as_deref() == Some("call_1")
+                                && result.content.iter().any(|content| matches!(
+                                    content,
+                                    crate::message::ToolResultContent::Text(text)
+                                        if text.text == super::TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER
+                                ))
+                    ))
+                    && content.iter().any(|item| matches!(
+                        item,
+                        UserContent::ToolResult(result)
+                            if result.id == "tool_call_2"
+                                && result.call_id.as_deref() == Some("call_2")
+                                && result.content.iter().any(|content| matches!(
+                                    content,
+                                    crate::message::ToolResultContent::Text(text)
+                                        if text.text.contains("Use one of these tools instead")
+                                ))
+                    ))
+        ));
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -794,6 +794,7 @@ where
             // that sentinel as "no assistant output" so it does not pollute returned history.
             let mut skipped_tool_results = BTreeMap::new();
             let mut invalid_tool_call_recovered = false;
+            let mut invalid_tool_call_skipped = false;
             if has_tool_calls {
                 for choice in response_choice.iter_mut() {
                     let AssistantContent::ToolCall(tool_call) = choice else {
@@ -879,8 +880,27 @@ where
                             };
                             skipped_tool_results.insert(tool_call.id.clone(), user_content);
                             invalid_tool_call_recovered = true;
+                            invalid_tool_call_skipped = true;
                         }
                     }
+                }
+            }
+
+            if invalid_tool_call_skipped {
+                for choice in response_choice.iter() {
+                    let AssistantContent::ToolCall(tool_call) = choice else {
+                        continue;
+                    };
+
+                    skipped_tool_results
+                        .entry(tool_call.id.clone())
+                        .or_insert_with(|| {
+                            tool_result_user_content(
+                                tool_call.id.clone(),
+                                tool_call.call_id.clone(),
+                                TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER.to_string(),
+                            )
+                        });
                 }
             }
 
@@ -1408,6 +1428,21 @@ mod tests {
             _args: &str,
         ) -> ToolCallHookAction {
             panic!("unknown tool call should fail before tool hooks run")
+        }
+    }
+
+    #[derive(Clone)]
+    struct PanicOnToolCallHook;
+
+    impl PromptHook<MockCompletionModel> for PanicOnToolCallHook {
+        async fn on_tool_call(
+            &self,
+            _tool_name: &str,
+            _tool_call_id: Option<String>,
+            _internal_call_id: &str,
+            _args: &str,
+        ) -> ToolCallHookAction {
+            panic!("recovered invalid turn should not invoke normal tool hooks")
         }
     }
 
@@ -2014,6 +2049,76 @@ mod tests {
                                     content,
                                     crate::message::ToolResultContent::Text(text)
                                         if text.text.contains("Use one of these tools instead")
+                                ))
+            ))
+        ));
+    }
+
+    #[tokio::test]
+    async fn invalid_tool_call_hook_skips_mixed_non_streaming_turn_without_executing_valid_call() {
+        let add_calls = Arc::new(AtomicU32::new(0));
+        let mut valid_tool_call = ToolCall::new(
+            "tool_call_1".to_string(),
+            ToolFunction::new("add".to_string(), json!({"x": 2, "y": 3})),
+        );
+        valid_tool_call.call_id = Some("call_1".to_string());
+        let mut invalid_tool_call = ToolCall::new(
+            "tool_call_2".to_string(),
+            ToolFunction::new("default_api".to_string(), json!({"x": 4, "y": 5})),
+        );
+        invalid_tool_call.call_id = Some("call_2".to_string());
+        let model = MockCompletionModel::new([
+            MockTurn::from_contents([
+                AssistantContent::ToolCall(valid_tool_call),
+                AssistantContent::ToolCall(invalid_tool_call),
+            ])
+            .expect("tool-call response should be non-empty"),
+            MockTurn::text("skipped"),
+        ]);
+        let agent = AgentBuilder::new(model)
+            .tool(CountingAddTool {
+                calls: add_calls.clone(),
+            })
+            .build();
+
+        let response = agent
+            .prompt("add")
+            .with_hook(PanicOnToolCallHook)
+            .with_invalid_tool_call_hook(SkipDefaultApiHook)
+            .max_turns(3)
+            .extended_details()
+            .await
+            .expect("skip should recover without executing peer tools");
+
+        assert_eq!(response.output, "skipped");
+        assert_eq!(add_calls.load(Ordering::SeqCst), 0);
+        let messages = response.messages.expect("messages should be present");
+        assert!(history_contains_tool_call(&messages, "add"));
+        assert!(history_contains_tool_call(&messages, "default_api"));
+        assert!(matches!(
+            messages.get(2),
+            Some(Message::User { content })
+                if content.iter().filter(|item| matches!(item, UserContent::ToolResult(_))).count() == 2
+                    && content.iter().any(|item| matches!(
+                        item,
+                        UserContent::ToolResult(result)
+                            if result.id == "tool_call_1"
+                                && result.call_id.as_deref() == Some("call_1")
+                                && result.content.iter().any(|content| matches!(
+                                    content,
+                                    crate::message::ToolResultContent::Text(text)
+                                        if text.text == super::TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER
+                                ))
+                    ))
+                    && content.iter().any(|item| matches!(
+                        item,
+                        UserContent::ToolResult(result)
+                            if result.id == "tool_call_2"
+                                && result.call_id.as_deref() == Some("call_2")
+                                && result.content.iter().any(|content| matches!(
+                                    content,
+                                    crate::message::ToolResultContent::Text(text)
+                                        if text.text == "default_api is not available"
                                 ))
                     ))
         ));

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -1013,6 +1013,8 @@ where
                                                 internal_call_id,
                                             },
                                         ));
+                                        text_delta_response.clear();
+                                        saw_text_this_turn = false;
                                         continue 'outer;
                                     }
                                 }
@@ -1108,6 +1110,8 @@ where
                                                         internal_call_id,
                                                     },
                                                 ));
+                                                text_delta_response.clear();
+                                                saw_text_this_turn = false;
                                                 continue 'outer;
                                             }
                                             InvalidToolCallResolution::Retry(feedback) => {
@@ -1143,6 +1147,8 @@ where
                                                 };
                                                 new_messages.push(assistant_message);
                                                 new_messages.push(user_message);
+                                                text_delta_response.clear();
+                                                saw_text_this_turn = false;
                                                 continue 'outer;
                                             }
                                             InvalidToolCallResolution::Repair(repaired_name) => {
@@ -2177,6 +2183,39 @@ mod tests {
     }
 
     #[derive(Clone, Default)]
+    struct RecordingTextDeltaHook {
+        deltas: Arc<Mutex<Vec<(String, String)>>>,
+    }
+
+    impl RecordingTextDeltaHook {
+        fn observed(&self) -> Vec<(String, String)> {
+            self.deltas
+                .lock()
+                .expect("text delta hook records mutex was poisoned")
+                .clone()
+        }
+    }
+
+    impl PromptHook<MockCompletionModel> for RecordingTextDeltaHook {
+        fn on_text_delta(
+            &self,
+            text_delta: &str,
+            full_text: &str,
+        ) -> impl Future<Output = HookAction> + Send {
+            let deltas = self.deltas.clone();
+            let event = (text_delta.to_string(), full_text.to_string());
+
+            async move {
+                deltas
+                    .lock()
+                    .expect("text delta hook records mutex was poisoned")
+                    .push(event);
+                HookAction::cont()
+            }
+        }
+    }
+
+    #[derive(Clone, Default)]
     struct TerminatingToolCallDeltaHook {
         deltas: Arc<Mutex<Vec<RecordedToolCallDelta>>>,
     }
@@ -2724,6 +2763,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn invalid_tool_call_hook_skip_resets_streaming_text_delta_state() {
+        let text_hook = RecordingTextDeltaHook::default();
+        let model = MockCompletionModel::from_stream_turns([
+            vec![
+                MockStreamEvent::text("stale "),
+                MockStreamEvent::tool_call(
+                    "tool_call_1",
+                    "default_api",
+                    serde_json::json!({"x": 2, "y": 3}),
+                ),
+                MockStreamEvent::final_response_with_total_tokens(4),
+            ],
+            vec![
+                MockStreamEvent::text("fresh"),
+                MockStreamEvent::final_response_with_total_tokens(6),
+            ],
+        ]);
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
+
+        let mut stream = agent
+            .stream_prompt("use the tool")
+            .with_hook(text_hook.clone())
+            .with_invalid_tool_call_hook(SkipDefaultApiHook)
+            .multi_turn(3)
+            .with_history(Vec::<Message>::new())
+            .await;
+
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(MultiTurnStreamItem::FinalResponse(_)) => break,
+                Ok(_) => {}
+                Err(err) => panic!("unexpected streaming error: {err:?}"),
+            }
+        }
+
+        assert_eq!(
+            text_hook.observed(),
+            vec![
+                ("stale ".to_string(), "stale ".to_string()),
+                ("fresh".to_string(), "fresh".to_string()),
+            ]
+        );
+    }
+
+    #[tokio::test]
     async fn invalid_tool_call_delta_retry_uses_structured_tool_feedback() {
         let delta_hook = RecordingToolCallDeltaHook::default();
         let add_calls = Arc::new(AtomicU32::new(0));
@@ -2834,6 +2918,53 @@ mod tests {
                             ))
                 ))
         ));
+    }
+
+    #[tokio::test]
+    async fn invalid_tool_call_delta_retry_resets_streaming_text_delta_state() {
+        let text_hook = RecordingTextDeltaHook::default();
+        let model = MockCompletionModel::from_stream_turns([
+            vec![
+                MockStreamEvent::text("stale "),
+                MockStreamEvent::tool_call_arguments_delta(
+                    "tool_call_1",
+                    "internal_1",
+                    r#"{"x":2,"y":3}"#,
+                ),
+                MockStreamEvent::tool_call_name_delta("tool_call_1", "internal_1", "default_api"),
+                MockStreamEvent::final_response_with_total_tokens(4),
+            ],
+            vec![
+                MockStreamEvent::text("fresh"),
+                MockStreamEvent::final_response_with_total_tokens(6),
+            ],
+        ]);
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
+
+        let mut stream = agent
+            .stream_prompt("use the tool")
+            .with_hook(text_hook.clone())
+            .with_invalid_tool_call_hook(RetryDefaultApiHook)
+            .multi_turn(3)
+            .with_history(Vec::<Message>::new())
+            .max_invalid_tool_call_retries(1)
+            .await;
+
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(MultiTurnStreamItem::FinalResponse(_)) => break,
+                Ok(_) => {}
+                Err(err) => panic!("unexpected streaming error: {err:?}"),
+            }
+        }
+
+        assert_eq!(
+            text_hook.observed(),
+            vec![
+                ("stale ".to_string(), "stale ".to_string()),
+                ("fresh".to_string(), "fresh".to_string()),
+            ]
+        );
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -284,6 +284,38 @@ fn build_tool_call_validation_history(input: ToolCallValidationHistory<'_>) -> V
     build_full_history(input.chat_history, messages)
 }
 
+async fn drain_recovered_stream_usage<R>(
+    stream: &mut crate::streaming::StreamingCompletionResponse<R>,
+    tool_call_delta_states: &HashMap<(String, String), ToolCallDeltaState>,
+    current_call_usage: &mut Option<crate::completion::Usage>,
+    aggregated_usage: &mut crate::completion::Usage,
+) -> Result<(), StreamingError>
+where
+    R: Clone + Unpin + GetTokenUsage,
+{
+    if let Some(err) = pending_tool_call_delta_error(tool_call_delta_states) {
+        return Err(err.into());
+    }
+
+    while let Some(content) = stream.next().await {
+        match content {
+            Ok(StreamedAssistantContent::Final(final_resp)) => {
+                if let Some(usage) = final_resp.token_usage() {
+                    *current_call_usage = reported_usage(usage);
+                }
+                if let Some(usage) = *current_call_usage {
+                    *aggregated_usage += usage;
+                }
+                return Ok(());
+            }
+            Ok(_) => {}
+            Err(err) => return Err(err.into()),
+        }
+    }
+
+    Ok(())
+}
+
 fn record_completion_call_if_needed(
     completion_calls: &mut Vec<CompletionCall>,
     completion_call_emitted: &mut bool,
@@ -1035,6 +1067,17 @@ where
                                         };
                                         new_messages.push(assistant_message);
                                         new_messages.push(user_message);
+                                        if let Err(err) = drain_recovered_stream_usage(
+                                            &mut stream,
+                                            &tool_call_delta_states,
+                                            &mut current_call_usage,
+                                            &mut aggregated_usage,
+                                        )
+                                        .await
+                                        {
+                                            yield Err(err);
+                                            break 'outer;
+                                        }
                                         if let Some(completion_call) = record_completion_call_if_needed(
                                             &mut completion_calls,
                                             &mut completion_call_emitted,
@@ -1090,6 +1133,17 @@ where
                                             call_id: skipped_tool_result.call_id,
                                             content: skipped_tool_result.content,
                                         };
+                                        if let Err(err) = drain_recovered_stream_usage(
+                                            &mut stream,
+                                            &tool_call_delta_states,
+                                            &mut current_call_usage,
+                                            &mut aggregated_usage,
+                                        )
+                                        .await
+                                        {
+                                            yield Err(err);
+                                            break 'outer;
+                                        }
                                         if let Some(completion_call) = record_completion_call_if_needed(
                                             &mut completion_calls,
                                             &mut completion_call_emitted,
@@ -1206,6 +1260,17 @@ where
                                                         reason,
                                                     ),
                                                 };
+                                                if let Err(err) = drain_recovered_stream_usage(
+                                                    &mut stream,
+                                                    &tool_call_delta_states,
+                                                    &mut current_call_usage,
+                                                    &mut aggregated_usage,
+                                                )
+                                                .await
+                                                {
+                                                    yield Err(err);
+                                                    break 'outer;
+                                                }
                                                 if let Some(completion_call) = record_completion_call_if_needed(
                                                     &mut completion_calls,
                                                     &mut completion_call_emitted,
@@ -1227,6 +1292,7 @@ where
                                                 continue 'outer;
                                             }
                                             InvalidToolCallResolution::Retry(feedback) => {
+                                                tool_call_delta_states.remove(&key);
                                                 if invalid_tool_call_retries >= self.max_invalid_tool_call_retries {
                                                     yield Err(Box::new(PromptError::UnknownToolCall {
                                                         tool_name: emitted_tool_name,
@@ -1263,6 +1329,17 @@ where
                                                 };
                                                 new_messages.push(assistant_message);
                                                 new_messages.push(user_message);
+                                                if let Err(err) = drain_recovered_stream_usage(
+                                                    &mut stream,
+                                                    &tool_call_delta_states,
+                                                    &mut current_call_usage,
+                                                    &mut aggregated_usage,
+                                                )
+                                                .await
+                                                {
+                                                    yield Err(err);
+                                                    break 'outer;
+                                                }
                                                 if let Some(completion_call) = record_completion_call_if_needed(
                                                     &mut completion_calls,
                                                     &mut completion_call_emitted,
@@ -2831,6 +2908,7 @@ mod tests {
             .await;
         let mut completion_call_events = Vec::new();
         let mut final_response_text = None;
+        let mut final_response_usage = Usage::new();
         let mut final_completion_calls = Vec::new();
 
         while let Some(item) = stream.next().await {
@@ -2840,6 +2918,7 @@ mod tests {
                 }
                 Ok(MultiTurnStreamItem::FinalResponse(response)) => {
                     final_response_text = Some(response.response().to_string());
+                    final_response_usage = response.usage();
                     final_completion_calls = response.completion_calls().to_vec();
                     break;
                 }
@@ -2850,14 +2929,17 @@ mod tests {
 
         assert_eq!(final_response_text.as_deref(), Some("retried"));
         assert_eq!(add_calls.load(Ordering::SeqCst), 0);
+        let mut first_usage = Usage::new();
+        first_usage.total_tokens = 4;
         let mut second_usage = Usage::new();
         second_usage.total_tokens = 6;
         let expected_completion_calls = vec![
-            CompletionCall::new(0, None),
+            CompletionCall::new(0, Some(first_usage)),
             CompletionCall::new(1, Some(second_usage)),
         ];
         assert_eq!(completion_call_events, expected_completion_calls);
         assert_eq!(final_completion_calls, expected_completion_calls);
+        assert_eq!(final_response_usage.total_tokens, 10);
 
         let requests = recorded.requests();
         assert_eq!(requests.len(), 2);
@@ -3209,15 +3291,23 @@ mod tests {
             .with_history(Vec::<Message>::new())
             .max_invalid_tool_call_retries(1)
             .await;
+        let mut completion_call_events = Vec::new();
         let mut final_response_text = None;
+        let mut final_response_usage = Usage::new();
+        let mut final_completion_calls = Vec::new();
 
         while let Some(item) = stream.next().await {
             match item {
+                Ok(MultiTurnStreamItem::CompletionCall(completion_call)) => {
+                    completion_call_events.push(completion_call);
+                }
                 Ok(MultiTurnStreamItem::StreamAssistantItem(
                     StreamedAssistantContent::ToolCallDelta { .. },
                 )) => panic!("invalid tool-call delta should not be emitted"),
                 Ok(MultiTurnStreamItem::FinalResponse(response)) => {
                     final_response_text = Some(response.response().to_string());
+                    final_response_usage = response.usage();
+                    final_completion_calls = response.completion_calls().to_vec();
                     break;
                 }
                 Ok(_) => {}
@@ -3228,6 +3318,17 @@ mod tests {
         assert_eq!(final_response_text.as_deref(), Some("retried"));
         assert!(delta_hook.observed().is_empty());
         assert_eq!(add_calls.load(Ordering::SeqCst), 0);
+        let mut first_usage = Usage::new();
+        first_usage.total_tokens = 4;
+        let mut second_usage = Usage::new();
+        second_usage.total_tokens = 6;
+        let expected_completion_calls = vec![
+            CompletionCall::new(0, Some(first_usage)),
+            CompletionCall::new(1, Some(second_usage)),
+        ];
+        assert_eq!(completion_call_events, expected_completion_calls);
+        assert_eq!(final_completion_calls, expected_completion_calls);
+        assert_eq!(final_response_usage.total_tokens, 10);
 
         let requests = recorded.requests();
         assert_eq!(requests.len(), 2);

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -2,7 +2,7 @@ use crate::{
     OneOrMany,
     agent::completion::{DynamicContextStore, build_prepared_completion_request},
     agent::prompt_request::{
-        HookAction, InvalidToolCallResolution,
+        HookAction, InvalidToolCallResolution, TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER,
         hooks::{InvalidToolCallHook, PromptHook},
         resolve_invalid_tool_call, validate_tool_call_name,
     },
@@ -284,9 +284,6 @@ fn tool_result_to_user_message(
         content: OneOrMany::one(user_content),
     }
 }
-
-const TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER: &str =
-    "Tool not executed because another tool call in the same assistant turn was invalid.";
 
 fn tool_result_user_content(
     id: String,
@@ -1024,14 +1021,32 @@ where
                                                 yield Err(Box::new(err).into());
                                                 break 'outer;
                                             }
-                                            InvalidToolCallResolution::Skip(_) => {
-                                                yield Err(Box::new(PromptError::UnknownToolCall {
-                                                    tool_name: emitted_tool_name,
-                                                    available_tools: executable_tool_names.iter().cloned().collect(),
-                                                    allowed_tools: allowed_tool_names.iter().cloned().collect(),
-                                                    chat_history: Box::new(diagnostic_history),
-                                                }).into());
-                                                break 'outer;
+                                            InvalidToolCallResolution::Skip(reason) => {
+                                                tool_call_delta_states.remove(&key);
+                                                let (assistant_message, user_message) =
+                                                    invalid_streaming_name_delta_retry_messages(
+                                                        &stream.message_id,
+                                                        id.clone(),
+                                                        emitted_tool_name,
+                                                        buffered_args,
+                                                        reason.clone(),
+                                                    );
+                                                new_messages.push(assistant_message);
+                                                new_messages.push(user_message);
+                                                let tool_result = ToolResult {
+                                                    id,
+                                                    call_id: None,
+                                                    content: ToolResultContent::from_tool_output(
+                                                        reason,
+                                                    ),
+                                                };
+                                                yield Ok(MultiTurnStreamItem::StreamUserItem(
+                                                    StreamedUserContent::ToolResult {
+                                                        tool_result,
+                                                        internal_call_id,
+                                                    },
+                                                ));
+                                                continue 'outer;
                                             }
                                             InvalidToolCallResolution::Retry(feedback) => {
                                                 if invalid_tool_call_retries >= self.max_invalid_tool_call_retries {
@@ -2590,6 +2605,105 @@ mod tests {
                                 content,
                                 ToolResultContent::Text(text)
                                     if text.text == "Use the add tool instead"
+                            ))
+                ))
+        ));
+    }
+
+    #[tokio::test]
+    async fn invalid_tool_call_delta_skip_uses_structured_tool_feedback() {
+        let delta_hook = RecordingToolCallDeltaHook::default();
+        let add_calls = Arc::new(AtomicU32::new(0));
+        let model = MockCompletionModel::from_stream_turns([
+            vec![
+                MockStreamEvent::tool_call_arguments_delta(
+                    "tool_call_1",
+                    "internal_1",
+                    r#"{"x":2,"y":3}"#,
+                ),
+                MockStreamEvent::tool_call_name_delta("tool_call_1", "internal_1", "default_api"),
+                MockStreamEvent::final_response_with_total_tokens(4),
+            ],
+            vec![
+                MockStreamEvent::text("continued"),
+                MockStreamEvent::final_response_with_total_tokens(6),
+            ],
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model)
+            .tool(CountingAddTool {
+                calls: add_calls.clone(),
+            })
+            .build();
+
+        let mut stream = agent
+            .stream_prompt("use the tool")
+            .with_hook(delta_hook.clone())
+            .with_invalid_tool_call_hook(SkipDefaultApiHook)
+            .multi_turn(3)
+            .with_history(Vec::<Message>::new())
+            .await;
+        let mut skipped_tool_result = None;
+        let mut final_response_text = None;
+
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(MultiTurnStreamItem::StreamAssistantItem(
+                    StreamedAssistantContent::ToolCallDelta { .. },
+                )) => panic!("invalid tool-call delta should not be emitted"),
+                Ok(MultiTurnStreamItem::StreamUserItem(StreamedUserContent::ToolResult {
+                    tool_result,
+                    internal_call_id,
+                })) => {
+                    assert_eq!(internal_call_id, "internal_1");
+                    skipped_tool_result = Some(tool_result);
+                }
+                Ok(MultiTurnStreamItem::FinalResponse(response)) => {
+                    final_response_text = Some(response.response().to_string());
+                    break;
+                }
+                Ok(_) => {}
+                Err(err) => panic!("unexpected streaming error: {err:?}"),
+            }
+        }
+
+        let skipped_tool_result =
+            skipped_tool_result.expect("skip recovery should emit a synthetic tool result");
+        assert_eq!(skipped_tool_result.id, "tool_call_1");
+        assert!(skipped_tool_result.call_id.is_none());
+        assert!(skipped_tool_result.content.iter().any(|content| matches!(
+            content,
+            ToolResultContent::Text(text) if text.text == "default_api was skipped"
+        )));
+        assert_eq!(final_response_text.as_deref(), Some("continued"));
+        assert!(delta_hook.observed().is_empty());
+        assert_eq!(add_calls.load(Ordering::SeqCst), 0);
+
+        let requests = recorded.requests();
+        assert_eq!(requests.len(), 2);
+        let follow_up_history = requests[1].chat_history.iter().cloned().collect::<Vec<_>>();
+        assert!(matches!(
+            follow_up_history.get(1),
+            Some(Message::Assistant { content, .. })
+                if content.iter().any(|item| matches!(
+                    item,
+                    AssistantContent::ToolCall(tool_call)
+                        if tool_call.id == "tool_call_1"
+                            && tool_call.function.name == "default_api"
+                            && tool_call.function.arguments == serde_json::json!({"x": 2, "y": 3})
+                ))
+        ));
+        assert!(matches!(
+            follow_up_history.get(2),
+            Some(Message::User { content })
+                if content.iter().any(|item| matches!(
+                    item,
+                    UserContent::ToolResult(result)
+                        if result.id == "tool_call_1"
+                            && result.content.iter().any(|content| matches!(
+                                content,
+                                ToolResultContent::Text(text)
+                                    if text.text == "default_api was skipped"
                             ))
                 ))
         ));

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -925,7 +925,7 @@ where
                                 match resolve_invalid_tool_call::<M, I>(
                                     self.invalid_tool_call_hook.as_ref(),
                                     &emitted_tool_name,
-                                    tool_call.call_id.clone(),
+                                    Some(tool_call.id.clone()),
                                     Some(internal_call_id.clone()),
                                     Some(args),
                                     &executable_tool_names,
@@ -2499,6 +2499,52 @@ mod tests {
         assert!(saw_tool_result);
         assert_eq!(final_response_text.as_deref(), Some("done"));
         assert_eq!(recorded.request_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn invalid_tool_call_context_uses_completed_streaming_tool_call_provider_id() {
+        let invalid_hook = RecordingInvalidToolCallHook::default();
+        let model = MockCompletionModel::from_stream_turns([
+            vec![
+                MockStreamEvent::tool_call(
+                    "tool_call_1",
+                    "default_api",
+                    serde_json::json!({"x": 2, "y": 3}),
+                )
+                .with_call_id("provider_call_1"),
+                MockStreamEvent::final_response_with_total_tokens(4),
+            ],
+            vec![
+                MockStreamEvent::text("should not be requested"),
+                MockStreamEvent::final_response_with_total_tokens(6),
+            ],
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
+
+        let mut stream = agent
+            .stream_prompt("use the tool")
+            .with_invalid_tool_call_hook(invalid_hook.clone())
+            .multi_turn(3)
+            .await;
+        let mut error = None;
+
+        while let Some(item) = stream.next().await {
+            if let Err(err) = item {
+                error = Some(err);
+                break;
+            }
+        }
+
+        assert!(error.is_some(), "invalid tool should fail");
+        assert_eq!(recorded.request_count(), 1);
+        let contexts = invalid_hook.observed();
+        assert_eq!(contexts.len(), 1);
+        let context = &contexts[0];
+        assert_eq!(context.tool_name, "default_api");
+        assert_eq!(context.tool_call_id.as_deref(), Some("tool_call_1"));
+        assert!(context.internal_call_id.is_some());
+        assert!(context.is_streaming);
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -285,6 +285,93 @@ fn tool_result_to_user_message(
     }
 }
 
+const TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER: &str =
+    "Tool not executed because another tool call in the same assistant turn was invalid.";
+
+fn tool_result_user_content(
+    id: String,
+    call_id: Option<String>,
+    tool_result: String,
+) -> UserContent {
+    let content = ToolResultContent::from_tool_output(tool_result);
+    match call_id {
+        Some(call_id) => UserContent::tool_result_with_call_id(id, call_id, content),
+        None => UserContent::tool_result(id, content),
+    }
+}
+
+fn invalid_streaming_tool_retry_messages(
+    assistant_message_id: &Option<String>,
+    text_delta_response: Option<&str>,
+    pending_tool_calls: &[(ToolCall, String)],
+    invalid_tool_call: ToolCall,
+    feedback: String,
+) -> Option<(Message, Message)> {
+    let mut assistant_content = Vec::new();
+    if let Some(text) = text_delta_response
+        && !text.is_empty()
+    {
+        assistant_content.push(AssistantContent::text(text.to_string()));
+    }
+    assistant_content.extend(
+        pending_tool_calls
+            .iter()
+            .map(|(tool_call, _)| AssistantContent::ToolCall(tool_call.clone())),
+    );
+    assistant_content.push(AssistantContent::ToolCall(invalid_tool_call.clone()));
+
+    let assistant_content = OneOrMany::from_iter_optional(assistant_content)?;
+    let assistant_message = Message::Assistant {
+        id: assistant_message_id.clone(),
+        content: assistant_content,
+    };
+
+    let mut retry_results = pending_tool_calls
+        .iter()
+        .map(|(tool_call, _)| {
+            tool_result_user_content(
+                tool_call.id.clone(),
+                tool_call.call_id.clone(),
+                TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER.to_string(),
+            )
+        })
+        .collect::<Vec<_>>();
+    retry_results.push(tool_result_user_content(
+        invalid_tool_call.id,
+        invalid_tool_call.call_id,
+        feedback,
+    ));
+
+    let user_message = Message::User {
+        content: OneOrMany::from_iter_optional(retry_results)?,
+    };
+
+    Some((assistant_message, user_message))
+}
+
+fn invalid_streaming_name_delta_retry_messages(
+    assistant_message_id: &Option<String>,
+    id: String,
+    name: String,
+    buffered_args: String,
+    feedback: String,
+) -> (Message, Message) {
+    let args = if buffered_args.trim().is_empty() {
+        serde_json::Value::Null
+    } else {
+        serde_json::from_str(&buffered_args).unwrap_or(serde_json::Value::Null)
+    };
+
+    let tool_call = ToolCall::new(id, ToolFunction::new(name, args));
+    let assistant_message = Message::Assistant {
+        id: assistant_message_id.clone(),
+        content: OneOrMany::one(AssistantContent::ToolCall(tool_call.clone())),
+    };
+    let user_message = tool_result_to_user_message(tool_call.id, tool_call.call_id, feedback);
+
+    (assistant_message, user_message)
+}
+
 fn assistant_text_from_choice(choice: &OneOrMany<AssistantContent>) -> String {
     choice
         .iter()
@@ -815,7 +902,7 @@ where
                                     &executable_tool_names,
                                     &allowed_tool_names,
                                     self.tool_choice.as_ref(),
-                                    diagnostic_history,
+                                    diagnostic_history.clone(),
                                     true,
                                 ).await {
                                     InvalidToolCallResolution::Fail(err) => {
@@ -828,21 +915,32 @@ where
                                                 tool_name: emitted_tool_name,
                                                 available_tools: executable_tool_names.iter().cloned().collect(),
                                                 allowed_tools: allowed_tool_names.iter().cloned().collect(),
-                                                chat_history: Box::new(build_full_history(chat_history.as_deref(), new_messages.clone())),
+                                                chat_history: Box::new(diagnostic_history),
                                             }).into());
                                             break 'outer;
                                         }
 
                                         invalid_tool_call_retries += 1;
-                                        new_messages.push(Message::Assistant {
-                                            id: stream.message_id.clone(),
-                                            content: OneOrMany::one(AssistantContent::ToolCall(tool_call.clone())),
-                                        });
-                                        new_messages.push(tool_result_to_user_message(
-                                            tool_call.id.clone(),
-                                            tool_call.call_id.clone(),
-                                            feedback,
-                                        ));
+                                        let Some((assistant_message, user_message)) =
+                                            invalid_streaming_tool_retry_messages(
+                                                &stream.message_id,
+                                                saw_text_this_turn.then_some(text_delta_response.as_str()),
+                                                &pending_tool_calls,
+                                                tool_call,
+                                                feedback,
+                                            )
+                                        else {
+                                            yield Err(cancelled_prompt_error(
+                                                chat_history.as_deref(),
+                                                new_messages.clone(),
+                                                "invalid tool call retry produced no retry messages".to_string(),
+                                            ).await);
+                                            break 'outer;
+                                        };
+                                        new_messages.push(assistant_message);
+                                        new_messages.push(user_message);
+                                        text_delta_response.clear();
+                                        saw_text_this_turn = false;
                                         continue 'outer;
                                     }
                                     InvalidToolCallResolution::Repair(repaired_name) => {
@@ -869,9 +967,19 @@ where
 
                             match content {
                                 ToolCallDeltaContent::Name(mut name) => {
+                                    let buffered_args = tool_call_delta_states
+                                        .get(&key)
+                                        .map(|state| state.buffered_arguments.join(""))
+                                        .unwrap_or_default();
+                                    let diagnostic_args = if buffered_args.trim().is_empty() {
+                                        serde_json::Value::Null
+                                    } else {
+                                        serde_json::from_str(&buffered_args)
+                                            .unwrap_or(serde_json::Value::Null)
+                                    };
                                     let diagnostic_tool_call = ToolCall::new(
                                         id.clone(),
-                                        ToolFunction::new(name.clone(), serde_json::Value::Null),
+                                        ToolFunction::new(name.clone(), diagnostic_args),
                                     );
                                     let diagnostic_history = build_tool_call_validation_history(
                                         chat_history.as_deref(),
@@ -890,11 +998,11 @@ where
                                             &emitted_tool_name,
                                             None,
                                             Some(internal_call_id.clone()),
-                                            None,
+                                            Some(buffered_args.clone()),
                                             &executable_tool_names,
                                             &allowed_tool_names,
                                             self.tool_choice.as_ref(),
-                                            diagnostic_history,
+                                            diagnostic_history.clone(),
                                             true,
                                         ).await {
                                             InvalidToolCallResolution::Fail(err) => {
@@ -906,7 +1014,7 @@ where
                                                     tool_name: emitted_tool_name,
                                                     available_tools: executable_tool_names.iter().cloned().collect(),
                                                     allowed_tools: allowed_tool_names.iter().cloned().collect(),
-                                                    chat_history: Box::new(build_full_history(chat_history.as_deref(), new_messages.clone())),
+                                                    chat_history: Box::new(diagnostic_history),
                                                 }).into());
                                                 break 'outer;
                                             }
@@ -916,13 +1024,22 @@ where
                                                         tool_name: emitted_tool_name,
                                                         available_tools: executable_tool_names.iter().cloned().collect(),
                                                         allowed_tools: allowed_tool_names.iter().cloned().collect(),
-                                                        chat_history: Box::new(build_full_history(chat_history.as_deref(), new_messages.clone())),
+                                                        chat_history: Box::new(diagnostic_history),
                                                     }).into());
                                                     break 'outer;
                                                 }
 
                                                 invalid_tool_call_retries += 1;
-                                                new_messages.push(Message::user(feedback));
+                                                let (assistant_message, user_message) =
+                                                    invalid_streaming_name_delta_retry_messages(
+                                                        &stream.message_id,
+                                                        id.clone(),
+                                                        emitted_tool_name,
+                                                        buffered_args,
+                                                        feedback,
+                                                    );
+                                                new_messages.push(assistant_message);
+                                                new_messages.push(user_message);
                                                 continue 'outer;
                                             }
                                             InvalidToolCallResolution::Repair(repaired_name) => {
@@ -1880,6 +1997,26 @@ mod tests {
         }
     }
 
+    #[derive(Clone)]
+    struct RetryDefaultApiHook;
+
+    impl InvalidToolCallHook<MockCompletionModel> for RetryDefaultApiHook {
+        fn on_invalid_tool_call(
+            &self,
+            context: &InvalidToolCallContext,
+        ) -> impl Future<Output = InvalidToolCallHookAction> + Send {
+            let tool_name = context.tool_name.clone();
+            let args = context.args.clone();
+            async move {
+                assert_eq!(tool_name, "default_api");
+                if let Some(args) = args {
+                    assert!(!args.is_empty());
+                }
+                InvalidToolCallHookAction::retry("Use the add tool instead")
+            }
+        }
+    }
+
     #[derive(Clone, Default)]
     struct RecordingToolCallDeltaHook {
         deltas: Arc<Mutex<Vec<RecordedToolCallDelta>>>,
@@ -2159,6 +2296,242 @@ mod tests {
         assert!(saw_tool_result);
         assert_eq!(final_response_text.as_deref(), Some("done"));
         assert_eq!(recorded.request_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn invalid_tool_call_hook_retries_mixed_streaming_turn_without_executing_valid_call() {
+        let add_calls = Arc::new(AtomicU32::new(0));
+        let model = MockCompletionModel::from_stream_turns([
+            vec![
+                MockStreamEvent::text("checking "),
+                MockStreamEvent::tool_call(
+                    "tool_call_1",
+                    "add",
+                    serde_json::json!({"x": 2, "y": 3}),
+                )
+                .with_call_id("call_1"),
+                MockStreamEvent::tool_call(
+                    "tool_call_2",
+                    "default_api",
+                    serde_json::json!({"x": 4, "y": 5}),
+                )
+                .with_call_id("call_2"),
+                MockStreamEvent::final_response_with_total_tokens(4),
+            ],
+            vec![
+                MockStreamEvent::text("retried"),
+                MockStreamEvent::final_response_with_total_tokens(6),
+            ],
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model)
+            .tool(CountingAddTool {
+                calls: add_calls.clone(),
+            })
+            .build();
+
+        let mut stream = agent
+            .stream_prompt("use the tool")
+            .with_invalid_tool_call_hook(RetryDefaultApiHook)
+            .multi_turn(3)
+            .with_history(Vec::<Message>::new())
+            .max_invalid_tool_call_retries(1)
+            .await;
+        let mut final_response_text = None;
+
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(MultiTurnStreamItem::FinalResponse(response)) => {
+                    final_response_text = Some(response.response().to_string());
+                    break;
+                }
+                Ok(_) => {}
+                Err(err) => panic!("unexpected streaming error: {err:?}"),
+            }
+        }
+
+        assert_eq!(final_response_text.as_deref(), Some("retried"));
+        assert_eq!(add_calls.load(Ordering::SeqCst), 0);
+
+        let requests = recorded.requests();
+        assert_eq!(requests.len(), 2);
+        let retry_history = requests[1].chat_history.iter().cloned().collect::<Vec<_>>();
+        assert_eq!(retry_history.len(), 3);
+        assert!(matches!(
+            retry_history.get(1),
+            Some(Message::Assistant { content, .. })
+                if content.iter().any(|item| matches!(
+                    item,
+                    AssistantContent::Text(text) if text.text == "checking "
+                ))
+                    && content.iter().any(|item| matches!(
+                        item,
+                        AssistantContent::ToolCall(tool_call)
+                            if tool_call.id == "tool_call_1"
+                                && tool_call.function.name == "add"
+                    ))
+                    && content.iter().any(|item| matches!(
+                        item,
+                        AssistantContent::ToolCall(tool_call)
+                            if tool_call.id == "tool_call_2"
+                                && tool_call.function.name == "default_api"
+                    ))
+        ));
+        assert!(matches!(
+            retry_history.get(2),
+            Some(Message::User { content })
+                if content.iter().filter(|item| matches!(item, UserContent::ToolResult(_))).count() == 2
+                    && content.iter().any(|item| matches!(
+                        item,
+                        UserContent::ToolResult(result)
+                            if result.id == "tool_call_1"
+                                && result.content.iter().any(|content| matches!(
+                                    content,
+                                    ToolResultContent::Text(text)
+                                        if text.text == TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER
+                                ))
+                    ))
+                    && content.iter().any(|item| matches!(
+                        item,
+                        UserContent::ToolResult(result)
+                            if result.id == "tool_call_2"
+                                && result.content.iter().any(|content| matches!(
+                                    content,
+                                    ToolResultContent::Text(text)
+                                        if text.text == "Use the add tool instead"
+                                ))
+                    ))
+        ));
+    }
+
+    #[tokio::test]
+    async fn invalid_tool_call_delta_retry_uses_structured_tool_feedback() {
+        let delta_hook = RecordingToolCallDeltaHook::default();
+        let model = MockCompletionModel::from_stream_turns([
+            vec![
+                MockStreamEvent::tool_call_arguments_delta(
+                    "tool_call_1",
+                    "internal_1",
+                    r#"{"x":2,"y":3}"#,
+                ),
+                MockStreamEvent::tool_call_name_delta("tool_call_1", "internal_1", "default_api"),
+                MockStreamEvent::final_response_with_total_tokens(4),
+            ],
+            vec![
+                MockStreamEvent::text("retried"),
+                MockStreamEvent::final_response_with_total_tokens(6),
+            ],
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
+
+        let mut stream = agent
+            .stream_prompt("use the tool")
+            .with_hook(delta_hook.clone())
+            .with_invalid_tool_call_hook(RetryDefaultApiHook)
+            .multi_turn(3)
+            .with_history(Vec::<Message>::new())
+            .max_invalid_tool_call_retries(1)
+            .await;
+        let mut final_response_text = None;
+
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(MultiTurnStreamItem::StreamAssistantItem(
+                    StreamedAssistantContent::ToolCallDelta { .. },
+                )) => panic!("invalid tool-call delta should not be emitted"),
+                Ok(MultiTurnStreamItem::FinalResponse(response)) => {
+                    final_response_text = Some(response.response().to_string());
+                    break;
+                }
+                Ok(_) => {}
+                Err(err) => panic!("unexpected streaming error: {err:?}"),
+            }
+        }
+
+        assert_eq!(final_response_text.as_deref(), Some("retried"));
+        assert!(delta_hook.observed().is_empty());
+
+        let requests = recorded.requests();
+        assert_eq!(requests.len(), 2);
+        let retry_history = requests[1].chat_history.iter().cloned().collect::<Vec<_>>();
+        assert!(matches!(
+            retry_history.get(1),
+            Some(Message::Assistant { content, .. })
+                if content.iter().any(|item| matches!(
+                    item,
+                    AssistantContent::ToolCall(tool_call)
+                        if tool_call.id == "tool_call_1"
+                            && tool_call.function.name == "default_api"
+                            && tool_call.function.arguments == serde_json::json!({"x": 2, "y": 3})
+                ))
+        ));
+        assert!(matches!(
+            retry_history.get(2),
+            Some(Message::User { content })
+                if content.iter().any(|item| matches!(
+                    item,
+                    UserContent::ToolResult(result)
+                        if result.id == "tool_call_1"
+                            && result.content.iter().any(|content| matches!(
+                                content,
+                                ToolResultContent::Text(text)
+                                    if text.text == "Use the add tool instead"
+                            ))
+                ))
+        ));
+    }
+
+    #[tokio::test]
+    async fn streaming_retry_budget_exhaustion_history_contains_invalid_tool_call() {
+        let model = MockCompletionModel::from_stream_turns([
+            vec![
+                MockStreamEvent::tool_call(
+                    "tool_call_1",
+                    "default_api",
+                    serde_json::json!({"x": 1, "y": 2}),
+                ),
+                MockStreamEvent::final_response_with_total_tokens(4),
+            ],
+            vec![
+                MockStreamEvent::text("should not be requested"),
+                MockStreamEvent::final_response_with_total_tokens(6),
+            ],
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
+
+        let mut stream = agent
+            .stream_prompt("use the tool")
+            .with_invalid_tool_call_hook(RetryDefaultApiHook)
+            .multi_turn(3)
+            .max_invalid_tool_call_retries(0)
+            .await;
+        let mut error = None;
+
+        while let Some(item) = stream.next().await {
+            if let Err(err) = item {
+                error = Some(err);
+                break;
+            }
+        }
+
+        let error = error.expect("retry budget exhaustion should fail");
+        match error {
+            StreamingError::Prompt(err) => match *err {
+                PromptError::UnknownToolCall {
+                    tool_name,
+                    chat_history,
+                    ..
+                } => {
+                    assert_eq!(tool_name, "default_api");
+                    assert!(history_contains_tool_call(&chat_history, "default_api"));
+                }
+                other => panic!("expected UnknownToolCall, got {other:?}"),
+            },
+            other => panic!("expected prompt streaming error, got {other:?}"),
+        }
+        assert_eq!(recorded.request_count(), 1);
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -218,50 +218,86 @@ fn build_full_history(
     input.iter().cloned().chain(new_messages).collect()
 }
 
-fn build_tool_call_validation_history(
-    chat_history: Option<&[Message]>,
-    new_messages: &[Message],
-    assistant_message_id: &Option<String>,
-    final_turn_content: Option<&OneOrMany<AssistantContent>>,
-    text_delta_response: Option<&str>,
-    pending_tool_calls: &[(ToolCall, String)],
+struct ToolCallValidationHistory<'a> {
+    chat_history: Option<&'a [Message]>,
+    new_messages: &'a [Message],
+    assistant_message_id: &'a Option<String>,
+    final_turn_content: Option<&'a OneOrMany<AssistantContent>>,
+    text_delta_response: Option<&'a str>,
+    accumulated_reasoning: &'a [crate::message::Reasoning],
+    pending_reasoning_delta_text: &'a str,
+    pending_reasoning_delta_id: &'a Option<String>,
+    pending_tool_calls: &'a [(ToolCall, String)],
     current_tool_call: Option<ToolCall>,
-) -> Vec<Message> {
-    let mut messages = new_messages.to_vec();
+}
 
-    if let Some(final_turn_content) = final_turn_content
+fn build_tool_call_validation_history(input: ToolCallValidationHistory<'_>) -> Vec<Message> {
+    let mut messages = input.new_messages.to_vec();
+
+    if let Some(final_turn_content) = input.final_turn_content
         && !is_empty_assistant_choice(final_turn_content)
     {
         messages.push(Message::Assistant {
-            id: assistant_message_id.clone(),
+            id: input.assistant_message_id.clone(),
             content: final_turn_content.clone(),
         });
-        return build_full_history(chat_history, messages);
+        return build_full_history(input.chat_history, messages);
     }
 
     let mut content_items = Vec::new();
-    if let Some(text) = text_delta_response
+    if let Some(text) = input.text_delta_response
         && !text.is_empty()
     {
         content_items.push(AssistantContent::text(text.to_string()));
     }
     content_items.extend(
-        pending_tool_calls
+        input
+            .accumulated_reasoning
+            .iter()
+            .cloned()
+            .map(AssistantContent::Reasoning),
+    );
+    if input.accumulated_reasoning.is_empty() && !input.pending_reasoning_delta_text.is_empty() {
+        let mut reasoning = crate::message::Reasoning::new(input.pending_reasoning_delta_text);
+        if let Some(id) = input.pending_reasoning_delta_id.clone() {
+            reasoning = reasoning.with_id(id);
+        }
+        content_items.push(AssistantContent::Reasoning(reasoning));
+    }
+    content_items.extend(
+        input
+            .pending_tool_calls
             .iter()
             .map(|(tool_call, _)| AssistantContent::ToolCall(tool_call.clone())),
     );
-    if let Some(tool_call) = current_tool_call {
+    if let Some(tool_call) = input.current_tool_call {
         content_items.push(AssistantContent::ToolCall(tool_call));
     }
 
     if let Some(content) = OneOrMany::from_iter_optional(content_items) {
         messages.push(Message::Assistant {
-            id: assistant_message_id.clone(),
+            id: input.assistant_message_id.clone(),
             content,
         });
     }
 
-    build_full_history(chat_history, messages)
+    build_full_history(input.chat_history, messages)
+}
+
+fn record_completion_call_if_needed(
+    completion_calls: &mut Vec<CompletionCall>,
+    completion_call_emitted: &mut bool,
+    call_index: usize,
+    current_call_usage: Option<crate::completion::Usage>,
+) -> Option<CompletionCall> {
+    if *completion_call_emitted {
+        return None;
+    }
+
+    let completion_call = CompletionCall::new(call_index, current_call_usage);
+    completion_calls.push(completion_call);
+    *completion_call_emitted = true;
+    Some(completion_call)
 }
 
 /// Combine input history with new messages for building completion requests.
@@ -929,15 +965,20 @@ where
                             yield Ok(MultiTurnStreamItem::stream_item(StreamedAssistantContent::Text(text)));
                         },
                         Ok(StreamedAssistantContent::ToolCall { mut tool_call, internal_call_id }) => {
-                            let diagnostic_history = build_tool_call_validation_history(
-                                chat_history.as_deref(),
-                                &new_messages,
-                                &stream.message_id,
-                                None,
-                                saw_text_this_turn.then_some(text_delta_response.as_str()),
-                                &pending_tool_calls,
-                                Some(tool_call.clone()),
-                            );
+                            let diagnostic_history =
+                                build_tool_call_validation_history(ToolCallValidationHistory {
+                                    chat_history: chat_history.as_deref(),
+                                    new_messages: &new_messages,
+                                    assistant_message_id: &stream.message_id,
+                                    final_turn_content: None,
+                                    text_delta_response: saw_text_this_turn
+                                        .then_some(text_delta_response.as_str()),
+                                    accumulated_reasoning: &accumulated_reasoning,
+                                    pending_reasoning_delta_text: &pending_reasoning_delta_text,
+                                    pending_reasoning_delta_id: &pending_reasoning_delta_id,
+                                    pending_tool_calls: &pending_tool_calls,
+                                    current_tool_call: Some(tool_call.clone()),
+                                });
 
                             if !allowed_tool_names.contains(&tool_call.function.name) {
                                 let args = json_utils::value_to_json_string(&tool_call.function.arguments);
@@ -994,6 +1035,16 @@ where
                                         };
                                         new_messages.push(assistant_message);
                                         new_messages.push(user_message);
+                                        if let Some(completion_call) = record_completion_call_if_needed(
+                                            &mut completion_calls,
+                                            &mut completion_call_emitted,
+                                            call_index,
+                                            current_call_usage,
+                                        ) {
+                                            yield Ok(MultiTurnStreamItem::CompletionCall(
+                                                completion_call,
+                                            ));
+                                        }
                                         text_delta_response.clear();
                                         saw_text_this_turn = false;
                                         continue 'outer;
@@ -1039,6 +1090,16 @@ where
                                             call_id: skipped_tool_result.call_id,
                                             content: skipped_tool_result.content,
                                         };
+                                        if let Some(completion_call) = record_completion_call_if_needed(
+                                            &mut completion_calls,
+                                            &mut completion_call_emitted,
+                                            call_index,
+                                            current_call_usage,
+                                        ) {
+                                            yield Ok(MultiTurnStreamItem::CompletionCall(
+                                                completion_call,
+                                            ));
+                                        }
                                         yield Ok(MultiTurnStreamItem::StreamUserItem(
                                             StreamedUserContent::ToolResult {
                                                 tool_result,
@@ -1078,15 +1139,20 @@ where
                                         id.clone(),
                                         ToolFunction::new(name.clone(), diagnostic_args),
                                     );
-                                    let diagnostic_history = build_tool_call_validation_history(
-                                        chat_history.as_deref(),
-                                        &new_messages,
-                                        &stream.message_id,
-                                        None,
-                                        saw_text_this_turn.then_some(text_delta_response.as_str()),
-                                        &pending_tool_calls,
-                                        Some(diagnostic_tool_call.clone()),
-                                    );
+                                    let diagnostic_history =
+                                        build_tool_call_validation_history(ToolCallValidationHistory {
+                                            chat_history: chat_history.as_deref(),
+                                            new_messages: &new_messages,
+                                            assistant_message_id: &stream.message_id,
+                                            final_turn_content: None,
+                                            text_delta_response: saw_text_this_turn
+                                                .then_some(text_delta_response.as_str()),
+                                            accumulated_reasoning: &accumulated_reasoning,
+                                            pending_reasoning_delta_text: &pending_reasoning_delta_text,
+                                            pending_reasoning_delta_id: &pending_reasoning_delta_id,
+                                            pending_tool_calls: &pending_tool_calls,
+                                            current_tool_call: Some(diagnostic_tool_call.clone()),
+                                        });
 
                                     if !allowed_tool_names.contains(&name) {
                                         let emitted_tool_name = name.clone();
@@ -1140,6 +1206,16 @@ where
                                                         reason,
                                                     ),
                                                 };
+                                                if let Some(completion_call) = record_completion_call_if_needed(
+                                                    &mut completion_calls,
+                                                    &mut completion_call_emitted,
+                                                    call_index,
+                                                    current_call_usage,
+                                                ) {
+                                                    yield Ok(MultiTurnStreamItem::CompletionCall(
+                                                        completion_call,
+                                                    ));
+                                                }
                                                 yield Ok(MultiTurnStreamItem::StreamUserItem(
                                                     StreamedUserContent::ToolResult {
                                                         tool_result,
@@ -1187,6 +1263,16 @@ where
                                                 };
                                                 new_messages.push(assistant_message);
                                                 new_messages.push(user_message);
+                                                if let Some(completion_call) = record_completion_call_if_needed(
+                                                    &mut completion_calls,
+                                                    &mut completion_call_emitted,
+                                                    call_index,
+                                                    current_call_usage,
+                                                ) {
+                                                    yield Ok(MultiTurnStreamItem::CompletionCall(
+                                                        completion_call,
+                                                    ));
+                                                }
                                                 text_delta_response.clear();
                                                 saw_text_this_turn = false;
                                                 continue 'outer;
@@ -1330,15 +1416,19 @@ where
                 tracing::Span::current().record("gen_ai.completion", &turn_text_response);
 
                 if !pending_tool_calls.is_empty() {
-                    let diagnostic_history = build_tool_call_validation_history(
-                        chat_history.as_deref(),
-                        &new_messages,
-                        &stream.message_id,
-                        Some(&final_turn_content),
-                        None,
-                        &pending_tool_calls,
-                        None,
-                    );
+                    let diagnostic_history =
+                        build_tool_call_validation_history(ToolCallValidationHistory {
+                            chat_history: chat_history.as_deref(),
+                            new_messages: &new_messages,
+                            assistant_message_id: &stream.message_id,
+                            final_turn_content: Some(&final_turn_content),
+                            text_delta_response: None,
+                            accumulated_reasoning: &accumulated_reasoning,
+                            pending_reasoning_delta_text: "",
+                            pending_reasoning_delta_id: &None,
+                            pending_tool_calls: &pending_tool_calls,
+                            current_tool_call: None,
+                        });
 
                     for (tool_call, _) in &pending_tool_calls {
                         if let Err(err) = validate_tool_call_name(
@@ -2739,12 +2829,18 @@ mod tests {
             .with_history(Vec::<Message>::new())
             .max_invalid_tool_call_retries(1)
             .await;
+        let mut completion_call_events = Vec::new();
         let mut final_response_text = None;
+        let mut final_completion_calls = Vec::new();
 
         while let Some(item) = stream.next().await {
             match item {
+                Ok(MultiTurnStreamItem::CompletionCall(completion_call)) => {
+                    completion_call_events.push(completion_call);
+                }
                 Ok(MultiTurnStreamItem::FinalResponse(response)) => {
                     final_response_text = Some(response.response().to_string());
+                    final_completion_calls = response.completion_calls().to_vec();
                     break;
                 }
                 Ok(_) => {}
@@ -2754,6 +2850,14 @@ mod tests {
 
         assert_eq!(final_response_text.as_deref(), Some("retried"));
         assert_eq!(add_calls.load(Ordering::SeqCst), 0);
+        let mut second_usage = Usage::new();
+        second_usage.total_tokens = 6;
+        let expected_completion_calls = vec![
+            CompletionCall::new(0, None),
+            CompletionCall::new(1, Some(second_usage)),
+        ];
+        assert_eq!(completion_call_events, expected_completion_calls);
+        assert_eq!(final_completion_calls, expected_completion_calls);
 
         let requests = recorded.requests();
         assert_eq!(requests.len(), 2);
@@ -3070,6 +3174,7 @@ mod tests {
         let model = MockCompletionModel::from_stream_turns([
             vec![
                 MockStreamEvent::text("checking "),
+                MockStreamEvent::reasoning_delta(Some("rs_1"), "diagnostic reason"),
                 MockStreamEvent::tool_call(
                     "tool_call_0",
                     "add",
@@ -3182,6 +3287,7 @@ mod tests {
         let model = MockCompletionModel::from_stream_turns([
             vec![
                 MockStreamEvent::text("checking "),
+                MockStreamEvent::reasoning_delta(Some("rs_1"), "diagnostic reason"),
                 MockStreamEvent::tool_call(
                     "tool_call_0",
                     "add",
@@ -3228,6 +3334,15 @@ mod tests {
         assert_eq!(context.internal_call_id.as_deref(), Some("internal_1"));
         assert!(context.is_streaming);
         assert!(history_contains_text(&context.chat_history, "checking "));
+        assert!(
+            assistant_reasoning_precedes_tool_call(
+                &context.chat_history,
+                "diagnostic reason",
+                "add"
+            ),
+            "{:?}",
+            context.chat_history
+        );
         assert!(history_contains_tool_call(&context.chat_history, "add"));
         assert!(history_contains_tool_call(
             &context.chat_history,

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -348,25 +348,57 @@ fn invalid_streaming_tool_retry_messages(
 
 fn invalid_streaming_name_delta_retry_messages(
     assistant_message_id: &Option<String>,
+    text_delta_response: Option<&str>,
+    pending_tool_calls: &[(ToolCall, String)],
     id: String,
     name: String,
     buffered_args: String,
     feedback: String,
-) -> (Message, Message) {
+) -> Option<(Message, Message)> {
     let args = if buffered_args.trim().is_empty() {
         serde_json::Value::Null
     } else {
         serde_json::from_str(&buffered_args).unwrap_or(serde_json::Value::Null)
     };
 
-    let tool_call = ToolCall::new(id, ToolFunction::new(name, args));
+    let invalid_tool_call = ToolCall::new(id, ToolFunction::new(name, args));
+    let mut assistant_content = Vec::new();
+    if let Some(text) = text_delta_response
+        && !text.is_empty()
+    {
+        assistant_content.push(AssistantContent::text(text.to_string()));
+    }
+    assistant_content.extend(
+        pending_tool_calls
+            .iter()
+            .map(|(tool_call, _)| AssistantContent::ToolCall(tool_call.clone())),
+    );
+    assistant_content.push(AssistantContent::ToolCall(invalid_tool_call.clone()));
+
     let assistant_message = Message::Assistant {
         id: assistant_message_id.clone(),
-        content: OneOrMany::one(AssistantContent::ToolCall(tool_call.clone())),
+        content: OneOrMany::from_iter_optional(assistant_content)?,
     };
-    let user_message = tool_result_to_user_message(tool_call.id, tool_call.call_id, feedback);
+    let mut retry_results = pending_tool_calls
+        .iter()
+        .map(|(tool_call, _)| {
+            tool_result_user_content(
+                tool_call.id.clone(),
+                tool_call.call_id.clone(),
+                TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER.to_string(),
+            )
+        })
+        .collect::<Vec<_>>();
+    retry_results.push(tool_result_user_content(
+        invalid_tool_call.id,
+        invalid_tool_call.call_id,
+        feedback,
+    ));
+    let user_message = Message::User {
+        content: OneOrMany::from_iter_optional(retry_results)?,
+    };
 
-    (assistant_message, user_message)
+    Some((assistant_message, user_message))
 }
 
 fn assistant_text_from_choice(choice: &OneOrMany<AssistantContent>) -> String {
@@ -1023,14 +1055,25 @@ where
                                             }
                                             InvalidToolCallResolution::Skip(reason) => {
                                                 tool_call_delta_states.remove(&key);
-                                                let (assistant_message, user_message) =
+                                                let Some((assistant_message, user_message)) =
                                                     invalid_streaming_name_delta_retry_messages(
                                                         &stream.message_id,
+                                                        saw_text_this_turn
+                                                            .then_some(text_delta_response.as_str()),
+                                                        &pending_tool_calls,
                                                         id.clone(),
                                                         emitted_tool_name,
                                                         buffered_args,
                                                         reason.clone(),
-                                                    );
+                                                    )
+                                                else {
+                                                    yield Err(cancelled_prompt_error(
+                                                        chat_history.as_deref(),
+                                                        new_messages.clone(),
+                                                        "invalid tool call skip produced no recovery messages".to_string(),
+                                                    ).await);
+                                                    break 'outer;
+                                                };
                                                 new_messages.push(assistant_message);
                                                 new_messages.push(user_message);
                                                 let tool_result = ToolResult {
@@ -1060,14 +1103,25 @@ where
                                                 }
 
                                                 invalid_tool_call_retries += 1;
-                                                let (assistant_message, user_message) =
+                                                let Some((assistant_message, user_message)) =
                                                     invalid_streaming_name_delta_retry_messages(
                                                         &stream.message_id,
+                                                        saw_text_this_turn
+                                                            .then_some(text_delta_response.as_str()),
+                                                        &pending_tool_calls,
                                                         id.clone(),
                                                         emitted_tool_name,
                                                         buffered_args,
                                                         feedback,
-                                                    );
+                                                    )
+                                                else {
+                                                    yield Err(cancelled_prompt_error(
+                                                        chat_history.as_deref(),
+                                                        new_messages.clone(),
+                                                        "invalid tool call retry produced no retry messages".to_string(),
+                                                    ).await);
+                                                    break 'outer;
+                                                };
                                                 new_messages.push(assistant_message);
                                                 new_messages.push(user_message);
                                                 continue 'outer;
@@ -2535,8 +2589,16 @@ mod tests {
     #[tokio::test]
     async fn invalid_tool_call_delta_retry_uses_structured_tool_feedback() {
         let delta_hook = RecordingToolCallDeltaHook::default();
+        let add_calls = Arc::new(AtomicU32::new(0));
         let model = MockCompletionModel::from_stream_turns([
             vec![
+                MockStreamEvent::text("checking "),
+                MockStreamEvent::tool_call(
+                    "tool_call_0",
+                    "add",
+                    serde_json::json!({"x": 1, "y": 2}),
+                )
+                .with_call_id("call_0"),
                 MockStreamEvent::tool_call_arguments_delta(
                     "tool_call_1",
                     "internal_1",
@@ -2551,7 +2613,11 @@ mod tests {
             ],
         ]);
         let recorded = model.clone();
-        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
+        let agent = AgentBuilder::new(model)
+            .tool(CountingAddTool {
+                calls: add_calls.clone(),
+            })
+            .build();
 
         let mut stream = agent
             .stream_prompt("use the tool")
@@ -2579,6 +2645,7 @@ mod tests {
 
         assert_eq!(final_response_text.as_deref(), Some("retried"));
         assert!(delta_hook.observed().is_empty());
+        assert_eq!(add_calls.load(Ordering::SeqCst), 0);
 
         let requests = recorded.requests();
         assert_eq!(requests.len(), 2);
@@ -2587,6 +2654,16 @@ mod tests {
             retry_history.get(1),
             Some(Message::Assistant { content, .. })
                 if content.iter().any(|item| matches!(
+                    item,
+                    AssistantContent::Text(text) if text.text == "checking "
+                ))
+                    && content.iter().any(|item| matches!(
+                        item,
+                        AssistantContent::ToolCall(tool_call)
+                            if tool_call.id == "tool_call_0"
+                                && tool_call.function.name == "add"
+                    ))
+                    && content.iter().any(|item| matches!(
                     item,
                     AssistantContent::ToolCall(tool_call)
                         if tool_call.id == "tool_call_1"
@@ -2597,7 +2674,19 @@ mod tests {
         assert!(matches!(
             retry_history.get(2),
             Some(Message::User { content })
-                if content.iter().any(|item| matches!(
+                if content.iter().filter(|item| matches!(item, UserContent::ToolResult(_))).count() == 2
+                    && content.iter().any(|item| matches!(
+                        item,
+                        UserContent::ToolResult(result)
+                            if result.id == "tool_call_0"
+                                && result.call_id.as_deref() == Some("call_0")
+                                && result.content.iter().any(|content| matches!(
+                                    content,
+                                    ToolResultContent::Text(text)
+                                        if text.text == TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER
+                                ))
+                    ))
+                    && content.iter().any(|item| matches!(
                     item,
                     UserContent::ToolResult(result)
                         if result.id == "tool_call_1"
@@ -2616,6 +2705,13 @@ mod tests {
         let add_calls = Arc::new(AtomicU32::new(0));
         let model = MockCompletionModel::from_stream_turns([
             vec![
+                MockStreamEvent::text("checking "),
+                MockStreamEvent::tool_call(
+                    "tool_call_0",
+                    "add",
+                    serde_json::json!({"x": 1, "y": 2}),
+                )
+                .with_call_id("call_0"),
                 MockStreamEvent::tool_call_arguments_delta(
                     "tool_call_1",
                     "internal_1",
@@ -2687,6 +2783,16 @@ mod tests {
             Some(Message::Assistant { content, .. })
                 if content.iter().any(|item| matches!(
                     item,
+                    AssistantContent::Text(text) if text.text == "checking "
+                ))
+                    && content.iter().any(|item| matches!(
+                        item,
+                        AssistantContent::ToolCall(tool_call)
+                            if tool_call.id == "tool_call_0"
+                                && tool_call.function.name == "add"
+                    ))
+                    && content.iter().any(|item| matches!(
+                    item,
                     AssistantContent::ToolCall(tool_call)
                         if tool_call.id == "tool_call_1"
                             && tool_call.function.name == "default_api"
@@ -2696,7 +2802,19 @@ mod tests {
         assert!(matches!(
             follow_up_history.get(2),
             Some(Message::User { content })
-                if content.iter().any(|item| matches!(
+                if content.iter().filter(|item| matches!(item, UserContent::ToolResult(_))).count() == 2
+                    && content.iter().any(|item| matches!(
+                        item,
+                        UserContent::ToolResult(result)
+                            if result.id == "tool_call_0"
+                                && result.call_id.as_deref() == Some("call_0")
+                                && result.content.iter().any(|content| matches!(
+                                    content,
+                                    ToolResultContent::Text(text)
+                                        if text.text == TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER
+                                ))
+                    ))
+                    && content.iter().any(|item| matches!(
                     item,
                     UserContent::ToolResult(result)
                         if result.id == "tool_call_1"

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -1051,8 +1051,8 @@ where
                                         &new_messages,
                                         &stream.message_id,
                                         None,
-                                        None,
-                                        &[],
+                                        saw_text_this_turn.then_some(text_delta_response.as_str()),
+                                        &pending_tool_calls,
                                         Some(diagnostic_tool_call),
                                     );
 
@@ -1061,7 +1061,7 @@ where
                                         match resolve_invalid_tool_call::<M, I>(
                                             self.invalid_tool_call_hook.as_ref(),
                                             &emitted_tool_name,
-                                            None,
+                                            Some(id.clone()),
                                             Some(internal_call_id.clone()),
                                             Some(buffered_args.clone()),
                                             &executable_tool_names,
@@ -1802,6 +1802,19 @@ mod tests {
         })
     }
 
+    fn history_contains_text(history: &[Message], expected: &str) -> bool {
+        history.iter().any(|message| {
+            matches!(
+                message,
+                Message::Assistant { content, .. }
+                    if content.iter().any(|item| matches!(
+                        item,
+                        AssistantContent::Text(text) if text.text == expected
+                    ))
+            )
+        })
+    }
+
     #[derive(Clone)]
     struct PanicOnUnknownToolHook;
 
@@ -2138,6 +2151,38 @@ mod tests {
             async move {
                 assert_eq!(tool_name, "default_api");
                 InvalidToolCallHookAction::skip("default_api was skipped")
+            }
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct RecordingInvalidToolCallHook {
+        contexts: Arc<Mutex<Vec<InvalidToolCallContext>>>,
+    }
+
+    impl RecordingInvalidToolCallHook {
+        fn observed(&self) -> Vec<InvalidToolCallContext> {
+            self.contexts
+                .lock()
+                .expect("invalid tool context records mutex was poisoned")
+                .clone()
+        }
+    }
+
+    impl InvalidToolCallHook<MockCompletionModel> for RecordingInvalidToolCallHook {
+        fn on_invalid_tool_call(
+            &self,
+            context: &InvalidToolCallContext,
+        ) -> impl Future<Output = InvalidToolCallHookAction> + Send {
+            let contexts = self.contexts.clone();
+            let context = context.clone();
+
+            async move {
+                contexts
+                    .lock()
+                    .expect("invalid tool context records mutex was poisoned")
+                    .push(context);
+                InvalidToolCallHookAction::fail()
             }
         }
     }
@@ -2921,6 +2966,65 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn invalid_tool_call_delta_context_includes_same_turn_history_and_tool_call_id() {
+        let invalid_hook = RecordingInvalidToolCallHook::default();
+        let model = MockCompletionModel::from_stream_turns([
+            vec![
+                MockStreamEvent::text("checking "),
+                MockStreamEvent::tool_call(
+                    "tool_call_0",
+                    "add",
+                    serde_json::json!({"x": 1, "y": 2}),
+                )
+                .with_call_id("call_0"),
+                MockStreamEvent::tool_call_arguments_delta(
+                    "tool_call_1",
+                    "internal_1",
+                    r#"{"x":2,"y":3}"#,
+                ),
+                MockStreamEvent::tool_call_name_delta("tool_call_1", "internal_1", "default_api"),
+                MockStreamEvent::final_response_with_total_tokens(4),
+            ],
+            vec![
+                MockStreamEvent::text("should not be requested"),
+                MockStreamEvent::final_response_with_total_tokens(6),
+            ],
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
+
+        let mut stream = agent
+            .stream_prompt("use the tool")
+            .with_invalid_tool_call_hook(invalid_hook.clone())
+            .multi_turn(3)
+            .await;
+        let mut error = None;
+
+        while let Some(item) = stream.next().await {
+            if let Err(err) = item {
+                error = Some(err);
+                break;
+            }
+        }
+
+        assert!(error.is_some(), "invalid name delta should fail");
+        assert_eq!(recorded.request_count(), 1);
+        let contexts = invalid_hook.observed();
+        assert_eq!(contexts.len(), 1);
+        let context = &contexts[0];
+        assert_eq!(context.tool_name, "default_api");
+        assert_eq!(context.tool_call_id.as_deref(), Some("tool_call_1"));
+        assert_eq!(context.internal_call_id.as_deref(), Some("internal_1"));
+        assert!(context.is_streaming);
+        assert!(history_contains_text(&context.chat_history, "checking "));
+        assert!(history_contains_tool_call(&context.chat_history, "add"));
+        assert!(history_contains_tool_call(
+            &context.chat_history,
+            "default_api"
+        ));
+    }
+
+    #[tokio::test]
     async fn invalid_tool_call_delta_retry_resets_streaming_text_delta_state() {
         let text_hook = RecordingTextDeltaHook::default();
         let model = MockCompletionModel::from_stream_turns([
@@ -3138,6 +3242,68 @@ mod tests {
                     ..
                 } => {
                     assert_eq!(tool_name, "default_api");
+                    assert!(history_contains_tool_call(&chat_history, "default_api"));
+                }
+                other => panic!("expected UnknownToolCall, got {other:?}"),
+            },
+            other => panic!("expected prompt streaming error, got {other:?}"),
+        }
+        assert_eq!(recorded.request_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn streaming_name_delta_retry_budget_exhaustion_history_includes_same_turn_context() {
+        let model = MockCompletionModel::from_stream_turns([
+            vec![
+                MockStreamEvent::text("checking "),
+                MockStreamEvent::tool_call(
+                    "tool_call_0",
+                    "add",
+                    serde_json::json!({"x": 1, "y": 2}),
+                )
+                .with_call_id("call_0"),
+                MockStreamEvent::tool_call_arguments_delta(
+                    "tool_call_1",
+                    "internal_1",
+                    r#"{"x":2,"y":3}"#,
+                ),
+                MockStreamEvent::tool_call_name_delta("tool_call_1", "internal_1", "default_api"),
+                MockStreamEvent::final_response_with_total_tokens(4),
+            ],
+            vec![
+                MockStreamEvent::text("should not be requested"),
+                MockStreamEvent::final_response_with_total_tokens(6),
+            ],
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
+
+        let mut stream = agent
+            .stream_prompt("use the tool")
+            .with_invalid_tool_call_hook(RetryDefaultApiHook)
+            .multi_turn(3)
+            .max_invalid_tool_call_retries(0)
+            .await;
+        let mut error = None;
+
+        while let Some(item) = stream.next().await {
+            if let Err(err) = item {
+                error = Some(err);
+                break;
+            }
+        }
+
+        let error = error.expect("retry budget exhaustion should fail");
+        match error {
+            StreamingError::Prompt(err) => match *err {
+                PromptError::UnknownToolCall {
+                    tool_name,
+                    chat_history,
+                    ..
+                } => {
+                    assert_eq!(tool_name, "default_api");
+                    assert!(history_contains_text(&chat_history, "checking "));
+                    assert!(history_contains_tool_call(&chat_history, "add"));
                     assert!(history_contains_tool_call(&chat_history, "default_api"));
                 }
                 other => panic!("expected UnknownToolCall, got {other:?}"),

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -976,25 +976,44 @@ where
                                         tool_call.function.name = repaired_name;
                                     }
                                     InvalidToolCallResolution::Skip(reason) => {
-                                        tool_calls.push(AssistantContent::ToolCall(tool_call.clone()));
-                                        tool_results.push((
-                                            tool_call.id.clone(),
-                                            tool_call.call_id.clone(),
-                                            reason.clone(),
-                                        ));
-                                        let tool_result = ToolResult {
-                                            id: tool_call.id,
-                                            call_id: tool_call.call_id,
-                                            content: ToolResultContent::from_tool_output(reason),
+                                        let skipped_tool_result = ToolResult {
+                                            id: tool_call.id.clone(),
+                                            call_id: tool_call.call_id.clone(),
+                                            content: ToolResultContent::from_tool_output(
+                                                reason.clone(),
+                                            ),
                                         };
-                                        saw_tool_call_this_turn = true;
+                                        let Some((assistant_message, user_message)) =
+                                            invalid_streaming_tool_retry_messages(
+                                                &stream.message_id,
+                                                saw_text_this_turn
+                                                    .then_some(text_delta_response.as_str()),
+                                                &pending_tool_calls,
+                                                tool_call,
+                                                reason,
+                                            )
+                                        else {
+                                            yield Err(cancelled_prompt_error(
+                                                chat_history.as_deref(),
+                                                new_messages.clone(),
+                                                "invalid tool call skip produced no recovery messages".to_string(),
+                                            ).await);
+                                            break 'outer;
+                                        };
+                                        new_messages.push(assistant_message);
+                                        new_messages.push(user_message);
+                                        let tool_result = ToolResult {
+                                            id: skipped_tool_result.id,
+                                            call_id: skipped_tool_result.call_id,
+                                            content: skipped_tool_result.content,
+                                        };
                                         yield Ok(MultiTurnStreamItem::StreamUserItem(
                                             StreamedUserContent::ToolResult {
                                                 tool_result,
                                                 internal_call_id,
                                             },
                                         ));
-                                        continue;
+                                        continue 'outer;
                                     }
                                 }
                             }
@@ -2581,6 +2600,124 @@ mod tests {
                                     content,
                                     ToolResultContent::Text(text)
                                         if text.text == "Use the add tool instead"
+                                ))
+                    ))
+        ));
+    }
+
+    #[tokio::test]
+    async fn invalid_tool_call_hook_skips_mixed_streaming_turn_without_executing_valid_call() {
+        let add_calls = Arc::new(AtomicU32::new(0));
+        let model = MockCompletionModel::from_stream_turns([
+            vec![
+                MockStreamEvent::text("checking "),
+                MockStreamEvent::tool_call(
+                    "tool_call_1",
+                    "add",
+                    serde_json::json!({"x": 2, "y": 3}),
+                )
+                .with_call_id("call_1"),
+                MockStreamEvent::tool_call(
+                    "tool_call_2",
+                    "default_api",
+                    serde_json::json!({"x": 4, "y": 5}),
+                )
+                .with_call_id("call_2"),
+                MockStreamEvent::final_response_with_total_tokens(4),
+            ],
+            vec![
+                MockStreamEvent::text("continued"),
+                MockStreamEvent::final_response_with_total_tokens(6),
+            ],
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model)
+            .tool(CountingAddTool {
+                calls: add_calls.clone(),
+            })
+            .build();
+
+        let mut stream = agent
+            .stream_prompt("use the tool")
+            .with_invalid_tool_call_hook(SkipDefaultApiHook)
+            .multi_turn(3)
+            .with_history(Vec::<Message>::new())
+            .await;
+        let mut skipped_tool_result = None;
+        let mut final_response_text = None;
+
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(MultiTurnStreamItem::StreamUserItem(StreamedUserContent::ToolResult {
+                    tool_result,
+                    ..
+                })) => {
+                    skipped_tool_result = Some(tool_result);
+                }
+                Ok(MultiTurnStreamItem::FinalResponse(response)) => {
+                    final_response_text = Some(response.response().to_string());
+                    break;
+                }
+                Ok(_) => {}
+                Err(err) => panic!("unexpected streaming error: {err:?}"),
+            }
+        }
+
+        let skipped_tool_result =
+            skipped_tool_result.expect("skip recovery should emit a synthetic tool result");
+        assert_eq!(skipped_tool_result.id, "tool_call_2");
+        assert_eq!(skipped_tool_result.call_id.as_deref(), Some("call_2"));
+        assert_eq!(final_response_text.as_deref(), Some("continued"));
+        assert_eq!(add_calls.load(Ordering::SeqCst), 0);
+
+        let requests = recorded.requests();
+        assert_eq!(requests.len(), 2);
+        let follow_up_history = requests[1].chat_history.iter().cloned().collect::<Vec<_>>();
+        assert_eq!(follow_up_history.len(), 3);
+        assert!(matches!(
+            follow_up_history.get(1),
+            Some(Message::Assistant { content, .. })
+                if content.iter().any(|item| matches!(
+                    item,
+                    AssistantContent::Text(text) if text.text == "checking "
+                ))
+                    && content.iter().any(|item| matches!(
+                        item,
+                        AssistantContent::ToolCall(tool_call)
+                            if tool_call.id == "tool_call_1"
+                                && tool_call.function.name == "add"
+                    ))
+                    && content.iter().any(|item| matches!(
+                        item,
+                        AssistantContent::ToolCall(tool_call)
+                            if tool_call.id == "tool_call_2"
+                                && tool_call.function.name == "default_api"
+                    ))
+        ));
+        assert!(matches!(
+            follow_up_history.get(2),
+            Some(Message::User { content })
+                if content.iter().filter(|item| matches!(item, UserContent::ToolResult(_))).count() == 2
+                    && content.iter().any(|item| matches!(
+                        item,
+                        UserContent::ToolResult(result)
+                            if result.id == "tool_call_1"
+                                && result.call_id.as_deref() == Some("call_1")
+                                && result.content.iter().any(|content| matches!(
+                                    content,
+                                    ToolResultContent::Text(text)
+                                        if text.text == TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER
+                                ))
+                    ))
+                    && content.iter().any(|item| matches!(
+                        item,
+                        UserContent::ToolResult(result)
+                            if result.id == "tool_call_2"
+                                && result.call_id.as_deref() == Some("call_2")
+                                && result.content.iter().any(|content| matches!(
+                                    content,
+                                    ToolResultContent::Text(text)
+                                        if text.text == "default_api was skipped"
                                 ))
                     ))
         ));

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -948,8 +948,23 @@ where
                                     }
                                     InvalidToolCallResolution::Skip(reason) => {
                                         tool_calls.push(AssistantContent::ToolCall(tool_call.clone()));
-                                        tool_results.push((tool_call.id.clone(), tool_call.call_id.clone(), reason));
+                                        tool_results.push((
+                                            tool_call.id.clone(),
+                                            tool_call.call_id.clone(),
+                                            reason.clone(),
+                                        ));
+                                        let tool_result = ToolResult {
+                                            id: tool_call.id,
+                                            call_id: tool_call.call_id,
+                                            content: ToolResultContent::from_tool_output(reason),
+                                        };
                                         saw_tool_call_this_turn = true;
+                                        yield Ok(MultiTurnStreamItem::StreamUserItem(
+                                            StreamedUserContent::ToolResult {
+                                                tool_result,
+                                                internal_call_id,
+                                            },
+                                        ));
                                         continue;
                                     }
                                 }
@@ -2017,6 +2032,22 @@ mod tests {
         }
     }
 
+    #[derive(Clone)]
+    struct SkipDefaultApiHook;
+
+    impl InvalidToolCallHook<MockCompletionModel> for SkipDefaultApiHook {
+        fn on_invalid_tool_call(
+            &self,
+            context: &InvalidToolCallContext,
+        ) -> impl Future<Output = InvalidToolCallHookAction> + Send {
+            let tool_name = context.tool_name.clone();
+            async move {
+                assert_eq!(tool_name, "default_api");
+                InvalidToolCallHookAction::skip("default_api was skipped")
+            }
+        }
+    }
+
     #[derive(Clone, Default)]
     struct RecordingToolCallDeltaHook {
         deltas: Arc<Mutex<Vec<RecordedToolCallDelta>>>,
@@ -2296,6 +2327,88 @@ mod tests {
         assert!(saw_tool_result);
         assert_eq!(final_response_text.as_deref(), Some("done"));
         assert_eq!(recorded.request_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn invalid_tool_call_hook_skip_emits_streaming_tool_result() {
+        let add_calls = Arc::new(AtomicU32::new(0));
+        let model = MockCompletionModel::from_stream_turns([
+            vec![
+                MockStreamEvent::tool_call(
+                    "tool_call_1",
+                    "default_api",
+                    serde_json::json!({"x": 2, "y": 3}),
+                )
+                .with_call_id("call_1"),
+                MockStreamEvent::final_response_with_total_tokens(4),
+            ],
+            vec![
+                MockStreamEvent::text("continued"),
+                MockStreamEvent::final_response_with_total_tokens(6),
+            ],
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model)
+            .tool(CountingAddTool {
+                calls: add_calls.clone(),
+            })
+            .build();
+
+        let mut stream = agent
+            .stream_prompt("use the tool")
+            .with_invalid_tool_call_hook(SkipDefaultApiHook)
+            .multi_turn(3)
+            .with_history(Vec::<Message>::new())
+            .await;
+        let mut skipped_tool_result = None;
+        let mut final_response_text = None;
+
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(MultiTurnStreamItem::StreamUserItem(StreamedUserContent::ToolResult {
+                    tool_result,
+                    internal_call_id,
+                })) => {
+                    assert!(!internal_call_id.is_empty());
+                    skipped_tool_result = Some(tool_result);
+                }
+                Ok(MultiTurnStreamItem::FinalResponse(response)) => {
+                    final_response_text = Some(response.response().to_string());
+                    break;
+                }
+                Ok(_) => {}
+                Err(err) => panic!("unexpected streaming error: {err:?}"),
+            }
+        }
+
+        let skipped_tool_result =
+            skipped_tool_result.expect("skip recovery should emit a synthetic tool result");
+        assert_eq!(skipped_tool_result.id, "tool_call_1");
+        assert_eq!(skipped_tool_result.call_id.as_deref(), Some("call_1"));
+        assert!(skipped_tool_result.content.iter().any(|content| matches!(
+            content,
+            ToolResultContent::Text(text) if text.text == "default_api was skipped"
+        )));
+        assert_eq!(final_response_text.as_deref(), Some("continued"));
+        assert_eq!(add_calls.load(Ordering::SeqCst), 0);
+
+        let requests = recorded.requests();
+        assert_eq!(requests.len(), 2);
+        let follow_up_history = requests[1].chat_history.iter().cloned().collect::<Vec<_>>();
+        assert!(matches!(
+            follow_up_history.get(2),
+            Some(Message::User { content })
+                if content.iter().any(|item| matches!(
+                    item,
+                    UserContent::ToolResult(result)
+                        if result.id == "tool_call_1"
+                            && result.content.iter().any(|content| matches!(
+                                content,
+                                ToolResultContent::Text(text)
+                                    if text.text == "default_api was skipped"
+                            ))
+                ))
+        ));
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -194,6 +194,21 @@ fn merge_reasoning_blocks(
     }
 }
 
+fn flush_pending_reasoning_delta(
+    accumulated_reasoning: &mut Vec<crate::message::Reasoning>,
+    pending_reasoning_delta_text: &mut String,
+    pending_reasoning_delta_id: &mut Option<String>,
+) {
+    if accumulated_reasoning.is_empty() && !pending_reasoning_delta_text.is_empty() {
+        let mut assembled = crate::message::Reasoning::new(&*pending_reasoning_delta_text);
+        if let Some(id) = pending_reasoning_delta_id.take() {
+            assembled = assembled.with_id(id);
+        }
+        accumulated_reasoning.push(assembled);
+        pending_reasoning_delta_text.clear();
+    }
+}
+
 /// Build full history for error reporting (input + new messages).
 fn build_full_history(
     chat_history: Option<&[Message]>,
@@ -300,6 +315,7 @@ fn tool_result_user_content(
 fn invalid_streaming_tool_retry_messages(
     assistant_message_id: &Option<String>,
     text_delta_response: Option<&str>,
+    accumulated_reasoning: &[crate::message::Reasoning],
     pending_tool_calls: &[(ToolCall, String)],
     invalid_tool_call: ToolCall,
     feedback: String,
@@ -310,6 +326,12 @@ fn invalid_streaming_tool_retry_messages(
     {
         assistant_content.push(AssistantContent::text(text.to_string()));
     }
+    assistant_content.extend(
+        accumulated_reasoning
+            .iter()
+            .cloned()
+            .map(AssistantContent::Reasoning),
+    );
     assistant_content.extend(
         pending_tool_calls
             .iter()
@@ -349,25 +371,23 @@ fn invalid_streaming_tool_retry_messages(
 fn invalid_streaming_name_delta_retry_messages(
     assistant_message_id: &Option<String>,
     text_delta_response: Option<&str>,
+    accumulated_reasoning: &[crate::message::Reasoning],
     pending_tool_calls: &[(ToolCall, String)],
-    id: String,
-    name: String,
-    buffered_args: String,
+    invalid_tool_call: ToolCall,
     feedback: String,
 ) -> Option<(Message, Message)> {
-    let args = if buffered_args.trim().is_empty() {
-        serde_json::Value::Null
-    } else {
-        serde_json::from_str(&buffered_args).unwrap_or(serde_json::Value::Null)
-    };
-
-    let invalid_tool_call = ToolCall::new(id, ToolFunction::new(name, args));
     let mut assistant_content = Vec::new();
     if let Some(text) = text_delta_response
         && !text.is_empty()
     {
         assistant_content.push(AssistantContent::text(text.to_string()));
     }
+    assistant_content.extend(
+        accumulated_reasoning
+            .iter()
+            .cloned()
+            .map(AssistantContent::Reasoning),
+    );
     assistant_content.extend(
         pending_tool_calls
             .iter()
@@ -950,10 +970,16 @@ where
                                         }
 
                                         invalid_tool_call_retries += 1;
+                                        flush_pending_reasoning_delta(
+                                            &mut accumulated_reasoning,
+                                            &mut pending_reasoning_delta_text,
+                                            &mut pending_reasoning_delta_id,
+                                        );
                                         let Some((assistant_message, user_message)) =
                                             invalid_streaming_tool_retry_messages(
                                                 &stream.message_id,
                                                 saw_text_this_turn.then_some(text_delta_response.as_str()),
+                                                &accumulated_reasoning,
                                                 &pending_tool_calls,
                                                 tool_call,
                                                 feedback,
@@ -983,11 +1009,17 @@ where
                                                 reason.clone(),
                                             ),
                                         };
+                                        flush_pending_reasoning_delta(
+                                            &mut accumulated_reasoning,
+                                            &mut pending_reasoning_delta_text,
+                                            &mut pending_reasoning_delta_id,
+                                        );
                                         let Some((assistant_message, user_message)) =
                                             invalid_streaming_tool_retry_messages(
                                                 &stream.message_id,
                                                 saw_text_this_turn
                                                     .then_some(text_delta_response.as_str()),
+                                                &accumulated_reasoning,
                                                 &pending_tool_calls,
                                                 tool_call,
                                                 reason,
@@ -1053,7 +1085,7 @@ where
                                         None,
                                         saw_text_this_turn.then_some(text_delta_response.as_str()),
                                         &pending_tool_calls,
-                                        Some(diagnostic_tool_call),
+                                        Some(diagnostic_tool_call.clone()),
                                     );
 
                                     if !allowed_tool_names.contains(&name) {
@@ -1076,15 +1108,19 @@ where
                                             }
                                             InvalidToolCallResolution::Skip(reason) => {
                                                 tool_call_delta_states.remove(&key);
+                                                flush_pending_reasoning_delta(
+                                                    &mut accumulated_reasoning,
+                                                    &mut pending_reasoning_delta_text,
+                                                    &mut pending_reasoning_delta_id,
+                                                );
                                                 let Some((assistant_message, user_message)) =
                                                     invalid_streaming_name_delta_retry_messages(
                                                         &stream.message_id,
                                                         saw_text_this_turn
                                                             .then_some(text_delta_response.as_str()),
+                                                        &accumulated_reasoning,
                                                         &pending_tool_calls,
-                                                        id.clone(),
-                                                        emitted_tool_name,
-                                                        buffered_args,
+                                                        diagnostic_tool_call.clone(),
                                                         reason.clone(),
                                                     )
                                                 else {
@@ -1126,15 +1162,19 @@ where
                                                 }
 
                                                 invalid_tool_call_retries += 1;
+                                                flush_pending_reasoning_delta(
+                                                    &mut accumulated_reasoning,
+                                                    &mut pending_reasoning_delta_text,
+                                                    &mut pending_reasoning_delta_id,
+                                                );
                                                 let Some((assistant_message, user_message)) =
                                                     invalid_streaming_name_delta_retry_messages(
                                                         &stream.message_id,
                                                         saw_text_this_turn
                                                             .then_some(text_delta_response.as_str()),
+                                                        &accumulated_reasoning,
                                                         &pending_tool_calls,
-                                                        id.clone(),
-                                                        emitted_tool_name,
-                                                        buffered_args,
+                                                        diagnostic_tool_call.clone(),
                                                         feedback,
                                                     )
                                                 else {
@@ -1279,13 +1319,11 @@ where
                 // Providers like Gemini emit thinking as incremental deltas
                 // without signatures; assemble into a single block so
                 // reasoning survives into the next turn's chat history.
-                if accumulated_reasoning.is_empty() && !pending_reasoning_delta_text.is_empty() {
-                    let mut assembled = crate::message::Reasoning::new(&pending_reasoning_delta_text);
-                    if let Some(id) = pending_reasoning_delta_id.take() {
-                        assembled = assembled.with_id(id);
-                    }
-                    accumulated_reasoning.push(assembled);
-                }
+                flush_pending_reasoning_delta(
+                    &mut accumulated_reasoning,
+                    &mut pending_reasoning_delta_text,
+                    &mut pending_reasoning_delta_id,
+                );
 
                 let final_turn_content = stream.choice.clone();
                 let turn_text_response = assistant_text_from_choice(&final_turn_content);
@@ -1812,6 +1850,39 @@ mod tests {
                         AssistantContent::Text(text) if text.text == expected
                     ))
             )
+        })
+    }
+
+    fn assistant_reasoning_precedes_tool_call(
+        history: &[Message],
+        expected_reasoning: &str,
+        tool_name: &str,
+    ) -> bool {
+        history.iter().any(|message| {
+            let Message::Assistant { content, .. } = message else {
+                return false;
+            };
+
+            let reasoning_index = content.iter().position(|item| {
+                matches!(
+                    item,
+                    AssistantContent::Reasoning(reasoning)
+                        if reasoning.content.iter().any(|content| matches!(
+                            content,
+                            ReasoningContent::Text { text, .. }
+                                if text == expected_reasoning
+                        ))
+                )
+            });
+            let tool_index = content.iter().position(|item| {
+                matches!(
+                    item,
+                    AssistantContent::ToolCall(tool_call)
+                        if tool_call.function.name == tool_name
+                )
+            });
+
+            matches!((reasoning_index, tool_index), (Some(reasoning), Some(tool)) if reasoning < tool)
         })
     }
 
@@ -2849,7 +2920,101 @@ mod tests {
                                     ToolResultContent::Text(text)
                                         if text.text == "default_api was skipped"
                                 ))
-                    ))
+            ))
+        ));
+    }
+
+    #[tokio::test]
+    async fn invalid_completed_tool_call_skip_preserves_streaming_reasoning_history() {
+        let model = MockCompletionModel::from_stream_turns([
+            vec![
+                MockStreamEvent::text("checking "),
+                MockStreamEvent::reasoning("reasoned step").with_reasoning_id("rs_1"),
+                MockStreamEvent::tool_call(
+                    "tool_call_1",
+                    "default_api",
+                    serde_json::json!({"x": 2, "y": 3}),
+                ),
+                MockStreamEvent::final_response_with_total_tokens(4),
+            ],
+            vec![
+                MockStreamEvent::text("continued"),
+                MockStreamEvent::final_response_with_total_tokens(6),
+            ],
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
+
+        let mut stream = agent
+            .stream_prompt("use the tool")
+            .with_invalid_tool_call_hook(SkipDefaultApiHook)
+            .multi_turn(3)
+            .with_history(Vec::<Message>::new())
+            .await;
+
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(MultiTurnStreamItem::FinalResponse(_)) => break,
+                Ok(_) => {}
+                Err(err) => panic!("unexpected streaming error: {err:?}"),
+            }
+        }
+
+        let requests = recorded.requests();
+        assert_eq!(requests.len(), 2);
+        let follow_up_history = requests[1].chat_history.iter().cloned().collect::<Vec<_>>();
+        assert!(history_contains_text(&follow_up_history, "checking "));
+        assert!(assistant_reasoning_precedes_tool_call(
+            &follow_up_history,
+            "reasoned step",
+            "default_api"
+        ));
+    }
+
+    #[tokio::test]
+    async fn invalid_name_delta_retry_preserves_streaming_reasoning_history() {
+        let model = MockCompletionModel::from_stream_turns([
+            vec![
+                MockStreamEvent::reasoning_delta(Some("rs_1"), "delta reason"),
+                MockStreamEvent::tool_call_arguments_delta(
+                    "tool_call_1",
+                    "internal_1",
+                    r#"{"x":2,"y":3}"#,
+                ),
+                MockStreamEvent::tool_call_name_delta("tool_call_1", "internal_1", "default_api"),
+                MockStreamEvent::final_response_with_total_tokens(4),
+            ],
+            vec![
+                MockStreamEvent::text("retried"),
+                MockStreamEvent::final_response_with_total_tokens(6),
+            ],
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
+
+        let mut stream = agent
+            .stream_prompt("use the tool")
+            .with_invalid_tool_call_hook(RetryDefaultApiHook)
+            .multi_turn(3)
+            .with_history(Vec::<Message>::new())
+            .max_invalid_tool_call_retries(1)
+            .await;
+
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(MultiTurnStreamItem::FinalResponse(_)) => break,
+                Ok(_) => {}
+                Err(err) => panic!("unexpected streaming error: {err:?}"),
+            }
+        }
+
+        let requests = recorded.requests();
+        assert_eq!(requests.len(), 2);
+        let retry_history = requests[1].chat_history.iter().cloned().collect::<Vec<_>>();
+        assert!(assistant_reasoning_precedes_tool_call(
+            &retry_history,
+            "delta reason",
+            "default_api"
         ));
     }
 

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -1,7 +1,11 @@
 use crate::{
     OneOrMany,
     agent::completion::{DynamicContextStore, build_prepared_completion_request},
-    agent::prompt_request::{HookAction, hooks::PromptHook, validate_tool_call_name},
+    agent::prompt_request::{
+        HookAction, InvalidToolCallResolution,
+        hooks::{InvalidToolCallHook, PromptHook},
+        resolve_invalid_tool_call, validate_tool_call_name,
+    },
     completion::{Document, GetTokenUsage},
     json_utils,
     memory::ConversationMemory,
@@ -361,10 +365,11 @@ const UNKNOWN_AGENT_NAME: &str = "Unnamed Agent";
 /// attempting to await (which will send the prompt request) can potentially return
 /// [`crate::completion::request::PromptError::MaxTurnsError`] if the agent decides to call tools
 /// back to back.
-pub struct StreamingPromptRequest<M, P>
+pub struct StreamingPromptRequest<M, P, I = ()>
 where
     M: CompletionModel,
     P: PromptHook<M> + 'static,
+    I: InvalidToolCallHook<M> + 'static,
 {
     /// The prompt message to send to the model
     prompt: Message,
@@ -398,17 +403,22 @@ where
     output_schema: Option<schemars::Schema>,
     /// Optional per-request hook for events
     hook: Option<P>,
+    /// Optional per-request hook for invalid model-emitted tool calls.
+    invalid_tool_call_hook: Option<I>,
+    /// Maximum number of invalid tool-call retries for this request.
+    max_invalid_tool_call_retries: usize,
     /// Optional conversation memory backend cloned from the agent.
     memory: Option<Arc<dyn ConversationMemory>>,
     /// Optional conversation id used for loading and saving memory.
     conversation_id: Option<String>,
 }
 
-impl<M, P> StreamingPromptRequest<M, P>
+impl<M, P, I> StreamingPromptRequest<M, P, I>
 where
     M: CompletionModel + 'static,
     <M as CompletionModel>::StreamingResponse: WasmCompatSend + GetTokenUsage,
     P: PromptHook<M>,
+    I: InvalidToolCallHook<M>,
 {
     /// Create a new StreamingPromptRequest with the given prompt and model.
     /// Note: This creates a request without an agent hook. Use `from_agent` to include the agent's hook.
@@ -429,6 +439,8 @@ where
             tool_choice: agent.tool_choice.clone(),
             output_schema: agent.output_schema.clone(),
             hook: None,
+            invalid_tool_call_hook: None,
+            max_invalid_tool_call_retries: 0,
             memory: agent.memory.clone(),
             conversation_id: agent.default_conversation_id.clone(),
         }
@@ -458,6 +470,8 @@ where
             tool_choice: agent.tool_choice.clone(),
             output_schema: agent.output_schema.clone(),
             hook: agent.hook.clone(),
+            invalid_tool_call_hook: None,
+            max_invalid_tool_call_retries: 0,
             memory: agent.memory.clone(),
             conversation_id: agent.default_conversation_id.clone(),
         }
@@ -486,9 +500,9 @@ where
     /// // ... consume stream ...
     /// // Access updated history from FinalResponse::history()
     /// ```
-    pub fn with_history<I, T>(mut self, history: I) -> Self
+    pub fn with_history<H, T>(mut self, history: H) -> Self
     where
-        I: IntoIterator<Item = T>,
+        H: IntoIterator<Item = T>,
         T: Into<Message>,
     {
         self.chat_history = Some(history.into_iter().map(Into::into).collect());
@@ -497,7 +511,7 @@ where
 
     /// Attach a per-request hook for tool call events.
     /// This overrides any default hook set on the agent.
-    pub fn with_hook<P2>(self, hook: P2) -> StreamingPromptRequest<M, P2>
+    pub fn with_hook<P2>(self, hook: P2) -> StreamingPromptRequest<M, P2, I>
     where
         P2: PromptHook<M>,
     {
@@ -517,9 +531,49 @@ where
             tool_choice: self.tool_choice,
             output_schema: self.output_schema,
             hook: Some(hook),
+            invalid_tool_call_hook: self.invalid_tool_call_hook,
+            max_invalid_tool_call_retries: self.max_invalid_tool_call_retries,
             memory: self.memory,
             conversation_id: self.conversation_id,
         }
+    }
+
+    /// Attach a per-request hook for invalid model-emitted tool calls.
+    ///
+    /// Without this hook, Rig preserves fail-fast validation.
+    pub fn with_invalid_tool_call_hook<I2>(self, hook: I2) -> StreamingPromptRequest<M, P, I2>
+    where
+        I2: InvalidToolCallHook<M>,
+    {
+        StreamingPromptRequest {
+            prompt: self.prompt,
+            chat_history: self.chat_history,
+            max_turns: self.max_turns,
+            model: self.model,
+            agent_name: self.agent_name,
+            preamble: self.preamble,
+            static_context: self.static_context,
+            temperature: self.temperature,
+            max_tokens: self.max_tokens,
+            additional_params: self.additional_params,
+            tool_server_handle: self.tool_server_handle,
+            dynamic_context: self.dynamic_context,
+            tool_choice: self.tool_choice,
+            output_schema: self.output_schema,
+            hook: self.hook,
+            invalid_tool_call_hook: Some(hook),
+            max_invalid_tool_call_retries: self.max_invalid_tool_call_retries,
+            memory: self.memory,
+            conversation_id: self.conversation_id,
+        }
+    }
+
+    /// Set the retry budget for [`crate::agent::prompt_request::hooks::InvalidToolCallHookAction::Retry`].
+    ///
+    /// Invalid tool-call retries also consume normal multi-turn depth.
+    pub fn max_invalid_tool_call_retries(mut self, retries: usize) -> Self {
+        self.max_invalid_tool_call_retries = retries;
+        self
     }
 
     /// Set the conversation id used to load and persist memory for this request.
@@ -609,6 +663,7 @@ where
         let mut aggregated_usage = crate::completion::Usage::new();
         let mut completion_calls = Vec::new();
         let mut completion_call_index = 0;
+        let mut invalid_tool_call_retries = 0;
 
         // NOTE: We use .instrument(agent_span) instead of span.enter() to avoid
         // span context leaking to other concurrent tasks. Using span.enter() inside
@@ -737,7 +792,7 @@ where
 
                             yield Ok(MultiTurnStreamItem::stream_item(StreamedAssistantContent::Text(text)));
                         },
-                        Ok(StreamedAssistantContent::ToolCall { tool_call, internal_call_id }) => {
+                        Ok(StreamedAssistantContent::ToolCall { mut tool_call, internal_call_id }) => {
                             let diagnostic_history = build_tool_call_validation_history(
                                 chat_history.as_deref(),
                                 &new_messages,
@@ -748,14 +803,58 @@ where
                                 Some(tool_call.clone()),
                             );
 
-                            if let Err(err) = validate_tool_call_name(
-                                &tool_call.function.name,
-                                &executable_tool_names,
-                                &allowed_tool_names,
-                                diagnostic_history,
-                            ) {
-                                yield Err(Box::new(err).into());
-                                break 'outer;
+                            if !allowed_tool_names.contains(&tool_call.function.name) {
+                                let args = json_utils::value_to_json_string(&tool_call.function.arguments);
+                                let emitted_tool_name = tool_call.function.name.clone();
+                                match resolve_invalid_tool_call::<M, I>(
+                                    self.invalid_tool_call_hook.as_ref(),
+                                    &emitted_tool_name,
+                                    tool_call.call_id.clone(),
+                                    Some(internal_call_id.clone()),
+                                    Some(args),
+                                    &executable_tool_names,
+                                    &allowed_tool_names,
+                                    self.tool_choice.as_ref(),
+                                    diagnostic_history,
+                                    true,
+                                ).await {
+                                    InvalidToolCallResolution::Fail(err) => {
+                                        yield Err(Box::new(err).into());
+                                        break 'outer;
+                                    }
+                                    InvalidToolCallResolution::Retry(feedback) => {
+                                        if invalid_tool_call_retries >= self.max_invalid_tool_call_retries {
+                                            yield Err(Box::new(PromptError::UnknownToolCall {
+                                                tool_name: emitted_tool_name,
+                                                available_tools: executable_tool_names.iter().cloned().collect(),
+                                                allowed_tools: allowed_tool_names.iter().cloned().collect(),
+                                                chat_history: Box::new(build_full_history(chat_history.as_deref(), new_messages.clone())),
+                                            }).into());
+                                            break 'outer;
+                                        }
+
+                                        invalid_tool_call_retries += 1;
+                                        new_messages.push(Message::Assistant {
+                                            id: stream.message_id.clone(),
+                                            content: OneOrMany::one(AssistantContent::ToolCall(tool_call.clone())),
+                                        });
+                                        new_messages.push(tool_result_to_user_message(
+                                            tool_call.id.clone(),
+                                            tool_call.call_id.clone(),
+                                            feedback,
+                                        ));
+                                        continue 'outer;
+                                    }
+                                    InvalidToolCallResolution::Repair(repaired_name) => {
+                                        tool_call.function.name = repaired_name;
+                                    }
+                                    InvalidToolCallResolution::Skip(reason) => {
+                                        tool_calls.push(AssistantContent::ToolCall(tool_call.clone()));
+                                        tool_results.push((tool_call.id.clone(), tool_call.call_id.clone(), reason));
+                                        saw_tool_call_this_turn = true;
+                                        continue;
+                                    }
+                                }
                             }
 
                             pending_tool_calls.push((tool_call, internal_call_id));
@@ -769,7 +868,7 @@ where
                             let mut deltas_to_emit = Vec::new();
 
                             match content {
-                                ToolCallDeltaContent::Name(name) => {
+                                ToolCallDeltaContent::Name(mut name) => {
                                     let diagnostic_tool_call = ToolCall::new(
                                         id.clone(),
                                         ToolFunction::new(name.clone(), serde_json::Value::Null),
@@ -784,14 +883,52 @@ where
                                         Some(diagnostic_tool_call),
                                     );
 
-                                    if let Err(err) = validate_tool_call_name(
-                                        &name,
-                                        &executable_tool_names,
-                                        &allowed_tool_names,
-                                        diagnostic_history,
-                                    ) {
-                                        yield Err(Box::new(err).into());
-                                        break 'outer;
+                                    if !allowed_tool_names.contains(&name) {
+                                        let emitted_tool_name = name.clone();
+                                        match resolve_invalid_tool_call::<M, I>(
+                                            self.invalid_tool_call_hook.as_ref(),
+                                            &emitted_tool_name,
+                                            None,
+                                            Some(internal_call_id.clone()),
+                                            None,
+                                            &executable_tool_names,
+                                            &allowed_tool_names,
+                                            self.tool_choice.as_ref(),
+                                            diagnostic_history,
+                                            true,
+                                        ).await {
+                                            InvalidToolCallResolution::Fail(err) => {
+                                                yield Err(Box::new(err).into());
+                                                break 'outer;
+                                            }
+                                            InvalidToolCallResolution::Skip(_) => {
+                                                yield Err(Box::new(PromptError::UnknownToolCall {
+                                                    tool_name: emitted_tool_name,
+                                                    available_tools: executable_tool_names.iter().cloned().collect(),
+                                                    allowed_tools: allowed_tool_names.iter().cloned().collect(),
+                                                    chat_history: Box::new(build_full_history(chat_history.as_deref(), new_messages.clone())),
+                                                }).into());
+                                                break 'outer;
+                                            }
+                                            InvalidToolCallResolution::Retry(feedback) => {
+                                                if invalid_tool_call_retries >= self.max_invalid_tool_call_retries {
+                                                    yield Err(Box::new(PromptError::UnknownToolCall {
+                                                        tool_name: emitted_tool_name,
+                                                        available_tools: executable_tool_names.iter().cloned().collect(),
+                                                        allowed_tools: allowed_tool_names.iter().cloned().collect(),
+                                                        chat_history: Box::new(build_full_history(chat_history.as_deref(), new_messages.clone())),
+                                                    }).into());
+                                                    break 'outer;
+                                                }
+
+                                                invalid_tool_call_retries += 1;
+                                                new_messages.push(Message::user(feedback));
+                                                continue 'outer;
+                                            }
+                                            InvalidToolCallResolution::Repair(repaired_name) => {
+                                                name = repaired_name;
+                                            }
+                                        }
                                     }
 
                                     let state =
@@ -1126,11 +1263,12 @@ where
     }
 }
 
-impl<M, P> IntoFuture for StreamingPromptRequest<M, P>
+impl<M, P, I> IntoFuture for StreamingPromptRequest<M, P, I>
 where
     M: CompletionModel + 'static,
     <M as CompletionModel>::StreamingResponse: WasmCompatSend,
     P: PromptHook<M> + 'static,
+    I: InvalidToolCallHook<M> + 'static,
 {
     type Output = StreamingResult<M::StreamingResponse>; // what `.await` returns
     type IntoFuture = WasmBoxedFuture<'static, Self::Output>;
@@ -1184,7 +1322,10 @@ pub async fn stream_to_stdout<R>(
 mod tests {
     use super::*;
     use crate::agent::AgentBuilder;
-    use crate::agent::prompt_request::hooks::{PromptHook, ToolCallHookAction};
+    use crate::agent::prompt_request::hooks::{
+        InvalidToolCallContext, InvalidToolCallHook, InvalidToolCallHookAction, PromptHook,
+        ToolCallHookAction,
+    };
     use crate::client::ProviderClient;
     use crate::client::completion::CompletionClient;
     use crate::completion::{CompletionRequest, PromptError, ToolDefinition, Usage};
@@ -1439,32 +1580,32 @@ mod tests {
     struct PanicOnUnknownToolHook;
 
     impl PromptHook<MockCompletionModel> for PanicOnUnknownToolHook {
-        fn on_tool_call_delta(
+        async fn on_tool_call_delta(
             &self,
             _tool_call_id: &str,
             _internal_call_id: &str,
             _tool_name: Option<&str>,
             _tool_call_delta: &str,
-        ) -> impl std::future::Future<Output = HookAction> + Send {
-            async { panic!("unknown tool call delta should fail before delta hooks run") }
+        ) -> HookAction {
+            panic!("unknown tool call delta should fail before delta hooks run")
         }
 
-        fn on_tool_call(
+        async fn on_tool_call(
             &self,
             _tool_name: &str,
             _tool_call_id: Option<String>,
             _internal_call_id: &str,
             _args: &str,
-        ) -> impl std::future::Future<Output = ToolCallHookAction> + Send {
-            async { panic!("unknown tool call should fail before tool hooks run") }
+        ) -> ToolCallHookAction {
+            panic!("unknown tool call should fail before tool hooks run")
         }
 
-        fn on_stream_completion_response_finish(
+        async fn on_stream_completion_response_finish(
             &self,
             _prompt: &Message,
             _response: &MockResponse,
-        ) -> impl std::future::Future<Output = HookAction> + Send {
-            async { panic!("unknown tool call should fail before stream finish hooks run") }
+        ) -> HookAction {
+            panic!("unknown tool call should fail before stream finish hooks run")
         }
     }
 
@@ -1723,6 +1864,22 @@ mod tests {
 
     type RecordedToolCallDelta = (String, String, Option<String>, String);
 
+    #[derive(Clone)]
+    struct RepairDefaultApiHook;
+
+    impl InvalidToolCallHook<MockCompletionModel> for RepairDefaultApiHook {
+        fn on_invalid_tool_call(
+            &self,
+            context: &InvalidToolCallContext,
+        ) -> impl Future<Output = InvalidToolCallHookAction> + Send {
+            let tool_name = context.tool_name.clone();
+            async move {
+                assert_eq!(tool_name, "default_api");
+                InvalidToolCallHookAction::repair("add")
+            }
+        }
+    }
+
     #[derive(Clone, Default)]
     struct RecordingToolCallDeltaHook {
         deltas: Arc<Mutex<Vec<RecordedToolCallDelta>>>,
@@ -1938,6 +2095,70 @@ mod tests {
             other => panic!("expected prompt streaming error, got {other:?}"),
         }
         assert_eq!(recorded.request_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn invalid_tool_call_hook_can_repair_streaming_tool_name() {
+        let model = MockCompletionModel::from_stream_turns([
+            vec![
+                MockStreamEvent::tool_call(
+                    "tool_call_1",
+                    "default_api",
+                    serde_json::json!({"x": 2, "y": 3}),
+                ),
+                MockStreamEvent::final_response_with_total_tokens(4),
+            ],
+            vec![
+                MockStreamEvent::text("done"),
+                MockStreamEvent::final_response_with_total_tokens(6),
+            ],
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model).tool(MockAddTool).build();
+
+        let mut stream = agent
+            .stream_prompt("use the tool")
+            .with_invalid_tool_call_hook(RepairDefaultApiHook)
+            .multi_turn(3)
+            .with_history(Vec::<Message>::new())
+            .await;
+        let mut saw_repaired_tool_call = false;
+        let mut saw_tool_result = false;
+        let mut final_response_text = None;
+
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(MultiTurnStreamItem::StreamAssistantItem(
+                    StreamedAssistantContent::ToolCall { tool_call, .. },
+                )) => {
+                    assert_eq!(tool_call.function.name, "add");
+                    saw_repaired_tool_call = true;
+                }
+                Ok(MultiTurnStreamItem::StreamUserItem(StreamedUserContent::ToolResult {
+                    tool_result,
+                    ..
+                })) => {
+                    assert!(tool_result.content.iter().any(|content| {
+                        matches!(
+                            content,
+                            ToolResultContent::Text(text) if text.text == "5"
+                        )
+                    }));
+                    saw_tool_result = true;
+                }
+                Ok(MultiTurnStreamItem::FinalResponse(response)) => {
+                    final_response_text = Some(response.response().to_string());
+                    break;
+                }
+                Ok(_) => {}
+                Err(err) => panic!("unexpected streaming error: {err:?}"),
+            }
+        }
+
+        assert!(saw_repaired_tool_call);
+        assert!(saw_tool_result);
+        assert_eq!(final_response_text.as_deref(), Some("done"));
+        assert_eq!(recorded.request_count(), 2);
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/test_utils/streaming.rs
+++ b/crates/rig-core/src/test_utils/streaming.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     completion::{CompletionError, GetTokenUsage, Usage},
+    message::ReasoningContent,
     streaming::{RawStreamingChoice, RawStreamingToolCall, ToolCallDeltaContent},
 };
 use serde::{Deserialize, Serialize};
@@ -60,6 +61,16 @@ pub enum MockStreamEvent {
         id: String,
         internal_call_id: String,
         content: ToolCallDeltaContent,
+    },
+    /// Complete reasoning event.
+    Reasoning {
+        id: Option<String>,
+        content: ReasoningContent,
+    },
+    /// Reasoning delta event.
+    ReasoningDelta {
+        id: Option<String>,
+        reasoning: String,
     },
     /// Provider-assigned message ID.
     MessageId(String),
@@ -135,6 +146,33 @@ impl MockStreamEvent {
         }
     }
 
+    /// Create a complete reasoning event.
+    pub fn reasoning(reasoning: impl Into<String>) -> Self {
+        Self::Reasoning {
+            id: None,
+            content: ReasoningContent::Text {
+                text: reasoning.into(),
+                signature: None,
+            },
+        }
+    }
+
+    /// Attach a provider-specific reasoning ID to a complete reasoning event.
+    pub fn with_reasoning_id(mut self, reasoning_id: impl Into<String>) -> Self {
+        if let Self::Reasoning { id, .. } = &mut self {
+            *id = Some(reasoning_id.into());
+        }
+        self
+    }
+
+    /// Create a reasoning delta event.
+    pub fn reasoning_delta(id: Option<impl Into<String>>, reasoning: impl Into<String>) -> Self {
+        Self::ReasoningDelta {
+            id: id.map(Into::into),
+            reasoning: reasoning.into(),
+        }
+    }
+
     /// Create a provider-assigned message ID event.
     pub fn message_id(id: impl Into<String>) -> Self {
         Self::MessageId(id.into())
@@ -192,6 +230,10 @@ impl MockStreamEvent {
                 internal_call_id,
                 content,
             }),
+            Self::Reasoning { id, content } => Ok(RawStreamingChoice::Reasoning { id, content }),
+            Self::ReasoningDelta { id, reasoning } => {
+                Ok(RawStreamingChoice::ReasoningDelta { id, reasoning })
+            }
             Self::MessageId(id) => Ok(RawStreamingChoice::MessageId(id)),
             Self::FinalResponse(response) => Ok(RawStreamingChoice::FinalResponse(response)),
             Self::Error(error) => Err(error.into_completion_error()),


### PR DESCRIPTION
## Summary

Adds an opt-in invalid tool-call hook system at the validation boundary introduced by the model tool-call validation work.

- Add `InvalidToolCallHook`, `InvalidToolCallContext`, and `InvalidToolCallHookAction`
- Add per-request `.with_invalid_tool_call_hook(...)` and `.max_invalid_tool_call_retries(...)`
- Support fail-fast, retry with feedback, repair, and skip recovery actions
- Wire recovery through non-streaming and streaming prompt paths while preserving fail-fast defaults
- Add focused tests for non-streaming repair/retry/skip and streaming repair
