### PR TITLE
fix(openai): make token usage details optional in responses API

### DIFF
--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -709,21 +709,19 @@ impl Add for ResponsesUsage {
 
     fn add(self, rhs: Self) -> Self::Output {
         let input_tokens = self.input_tokens + rhs.input_tokens;
-        let input_tokens_details = self.input_tokens_details.map(|lhs| {
-            if let Some(tokens) = rhs.input_tokens_details {
-                lhs + tokens
-            } else {
-                lhs
-            }
-        });
+        let input_tokens_details = match (self.input_tokens_details, rhs.input_tokens_details) {
+            (Some(lhs), Some(rhs)) => Some(lhs + rhs),
+            (Some(lhs), None) => Some(lhs),
+            (None, Some(rhs)) => Some(rhs),
+            (None, None) => None,
+        };
         let output_tokens = self.output_tokens + rhs.output_tokens;
-        let output_tokens_details = self.output_tokens_details.map(|lhs| {
-            if let Some(tokens) = rhs.output_tokens_details {
-                lhs + tokens
-            } else {
-                lhs
-            }
-        });
+        let output_tokens_details = match (self.output_tokens_details, rhs.output_tokens_details) {
+            (Some(lhs), Some(rhs)) => Some(lhs + rhs),
+            (Some(lhs), None) => Some(lhs),
+            (None, Some(rhs)) => Some(rhs),
+            (None, None) => None,
+        };
         let total_tokens = self.total_tokens + rhs.total_tokens;
         Self {
             input_tokens,
@@ -2041,6 +2039,58 @@ mod tests {
         assert_eq!(token_usage.output_tokens, 50);
         assert_eq!(token_usage.reasoning_tokens, 15);
         assert_eq!(token_usage.total_tokens, 150);
+    }
+
+    #[test]
+    fn responses_usage_deserializes_without_output_token_details() {
+        let usage: ResponsesUsage = serde_json::from_value(json!({
+            "input_tokens": 100,
+            "input_tokens_details": {
+                "cached_tokens": 25
+            },
+            "output_tokens": 50,
+            "total_tokens": 150
+        }))
+        .expect("usage should deserialize when output token details are omitted");
+
+        assert!(usage.output_tokens_details.is_none());
+
+        let token_usage = usage.token_usage().expect("usage should be present");
+
+        assert_eq!(token_usage.input_tokens, 100);
+        assert_eq!(token_usage.cached_input_tokens, 25);
+        assert_eq!(token_usage.output_tokens, 50);
+        assert_eq!(token_usage.reasoning_tokens, 0);
+        assert_eq!(token_usage.total_tokens, 150);
+    }
+
+    #[test]
+    fn responses_usage_add_preserves_rhs_details_when_lhs_details_are_absent() {
+        let lhs = ResponsesUsage {
+            input_tokens: 10,
+            input_tokens_details: None,
+            output_tokens: 20,
+            output_tokens_details: None,
+            total_tokens: 30,
+        };
+        let rhs = ResponsesUsage {
+            input_tokens: 3,
+            input_tokens_details: Some(InputTokensDetails { cached_tokens: 2 }),
+            output_tokens: 5,
+            output_tokens_details: Some(OutputTokensDetails {
+                reasoning_tokens: 4,
+            }),
+            total_tokens: 8,
+        };
+
+        let usage = lhs + rhs;
+        let token_usage = usage.token_usage().expect("usage should be present");
+
+        assert_eq!(token_usage.input_tokens, 13);
+        assert_eq!(token_usage.cached_input_tokens, 2);
+        assert_eq!(token_usage.output_tokens, 25);
+        assert_eq!(token_usage.reasoning_tokens, 4);
+        assert_eq!(token_usage.total_tokens, 38);
     }
 
     #[test]

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -663,7 +663,8 @@ pub struct ResponsesUsage {
     /// Output tokens
     pub output_tokens: u64,
     /// In-depth detail on output tokens (reasoning tokens)
-    pub output_tokens_details: OutputTokensDetails,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_tokens_details: Option<OutputTokensDetails>,
     /// Total tokens used (for a given prompt)
     pub total_tokens: u64,
 }
@@ -675,7 +676,7 @@ impl ResponsesUsage {
             input_tokens: 0,
             input_tokens_details: Some(InputTokensDetails::new()),
             output_tokens: 0,
-            output_tokens_details: OutputTokensDetails::new(),
+            output_tokens_details: Some(OutputTokensDetails::new()),
             total_tokens: 0,
         }
     }
@@ -694,7 +695,11 @@ impl GetTokenUsage for ResponsesUsage {
                 .unwrap_or(0),
             cache_creation_input_tokens: 0,
             tool_use_prompt_tokens: 0,
-            reasoning_tokens: self.output_tokens_details.reasoning_tokens,
+            reasoning_tokens: self
+                .output_tokens_details
+                .as_ref()
+                .map(|details| details.reasoning_tokens)
+                .unwrap_or(0),
         })
     }
 }
@@ -712,7 +717,13 @@ impl Add for ResponsesUsage {
             }
         });
         let output_tokens = self.output_tokens + rhs.output_tokens;
-        let output_tokens_details = self.output_tokens_details + rhs.output_tokens_details;
+        let output_tokens_details = self.output_tokens_details.map(|lhs| {
+            if let Some(tokens) = rhs.output_tokens_details {
+                lhs + tokens
+            } else {
+                lhs
+            }
+        });
         let total_tokens = self.total_tokens + rhs.total_tokens;
         Self {
             input_tokens,
@@ -2017,9 +2028,9 @@ mod tests {
             input_tokens: 100,
             input_tokens_details: Some(InputTokensDetails { cached_tokens: 25 }),
             output_tokens: 50,
-            output_tokens_details: OutputTokensDetails {
+            output_tokens_details: Some(OutputTokensDetails {
                 reasoning_tokens: 15,
-            },
+            }),
             total_tokens: 150,
         };
 

--- a/crates/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -1280,9 +1280,9 @@ mod tests {
             input_tokens: 10,
             input_tokens_details: None,
             output_tokens: 5,
-            output_tokens_details: OutputTokensDetails {
+            output_tokens_details: Some(OutputTokensDetails {
                 reasoning_tokens: 0,
-            },
+            }),
             total_tokens: 15,
         });
 
@@ -1325,9 +1325,9 @@ mod tests {
             input_tokens: 4,
             input_tokens_details: None,
             output_tokens: 2,
-            output_tokens_details: OutputTokensDetails {
+            output_tokens_details: Some(OutputTokensDetails {
                 reasoning_tokens: 0,
-            },
+            }),
             total_tokens: 6,
         });
 

--- a/crates/rig-core/src/providers/openai/responses_api/websocket.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/websocket.rs
@@ -837,9 +837,9 @@ mod tests {
                 input_tokens_details: None,
                 output_tokens: 2,
                 output_tokens_details:
-                    crate::providers::openai::responses_api::OutputTokensDetails {
+                    Some(crate::providers::openai::responses_api::OutputTokensDetails {
                         reasoning_tokens: 0,
-                    },
+                    }),
                 total_tokens: 3,
             }),
             output: Vec::new(),

--- a/crates/rig-core/src/providers/openai/responses_api/websocket.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/websocket.rs
@@ -836,10 +836,11 @@ mod tests {
                 input_tokens: 1,
                 input_tokens_details: None,
                 output_tokens: 2,
-                output_tokens_details:
-                    Some(crate::providers::openai::responses_api::OutputTokensDetails {
+                output_tokens_details: Some(
+                    crate::providers::openai::responses_api::OutputTokensDetails {
                         reasoning_tokens: 0,
-                    }),
+                    },
+                ),
                 total_tokens: 3,
             }),
             output: Vec::new(),


### PR DESCRIPTION
This PR resolves issue #1569 where using the `openai` provider with compatible backends (such as `mistral.rs` or `llama.cpp`) results in a deserialization error due to missing token usage details.

Changes:
- Made `output_tokens_details` in `ResponsesUsage` optional (`Option<OutputTokensDetails>`) and marked it with `#[serde(skip_serializing_if = "Option::is_none")]`.
- Updated usage extraction to gracefully handle missing values (falling back to default/0).
- Updated existing test cases to wrap test token usage structures accordingly.

Closes #1569