### PR TITLE
chore: unify workspace crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8950,7 +8950,7 @@ checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
 name = "rig"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -9013,7 +9013,7 @@ dependencies = [
 
 [[package]]
 name = "rig-bedrock"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -9036,7 +9036,7 @@ dependencies = [
 
 [[package]]
 name = "rig-core"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "as-any",
@@ -9090,7 +9090,7 @@ dependencies = [
 
 [[package]]
 name = "rig-derive"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "convert_case",
@@ -9111,7 +9111,7 @@ dependencies = [
 
 [[package]]
 name = "rig-fastembed"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "fastembed",
@@ -9125,7 +9125,7 @@ dependencies = [
 
 [[package]]
 name = "rig-gemini-grpc"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -9148,7 +9148,7 @@ dependencies = [
 
 [[package]]
 name = "rig-helixdb"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "reqwest 0.13.3",
@@ -9161,7 +9161,7 @@ dependencies = [
 
 [[package]]
 name = "rig-lancedb"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -9177,7 +9177,7 @@ dependencies = [
 
 [[package]]
 name = "rig-memory"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "rig-core",
@@ -9188,7 +9188,7 @@ dependencies = [
 
 [[package]]
 name = "rig-milvus"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "reqwest 0.13.3",
@@ -9202,7 +9202,7 @@ dependencies = [
 
 [[package]]
 name = "rig-mongodb"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "futures",
@@ -9219,7 +9219,7 @@ dependencies = [
 
 [[package]]
 name = "rig-neo4j"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "futures",
@@ -9238,7 +9238,7 @@ dependencies = [
 
 [[package]]
 name = "rig-postgres"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -9259,7 +9259,7 @@ dependencies = [
 
 [[package]]
 name = "rig-qdrant"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "httpmock",
@@ -9274,7 +9274,7 @@ dependencies = [
 
 [[package]]
 name = "rig-s3vectors"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -9291,7 +9291,7 @@ dependencies = [
 
 [[package]]
 name = "rig-scylladb"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9310,7 +9310,7 @@ dependencies = [
 
 [[package]]
 name = "rig-sqlite"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9329,7 +9329,7 @@ dependencies = [
 
 [[package]]
 name = "rig-surrealdb"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "rig-core",
@@ -9344,7 +9344,7 @@ dependencies = [
 
 [[package]]
 name = "rig-vectorize"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "reqwest 0.13.3",
@@ -9359,7 +9359,7 @@ dependencies = [
 
 [[package]]
 name = "rig-vertexai"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "google-cloud-aiplatform-v1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8950,7 +8950,7 @@ checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
 name = "rig"
-version = "0.37.1"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -9013,7 +9013,7 @@ dependencies = [
 
 [[package]]
 name = "rig-bedrock"
-version = "0.4.7"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -9090,7 +9090,7 @@ dependencies = [
 
 [[package]]
 name = "rig-derive"
-version = "0.1.15"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "convert_case",
@@ -9111,7 +9111,7 @@ dependencies = [
 
 [[package]]
 name = "rig-fastembed"
-version = "0.4.2"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "fastembed",
@@ -9125,7 +9125,7 @@ dependencies = [
 
 [[package]]
 name = "rig-gemini-grpc"
-version = "0.2.7"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -9148,7 +9148,7 @@ dependencies = [
 
 [[package]]
 name = "rig-helixdb"
-version = "0.2.7"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "reqwest 0.13.3",
@@ -9161,7 +9161,7 @@ dependencies = [
 
 [[package]]
 name = "rig-lancedb"
-version = "0.4.7"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -9177,7 +9177,7 @@ dependencies = [
 
 [[package]]
 name = "rig-memory"
-version = "0.1.2"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "rig-core",
@@ -9188,7 +9188,7 @@ dependencies = [
 
 [[package]]
 name = "rig-milvus"
-version = "0.2.7"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "reqwest 0.13.3",
@@ -9202,7 +9202,7 @@ dependencies = [
 
 [[package]]
 name = "rig-mongodb"
-version = "0.4.7"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -9219,7 +9219,7 @@ dependencies = [
 
 [[package]]
 name = "rig-neo4j"
-version = "0.5.7"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -9238,7 +9238,7 @@ dependencies = [
 
 [[package]]
 name = "rig-postgres"
-version = "0.2.7"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -9259,7 +9259,7 @@ dependencies = [
 
 [[package]]
 name = "rig-qdrant"
-version = "0.2.7"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "httpmock",
@@ -9274,7 +9274,7 @@ dependencies = [
 
 [[package]]
 name = "rig-s3vectors"
-version = "0.2.7"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -9291,7 +9291,7 @@ dependencies = [
 
 [[package]]
 name = "rig-scylladb"
-version = "0.2.7"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9310,7 +9310,7 @@ dependencies = [
 
 [[package]]
 name = "rig-sqlite"
-version = "0.3.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -9329,7 +9329,7 @@ dependencies = [
 
 [[package]]
 name = "rig-surrealdb"
-version = "0.2.7"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "rig-core",
@@ -9344,7 +9344,7 @@ dependencies = [
 
 [[package]]
 name = "rig-vectorize"
-version = "0.2.7"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "reqwest 0.13.3",
@@ -9359,7 +9359,7 @@ dependencies = [
 
 [[package]]
 name = "rig-vertexai"
-version = "0.3.7"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "google-cloud-aiplatform-v1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig"
-version = "0.37.1"
+version.workspace = true
 edition = { workspace = true }
 license = "MIT"
 readme = "README.md"
@@ -40,6 +40,7 @@ opt-level = "s"
 
 
 [workspace.package]
+version = "0.38.0"
 edition = "2024"
 
 [workspace.dependencies]
@@ -146,23 +147,23 @@ workspace = true
 
 [dependencies]
 rig-core = { path = "crates/rig-core", version = "0.38.0", default-features = false }
-rig-bedrock = { path = "crates/rig-bedrock", version = "0.4.7", optional = true, default-features = false }
-rig-fastembed = { path = "crates/rig-fastembed", version = "0.4.2", optional = true, default-features = false }
-rig-gemini-grpc = { path = "crates/rig-gemini-grpc", version = "0.2.7", optional = true, default-features = false }
-rig-helixdb = { path = "crates/rig-helixdb", version = "0.2.7", optional = true, default-features = false }
-rig-lancedb = { path = "crates/rig-lancedb", version = "0.4.7", optional = true, default-features = false }
-rig-memory = { path = "crates/rig-memory", version = "0.1.2", optional = true, default-features = false }
-rig-milvus = { path = "crates/rig-milvus", version = "0.2.7", optional = true, default-features = false }
-rig-mongodb = { path = "crates/rig-mongodb", version = "0.4.7", optional = true, default-features = false }
-rig-neo4j = { path = "crates/rig-neo4j", version = "0.5.7", optional = true, default-features = false }
-rig-postgres = { path = "crates/rig-postgres", version = "0.2.7", optional = true, default-features = false }
-rig-qdrant = { path = "crates/rig-qdrant", version = "0.2.7", optional = true, default-features = false }
-rig-s3vectors = { path = "crates/rig-s3vectors", version = "0.2.7", optional = true, default-features = false }
-rig-scylladb = { path = "crates/rig-scylladb", version = "0.2.7", optional = true, default-features = false }
-rig-sqlite = { path = "crates/rig-sqlite", version = "0.3.0", optional = true, default-features = false }
-rig-surrealdb = { path = "crates/rig-surrealdb", version = "0.2.7", optional = true, default-features = false }
-rig-vectorize = { path = "crates/rig-vectorize", version = "0.2.7", optional = true, default-features = false }
-rig-vertexai = { path = "crates/rig-vertexai", version = "0.3.7", optional = true, default-features = false }
+rig-bedrock = { path = "crates/rig-bedrock", version = "0.38.0", optional = true, default-features = false }
+rig-fastembed = { path = "crates/rig-fastembed", version = "0.38.0", optional = true, default-features = false }
+rig-gemini-grpc = { path = "crates/rig-gemini-grpc", version = "0.38.0", optional = true, default-features = false }
+rig-helixdb = { path = "crates/rig-helixdb", version = "0.38.0", optional = true, default-features = false }
+rig-lancedb = { path = "crates/rig-lancedb", version = "0.38.0", optional = true, default-features = false }
+rig-memory = { path = "crates/rig-memory", version = "0.38.0", optional = true, default-features = false }
+rig-milvus = { path = "crates/rig-milvus", version = "0.38.0", optional = true, default-features = false }
+rig-mongodb = { path = "crates/rig-mongodb", version = "0.38.0", optional = true, default-features = false }
+rig-neo4j = { path = "crates/rig-neo4j", version = "0.38.0", optional = true, default-features = false }
+rig-postgres = { path = "crates/rig-postgres", version = "0.38.0", optional = true, default-features = false }
+rig-qdrant = { path = "crates/rig-qdrant", version = "0.38.0", optional = true, default-features = false }
+rig-s3vectors = { path = "crates/rig-s3vectors", version = "0.38.0", optional = true, default-features = false }
+rig-scylladb = { path = "crates/rig-scylladb", version = "0.38.0", optional = true, default-features = false }
+rig-sqlite = { path = "crates/rig-sqlite", version = "0.38.0", optional = true, default-features = false }
+rig-surrealdb = { path = "crates/rig-surrealdb", version = "0.38.0", optional = true, default-features = false }
+rig-vectorize = { path = "crates/rig-vectorize", version = "0.38.0", optional = true, default-features = false }
+rig-vertexai = { path = "crates/rig-vertexai", version = "0.38.0", optional = true, default-features = false }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig"
-version = "0.38.0"
+version.workspace = true
 edition = { workspace = true }
 license = "MIT"
 readme = "README.md"
@@ -40,6 +40,7 @@ opt-level = "s"
 
 
 [workspace.package]
+version = "0.38.0"
 edition = "2024"
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ opt-level = "s"
 
 
 [workspace.package]
-version = "0.38.0"
+version = "0.38.1"
 edition = "2024"
 
 [workspace.dependencies]
@@ -146,31 +146,31 @@ exclude-members = ["crates/rig-core", "crates/rig-derive"]
 workspace = true
 
 [dependencies]
-rig-core = { path = "crates/rig-core", version = "0.38.0", default-features = false }
-rig-bedrock = { path = "crates/rig-bedrock", version = "0.38.0", optional = true, default-features = false }
-rig-fastembed = { path = "crates/rig-fastembed", version = "0.38.0", optional = true, default-features = false }
-rig-gemini-grpc = { path = "crates/rig-gemini-grpc", version = "0.38.0", optional = true, default-features = false }
-rig-helixdb = { path = "crates/rig-helixdb", version = "0.38.0", optional = true, default-features = false }
-rig-lancedb = { path = "crates/rig-lancedb", version = "0.38.0", optional = true, default-features = false }
-rig-memory = { path = "crates/rig-memory", version = "0.38.0", optional = true, default-features = false }
-rig-milvus = { path = "crates/rig-milvus", version = "0.38.0", optional = true, default-features = false }
-rig-mongodb = { path = "crates/rig-mongodb", version = "0.38.0", optional = true, default-features = false }
-rig-neo4j = { path = "crates/rig-neo4j", version = "0.38.0", optional = true, default-features = false }
-rig-postgres = { path = "crates/rig-postgres", version = "0.38.0", optional = true, default-features = false }
-rig-qdrant = { path = "crates/rig-qdrant", version = "0.38.0", optional = true, default-features = false }
-rig-s3vectors = { path = "crates/rig-s3vectors", version = "0.38.0", optional = true, default-features = false }
-rig-scylladb = { path = "crates/rig-scylladb", version = "0.38.0", optional = true, default-features = false }
-rig-sqlite = { path = "crates/rig-sqlite", version = "0.38.0", optional = true, default-features = false }
-rig-surrealdb = { path = "crates/rig-surrealdb", version = "0.38.0", optional = true, default-features = false }
-rig-vectorize = { path = "crates/rig-vectorize", version = "0.38.0", optional = true, default-features = false }
-rig-vertexai = { path = "crates/rig-vertexai", version = "0.38.0", optional = true, default-features = false }
+rig-core = { path = "crates/rig-core", version = "0.38.1", default-features = false }
+rig-bedrock = { path = "crates/rig-bedrock", version = "0.38.1", optional = true, default-features = false }
+rig-fastembed = { path = "crates/rig-fastembed", version = "0.38.1", optional = true, default-features = false }
+rig-gemini-grpc = { path = "crates/rig-gemini-grpc", version = "0.38.1", optional = true, default-features = false }
+rig-helixdb = { path = "crates/rig-helixdb", version = "0.38.1", optional = true, default-features = false }
+rig-lancedb = { path = "crates/rig-lancedb", version = "0.38.1", optional = true, default-features = false }
+rig-memory = { path = "crates/rig-memory", version = "0.38.1", optional = true, default-features = false }
+rig-milvus = { path = "crates/rig-milvus", version = "0.38.1", optional = true, default-features = false }
+rig-mongodb = { path = "crates/rig-mongodb", version = "0.38.1", optional = true, default-features = false }
+rig-neo4j = { path = "crates/rig-neo4j", version = "0.38.1", optional = true, default-features = false }
+rig-postgres = { path = "crates/rig-postgres", version = "0.38.1", optional = true, default-features = false }
+rig-qdrant = { path = "crates/rig-qdrant", version = "0.38.1", optional = true, default-features = false }
+rig-s3vectors = { path = "crates/rig-s3vectors", version = "0.38.1", optional = true, default-features = false }
+rig-scylladb = { path = "crates/rig-scylladb", version = "0.38.1", optional = true, default-features = false }
+rig-sqlite = { path = "crates/rig-sqlite", version = "0.38.1", optional = true, default-features = false }
+rig-surrealdb = { path = "crates/rig-surrealdb", version = "0.38.1", optional = true, default-features = false }
+rig-vectorize = { path = "crates/rig-vectorize", version = "0.38.1", optional = true, default-features = false }
+rig-vertexai = { path = "crates/rig-vertexai", version = "0.38.1", optional = true, default-features = false }
 
 [dev-dependencies]
 anyhow = { workspace = true }
 arrow-array = { workspace = true }
 assert_fs = { workspace = true }
 async-stream = { workspace = true }
-rig-core = { path = "crates/rig-core", version = "0.38.0", default-features = false, features = [
+rig-core = { path = "crates/rig-core", version = "0.38.1", default-features = false, features = [
   "test-utils",
 ] }
 tokio = { workspace = true, features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig"
-version.workspace = true
+version = "0.38.0"
 edition = { workspace = true }
 license = "MIT"
 readme = "README.md"
@@ -40,7 +40,6 @@ opt-level = "s"
 
 
 [workspace.package]
-version = "0.38.0"
 edition = "2024"
 
 [workspace.dependencies]

--- a/crates/rig-bedrock/Cargo.toml
+++ b/crates/rig-bedrock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-bedrock"
-version = "0.38.0"
+version.workspace = true
 edition = { workspace = true }
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-bedrock/Cargo.toml
+++ b/crates/rig-bedrock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-bedrock"
-version.workspace = true
+version = "0.38.0"
 edition = { workspace = true }
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-bedrock/Cargo.toml
+++ b/crates/rig-bedrock/Cargo.toml
@@ -18,11 +18,11 @@ aws-config = { workspace = true, features = ["behavior-version-latest"] }
 aws-sdk-bedrockruntime = { workspace = true, features = ["rt-tokio", "default-https-client"] }
 aws-smithy-types = { workspace = true }
 base64 = { workspace = true }
-rig-core = { path = "../rig-core", version = "0.38.0", default-features = false, features = [
+rig-core = { path = "../rig-core", version = "0.38.1", default-features = false, features = [
     "image",
 ] }
 nanoid = { workspace = true }
-rig-derive = { path = "../rig-derive", version = "0.38.0" }
+rig-derive = { path = "../rig-derive", version = "0.38.1" }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/rig-bedrock/Cargo.toml
+++ b/crates/rig-bedrock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-bedrock"
-version = "0.4.7"
+version.workspace = true
 edition = { workspace = true }
 license = "MIT"
 readme = "README.md"
@@ -22,7 +22,7 @@ rig-core = { path = "../rig-core", version = "0.38.0", default-features = false,
     "image",
 ] }
 nanoid = { workspace = true }
-rig-derive = { path = "../rig-derive", version = "0.1.15" }
+rig-derive = { path = "../rig-derive", version = "0.38.0" }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/rig-core/Cargo.toml
+++ b/crates/rig-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-core"
-version = "0.38.0"
+version.workspace = true
 edition = { workspace = true }
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-core/Cargo.toml
+++ b/crates/rig-core/Cargo.toml
@@ -33,7 +33,7 @@ ordered-float = { workspace = true }
 quick-xml = { workspace = true, optional = true }
 rayon = { workspace = true, optional = true }
 reqwest = { workspace = true, features = ["json", "stream", "multipart"] }
-rig-derive = { version = "0.38.0", path = "../rig-derive", optional = true }
+rig-derive = { version = "0.38.1", path = "../rig-derive", optional = true }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/rig-core/Cargo.toml
+++ b/crates/rig-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-core"
-version.workspace = true
+version = "0.38.0"
 edition = { workspace = true }
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-core/Cargo.toml
+++ b/crates/rig-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-core"
-version = "0.38.0"
+version.workspace = true
 edition = { workspace = true }
 license = "MIT"
 readme = "README.md"
@@ -33,7 +33,7 @@ ordered-float = { workspace = true }
 quick-xml = { workspace = true, optional = true }
 rayon = { workspace = true, optional = true }
 reqwest = { workspace = true, features = ["json", "stream", "multipart"] }
-rig-derive = { version = "0.1.15", path = "../rig-derive", optional = true }
+rig-derive = { version = "0.38.0", path = "../rig-derive", optional = true }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/rig-derive/Cargo.toml
+++ b/crates/rig-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-derive"
-version.workspace = true
+version = "0.38.0"
 edition = { workspace = true }
 license = "MIT"
 description = "Internal crate that implements Rig derive macros."

--- a/crates/rig-derive/Cargo.toml
+++ b/crates/rig-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-derive"
-version = "0.1.15"
+version.workspace = true
 edition = { workspace = true }
 license = "MIT"
 description = "Internal crate that implements Rig derive macros."

--- a/crates/rig-derive/Cargo.toml
+++ b/crates/rig-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-derive"
-version = "0.38.0"
+version.workspace = true
 edition = { workspace = true }
 license = "MIT"
 description = "Internal crate that implements Rig derive macros."

--- a/crates/rig-fastembed/Cargo.toml
+++ b/crates/rig-fastembed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-fastembed"
-version.workspace = true
+version = "0.38.0"
 edition = { workspace = true }
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-fastembed/Cargo.toml
+++ b/crates/rig-fastembed/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/0xPlaygrounds/rig"
 workspace = true
 
 [dependencies]
-rig-core = { path = "../rig-core", version = "0.38.0", default-features = false }
+rig-core = { path = "../rig-core", version = "0.38.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tracing = { workspace = true }

--- a/crates/rig-fastembed/Cargo.toml
+++ b/crates/rig-fastembed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-fastembed"
-version = "0.4.2"
+version.workspace = true
 edition = { workspace = true }
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-fastembed/Cargo.toml
+++ b/crates/rig-fastembed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-fastembed"
-version = "0.38.0"
+version.workspace = true
 edition = { workspace = true }
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-gemini-grpc/Cargo.toml
+++ b/crates/rig-gemini-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-gemini-grpc"
-version.workspace = true
+version = "0.38.0"
 edition.workspace = true
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-gemini-grpc/Cargo.toml
+++ b/crates/rig-gemini-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-gemini-grpc"
-version = "0.2.7"
+version.workspace = true
 edition.workspace = true
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-gemini-grpc/Cargo.toml
+++ b/crates/rig-gemini-grpc/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/0xPlaygrounds/rig"
 workspace = true
 
 [dependencies]
-rig-core = { path = "../rig-core", version = "0.38.0", default-features = false }
+rig-core = { path = "../rig-core", version = "0.38.1", default-features = false }
 async-stream = { workspace = true }
 base64 = { workspace = true }
 futures = { workspace = true }

--- a/crates/rig-gemini-grpc/Cargo.toml
+++ b/crates/rig-gemini-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-gemini-grpc"
-version = "0.38.0"
+version.workspace = true
 edition.workspace = true
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-helixdb/Cargo.toml
+++ b/crates/rig-helixdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-helixdb"
-version.workspace = true
+version = "0.38.0"
 edition.workspace = true
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-helixdb/Cargo.toml
+++ b/crates/rig-helixdb/Cargo.toml
@@ -15,7 +15,7 @@ reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror = { workspace = true }
-rig-core = { path = "../rig-core", version = "0.38.0", default-features = false }
+rig-core = { path = "../rig-core", version = "0.38.1", default-features = false }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/crates/rig-helixdb/Cargo.toml
+++ b/crates/rig-helixdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-helixdb"
-version = "0.2.7"
+version.workspace = true
 edition.workspace = true
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-helixdb/Cargo.toml
+++ b/crates/rig-helixdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-helixdb"
-version = "0.38.0"
+version.workspace = true
 edition.workspace = true
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-lancedb/Cargo.toml
+++ b/crates/rig-lancedb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-lancedb"
-version = "0.4.7"
+version.workspace = true
 edition = { workspace = true }
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-lancedb/Cargo.toml
+++ b/crates/rig-lancedb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-lancedb"
-version.workspace = true
+version = "0.38.0"
 edition = { workspace = true }
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-lancedb/Cargo.toml
+++ b/crates/rig-lancedb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-lancedb"
-version = "0.38.0"
+version.workspace = true
 edition = { workspace = true }
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-lancedb/Cargo.toml
+++ b/crates/rig-lancedb/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 
 [dependencies]
 lancedb = { workspace = true }
-rig-core = { path = "../rig-core", version = "0.38.0", default-features = false }
+rig-core = { path = "../rig-core", version = "0.38.1", default-features = false }
 arrow-array = { workspace = true }
 serde_json = { workspace = true }
 serde = { workspace = true }

--- a/crates/rig-memory/Cargo.toml
+++ b/crates/rig-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-memory"
-version = "0.38.0"
+version.workspace = true
 edition = { workspace = true }
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-memory/Cargo.toml
+++ b/crates/rig-memory/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/0xPlaygrounds/rig"
 workspace = true
 
 [dependencies]
-rig-core = { path = "../rig-core", version = "0.38.0", default-features = false }
+rig-core = { path = "../rig-core", version = "0.38.1", default-features = false }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/rig-memory/Cargo.toml
+++ b/crates/rig-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-memory"
-version.workspace = true
+version = "0.38.0"
 edition = { workspace = true }
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-memory/Cargo.toml
+++ b/crates/rig-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-memory"
-version = "0.1.2"
+version.workspace = true
 edition = { workspace = true }
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-milvus/Cargo.toml
+++ b/crates/rig-milvus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-milvus"
-version = "0.38.0"
+version.workspace = true
 edition = { workspace = true }
 description = "Milvus vector store implementation for the rig framework"
 license = "MIT"

--- a/crates/rig-milvus/Cargo.toml
+++ b/crates/rig-milvus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-milvus"
-version = "0.2.7"
+version.workspace = true
 edition = { workspace = true }
 description = "Milvus vector store implementation for the rig framework"
 license = "MIT"

--- a/crates/rig-milvus/Cargo.toml
+++ b/crates/rig-milvus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-milvus"
-version.workspace = true
+version = "0.38.0"
 edition = { workspace = true }
 description = "Milvus vector store implementation for the rig framework"
 license = "MIT"

--- a/crates/rig-milvus/Cargo.toml
+++ b/crates/rig-milvus/Cargo.toml
@@ -10,7 +10,7 @@ workspace = true
 
 [dependencies]
 reqwest = { workspace = true, features = ["json"] }
-rig-core = { path = "../rig-core", version = "0.38.0", default-features = false }
+rig-core = { path = "../rig-core", version = "0.38.1", default-features = false }
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }

--- a/crates/rig-mongodb/Cargo.toml
+++ b/crates/rig-mongodb/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [dependencies]
 futures = { workspace = true }
 mongodb = { workspace = true }
-rig-core = { path = "../rig-core", version = "0.38.0", default-features = false }
+rig-core = { path = "../rig-core", version = "0.38.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tracing = { workspace = true }

--- a/crates/rig-mongodb/Cargo.toml
+++ b/crates/rig-mongodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-mongodb"
-version = "0.4.7"
+version.workspace = true
 edition = { workspace = true }
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-mongodb/Cargo.toml
+++ b/crates/rig-mongodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-mongodb"
-version.workspace = true
+version = "0.38.0"
 edition = { workspace = true }
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-mongodb/Cargo.toml
+++ b/crates/rig-mongodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-mongodb"
-version = "0.38.0"
+version.workspace = true
 edition = { workspace = true }
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-neo4j/Cargo.toml
+++ b/crates/rig-neo4j/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-neo4j"
-version.workspace = true
+version = "0.38.0"
 edition = { workspace = true }
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-neo4j/Cargo.toml
+++ b/crates/rig-neo4j/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-neo4j"
-version = "0.38.0"
+version.workspace = true
 edition = { workspace = true }
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-neo4j/Cargo.toml
+++ b/crates/rig-neo4j/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-neo4j"
-version = "0.5.7"
+version.workspace = true
 edition = { workspace = true }
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-neo4j/Cargo.toml
+++ b/crates/rig-neo4j/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 [dependencies]
 futures = { workspace = true }
 neo4rs = { workspace = true }
-rig-core = { path = "../rig-core", version = "0.38.0", default-features = false }
+rig-core = { path = "../rig-core", version = "0.38.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tracing = { workspace = true }

--- a/crates/rig-postgres/Cargo.toml
+++ b/crates/rig-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-postgres"
-version = "0.2.7"
+version.workspace = true
 edition = { workspace = true }
 description = "PostgreSQL-based vector store implementation for the rig framework"
 license = "MIT"

--- a/crates/rig-postgres/Cargo.toml
+++ b/crates/rig-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-postgres"
-version = "0.38.0"
+version.workspace = true
 edition = { workspace = true }
 description = "PostgreSQL-based vector store implementation for the rig framework"
 license = "MIT"

--- a/crates/rig-postgres/Cargo.toml
+++ b/crates/rig-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-postgres"
-version.workspace = true
+version = "0.38.0"
 edition = { workspace = true }
 description = "PostgreSQL-based vector store implementation for the rig framework"
 license = "MIT"

--- a/crates/rig-postgres/Cargo.toml
+++ b/crates/rig-postgres/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/0xPlaygrounds/rig"
 workspace = true
 
 [dependencies]
-rig-core = { path = "../rig-core", version = "0.38.0", default-features = false, features = [
+rig-core = { path = "../rig-core", version = "0.38.1", default-features = false, features = [
   "derive",
 ] }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/rig-qdrant/Cargo.toml
+++ b/crates/rig-qdrant/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/0xPlaygrounds/rig"
 workspace = true
 
 [dependencies]
-rig-core = { path = "../rig-core", version = "0.38.0", default-features = false }
+rig-core = { path = "../rig-core", version = "0.38.1", default-features = false }
 serde_json = { workspace = true }
 serde = { workspace = true }
 qdrant-client = { workspace = true }

--- a/crates/rig-qdrant/Cargo.toml
+++ b/crates/rig-qdrant/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-qdrant"
-version.workspace = true
+version = "0.38.0"
 edition = { workspace = true }
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-qdrant/Cargo.toml
+++ b/crates/rig-qdrant/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-qdrant"
-version = "0.2.7"
+version.workspace = true
 edition = { workspace = true }
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-qdrant/Cargo.toml
+++ b/crates/rig-qdrant/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-qdrant"
-version = "0.38.0"
+version.workspace = true
 edition = { workspace = true }
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-s3vectors/Cargo.toml
+++ b/crates/rig-s3vectors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-s3vectors"
-version.workspace = true
+version = "0.38.0"
 edition = { workspace = true }
 description = "AWS S3Vectors vector store implementation for the rig framework"
 license = "MIT"

--- a/crates/rig-s3vectors/Cargo.toml
+++ b/crates/rig-s3vectors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-s3vectors"
-version = "0.2.7"
+version.workspace = true
 edition = { workspace = true }
 description = "AWS S3Vectors vector store implementation for the rig framework"
 license = "MIT"

--- a/crates/rig-s3vectors/Cargo.toml
+++ b/crates/rig-s3vectors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-s3vectors"
-version = "0.38.0"
+version.workspace = true
 edition = { workspace = true }
 description = "AWS S3Vectors vector store implementation for the rig framework"
 license = "MIT"

--- a/crates/rig-s3vectors/Cargo.toml
+++ b/crates/rig-s3vectors/Cargo.toml
@@ -14,7 +14,7 @@ aws-smithy-types = { workspace = true, features = [
   "serde-deserialize",
   "serde-serialize",
 ] }
-rig-core = { path = "../rig-core", version = "0.38.0", default-features = false, features = [
+rig-core = { path = "../rig-core", version = "0.38.1", default-features = false, features = [
   "derive",
 ] }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/rig-scylladb/Cargo.toml
+++ b/crates/rig-scylladb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-scylladb"
-version = "0.2.7"
+version.workspace = true
 edition = { workspace = true }
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-scylladb/Cargo.toml
+++ b/crates/rig-scylladb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-scylladb"
-version = "0.38.0"
+version.workspace = true
 edition = { workspace = true }
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-scylladb/Cargo.toml
+++ b/crates/rig-scylladb/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/0xPlaygrounds/rig"
 workspace = true
 
 [dependencies]
-rig-core = { path = "../rig-core", version = "0.38.0", default-features = false, features = [
+rig-core = { path = "../rig-core", version = "0.38.1", default-features = false, features = [
   "derive",
 ] }
 serde_json = { workspace = true }

--- a/crates/rig-scylladb/Cargo.toml
+++ b/crates/rig-scylladb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-scylladb"
-version.workspace = true
+version = "0.38.0"
 edition = { workspace = true }
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-sqlite/Cargo.toml
+++ b/crates/rig-sqlite/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 doctest = false
 
 [dependencies]
-rig-core = { path = "../rig-core", version = "0.38.0", default-features = false, features = [
+rig-core = { path = "../rig-core", version = "0.38.1", default-features = false, features = [
   "derive",
 ] }
 rusqlite = { workspace = true, features = ["bundled"] }

--- a/crates/rig-sqlite/Cargo.toml
+++ b/crates/rig-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-sqlite"
-version.workspace = true
+version = "0.38.0"
 edition = { workspace = true }
 description = "SQLite-based vector store implementation for the rig framework"
 license = "MIT"

--- a/crates/rig-sqlite/Cargo.toml
+++ b/crates/rig-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-sqlite"
-version = "0.38.0"
+version.workspace = true
 edition = { workspace = true }
 description = "SQLite-based vector store implementation for the rig framework"
 license = "MIT"

--- a/crates/rig-sqlite/Cargo.toml
+++ b/crates/rig-sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-sqlite"
-version = "0.3.0"
+version.workspace = true
 edition = { workspace = true }
 description = "SQLite-based vector store implementation for the rig framework"
 license = "MIT"

--- a/crates/rig-surrealdb/Cargo.toml
+++ b/crates/rig-surrealdb/Cargo.toml
@@ -10,7 +10,7 @@ workspace = true
 
 [dependencies]
 surrealdb = { workspace = true, features = ["protocol-ws", "kv-mem"] }
-rig-core = { path = "../rig-core", version = "0.38.0", default-features = false, features = [
+rig-core = { path = "../rig-core", version = "0.38.1", default-features = false, features = [
   "derive",
 ] }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/rig-surrealdb/Cargo.toml
+++ b/crates/rig-surrealdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-surrealdb"
-version = "0.2.7"
+version.workspace = true
 edition = { workspace = true }
 description = "SurrealDB vector store implementation for the rig framework"
 license = "MIT"

--- a/crates/rig-surrealdb/Cargo.toml
+++ b/crates/rig-surrealdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-surrealdb"
-version = "0.38.0"
+version.workspace = true
 edition = { workspace = true }
 description = "SurrealDB vector store implementation for the rig framework"
 license = "MIT"

--- a/crates/rig-surrealdb/Cargo.toml
+++ b/crates/rig-surrealdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-surrealdb"
-version.workspace = true
+version = "0.38.0"
 edition = { workspace = true }
 description = "SurrealDB vector store implementation for the rig framework"
 license = "MIT"

--- a/crates/rig-vectorize/Cargo.toml
+++ b/crates/rig-vectorize/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/0xPlaygrounds/rig"
 workspace = true
 
 [dependencies]
-rig-core = { path = "../rig-core", version = "0.38.0" }
+rig-core = { path = "../rig-core", version = "0.38.1" }
 reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/rig-vectorize/Cargo.toml
+++ b/crates/rig-vectorize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-vectorize"
-version = "0.2.7"
+version.workspace = true
 edition.workspace = true
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-vectorize/Cargo.toml
+++ b/crates/rig-vectorize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-vectorize"
-version = "0.38.0"
+version.workspace = true
 edition.workspace = true
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-vectorize/Cargo.toml
+++ b/crates/rig-vectorize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-vectorize"
-version.workspace = true
+version = "0.38.0"
 edition.workspace = true
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-vertexai/Cargo.toml
+++ b/crates/rig-vertexai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-vertexai"
-version = "0.3.7"
+version.workspace = true
 edition.workspace = true
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-vertexai/Cargo.toml
+++ b/crates/rig-vertexai/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 google-cloud-aiplatform-v1 = { workspace = true }
 google-cloud-auth = { workspace = true }
-rig-core = { path = "../rig-core", version = "0.38.0", default-features = false }
+rig-core = { path = "../rig-core", version = "0.38.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/rig-vertexai/Cargo.toml
+++ b/crates/rig-vertexai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-vertexai"
-version.workspace = true
+version = "0.38.0"
 edition.workspace = true
 license = "MIT"
 readme = "README.md"

--- a/crates/rig-vertexai/Cargo.toml
+++ b/crates/rig-vertexai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rig-vertexai"
-version = "0.38.0"
+version.workspace = true
 edition.workspace = true
 license = "MIT"
 readme = "README.md"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,5 +1,90 @@
 [workspace]
 git_release_body = """{{ changelog }}"""
+git_release_enable = false
+git_tag_enable = false
+
+[[package]]
+name = "rig"
+version_group = "rig"
+git_release_enable = true
+git_tag_enable = true
+git_tag_name = "v{{ version }}"
+
+[[package]]
+name = "rig-core"
+version_group = "rig"
+
+[[package]]
+name = "rig-derive"
+version_group = "rig"
+
+[[package]]
+name = "rig-bedrock"
+version_group = "rig"
+
+[[package]]
+name = "rig-fastembed"
+version_group = "rig"
+
+[[package]]
+name = "rig-gemini-grpc"
+version_group = "rig"
+
+[[package]]
+name = "rig-helixdb"
+version_group = "rig"
+
+[[package]]
+name = "rig-lancedb"
+version_group = "rig"
+
+[[package]]
+name = "rig-memory"
+version_group = "rig"
+
+[[package]]
+name = "rig-milvus"
+version_group = "rig"
+
+[[package]]
+name = "rig-mongodb"
+version_group = "rig"
+
+[[package]]
+name = "rig-neo4j"
+version_group = "rig"
+
+[[package]]
+name = "rig-postgres"
+version_group = "rig"
+
+[[package]]
+name = "rig-qdrant"
+version_group = "rig"
+
+[[package]]
+name = "rig-s3vectors"
+version_group = "rig"
+
+[[package]]
+name = "rig-scylladb"
+version_group = "rig"
+
+[[package]]
+name = "rig-sqlite"
+version_group = "rig"
+
+[[package]]
+name = "rig-surrealdb"
+version_group = "rig"
+
+[[package]]
+name = "rig-vectorize"
+version_group = "rig"
+
+[[package]]
+name = "rig-vertexai"
+version_group = "rig"
 
 [changelog]
 body = """

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,6 +2,7 @@
 git_release_body = """{{ changelog }}"""
 git_release_enable = false
 git_tag_enable = false
+release_always = true
 
 [[package]]
 name = "rig"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -2,7 +2,7 @@
 git_release_body = """{{ changelog }}"""
 git_release_enable = false
 git_tag_enable = false
-release_always = true
+release_always = false
 
 [[package]]
 name = "rig"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -6,86 +6,9 @@ release_always = true
 
 [[package]]
 name = "rig"
-version_group = "rig"
 git_release_enable = true
 git_tag_enable = true
 git_tag_name = "v{{ version }}"
-
-[[package]]
-name = "rig-core"
-version_group = "rig"
-
-[[package]]
-name = "rig-derive"
-version_group = "rig"
-
-[[package]]
-name = "rig-bedrock"
-version_group = "rig"
-
-[[package]]
-name = "rig-fastembed"
-version_group = "rig"
-
-[[package]]
-name = "rig-gemini-grpc"
-version_group = "rig"
-
-[[package]]
-name = "rig-helixdb"
-version_group = "rig"
-
-[[package]]
-name = "rig-lancedb"
-version_group = "rig"
-
-[[package]]
-name = "rig-memory"
-version_group = "rig"
-
-[[package]]
-name = "rig-milvus"
-version_group = "rig"
-
-[[package]]
-name = "rig-mongodb"
-version_group = "rig"
-
-[[package]]
-name = "rig-neo4j"
-version_group = "rig"
-
-[[package]]
-name = "rig-postgres"
-version_group = "rig"
-
-[[package]]
-name = "rig-qdrant"
-version_group = "rig"
-
-[[package]]
-name = "rig-s3vectors"
-version_group = "rig"
-
-[[package]]
-name = "rig-scylladb"
-version_group = "rig"
-
-[[package]]
-name = "rig-sqlite"
-version_group = "rig"
-
-[[package]]
-name = "rig-surrealdb"
-version_group = "rig"
-
-[[package]]
-name = "rig-vectorize"
-version_group = "rig"
-
-[[package]]
-name = "rig-vertexai"
-version_group = "rig"
 
 [changelog]
 body = """


### PR DESCRIPTION
## Summary
- move all Rig crates to a single workspace package version
- set internal Rig path dependency versions to the shared workspace version
- configure release-plz to bump all crates together through one version group and publish one root GitHub release/tag

## Verification
- cargo metadata --format-version 1 --no-deps
- cargo fmt --all -- --check
- cargo check -p rig-core --all-targets
- cargo check -p rig --no-default-features