### PR TITLE
Unify invalid tool call recovery with prompt hooks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -327,5 +327,9 @@ name = "gemini_extractor_with_rag"
 required-features = ["derive"]
 
 [[example]]
+name = "gemini_default_api_recovery"
+required-features = ["derive"]
+
+[[example]]
 name = "vector_search_ollama"
 required-features = ["derive"]

--- a/crates/rig-core/src/agent/mod.rs
+++ b/crates/rig-core/src/agent/mod.rs
@@ -113,8 +113,7 @@ pub use crate::message::Text;
 pub use builder::{AgentBuilder, NoToolConfig, WithBuilderTools, WithToolServerHandle};
 pub use completion::Agent;
 pub use prompt_request::hooks::{
-    HookAction, InvalidToolCallContext, InvalidToolCallHook, InvalidToolCallHookAction, PromptHook,
-    ToolCallHookAction,
+    HookAction, InvalidToolCallContext, InvalidToolCallHookAction, PromptHook, ToolCallHookAction,
 };
 pub use prompt_request::streaming::{
     FinalResponse, MultiTurnStreamItem, StreamingError, StreamingPromptRequest, StreamingResult,

--- a/crates/rig-core/src/agent/prompt_request/hooks.rs
+++ b/crates/rig-core/src/agent/prompt_request/hooks.rs
@@ -8,7 +8,7 @@ use crate::{
     wasm_compat::{WasmCompatSend, WasmCompatSync},
 };
 
-/// Context passed to [`InvalidToolCallHook`] when the model emits a tool call
+/// Context passed to [`PromptHook::on_invalid_tool_call`] when the model emits a tool call
 /// that Rig would reject before normal tool-call hooks or execution.
 #[derive(Debug, Clone)]
 pub struct InvalidToolCallContext {
@@ -31,27 +31,6 @@ pub struct InvalidToolCallContext {
     /// Whether the rejected call came from the streaming path.
     pub is_streaming: bool,
 }
-
-/// Trait for recovering from model-emitted tool calls that Rig rejects during
-/// validation.
-///
-/// The default behavior remains fail-fast. Attach an implementation with
-/// `.with_invalid_tool_call_hook(...)` to opt into recovery.
-pub trait InvalidToolCallHook<M>: Clone + WasmCompatSend + WasmCompatSync
-where
-    M: CompletionModel,
-{
-    /// Called when a model-emitted tool call is unknown or disallowed by the
-    /// current request's tool choice.
-    fn on_invalid_tool_call(
-        &self,
-        _context: &InvalidToolCallContext,
-    ) -> impl Future<Output = InvalidToolCallHookAction> + WasmCompatSend {
-        async { InvalidToolCallHookAction::fail() }
-    }
-}
-
-impl<M> InvalidToolCallHook<M> for () where M: CompletionModel {}
 
 /// Recovery action for invalid tool-call hooks.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -117,6 +96,18 @@ where
         _response: &crate::completion::CompletionResponse<M::Response>,
     ) -> impl Future<Output = HookAction> + WasmCompatSend {
         async { HookAction::cont() }
+    }
+
+    /// Called when a model-emitted tool call is unknown or disallowed by the
+    /// current request's tool choice.
+    ///
+    /// The default behavior remains fail-fast. Override this method to opt into
+    /// retry, repair, or skip recovery for invalid tool calls.
+    fn on_invalid_tool_call(
+        &self,
+        _context: &InvalidToolCallContext,
+    ) -> impl Future<Output = InvalidToolCallHookAction> + WasmCompatSend {
+        async { InvalidToolCallHookAction::fail() }
     }
 
     /// Called before a tool is invoked.

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -16,8 +16,7 @@ use crate::{
 };
 use futures::{StreamExt, stream};
 use hooks::{
-    HookAction, InvalidToolCallContext, InvalidToolCallHook, InvalidToolCallHookAction, PromptHook,
-    ToolCallHookAction,
+    HookAction, InvalidToolCallContext, InvalidToolCallHookAction, PromptHook, ToolCallHookAction,
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -47,12 +46,11 @@ impl PromptType for Extended {}
 /// attempting to await (which will send the prompt request) can potentially return
 /// [`crate::completion::request::PromptError::MaxTurnsError`] if the agent decides to call tools
 /// back to back.
-pub struct PromptRequest<S, M, P, I = ()>
+pub struct PromptRequest<S, M, P>
 where
     S: PromptType,
     M: CompletionModel,
     P: PromptHook<M>,
-    I: InvalidToolCallHook<M>,
 {
     /// The prompt message to send to the model
     prompt: Message,
@@ -87,8 +85,6 @@ where
     state: PhantomData<S>,
     /// Optional per-request hook for events
     hook: Option<P>,
-    /// Optional per-request hook for invalid model-emitted tool calls.
-    invalid_tool_call_hook: Option<I>,
     /// Maximum number of invalid tool-call retries for this request.
     max_invalid_tool_call_retries: usize,
     /// How many tools should be executed at the same time (1 by default).
@@ -101,7 +97,7 @@ where
     conversation_id: Option<String>,
 }
 
-impl<M, P> PromptRequest<Standard, M, P, ()>
+impl<M, P> PromptRequest<Standard, M, P>
 where
     M: CompletionModel,
     P: PromptHook<M>,
@@ -124,7 +120,6 @@ where
             tool_choice: agent.tool_choice.clone(),
             state: PhantomData,
             hook: agent.hook.clone(),
-            invalid_tool_call_hook: None,
             max_invalid_tool_call_retries: 0,
             concurrency: 1,
             output_schema: agent.output_schema.clone(),
@@ -134,12 +129,11 @@ where
     }
 }
 
-impl<S, M, P, I> PromptRequest<S, M, P, I>
+impl<S, M, P> PromptRequest<S, M, P>
 where
     S: PromptType,
     M: CompletionModel,
     P: PromptHook<M>,
-    I: InvalidToolCallHook<M>,
 {
     /// Enable returning extended details for responses (includes aggregated token usage
     /// and the full message history accumulated during the agent loop).
@@ -147,7 +141,7 @@ where
     /// Note: This changes the type of the response from `.send` to return a `PromptResponse` struct
     /// instead of a simple `String`. This is useful for tracking token usage across multiple turns
     /// of conversation and inspecting the full message exchange.
-    pub fn extended_details(self) -> PromptRequest<Extended, M, P, I> {
+    pub fn extended_details(self) -> PromptRequest<Extended, M, P> {
         PromptRequest {
             prompt: self.prompt,
             chat_history: self.chat_history,
@@ -164,7 +158,6 @@ where
             tool_choice: self.tool_choice,
             state: PhantomData,
             hook: self.hook,
-            invalid_tool_call_hook: self.invalid_tool_call_hook,
             max_invalid_tool_call_retries: self.max_invalid_tool_call_retries,
             concurrency: self.concurrency,
             output_schema: self.output_schema,
@@ -217,7 +210,7 @@ where
 
     /// Attach a per-request hook for tool call events.
     /// This overrides any default hook set on the agent.
-    pub fn with_hook<P2>(self, hook: P2) -> PromptRequest<S, M, P2, I>
+    pub fn with_hook<P2>(self, hook: P2) -> PromptRequest<S, M, P2>
     where
         P2: PromptHook<M>,
     {
@@ -237,39 +230,6 @@ where
             tool_choice: self.tool_choice,
             state: PhantomData,
             hook: Some(hook),
-            invalid_tool_call_hook: self.invalid_tool_call_hook,
-            max_invalid_tool_call_retries: self.max_invalid_tool_call_retries,
-            concurrency: self.concurrency,
-            output_schema: self.output_schema,
-            memory: self.memory,
-            conversation_id: self.conversation_id,
-        }
-    }
-
-    /// Attach a per-request hook for invalid model-emitted tool calls.
-    ///
-    /// Without this hook, Rig preserves fail-fast validation.
-    pub fn with_invalid_tool_call_hook<I2>(self, hook: I2) -> PromptRequest<S, M, P, I2>
-    where
-        I2: InvalidToolCallHook<M>,
-    {
-        PromptRequest {
-            prompt: self.prompt,
-            chat_history: self.chat_history,
-            max_turns: self.max_turns,
-            model: self.model,
-            agent_name: self.agent_name,
-            preamble: self.preamble,
-            static_context: self.static_context,
-            temperature: self.temperature,
-            max_tokens: self.max_tokens,
-            additional_params: self.additional_params,
-            tool_server_handle: self.tool_server_handle,
-            dynamic_context: self.dynamic_context,
-            tool_choice: self.tool_choice,
-            state: PhantomData,
-            hook: self.hook,
-            invalid_tool_call_hook: Some(hook),
             max_invalid_tool_call_retries: self.max_invalid_tool_call_retries,
             concurrency: self.concurrency,
             output_schema: self.output_schema,
@@ -290,11 +250,10 @@ where
 /// Due to: [RFC 2515](https://github.com/rust-lang/rust/issues/63063), we have to use a `BoxFuture`
 ///  for the `IntoFuture` implementation. In the future, we should be able to use `impl Future<...>`
 ///  directly via the associated type.
-impl<M, P, I> IntoFuture for PromptRequest<Standard, M, P, I>
+impl<M, P> IntoFuture for PromptRequest<Standard, M, P>
 where
     M: CompletionModel + 'static,
     P: PromptHook<M> + 'static,
-    I: InvalidToolCallHook<M> + 'static,
 {
     type Output = Result<String, PromptError>;
     type IntoFuture = WasmBoxedFuture<'static, Self::Output>;
@@ -304,11 +263,10 @@ where
     }
 }
 
-impl<M, P, I> IntoFuture for PromptRequest<Extended, M, P, I>
+impl<M, P> IntoFuture for PromptRequest<Extended, M, P>
 where
     M: CompletionModel + 'static,
     P: PromptHook<M> + 'static,
-    I: InvalidToolCallHook<M> + 'static,
 {
     type Output = Result<PromptResponse, PromptError>;
     type IntoFuture = WasmBoxedFuture<'static, Self::Output>;
@@ -318,11 +276,10 @@ where
     }
 }
 
-impl<M, P, I> PromptRequest<Standard, M, P, I>
+impl<M, P> PromptRequest<Standard, M, P>
 where
     M: CompletionModel,
     P: PromptHook<M>,
-    I: InvalidToolCallHook<M>,
 {
     async fn send(self) -> Result<String, PromptError> {
         self.extended_details().send().await.map(|resp| resp.output)
@@ -537,8 +494,8 @@ enum InvalidToolCallResolution {
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn resolve_invalid_tool_call<M, I>(
-    hook: Option<&I>,
+async fn resolve_invalid_tool_call<M, P>(
+    hook: Option<&P>,
     tool_name: &str,
     tool_call_id: Option<String>,
     internal_call_id: Option<String>,
@@ -551,7 +508,7 @@ async fn resolve_invalid_tool_call<M, I>(
 ) -> InvalidToolCallResolution
 where
     M: CompletionModel,
-    I: InvalidToolCallHook<M>,
+    P: PromptHook<M>,
 {
     let err = PromptError::UnknownToolCall {
         tool_name: tool_name.to_owned(),
@@ -619,11 +576,10 @@ fn assistant_text_from_choice(choice: &OneOrMany<AssistantContent>) -> String {
         .collect()
 }
 
-impl<M, P, I> PromptRequest<Extended, M, P, I>
+impl<M, P> PromptRequest<Extended, M, P>
 where
     M: CompletionModel,
     P: PromptHook<M>,
-    I: InvalidToolCallHook<M>,
 {
     fn agent_name(&self) -> &str {
         self.agent_name.as_deref().unwrap_or(UNKNOWN_AGENT_NAME)
@@ -815,8 +771,8 @@ where
                     let args = json_utils::value_to_json_string(&tool_call.function.arguments);
                     let emitted_tool_name = tool_call.function.name.clone();
 
-                    match resolve_invalid_tool_call::<M, I>(
-                        self.invalid_tool_call_hook.as_ref(),
+                    match resolve_invalid_tool_call::<M, P>(
+                        self.hook.as_ref(),
                         &emitted_tool_name,
                         Some(tool_call.id.clone()),
                         None,
@@ -1158,19 +1114,18 @@ use serde::de::DeserializeOwned;
 ///     .max_turns(3)
 ///     .await?;
 /// ```
-pub struct TypedPromptRequest<T, S, M, P, I = ()>
+pub struct TypedPromptRequest<T, S, M, P>
 where
     T: JsonSchema + DeserializeOwned + WasmCompatSend,
     S: PromptType,
     M: CompletionModel,
     P: PromptHook<M>,
-    I: InvalidToolCallHook<M>,
 {
-    inner: PromptRequest<S, M, P, I>,
+    inner: PromptRequest<S, M, P>,
     _phantom: std::marker::PhantomData<T>,
 }
 
-impl<T, M, P> TypedPromptRequest<T, Standard, M, P, ()>
+impl<T, M, P> TypedPromptRequest<T, Standard, M, P>
 where
     T: JsonSchema + DeserializeOwned + WasmCompatSend,
     M: CompletionModel,
@@ -1190,20 +1145,19 @@ where
     }
 }
 
-impl<T, S, M, P, I> TypedPromptRequest<T, S, M, P, I>
+impl<T, S, M, P> TypedPromptRequest<T, S, M, P>
 where
     T: JsonSchema + DeserializeOwned + WasmCompatSend,
     S: PromptType,
     M: CompletionModel,
     P: PromptHook<M>,
-    I: InvalidToolCallHook<M>,
 {
     /// Enable returning extended details for responses (includes aggregated token usage).
     ///
     /// Note: This changes the type of the response from `.send()` to return a `TypedPromptResponse<T>` struct
     /// instead of just `T`. This is useful for tracking token usage across multiple turns
     /// of conversation.
-    pub fn extended_details(self) -> TypedPromptRequest<T, Extended, M, P, I> {
+    pub fn extended_details(self) -> TypedPromptRequest<T, Extended, M, P> {
         TypedPromptRequest {
             inner: self.inner.extended_details(),
             _phantom: std::marker::PhantomData,
@@ -1266,7 +1220,7 @@ where
     /// Attach a per-request hook for tool call events.
     ///
     /// This overrides any default hook set on the agent.
-    pub fn with_hook<P2>(self, hook: P2) -> TypedPromptRequest<T, S, M, P2, I>
+    pub fn with_hook<P2>(self, hook: P2) -> TypedPromptRequest<T, S, M, P2>
     where
         P2: PromptHook<M>,
     {
@@ -1275,27 +1229,13 @@ where
             _phantom: std::marker::PhantomData,
         }
     }
-
-    /// Attach a per-request hook for invalid model-emitted tool calls.
-    ///
-    /// Without this hook, Rig preserves fail-fast validation.
-    pub fn with_invalid_tool_call_hook<I2>(self, hook: I2) -> TypedPromptRequest<T, S, M, P, I2>
-    where
-        I2: InvalidToolCallHook<M>,
-    {
-        TypedPromptRequest {
-            inner: self.inner.with_invalid_tool_call_hook(hook),
-            _phantom: std::marker::PhantomData,
-        }
-    }
 }
 
-impl<T, M, P, I> TypedPromptRequest<T, Standard, M, P, I>
+impl<T, M, P> TypedPromptRequest<T, Standard, M, P>
 where
     T: JsonSchema + DeserializeOwned + WasmCompatSend,
     M: CompletionModel,
     P: PromptHook<M>,
-    I: InvalidToolCallHook<M>,
 {
     /// Send the typed prompt request and deserialize the response.
     async fn send(self) -> Result<T, StructuredOutputError> {
@@ -1310,12 +1250,11 @@ where
     }
 }
 
-impl<T, M, P, I> TypedPromptRequest<T, Extended, M, P, I>
+impl<T, M, P> TypedPromptRequest<T, Extended, M, P>
 where
     T: JsonSchema + DeserializeOwned + WasmCompatSend,
     M: CompletionModel,
     P: PromptHook<M>,
-    I: InvalidToolCallHook<M>,
 {
     /// Send the typed prompt request with extended details and deserialize the response.
     async fn send(self) -> Result<TypedPromptResponse<T>, StructuredOutputError> {
@@ -1331,12 +1270,11 @@ where
     }
 }
 
-impl<T, M, P, I> IntoFuture for TypedPromptRequest<T, Standard, M, P, I>
+impl<T, M, P> IntoFuture for TypedPromptRequest<T, Standard, M, P>
 where
     T: JsonSchema + DeserializeOwned + WasmCompatSend + 'static,
     M: CompletionModel + 'static,
     P: PromptHook<M> + 'static,
-    I: InvalidToolCallHook<M> + 'static,
 {
     type Output = Result<T, StructuredOutputError>;
     type IntoFuture = WasmBoxedFuture<'static, Self::Output>;
@@ -1346,12 +1284,11 @@ where
     }
 }
 
-impl<T, M, P, I> IntoFuture for TypedPromptRequest<T, Extended, M, P, I>
+impl<T, M, P> IntoFuture for TypedPromptRequest<T, Extended, M, P>
 where
     T: JsonSchema + DeserializeOwned + WasmCompatSend + 'static,
     M: CompletionModel + 'static,
     P: PromptHook<M> + 'static,
-    I: InvalidToolCallHook<M> + 'static,
 {
     type Output = Result<TypedPromptResponse<T>, StructuredOutputError>;
     type IntoFuture = WasmBoxedFuture<'static, Self::Output>;
@@ -1368,8 +1305,8 @@ mod tests {
         agent::{
             AgentBuilder,
             prompt_request::hooks::{
-                HookAction, InvalidToolCallContext, InvalidToolCallHook, InvalidToolCallHookAction,
-                PromptHook, ToolCallHookAction,
+                HookAction, InvalidToolCallContext, InvalidToolCallHookAction, PromptHook,
+                ToolCallHookAction,
             },
         },
         completion::{
@@ -1447,9 +1384,33 @@ mod tests {
     }
 
     #[derive(Clone)]
+    struct SkipDefaultApiAndPanicOnToolCallHook;
+
+    impl PromptHook<MockCompletionModel> for SkipDefaultApiAndPanicOnToolCallHook {
+        async fn on_invalid_tool_call(
+            &self,
+            context: &InvalidToolCallContext,
+        ) -> InvalidToolCallHookAction {
+            SkipDefaultApiHook.on_invalid_tool_call(context).await
+        }
+
+        async fn on_tool_call(
+            &self,
+            tool_name: &str,
+            tool_call_id: Option<String>,
+            internal_call_id: &str,
+            args: &str,
+        ) -> ToolCallHookAction {
+            PanicOnToolCallHook
+                .on_tool_call(tool_name, tool_call_id, internal_call_id, args)
+                .await
+        }
+    }
+
+    #[derive(Clone)]
     struct RepairDefaultApiHook;
 
-    impl InvalidToolCallHook<MockCompletionModel> for RepairDefaultApiHook {
+    impl PromptHook<MockCompletionModel> for RepairDefaultApiHook {
         fn on_invalid_tool_call(
             &self,
             context: &InvalidToolCallContext,
@@ -1465,7 +1426,7 @@ mod tests {
     #[derive(Clone)]
     struct RepairToSubtractHook;
 
-    impl InvalidToolCallHook<MockCompletionModel> for RepairToSubtractHook {
+    impl PromptHook<MockCompletionModel> for RepairToSubtractHook {
         async fn on_invalid_tool_call(
             &self,
             _context: &InvalidToolCallContext,
@@ -1477,7 +1438,7 @@ mod tests {
     #[derive(Clone)]
     struct RetryDefaultApiHook;
 
-    impl InvalidToolCallHook<MockCompletionModel> for RetryDefaultApiHook {
+    impl PromptHook<MockCompletionModel> for RetryDefaultApiHook {
         fn on_invalid_tool_call(
             &self,
             context: &InvalidToolCallContext,
@@ -1494,7 +1455,7 @@ mod tests {
     #[derive(Clone)]
     struct SkipDefaultApiHook;
 
-    impl InvalidToolCallHook<MockCompletionModel> for SkipDefaultApiHook {
+    impl PromptHook<MockCompletionModel> for SkipDefaultApiHook {
         async fn on_invalid_tool_call(
             &self,
             _context: &InvalidToolCallContext,
@@ -1517,7 +1478,7 @@ mod tests {
         }
     }
 
-    impl InvalidToolCallHook<MockCompletionModel> for RecordingInvalidToolCallHook {
+    impl PromptHook<MockCompletionModel> for RecordingInvalidToolCallHook {
         async fn on_invalid_tool_call(
             &self,
             context: &InvalidToolCallContext,
@@ -1788,7 +1749,7 @@ mod tests {
 
         let err = agent
             .prompt("use the tool")
-            .with_invalid_tool_call_hook(invalid_hook.clone())
+            .with_hook(invalid_hook.clone())
             .max_turns(3)
             .await
             .expect_err("invalid tool should fail");
@@ -1892,7 +1853,7 @@ mod tests {
 
         let response = agent
             .prompt("add")
-            .with_invalid_tool_call_hook(RepairDefaultApiHook)
+            .with_hook(RepairDefaultApiHook)
             .max_turns(3)
             .extended_details()
             .await
@@ -1934,7 +1895,7 @@ mod tests {
 
         let response = agent
             .prompt("add")
-            .with_invalid_tool_call_hook(RetryDefaultApiHook)
+            .with_hook(RetryDefaultApiHook)
             .max_invalid_tool_call_retries(1)
             .max_turns(3)
             .extended_details()
@@ -1996,7 +1957,7 @@ mod tests {
 
         let response = agent
             .prompt("add")
-            .with_invalid_tool_call_hook(RetryDefaultApiHook)
+            .with_hook(RetryDefaultApiHook)
             .max_invalid_tool_call_retries(1)
             .max_turns(3)
             .extended_details()
@@ -2083,8 +2044,7 @@ mod tests {
 
         let response = agent
             .prompt("add")
-            .with_hook(PanicOnToolCallHook)
-            .with_invalid_tool_call_hook(SkipDefaultApiHook)
+            .with_hook(SkipDefaultApiAndPanicOnToolCallHook)
             .max_turns(3)
             .extended_details()
             .await
@@ -2135,7 +2095,7 @@ mod tests {
 
         let err = agent
             .prompt("add")
-            .with_invalid_tool_call_hook(RetryDefaultApiHook)
+            .with_hook(RetryDefaultApiHook)
             .max_invalid_tool_call_retries(0)
             .max_turns(3)
             .await
@@ -2165,7 +2125,7 @@ mod tests {
 
         let response = agent
             .prompt("add")
-            .with_invalid_tool_call_hook(SkipDefaultApiHook)
+            .with_hook(SkipDefaultApiHook)
             .max_turns(3)
             .extended_details()
             .await
@@ -2210,7 +2170,7 @@ mod tests {
 
         let response = agent
             .prompt("add")
-            .with_invalid_tool_call_hook(SkipDefaultApiHook)
+            .with_hook(SkipDefaultApiHook)
             .max_turns(3)
             .extended_details()
             .await
@@ -2258,7 +2218,7 @@ mod tests {
 
         let err = agent
             .prompt("add")
-            .with_invalid_tool_call_hook(RepairToSubtractHook)
+            .with_hook(RepairToSubtractHook)
             .max_turns(3)
             .await
             .expect_err("repair to a disallowed tool should fail");
@@ -2286,7 +2246,7 @@ mod tests {
 
         let err = agent
             .prompt("do not use tools")
-            .with_invalid_tool_call_hook(RepairDefaultApiHook)
+            .with_hook(RepairDefaultApiHook)
             .max_turns(3)
             .await
             .expect_err("ToolChoice::None should reject repaired tool calls");
@@ -2314,7 +2274,7 @@ mod tests {
 
         let err = agent
             .prompt("do not use tools")
-            .with_invalid_tool_call_hook(SkipDefaultApiHook)
+            .with_hook(SkipDefaultApiHook)
             .max_turns(3)
             .await
             .expect_err("ToolChoice::None should reject skipped tool calls");
@@ -2366,7 +2326,7 @@ mod tests {
 
         let response = agent
             .prompt_typed::<TypedAnswer>("return typed json")
-            .with_invalid_tool_call_hook(RepairDefaultApiHook)
+            .with_hook(RepairDefaultApiHook)
             .max_turns(3)
             .await
             .expect("typed prompt should repair invalid tool call");
@@ -2390,7 +2350,7 @@ mod tests {
 
         let response = agent
             .prompt_typed::<TypedAnswer>("return typed json")
-            .with_invalid_tool_call_hook(RetryDefaultApiHook)
+            .with_hook(RetryDefaultApiHook)
             .max_invalid_tool_call_retries(1)
             .max_turns(3)
             .await
@@ -2416,7 +2376,7 @@ mod tests {
 
         let err = agent
             .prompt_typed::<TypedAnswer>("return typed json")
-            .with_invalid_tool_call_hook(RetryDefaultApiHook)
+            .with_hook(RetryDefaultApiHook)
             .max_invalid_tool_call_retries(0)
             .max_turns(3)
             .await

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -3,8 +3,7 @@ use crate::{
     agent::completion::{DynamicContextStore, build_prepared_completion_request},
     agent::prompt_request::{
         HookAction, InvalidToolCallResolution, TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER,
-        hooks::{InvalidToolCallHook, PromptHook},
-        resolve_invalid_tool_call, validate_tool_call_name,
+        hooks::PromptHook, resolve_invalid_tool_call, validate_tool_call_name,
     },
     completion::{Document, GetTokenUsage},
     json_utils,
@@ -569,11 +568,10 @@ const UNKNOWN_AGENT_NAME: &str = "Unnamed Agent";
 /// attempting to await (which will send the prompt request) can potentially return
 /// [`crate::completion::request::PromptError::MaxTurnsError`] if the agent decides to call tools
 /// back to back.
-pub struct StreamingPromptRequest<M, P, I = ()>
+pub struct StreamingPromptRequest<M, P>
 where
     M: CompletionModel,
     P: PromptHook<M> + 'static,
-    I: InvalidToolCallHook<M> + 'static,
 {
     /// The prompt message to send to the model
     prompt: Message,
@@ -607,8 +605,6 @@ where
     output_schema: Option<schemars::Schema>,
     /// Optional per-request hook for events
     hook: Option<P>,
-    /// Optional per-request hook for invalid model-emitted tool calls.
-    invalid_tool_call_hook: Option<I>,
     /// Maximum number of invalid tool-call retries for this request.
     max_invalid_tool_call_retries: usize,
     /// Optional conversation memory backend cloned from the agent.
@@ -617,12 +613,11 @@ where
     conversation_id: Option<String>,
 }
 
-impl<M, P, I> StreamingPromptRequest<M, P, I>
+impl<M, P> StreamingPromptRequest<M, P>
 where
     M: CompletionModel + 'static,
     <M as CompletionModel>::StreamingResponse: WasmCompatSend + GetTokenUsage,
     P: PromptHook<M>,
-    I: InvalidToolCallHook<M>,
 {
     /// Create a new StreamingPromptRequest with the given prompt and model.
     /// Note: This creates a request without an agent hook. Use `from_agent` to include the agent's hook.
@@ -643,7 +638,6 @@ where
             tool_choice: agent.tool_choice.clone(),
             output_schema: agent.output_schema.clone(),
             hook: None,
-            invalid_tool_call_hook: None,
             max_invalid_tool_call_retries: 0,
             memory: agent.memory.clone(),
             conversation_id: agent.default_conversation_id.clone(),
@@ -674,7 +668,6 @@ where
             tool_choice: agent.tool_choice.clone(),
             output_schema: agent.output_schema.clone(),
             hook: agent.hook.clone(),
-            invalid_tool_call_hook: None,
             max_invalid_tool_call_retries: 0,
             memory: agent.memory.clone(),
             conversation_id: agent.default_conversation_id.clone(),
@@ -715,7 +708,7 @@ where
 
     /// Attach a per-request hook for tool call events.
     /// This overrides any default hook set on the agent.
-    pub fn with_hook<P2>(self, hook: P2) -> StreamingPromptRequest<M, P2, I>
+    pub fn with_hook<P2>(self, hook: P2) -> StreamingPromptRequest<M, P2>
     where
         P2: PromptHook<M>,
     {
@@ -735,37 +728,6 @@ where
             tool_choice: self.tool_choice,
             output_schema: self.output_schema,
             hook: Some(hook),
-            invalid_tool_call_hook: self.invalid_tool_call_hook,
-            max_invalid_tool_call_retries: self.max_invalid_tool_call_retries,
-            memory: self.memory,
-            conversation_id: self.conversation_id,
-        }
-    }
-
-    /// Attach a per-request hook for invalid model-emitted tool calls.
-    ///
-    /// Without this hook, Rig preserves fail-fast validation.
-    pub fn with_invalid_tool_call_hook<I2>(self, hook: I2) -> StreamingPromptRequest<M, P, I2>
-    where
-        I2: InvalidToolCallHook<M>,
-    {
-        StreamingPromptRequest {
-            prompt: self.prompt,
-            chat_history: self.chat_history,
-            max_turns: self.max_turns,
-            model: self.model,
-            agent_name: self.agent_name,
-            preamble: self.preamble,
-            static_context: self.static_context,
-            temperature: self.temperature,
-            max_tokens: self.max_tokens,
-            additional_params: self.additional_params,
-            tool_server_handle: self.tool_server_handle,
-            dynamic_context: self.dynamic_context,
-            tool_choice: self.tool_choice,
-            output_schema: self.output_schema,
-            hook: self.hook,
-            invalid_tool_call_hook: Some(hook),
             max_invalid_tool_call_retries: self.max_invalid_tool_call_retries,
             memory: self.memory,
             conversation_id: self.conversation_id,
@@ -1015,8 +977,8 @@ where
                             if !allowed_tool_names.contains(&tool_call.function.name) {
                                 let args = json_utils::value_to_json_string(&tool_call.function.arguments);
                                 let emitted_tool_name = tool_call.function.name.clone();
-                                match resolve_invalid_tool_call::<M, I>(
-                                    self.invalid_tool_call_hook.as_ref(),
+                                match resolve_invalid_tool_call::<M, P>(
+                                    self.hook.as_ref(),
                                     &emitted_tool_name,
                                     Some(tool_call.id.clone()),
                                     Some(internal_call_id.clone()),
@@ -1210,8 +1172,8 @@ where
 
                                     if !allowed_tool_names.contains(&name) {
                                         let emitted_tool_name = name.clone();
-                                        match resolve_invalid_tool_call::<M, I>(
-                                            self.invalid_tool_call_hook.as_ref(),
+                                        match resolve_invalid_tool_call::<M, P>(
+                                            self.hook.as_ref(),
                                             &emitted_tool_name,
                                             Some(id.clone()),
                                             Some(internal_call_id.clone()),
@@ -1698,12 +1660,11 @@ where
     }
 }
 
-impl<M, P, I> IntoFuture for StreamingPromptRequest<M, P, I>
+impl<M, P> IntoFuture for StreamingPromptRequest<M, P>
 where
     M: CompletionModel + 'static,
     <M as CompletionModel>::StreamingResponse: WasmCompatSend,
     P: PromptHook<M> + 'static,
-    I: InvalidToolCallHook<M> + 'static,
 {
     type Output = StreamingResult<M::StreamingResponse>; // what `.await` returns
     type IntoFuture = WasmBoxedFuture<'static, Self::Output>;
@@ -1758,8 +1719,7 @@ mod tests {
     use super::*;
     use crate::agent::AgentBuilder;
     use crate::agent::prompt_request::hooks::{
-        InvalidToolCallContext, InvalidToolCallHook, InvalidToolCallHookAction, PromptHook,
-        ToolCallHookAction,
+        InvalidToolCallContext, InvalidToolCallHookAction, PromptHook, ToolCallHookAction,
     };
     use crate::client::ProviderClient;
     use crate::client::completion::CompletionClient;
@@ -2348,7 +2308,7 @@ mod tests {
     #[derive(Clone)]
     struct RepairDefaultApiHook;
 
-    impl InvalidToolCallHook<MockCompletionModel> for RepairDefaultApiHook {
+    impl PromptHook<MockCompletionModel> for RepairDefaultApiHook {
         fn on_invalid_tool_call(
             &self,
             context: &InvalidToolCallContext,
@@ -2364,7 +2324,7 @@ mod tests {
     #[derive(Clone)]
     struct RetryDefaultApiHook;
 
-    impl InvalidToolCallHook<MockCompletionModel> for RetryDefaultApiHook {
+    impl PromptHook<MockCompletionModel> for RetryDefaultApiHook {
         fn on_invalid_tool_call(
             &self,
             context: &InvalidToolCallContext,
@@ -2384,7 +2344,7 @@ mod tests {
     #[derive(Clone)]
     struct SkipDefaultApiHook;
 
-    impl InvalidToolCallHook<MockCompletionModel> for SkipDefaultApiHook {
+    impl PromptHook<MockCompletionModel> for SkipDefaultApiHook {
         fn on_invalid_tool_call(
             &self,
             context: &InvalidToolCallContext,
@@ -2411,7 +2371,7 @@ mod tests {
         }
     }
 
-    impl InvalidToolCallHook<MockCompletionModel> for RecordingInvalidToolCallHook {
+    impl PromptHook<MockCompletionModel> for RecordingInvalidToolCallHook {
         fn on_invalid_tool_call(
             &self,
             context: &InvalidToolCallContext,
@@ -2499,6 +2459,108 @@ mod tests {
                     .push(event);
                 HookAction::cont()
             }
+        }
+    }
+
+    #[derive(Clone)]
+    struct RecordingTextAndSkipInvalidToolHook {
+        text: RecordingTextDeltaHook,
+    }
+
+    impl PromptHook<MockCompletionModel> for RecordingTextAndSkipInvalidToolHook {
+        fn on_text_delta(
+            &self,
+            text_delta: &str,
+            full_text: &str,
+        ) -> impl Future<Output = HookAction> + Send {
+            self.text.on_text_delta(text_delta, full_text)
+        }
+
+        fn on_invalid_tool_call(
+            &self,
+            context: &InvalidToolCallContext,
+        ) -> impl Future<Output = InvalidToolCallHookAction> + Send {
+            SkipDefaultApiHook.on_invalid_tool_call(context)
+        }
+    }
+
+    #[derive(Clone)]
+    struct RecordingTextAndRetryInvalidToolHook {
+        text: RecordingTextDeltaHook,
+    }
+
+    impl PromptHook<MockCompletionModel> for RecordingTextAndRetryInvalidToolHook {
+        fn on_text_delta(
+            &self,
+            text_delta: &str,
+            full_text: &str,
+        ) -> impl Future<Output = HookAction> + Send {
+            self.text.on_text_delta(text_delta, full_text)
+        }
+
+        fn on_invalid_tool_call(
+            &self,
+            context: &InvalidToolCallContext,
+        ) -> impl Future<Output = InvalidToolCallHookAction> + Send {
+            RetryDefaultApiHook.on_invalid_tool_call(context)
+        }
+    }
+
+    #[derive(Clone)]
+    struct RecordingDeltaAndRetryInvalidToolHook {
+        delta: RecordingToolCallDeltaHook,
+    }
+
+    impl PromptHook<MockCompletionModel> for RecordingDeltaAndRetryInvalidToolHook {
+        fn on_tool_call_delta(
+            &self,
+            tool_call_id: &str,
+            internal_call_id: &str,
+            tool_name: Option<&str>,
+            tool_call_delta: &str,
+        ) -> impl Future<Output = HookAction> + Send {
+            self.delta.on_tool_call_delta(
+                tool_call_id,
+                internal_call_id,
+                tool_name,
+                tool_call_delta,
+            )
+        }
+
+        fn on_invalid_tool_call(
+            &self,
+            context: &InvalidToolCallContext,
+        ) -> impl Future<Output = InvalidToolCallHookAction> + Send {
+            RetryDefaultApiHook.on_invalid_tool_call(context)
+        }
+    }
+
+    #[derive(Clone)]
+    struct RecordingDeltaAndSkipInvalidToolHook {
+        delta: RecordingToolCallDeltaHook,
+    }
+
+    impl PromptHook<MockCompletionModel> for RecordingDeltaAndSkipInvalidToolHook {
+        fn on_tool_call_delta(
+            &self,
+            tool_call_id: &str,
+            internal_call_id: &str,
+            tool_name: Option<&str>,
+            tool_call_delta: &str,
+        ) -> impl Future<Output = HookAction> + Send {
+            self.delta.on_tool_call_delta(
+                tool_call_id,
+                internal_call_id,
+                tool_name,
+                tool_call_delta,
+            )
+        }
+
+        fn on_invalid_tool_call(
+            &self,
+            context: &InvalidToolCallContext,
+        ) -> impl Future<Output = InvalidToolCallHookAction> + Send {
+            SkipDefaultApiHook.on_invalid_tool_call(context)
         }
     }
 
@@ -2700,7 +2762,7 @@ mod tests {
 
         let mut stream = agent
             .stream_prompt("use the tool")
-            .with_invalid_tool_call_hook(RepairDefaultApiHook)
+            .with_hook(RepairDefaultApiHook)
             .multi_turn(3)
             .with_history(Vec::<Message>::new())
             .await;
@@ -2766,7 +2828,7 @@ mod tests {
 
         let mut stream = agent
             .stream_prompt("use the tool")
-            .with_invalid_tool_call_hook(invalid_hook.clone())
+            .with_hook(invalid_hook.clone())
             .multi_turn(3)
             .await;
         let mut error = None;
@@ -2816,7 +2878,7 @@ mod tests {
 
         let mut stream = agent
             .stream_prompt("use the tool")
-            .with_invalid_tool_call_hook(SkipDefaultApiHook)
+            .with_hook(SkipDefaultApiHook)
             .multi_turn(3)
             .with_history(Vec::<Message>::new())
             .await;
@@ -2905,7 +2967,7 @@ mod tests {
 
         let mut stream = agent
             .stream_prompt("use the tool")
-            .with_invalid_tool_call_hook(RetryDefaultApiHook)
+            .with_hook(RetryDefaultApiHook)
             .multi_turn(3)
             .with_history(Vec::<Message>::new())
             .max_invalid_tool_call_retries(1)
@@ -3030,7 +3092,7 @@ mod tests {
 
         let mut stream = agent
             .stream_prompt("use the tool")
-            .with_invalid_tool_call_hook(SkipDefaultApiHook)
+            .with_hook(SkipDefaultApiHook)
             .multi_turn(3)
             .with_history(Vec::<Message>::new())
             .await;
@@ -3137,7 +3199,7 @@ mod tests {
 
         let mut stream = agent
             .stream_prompt("use the tool")
-            .with_invalid_tool_call_hook(SkipDefaultApiHook)
+            .with_hook(SkipDefaultApiHook)
             .multi_turn(3)
             .with_history(Vec::<Message>::new())
             .await;
@@ -3184,7 +3246,7 @@ mod tests {
 
         let mut stream = agent
             .stream_prompt("use the tool")
-            .with_invalid_tool_call_hook(RetryDefaultApiHook)
+            .with_hook(RetryDefaultApiHook)
             .multi_turn(3)
             .with_history(Vec::<Message>::new())
             .max_invalid_tool_call_retries(1)
@@ -3230,8 +3292,9 @@ mod tests {
 
         let mut stream = agent
             .stream_prompt("use the tool")
-            .with_hook(text_hook.clone())
-            .with_invalid_tool_call_hook(SkipDefaultApiHook)
+            .with_hook(RecordingTextAndSkipInvalidToolHook {
+                text: text_hook.clone(),
+            })
             .multi_turn(3)
             .with_history(Vec::<Message>::new())
             .await;
@@ -3289,8 +3352,9 @@ mod tests {
 
         let mut stream = agent
             .stream_prompt("use the tool")
-            .with_hook(delta_hook.clone())
-            .with_invalid_tool_call_hook(RetryDefaultApiHook)
+            .with_hook(RecordingDeltaAndRetryInvalidToolHook {
+                delta: delta_hook.clone(),
+            })
             .multi_turn(3)
             .with_history(Vec::<Message>::new())
             .max_invalid_tool_call_retries(1)
@@ -3417,7 +3481,7 @@ mod tests {
 
         let mut stream = agent
             .stream_prompt("use the tool")
-            .with_invalid_tool_call_hook(invalid_hook.clone())
+            .with_hook(invalid_hook.clone())
             .multi_turn(3)
             .await;
         let mut error = None;
@@ -3478,8 +3542,9 @@ mod tests {
 
         let mut stream = agent
             .stream_prompt("use the tool")
-            .with_hook(text_hook.clone())
-            .with_invalid_tool_call_hook(RetryDefaultApiHook)
+            .with_hook(RecordingTextAndRetryInvalidToolHook {
+                text: text_hook.clone(),
+            })
             .multi_turn(3)
             .with_history(Vec::<Message>::new())
             .max_invalid_tool_call_retries(1)
@@ -3537,8 +3602,9 @@ mod tests {
 
         let mut stream = agent
             .stream_prompt("use the tool")
-            .with_hook(delta_hook.clone())
-            .with_invalid_tool_call_hook(SkipDefaultApiHook)
+            .with_hook(RecordingDeltaAndSkipInvalidToolHook {
+                delta: delta_hook.clone(),
+            })
             .multi_turn(3)
             .with_history(Vec::<Message>::new())
             .await;
@@ -3651,7 +3717,7 @@ mod tests {
 
         let mut stream = agent
             .stream_prompt("use the tool")
-            .with_invalid_tool_call_hook(RetryDefaultApiHook)
+            .with_hook(RetryDefaultApiHook)
             .multi_turn(3)
             .max_invalid_tool_call_retries(0)
             .await;
@@ -3711,7 +3777,7 @@ mod tests {
 
         let mut stream = agent
             .stream_prompt("use the tool")
-            .with_invalid_tool_call_hook(RetryDefaultApiHook)
+            .with_hook(RetryDefaultApiHook)
             .multi_turn(3)
             .max_invalid_tool_call_retries(0)
             .await;

--- a/examples/gemini_default_api_recovery.rs
+++ b/examples/gemini_default_api_recovery.rs
@@ -1,0 +1,440 @@
+//! Demonstrates recovering from Gemini emitting a legacy `default_api` tool name.
+//! Requires `GEMINI_API_KEY`.
+//!
+//! Run with `RIG_GEMINI_DEFAULT_API_CANARY_ATTEMPTS=6` to increase the chance of
+//! seeing the recoverable legacy tool-name emission.
+
+use futures::StreamExt;
+use rig::agent::{
+    FinalResponse, InvalidToolCallContext, InvalidToolCallHookAction, MultiTurnStreamItem,
+    PromptHook, StreamingResult,
+};
+use rig::client::{CompletionClient, ProviderClient};
+use rig::completion::{CompletionModel, ToolDefinition};
+use rig::message::ToolResultContent;
+use rig::providers::gemini::{
+    self,
+    completion::gemini_api_types::{AdditionalParameters, GenerationConfig, ThinkingConfig},
+};
+use rig::streaming::{StreamedAssistantContent, StreamedUserContent, StreamingPrompt};
+use rig::tool::Tool;
+use schemars::{JsonSchema, schema_for};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::env;
+use std::sync::{Arc, Mutex};
+
+const GEMINI_CANARY_MODEL: &str = "gemini-3.1-pro-preview";
+const THINKING_BUDGET: u32 = 1024 * 16;
+const CANARY_MAX_TURNS: usize = 8;
+const DEFAULT_CANARY_ATTEMPTS: usize = 2;
+const CANARY_ATTEMPTS_ENV: &str = "RIG_GEMINI_DEFAULT_API_CANARY_ATTEMPTS";
+const JAVASCRIPT_MARKER: &str = "workspace-canary-marker";
+
+const WORKSPACE_STYLE_PREAMBLE: &str = r#"
+<role>
+You are an assistant operating within a private workspace. Your goal is to help the user achieve their stated task. This includes understanding their intent, planning a course of action, optionally executing it using your tools, and communicating a detailed response that fits the user's intent.
+</role>
+
+<capabilities>
+<execution-runtime>
+Access higher-level workspace inspection through JavaScript execution. The runtime exposes private application APIs through global namespaces, and those APIs can be used to traverse, transform, and inspect workspace data.
+
+Optional use implied, goal is to serve user. Instead of optimistically reaching for execution runtime, only leverage when necessary for extra context gathering and grounding.
+
+Execute in series if needed, the response from one execution may be necessary for future executions.
+
+If continuous execution cannot be completed, explain why to the user.
+
+In the runtime, APIs are exposed as static async methods on global namespaces, with each namespace granting explicit capabilities based on the integration. You will have to use `await` when calling them.
+
+## Workspace
+Access workspace records through the `Workspace` object. All methods are async and require `await`.
+
+- `Workspace.getRecord(id: string)`: get record metadata by ID; includes `counts: { words, chars, lines }`, collectionIds, author, timestamps.
+- `Workspace.listLibrary(filter?: string)`: returns a flat library overview `{ collections: [{ id, title }], records }`.
+- `Workspace.listCollection(collection_id: string, depth?: number, filter?: string)`: returns collection contents `{ id, title, collections, records }`.
+- `Workspace.getRecordCollections(id: string)`: returns all collections that contain this record as `[{ id, title }]`.
+- `Workspace.readRecord(id: string, range?: [number, number])`: read record content, optional byte range [start, end].
+- `Workspace.searchRecords(pattern: string)`: regex search across all text records.
+
+### Notes
+
+**Collections** - names are not unique, always use IDs. A record can appear in multiple collections simultaneously. Removing a record from a collection never deletes it; it always stays in the library.
+
+**Listing** - use `listLibrary()` for a fast overview of all records and collections. Use `listCollection(id)` to drill into a specific collection. The `depth` param on `listCollection` controls recursive flattening.
+</execution-runtime>
+</capabilities>
+
+<extra-scripting-notes>
+The last expression in your script will be returned, no need for explicit `return` statement.
+Make sure your script ends with the value you want to inspect.
+Console functions like `console.log` and `console.table` are not available, you must return values at the end of your script to see them.
+Top-level await is not available, you must write an async function and execute any async functions inside of that.
+You have access to standard JavaScript data structures and control flow, but not networking or any storage/filesystem operations aside from the documented APIs.
+No access to Node.js APIs or browser APIs, only standard ECMAScript.
+Use JavaScript's built-in array methods (`map`, `filter`, `reduce`) for data transformation.
+</extra-scripting-notes>
+"#;
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+struct JavaScriptProgram {
+    title: String,
+    description: String,
+    code: String,
+}
+
+#[repr(transparent)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ExecutorResponse(std::result::Result<serde_json::Value, String>);
+
+impl ExecutorResponse {
+    fn ok(value: serde_json::Value) -> Self {
+        Self(Ok(value))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("JavaScript tool error")]
+struct JavaScriptToolError;
+
+#[derive(Clone)]
+struct JavaScript;
+
+impl Tool for JavaScript {
+    const NAME: &'static str = "JavaScript";
+    type Error = JavaScriptToolError;
+    type Args = JavaScriptProgram;
+    type Output = ExecutorResponse;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: Self::NAME.into(),
+            description: "JavaScript runtime with an array of tools for completing the tasks assigned by the user. Legacy workspace agents may refer to this runtime as default_api.".into(),
+            parameters: schema_for!(JavaScriptProgram).to_value(),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        Ok(ExecutorResponse::ok(json!({
+            "id": "collection-canary-id",
+            "title": "Canary Collection",
+            "collections": [],
+            "records": [{
+                "id": "record-canary-marker",
+                "title": JAVASCRIPT_MARKER,
+                "counts": { "words": 3, "chars": 21, "lines": 1 },
+                "collectionIds": ["collection-canary-id"]
+            }],
+            "receivedCode": args.code
+        })))
+    }
+}
+
+#[derive(Clone, Default)]
+struct DefaultApiRepairHook {
+    invalid_tool_names: Arc<Mutex<Vec<String>>>,
+}
+
+impl DefaultApiRepairHook {
+    fn invalid_tool_names(&self) -> Vec<String> {
+        self.invalid_tool_names
+            .lock()
+            .map(|names| names.clone())
+            .unwrap_or_default()
+    }
+}
+
+impl<M> PromptHook<M> for DefaultApiRepairHook
+where
+    M: CompletionModel,
+{
+    async fn on_invalid_tool_call(
+        &self,
+        context: &InvalidToolCallContext,
+    ) -> InvalidToolCallHookAction {
+        if let Ok(mut invalid_tool_names) = self.invalid_tool_names.lock() {
+            invalid_tool_names.push(context.tool_name.clone());
+        }
+
+        if context.tool_name == "default_api" {
+            InvalidToolCallHookAction::repair(JavaScript::NAME)
+        } else {
+            InvalidToolCallHookAction::fail()
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct WorkspaceStreamObservation {
+    streamed_text: String,
+    reasoning_text: String,
+    final_response: Option<FinalResponse>,
+    tool_calls: Vec<String>,
+    tool_call_deltas: usize,
+    executions: Vec<JavaScriptProgram>,
+    tool_results: Vec<String>,
+    executor_results: Vec<ExecutorResponse>,
+    completion_calls: Vec<String>,
+    invalid_tool_names: Vec<String>,
+    events: Vec<&'static str>,
+}
+
+impl WorkspaceStreamObservation {
+    fn final_response_text(&self) -> Option<&str> {
+        self.final_response
+            .as_ref()
+            .map(|response| response.response())
+    }
+
+    fn diagnostic_summary(&self) -> String {
+        format!(
+            "events={:?}, tool_calls={:?}, tool_call_deltas={}, invalid_tool_names={:?}, executions={:?}, tool_results={:?}, executor_results={:?}, streamed_text={:?}, reasoning_text={:?}, completion_calls={:?}, final={:?}, final_usage={:?}",
+            self.events,
+            self.tool_calls,
+            self.tool_call_deltas,
+            self.invalid_tool_names,
+            self.executions,
+            self.tool_results,
+            self.executor_results,
+            self.streamed_text,
+            self.reasoning_text,
+            self.completion_calls,
+            self.final_response_text(),
+            self.final_response
+                .as_ref()
+                .map(|response| response.usage())
+        )
+    }
+}
+
+fn gemini_canary_additional_params() -> Result<serde_json::Value, serde_json::Error> {
+    let additional_params = AdditionalParameters {
+        generation_config: Some(GenerationConfig {
+            thinking_config: Some(ThinkingConfig {
+                include_thoughts: Some(true),
+                thinking_budget: Some(THINKING_BUDGET),
+                thinking_level: None,
+            }),
+            ..Default::default()
+        }),
+        additional_params: None,
+    };
+
+    serde_json::to_value(&additional_params)
+}
+
+async fn consume_workspace_like_stream(
+    mut stream: StreamingResult<gemini::streaming::StreamingCompletionResponse>,
+) -> Result<WorkspaceStreamObservation, String> {
+    let mut observation = WorkspaceStreamObservation::default();
+
+    while let Some(item) = stream.next().await {
+        match item.map_err(|error| error.to_string())? {
+            MultiTurnStreamItem::StreamAssistantItem(StreamedAssistantContent::Text(text)) => {
+                observation.events.push("text");
+                observation.streamed_text.push_str(&text.text);
+            }
+            MultiTurnStreamItem::StreamAssistantItem(StreamedAssistantContent::Reasoning(
+                reasoning,
+            )) => {
+                observation.events.push("reasoning");
+                observation
+                    .reasoning_text
+                    .push_str(&reasoning.display_text());
+            }
+            MultiTurnStreamItem::StreamAssistantItem(
+                StreamedAssistantContent::ReasoningDelta { reasoning, .. },
+            ) => {
+                observation.events.push("reasoning_delta");
+                observation.reasoning_text.push_str(&reasoning);
+            }
+            MultiTurnStreamItem::StreamAssistantItem(StreamedAssistantContent::ToolCall {
+                tool_call,
+                ..
+            }) => {
+                observation.events.push("tool_call");
+                observation.tool_calls.push(tool_call.function.name.clone());
+                let execution: JavaScriptProgram =
+                    serde_json::from_value(tool_call.function.arguments.clone())
+                        .map_err(|error| error.to_string())?;
+                observation.executions.push(execution);
+            }
+            MultiTurnStreamItem::StreamAssistantItem(StreamedAssistantContent::ToolCallDelta {
+                ..
+            }) => {
+                observation.events.push("tool_call_delta");
+                observation.tool_call_deltas += 1;
+            }
+            MultiTurnStreamItem::StreamUserItem(StreamedUserContent::ToolResult {
+                tool_result,
+                ..
+            }) => {
+                observation.events.push("tool_result");
+                let ToolResultContent::Text(text) = tool_result.content.first() else {
+                    return Err("JS Runtime can only respond with JSON text".to_string());
+                };
+                observation.tool_results.push(text.text.clone());
+                let result: ExecutorResponse =
+                    serde_json::from_str(&text.text).map_err(|error| error.to_string())?;
+                observation.executor_results.push(result);
+            }
+            MultiTurnStreamItem::CompletionCall(completion_call) => {
+                observation.events.push("completion_call");
+                observation.completion_calls.push(format!(
+                    "call_index={}, usage={:?}",
+                    completion_call.call_index, completion_call.usage
+                ));
+            }
+            MultiTurnStreamItem::FinalResponse(final_response) => {
+                observation.events.push("final_response");
+                observation.final_response = Some(final_response);
+                return Ok(observation);
+            }
+            _ => {}
+        }
+    }
+
+    Ok(observation)
+}
+
+fn canary_attempts() -> usize {
+    env::var(CANARY_ATTEMPTS_ENV)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .filter(|attempts| *attempts > 0)
+        .unwrap_or(DEFAULT_CANARY_ATTEMPTS)
+}
+
+fn workspace_canary_prompt(attempt: usize) -> String {
+    format!(
+        "Inspect the workspace collection with id `collection-canary-id`. This canary intentionally \
+         exercises a legacy workspace namespace leak. Older workspace agents often call the \
+         execution runtime by the structured tool name `default_api`. Use the legacy \
+         `default_api` workspace runtime name to inspect the collection. The expected program is: \
+         async function inspectCollection() {{ try {{ const collection = await Workspace.listCollection(\"collection-canary-id\", 1); return collection; }} catch (e) {{ return `Error: ${{e.message}}`; }} }} inspectCollection(); \
+         After inspecting the collection, answer in one sentence and include `{JAVASCRIPT_MARKER}`. \
+         Canary attempt {attempt}."
+    )
+}
+
+async fn run_workspace_canary_attempt(
+    attempt: usize,
+) -> Result<WorkspaceStreamObservation, String> {
+    let client = gemini::Client::from_env().map_err(|error| error.to_string())?;
+    let agent_name = format!("workspace-default-api-canary-{attempt}");
+    let agent = client
+        .agent(GEMINI_CANARY_MODEL)
+        .name(&agent_name)
+        .preamble(WORKSPACE_STYLE_PREAMBLE)
+        .additional_params(gemini_canary_additional_params().map_err(|error| error.to_string())?)
+        .tool(JavaScript)
+        .default_max_turns(CANARY_MAX_TURNS)
+        .temperature(0.0)
+        .build();
+    let repair_hook = DefaultApiRepairHook::default();
+
+    let stream = agent
+        .stream_prompt(workspace_canary_prompt(attempt))
+        .with_hook(repair_hook.clone())
+        .with_history(Vec::<rig::message::Message>::new())
+        .await;
+
+    let mut observation = consume_workspace_like_stream(stream).await?;
+    observation.invalid_tool_names = repair_hook.invalid_tool_names();
+    Ok(observation)
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let attempts = canary_attempts();
+    let mut successful_attempts = Vec::new();
+    let mut repaired_default_api = false;
+
+    for attempt in 1..=attempts {
+        let observation = run_workspace_canary_attempt(attempt)
+            .await
+            .map_err(anyhow::Error::msg)?;
+        let diagnostics = observation.diagnostic_summary();
+
+        repaired_default_api |= observation
+            .invalid_tool_names
+            .iter()
+            .any(|name| name == "default_api");
+
+        if observation
+            .tool_results
+            .iter()
+            .any(|result| result.contains("ToolNotFoundError: default_api"))
+        {
+            anyhow::bail!(
+                "attempt {attempt}: Rig returned the production ToolNotFoundError symptom. {diagnostics}"
+            );
+        }
+        if !observation
+            .tool_calls
+            .iter()
+            .all(|name| !name.contains("default_api"))
+        {
+            anyhow::bail!(
+                "attempt {attempt}: repaired default_api should not reach the public tool-call stream. {diagnostics}"
+            );
+        }
+        if observation.reasoning_text.contains("tool_code")
+            || observation.streamed_text.contains("tool_code")
+        {
+            anyhow::bail!(
+                "attempt {attempt}: Gemini emitted markdown tool_code text instead of a function call. {diagnostics}"
+            );
+        }
+        if !observation
+            .tool_calls
+            .iter()
+            .any(|name| name == JavaScript::NAME)
+        {
+            anyhow::bail!(
+                "attempt {attempt}: expected live Gemini to call JavaScript. {diagnostics}"
+            );
+        }
+        if !observation
+            .executions
+            .iter()
+            .any(|execution| execution.code.contains("Workspace.listCollection"))
+        {
+            anyhow::bail!(
+                "attempt {attempt}: expected workspace-shaped JavaScript execution. {diagnostics}"
+            );
+        }
+        if observation.executor_results.is_empty() {
+            anyhow::bail!(
+                "attempt {attempt}: expected at least one parsed ExecutorResponse. {diagnostics}"
+            );
+        }
+
+        let Some(final_response) = observation.final_response.as_ref() else {
+            anyhow::bail!("attempt {attempt}: stream should yield a final response. {diagnostics}");
+        };
+        if final_response.response().trim().is_empty() {
+            anyhow::bail!(
+                "attempt {attempt}: final response should not be empty after the tool roundtrip. {diagnostics}"
+            );
+        }
+        if !final_response.response().contains(JAVASCRIPT_MARKER) {
+            anyhow::bail!(
+                "attempt {attempt}: final response should mention the tool marker. {diagnostics}"
+            );
+        }
+
+        successful_attempts.push(diagnostics);
+    }
+
+    if !repaired_default_api {
+        anyhow::bail!(
+            "expected at least one attempt to emit an invalid default_api tool call repaired by the hook. Attempts: {successful_attempts:#?}"
+        );
+    }
+
+    println!("Gemini default_api canary completed {attempts} attempt(s): {successful_attempts:#?}");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- move invalid tool-call recovery onto PromptHook::on_invalid_tool_call
- remove the separate InvalidToolCallHook trait and with_invalid_tool_call_hook request APIs
- update streaming, non-streaming, and typed prompt requests to use the unified hook path

## Verification
- cargo fmt --all -- --check
- cargo check -p rig-core
- cargo test -p rig-core invalid_tool_call -- --nocapture
- cargo test -p rig-core