### PR TITLE
feat(vector-store): Add Pinecone vector store integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8982,6 +8982,7 @@ dependencies = [
  "rig-milvus",
  "rig-mongodb",
  "rig-neo4j",
+ "rig-pinecone",
  "rig-postgres",
  "rig-qdrant",
  "rig-s3vectors",
@@ -9234,6 +9235,21 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "rig-pinecone"
+version = "0.38.1"
+dependencies = [
+ "anyhow",
+ "httpmock",
+ "reqwest 0.13.3",
+ "rig-core",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,7 @@ rig-helixdb = { path = "crates/rig-helixdb", version = "0.38.1", optional = true
 rig-lancedb = { path = "crates/rig-lancedb", version = "0.38.1", optional = true, default-features = false }
 rig-memory = { path = "crates/rig-memory", version = "0.38.1", optional = true, default-features = false }
 rig-milvus = { path = "crates/rig-milvus", version = "0.38.1", optional = true, default-features = false }
+rig-pinecone = { path = "crates/rig-pinecone", version = "0.38.1", optional = true, default-features = false }
 rig-mongodb = { path = "crates/rig-mongodb", version = "0.38.1", optional = true, default-features = false }
 rig-neo4j = { path = "crates/rig-neo4j", version = "0.38.1", optional = true, default-features = false }
 rig-postgres = { path = "crates/rig-postgres", version = "0.38.1", optional = true, default-features = false }
@@ -242,6 +243,7 @@ memory = ["dep:rig-memory"]
 milvus = ["dep:rig-milvus"]
 mongodb = ["dep:rig-mongodb"]
 neo4j = ["dep:rig-neo4j"]
+pinecone = ["dep:rig-pinecone"]
 postgres = ["dep:rig-postgres"]
 qdrant = ["dep:rig-qdrant"]
 s3vectors = ["dep:rig-s3vectors"]
@@ -272,6 +274,7 @@ rustls = [
   "rig-helixdb?/rustls",
   "rig-lancedb?/rig-rustls",
   "rig-milvus?/rustls",
+  "rig-pinecone?/rustls",
 ]
 native-tls = [
   "rig-core/native-tls",
@@ -279,6 +282,7 @@ native-tls = [
   "rig-helixdb?/native-tls",
   "rig-lancedb?/rig-native-tls",
   "rig-milvus?/native-tls",
+  "rig-pinecone?/native-tls",
 ]
 reqwest-middleware = ["rig-core/reqwest-middleware"]
 reqwest-middleware-rustls = ["rig-core/reqwest-middleware-rustls"]

--- a/crates/rig-pinecone/Cargo.toml
+++ b/crates/rig-pinecone/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "rig-pinecone"
+version.workspace = true
+edition.workspace = true
+license = "MIT"
+readme = "README.md"
+description = "Rig vector store index integration for Pinecone. https://www.pinecone.io/"
+repository = "https://github.com/0xPlaygrounds/rig"
+
+[lints]
+workspace = true
+
+[dependencies]
+reqwest = { workspace = true, features = ["json"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+thiserror = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
+rig-core = { path = "../rig-core", version = "0.38.1", default-features = false }
+
+[dev-dependencies]
+anyhow = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+httpmock = { workspace = true }
+rig-core = { path = "../rig-core", version = "0.38.1", default-features = false, features = ["derive"] }
+
+[features]
+default = ["rustls"]
+rustls = ["reqwest/rustls", "rig-core/rustls"]
+native-tls = ["reqwest/native-tls", "rig-core/native-tls"]

--- a/crates/rig-pinecone/README.md
+++ b/crates/rig-pinecone/README.md
@@ -1,0 +1,15 @@
+# Rig Pinecone integration
+This crate integrates Pinecone into Rig, allowing you to use Pinecone as a vector store for RAG applications.
+
+## Installation
+To install this crate, run:
+```bash
+cargo add rig-pinecone
+```
+
+## Usage
+The Pinecone integration assumes you have set up a Pinecone index. You will need:
+1. A Pinecone API Key.
+2. The host URL for your index (found in the Pinecone console).
+
+See the examples directory for a full example.

--- a/crates/rig-pinecone/src/lib.rs
+++ b/crates/rig-pinecone/src/lib.rs
@@ -1,0 +1,312 @@
+//! Pinecone vector store integration for Rig.
+//!
+//! This crate provides [`PineconeVectorStore`], a Rig vector store index backed
+//! by a Pinecone index. It supports dense vector search, namespace isolation,
+//! and metadata filtering.
+//!
+//! The root `rig` facade re-exports this crate as `rig::pinecone` when the
+//! `pinecone` feature is enabled.
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use rig_core::{
+    Embed, OneOrMany,
+    embeddings::{Embedding, EmbeddingModel},
+    vector_store::{
+        InsertDocuments, VectorStoreError, VectorStoreIndex,
+        request::{Filter, VectorSearchRequest},
+    },
+};
+
+/// Errors returned by the Pinecone client.
+#[derive(Debug, thiserror::Error)]
+pub enum PineconeError {
+    /// Error communicating with the server.
+    #[error("error communicating with server: {0}")]
+    ReqwestError(#[from] reqwest::Error),
+
+    /// Serialization/deserialization error.
+    #[error("serialization/deserialization error: {0}")]
+    SerdeError(#[from] serde_json::Error),
+
+    /// Pinecone API returned a non-success response.
+    #[error("got error from server: {status} - {message}")]
+    RemoteError {
+        status: reqwest::StatusCode,
+        message: String,
+    },
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn datastore_error<E>(error: E) -> VectorStoreError
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    VectorStoreError::DatastoreError(Box::new(error))
+}
+
+#[cfg(target_family = "wasm")]
+fn datastore_error<E>(error: E) -> VectorStoreError
+where
+    E: std::error::Error + 'static,
+{
+    VectorStoreError::DatastoreError(Box::new(error))
+}
+
+/// A minimal Pinecone REST API client.
+#[derive(Clone, Debug)]
+pub struct PineconeClient {
+    client: reqwest::Client,
+    api_key: String,
+    host: String,
+}
+
+impl PineconeClient {
+    /// Creates a new Pinecone client.
+    ///
+    /// # Arguments
+    /// * `api_key` - Pinecone API Key
+    /// * `host` - Host URL of the index (e.g. `https://my-index-123.svc.us-east1-gcp.pinecone.io`)
+    pub fn new(api_key: &str, host: &str) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            api_key: api_key.to_string(),
+            host: host.trim_end_matches('/').to_string(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct UpsertRequest {
+    vectors: Vec<PineconeVector>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    namespace: Option<String>,
+}
+
+#[derive(Serialize)]
+struct PineconeVector {
+    id: String,
+    values: Vec<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metadata: Option<serde_json::Value>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct QueryRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    namespace: Option<String>,
+    vector: Vec<f32>,
+    top_k: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    filter: Option<serde_json::Value>,
+    include_values: bool,
+    include_metadata: bool,
+}
+
+#[derive(Deserialize)]
+struct QueryResponse {
+    matches: Vec<PineconeMatch>,
+}
+
+#[derive(Deserialize)]
+struct PineconeMatch {
+    id: String,
+    score: f32,
+    #[serde(default)]
+    metadata: Option<serde_json::Value>,
+}
+
+impl PineconeClient {
+    async fn upsert(&self, req: UpsertRequest) -> Result<(), PineconeError> {
+        let url = format!("{}/vectors/upsert", self.host);
+        let resp = self.client.post(&url)
+            .header("Api-Key", &self.api_key)
+            .header("X-Pinecone-Api-Version", "2025-01")
+            .json(&req)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let message = resp.text().await.unwrap_or_default();
+            return Err(PineconeError::RemoteError { status, message });
+        }
+
+        Ok(())
+    }
+
+    async fn query(&self, req: QueryRequest) -> Result<QueryResponse, PineconeError> {
+        let url = format!("{}/query", self.host);
+        let resp = self.client.post(&url)
+            .header("Api-Key", &self.api_key)
+            .header("X-Pinecone-Api-Version", "2025-01")
+            .json(&req)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let message = resp.text().await.unwrap_or_default();
+            return Err(PineconeError::RemoteError { status, message });
+        }
+
+        let query_response: QueryResponse = resp.json().await?;
+        Ok(query_response)
+    }
+}
+
+/// A Pinecone vector store implementation.
+pub struct PineconeVectorStore<M: EmbeddingModel> {
+    client: PineconeClient,
+    model: M,
+    namespace: Option<String>,
+}
+
+impl<M: EmbeddingModel> PineconeVectorStore<M> {
+    /// Creates a new Pinecone vector store.
+    pub fn new(client: PineconeClient, model: M, namespace: Option<String>) -> Self {
+        Self {
+            client,
+            model,
+            namespace,
+        }
+    }
+}
+
+impl<M> InsertDocuments for PineconeVectorStore<M>
+where
+    M: EmbeddingModel + Send + Sync,
+{
+    async fn insert_documents<Doc: Serialize + Embed + Send>(
+        &self,
+        documents: Vec<(Doc, OneOrMany<Embedding>)>,
+    ) -> Result<(), VectorStoreError> {
+        let mut vectors = Vec::new();
+
+        for (document, embeddings) in documents {
+            let json_document = serde_json::to_value(&document)?;
+            let metadata = serde_json::json!({
+                "document": json_document
+            });
+
+            for embedding in embeddings {
+                let values: Vec<f32> = embedding.vec.into_iter().map(|x| x as f32).collect();
+                vectors.push(PineconeVector {
+                    id: Uuid::new_v4().to_string(),
+                    values,
+                    metadata: Some(metadata.clone()),
+                });
+            }
+        }
+
+        if !vectors.is_empty() {
+            let req = UpsertRequest {
+                vectors,
+                namespace: self.namespace.clone(),
+            };
+            self.client.upsert(req).await.map_err(datastore_error)?;
+        }
+
+        Ok(())
+    }
+}
+
+fn translate_filter(filter: &Filter<serde_json::Value>) -> serde_json::Value {
+    match filter {
+        Filter::Eq(key, val) => serde_json::json!({ key: { "$eq": val } }),
+        Filter::Gt(key, val) => serde_json::json!({ key: { "$gt": val } }),
+        Filter::Lt(key, val) => serde_json::json!({ key: { "$lt": val } }),
+        Filter::And(lhs, rhs) => serde_json::json!({
+            "$and": [translate_filter(lhs), translate_filter(rhs)]
+        }),
+        Filter::Or(lhs, rhs) => serde_json::json!({
+            "$or": [translate_filter(lhs), translate_filter(rhs)]
+        }),
+    }
+}
+
+impl<M> VectorStoreIndex for PineconeVectorStore<M>
+where
+    M: EmbeddingModel + Send + Sync,
+{
+    type Filter = Filter<serde_json::Value>;
+
+    async fn top_n<T: for<'a> Deserialize<'a> + Send>(
+        &self,
+        req: VectorSearchRequest<Self::Filter>,
+    ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {
+        let query_vector = self.model.embed_text(req.query()).await?.vec;
+        let query_vector_f32: Vec<f32> = query_vector.into_iter().map(|x| x as f32).collect();
+
+        let filter_val = req.filter().as_ref().map(translate_filter);
+
+        let query_req = QueryRequest {
+            namespace: self.namespace.clone(),
+            vector: query_vector_f32,
+            top_k: req.samples() as usize,
+            filter: filter_val,
+            include_values: false,
+            include_metadata: true,
+        };
+
+        let response = self.client.query(query_req).await.map_err(datastore_error)?;
+
+        let mut results = Vec::new();
+        for m in response.matches {
+            let score = m.score as f64;
+            if let Some(threshold) = req.threshold() {
+                if score < threshold {
+                    continue;
+                }
+            }
+
+            let metadata = m.metadata.ok_or_else(|| {
+                VectorStoreError::DatastoreError("Missing metadata in Pinecone query result".into())
+            })?;
+
+            let doc_val = metadata.get("document").ok_or_else(|| {
+                VectorStoreError::DatastoreError("Missing 'document' field in Pinecone metadata".into())
+            })?;
+
+            let doc: T = serde_json::from_value(doc_val.clone())?;
+            results.push((score, m.id, doc));
+        }
+
+        Ok(results)
+    }
+
+    async fn top_n_ids(
+        &self,
+        req: VectorSearchRequest<Self::Filter>,
+    ) -> Result<Vec<(f64, String)>, VectorStoreError> {
+        let query_vector = self.model.embed_text(req.query()).await?.vec;
+        let query_vector_f32: Vec<f32> = query_vector.into_iter().map(|x| x as f32).collect();
+
+        let filter_val = req.filter().as_ref().map(translate_filter);
+
+        let query_req = QueryRequest {
+            namespace: self.namespace.clone(),
+            vector: query_vector_f32,
+            top_k: req.samples() as usize,
+            filter: filter_val,
+            include_values: false,
+            include_metadata: false,
+        };
+
+        let response = self.client.query(query_req).await.map_err(datastore_error)?;
+
+        let mut results = Vec::new();
+        for m in response.matches {
+            let score = m.score as f64;
+            if let Some(threshold) = req.threshold() {
+                if score < threshold {
+                    continue;
+                }
+            }
+            results.push((score, m.id));
+        }
+
+        Ok(results)
+    }
+}

--- a/crates/rig-pinecone/tests/pinecone_tests.rs
+++ b/crates/rig-pinecone/tests/pinecone_tests.rs
@@ -1,0 +1,228 @@
+use httpmock::MockServer;
+use rig_core::{
+    Embed,
+    embeddings::{Embedding, EmbeddingError, EmbeddingModel, EmbeddingsBuilder, embed::{EmbedError, TextEmbedder}},
+    vector_store::{InsertDocuments, VectorStoreIndex, request::{Filter, VectorSearchRequest, SearchFilter}},
+};
+use rig_pinecone::{PineconeClient, PineconeVectorStore};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone)]
+struct MockModel;
+
+impl EmbeddingModel for MockModel {
+    const MAX_DOCUMENTS: usize = 100;
+    type Client = rig_core::client::Nothing;
+
+    fn make(_client: &Self::Client, _model: impl Into<String>, _ndims: Option<usize>) -> Self {
+        Self
+    }
+
+    fn ndims(&self) -> usize {
+        2
+    }
+
+    async fn embed_texts(
+        &self,
+        documents: impl IntoIterator<Item = String> + Send,
+    ) -> Result<Vec<Embedding>, EmbeddingError> {
+        Ok(documents
+            .into_iter()
+            .map(|d| Embedding {
+                document: d,
+                vec: vec![0.1, 0.2],
+            })
+            .collect())
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct MyDoc {
+    text: String,
+    tag: String,
+}
+
+impl Embed for MyDoc {
+    fn embed(&self, embedder: &mut TextEmbedder) -> Result<(), EmbedError> {
+        embedder.embed(self.text.clone());
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn test_pinecone_upsert_and_query() {
+    let server = MockServer::start();
+
+    // 1. Mock the upsert endpoint (matching request without random UUIDs)
+    let upsert_mock = server.mock(|when, then| {
+        when.method(httpmock::Method::POST)
+            .path("/vectors/upsert")
+            .header("Api-Key", "test-key")
+            .header("X-Pinecone-Api-Version", "2025-01");
+        then.status(200)
+            .json_body(serde_json::json!({
+                "upsertedCount": 1
+            }));
+    });
+
+    // 2. Mock the query endpoint for top_n
+    let query_mock = server.mock(|when, then| {
+        when.method(httpmock::Method::POST)
+            .path("/query")
+            .header("Api-Key", "test-key")
+            .header("X-Pinecone-Api-Version", "2025-01")
+            .json_body(serde_json::json!({
+                "namespace": "test-namespace",
+                "vector": [0.1, 0.2],
+                "topK": 2,
+                "includeValues": false,
+                "includeMetadata": true
+            }));
+        then.status(200)
+            .json_body(serde_json::json!({
+                "matches": [
+                    {
+                        "id": "doc-123",
+                        "score": 0.95,
+                        "metadata": {
+                            "document": {
+                                "text": "hello",
+                                "tag": "test"
+                            }
+                        }
+                    }
+                ]
+            }));
+    });
+
+    // 3. Mock the query endpoint for top_n_ids
+    let query_ids_mock = server.mock(|when, then| {
+        when.method(httpmock::Method::POST)
+            .path("/query")
+            .header("Api-Key", "test-key")
+            .header("X-Pinecone-Api-Version", "2025-01")
+            .json_body(serde_json::json!({
+                "namespace": "test-namespace",
+                "vector": [0.1, 0.2],
+                "topK": 2,
+                "includeValues": false,
+                "includeMetadata": false
+            }));
+        then.status(200)
+            .json_body(serde_json::json!({
+                "matches": [
+                    {
+                        "id": "doc-123",
+                        "score": 0.95
+                    }
+                ]
+            }));
+    });
+
+    let client = PineconeClient::new("test-key", &server.url(""));
+    let store = PineconeVectorStore::new(client, MockModel, Some("test-namespace".to_string()));
+
+    let docs = vec![MyDoc {
+        text: "hello".to_string(),
+        tag: "test".to_string(),
+    }];
+
+    let documents = EmbeddingsBuilder::new(MockModel)
+        .documents(docs)
+        .unwrap()
+        .build()
+        .await
+        .unwrap();
+
+    // Test upsert
+    store.insert_documents(documents).await.unwrap();
+    upsert_mock.assert();
+
+    // Test query (top_n)
+    let search_req = VectorSearchRequest::builder()
+        .query("hello")
+        .samples(2)
+        .build();
+
+    let results: Vec<(f64, String, MyDoc)> = store.top_n(search_req).await.unwrap();
+    query_mock.assert();
+
+    assert_eq!(results.len(), 1);
+    let (score, id, doc) = &results[0];
+    assert_eq!(*score, 0.95);
+    assert_eq!(id, "doc-123");
+    assert_eq!(doc.text, "hello");
+    assert_eq!(doc.tag, "test");
+
+    // Test query (top_n_ids)
+    let search_req_ids = VectorSearchRequest::builder()
+        .query("hello")
+        .samples(2)
+        .build();
+
+    let id_results = store.top_n_ids(search_req_ids).await.unwrap();
+    query_ids_mock.assert();
+
+    assert_eq!(id_results.len(), 1);
+    assert_eq!(id_results[0], (0.95, "doc-123".to_string()));
+}
+
+#[tokio::test]
+async fn test_pinecone_filters() {
+    let server = MockServer::start();
+
+    // Mock query with complex filters
+    let query_mock = server.mock(|when, then| {
+        when.method(httpmock::Method::POST)
+            .path("/query")
+            .header("Api-Key", "test-key")
+            .header("X-Pinecone-Api-Version", "2025-01")
+            .json_body(serde_json::json!({
+                "namespace": "test-namespace",
+                "vector": [0.1, 0.2],
+                "topK": 2,
+                "filter": {
+                    "$and": [
+                        { "tag": { "$eq": "test" } },
+                        { "price": { "$gt": 100 } }
+                    ]
+                },
+                "includeValues": false,
+                "includeMetadata": true
+            }));
+        then.status(200)
+            .json_body(serde_json::json!({
+                "matches": [
+                    {
+                        "id": "doc-123",
+                        "score": 0.95,
+                        "metadata": {
+                            "document": {
+                                "text": "hello",
+                                "tag": "test"
+                            }
+                        }
+                    }
+                ]
+            }));
+    });
+
+    let client = PineconeClient::new("test-key", &server.url(""));
+    let store = PineconeVectorStore::new(client, MockModel, Some("test-namespace".to_string()));
+
+    let filter = Filter::and(
+        Filter::eq("tag", serde_json::json!("test")),
+        Filter::gt("price", serde_json::json!(100)),
+    );
+
+    let search_req = VectorSearchRequest::builder()
+        .query("hello")
+        .samples(2)
+        .filter(filter)
+        .build();
+
+    let results: Vec<(f64, String, MyDoc)> = store.top_n(search_req).await.unwrap();
+    query_mock.assert();
+
+    assert_eq!(results.len(), 1);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,12 @@ pub mod neo4j {
     pub use rig_neo4j::*;
 }
 
+#[cfg(feature = "pinecone")]
+#[cfg_attr(docsrs, doc(cfg(feature = "pinecone")))]
+pub mod pinecone {
+    pub use rig_pinecone::*;
+}
+
 #[cfg(feature = "postgres")]
 #[cfg_attr(docsrs, doc(cfg(feature = "postgres")))]
 pub mod postgres {


### PR DESCRIPTION
This PR adds Pinecone vector store integration for Rig.

It implements `PineconeVectorStore` supporting:
- Document insertions with UUID generation and custom document metadata framing
- Vector search via `top_n` and `top_n_ids`
- Filter translation (Eq, Gt, Lt, And, Or) mapping to Pinecone query syntax

An integration test suite has been added under `crates/rig-pinecone/tests/pinecone_tests.rs` using `httpmock` to verify the end-to-end integration and translation without needing real API keys.

Closes #37