### PR TITLE
feat(agent): add `push_notification` to inject messages during multi-turn prompts

### DIFF
--- a/crates/rig-core/src/agent/builder.rs
+++ b/crates/rig-core/src/agent/builder.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 
 use schemars::{JsonSchema, Schema, schema_for};
 
@@ -533,6 +536,7 @@ where
             output_schema: self.output_schema,
             memory: self.memory,
             default_conversation_id: self.default_conversation_id,
+            pending_notifications: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 }
@@ -561,6 +565,7 @@ where
             output_schema: self.output_schema,
             memory: self.memory,
             default_conversation_id: self.default_conversation_id,
+            pending_notifications: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 }
@@ -648,6 +653,7 @@ where
             output_schema: self.output_schema,
             memory: self.memory,
             default_conversation_id: self.default_conversation_id,
+            pending_notifications: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 }

--- a/crates/rig-core/src/agent/completion.rs
+++ b/crates/rig-core/src/agent/completion.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use std::{
     collections::{BTreeSet, HashMap},
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 
 const UNKNOWN_AGENT_NAME: &str = "Unnamed Agent";
@@ -300,6 +300,8 @@ where
     pub memory: Option<Arc<dyn crate::memory::ConversationMemory>>,
     /// Optional default conversation id used when none is set per-request.
     pub default_conversation_id: Option<String>,
+    /// Notification messages, indexed by conversation ID, that will be consumed during multi-turn prompt requests.
+    pub pending_notifications: Arc<Mutex<HashMap<String, Vec<String>>>>,
 }
 
 impl<M, P> Agent<M, P>
@@ -310,6 +312,52 @@ where
     /// Returns the name of the agent.
     pub(crate) fn name(&self) -> &str {
         self.name.as_deref().unwrap_or(UNKNOWN_AGENT_NAME)
+    }
+
+    /// Notify the agent with a new message during a multi-turn prompt request.
+    ///
+    /// The message is queued and injected as a user message in the next
+    /// iteration of the agent's prompt loop, keyed by `conversation_id`.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use rig_core::client::{CompletionClient, ProviderClient};
+    /// use rig_core::completion::Prompt;
+    /// use rig_core::providers::openai;
+    ///
+    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let some_event = tokio::time::sleep(std::time::Duration::from_secs(1));
+    /// let agent = openai::Client::from_env()?
+    ///     .agent(openai::GPT_5_2)
+    ///     .conversation_id("my-conv")
+    ///     .build();
+    ///
+    /// // Clone the agent to share access across tasks.
+    /// let agent_clone = agent.clone();
+    ///
+    /// // Prompt the agent in a background task.
+    /// tokio::spawn(async move {
+    ///     let _ = agent.prompt("Start the conversation, use some tools.").await;
+    /// });
+    ///
+    /// // Wait for some other event and notify the agent about something.
+    /// some_event.await;
+    /// agent_clone.push_notification(
+    ///     "my-conv",
+    ///     "Keep going but know that something came up: ...".to_string()
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn push_notification(&self, conversation_id: &str, message: String) {
+        let mut notifications_guard = match self.pending_notifications.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        notifications_guard
+            .entry(conversation_id.to_owned())
+            .or_default()
+            .push(message);
     }
 }
 

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -20,11 +20,11 @@ use hooks::{
 };
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, HashMap},
     future::IntoFuture,
     marker::PhantomData,
     sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicU64, Ordering},
     },
 };
@@ -80,6 +80,8 @@ where
     dynamic_context: DynamicContextStore,
     /// Tool choice setting
     tool_choice: Option<ToolChoice>,
+    /// Notification messages, indexed by conversation ID, that will be consumed during multi-turn prompt requests.
+    pending_notifications: Arc<Mutex<HashMap<String, Vec<String>>>>,
 
     /// Phantom data to track the type of the request
     state: PhantomData<S>,
@@ -125,6 +127,7 @@ where
             output_schema: agent.output_schema.clone(),
             memory: agent.memory.clone(),
             conversation_id: agent.default_conversation_id.clone(),
+            pending_notifications: agent.pending_notifications.clone(),
         }
     }
 }
@@ -163,6 +166,7 @@ where
             output_schema: self.output_schema,
             memory: self.memory,
             conversation_id: self.conversation_id,
+            pending_notifications: self.pending_notifications,
         }
     }
 
@@ -235,6 +239,7 @@ where
             output_schema: self.output_schema,
             memory: self.memory,
             conversation_id: self.conversation_id,
+            pending_notifications: self.pending_notifications,
         }
     }
 
@@ -616,9 +621,9 @@ where
         // missing, behave as if no memory is configured.
         let (chat_history, memory_handle) = match self.chat_history {
             Some(history) => (Some(history), None),
-            None => match (self.memory, self.conversation_id) {
+            None => match (self.memory, self.conversation_id.as_deref()) {
                 (Some(memory), Some(id)) => {
-                    let loaded = memory.load(&id).await?;
+                    let loaded = memory.load(id).await?;
                     (Some(loaded), Some((memory, id)))
                 }
                 _ => (None, None),
@@ -635,6 +640,23 @@ where
 
         // We need to do at least 2 loops for 1 roundtrip (user expects normal message)
         let last_prompt = 'prompt_loop: loop {
+            // Retrieve and inject pending notifications, if any.
+            let notifications = match self.pending_notifications.lock() {
+                Ok(mut guard) => self
+                    .conversation_id
+                    .as_deref()
+                    .and_then(|conv_id| guard.remove(conv_id)),
+                Err(poisoned) => self
+                    .conversation_id
+                    .as_deref()
+                    .and_then(|conv_id| poisoned.into_inner().remove(conv_id)),
+            };
+            if let Some(notifications) = notifications {
+                for msg in notifications {
+                    new_messages.push(Message::user(msg));
+                }
+            }
+
             // Get the last message (the current prompt)
             let Some((prompt_ref, history_for_current_turn)) = new_messages.split_last() else {
                 return Err(PromptError::prompt_cancelled(
@@ -2824,5 +2846,52 @@ mod tests {
             .expect("append failure must not block successful completion");
 
         assert!(!response.is_empty());
+    }
+
+    #[tokio::test]
+    async fn prompt_request_injects_pending_notification_during_multi_turn() {
+        let model = MockCompletionModel::new([
+            MockTurn::tool_call("tool_call_1", "add", json!({"x": 1, "y": 2}))
+                .with_call_id("call_1"),
+            MockTurn::text("final result"),
+        ]);
+
+        let agent = AgentBuilder::new(model)
+            .tool(MockAddTool)
+            .conversation_id("test-conv")
+            .build();
+
+        agent.push_notification("test-conv", "injected user message".to_string());
+
+        let response = agent
+            .prompt("do tool work")
+            .max_turns(3)
+            .extended_details()
+            .await
+            .expect("multi-turn prompt with tool call should succeed");
+
+        assert_eq!(response.output, "final result");
+
+        let history = response
+            .messages
+            .expect("extended response should include history");
+
+        let notification_count = history
+            .iter()
+            .filter(|msg| {
+                matches!(
+                    msg,
+                    Message::User { content } if content.iter().any(|c| matches!(
+                        c,
+                        UserContent::Text(t) if t.text == "injected user message"
+                    ))
+                )
+            })
+            .count();
+
+        assert_eq!(
+            notification_count, 1,
+            "notification should appear exactly once in history"
+        );
     }
 }

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -18,7 +18,11 @@ use crate::{
 };
 use futures::{Stream, StreamExt};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, pin::Pin, sync::Arc};
+use std::{
+    collections::HashMap,
+    pin::Pin,
+    sync::{Arc, Mutex},
+};
 use tracing::info_span;
 use tracing_futures::Instrument;
 
@@ -611,6 +615,8 @@ where
     memory: Option<Arc<dyn ConversationMemory>>,
     /// Optional conversation id used for loading and saving memory.
     conversation_id: Option<String>,
+    /// Notification messages, indexed by conversation ID, that will be consumed during multi-turn prompt requests.
+    pending_notifications: Arc<Mutex<HashMap<String, Vec<String>>>>,
 }
 
 impl<M, P> StreamingPromptRequest<M, P>
@@ -641,6 +647,7 @@ where
             max_invalid_tool_call_retries: 0,
             memory: agent.memory.clone(),
             conversation_id: agent.default_conversation_id.clone(),
+            pending_notifications: agent.pending_notifications.clone(),
         }
     }
 
@@ -671,6 +678,7 @@ where
             max_invalid_tool_call_retries: 0,
             memory: agent.memory.clone(),
             conversation_id: agent.default_conversation_id.clone(),
+            pending_notifications: agent.pending_notifications.clone(),
         }
     }
 
@@ -731,6 +739,7 @@ where
             max_invalid_tool_call_retries: self.max_invalid_tool_call_retries,
             memory: self.memory,
             conversation_id: self.conversation_id,
+            pending_notifications: self.pending_notifications,
         }
     }
 
@@ -796,6 +805,8 @@ where
         let dynamic_context = self.dynamic_context.clone();
         let tool_choice = self.tool_choice.clone();
         let agent_name = self.agent_name.clone();
+        let conversation_id = self.conversation_id.clone();
+        let pending_notifications = self.pending_notifications.clone();
         // When the caller passes explicit history, memory is fully bypassed for
         // this request (no load AND no save). Otherwise, if a memory backend and
         // conversation id are both configured, load prior history; if either is
@@ -839,6 +850,22 @@ where
         // See also: https://github.com/rust-lang/rust-clippy/issues/8722
         let stream = async_stream::stream! {
             'outer: loop {
+                // Retrieve and inject pending notifications, if any.
+                let notifications = match pending_notifications.lock() {
+                    Ok(mut guard) => conversation_id
+                        .as_deref()
+                        .and_then(|conv_id| guard.remove(conv_id)),
+                    Err(poisoned) => conversation_id
+                        .as_deref()
+                        .and_then(|conv_id| poisoned.into_inner().remove(conv_id)),
+                };
+                if let Some(notifications) = notifications {
+                    for msg in notifications {
+                        new_messages.push(Message::user(msg));
+                    }
+                }
+
+            // Get the last message (the current prompt)
                 let Some((current_prompt_ref, previous_messages)) = new_messages.split_last() else {
                     yield Err(cancelled_prompt_error(
                         chat_history.as_deref(),
@@ -5625,6 +5652,87 @@ mod tests {
         assert!(
             saw_final,
             "FinalResponse must be yielded even when memory.append fails"
+        );
+    }
+
+    #[tokio::test]
+    async fn stream_prompt_injects_pending_notification_during_multi_turn() {
+        let model = MockCompletionModel::from_stream_turns([
+            vec![
+                MockStreamEvent::tool_call(
+                    "tool_call_1",
+                    "add",
+                    serde_json::json!({"x": 1, "y": 2}),
+                )
+                .with_call_id("call_1"),
+                MockStreamEvent::final_response_with_total_tokens(4),
+            ],
+            vec![
+                MockStreamEvent::text("final streaming result"),
+                MockStreamEvent::final_response_with_total_tokens(6),
+            ],
+        ]);
+
+        let agent = AgentBuilder::new(model)
+            .tool(MockAddTool)
+            .conversation_id("test-conv")
+            .build();
+
+        agent.push_notification("test-conv", "injected user message".to_string());
+
+        let mut stream = agent
+            .stream_prompt("do tool work")
+            .with_history(Vec::<Message>::new())
+            .multi_turn(3)
+            .await;
+
+        let mut saw_tool_call = false;
+        let mut saw_tool_result = false;
+        let mut final_history = None;
+
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(MultiTurnStreamItem::StreamAssistantItem(
+                    StreamedAssistantContent::ToolCall { .. },
+                )) => {
+                    saw_tool_call = true;
+                }
+                Ok(MultiTurnStreamItem::StreamUserItem(StreamedUserContent::ToolResult {
+                    ..
+                })) => {
+                    saw_tool_result = true;
+                }
+                Ok(MultiTurnStreamItem::FinalResponse(res)) => {
+                    assert_eq!(res.response(), "final streaming result");
+                    final_history = res.history().map(|h| h.to_vec());
+                    break;
+                }
+                Ok(_) => {}
+                Err(err) => panic!("unexpected streaming error: {err:?}"),
+            }
+        }
+
+        assert!(saw_tool_call, "should have seen tool call");
+        assert!(saw_tool_result, "should have seen tool result");
+
+        let history = final_history.expect("final response should include history");
+
+        let notification_count = history
+            .iter()
+            .filter(|msg| {
+                matches!(
+                    msg,
+                    Message::User { content } if content.iter().any(|c| matches!(
+                        c,
+                        UserContent::Text(t) if t.text == "injected user message"
+                    ))
+                )
+            })
+            .count();
+
+        assert_eq!(
+            notification_count, 1,
+            "notification should appear exactly once in history"
         );
     }
 }


### PR DESCRIPTION
Hi!

This PR adds a `push_notification` method to `Agent` that allows injecting user messages into an already-running multi-turn prompt, similar to how OpenCode makes it possible to send input to an active agent mid-conversation.

## How it works

- `Agent::push_notification(conversation_id, message)` enqueues a message into a per-conversation pending queue.
- At the start of each loop iteration (both streaming and non-streaming), the queue is drained and messages are injected as `User` messages into the conversation history.
- The queue is stored behind `Arc<Mutex<...>>`, so cloning the agent shares the same queue, enabling cross-task patterns like spawning a background watcher that calls `push_notification` when an external event occurs.

## Example

```rust
let agent = openai::Client::from_env()?
    .agent(openai::GPT_5_2)
    .conversation_id("my-conv")
    .toot(some_tool)
    .build();
let agent_clone = agent.clone();

let prompt_task = tokio::spawn(async move {
    // Start a long running multi-turn prompt.
    let resp = agent.prompt("Do this and that with your available tools.").await.unwrap();
    println!("{resp}");
})

let some_watcher_task = tokio::spawn(async move {
    // ... wait for some condition ...
    agent_clone.push_notification("my-conv", "Continue, but you should know that ...".to_string());
});

// Wait on both tasks...
```

## Disclosure

- Feature code was handwritten.
- Tests were AI-generated then checked.

Thanks!