### PR TITLE
feat(rig-core): expose provider error response inspection

### DIFF
--- a/crates/rig-core/src/audio_generation.rs
+++ b/crates/rig-core/src/audio_generation.rs
@@ -14,10 +14,11 @@ use thiserror::Error;
 /// [`Self::provider_response_json`], and [`Self::provider_response_status`].
 ///
 /// Note: no provider path currently constructs [`Self::ProviderResponse`] for
-/// audio generation; real audio failures surface as [`Self::HttpError`], which
-/// the helpers already read. The variant is kept for symmetry with the other
-/// capability errors and for future provider paths that preserve a 2xx error
-/// envelope.
+/// audio generation; coverage is limited today — only Azure audio failures
+/// surface as [`Self::HttpError`], which the helpers read, while other audio
+/// providers still emit [`Self::ProviderError`]. The variant is kept for
+/// symmetry with the other capability errors and for future provider paths that
+/// preserve a 2xx error envelope.
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum AudioGenerationError {

--- a/crates/rig-core/src/audio_generation.rs
+++ b/crates/rig-core/src/audio_generation.rs
@@ -12,7 +12,14 @@ use thiserror::Error;
 ///
 /// Inspect provider failures with [`Self::provider_response_body`],
 /// [`Self::provider_response_json`], and [`Self::provider_response_status`].
+///
+/// Note: no provider path currently constructs [`Self::ProviderResponse`] for
+/// audio generation; real audio failures surface as [`Self::HttpError`], which
+/// the helpers already read. The variant is kept for symmetry with the other
+/// capability errors and for future provider paths that preserve a 2xx error
+/// envelope.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum AudioGenerationError {
     /// Http error (e.g.: connection error, timeout, etc.)
     #[error("HttpError: {0}")]
@@ -39,40 +46,7 @@ pub enum AudioGenerationError {
     ProviderResponse(provider_response::ProviderResponseError),
 }
 
-impl AudioGenerationError {
-    /// Returns the raw provider response body when available.
-    ///
-    /// This is available for:
-    /// - [`AudioGenerationError::ProviderResponse`] using its preserved body.
-    /// - [`AudioGenerationError::HttpError`] when it wraps an HTTP non-success response that carries a body.
-    pub fn provider_response_body(&self) -> Option<&str> {
-        match self {
-            Self::ProviderResponse(response) => Some(response.body.as_str()),
-            Self::HttpError(error) => error.non_success_body(),
-            _ => None,
-        }
-    }
-
-    /// Parses the provider response body as JSON.
-    ///
-    /// Returns:
-    /// - `Ok(Some(value))` when a body is present and valid JSON.
-    /// - `Ok(None)` when no provider response body is available.
-    /// - `Err(error)` when a body is present but isn't valid JSON.
-    pub fn provider_response_json(&self) -> Result<Option<serde_json::Value>, serde_json::Error> {
-        provider_response::json(self.provider_response_body())
-    }
-
-    /// Returns the HTTP status code when this error preserves one, either from a
-    /// non-success HTTP response or from a preserved provider response.
-    pub fn provider_response_status(&self) -> Option<http::StatusCode> {
-        match self {
-            Self::ProviderResponse(response) => response.status,
-            Self::HttpError(error) => error.non_success_status(),
-            _ => None,
-        }
-    }
-}
+crate::provider_response::impl_provider_response_helpers!(AudioGenerationError);
 
 pub trait AudioGeneration<M>
 where

--- a/crates/rig-core/src/audio_generation.rs
+++ b/crates/rig-core/src/audio_generation.rs
@@ -2,7 +2,7 @@
 //! Rig abstracts over a number of different providers using the [AudioGenerationModel] trait.
 use crate::markers::{Missing, Provided};
 use crate::{
-    http_client,
+    http_client, provider_response,
     wasm_compat::{WasmCompatSend, WasmCompatSync},
 };
 use serde_json::Value;
@@ -18,18 +18,52 @@ pub enum AudioGenerationError {
     #[error("JsonError: {0}")]
     JsonError(#[from] serde_json::Error),
 
-    /// Error building the transcription request
+    /// Error building the audio generation request
     #[error("RequestError: {0}")]
     RequestError(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
 
-    /// Error parsing the transcription response
+    /// Error parsing the audio generation response
     #[error("ResponseError: {0}")]
     ResponseError(String),
 
-    /// Error returned by the transcription model provider
+    /// Error returned by the audio generation model provider
     #[error("ProviderError: {0}")]
     ProviderError(String),
 }
+
+impl AudioGenerationError {
+    /// Returns the raw provider response body when available.
+    ///
+    /// This is available for:
+    /// - [`AudioGenerationError::ProviderError`] using its stored string.
+    /// - [`AudioGenerationError::HttpError`] when it wraps an HTTP non-success response that carries a body.
+    pub fn provider_response_body(&self) -> Option<&str> {
+        match self {
+            Self::ProviderError(body) => provider_response::body(Some(body.as_str()), None),
+            Self::HttpError(error) => provider_response::body(None, Some(error)),
+            _ => None,
+        }
+    }
+
+    /// Parses the provider response body as JSON.
+    ///
+    /// Returns:
+    /// - `Ok(Some(value))` when a body is present and valid JSON.
+    /// - `Ok(None)` when no provider response body is available.
+    /// - `Err(error)` when a body is present but isn't valid JSON.
+    pub fn provider_response_json(&self) -> Result<Option<serde_json::Value>, serde_json::Error> {
+        provider_response::json(self.provider_response_body())
+    }
+
+    /// Returns the HTTP status code when this error comes from a non-success HTTP response.
+    pub fn provider_response_status(&self) -> Option<http::StatusCode> {
+        match self {
+            Self::HttpError(error) => provider_response::status(Some(error)),
+            _ => None,
+        }
+    }
+}
+
 pub trait AudioGeneration<M>
 where
     M: AudioGenerationModel,
@@ -168,5 +202,53 @@ where
         let model = self.model.clone();
 
         model.audio_generation(self.build()).await
+    }
+}
+
+#[cfg(test)]
+mod provider_response_tests {
+    use super::*;
+    use http::StatusCode;
+
+    #[test]
+    fn audio_generation_error_provider_response_helpers_with_provider_json_body() {
+        let body = r#"{"error":{"message":"invalid voice"}}"#;
+        let error = AudioGenerationError::ProviderError(body.to_string());
+
+        assert_eq!(error.provider_response_body(), Some(body));
+        assert_eq!(error.provider_response_status(), None);
+        assert_eq!(
+            error.provider_response_json().expect("valid JSON"),
+            Some(serde_json::json!({ "error": { "message": "invalid voice" } }))
+        );
+    }
+
+    #[test]
+    fn audio_generation_error_provider_response_helpers_with_http_non_success() {
+        let body = r#"{"error":{"message":"bad request"}}"#;
+        let error =
+            AudioGenerationError::HttpError(http_client::Error::InvalidStatusCodeWithMessage(
+                StatusCode::BAD_REQUEST,
+                body.to_string(),
+            ));
+
+        assert_eq!(error.provider_response_body(), Some(body));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(StatusCode::BAD_REQUEST)
+        );
+        assert_eq!(
+            error.provider_response_json().expect("valid JSON"),
+            Some(serde_json::json!({ "error": { "message": "bad request" } }))
+        );
+    }
+
+    #[test]
+    fn audio_generation_error_provider_response_helpers_with_unrelated_variant() {
+        let error = AudioGenerationError::ResponseError("parse failed".to_string());
+
+        assert_eq!(error.provider_response_body(), None);
+        assert_eq!(error.provider_response_status(), None);
+        assert_eq!(error.provider_response_json().expect("no body"), None);
     }
 }

--- a/crates/rig-core/src/audio_generation.rs
+++ b/crates/rig-core/src/audio_generation.rs
@@ -33,18 +33,22 @@ pub enum AudioGenerationError {
     /// Error returned by the audio generation model provider
     #[error("ProviderError: {0}")]
     ProviderError(String),
+
+    /// Raw error response preserved from the audio generation model provider
+    #[error("ProviderResponseError: {0}")]
+    ProviderResponse(provider_response::ProviderResponseError),
 }
 
 impl AudioGenerationError {
     /// Returns the raw provider response body when available.
     ///
     /// This is available for:
-    /// - [`AudioGenerationError::ProviderError`] using its stored string.
+    /// - [`AudioGenerationError::ProviderResponse`] using its preserved body.
     /// - [`AudioGenerationError::HttpError`] when it wraps an HTTP non-success response that carries a body.
     pub fn provider_response_body(&self) -> Option<&str> {
         match self {
-            Self::ProviderError(body) => provider_response::body(Some(body.as_str()), None),
-            Self::HttpError(error) => provider_response::body(None, Some(error)),
+            Self::ProviderResponse(response) => Some(response.body.as_str()),
+            Self::HttpError(error) => error.non_success_body(),
             _ => None,
         }
     }
@@ -59,10 +63,12 @@ impl AudioGenerationError {
         provider_response::json(self.provider_response_body())
     }
 
-    /// Returns the HTTP status code when this error comes from a non-success HTTP response.
+    /// Returns the HTTP status code when this error preserves one, either from a
+    /// non-success HTTP response or from a preserved provider response.
     pub fn provider_response_status(&self) -> Option<http::StatusCode> {
         match self {
-            Self::HttpError(error) => provider_response::status(Some(error)),
+            Self::ProviderResponse(response) => response.status,
+            Self::HttpError(error) => error.non_success_status(),
             _ => None,
         }
     }
@@ -215,9 +221,13 @@ mod provider_response_tests {
     use http::StatusCode;
 
     #[test]
-    fn audio_generation_error_provider_response_helpers_with_provider_json_body() {
+    fn audio_generation_error_provider_response_helpers_with_preserved_json_body() {
         let body = r#"{"error":{"message":"invalid voice"}}"#;
-        let error = AudioGenerationError::ProviderError(body.to_string());
+        let error =
+            AudioGenerationError::ProviderResponse(provider_response::ProviderResponseError {
+                status: None,
+                body: body.to_string(),
+            });
 
         assert_eq!(error.provider_response_body(), Some(body));
         assert_eq!(error.provider_response_status(), None);
@@ -245,6 +255,15 @@ mod provider_response_tests {
             error.provider_response_json().expect("valid JSON"),
             Some(serde_json::json!({ "error": { "message": "bad request" } }))
         );
+    }
+
+    #[test]
+    fn audio_generation_error_provider_error_is_not_a_provider_response() {
+        let error = AudioGenerationError::ProviderError("internal diagnostic".to_string());
+
+        assert_eq!(error.provider_response_body(), None);
+        assert_eq!(error.provider_response_status(), None);
+        assert_eq!(error.provider_response_json().expect("no body"), None);
     }
 
     #[test]

--- a/crates/rig-core/src/audio_generation.rs
+++ b/crates/rig-core/src/audio_generation.rs
@@ -8,6 +8,10 @@ use crate::{
 use serde_json::Value;
 use thiserror::Error;
 
+/// Errors returned by audio generation models.
+///
+/// Inspect provider failures with [`Self::provider_response_body`],
+/// [`Self::provider_response_json`], and [`Self::provider_response_status`].
 #[derive(Debug, Error)]
 pub enum AudioGenerationError {
     /// Http error (e.g.: connection error, timeout, etc.)

--- a/crates/rig-core/src/client/mod.rs
+++ b/crates/rig-core/src/client/mod.rs
@@ -537,11 +537,18 @@ where
             }
             StatusCode::INTERNAL_SERVER_ERROR => {
                 let text = http_client::text(response).await?;
-                Err(VerifyError::ProviderError(text))
+                Err(VerifyError::HttpError(
+                    http_client::Error::InvalidStatusCodeWithMessage(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        text,
+                    ),
+                ))
             }
             status if status.as_u16() == 529 => {
                 let text = http_client::text(response).await?;
-                Err(VerifyError::ProviderError(text))
+                Err(VerifyError::HttpError(
+                    http_client::Error::InvalidStatusCodeWithMessage(status, text),
+                ))
             }
             _ => {
                 let status = response.status();
@@ -550,9 +557,9 @@ where
                     Ok(())
                 } else {
                     let text: String = String::from_utf8_lossy(&response.into_body().await?).into();
-                    Err(VerifyError::HttpError(http_client::Error::Instance(
-                        format!("Failed with '{status}': {text}").into(),
-                    )))
+                    Err(VerifyError::HttpError(
+                        http_client::Error::InvalidStatusCodeWithMessage(status, text),
+                    ))
                 }
             }
         }

--- a/crates/rig-core/src/client/verify.rs
+++ b/crates/rig-core/src/client/verify.rs
@@ -5,6 +5,11 @@ use thiserror::Error;
 ///
 /// Inspect provider failures with [`Self::provider_response_body`],
 /// [`Self::provider_response_json`], and [`Self::provider_response_status`].
+///
+/// Note: no provider path currently constructs [`Self::ProviderResponse`] for
+/// verification; real verify failures surface as [`Self::HttpError`], which
+/// the helpers read. The variant is kept for symmetry with the other capability
+/// errors and for future provider paths that preserve a 2xx error envelope.
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum VerifyError {

--- a/crates/rig-core/src/client/verify.rs
+++ b/crates/rig-core/src/client/verify.rs
@@ -11,6 +11,9 @@ pub enum VerifyError {
     InvalidAuthentication,
     #[error("provider error: {0}")]
     ProviderError(String),
+    /// Raw error response preserved from the provider
+    #[error("provider response error: {0}")]
+    ProviderResponse(provider_response::ProviderResponseError),
     #[error("http error: {0}")]
     HttpError(
         #[from]
@@ -23,12 +26,12 @@ impl VerifyError {
     /// Returns the raw provider response body when available.
     ///
     /// This is available for:
-    /// - [`VerifyError::ProviderError`] using its stored string.
+    /// - [`VerifyError::ProviderResponse`] using its preserved body.
     /// - [`VerifyError::HttpError`] when it wraps an HTTP non-success response that carries a body.
     pub fn provider_response_body(&self) -> Option<&str> {
         match self {
-            Self::ProviderError(body) => provider_response::body(Some(body.as_str()), None),
-            Self::HttpError(error) => provider_response::body(None, Some(error)),
+            Self::ProviderResponse(response) => Some(response.body.as_str()),
+            Self::HttpError(error) => error.non_success_body(),
             _ => None,
         }
     }
@@ -43,10 +46,12 @@ impl VerifyError {
         provider_response::json(self.provider_response_body())
     }
 
-    /// Returns the HTTP status code when this error comes from a non-success HTTP response.
+    /// Returns the HTTP status code when this error preserves one, either from a
+    /// non-success HTTP response or from a preserved provider response.
     pub fn provider_response_status(&self) -> Option<http::StatusCode> {
         match self {
-            Self::HttpError(error) => provider_response::status(Some(error)),
+            Self::ProviderResponse(response) => response.status,
+            Self::HttpError(error) => error.non_success_status(),
             _ => None,
         }
     }
@@ -65,9 +70,12 @@ mod provider_response_tests {
     use http::StatusCode;
 
     #[test]
-    fn verify_error_provider_response_helpers_with_provider_json_body() {
+    fn verify_error_provider_response_helpers_with_preserved_json_body() {
         let body = r#"{"error":{"message":"rate limited"}}"#;
-        let error = VerifyError::ProviderError(body.to_string());
+        let error = VerifyError::ProviderResponse(provider_response::ProviderResponseError {
+            status: None,
+            body: body.to_string(),
+        });
 
         assert_eq!(error.provider_response_body(), Some(body));
         assert_eq!(error.provider_response_status(), None);
@@ -97,11 +105,23 @@ mod provider_response_tests {
     }
 
     #[test]
-    fn verify_error_provider_response_helpers_with_plain_text_provider_body() {
-        let error = VerifyError::ProviderError("not json".to_string());
+    fn verify_error_provider_response_helpers_with_preserved_plain_text_body() {
+        let error = VerifyError::ProviderResponse(provider_response::ProviderResponseError {
+            status: None,
+            body: "not json".to_string(),
+        });
 
         assert_eq!(error.provider_response_body(), Some("not json"));
         assert!(error.provider_response_json().is_err());
+    }
+
+    #[test]
+    fn verify_error_provider_error_is_not_a_provider_response() {
+        let error = VerifyError::ProviderError("internal diagnostic".to_string());
+
+        assert_eq!(error.provider_response_body(), None);
+        assert_eq!(error.provider_response_status(), None);
+        assert_eq!(error.provider_response_json().expect("no body"), None);
     }
 
     #[test]

--- a/crates/rig-core/src/client/verify.rs
+++ b/crates/rig-core/src/client/verify.rs
@@ -1,6 +1,10 @@
 use crate::{http_client, provider_response, wasm_compat::WasmCompatSend};
 use thiserror::Error;
 
+/// Errors from provider client verification.
+///
+/// Inspect provider failures with [`Self::provider_response_body`],
+/// [`Self::provider_response_json`], and [`Self::provider_response_status`].
 #[derive(Debug, Error)]
 pub enum VerifyError {
     #[error("invalid authentication")]

--- a/crates/rig-core/src/client/verify.rs
+++ b/crates/rig-core/src/client/verify.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 /// Inspect provider failures with [`Self::provider_response_body`],
 /// [`Self::provider_response_json`], and [`Self::provider_response_status`].
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum VerifyError {
     #[error("invalid authentication")]
     InvalidAuthentication,
@@ -22,40 +23,7 @@ pub enum VerifyError {
     ),
 }
 
-impl VerifyError {
-    /// Returns the raw provider response body when available.
-    ///
-    /// This is available for:
-    /// - [`VerifyError::ProviderResponse`] using its preserved body.
-    /// - [`VerifyError::HttpError`] when it wraps an HTTP non-success response that carries a body.
-    pub fn provider_response_body(&self) -> Option<&str> {
-        match self {
-            Self::ProviderResponse(response) => Some(response.body.as_str()),
-            Self::HttpError(error) => error.non_success_body(),
-            _ => None,
-        }
-    }
-
-    /// Parses the provider response body as JSON.
-    ///
-    /// Returns:
-    /// - `Ok(Some(value))` when a body is present and valid JSON.
-    /// - `Ok(None)` when no provider response body is available.
-    /// - `Err(error)` when a body is present but isn't valid JSON.
-    pub fn provider_response_json(&self) -> Result<Option<serde_json::Value>, serde_json::Error> {
-        provider_response::json(self.provider_response_body())
-    }
-
-    /// Returns the HTTP status code when this error preserves one, either from a
-    /// non-success HTTP response or from a preserved provider response.
-    pub fn provider_response_status(&self) -> Option<http::StatusCode> {
-        match self {
-            Self::ProviderResponse(response) => response.status,
-            Self::HttpError(error) => error.non_success_status(),
-            _ => None,
-        }
-    }
-}
+crate::provider_response::impl_provider_response_helpers!(VerifyError);
 
 /// A provider client that can verify the configuration.
 /// Clone is required for conversions between client types.
@@ -131,5 +99,37 @@ mod provider_response_tests {
         assert_eq!(error.provider_response_body(), None);
         assert_eq!(error.provider_response_status(), None);
         assert_eq!(error.provider_response_json().expect("no body"), None);
+    }
+
+    #[tokio::test]
+    async fn verify_preserves_status_and_body_on_provider_error_response() {
+        use crate::client::VerifyClient;
+        use crate::providers::openai::Client;
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"error":{"message":"server exploded","type":"server_error"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(StatusCode::INTERNAL_SERVER_ERROR, body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+
+        let error = client
+            .verify()
+            .await
+            .expect_err("verify should fail on a 500 response");
+
+        assert_eq!(
+            error.provider_response_status(),
+            Some(StatusCode::INTERNAL_SERVER_ERROR)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+        let json = error
+            .provider_response_json()
+            .expect("raw body should be valid JSON")
+            .expect("parsed JSON should be present");
+        assert_eq!(json["error"]["type"], "server_error");
     }
 }

--- a/crates/rig-core/src/client/verify.rs
+++ b/crates/rig-core/src/client/verify.rs
@@ -1,4 +1,4 @@
-use crate::{http_client, wasm_compat::WasmCompatSend};
+use crate::{http_client, provider_response, wasm_compat::WasmCompatSend};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -15,9 +15,97 @@ pub enum VerifyError {
     ),
 }
 
+impl VerifyError {
+    /// Returns the raw provider response body when available.
+    ///
+    /// This is available for:
+    /// - [`VerifyError::ProviderError`] using its stored string.
+    /// - [`VerifyError::HttpError`] when it wraps an HTTP non-success response that carries a body.
+    pub fn provider_response_body(&self) -> Option<&str> {
+        match self {
+            Self::ProviderError(body) => provider_response::body(Some(body.as_str()), None),
+            Self::HttpError(error) => provider_response::body(None, Some(error)),
+            _ => None,
+        }
+    }
+
+    /// Parses the provider response body as JSON.
+    ///
+    /// Returns:
+    /// - `Ok(Some(value))` when a body is present and valid JSON.
+    /// - `Ok(None)` when no provider response body is available.
+    /// - `Err(error)` when a body is present but isn't valid JSON.
+    pub fn provider_response_json(&self) -> Result<Option<serde_json::Value>, serde_json::Error> {
+        provider_response::json(self.provider_response_body())
+    }
+
+    /// Returns the HTTP status code when this error comes from a non-success HTTP response.
+    pub fn provider_response_status(&self) -> Option<http::StatusCode> {
+        match self {
+            Self::HttpError(error) => provider_response::status(Some(error)),
+            _ => None,
+        }
+    }
+}
+
 /// A provider client that can verify the configuration.
 /// Clone is required for conversions between client types.
 pub trait VerifyClient {
     /// Verify the configuration.
     fn verify(&self) -> impl Future<Output = Result<(), VerifyError>> + WasmCompatSend;
+}
+
+#[cfg(test)]
+mod provider_response_tests {
+    use super::*;
+    use http::StatusCode;
+
+    #[test]
+    fn verify_error_provider_response_helpers_with_provider_json_body() {
+        let body = r#"{"error":{"message":"rate limited"}}"#;
+        let error = VerifyError::ProviderError(body.to_string());
+
+        assert_eq!(error.provider_response_body(), Some(body));
+        assert_eq!(error.provider_response_status(), None);
+        assert_eq!(
+            error.provider_response_json().expect("valid JSON"),
+            Some(serde_json::json!({ "error": { "message": "rate limited" } }))
+        );
+    }
+
+    #[test]
+    fn verify_error_provider_response_helpers_with_http_non_success() {
+        let body = r#"{"error":{"message":"bad request"}}"#;
+        let error = VerifyError::HttpError(http_client::Error::InvalidStatusCodeWithMessage(
+            StatusCode::BAD_REQUEST,
+            body.to_string(),
+        ));
+
+        assert_eq!(error.provider_response_body(), Some(body));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(StatusCode::BAD_REQUEST)
+        );
+        assert_eq!(
+            error.provider_response_json().expect("valid JSON"),
+            Some(serde_json::json!({ "error": { "message": "bad request" } }))
+        );
+    }
+
+    #[test]
+    fn verify_error_provider_response_helpers_with_plain_text_provider_body() {
+        let error = VerifyError::ProviderError("not json".to_string());
+
+        assert_eq!(error.provider_response_body(), Some("not json"));
+        assert!(error.provider_response_json().is_err());
+    }
+
+    #[test]
+    fn verify_error_provider_response_helpers_with_unrelated_variant() {
+        let error = VerifyError::InvalidAuthentication;
+
+        assert_eq!(error.provider_response_body(), None);
+        assert_eq!(error.provider_response_status(), None);
+        assert_eq!(error.provider_response_json().expect("no body"), None);
+    }
 }

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -118,6 +118,19 @@ impl CompletionError {
             _ => None,
         }
     }
+
+    /// Maps an SSE transport error into a completion error without flattening HTTP failures.
+    ///
+    /// Non-success HTTP responses remain [`CompletionError::HttpError`] so provider response
+    /// helpers can read status and body. Other transport failures keep the existing
+    /// [`CompletionError::ProviderError`] display string behavior.
+    pub(crate) fn from_stream_transport(error: http_client::Error) -> Self {
+        if error.non_success_status().is_some() {
+            Self::HttpError(error)
+        } else {
+            Self::ProviderError(error.to_string())
+        }
+    }
 }
 
 /// Prompt errors

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -59,6 +59,7 @@ use thiserror::Error;
 /// Inspect provider failures with [`Self::provider_response_body`],
 /// [`Self::provider_response_json`], and [`Self::provider_response_status`].
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum CompletionError {
     /// Http error (e.g.: connection error, timeout, etc.)
     #[error("HttpError: {0}")]
@@ -95,40 +96,9 @@ pub enum CompletionError {
     ProviderResponse(provider_response::ProviderResponseError),
 }
 
+crate::provider_response::impl_provider_response_helpers!(CompletionError);
+
 impl CompletionError {
-    /// Returns the raw provider response body when available.
-    ///
-    /// This is available for:
-    /// - [`CompletionError::ProviderResponse`] using its preserved body.
-    /// - [`CompletionError::HttpError`] when it wraps an HTTP non-success response that carries a body.
-    pub fn provider_response_body(&self) -> Option<&str> {
-        match self {
-            Self::ProviderResponse(response) => Some(response.body.as_str()),
-            Self::HttpError(error) => error.non_success_body(),
-            _ => None,
-        }
-    }
-
-    /// Parses the provider response body as JSON.
-    ///
-    /// Returns:
-    /// - `Ok(Some(value))` when a body is present and valid JSON.
-    /// - `Ok(None)` when no provider response body is available.
-    /// - `Err(error)` when a body is present but isn't valid JSON.
-    pub fn provider_response_json(&self) -> Result<Option<serde_json::Value>, serde_json::Error> {
-        provider_response::json(self.provider_response_body())
-    }
-
-    /// Returns the HTTP status code when this error preserves one, either from a
-    /// non-success HTTP response or from a preserved provider response.
-    pub fn provider_response_status(&self) -> Option<http::StatusCode> {
-        match self {
-            Self::ProviderResponse(response) => response.status,
-            Self::HttpError(error) => error.non_success_status(),
-            _ => None,
-        }
-    }
-
     /// Maps an SSE transport error into a completion error without flattening HTTP failures.
     ///
     /// Non-success HTTP responses remain [`CompletionError::HttpError`] so provider response

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -85,6 +85,41 @@ pub enum CompletionError {
     ProviderError(String),
 }
 
+impl CompletionError {
+    /// Returns the raw provider response body when available.
+    ///
+    /// This is available for:
+    /// - [`CompletionError::ProviderError`] using its stored string.
+    /// - [`CompletionError::HttpError`] when it wraps an HTTP non-success response that carries a body.
+    pub fn provider_response_body(&self) -> Option<&str> {
+        match self {
+            Self::ProviderError(body) => Some(body.as_str()),
+            Self::HttpError(error) => error.non_success_body(),
+            _ => None,
+        }
+    }
+
+    /// Parses the provider response body as JSON.
+    ///
+    /// Returns:
+    /// - `Ok(Some(value))` when a body is present and valid JSON.
+    /// - `Ok(None)` when no provider response body is available.
+    /// - `Err(error)` when a body is present but isn't valid JSON.
+    pub fn provider_response_json(&self) -> Result<Option<serde_json::Value>, serde_json::Error> {
+        self.provider_response_body()
+            .map(serde_json::from_str)
+            .transpose()
+    }
+
+    /// Returns the HTTP status code when this error comes from a non-success HTTP response.
+    pub fn provider_response_status(&self) -> Option<http::StatusCode> {
+        match self {
+            Self::HttpError(error) => error.non_success_status(),
+            _ => None,
+        }
+    }
+}
+
 /// Prompt errors
 #[derive(Debug, Error)]
 pub enum PromptError {
@@ -140,6 +175,36 @@ impl From<crate::memory::MemoryError> for PromptError {
 }
 
 impl PromptError {
+    /// Returns the provider response body when this wraps a completion error that exposes one.
+    pub fn provider_response_body(&self) -> Option<&str> {
+        match self {
+            Self::CompletionError(error) => error.provider_response_body(),
+            _ => None,
+        }
+    }
+
+    /// Parses the provider response body as JSON when available through a wrapped completion error.
+    ///
+    /// Returns:
+    /// - `Ok(Some(value))` when a body is present and valid JSON.
+    /// - `Ok(None)` when no provider response body is available.
+    /// - `Err(error)` when a body is present but isn't valid JSON.
+    pub fn provider_response_json(&self) -> Result<Option<serde_json::Value>, serde_json::Error> {
+        match self {
+            Self::CompletionError(error) => error.provider_response_json(),
+            _ => Ok(None),
+        }
+    }
+
+    /// Returns the HTTP status when this wraps a completion error
+    /// originating from a non-success HTTP response.
+    pub fn provider_response_status(&self) -> Option<http::StatusCode> {
+        match self {
+            Self::CompletionError(error) => error.provider_response_status(),
+            _ => None,
+        }
+    }
+
     pub(crate) fn prompt_cancelled(
         chat_history: impl IntoIterator<Item = Message>,
         reason: impl Into<String>,
@@ -1264,5 +1329,130 @@ mod tests {
             .filter(|message| is_document_message(message, "doc1"))
             .count();
         assert_eq!(document_messages, 1);
+    }
+
+    #[test]
+    fn completion_error_provider_response_helpers_with_provider_json_body() {
+        let body = r#"{"error":{"code":"rate_limit","message":"slow down"}}"#;
+        let error = CompletionError::ProviderError(body.to_string());
+
+        assert_eq!(error.provider_response_body(), Some(body));
+        assert_eq!(error.provider_response_status(), None);
+        assert_eq!(
+            error
+                .provider_response_json()
+                .expect("fixture body should parse as valid JSON"),
+            Some(serde_json::json!({
+                "error": {
+                    "code": "rate_limit",
+                    "message": "slow down"
+                }
+            }))
+        );
+    }
+
+    #[test]
+    fn completion_error_provider_response_helpers_with_provider_plain_text_body() {
+        let error = CompletionError::ProviderError("provider exploded".to_string());
+
+        assert_eq!(error.provider_response_body(), Some("provider exploded"));
+        assert_eq!(error.provider_response_status(), None);
+        assert!(error.provider_response_json().is_err());
+    }
+
+    #[test]
+    fn completion_error_provider_response_helpers_with_http_non_success_body_and_status() {
+        let body = r#"{"error":{"type":"invalid_request","message":"bad request"}}"#;
+        let error = CompletionError::HttpError(http_client::Error::InvalidStatusCodeWithMessage(
+            http::StatusCode::BAD_REQUEST,
+            body.to_string(),
+        ));
+
+        assert_eq!(error.provider_response_body(), Some(body));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::BAD_REQUEST)
+        );
+        assert_eq!(
+            error.provider_response_json().expect("valid JSON body"),
+            Some(serde_json::json!({
+                "error": {
+                    "type": "invalid_request",
+                    "message": "bad request"
+                }
+            }))
+        );
+    }
+
+    #[test]
+    fn completion_error_provider_response_helpers_with_unrelated_variant() {
+        let error = CompletionError::ResponseError("failed to parse provider response".to_string());
+
+        assert_eq!(error.provider_response_body(), None);
+        assert_eq!(error.provider_response_status(), None);
+        assert_eq!(
+            error
+                .provider_response_json()
+                .expect("no body is not an error"),
+            None
+        );
+    }
+
+    #[test]
+    fn prompt_error_provider_response_helpers_forward_wrapped_completion_error() {
+        let body = r#"{"error":{"code":"invalid_request","message":"bad input"}}"#;
+        let error = PromptError::CompletionError(CompletionError::ProviderError(body.to_string()));
+
+        assert_eq!(error.provider_response_body(), Some(body));
+        assert_eq!(error.provider_response_status(), None);
+        assert_eq!(
+            error.provider_response_json().expect("valid JSON body"),
+            Some(serde_json::json!({
+                "error": {
+                    "code": "invalid_request",
+                    "message": "bad input"
+                }
+            }))
+        );
+    }
+
+    #[test]
+    fn prompt_error_provider_response_helpers_forward_http_status_and_body() {
+        let body = r#"{"error":{"message":"unauthorized"}}"#;
+        let error = PromptError::CompletionError(CompletionError::HttpError(
+            http_client::Error::InvalidStatusCodeWithMessage(
+                http::StatusCode::UNAUTHORIZED,
+                body.to_string(),
+            ),
+        ));
+
+        assert_eq!(error.provider_response_body(), Some(body));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::UNAUTHORIZED)
+        );
+        assert_eq!(
+            error.provider_response_json().expect("valid JSON body"),
+            Some(serde_json::json!({
+                "error": { "message": "unauthorized" }
+            }))
+        );
+    }
+
+    #[test]
+    fn prompt_error_provider_response_helpers_return_none_for_unrelated_variant() {
+        let error = PromptError::PromptCancelled {
+            chat_history: vec![Message::user("hi")],
+            reason: "cancelled".to_string(),
+        };
+
+        assert_eq!(error.provider_response_body(), None);
+        assert_eq!(error.provider_response_status(), None);
+        assert_eq!(
+            error
+                .provider_response_json()
+                .expect("no body is not an error"),
+            None
+        );
     }
 }

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -193,8 +193,8 @@ impl PromptError {
         }
     }
 
-    /// Returns the HTTP status when this wraps a completion error
-    /// originating from a non-success HTTP response.
+    /// Returns the HTTP status when this wraps a completion error that preserves
+    /// one, including from non-success HTTP responses and 2xx error envelopes.
     pub fn provider_response_status(&self) -> Option<http::StatusCode> {
         match self {
             Self::CompletionError(error) => error.provider_response_status(),
@@ -214,6 +214,11 @@ impl PromptError {
 }
 
 /// Errors that can occur when using typed structured output via [`TypedPrompt::prompt_typed`].
+///
+/// When the failure wraps [`PromptError`] that in turn wraps a [`CompletionError`]
+/// exposing a provider response, [`Self::provider_response_body`],
+/// [`Self::provider_response_json`], and [`Self::provider_response_status`] forward
+/// through the chain.
 #[derive(Debug, Error)]
 pub enum StructuredOutputError {
     /// An error occurred during the prompt execution.
@@ -227,6 +232,37 @@ pub enum StructuredOutputError {
     /// The model returned an empty response.
     #[error("EmptyResponse: model returned no content")]
     EmptyResponse,
+}
+
+impl StructuredOutputError {
+    /// Returns the provider response body when this wraps a prompt error that exposes one.
+    pub fn provider_response_body(&self) -> Option<&str> {
+        match self {
+            Self::PromptError(error) => error.provider_response_body(),
+            _ => None,
+        }
+    }
+
+    /// Parses the provider response body as JSON when available through a wrapped prompt error.
+    ///
+    /// Returns:
+    /// - `Ok(Some(value))` when a body is present and valid JSON.
+    /// - `Ok(None)` when no provider response body is available.
+    /// - `Err(error)` when a body is present but isn't valid JSON.
+    pub fn provider_response_json(&self) -> Result<Option<serde_json::Value>, serde_json::Error> {
+        match self {
+            Self::PromptError(error) => error.provider_response_json(),
+            _ => Ok(None),
+        }
+    }
+
+    /// Returns the HTTP status when this wraps a prompt error that preserves one.
+    pub fn provider_response_status(&self) -> Option<http::StatusCode> {
+        match self {
+            Self::PromptError(error) => error.provider_response_status(),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1491,6 +1527,39 @@ mod tests {
             error
                 .provider_response_json()
                 .expect("no body is not an error"),
+            None
+        );
+    }
+
+    #[test]
+    fn structured_output_error_provider_response_helpers_forward_prompt_error() {
+        let body = r#"{"error":{"message":"bad input"}}"#;
+        let error = StructuredOutputError::PromptError(Box::new(PromptError::CompletionError(
+            CompletionError::ProviderResponse(provider_response::ProviderResponseError {
+                status: Some(http::StatusCode::BAD_REQUEST),
+                body: body.to_string(),
+            }),
+        )));
+
+        assert_eq!(error.provider_response_body(), Some(body));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::BAD_REQUEST)
+        );
+    }
+
+    #[test]
+    fn provider_response_json_returns_none_for_empty_preserved_body() {
+        let error = CompletionError::ProviderResponse(provider_response::ProviderResponseError {
+            status: None,
+            body: String::new(),
+        });
+
+        assert_eq!(error.provider_response_body(), Some(""));
+        assert_eq!(
+            error
+                .provider_response_json()
+                .expect("empty body is not a JSON parse error"),
             None
         );
     }

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -89,18 +89,22 @@ pub enum CompletionError {
     /// Error returned by the completion model provider
     #[error("ProviderError: {0}")]
     ProviderError(String),
+
+    /// Raw error response preserved from the completion model provider
+    #[error("ProviderResponseError: {0}")]
+    ProviderResponse(provider_response::ProviderResponseError),
 }
 
 impl CompletionError {
     /// Returns the raw provider response body when available.
     ///
     /// This is available for:
-    /// - [`CompletionError::ProviderError`] using its stored string.
+    /// - [`CompletionError::ProviderResponse`] using its preserved body.
     /// - [`CompletionError::HttpError`] when it wraps an HTTP non-success response that carries a body.
     pub fn provider_response_body(&self) -> Option<&str> {
         match self {
-            Self::ProviderError(body) => provider_response::body(Some(body.as_str()), None),
-            Self::HttpError(error) => provider_response::body(None, Some(error)),
+            Self::ProviderResponse(response) => Some(response.body.as_str()),
+            Self::HttpError(error) => error.non_success_body(),
             _ => None,
         }
     }
@@ -115,10 +119,12 @@ impl CompletionError {
         provider_response::json(self.provider_response_body())
     }
 
-    /// Returns the HTTP status code when this error comes from a non-success HTTP response.
+    /// Returns the HTTP status code when this error preserves one, either from a
+    /// non-success HTTP response or from a preserved provider response.
     pub fn provider_response_status(&self) -> Option<http::StatusCode> {
         match self {
-            Self::HttpError(error) => provider_response::status(Some(error)),
+            Self::ProviderResponse(response) => response.status,
+            Self::HttpError(error) => error.non_success_status(),
             _ => None,
         }
     }
@@ -1353,9 +1359,12 @@ mod tests {
     }
 
     #[test]
-    fn completion_error_provider_response_helpers_with_provider_json_body() {
+    fn completion_error_provider_response_helpers_with_preserved_json_body() {
         let body = r#"{"error":{"code":"rate_limit","message":"slow down"}}"#;
-        let error = CompletionError::ProviderError(body.to_string());
+        let error = CompletionError::ProviderResponse(provider_response::ProviderResponseError {
+            status: None,
+            body: body.to_string(),
+        });
 
         assert_eq!(error.provider_response_body(), Some(body));
         assert_eq!(error.provider_response_status(), None);
@@ -1373,12 +1382,46 @@ mod tests {
     }
 
     #[test]
-    fn completion_error_provider_response_helpers_with_provider_plain_text_body() {
-        let error = CompletionError::ProviderError("provider exploded".to_string());
+    fn completion_error_provider_response_helpers_with_preserved_status() {
+        let body = r#"{"error":{"message":"too many requests"}}"#;
+        let error = CompletionError::ProviderResponse(provider_response::ProviderResponseError {
+            status: Some(http::StatusCode::TOO_MANY_REQUESTS),
+            body: body.to_string(),
+        });
+
+        assert_eq!(error.provider_response_body(), Some(body));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::TOO_MANY_REQUESTS)
+        );
+    }
+
+    #[test]
+    fn completion_error_provider_response_helpers_with_preserved_plain_text_body() {
+        let error = CompletionError::ProviderResponse(provider_response::ProviderResponseError {
+            status: None,
+            body: "provider exploded".to_string(),
+        });
 
         assert_eq!(error.provider_response_body(), Some("provider exploded"));
         assert_eq!(error.provider_response_status(), None);
         assert!(error.provider_response_json().is_err());
+    }
+
+    #[test]
+    fn completion_error_provider_error_is_not_a_provider_response() {
+        // `ProviderError` also carries Rig-generated diagnostics, so the helpers
+        // must not report its string as a provider response body.
+        let error = CompletionError::ProviderError("stream transport failed".to_string());
+
+        assert_eq!(error.provider_response_body(), None);
+        assert_eq!(error.provider_response_status(), None);
+        assert_eq!(
+            error
+                .provider_response_json()
+                .expect("no body is not an error"),
+            None
+        );
     }
 
     #[test]
@@ -1422,7 +1465,12 @@ mod tests {
     #[test]
     fn prompt_error_provider_response_helpers_forward_wrapped_completion_error() {
         let body = r#"{"error":{"code":"invalid_request","message":"bad input"}}"#;
-        let error = PromptError::CompletionError(CompletionError::ProviderError(body.to_string()));
+        let error = PromptError::CompletionError(CompletionError::ProviderResponse(
+            provider_response::ProviderResponseError {
+                status: None,
+                body: body.to_string(),
+            },
+        ));
 
         assert_eq!(error.provider_response_body(), Some(body));
         assert_eq!(error.provider_response_status(), None);

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -36,6 +36,7 @@
 
 use super::message::{AssistantContent, DocumentMediaType};
 use crate::message::ToolChoice;
+use crate::provider_response;
 use crate::streaming::StreamingCompletionResponse;
 use crate::tool::server::ToolServerError;
 use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
@@ -45,6 +46,7 @@ use crate::{
     message::{Message, UserContent},
     tool::ToolSetError,
 };
+
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -93,8 +95,8 @@ impl CompletionError {
     /// - [`CompletionError::HttpError`] when it wraps an HTTP non-success response that carries a body.
     pub fn provider_response_body(&self) -> Option<&str> {
         match self {
-            Self::ProviderError(body) => Some(body.as_str()),
-            Self::HttpError(error) => error.non_success_body(),
+            Self::ProviderError(body) => provider_response::body(Some(body.as_str()), None),
+            Self::HttpError(error) => provider_response::body(None, Some(error)),
             _ => None,
         }
     }
@@ -106,15 +108,13 @@ impl CompletionError {
     /// - `Ok(None)` when no provider response body is available.
     /// - `Err(error)` when a body is present but isn't valid JSON.
     pub fn provider_response_json(&self) -> Result<Option<serde_json::Value>, serde_json::Error> {
-        self.provider_response_body()
-            .map(serde_json::from_str)
-            .transpose()
+        provider_response::json(self.provider_response_body())
     }
 
     /// Returns the HTTP status code when this error comes from a non-success HTTP response.
     pub fn provider_response_status(&self) -> Option<http::StatusCode> {
         match self {
-            Self::HttpError(error) => error.non_success_status(),
+            Self::HttpError(error) => provider_response::status(Some(error)),
             _ => None,
         }
     }

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -54,6 +54,10 @@ use std::ops::{Add, AddAssign};
 use thiserror::Error;
 
 // Errors
+/// Errors returned by completion models.
+///
+/// Inspect provider failures with [`Self::provider_response_body`],
+/// [`Self::provider_response_json`], and [`Self::provider_response_status`].
 #[derive(Debug, Error)]
 pub enum CompletionError {
     /// Http error (e.g.: connection error, timeout, etc.)
@@ -133,7 +137,11 @@ impl CompletionError {
     }
 }
 
-/// Prompt errors
+/// Errors from agent prompting.
+///
+/// When the failure wraps [`CompletionError`], [`Self::provider_response_body`],
+/// [`Self::provider_response_json`], and [`Self::provider_response_status`] forward
+/// to the inner completion error's helpers.
 #[derive(Debug, Error)]
 pub enum PromptError {
     /// Something went wrong with the completion

--- a/crates/rig-core/src/embeddings/embedding.rs
+++ b/crates/rig-core/src/embeddings/embedding.rs
@@ -13,6 +13,10 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 
+/// Errors returned by embedding models.
+///
+/// Inspect provider failures with [`Self::provider_response_body`],
+/// [`Self::provider_response_json`], and [`Self::provider_response_status`].
 #[derive(Debug, thiserror::Error)]
 pub enum EmbeddingError {
     /// Http error (e.g.: connection error, timeout, etc.)

--- a/crates/rig-core/src/embeddings/embedding.rs
+++ b/crates/rig-core/src/embeddings/embedding.rs
@@ -48,18 +48,22 @@ pub enum EmbeddingError {
     /// Error returned by the embedding model provider
     #[error("ProviderError: {0}")]
     ProviderError(String),
+
+    /// Raw error response preserved from the embedding model provider
+    #[error("ProviderResponseError: {0}")]
+    ProviderResponse(provider_response::ProviderResponseError),
 }
 
 impl EmbeddingError {
     /// Returns the raw provider response body when available.
     ///
     /// This is available for:
-    /// - [`EmbeddingError::ProviderError`] using its stored string.
+    /// - [`EmbeddingError::ProviderResponse`] using its preserved body.
     /// - [`EmbeddingError::HttpError`] when it wraps an HTTP non-success response that carries a body.
     pub fn provider_response_body(&self) -> Option<&str> {
         match self {
-            Self::ProviderError(body) => provider_response::body(Some(body.as_str()), None),
-            Self::HttpError(error) => provider_response::body(None, Some(error)),
+            Self::ProviderResponse(response) => Some(response.body.as_str()),
+            Self::HttpError(error) => error.non_success_body(),
             _ => None,
         }
     }
@@ -74,10 +78,12 @@ impl EmbeddingError {
         provider_response::json(self.provider_response_body())
     }
 
-    /// Returns the HTTP status code when this error comes from a non-success HTTP response.
+    /// Returns the HTTP status code when this error preserves one, either from a
+    /// non-success HTTP response or from a preserved provider response.
     pub fn provider_response_status(&self) -> Option<http::StatusCode> {
         match self {
-            Self::HttpError(error) => provider_response::status(Some(error)),
+            Self::ProviderResponse(response) => response.status,
+            Self::HttpError(error) => error.non_success_status(),
             _ => None,
         }
     }
@@ -223,9 +229,12 @@ mod provider_response_tests {
     use http::StatusCode;
 
     #[test]
-    fn embedding_error_provider_response_helpers_with_provider_json_body() {
+    fn embedding_error_provider_response_helpers_with_preserved_json_body() {
         let body = r#"{"error":{"message":"rate limited"}}"#;
-        let error = EmbeddingError::ProviderError(body.to_string());
+        let error = EmbeddingError::ProviderResponse(provider_response::ProviderResponseError {
+            status: None,
+            body: body.to_string(),
+        });
 
         assert_eq!(error.provider_response_body(), Some(body));
         assert_eq!(error.provider_response_status(), None);
@@ -233,6 +242,15 @@ mod provider_response_tests {
             error.provider_response_json().expect("valid JSON"),
             Some(serde_json::json!({ "error": { "message": "rate limited" } }))
         );
+    }
+
+    #[test]
+    fn embedding_error_provider_error_is_not_a_provider_response() {
+        let error = EmbeddingError::ProviderError("internal diagnostic".to_string());
+
+        assert_eq!(error.provider_response_body(), None);
+        assert_eq!(error.provider_response_status(), None);
+        assert_eq!(error.provider_response_json().expect("no body"), None);
     }
 
     #[test]
@@ -255,8 +273,11 @@ mod provider_response_tests {
     }
 
     #[test]
-    fn embedding_error_provider_response_helpers_with_plain_text_provider_body() {
-        let error = EmbeddingError::ProviderError("not json".to_string());
+    fn embedding_error_provider_response_helpers_with_preserved_plain_text_body() {
+        let error = EmbeddingError::ProviderResponse(provider_response::ProviderResponseError {
+            status: None,
+            body: "not json".to_string(),
+        });
 
         assert_eq!(error.provider_response_body(), Some("not json"));
         assert!(error.provider_response_json().is_err());

--- a/crates/rig-core/src/embeddings/embedding.rs
+++ b/crates/rig-core/src/embeddings/embedding.rs
@@ -8,7 +8,7 @@
 
 use crate::{
     completion::Usage,
-    http_client,
+    http_client, provider_response,
     wasm_compat::{WasmCompatSend, WasmCompatSync},
 };
 use serde::{Deserialize, Serialize};
@@ -44,6 +44,39 @@ pub enum EmbeddingError {
     /// Error returned by the embedding model provider
     #[error("ProviderError: {0}")]
     ProviderError(String),
+}
+
+impl EmbeddingError {
+    /// Returns the raw provider response body when available.
+    ///
+    /// This is available for:
+    /// - [`EmbeddingError::ProviderError`] using its stored string.
+    /// - [`EmbeddingError::HttpError`] when it wraps an HTTP non-success response that carries a body.
+    pub fn provider_response_body(&self) -> Option<&str> {
+        match self {
+            Self::ProviderError(body) => provider_response::body(Some(body.as_str()), None),
+            Self::HttpError(error) => provider_response::body(None, Some(error)),
+            _ => None,
+        }
+    }
+
+    /// Parses the provider response body as JSON.
+    ///
+    /// Returns:
+    /// - `Ok(Some(value))` when a body is present and valid JSON.
+    /// - `Ok(None)` when no provider response body is available.
+    /// - `Err(error)` when a body is present but isn't valid JSON.
+    pub fn provider_response_json(&self) -> Result<Option<serde_json::Value>, serde_json::Error> {
+        provider_response::json(self.provider_response_body())
+    }
+
+    /// Returns the HTTP status code when this error comes from a non-success HTTP response.
+    pub fn provider_response_status(&self) -> Option<http::StatusCode> {
+        match self {
+            Self::HttpError(error) => provider_response::status(Some(error)),
+            _ => None,
+        }
+    }
 }
 
 /// Trait for embedding models that can generate embeddings for documents.
@@ -179,3 +212,58 @@ impl PartialEq for Embedding {
 }
 
 impl Eq for Embedding {}
+
+#[cfg(test)]
+mod provider_response_tests {
+    use super::*;
+    use http::StatusCode;
+
+    #[test]
+    fn embedding_error_provider_response_helpers_with_provider_json_body() {
+        let body = r#"{"error":{"message":"rate limited"}}"#;
+        let error = EmbeddingError::ProviderError(body.to_string());
+
+        assert_eq!(error.provider_response_body(), Some(body));
+        assert_eq!(error.provider_response_status(), None);
+        assert_eq!(
+            error.provider_response_json().expect("valid JSON"),
+            Some(serde_json::json!({ "error": { "message": "rate limited" } }))
+        );
+    }
+
+    #[test]
+    fn embedding_error_provider_response_helpers_with_http_non_success() {
+        let body = r#"{"error":{"message":"bad request"}}"#;
+        let error = EmbeddingError::HttpError(http_client::Error::InvalidStatusCodeWithMessage(
+            StatusCode::BAD_REQUEST,
+            body.to_string(),
+        ));
+
+        assert_eq!(error.provider_response_body(), Some(body));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(StatusCode::BAD_REQUEST)
+        );
+        assert_eq!(
+            error.provider_response_json().expect("valid JSON"),
+            Some(serde_json::json!({ "error": { "message": "bad request" } }))
+        );
+    }
+
+    #[test]
+    fn embedding_error_provider_response_helpers_with_plain_text_provider_body() {
+        let error = EmbeddingError::ProviderError("not json".to_string());
+
+        assert_eq!(error.provider_response_body(), Some("not json"));
+        assert!(error.provider_response_json().is_err());
+    }
+
+    #[test]
+    fn embedding_error_provider_response_helpers_with_unrelated_variant() {
+        let error = EmbeddingError::ResponseError("parse failed".to_string());
+
+        assert_eq!(error.provider_response_body(), None);
+        assert_eq!(error.provider_response_status(), None);
+        assert_eq!(error.provider_response_json().expect("no body"), None);
+    }
+}

--- a/crates/rig-core/src/embeddings/embedding.rs
+++ b/crates/rig-core/src/embeddings/embedding.rs
@@ -18,6 +18,7 @@ use serde::{Deserialize, Serialize};
 /// Inspect provider failures with [`Self::provider_response_body`],
 /// [`Self::provider_response_json`], and [`Self::provider_response_status`].
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum EmbeddingError {
     /// Http error (e.g.: connection error, timeout, etc.)
     #[error("HttpError: {0}")]
@@ -54,40 +55,7 @@ pub enum EmbeddingError {
     ProviderResponse(provider_response::ProviderResponseError),
 }
 
-impl EmbeddingError {
-    /// Returns the raw provider response body when available.
-    ///
-    /// This is available for:
-    /// - [`EmbeddingError::ProviderResponse`] using its preserved body.
-    /// - [`EmbeddingError::HttpError`] when it wraps an HTTP non-success response that carries a body.
-    pub fn provider_response_body(&self) -> Option<&str> {
-        match self {
-            Self::ProviderResponse(response) => Some(response.body.as_str()),
-            Self::HttpError(error) => error.non_success_body(),
-            _ => None,
-        }
-    }
-
-    /// Parses the provider response body as JSON.
-    ///
-    /// Returns:
-    /// - `Ok(Some(value))` when a body is present and valid JSON.
-    /// - `Ok(None)` when no provider response body is available.
-    /// - `Err(error)` when a body is present but isn't valid JSON.
-    pub fn provider_response_json(&self) -> Result<Option<serde_json::Value>, serde_json::Error> {
-        provider_response::json(self.provider_response_body())
-    }
-
-    /// Returns the HTTP status code when this error preserves one, either from a
-    /// non-success HTTP response or from a preserved provider response.
-    pub fn provider_response_status(&self) -> Option<http::StatusCode> {
-        match self {
-            Self::ProviderResponse(response) => response.status,
-            Self::HttpError(error) => error.non_success_status(),
-            _ => None,
-        }
-    }
-}
+crate::provider_response::impl_provider_response_helpers!(EmbeddingError);
 
 /// Trait for embedding models that can generate embeddings for documents.
 pub trait EmbeddingModel: WasmCompatSend + WasmCompatSync {

--- a/crates/rig-core/src/http_client/mod.rs
+++ b/crates/rig-core/src/http_client/mod.rs
@@ -36,6 +36,24 @@ pub enum Error {
     Instance(#[from] Box<dyn std::error::Error + 'static>),
 }
 
+impl Error {
+    pub(crate) fn non_success_status(&self) -> Option<StatusCode> {
+        match self {
+            Self::InvalidStatusCode(status) | Self::InvalidStatusCodeWithMessage(status, _) => {
+                Some(*status)
+            }
+            _ => None,
+        }
+    }
+
+    pub(crate) fn non_success_body(&self) -> Option<&str> {
+        match self {
+            Self::InvalidStatusCodeWithMessage(_, body) => Some(body.as_str()),
+            _ => None,
+        }
+    }
+}
+
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[cfg(not(target_family = "wasm"))]

--- a/crates/rig-core/src/image_generation.rs
+++ b/crates/rig-core/src/image_generation.rs
@@ -5,6 +5,10 @@ use crate::{http_client, provider_response};
 use serde_json::Value;
 use thiserror::Error;
 
+/// Errors returned by image generation models.
+///
+/// Inspect provider failures with [`Self::provider_response_body`],
+/// [`Self::provider_response_json`], and [`Self::provider_response_status`].
 #[derive(Debug, Error)]
 pub enum ImageGenerationError {
     /// Http error (e.g.: connection error, timeout, etc.)

--- a/crates/rig-core/src/image_generation.rs
+++ b/crates/rig-core/src/image_generation.rs
@@ -10,6 +10,7 @@ use thiserror::Error;
 /// Inspect provider failures with [`Self::provider_response_body`],
 /// [`Self::provider_response_json`], and [`Self::provider_response_status`].
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ImageGenerationError {
     /// Http error (e.g.: connection error, timeout, etc.)
     #[error("HttpError: {0}")]
@@ -36,40 +37,7 @@ pub enum ImageGenerationError {
     ProviderResponse(provider_response::ProviderResponseError),
 }
 
-impl ImageGenerationError {
-    /// Returns the raw provider response body when available.
-    ///
-    /// This is available for:
-    /// - [`ImageGenerationError::ProviderResponse`] using its preserved body.
-    /// - [`ImageGenerationError::HttpError`] when it wraps an HTTP non-success response that carries a body.
-    pub fn provider_response_body(&self) -> Option<&str> {
-        match self {
-            Self::ProviderResponse(response) => Some(response.body.as_str()),
-            Self::HttpError(error) => error.non_success_body(),
-            _ => None,
-        }
-    }
-
-    /// Parses the provider response body as JSON.
-    ///
-    /// Returns:
-    /// - `Ok(Some(value))` when a body is present and valid JSON.
-    /// - `Ok(None)` when no provider response body is available.
-    /// - `Err(error)` when a body is present but isn't valid JSON.
-    pub fn provider_response_json(&self) -> Result<Option<serde_json::Value>, serde_json::Error> {
-        provider_response::json(self.provider_response_body())
-    }
-
-    /// Returns the HTTP status code when this error preserves one, either from a
-    /// non-success HTTP response or from a preserved provider response.
-    pub fn provider_response_status(&self) -> Option<http::StatusCode> {
-        match self {
-            Self::ProviderResponse(response) => response.status,
-            Self::HttpError(error) => error.non_success_status(),
-            _ => None,
-        }
-    }
-}
+crate::provider_response::impl_provider_response_helpers!(ImageGenerationError);
 
 pub trait ImageGeneration<M>
 where

--- a/crates/rig-core/src/image_generation.rs
+++ b/crates/rig-core/src/image_generation.rs
@@ -1,7 +1,7 @@
 //! Everything related to core image generation abstractions in Rig.
 //! Rig allows calling a number of different providers (that support image generation) using the [ImageGenerationModel] trait.
-use crate::http_client;
 use crate::markers::{Missing, Provided};
+use crate::{http_client, provider_response};
 use serde_json::Value;
 use thiserror::Error;
 
@@ -15,18 +15,52 @@ pub enum ImageGenerationError {
     #[error("JsonError: {0}")]
     JsonError(#[from] serde_json::Error),
 
-    /// Error building the transcription request
+    /// Error building the image generation request
     #[error("RequestError: {0}")]
     RequestError(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
 
-    /// Error parsing the transcription response
+    /// Error parsing the image generation response
     #[error("ResponseError: {0}")]
     ResponseError(String),
 
-    /// Error returned by the transcription model provider
+    /// Error returned by the image generation model provider
     #[error("ProviderError: {0}")]
     ProviderError(String),
 }
+
+impl ImageGenerationError {
+    /// Returns the raw provider response body when available.
+    ///
+    /// This is available for:
+    /// - [`ImageGenerationError::ProviderError`] using its stored string.
+    /// - [`ImageGenerationError::HttpError`] when it wraps an HTTP non-success response that carries a body.
+    pub fn provider_response_body(&self) -> Option<&str> {
+        match self {
+            Self::ProviderError(body) => provider_response::body(Some(body.as_str()), None),
+            Self::HttpError(error) => provider_response::body(None, Some(error)),
+            _ => None,
+        }
+    }
+
+    /// Parses the provider response body as JSON.
+    ///
+    /// Returns:
+    /// - `Ok(Some(value))` when a body is present and valid JSON.
+    /// - `Ok(None)` when no provider response body is available.
+    /// - `Err(error)` when a body is present but isn't valid JSON.
+    pub fn provider_response_json(&self) -> Result<Option<serde_json::Value>, serde_json::Error> {
+        provider_response::json(self.provider_response_body())
+    }
+
+    /// Returns the HTTP status code when this error comes from a non-success HTTP response.
+    pub fn provider_response_status(&self) -> Option<http::StatusCode> {
+        match self {
+            Self::HttpError(error) => provider_response::status(Some(error)),
+            _ => None,
+        }
+    }
+}
+
 pub trait ImageGeneration<M>
 where
     M: ImageGenerationModel,
@@ -162,5 +196,53 @@ where
         let model = self.model.clone();
 
         model.image_generation(self.build()).await
+    }
+}
+
+#[cfg(test)]
+mod provider_response_tests {
+    use super::*;
+    use http::StatusCode;
+
+    #[test]
+    fn image_generation_error_provider_response_helpers_with_provider_json_body() {
+        let body = r#"{"error":{"message":"content policy"}}"#;
+        let error = ImageGenerationError::ProviderError(body.to_string());
+
+        assert_eq!(error.provider_response_body(), Some(body));
+        assert_eq!(error.provider_response_status(), None);
+        assert_eq!(
+            error.provider_response_json().expect("valid JSON"),
+            Some(serde_json::json!({ "error": { "message": "content policy" } }))
+        );
+    }
+
+    #[test]
+    fn image_generation_error_provider_response_helpers_with_http_non_success() {
+        let body = r#"{"error":{"message":"bad request"}}"#;
+        let error =
+            ImageGenerationError::HttpError(http_client::Error::InvalidStatusCodeWithMessage(
+                StatusCode::BAD_REQUEST,
+                body.to_string(),
+            ));
+
+        assert_eq!(error.provider_response_body(), Some(body));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(StatusCode::BAD_REQUEST)
+        );
+        assert_eq!(
+            error.provider_response_json().expect("valid JSON"),
+            Some(serde_json::json!({ "error": { "message": "bad request" } }))
+        );
+    }
+
+    #[test]
+    fn image_generation_error_provider_response_helpers_with_unrelated_variant() {
+        let error = ImageGenerationError::ResponseError("parse failed".to_string());
+
+        assert_eq!(error.provider_response_body(), None);
+        assert_eq!(error.provider_response_status(), None);
+        assert_eq!(error.provider_response_json().expect("no body"), None);
     }
 }

--- a/crates/rig-core/src/image_generation.rs
+++ b/crates/rig-core/src/image_generation.rs
@@ -30,18 +30,22 @@ pub enum ImageGenerationError {
     /// Error returned by the image generation model provider
     #[error("ProviderError: {0}")]
     ProviderError(String),
+
+    /// Raw error response preserved from the image generation model provider
+    #[error("ProviderResponseError: {0}")]
+    ProviderResponse(provider_response::ProviderResponseError),
 }
 
 impl ImageGenerationError {
     /// Returns the raw provider response body when available.
     ///
     /// This is available for:
-    /// - [`ImageGenerationError::ProviderError`] using its stored string.
+    /// - [`ImageGenerationError::ProviderResponse`] using its preserved body.
     /// - [`ImageGenerationError::HttpError`] when it wraps an HTTP non-success response that carries a body.
     pub fn provider_response_body(&self) -> Option<&str> {
         match self {
-            Self::ProviderError(body) => provider_response::body(Some(body.as_str()), None),
-            Self::HttpError(error) => provider_response::body(None, Some(error)),
+            Self::ProviderResponse(response) => Some(response.body.as_str()),
+            Self::HttpError(error) => error.non_success_body(),
             _ => None,
         }
     }
@@ -56,10 +60,12 @@ impl ImageGenerationError {
         provider_response::json(self.provider_response_body())
     }
 
-    /// Returns the HTTP status code when this error comes from a non-success HTTP response.
+    /// Returns the HTTP status code when this error preserves one, either from a
+    /// non-success HTTP response or from a preserved provider response.
     pub fn provider_response_status(&self) -> Option<http::StatusCode> {
         match self {
-            Self::HttpError(error) => provider_response::status(Some(error)),
+            Self::ProviderResponse(response) => response.status,
+            Self::HttpError(error) => error.non_success_status(),
             _ => None,
         }
     }
@@ -209,9 +215,13 @@ mod provider_response_tests {
     use http::StatusCode;
 
     #[test]
-    fn image_generation_error_provider_response_helpers_with_provider_json_body() {
+    fn image_generation_error_provider_response_helpers_with_preserved_json_body() {
         let body = r#"{"error":{"message":"content policy"}}"#;
-        let error = ImageGenerationError::ProviderError(body.to_string());
+        let error =
+            ImageGenerationError::ProviderResponse(provider_response::ProviderResponseError {
+                status: None,
+                body: body.to_string(),
+            });
 
         assert_eq!(error.provider_response_body(), Some(body));
         assert_eq!(error.provider_response_status(), None);
@@ -239,6 +249,15 @@ mod provider_response_tests {
             error.provider_response_json().expect("valid JSON"),
             Some(serde_json::json!({ "error": { "message": "bad request" } }))
         );
+    }
+
+    #[test]
+    fn image_generation_error_provider_error_is_not_a_provider_response() {
+        let error = ImageGenerationError::ProviderError("internal diagnostic".to_string());
+
+        assert_eq!(error.provider_response_body(), None);
+        assert_eq!(error.provider_response_status(), None);
+        assert_eq!(error.provider_response_json().expect("no body"), None);
     }
 
     #[test]

--- a/crates/rig-core/src/image_generation.rs
+++ b/crates/rig-core/src/image_generation.rs
@@ -43,9 +43,9 @@ pub trait ImageGeneration<M>
 where
     M: ImageGenerationModel,
 {
-    /// Generates a transcription request builder for the given `file`.
+    /// Generates an image generation request builder for the given prompt and size.
     /// This function is meant to be called by the user to further customize the
-    /// request at transcription time before sending it.
+    /// request at image generation time before sending it.
     ///
     /// ❗IMPORTANT: The type that implements this trait might have already
     /// populated fields in the builder (the exact fields depend on the type).

--- a/crates/rig-core/src/lib.rs
+++ b/crates/rig-core/src/lib.rs
@@ -186,6 +186,7 @@ pub use completion::message;
 pub use embeddings::Embed;
 pub use extractor::ExtractionResponse;
 pub use one_or_many::{EmptyListError, OneOrMany};
+pub use provider_response::ProviderResponseError;
 pub use schemars;
 
 #[cfg(feature = "derive")]

--- a/crates/rig-core/src/lib.rs
+++ b/crates/rig-core/src/lib.rs
@@ -168,6 +168,7 @@ pub mod model;
 pub mod one_or_many;
 pub mod pipeline;
 pub mod prelude;
+pub(crate) mod provider_response;
 pub mod providers;
 
 pub mod streaming;

--- a/crates/rig-core/src/provider_response.rs
+++ b/crates/rig-core/src/provider_response.rs
@@ -35,3 +35,59 @@ impl std::error::Error for ProviderResponseError {}
 pub(crate) fn json(body: Option<&str>) -> Result<Option<serde_json::Value>, serde_json::Error> {
     body.map(serde_json::from_str).transpose()
 }
+
+/// Implements the `provider_response_*` inspection helpers on a capability error
+/// enum.
+///
+/// The enum must have a `ProviderResponse(`[`ProviderResponseError`]`)` variant
+/// and an `HttpError(`[`http_client::Error`](crate::http_client::Error)`)`
+/// variant; the generated helpers read from those two sources only, since they
+/// are the only ones that genuinely represent a provider's response.
+macro_rules! impl_provider_response_helpers {
+    ($error:ty) => {
+        impl $error {
+            /// Returns the raw provider response body when available.
+            ///
+            /// This is available for:
+            /// - `Self::ProviderResponse` using its preserved body.
+            /// - `Self::HttpError` when it wraps an HTTP non-success response that
+            ///   carries a body.
+            ///
+            /// Availability depends on the provider path preserving the response
+            /// body; not every provider is covered yet, so this can return `None`
+            /// for failures from providers that haven't been wired up.
+            pub fn provider_response_body(&self) -> Option<&str> {
+                match self {
+                    Self::ProviderResponse(response) => Some(response.body.as_str()),
+                    Self::HttpError(error) => error.non_success_body(),
+                    _ => None,
+                }
+            }
+
+            /// Parses the provider response body as JSON.
+            ///
+            /// Returns:
+            /// - `Ok(Some(value))` when a body is present and valid JSON.
+            /// - `Ok(None)` when no provider response body is available.
+            /// - `Err(error)` when a body is present but isn't valid JSON.
+            pub fn provider_response_json(
+                &self,
+            ) -> Result<Option<serde_json::Value>, serde_json::Error> {
+                $crate::provider_response::json(self.provider_response_body())
+            }
+
+            /// Returns the HTTP status code when this error preserves one, either
+            /// from a non-success HTTP response or from a preserved provider
+            /// response.
+            pub fn provider_response_status(&self) -> Option<http::StatusCode> {
+                match self {
+                    Self::ProviderResponse(response) => response.status,
+                    Self::HttpError(error) => error.non_success_status(),
+                    _ => None,
+                }
+            }
+        }
+    };
+}
+
+pub(crate) use impl_provider_response_helpers;

--- a/crates/rig-core/src/provider_response.rs
+++ b/crates/rig-core/src/provider_response.rs
@@ -1,25 +1,30 @@
 //! Shared logic for inspecting provider error response bodies across capability errors.
-use crate::http_client;
 use http::StatusCode;
 
-/// Returns the best available provider response body for an error.
+/// A raw error response preserved from a provider.
 ///
-/// Prefers an explicitly supplied provider body, and falls back to the
-/// non-success body captured on the HTTP client error.
-pub(crate) fn body<'a>(
-    provider_body: Option<&'a str>,
-    http_error: Option<&'a http_client::Error>,
-) -> Option<&'a str> {
-    if let Some(body) = provider_body {
-        return Some(body);
-    }
-
-    if let Some(error) = http_error {
-        return error.non_success_body();
-    }
-
-    None
+/// Capability errors store this in their `ProviderResponse` variants when Rig
+/// has the provider's response body in hand. Unlike `ProviderError(String)`,
+/// which may carry Rig-generated diagnostics, this type always represents the
+/// payload the provider actually returned.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderResponseError {
+    /// HTTP status of the provider response, when it was captured alongside the body.
+    pub status: Option<StatusCode>,
+    /// Raw response body as returned by the provider.
+    pub body: String,
 }
+
+impl std::fmt::Display for ProviderResponseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.status {
+            Some(status) => write!(f, "status {status}: {}", self.body),
+            None => write!(f, "{}", self.body),
+        }
+    }
+}
+
+impl std::error::Error for ProviderResponseError {}
 
 /// Parses an optional response body as JSON.
 ///
@@ -29,12 +34,4 @@ pub(crate) fn body<'a>(
 /// - `Err(error)` when a body is present but isn't valid JSON.
 pub(crate) fn json(body: Option<&str>) -> Result<Option<serde_json::Value>, serde_json::Error> {
     body.map(serde_json::from_str).transpose()
-}
-
-/// Returns the non-success HTTP status from an HTTP client error, when present.
-pub(crate) fn status(http_error: Option<&http_client::Error>) -> Option<StatusCode> {
-    if let Some(error) = http_error {
-        return error.non_success_status();
-    }
-    None
 }

--- a/crates/rig-core/src/provider_response.rs
+++ b/crates/rig-core/src/provider_response.rs
@@ -15,6 +15,15 @@ pub struct ProviderResponseError {
     pub body: String,
 }
 
+impl ProviderResponseError {
+    pub(crate) fn without_status(body: impl Into<String>) -> Self {
+        Self {
+            status: None,
+            body: body.into(),
+        }
+    }
+}
+
 impl std::fmt::Display for ProviderResponseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.status {
@@ -33,7 +42,17 @@ impl std::error::Error for ProviderResponseError {}
 /// - `Ok(None)` when no body is present.
 /// - `Err(error)` when a body is present but isn't valid JSON.
 pub(crate) fn json(body: Option<&str>) -> Result<Option<serde_json::Value>, serde_json::Error> {
-    body.map(serde_json::from_str).transpose()
+    body.filter(|body| !body.is_empty())
+        .map(serde_json::from_str)
+        .transpose()
+}
+
+pub(crate) fn completion_error_from_body(
+    body: impl Into<String>,
+) -> crate::completion::CompletionError {
+    crate::completion::CompletionError::ProviderResponse(ProviderResponseError::without_status(
+        body,
+    ))
 }
 
 /// Implements the `provider_response_*` inspection helpers on a capability error
@@ -77,8 +96,8 @@ macro_rules! impl_provider_response_helpers {
             }
 
             /// Returns the HTTP status code when this error preserves one, either
-            /// from a non-success HTTP response or from a preserved provider
-            /// response.
+            /// from a non-success HTTP response, from a preserved provider
+            /// response, or from a 2xx error envelope.
             pub fn provider_response_status(&self) -> Option<http::StatusCode> {
                 match self {
                     Self::ProviderResponse(response) => response.status,

--- a/crates/rig-core/src/provider_response.rs
+++ b/crates/rig-core/src/provider_response.rs
@@ -1,0 +1,40 @@
+//! Shared logic for inspecting provider error response bodies across capability errors.
+use crate::http_client;
+use http::StatusCode;
+
+/// Returns the best available provider response body for an error.
+///
+/// Prefers an explicitly supplied provider body, and falls back to the
+/// non-success body captured on the HTTP client error.
+pub(crate) fn body<'a>(
+    provider_body: Option<&'a str>,
+    http_error: Option<&'a http_client::Error>,
+) -> Option<&'a str> {
+    if let Some(body) = provider_body {
+        return Some(body);
+    }
+
+    if let Some(error) = http_error {
+        return error.non_success_body();
+    }
+
+    None
+}
+
+/// Parses an optional response body as JSON.
+///
+/// Returns:
+/// - `Ok(Some(value))` when a body is present and valid JSON.
+/// - `Ok(None)` when no body is present.
+/// - `Err(error)` when a body is present but isn't valid JSON.
+pub(crate) fn json(body: Option<&str>) -> Result<Option<serde_json::Value>, serde_json::Error> {
+    body.map(serde_json::from_str).transpose()
+}
+
+/// Returns the non-success HTTP status from an HTTP client error, when present.
+pub(crate) fn status(http_error: Option<&http_client::Error>) -> Option<StatusCode> {
+    if let Some(error) = http_error {
+        return error.non_success_status();
+    }
+    None
+}

--- a/crates/rig-core/src/providers/azure.rs
+++ b/crates/rig-core/src/providers/azure.rs
@@ -378,21 +378,6 @@ pub struct EmbeddingResponse {
     pub usage: Usage,
 }
 
-impl From<ApiErrorResponse> for EmbeddingError {
-    fn from(err: ApiErrorResponse) -> Self {
-        EmbeddingError::ProviderError(err.message)
-    }
-}
-
-impl From<ApiResponse<EmbeddingResponse>> for Result<EmbeddingResponse, EmbeddingError> {
-    fn from(value: ApiResponse<EmbeddingResponse>) -> Self {
-        match value {
-            ApiResponse::Ok(response) => Ok(response),
-            ApiResponse::Err(err) => Err(EmbeddingError::ProviderError(err.message)),
-        }
-    }
-}
-
 #[derive(Debug, Deserialize)]
 pub struct EmbeddingData {
     pub object: String,
@@ -1195,6 +1180,40 @@ mod azure_tests {
         assert_eq!(
             error.provider_response_status(),
             Some(http::StatusCode::UNPROCESSABLE_ENTITY)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+
+    #[tokio::test]
+    async fn transcription_http_non_success_preserves_status_and_body() {
+        use crate::test_utils::RecordingHttpClient;
+        use crate::transcription::{TranscriptionError, TranscriptionModel as _};
+
+        let body = r#"{"error":{"message":"bad audio","type":"invalid_request_error"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::BAD_REQUEST, body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .azure_endpoint("https://example.openai.azure.com".to_string())
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = TranscriptionModel::new(client, "whisper");
+
+        let error = match model
+            .transcription_request()
+            .data(vec![0u8; 16])
+            .send()
+            .await
+        {
+            Err(error) => error,
+            Ok(_) => panic!("transcription should fail with non-success status"),
+        };
+
+        assert!(matches!(error, TranscriptionError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::BAD_REQUEST)
         );
         assert_eq!(error.provider_response_body(), Some(body));
     }

--- a/crates/rig-core/src/providers/azure.rs
+++ b/crates/rig-core/src/providers/azure.rs
@@ -479,7 +479,8 @@ where
 
         let response = self.client.send(req).await?;
 
-        if response.status().is_success() {
+        let status = response.status();
+        if status.is_success() {
             let response_body: Vec<u8> = response.into_body().await?;
             let parsed: ApiResponse<EmbeddingResponse> = serde_json::from_slice(&response_body)?;
 
@@ -508,14 +509,19 @@ where
                 }
                 ApiResponse::Err(err) => {
                     let _ = err.message;
-                    Err(EmbeddingError::ProviderError(
-                        String::from_utf8_lossy(&response_body).into_owned(),
+                    Err(EmbeddingError::ProviderResponse(
+                        crate::provider_response::ProviderResponseError {
+                            status: Some(status),
+                            body: String::from_utf8_lossy(&response_body).into_owned(),
+                        },
                     ))
                 }
             }
         } else {
             let text = http_client::text(response).await?;
-            Err(EmbeddingError::ProviderError(text))
+            Err(EmbeddingError::HttpError(
+                http_client::Error::InvalidStatusCodeWithMessage(status, text),
+            ))
         }
     }
 }
@@ -756,14 +762,20 @@ where
                     }
                     ApiResponse::Err(err) => {
                         let _ = err.message;
-                        Err(CompletionError::ProviderError(
-                            String::from_utf8_lossy(&response_body).into_owned(),
+                        Err(CompletionError::ProviderResponse(
+                            crate::provider_response::ProviderResponseError {
+                                status: Some(status),
+                                body: String::from_utf8_lossy(&response_body).into_owned(),
+                            },
                         ))
                     }
                 }
             } else {
-                Err(CompletionError::ProviderError(
-                    String::from_utf8_lossy(&response_body).to_string(),
+                Err(CompletionError::HttpError(
+                    http_client::Error::InvalidStatusCodeWithMessage(
+                        status,
+                        String::from_utf8_lossy(&response_body).to_string(),
+                    ),
                 ))
             }
         }
@@ -906,14 +918,20 @@ where
                 ApiResponse::Ok(response) => response.try_into(),
                 ApiResponse::Err(api_error_response) => {
                     let _ = api_error_response.message;
-                    Err(TranscriptionError::ProviderError(
-                        String::from_utf8_lossy(&response_body).into_owned(),
+                    Err(TranscriptionError::ProviderResponse(
+                        crate::provider_response::ProviderResponseError {
+                            status: Some(status),
+                            body: String::from_utf8_lossy(&response_body).into_owned(),
+                        },
                     ))
                 }
             }
         } else {
-            Err(TranscriptionError::ProviderError(
-                String::from_utf8_lossy(&response_body).to_string(),
+            Err(TranscriptionError::HttpError(
+                http_client::Error::InvalidStatusCodeWithMessage(
+                    status,
+                    String::from_utf8_lossy(&response_body).to_string(),
+                ),
             ))
         }
     }
@@ -982,18 +1000,23 @@ mod image_generation {
             let response_body = response.into_body().into_future().await?.to_vec();
 
             if !status.is_success() {
-                return Err(ImageGenerationError::ProviderError(format!(
-                    "{status}: {}",
-                    String::from_utf8_lossy(&response_body)
-                )));
+                return Err(ImageGenerationError::HttpError(
+                    crate::http_client::Error::InvalidStatusCodeWithMessage(
+                        status,
+                        String::from_utf8_lossy(&response_body).into_owned(),
+                    ),
+                ));
             }
 
             match serde_json::from_slice::<ApiResponse<ImageGenerationResponse>>(&response_body)? {
                 ApiResponse::Ok(response) => response.try_into(),
                 ApiResponse::Err(err) => {
                     let _ = err.message;
-                    Err(ImageGenerationError::ProviderError(
-                        String::from_utf8_lossy(&response_body).into_owned(),
+                    Err(ImageGenerationError::ProviderResponse(
+                        crate::provider_response::ProviderResponseError {
+                            status: Some(status),
+                            body: String::from_utf8_lossy(&response_body).into_owned(),
+                        },
                     ))
                 }
             }
@@ -1069,10 +1092,12 @@ mod audio_generation {
             let response_body = response.into_body().into_future().await?;
 
             if !status.is_success() {
-                return Err(AudioGenerationError::ProviderError(format!(
-                    "{status}: {}",
-                    String::from_utf8_lossy(&response_body)
-                )));
+                return Err(AudioGenerationError::HttpError(
+                    crate::http_client::Error::InvalidStatusCodeWithMessage(
+                        status,
+                        String::from_utf8_lossy(&response_body).into_owned(),
+                    ),
+                ));
             }
 
             Ok(AudioGenerationResponse {
@@ -1095,6 +1120,84 @@ mod azure_tests {
     use crate::embeddings::EmbeddingModel;
     use crate::prelude::TypedPrompt;
     use crate::providers::openai::GPT_5_MINI;
+
+    #[cfg(any(feature = "image", feature = "audio"))]
+    fn test_client(
+        http_client: crate::test_utils::RecordingHttpClient,
+    ) -> Client<crate::test_utils::RecordingHttpClient> {
+        Client::builder()
+            .api_key("test-key")
+            .azure_endpoint("https://example.openai.azure.com".to_string())
+            .http_client(http_client)
+            .build()
+            .expect("build client")
+    }
+
+    #[cfg(feature = "image")]
+    #[tokio::test]
+    async fn image_generation_non_success_response_preserves_status_and_body() {
+        use crate::image_generation::{
+            ImageGenerationError, ImageGenerationModel as ImageGenerationModelTrait,
+            ImageGenerationRequest,
+        };
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"error":{"message":"invalid image request"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::BAD_REQUEST, body);
+        let model = ImageGenerationModel::make(&test_client(http_client), "dall-e-3");
+
+        let error = model
+            .image_generation(ImageGenerationRequest {
+                prompt: "draw a cat".to_string(),
+                width: 256,
+                height: 256,
+                additional_params: None,
+            })
+            .await
+            .expect_err("image generation should fail with non-success status");
+
+        assert!(matches!(error, ImageGenerationError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::BAD_REQUEST)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+
+    #[cfg(feature = "audio")]
+    #[tokio::test]
+    async fn audio_generation_non_success_response_preserves_status_and_body() {
+        use crate::audio_generation::{
+            AudioGenerationError, AudioGenerationModel as _, AudioGenerationRequest,
+        };
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"error":{"message":"invalid voice"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::UNPROCESSABLE_ENTITY, body);
+        let model = AudioGenerationModel::new(test_client(http_client), "tts-1");
+
+        let error = match model
+            .audio_generation(AudioGenerationRequest {
+                text: "hello".to_string(),
+                voice: "alloy".to_string(),
+                speed: 1.0,
+                additional_params: None,
+            })
+            .await
+        {
+            Err(error) => error,
+            Ok(_) => panic!("audio generation should fail with non-success status"),
+        };
+
+        assert!(matches!(error, AudioGenerationError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::UNPROCESSABLE_ENTITY)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
 
     #[tokio::test]
     #[ignore]

--- a/crates/rig-core/src/providers/azure.rs
+++ b/crates/rig-core/src/providers/azure.rs
@@ -508,7 +508,7 @@ where
                         .collect())
                 }
                 ApiResponse::Err(err) => {
-                    let _ = err.message;
+                    tracing::warn!(message = %err.message, "provider returned an error response");
                     Err(EmbeddingError::ProviderResponse(
                         crate::provider_response::ProviderResponseError {
                             status: Some(status),
@@ -761,7 +761,7 @@ where
                         response.try_into()
                     }
                     ApiResponse::Err(err) => {
-                        let _ = err.message;
+                        tracing::warn!(message = %err.message, "provider returned an error response");
                         Err(CompletionError::ProviderResponse(
                             crate::provider_response::ProviderResponseError {
                                 status: Some(status),
@@ -917,7 +917,7 @@ where
             match serde_json::from_slice::<ApiResponse<TranscriptionResponse>>(&response_body)? {
                 ApiResponse::Ok(response) => response.try_into(),
                 ApiResponse::Err(api_error_response) => {
-                    let _ = api_error_response.message;
+                    tracing::warn!(message = %api_error_response.message, "provider returned an error response");
                     Err(TranscriptionError::ProviderResponse(
                         crate::provider_response::ProviderResponseError {
                             status: Some(status),
@@ -1011,7 +1011,7 @@ mod image_generation {
             match serde_json::from_slice::<ApiResponse<ImageGenerationResponse>>(&response_body)? {
                 ApiResponse::Ok(response) => response.try_into(),
                 ApiResponse::Err(err) => {
-                    let _ = err.message;
+                    tracing::warn!(message = %err.message, "provider returned an error response");
                     Err(ImageGenerationError::ProviderResponse(
                         crate::provider_response::ProviderResponseError {
                             status: Some(status),

--- a/crates/rig-core/src/providers/azure.rs
+++ b/crates/rig-core/src/providers/azure.rs
@@ -480,10 +480,10 @@ where
         let response = self.client.send(req).await?;
 
         if response.status().is_success() {
-            let body: Vec<u8> = response.into_body().await?;
-            let body: ApiResponse<EmbeddingResponse> = serde_json::from_slice(&body)?;
+            let response_body: Vec<u8> = response.into_body().await?;
+            let parsed: ApiResponse<EmbeddingResponse> = serde_json::from_slice(&response_body)?;
 
-            match body {
+            match parsed {
                 ApiResponse::Ok(response) => {
                     tracing::info!(target: "rig",
                         "Azure embedding token usage: {}",
@@ -506,7 +506,12 @@ where
                         })
                         .collect())
                 }
-                ApiResponse::Err(err) => Err(EmbeddingError::ProviderError(err.message)),
+                ApiResponse::Err(err) => {
+                    let _ = err.message;
+                    Err(EmbeddingError::ProviderError(
+                        String::from_utf8_lossy(&response_body).into_owned(),
+                    ))
+                }
             }
         } else {
             let text = http_client::text(response).await?;
@@ -749,7 +754,12 @@ where
                         }
                         response.try_into()
                     }
-                    ApiResponse::Err(err) => Err(CompletionError::ProviderError(err.message)),
+                    ApiResponse::Err(err) => {
+                        let _ = err.message;
+                        Err(CompletionError::ProviderError(
+                            String::from_utf8_lossy(&response_body).into_owned(),
+                        ))
+                    }
                 }
             } else {
                 Err(CompletionError::ProviderError(
@@ -894,9 +904,12 @@ where
         if status.is_success() {
             match serde_json::from_slice::<ApiResponse<TranscriptionResponse>>(&response_body)? {
                 ApiResponse::Ok(response) => response.try_into(),
-                ApiResponse::Err(api_error_response) => Err(TranscriptionError::ProviderError(
-                    api_error_response.message,
-                )),
+                ApiResponse::Err(api_error_response) => {
+                    let _ = api_error_response.message;
+                    Err(TranscriptionError::ProviderError(
+                        String::from_utf8_lossy(&response_body).into_owned(),
+                    ))
+                }
             }
         } else {
             Err(TranscriptionError::ProviderError(
@@ -977,7 +990,12 @@ mod image_generation {
 
             match serde_json::from_slice::<ApiResponse<ImageGenerationResponse>>(&response_body)? {
                 ApiResponse::Ok(response) => response.try_into(),
-                ApiResponse::Err(err) => Err(ImageGenerationError::ProviderError(err.message)),
+                ApiResponse::Err(err) => {
+                    let _ = err.message;
+                    Err(ImageGenerationError::ProviderError(
+                        String::from_utf8_lossy(&response_body).into_owned(),
+                    ))
+                }
             }
         }
     }

--- a/crates/rig-core/src/providers/chatgpt/mod.rs
+++ b/crates/rig-core/src/providers/chatgpt/mod.rs
@@ -443,12 +443,8 @@ where
             Err(CompletionError::ResponseError(message))
                 if message == "Response contained no parts" =>
             {
-                responses_api::streaming::completion_response_from_sse_body(
-                    &text,
-                    raw_response,
-                    "ChatGPT",
-                )
-                .await
+                responses_api::streaming::completion_response_from_sse_body(&text, raw_response)
+                    .await
             }
             Err(error) => Err(error),
         }
@@ -589,7 +585,6 @@ where
         Ok(responses_api::streaming::stream_from_event_source(
             event_source,
             span,
-            "ChatGPT",
         ))
     }
 }
@@ -777,13 +772,10 @@ data: [DONE]"#;
 
         let raw_response = responses_api::streaming::parse_sse_completion_body(body, "ChatGPT")
             .expect("expected response");
-        let response = responses_api::streaming::completion_response_from_sse_body(
-            body,
-            raw_response,
-            "ChatGPT",
-        )
-        .await
-        .expect("fallback response");
+        let response =
+            responses_api::streaming::completion_response_from_sse_body(body, raw_response)
+                .await
+                .expect("fallback response");
 
         let text: String = response
             .choice

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -822,7 +822,8 @@ where
         async move {
             let response = self.client.send(req).await?;
 
-            if response.status().is_success() {
+            let status = response.status();
+            if status.is_success() {
                 let body = http_client::text(response).await?;
                 match serde_json::from_str::<ChatApiResponse<ChatCompletionResponse>>(&body)? {
                     ChatApiResponse::Ok(response) => {
@@ -855,12 +856,19 @@ where
                     }
                     ChatApiResponse::Err(err) => {
                         let _ = err.error_message();
-                        Err(CompletionError::ProviderError(body))
+                        Err(CompletionError::ProviderResponse(
+                            crate::provider_response::ProviderResponseError {
+                                status: Some(status),
+                                body,
+                            },
+                        ))
                     }
                 }
             } else {
                 let body = http_client::text(response).await?;
-                Err(CompletionError::ProviderError(body))
+                Err(CompletionError::HttpError(
+                    http_client::Error::InvalidStatusCodeWithMessage(status, body),
+                ))
             }
         }
         .instrument(span)
@@ -903,7 +911,8 @@ where
 
         async move {
             let response = self.client.send(req).await?;
-            if response.status().is_success() {
+            let status = response.status();
+            if status.is_success() {
                 let body = http_client::text(response).await?;
                 let response = serde_json::from_str::<responses_api::CompletionResponse>(&body)?;
                 let core = completion::CompletionResponse::try_from(response.clone())?;
@@ -932,7 +941,9 @@ where
                 })
             } else {
                 let body = http_client::text(response).await?;
-                Err(CompletionError::ProviderError(body))
+                Err(CompletionError::HttpError(
+                    http_client::Error::InvalidStatusCodeWithMessage(status, body),
+                ))
             }
         }
         .instrument(span)
@@ -1330,7 +1341,8 @@ where
         .map_err(|err| EmbeddingError::HttpError(err.into()))?;
 
         let response = self.client.send(req).await?;
-        if response.status().is_success() {
+        let status = response.status();
+        if status.is_success() {
             let body: Vec<u8> = response.into_body().await?;
             #[derive(Deserialize)]
             struct NestedApiError {
@@ -1347,8 +1359,11 @@ where
                 Err(parse_error) => {
                     if let Ok(err) = serde_json::from_slice::<NestedApiError>(&body) {
                         let _ = err.error.message;
-                        return Err(EmbeddingError::ProviderError(
-                            String::from_utf8_lossy(&body).into_owned(),
+                        return Err(EmbeddingError::ProviderResponse(
+                            crate::provider_response::ProviderResponseError {
+                                status: Some(status),
+                                body: String::from_utf8_lossy(&body).into_owned(),
+                            },
                         ));
                     }
 
@@ -1380,7 +1395,9 @@ where
                 .collect())
         } else {
             let text = http_client::text(response).await?;
-            Err(EmbeddingError::ProviderError(text))
+            Err(EmbeddingError::HttpError(
+                http_client::Error::InvalidStatusCodeWithMessage(status, text),
+            ))
         }
     }
 }

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -1358,7 +1358,7 @@ where
                 Ok(parsed) => parsed,
                 Err(parse_error) => {
                     if let Ok(err) = serde_json::from_slice::<NestedApiError>(&body) {
-                        let _ = err.error.message;
+                        tracing::warn!(message = %err.error.message, "provider returned an error response");
                         return Err(EmbeddingError::ProviderResponse(
                             crate::provider_response::ProviderResponseError {
                                 status: Some(status),

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -853,9 +853,10 @@ where
                             message_id: core.message_id,
                         })
                     }
-                    ChatApiResponse::Err(err) => Err(CompletionError::ProviderError(
-                        err.error_message().to_string(),
-                    )),
+                    ChatApiResponse::Err(err) => {
+                        let _ = err.error_message();
+                        Err(CompletionError::ProviderError(body))
+                    }
                 }
             } else {
                 let body = http_client::text(response).await?;
@@ -1345,7 +1346,10 @@ where
                 Ok(parsed) => parsed,
                 Err(parse_error) => {
                     if let Ok(err) = serde_json::from_slice::<NestedApiError>(&body) {
-                        return Err(EmbeddingError::ProviderError(err.error.message));
+                        let _ = err.error.message;
+                        return Err(EmbeddingError::ProviderError(
+                            String::from_utf8_lossy(&body).into_owned(),
+                        ));
                     }
 
                     let preview = String::from_utf8_lossy(&body);

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -855,7 +855,10 @@ where
                         })
                     }
                     ChatApiResponse::Err(err) => {
-                        let _ = err.error_message();
+                        tracing::warn!(
+                            message = %err.error_message(),
+                            "provider returned an error response"
+                        );
                         Err(CompletionError::ProviderResponse(
                             crate::provider_response::ProviderResponseError {
                                 status: Some(status),

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -1158,7 +1158,7 @@ where
                         }
                         Err(error) => {
                             terminated_with_error = true;
-                            yield Err(CompletionError::ProviderError(error.to_string()));
+                            yield Err(CompletionError::from_stream_transport(error));
                             break;
                         }
                     }
@@ -2129,8 +2129,13 @@ mod tests {
                 Err(err) => {
                     assert_eq!(
                         err.to_string(),
-                        "ProviderError: Invalid status code: 502 Bad Gateway"
+                        "HttpError: Invalid status code: 502 Bad Gateway"
                     );
+                    assert_eq!(
+                        err.provider_response_status(),
+                        Some(http::StatusCode::BAD_GATEWAY)
+                    );
+                    assert_eq!(err.provider_response_body(), None);
                     saw_error = true;
                     break;
                 }

--- a/crates/rig-core/src/providers/deepseek.rs
+++ b/crates/rig-core/src/providers/deepseek.rs
@@ -616,7 +616,12 @@ where
                         }
                         response.try_into()
                     }
-                    ApiResponse::Err(err) => Err(CompletionError::ProviderError(err.message)),
+                    ApiResponse::Err(err) => {
+                        let _ = err.message;
+                        Err(CompletionError::ProviderError(
+                            String::from_utf8_lossy(&response_body).into_owned(),
+                        ))
+                    }
                 }
             } else {
                 Err(CompletionError::ProviderError(

--- a/crates/rig-core/src/providers/deepseek.rs
+++ b/crates/rig-core/src/providers/deepseek.rs
@@ -618,14 +618,20 @@ where
                     }
                     ApiResponse::Err(err) => {
                         let _ = err.message;
-                        Err(CompletionError::ProviderError(
-                            String::from_utf8_lossy(&response_body).into_owned(),
+                        Err(CompletionError::ProviderResponse(
+                            crate::provider_response::ProviderResponseError {
+                                status: Some(status),
+                                body: String::from_utf8_lossy(&response_body).into_owned(),
+                            },
                         ))
                     }
                 }
             } else {
-                Err(CompletionError::ProviderError(
-                    String::from_utf8_lossy(&response_body).to_string(),
+                Err(CompletionError::HttpError(
+                    http_client::Error::InvalidStatusCodeWithMessage(
+                        status,
+                        String::from_utf8_lossy(&response_body).to_string(),
+                    ),
                 ))
             }
         }

--- a/crates/rig-core/src/providers/deepseek.rs
+++ b/crates/rig-core/src/providers/deepseek.rs
@@ -617,7 +617,7 @@ where
                         response.try_into()
                     }
                     ApiResponse::Err(err) => {
-                        let _ = err.message;
+                        tracing::warn!(message = %err.message, "provider returned an error response");
                         Err(CompletionError::ProviderResponse(
                             crate::provider_response::ProviderResponseError {
                                 status: Some(status),

--- a/crates/rig-core/src/providers/galadriel.rs
+++ b/crates/rig-core/src/providers/galadriel.rs
@@ -614,7 +614,7 @@ where
                         response.try_into()
                     }
                     ApiResponse::Err(err) => {
-                        let _ = err.message;
+                        tracing::warn!(message = %err.message, "provider returned an error response");
                         Err(CompletionError::ProviderResponse(
                             crate::provider_response::ProviderResponseError {
                                 status: Some(status),

--- a/crates/rig-core/src/providers/galadriel.rs
+++ b/crates/rig-core/src/providers/galadriel.rs
@@ -612,7 +612,10 @@ where
                         }
                         response.try_into()
                     }
-                    ApiResponse::Err(err) => Err(CompletionError::ProviderError(err.message)),
+                    ApiResponse::Err(err) => {
+                        let _ = err.message;
+                        Err(CompletionError::ProviderError(t))
+                    }
                 }
             } else {
                 let text = http_client::text(response).await?;

--- a/crates/rig-core/src/providers/galadriel.rs
+++ b/crates/rig-core/src/providers/galadriel.rs
@@ -231,12 +231,6 @@ pub struct CompletionResponse {
     pub usage: Option<Usage>,
 }
 
-impl From<ApiErrorResponse> for CompletionError {
-    fn from(err: ApiErrorResponse) -> Self {
-        CompletionError::ProviderError(err.message)
-    }
-}
-
 impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionResponse> {
     type Error = CompletionError;
 

--- a/crates/rig-core/src/providers/galadriel.rs
+++ b/crates/rig-core/src/providers/galadriel.rs
@@ -588,7 +588,8 @@ where
         async move {
             let response = self.client.send(req).await?;
 
-            if response.status().is_success() {
+            let status = response.status();
+            if status.is_success() {
                 let t = http_client::text(response).await?;
 
                 if enabled!(tracing::Level::TRACE) {
@@ -614,13 +615,20 @@ where
                     }
                     ApiResponse::Err(err) => {
                         let _ = err.message;
-                        Err(CompletionError::ProviderError(t))
+                        Err(CompletionError::ProviderResponse(
+                            crate::provider_response::ProviderResponseError {
+                                status: Some(status),
+                                body: t,
+                            },
+                        ))
                     }
                 }
             } else {
                 let text = http_client::text(response).await?;
 
-                Err(CompletionError::ProviderError(text))
+                Err(CompletionError::HttpError(
+                    http_client::Error::InvalidStatusCodeWithMessage(status, text),
+                ))
             }
         }
         .instrument(span)

--- a/crates/rig-core/src/providers/groq.rs
+++ b/crates/rig-core/src/providers/groq.rs
@@ -813,7 +813,8 @@ mod tests {
         use crate::test_utils::RecordingHttpClient;
 
         let body = r#"{"message":"model overloaded","type":"server_error","code":"503"}"#;
-        let http_client = RecordingHttpClient::new(body);
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::ACCEPTED, body);
         let client = super::Client::builder()
             .api_key("test-key")
             .http_client(http_client)
@@ -830,7 +831,7 @@ mod tests {
         match &error {
             CompletionError::ProviderResponse(stored) => {
                 assert_eq!(stored.body, body);
-                assert_eq!(stored.status, Some(http::StatusCode::OK));
+                assert_eq!(stored.status, Some(http::StatusCode::ACCEPTED));
                 assert_eq!(error.provider_response_body(), Some(body));
                 let json = error
                     .provider_response_json()
@@ -850,7 +851,7 @@ mod tests {
 
         let body = r#"{"error":{"message":"service unavailable","code":"503"}}"#;
         let http_client =
-            RecordingHttpClient::with_error(http::StatusCode::SERVICE_UNAVAILABLE, body);
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
         let client = super::Client::builder()
             .api_key("test-key")
             .http_client(http_client)
@@ -868,6 +869,40 @@ mod tests {
         assert_eq!(
             error.provider_response_status(),
             Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+
+    #[tokio::test]
+    async fn transcription_http_non_success_preserves_status_and_body() {
+        use crate::client::transcription::TranscriptionClient;
+        use crate::test_utils::RecordingHttpClient;
+        use crate::transcription::{TranscriptionError, TranscriptionModel as _};
+
+        let body = r#"{"error":{"message":"bad audio","code":"400"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::BAD_REQUEST, body);
+        let client = super::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.transcription_model("whisper-large-v3");
+
+        let error = match model
+            .transcription_request()
+            .data(vec![0u8; 16])
+            .send()
+            .await
+        {
+            Err(error) => error,
+            Ok(_) => panic!("transcription should fail with non-success status"),
+        };
+
+        assert!(matches!(error, TranscriptionError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::BAD_REQUEST)
         );
         assert_eq!(error.provider_response_body(), Some(body));
     }

--- a/crates/rig-core/src/providers/groq.rs
+++ b/crates/rig-core/src/providers/groq.rs
@@ -434,7 +434,12 @@ where
 
                         response.try_into()
                     }
-                    ApiResponse::Err(err) => Err(CompletionError::ProviderError(err.message)),
+                    ApiResponse::Err(err) => {
+                        let _ = err.message;
+                        Err(CompletionError::ProviderError(
+                            String::from_utf8_lossy(&response_body).into_owned(),
+                        ))
+                    }
                 }
             } else {
                 Err(CompletionError::ProviderError(
@@ -589,9 +594,12 @@ where
         if status.is_success() {
             match serde_json::from_slice::<ApiResponse<TranscriptionResponse>>(&response_body)? {
                 ApiResponse::Ok(response) => response.try_into(),
-                ApiResponse::Err(api_error_response) => Err(TranscriptionError::ProviderError(
-                    api_error_response.message,
-                )),
+                ApiResponse::Err(api_error_response) => {
+                    let _ = api_error_response.message;
+                    Err(TranscriptionError::ProviderError(
+                        String::from_utf8_lossy(&response_body).into_owned(),
+                    ))
+                }
             }
         } else {
             Err(TranscriptionError::ProviderError(
@@ -784,5 +792,40 @@ mod tests {
             .api_key("dummy-key")
             .build()
             .expect("Client::builder() failed");
+    }
+
+    #[tokio::test]
+    async fn completion_preserves_raw_provider_error_json_on_api_error_envelope() {
+        use crate::client::CompletionClient;
+        use crate::completion::{CompletionError, CompletionModel};
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"message":"model overloaded","type":"server_error","code":"503"}"#;
+        let http_client = RecordingHttpClient::new(body);
+        let client = super::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model("llama-3.3-70b-versatile");
+        let request = model.completion_request("hello").build();
+
+        let error = model
+            .completion(request)
+            .await
+            .expect_err("completion should fail with provider error envelope");
+
+        match &error {
+            CompletionError::ProviderError(stored) => {
+                assert_eq!(stored, body);
+                assert_eq!(error.provider_response_body(), Some(body));
+                let json = error
+                    .provider_response_json()
+                    .expect("raw body should be valid JSON")
+                    .expect("parsed JSON should be present");
+                assert_eq!(json["code"], "503");
+            }
+            other => panic!("expected ProviderError, got {other:?}"),
+        }
     }
 }

--- a/crates/rig-core/src/providers/groq.rs
+++ b/crates/rig-core/src/providers/groq.rs
@@ -436,14 +436,20 @@ where
                     }
                     ApiResponse::Err(err) => {
                         let _ = err.message;
-                        Err(CompletionError::ProviderError(
-                            String::from_utf8_lossy(&response_body).into_owned(),
+                        Err(CompletionError::ProviderResponse(
+                            crate::provider_response::ProviderResponseError {
+                                status: Some(status),
+                                body: String::from_utf8_lossy(&response_body).into_owned(),
+                            },
                         ))
                     }
                 }
             } else {
-                Err(CompletionError::ProviderError(
-                    String::from_utf8_lossy(&response_body).to_string(),
+                Err(CompletionError::HttpError(
+                    http_client::Error::InvalidStatusCodeWithMessage(
+                        status,
+                        String::from_utf8_lossy(&response_body).to_string(),
+                    ),
                 ))
             }
         };
@@ -596,14 +602,20 @@ where
                 ApiResponse::Ok(response) => response.try_into(),
                 ApiResponse::Err(api_error_response) => {
                     let _ = api_error_response.message;
-                    Err(TranscriptionError::ProviderError(
-                        String::from_utf8_lossy(&response_body).into_owned(),
+                    Err(TranscriptionError::ProviderResponse(
+                        crate::provider_response::ProviderResponseError {
+                            status: Some(status),
+                            body: String::from_utf8_lossy(&response_body).into_owned(),
+                        },
                     ))
                 }
             }
         } else {
-            Err(TranscriptionError::ProviderError(
-                String::from_utf8_lossy(&response_body).to_string(),
+            Err(TranscriptionError::HttpError(
+                http_client::Error::InvalidStatusCodeWithMessage(
+                    status,
+                    String::from_utf8_lossy(&response_body).to_string(),
+                ),
             ))
         }
     }
@@ -816,8 +828,9 @@ mod tests {
             .expect_err("completion should fail with provider error envelope");
 
         match &error {
-            CompletionError::ProviderError(stored) => {
-                assert_eq!(stored, body);
+            CompletionError::ProviderResponse(stored) => {
+                assert_eq!(stored.body, body);
+                assert_eq!(stored.status, Some(http::StatusCode::OK));
                 assert_eq!(error.provider_response_body(), Some(body));
                 let json = error
                     .provider_response_json()
@@ -825,7 +838,37 @@ mod tests {
                     .expect("parsed JSON should be present");
                 assert_eq!(json["code"], "503");
             }
-            other => panic!("expected ProviderError, got {other:?}"),
+            other => panic!("expected ProviderResponse, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn completion_http_non_success_preserves_status_and_body() {
+        use crate::client::CompletionClient;
+        use crate::completion::{CompletionError, CompletionModel};
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"error":{"message":"service unavailable","code":"503"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = super::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model("llama-3.3-70b-versatile");
+        let request = model.completion_request("hello").build();
+
+        let error = model
+            .completion(request)
+            .await
+            .expect_err("completion should fail with non-success status");
+
+        assert!(matches!(error, CompletionError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
     }
 }

--- a/crates/rig-core/src/providers/groq.rs
+++ b/crates/rig-core/src/providers/groq.rs
@@ -435,7 +435,7 @@ where
                         response.try_into()
                     }
                     ApiResponse::Err(err) => {
-                        let _ = err.message;
+                        tracing::warn!(message = %err.message, "provider returned an error response");
                         Err(CompletionError::ProviderResponse(
                             crate::provider_response::ProviderResponseError {
                                 status: Some(status),
@@ -601,7 +601,7 @@ where
             match serde_json::from_slice::<ApiResponse<TranscriptionResponse>>(&response_body)? {
                 ApiResponse::Ok(response) => response.try_into(),
                 ApiResponse::Err(api_error_response) => {
-                    let _ = api_error_response.message;
+                    tracing::warn!(message = %api_error_response.message, "provider returned an error response");
                     Err(TranscriptionError::ProviderResponse(
                         crate::provider_response::ProviderResponseError {
                             status: Some(status),

--- a/crates/rig-core/src/providers/huggingface/completion.rs
+++ b/crates/rig-core/src/providers/huggingface/completion.rs
@@ -799,7 +799,7 @@ where
                     }
                     ApiResponse::Err(err) => {
                         tracing::warn!(
-                            error = %err,
+                            message = %err,
                             "provider returned an error response"
                         );
                         Err(CompletionError::ProviderResponse(

--- a/crates/rig-core/src/providers/huggingface/completion.rs
+++ b/crates/rig-core/src/providers/huggingface/completion.rs
@@ -774,7 +774,8 @@ where
         async move {
             let response = self.client.send(request).await?;
 
-            if response.status().is_success() {
+            let status = response.status();
+            if status.is_success() {
                 let bytes: Vec<u8> = response.into_body().await?;
                 let text = String::from_utf8_lossy(&bytes);
 
@@ -798,20 +799,21 @@ where
                     }
                     ApiResponse::Err(err) => {
                         let _ = err;
-                        Err(CompletionError::ProviderError(
-                            String::from_utf8_lossy(&bytes).into_owned(),
+                        Err(CompletionError::ProviderResponse(
+                            crate::provider_response::ProviderResponseError {
+                                status: Some(status),
+                                body: String::from_utf8_lossy(&bytes).into_owned(),
+                            },
                         ))
                     }
                 }
             } else {
-                let status = response.status();
                 let text: Vec<u8> = response.into_body().await?;
                 let text: String = String::from_utf8_lossy(&text).into();
 
-                Err(CompletionError::ProviderError(format!(
-                    "{}: {}",
-                    status, text
-                )))
+                Err(CompletionError::HttpError(
+                    crate::http_client::Error::InvalidStatusCodeWithMessage(status, text),
+                ))
             }
         }
         .instrument(span)

--- a/crates/rig-core/src/providers/huggingface/completion.rs
+++ b/crates/rig-core/src/providers/huggingface/completion.rs
@@ -796,7 +796,12 @@ where
 
                         response.try_into()
                     }
-                    ApiResponse::Err(err) => Err(CompletionError::ProviderError(err.to_string())),
+                    ApiResponse::Err(err) => {
+                        let _ = err;
+                        Err(CompletionError::ProviderError(
+                            String::from_utf8_lossy(&bytes).into_owned(),
+                        ))
+                    }
                 }
             } else {
                 let status = response.status();

--- a/crates/rig-core/src/providers/huggingface/completion.rs
+++ b/crates/rig-core/src/providers/huggingface/completion.rs
@@ -798,7 +798,10 @@ where
                         response.try_into()
                     }
                     ApiResponse::Err(err) => {
-                        let _ = err;
+                        tracing::warn!(
+                            error = %err,
+                            "provider returned an error response"
+                        );
                         Err(CompletionError::ProviderResponse(
                             crate::provider_response::ProviderResponseError {
                                 status: Some(status),

--- a/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
+++ b/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
@@ -20,6 +20,23 @@ use crate::json_utils;
 use crate::streaming::{self, RawStreamingChoice, RawStreamingToolCall, ToolCallDeltaContent};
 use crate::wasm_compat::WasmCompatSend;
 
+fn provider_response_from_compatible_sse_data(data: &str) -> Option<CompletionError> {
+    let value = serde_json::from_str::<serde_json::Value>(data).ok()?;
+    if value.get("error").is_none() || value.get("choices").is_some() {
+        return None;
+    }
+
+    if let Some(message) = value
+        .get("error")
+        .and_then(|error| error.get("message"))
+        .and_then(serde_json::Value::as_str)
+    {
+        tracing::warn!(message, "provider returned a streaming error event");
+    }
+
+    Some(crate::provider_response::completion_error_from_body(data))
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CompatibleFinishReason {
     ToolCalls,
@@ -221,6 +238,12 @@ where
                 Ok(Event::Message(message)) => {
                     if message.data.trim().is_empty() || message.data == "[DONE]" {
                         continue;
+                    }
+
+                    if let Some(error) = provider_response_from_compatible_sse_data(&message.data) {
+                        terminated_with_error = true;
+                        yield Err(error);
+                        break;
                     }
 
                     let chunk = match profile.normalize_chunk(&message.data) {
@@ -816,6 +839,52 @@ mod tests {
         assert!(
             stream.next().await.is_none(),
             "stream should terminate after HTTP non-success"
+        );
+    }
+
+    #[tokio::test]
+    async fn streaming_in_band_error_envelope_preserves_full_payload() {
+        use crate::providers::openai::send_compatible_streaming_request;
+        use crate::test_utils::MockStreamingClient;
+
+        let body = r#"{"error":{"message":"upstream unavailable","type":"server_error"}}"#;
+        let client = MockStreamingClient {
+            sse_bytes: sse_bytes_from_data_lines([
+                "{\"choices\":[{\"delta\":{\"content\":\"partial\",\"tool_calls\":[]}}],\"usage\":null}",
+                body,
+            ]),
+        };
+        let req = http::Request::builder()
+            .method("POST")
+            .uri("http://localhost/v1/chat/completions")
+            .body(Vec::new())
+            .expect("request should build");
+
+        let mut stream = send_compatible_streaming_request(client, req)
+            .await
+            .expect("stream should start");
+
+        let first = stream
+            .next()
+            .await
+            .expect("stream should yield partial content")
+            .expect("partial content should be ok");
+        assert!(matches!(
+            first,
+            StreamedAssistantContent::Text(text) if text.text == "partial"
+        ));
+
+        let err = match stream.next().await {
+            Some(Err(err)) => err,
+            Some(Ok(_)) => panic!("expected in-band provider error after partial content"),
+            None => panic!("stream ended before in-band provider error"),
+        };
+        assert!(matches!(err, CompletionError::ProviderResponse(_)));
+        assert_eq!(err.provider_response_status(), None);
+        assert_eq!(err.provider_response_body(), Some(body));
+        assert!(
+            stream.next().await.is_none(),
+            "stream should terminate after in-band provider error"
         );
     }
 

--- a/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
+++ b/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
@@ -924,10 +924,8 @@ mod tests {
             "ProviderError: Invalid content type was returned: \"application/json\""
         );
         assert!(matches!(err, CompletionError::ProviderError(_)));
-        assert_eq!(
-            err.provider_response_body(),
-            Some("Invalid content type was returned: \"application/json\"")
-        );
+        // Rig-generated transport diagnostics are not provider response bodies.
+        assert_eq!(err.provider_response_body(), None);
         assert_eq!(err.provider_response_status(), None);
     }
 

--- a/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
+++ b/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
@@ -339,7 +339,7 @@ where
                 Err(error) => {
                     tracing::error!(?error, "SSE error");
                     terminated_with_error = true;
-                    yield Err(CompletionError::ProviderError(error.to_string()));
+                    yield Err(CompletionError::from_stream_transport(error));
                     break;
                 }
             }
@@ -598,6 +598,8 @@ pub(crate) mod test_support {
 mod tests {
     use super::test_support::sse_bytes_from_data_lines;
     use super::{finalize_pending_tool_call, send_compatible_streaming_request};
+    use crate::completion::CompletionError;
+    use crate::http_client;
     use crate::streaming::RawStreamingToolCall;
     use crate::streaming::StreamedAssistantContent;
     use crate::test_utils::MockStreamingClient;
@@ -766,6 +768,167 @@ mod tests {
             collected_tool_calls[1].function.arguments,
             serde_json::json!({"query":"two"})
         );
+    }
+
+    #[tokio::test]
+    async fn streaming_http_non_success_preserves_status_and_body() {
+        use crate::test_utils::HttpErrorStreamingClient;
+
+        let body = r#"{"error":{"type":"rate_limit","message":"slow down"}}"#;
+        let client = HttpErrorStreamingClient::new(http::StatusCode::TOO_MANY_REQUESTS, body);
+        let req = http::Request::builder()
+            .method("POST")
+            .uri("http://localhost/v1/chat/completions")
+            .body(Vec::new())
+            .expect("request should build");
+
+        let mut stream = send_compatible_streaming_request(client, req, FinishReasonCleanupProfile)
+            .await
+            .expect("stream should start");
+
+        let err = stream
+            .next()
+            .await
+            .expect("stream should yield transport error")
+            .expect_err("HTTP non-success should surface as a stream error");
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "HttpError: Invalid status code {} with message: {}",
+                http::StatusCode::TOO_MANY_REQUESTS,
+                body
+            )
+        );
+        assert_eq!(
+            err.provider_response_status(),
+            Some(http::StatusCode::TOO_MANY_REQUESTS)
+        );
+        assert_eq!(err.provider_response_body(), Some(body));
+        assert_eq!(
+            err.provider_response_json().expect("valid JSON body"),
+            Some(serde_json::json!({
+                "error": {
+                    "type": "rate_limit",
+                    "message": "slow down"
+                }
+            }))
+        );
+        assert!(
+            stream.next().await.is_none(),
+            "stream should terminate after HTTP non-success"
+        );
+    }
+
+    #[tokio::test]
+    async fn streaming_mid_stream_http_non_success_preserves_status_and_body() {
+        use crate::providers::openai::send_compatible_streaming_request;
+        use crate::test_utils::SequencedStreamingHttpClient;
+
+        let body = r#"{"error":{"message":"upstream unavailable"}}"#;
+        let chunks = vec![
+            Ok(sse_bytes_from_data_lines([
+                "{\"choices\":[{\"delta\":{\"content\":\"partial\",\"tool_calls\":[]}}],\"usage\":null}",
+            ])),
+            Err(http_client::Error::InvalidStatusCodeWithMessage(
+                http::StatusCode::BAD_GATEWAY,
+                body.to_string(),
+            )),
+        ];
+        let client = SequencedStreamingHttpClient::new(chunks);
+        let req = http::Request::builder()
+            .method("POST")
+            .uri("http://localhost/v1/chat/completions")
+            .body(Vec::new())
+            .expect("request should build");
+
+        let mut stream = send_compatible_streaming_request(client, req)
+            .await
+            .expect("stream should start");
+
+        let first = stream
+            .next()
+            .await
+            .expect("stream should yield partial content")
+            .expect("partial content should be ok");
+        assert!(matches!(
+            first,
+            StreamedAssistantContent::Text(text) if text.text == "partial"
+        ));
+
+        let err = match stream.next().await {
+            Some(Err(err)) => err,
+            Some(Ok(_)) => panic!("expected HTTP transport error after partial content"),
+            None => panic!("stream ended before HTTP transport error"),
+        };
+        assert_eq!(
+            err.provider_response_status(),
+            Some(http::StatusCode::BAD_GATEWAY)
+        );
+        assert_eq!(err.provider_response_body(), Some(body));
+        assert!(
+            stream.next().await.is_none(),
+            "stream should terminate after mid-stream HTTP non-success"
+        );
+    }
+
+    #[tokio::test]
+    async fn streaming_http_non_success_json_parse_error_is_visible() {
+        use crate::test_utils::HttpErrorStreamingClient;
+
+        let client = HttpErrorStreamingClient::new(http::StatusCode::BAD_REQUEST, "not json");
+        let req = http::Request::builder()
+            .method("POST")
+            .uri("http://localhost/v1/chat/completions")
+            .body(Vec::new())
+            .expect("request should build");
+
+        let mut stream = send_compatible_streaming_request(client, req, FinishReasonCleanupProfile)
+            .await
+            .expect("stream should start");
+
+        let err = match stream.next().await {
+            Some(Err(err)) => err,
+            _ => panic!("expected HTTP transport error"),
+        };
+        assert_eq!(err.provider_response_body(), Some("not json"));
+        assert!(err.provider_response_json().is_err());
+    }
+
+    #[tokio::test]
+    async fn streaming_non_http_transport_error_stays_provider_error() {
+        use crate::test_utils::SequencedStreamingHttpClient;
+
+        use crate::providers::openai::send_compatible_streaming_request;
+
+        let chunks = vec![Err(http_client::Error::InvalidContentType(
+            http::HeaderValue::from_static("application/json"),
+        ))];
+        let client = SequencedStreamingHttpClient::new(chunks);
+        let req = http::Request::builder()
+            .method("POST")
+            .uri("http://localhost/v1/chat/completions")
+            .body(Vec::new())
+            .expect("request should build");
+
+        let mut stream = send_compatible_streaming_request(client, req)
+            .await
+            .expect("stream should start");
+
+        let err = match stream.next().await {
+            Some(Err(err)) => err,
+            Some(Ok(_)) => panic!("expected non-HTTP transport error"),
+            None => panic!("stream ended before transport error"),
+        };
+        assert_eq!(
+            err.to_string(),
+            "ProviderError: Invalid content type was returned: \"application/json\""
+        );
+        assert!(matches!(err, CompletionError::ProviderError(_)));
+        assert_eq!(
+            err.provider_response_body(),
+            Some("Invalid content type was returned: \"application/json\"")
+        );
+        assert_eq!(err.provider_response_status(), None);
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/providers/llamafile.rs
+++ b/crates/rig-core/src/providers/llamafile.rs
@@ -437,14 +437,20 @@ where
                     }
                     ApiResponse::Err(err) => {
                         let _ = err.message;
-                        Err(CompletionError::ProviderError(
-                            String::from_utf8_lossy(&response_body).into_owned(),
+                        Err(CompletionError::ProviderResponse(
+                            crate::provider_response::ProviderResponseError {
+                                status: Some(status),
+                                body: String::from_utf8_lossy(&response_body).into_owned(),
+                            },
                         ))
                     }
                 }
             } else {
-                Err(CompletionError::ProviderError(
-                    String::from_utf8_lossy(&response_body).to_string(),
+                Err(CompletionError::HttpError(
+                    http_client::Error::InvalidStatusCodeWithMessage(
+                        status,
+                        String::from_utf8_lossy(&response_body).to_string(),
+                    ),
                 ))
             }
         }
@@ -689,7 +695,8 @@ where
 
         let response = self.client.send(req).await?;
 
-        if response.status().is_success() {
+        let status = response.status();
+        if status.is_success() {
             let response_body: Vec<u8> = response.into_body().await?;
             let parsed: ApiResponse<openai::EmbeddingResponse> =
                 serde_json::from_slice(&response_body)?;
@@ -723,14 +730,19 @@ where
                 }
                 ApiResponse::Err(err) => {
                     let _ = err.message;
-                    Err(EmbeddingError::ProviderError(
-                        String::from_utf8_lossy(&response_body).into_owned(),
+                    Err(EmbeddingError::ProviderResponse(
+                        crate::provider_response::ProviderResponseError {
+                            status: Some(status),
+                            body: String::from_utf8_lossy(&response_body).into_owned(),
+                        },
                     ))
                 }
             }
         } else {
             let text = http_client::text(response).await?;
-            Err(EmbeddingError::ProviderError(text))
+            Err(EmbeddingError::HttpError(
+                http_client::Error::InvalidStatusCodeWithMessage(status, text),
+            ))
         }
     }
 }

--- a/crates/rig-core/src/providers/llamafile.rs
+++ b/crates/rig-core/src/providers/llamafile.rs
@@ -436,7 +436,7 @@ where
                         response.try_into()
                     }
                     ApiResponse::Err(err) => {
-                        let _ = err.message;
+                        tracing::warn!(message = %err.message, "provider returned an error response");
                         Err(CompletionError::ProviderResponse(
                             crate::provider_response::ProviderResponseError {
                                 status: Some(status),
@@ -729,7 +729,7 @@ where
                         .collect())
                 }
                 ApiResponse::Err(err) => {
-                    let _ = err.message;
+                    tracing::warn!(message = %err.message, "provider returned an error response");
                     Err(EmbeddingError::ProviderResponse(
                         crate::provider_response::ProviderResponseError {
                             status: Some(status),

--- a/crates/rig-core/src/providers/llamafile.rs
+++ b/crates/rig-core/src/providers/llamafile.rs
@@ -435,7 +435,12 @@ where
 
                         response.try_into()
                     }
-                    ApiResponse::Err(err) => Err(CompletionError::ProviderError(err.message)),
+                    ApiResponse::Err(err) => {
+                        let _ = err.message;
+                        Err(CompletionError::ProviderError(
+                            String::from_utf8_lossy(&response_body).into_owned(),
+                        ))
+                    }
                 }
             } else {
                 Err(CompletionError::ProviderError(
@@ -685,10 +690,11 @@ where
         let response = self.client.send(req).await?;
 
         if response.status().is_success() {
-            let body: Vec<u8> = response.into_body().await?;
-            let body: ApiResponse<openai::EmbeddingResponse> = serde_json::from_slice(&body)?;
+            let response_body: Vec<u8> = response.into_body().await?;
+            let parsed: ApiResponse<openai::EmbeddingResponse> =
+                serde_json::from_slice(&response_body)?;
 
-            match body {
+            match parsed {
                 ApiResponse::Ok(response) => {
                     tracing::info!(target: "rig",
                         "Llamafile embedding token usage: {:?}",
@@ -715,7 +721,12 @@ where
                         })
                         .collect())
                 }
-                ApiResponse::Err(err) => Err(EmbeddingError::ProviderError(err.message)),
+                ApiResponse::Err(err) => {
+                    let _ = err.message;
+                    Err(EmbeddingError::ProviderError(
+                        String::from_utf8_lossy(&response_body).into_owned(),
+                    ))
+                }
             }
         } else {
             let text = http_client::text(response).await?;

--- a/crates/rig-core/src/providers/mistral/completion.rs
+++ b/crates/rig-core/src/providers/mistral/completion.rs
@@ -631,7 +631,10 @@ where
                         span.record_response_metadata(&response);
                         response.try_into()
                     }
-                    ApiResponse::Err(err) => Err(CompletionError::ProviderError(err.message)),
+                    ApiResponse::Err(err) => {
+                        let _ = err.message;
+                        Err(CompletionError::ProviderError(text))
+                    }
                 }
             } else {
                 let text = http_client::text(response).await?;

--- a/crates/rig-core/src/providers/mistral/completion.rs
+++ b/crates/rig-core/src/providers/mistral/completion.rs
@@ -622,7 +622,8 @@ where
         async move {
             let response = self.client.send(request).await?;
 
-            if response.status().is_success() {
+            let status = response.status();
+            if status.is_success() {
                 let text = http_client::text(response).await?;
                 match serde_json::from_str::<ApiResponse<CompletionResponse>>(&text)? {
                     ApiResponse::Ok(response) => {
@@ -633,12 +634,19 @@ where
                     }
                     ApiResponse::Err(err) => {
                         let _ = err.message;
-                        Err(CompletionError::ProviderError(text))
+                        Err(CompletionError::ProviderResponse(
+                            crate::provider_response::ProviderResponseError {
+                                status: Some(status),
+                                body: text,
+                            },
+                        ))
                     }
                 }
             } else {
                 let text = http_client::text(response).await?;
-                Err(CompletionError::ProviderError(text))
+                Err(CompletionError::HttpError(
+                    http_client::Error::InvalidStatusCodeWithMessage(status, text),
+                ))
             }
         }
         .instrument(span)

--- a/crates/rig-core/src/providers/mistral/completion.rs
+++ b/crates/rig-core/src/providers/mistral/completion.rs
@@ -633,7 +633,7 @@ where
                         response.try_into()
                     }
                     ApiResponse::Err(err) => {
-                        let _ = err.message;
+                        tracing::warn!(message = %err.message, "provider returned an error response");
                         Err(CompletionError::ProviderResponse(
                             crate::provider_response::ProviderResponseError {
                                 status: Some(status),

--- a/crates/rig-core/src/providers/mistral/embedding.rs
+++ b/crates/rig-core/src/providers/mistral/embedding.rs
@@ -77,10 +77,10 @@ where
         let response = self.client.send(req).await?;
 
         if response.status().is_success() {
-            let body: Vec<u8> = response.into_body().await?;
-            let body: ApiResponse<EmbeddingResponse> = serde_json::from_slice(&body)?;
+            let response_body: Vec<u8> = response.into_body().await?;
+            let parsed: ApiResponse<EmbeddingResponse> = serde_json::from_slice(&response_body)?;
 
-            match body {
+            match parsed {
                 ApiResponse::Ok(response) => {
                     tracing::debug!(target: "rig",
                         "Mistral embedding token usage: {}",
@@ -107,7 +107,12 @@ where
                         })
                         .collect())
                 }
-                ApiResponse::Err(err) => Err(EmbeddingError::ProviderError(err.message)),
+                ApiResponse::Err(err) => {
+                    let _ = err.message;
+                    Err(EmbeddingError::ProviderError(
+                        String::from_utf8_lossy(&response_body).into_owned(),
+                    ))
+                }
             }
         } else {
             let text = http_client::text(response).await?;

--- a/crates/rig-core/src/providers/mistral/embedding.rs
+++ b/crates/rig-core/src/providers/mistral/embedding.rs
@@ -109,7 +109,7 @@ where
                         .collect())
                 }
                 ApiResponse::Err(err) => {
-                    let _ = err.message;
+                    tracing::warn!(message = %err.message, "provider returned an error response");
                     Err(EmbeddingError::ProviderResponse(
                         crate::provider_response::ProviderResponseError {
                             status: Some(status),

--- a/crates/rig-core/src/providers/mistral/embedding.rs
+++ b/crates/rig-core/src/providers/mistral/embedding.rs
@@ -76,7 +76,8 @@ where
 
         let response = self.client.send(req).await?;
 
-        if response.status().is_success() {
+        let status = response.status();
+        if status.is_success() {
             let response_body: Vec<u8> = response.into_body().await?;
             let parsed: ApiResponse<EmbeddingResponse> = serde_json::from_slice(&response_body)?;
 
@@ -109,14 +110,19 @@ where
                 }
                 ApiResponse::Err(err) => {
                     let _ = err.message;
-                    Err(EmbeddingError::ProviderError(
-                        String::from_utf8_lossy(&response_body).into_owned(),
+                    Err(EmbeddingError::ProviderResponse(
+                        crate::provider_response::ProviderResponseError {
+                            status: Some(status),
+                            body: String::from_utf8_lossy(&response_body).into_owned(),
+                        },
                     ))
                 }
             }
         } else {
             let text = http_client::text(response).await?;
-            Err(EmbeddingError::ProviderError(text))
+            Err(EmbeddingError::HttpError(
+                http_client::Error::InvalidStatusCodeWithMessage(status, text),
+            ))
         }
     }
 }

--- a/crates/rig-core/src/providers/moonshot.rs
+++ b/crates/rig-core/src/providers/moonshot.rs
@@ -565,14 +565,20 @@ where
                     }
                     ApiResponse::Err(err) => {
                         let _ = err.error.message;
-                        Err(CompletionError::ProviderError(
-                            String::from_utf8_lossy(&response_body).into_owned(),
+                        Err(CompletionError::ProviderResponse(
+                            crate::provider_response::ProviderResponseError {
+                                status: Some(status),
+                                body: String::from_utf8_lossy(&response_body).into_owned(),
+                            },
                         ))
                     }
                 }
             } else {
-                Err(CompletionError::ProviderError(
-                    String::from_utf8_lossy(&response_body).to_string(),
+                Err(CompletionError::HttpError(
+                    http_client::Error::InvalidStatusCodeWithMessage(
+                        status,
+                        String::from_utf8_lossy(&response_body).to_string(),
+                    ),
                 ))
             }
         };

--- a/crates/rig-core/src/providers/moonshot.rs
+++ b/crates/rig-core/src/providers/moonshot.rs
@@ -563,7 +563,12 @@ where
                         }
                         response.try_into()
                     }
-                    ApiResponse::Err(err) => Err(CompletionError::ProviderError(err.error.message)),
+                    ApiResponse::Err(err) => {
+                        let _ = err.error.message;
+                        Err(CompletionError::ProviderError(
+                            String::from_utf8_lossy(&response_body).into_owned(),
+                        ))
+                    }
                 }
             } else {
                 Err(CompletionError::ProviderError(

--- a/crates/rig-core/src/providers/moonshot.rs
+++ b/crates/rig-core/src/providers/moonshot.rs
@@ -564,7 +564,7 @@ where
                         response.try_into()
                     }
                     ApiResponse::Err(err) => {
-                        let _ = err.error.message;
+                        tracing::warn!(message = %err.error.message, "provider returned an error response");
                         Err(CompletionError::ProviderResponse(
                             crate::provider_response::ProviderResponseError {
                                 status: Some(status),

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -1471,7 +1471,10 @@ where
 
                         response.try_into()
                     }
-                    ApiResponse::Err(err) => Err(CompletionError::ProviderError(err.message)),
+                    ApiResponse::Err(err) => {
+                        let _ = err.message;
+                        Err(CompletionError::ProviderError(text))
+                    }
                 }
             } else {
                 let text = http_client::text(response).await?;
@@ -2354,5 +2357,42 @@ mod tests {
         assert_eq!(parts.len(), 2);
         assert!(matches!(parts[0], UserContent::Text { .. }));
         assert!(matches!(parts[1], UserContent::File { .. }));
+    }
+
+    #[tokio::test]
+    async fn completion_preserves_raw_provider_error_json_on_api_error_envelope() {
+        use crate::client::CompletionClient;
+        use crate::completion::CompletionModel;
+        use crate::providers::openai::CompletionsClient;
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"message":"slow down","type":"rate_limit","code":"rate_limit_exceeded"}"#;
+        let http_client = RecordingHttpClient::new(body);
+        let client = CompletionsClient::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model("gpt-4o-mini");
+        let request = model.completion_request("hello").build();
+
+        let error = model
+            .completion(request)
+            .await
+            .expect_err("completion should fail with provider error envelope");
+
+        match &error {
+            CompletionError::ProviderError(stored) => {
+                assert_eq!(stored, body);
+                assert_eq!(error.provider_response_body(), Some(body));
+                let json = error
+                    .provider_response_json()
+                    .expect("raw body should be valid JSON")
+                    .expect("parsed JSON should be present");
+                assert_eq!(json["code"], "rate_limit_exceeded");
+                assert_eq!(json["type"], "rate_limit");
+            }
+            other => panic!("expected ProviderError, got {other:?}"),
+        }
     }
 }

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -2,10 +2,7 @@
 // OpenAI Completion API
 // ================================================================
 
-use super::{
-    client::{ApiErrorResponse, ApiResponse},
-    streaming::StreamingCompletionResponse,
-};
+use super::{client::ApiResponse, streaming::StreamingCompletionResponse};
 use crate::completion::{
     CompletionError, CompletionRequest as CoreCompletionRequest, GetTokenUsage,
 };
@@ -125,12 +122,6 @@ pub const GPT_4_1_NANO: &str = "gpt-4.1-nano";
 pub const GPT_4_1_2025_04_14: &str = "gpt-4.1-2025-04-14";
 /// `gpt-4.1` completion model
 pub const GPT_4_1: &str = "gpt-4.1";
-
-impl From<ApiErrorResponse> for CompletionError {
-    fn from(err: ApiErrorResponse) -> Self {
-        CompletionError::ProviderError(err.message)
-    }
-}
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 #[serde(tag = "role", rename_all = "lowercase")]
@@ -2375,7 +2366,8 @@ mod tests {
         use crate::test_utils::RecordingHttpClient;
 
         let body = r#"{"message":"slow down","type":"rate_limit","code":"rate_limit_exceeded"}"#;
-        let http_client = RecordingHttpClient::new(body);
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::ACCEPTED, body);
         let client = CompletionsClient::builder()
             .api_key("test-key")
             .http_client(http_client)
@@ -2392,9 +2384,12 @@ mod tests {
         match &error {
             CompletionError::ProviderResponse(stored) => {
                 assert_eq!(stored.body, body);
-                assert_eq!(stored.status, Some(http::StatusCode::OK));
+                assert_eq!(stored.status, Some(http::StatusCode::ACCEPTED));
                 assert_eq!(error.provider_response_body(), Some(body));
-                assert_eq!(error.provider_response_status(), Some(http::StatusCode::OK));
+                assert_eq!(
+                    error.provider_response_status(),
+                    Some(http::StatusCode::ACCEPTED)
+                );
                 let json = error
                     .provider_response_json()
                     .expect("raw body should be valid JSON")
@@ -2415,7 +2410,7 @@ mod tests {
 
         let body = r#"{"error":{"message":"rate limited","type":"rate_limit_error"}}"#;
         let http_client =
-            RecordingHttpClient::with_error(http::StatusCode::TOO_MANY_REQUESTS, body);
+            RecordingHttpClient::with_error_response(http::StatusCode::TOO_MANY_REQUESTS, body);
         let client = CompletionsClient::builder()
             .api_key("test-key")
             .http_client(http_client)

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -1473,7 +1473,7 @@ where
                         response.try_into()
                     }
                     ApiResponse::Err(err) => {
-                        let _ = err.message;
+                        tracing::warn!(message = %err.message, "provider returned an error response");
                         Err(CompletionError::ProviderResponse(
                             crate::provider_response::ProviderResponseError {
                                 status: Some(status),

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -1452,7 +1452,8 @@ where
         async move {
             let response = self.client.send(req).await?;
 
-            if response.status().is_success() {
+            let status = response.status();
+            if status.is_success() {
                 let text = http_client::text(response).await?;
 
                 match serde_json::from_str::<ApiResponse<CompletionResponse>>(&text)? {
@@ -1473,12 +1474,19 @@ where
                     }
                     ApiResponse::Err(err) => {
                         let _ = err.message;
-                        Err(CompletionError::ProviderError(text))
+                        Err(CompletionError::ProviderResponse(
+                            crate::provider_response::ProviderResponseError {
+                                status: Some(status),
+                                body: text,
+                            },
+                        ))
                     }
                 }
             } else {
                 let text = http_client::text(response).await?;
-                Err(CompletionError::ProviderError(text))
+                Err(CompletionError::HttpError(
+                    http_client::Error::InvalidStatusCodeWithMessage(status, text),
+                ))
             }
         }
         .instrument(span)
@@ -2382,9 +2390,11 @@ mod tests {
             .expect_err("completion should fail with provider error envelope");
 
         match &error {
-            CompletionError::ProviderError(stored) => {
-                assert_eq!(stored, body);
+            CompletionError::ProviderResponse(stored) => {
+                assert_eq!(stored.body, body);
+                assert_eq!(stored.status, Some(http::StatusCode::OK));
                 assert_eq!(error.provider_response_body(), Some(body));
+                assert_eq!(error.provider_response_status(), Some(http::StatusCode::OK));
                 let json = error
                     .provider_response_json()
                     .expect("raw body should be valid JSON")
@@ -2392,7 +2402,43 @@ mod tests {
                 assert_eq!(json["code"], "rate_limit_exceeded");
                 assert_eq!(json["type"], "rate_limit");
             }
-            other => panic!("expected ProviderError, got {other:?}"),
+            other => panic!("expected ProviderResponse, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn completion_http_non_success_preserves_status_and_body() {
+        use crate::client::CompletionClient;
+        use crate::completion::CompletionModel;
+        use crate::providers::openai::CompletionsClient;
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"error":{"message":"rate limited","type":"rate_limit_error"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error(http::StatusCode::TOO_MANY_REQUESTS, body);
+        let client = CompletionsClient::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model("gpt-4o-mini");
+        let request = model.completion_request("hello").build();
+
+        let error = model
+            .completion(request)
+            .await
+            .expect_err("completion should fail with non-success status");
+
+        assert!(matches!(error, CompletionError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::TOO_MANY_REQUESTS)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+        let json = error
+            .provider_response_json()
+            .expect("raw body should be valid JSON")
+            .expect("parsed JSON should be present");
+        assert_eq!(json["error"]["type"], "rate_limit_error");
     }
 }

--- a/crates/rig-core/src/providers/openai/embedding.rs
+++ b/crates/rig-core/src/providers/openai/embedding.rs
@@ -1,7 +1,4 @@
-use super::{
-    client::{ApiErrorResponse, ApiResponse},
-    completion::Usage,
-};
+use super::{client::ApiResponse, completion::Usage};
 use crate::embeddings::EmbeddingError;
 use crate::http_client::HttpClientExt;
 use crate::{embeddings, http_client};
@@ -24,21 +21,6 @@ pub struct EmbeddingResponse {
     pub data: Vec<EmbeddingData>,
     pub model: String,
     pub usage: Usage,
-}
-
-impl From<ApiErrorResponse> for EmbeddingError {
-    fn from(err: ApiErrorResponse) -> Self {
-        EmbeddingError::ProviderError(err.message)
-    }
-}
-
-impl From<ApiResponse<EmbeddingResponse>> for Result<EmbeddingResponse, EmbeddingError> {
-    fn from(value: ApiResponse<EmbeddingResponse>) -> Self {
-        match value {
-            ApiResponse::Ok(response) => Ok(response),
-            ApiResponse::Err(err) => Err(EmbeddingError::ProviderError(err.message)),
-        }
-    }
 }
 
 #[derive(Debug, Deserialize, Clone, Serialize)]
@@ -280,7 +262,8 @@ mod tests {
     #[tokio::test]
     async fn embedding_preserves_raw_provider_error_json_on_api_error_envelope() {
         let body = r#"{"message":"embedding quota exceeded","type":"insufficient_quota"}"#;
-        let http_client = RecordingHttpClient::new(body);
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::ACCEPTED, body);
         let client = CompletionsClient::builder()
             .api_key("test-key")
             .http_client(http_client)
@@ -296,7 +279,7 @@ mod tests {
         match &error {
             EmbeddingError::ProviderResponse(stored) => {
                 assert_eq!(stored.body, body);
-                assert_eq!(stored.status, Some(http::StatusCode::OK));
+                assert_eq!(stored.status, Some(http::StatusCode::ACCEPTED));
                 assert_eq!(error.provider_response_body(), Some(body));
                 let json = error
                     .provider_response_json()
@@ -311,7 +294,8 @@ mod tests {
     #[tokio::test]
     async fn embedding_http_non_success_preserves_status_and_body() {
         let body = r#"{"error":{"message":"invalid api key","type":"invalid_request_error"}}"#;
-        let http_client = RecordingHttpClient::with_error(http::StatusCode::UNAUTHORIZED, body);
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::UNAUTHORIZED, body);
         let client = CompletionsClient::builder()
             .api_key("test-key")
             .http_client(http_client)

--- a/crates/rig-core/src/providers/openai/embedding.rs
+++ b/crates/rig-core/src/providers/openai/embedding.rs
@@ -148,7 +148,8 @@ where
 
         let response = self.client.send(req).await?;
 
-        if response.status().is_success() {
+        let status = response.status();
+        if status.is_success() {
             let response_body: Vec<u8> = response.into_body().await?;
             let parsed: ApiResponse<EmbeddingResponse> = serde_json::from_slice(&response_body)?;
 
@@ -197,14 +198,19 @@ where
                 }
                 ApiResponse::Err(err) => {
                     let _ = err.message;
-                    Err(EmbeddingError::ProviderError(
-                        String::from_utf8_lossy(&response_body).into_owned(),
+                    Err(EmbeddingError::ProviderResponse(
+                        crate::provider_response::ProviderResponseError {
+                            status: Some(status),
+                            body: String::from_utf8_lossy(&response_body).into_owned(),
+                        },
                     ))
                 }
             }
         } else {
             let text = http_client::text(response).await?;
-            Err(EmbeddingError::ProviderError(text))
+            Err(EmbeddingError::HttpError(
+                http_client::Error::InvalidStatusCodeWithMessage(status, text),
+            ))
         }
     }
 }
@@ -288,8 +294,9 @@ mod tests {
             .expect_err("embedding should fail with provider error envelope");
 
         match &error {
-            EmbeddingError::ProviderError(stored) => {
-                assert_eq!(stored, body);
+            EmbeddingError::ProviderResponse(stored) => {
+                assert_eq!(stored.body, body);
+                assert_eq!(stored.status, Some(http::StatusCode::OK));
                 assert_eq!(error.provider_response_body(), Some(body));
                 let json = error
                     .provider_response_json()
@@ -297,7 +304,31 @@ mod tests {
                     .expect("parsed JSON should be present");
                 assert_eq!(json["type"], "insufficient_quota");
             }
-            other => panic!("expected ProviderError, got {other:?}"),
+            other => panic!("expected ProviderResponse, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn embedding_http_non_success_preserves_status_and_body() {
+        let body = r#"{"error":{"message":"invalid api key","type":"invalid_request_error"}}"#;
+        let http_client = RecordingHttpClient::with_error(http::StatusCode::UNAUTHORIZED, body);
+        let client = CompletionsClient::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.embedding_model("text-embedding-3-small");
+
+        let error = model
+            .embed_texts(["hello".to_string()])
+            .await
+            .expect_err("embedding should fail with non-success status");
+
+        assert!(matches!(error, EmbeddingError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::UNAUTHORIZED)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
     }
 }

--- a/crates/rig-core/src/providers/openai/embedding.rs
+++ b/crates/rig-core/src/providers/openai/embedding.rs
@@ -197,7 +197,7 @@ where
                     Ok(embeddings::EmbeddingResponse { embeddings, usage })
                 }
                 ApiResponse::Err(err) => {
-                    let _ = err.message;
+                    tracing::warn!(message = %err.message, "provider returned an error response");
                     Err(EmbeddingError::ProviderResponse(
                         crate::provider_response::ProviderResponseError {
                             status: Some(status),

--- a/crates/rig-core/src/providers/openai/embedding.rs
+++ b/crates/rig-core/src/providers/openai/embedding.rs
@@ -149,10 +149,10 @@ where
         let response = self.client.send(req).await?;
 
         if response.status().is_success() {
-            let body: Vec<u8> = response.into_body().await?;
-            let body: ApiResponse<EmbeddingResponse> = serde_json::from_slice(&body)?;
+            let response_body: Vec<u8> = response.into_body().await?;
+            let parsed: ApiResponse<EmbeddingResponse> = serde_json::from_slice(&response_body)?;
 
-            match body {
+            match parsed {
                 ApiResponse::Ok(response) => {
                     tracing::info!(target: "rig",
                         "OpenAI embedding token usage: {:?}",
@@ -195,7 +195,12 @@ where
 
                     Ok(embeddings::EmbeddingResponse { embeddings, usage })
                 }
-                ApiResponse::Err(err) => Err(EmbeddingError::ProviderError(err.message)),
+                ApiResponse::Err(err) => {
+                    let _ = err.message;
+                    Err(EmbeddingError::ProviderError(
+                        String::from_utf8_lossy(&response_body).into_owned(),
+                    ))
+                }
             }
         } else {
             let text = http_client::text(response).await?;
@@ -255,5 +260,44 @@ where
     pub fn user(mut self, user: impl Into<String>) -> Self {
         self.user = Some(user.into());
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::EmbeddingsClient;
+    use crate::embeddings::EmbeddingModel as _;
+    use crate::providers::openai::CompletionsClient;
+    use crate::test_utils::RecordingHttpClient;
+
+    #[tokio::test]
+    async fn embedding_preserves_raw_provider_error_json_on_api_error_envelope() {
+        let body = r#"{"message":"embedding quota exceeded","type":"insufficient_quota"}"#;
+        let http_client = RecordingHttpClient::new(body);
+        let client = CompletionsClient::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.embedding_model("text-embedding-3-small");
+
+        let error = model
+            .embed_texts(["hello".to_string()])
+            .await
+            .expect_err("embedding should fail with provider error envelope");
+
+        match &error {
+            EmbeddingError::ProviderError(stored) => {
+                assert_eq!(stored, body);
+                assert_eq!(error.provider_response_body(), Some(body));
+                let json = error
+                    .provider_response_json()
+                    .expect("raw body should be valid JSON")
+                    .expect("parsed JSON should be present");
+                assert_eq!(json["type"], "insufficient_quota");
+            }
+            other => panic!("expected ProviderError, got {other:?}"),
+        }
     }
 }

--- a/crates/rig-core/src/providers/openai/image_generation.rs
+++ b/crates/rig-core/src/providers/openai/image_generation.rs
@@ -113,14 +113,13 @@ where
 
         let response = self.client.send(request).await?;
 
-        if !response.status().is_success() {
-            let status = response.status();
+        let status = response.status();
+        if !status.is_success() {
             let text = http_client::text(response).await?;
 
-            return Err(ImageGenerationError::ProviderError(format!(
-                "{}: {}",
-                status, text,
-            )));
+            return Err(ImageGenerationError::HttpError(
+                http_client::Error::InvalidStatusCodeWithMessage(status, text),
+            ));
         }
 
         let text = http_client::text(response).await?;
@@ -129,8 +128,81 @@ where
             ApiResponse::Ok(response) => response.try_into(),
             ApiResponse::Err(err) => {
                 let _ = err.message;
-                Err(ImageGenerationError::ProviderError(text))
+                Err(ImageGenerationError::ProviderResponse(
+                    crate::provider_response::ProviderResponseError {
+                        status: Some(status),
+                        body: text,
+                    },
+                ))
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::image_generation::ImageGenerationClient;
+    use crate::image_generation::ImageGenerationModel as _;
+    use crate::test_utils::RecordingHttpClient;
+
+    fn request() -> ImageGenerationRequest {
+        ImageGenerationRequest {
+            prompt: "draw a cat".to_string(),
+            width: 256,
+            height: 256,
+            additional_params: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn image_generation_non_success_response_preserves_status_and_body() {
+        let body = r#"{"error":{"message":"invalid image","type":"invalid_request_error"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::BAD_REQUEST, body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.image_generation_model(DALL_E_3);
+
+        let error = model
+            .image_generation(request())
+            .await
+            .expect_err("image generation should fail with non-success status");
+
+        assert!(matches!(error, ImageGenerationError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::BAD_REQUEST)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+
+    #[tokio::test]
+    async fn image_generation_preserves_raw_provider_error_json_on_api_error_envelope() {
+        let body = r#"{"message":"quota exceeded","type":"insufficient_quota"}"#;
+        let http_client = RecordingHttpClient::new(body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.image_generation_model(DALL_E_3);
+
+        let error = model
+            .image_generation(request())
+            .await
+            .expect_err("image generation should fail with provider error envelope");
+
+        match &error {
+            ImageGenerationError::ProviderResponse(stored) => {
+                assert_eq!(stored.body, body);
+                assert_eq!(stored.status, Some(http::StatusCode::OK));
+                assert_eq!(error.provider_response_body(), Some(body));
+            }
+            other => panic!("expected ProviderResponse, got {other:?}"),
         }
     }
 }

--- a/crates/rig-core/src/providers/openai/image_generation.rs
+++ b/crates/rig-core/src/providers/openai/image_generation.rs
@@ -127,7 +127,7 @@ where
         match serde_json::from_str::<ApiResponse<ImageGenerationResponse>>(&text)? {
             ApiResponse::Ok(response) => response.try_into(),
             ApiResponse::Err(err) => {
-                let _ = err.message;
+                tracing::warn!(message = %err.message, "provider returned an error response");
                 Err(ImageGenerationError::ProviderResponse(
                     crate::provider_response::ProviderResponseError {
                         status: Some(status),

--- a/crates/rig-core/src/providers/openai/image_generation.rs
+++ b/crates/rig-core/src/providers/openai/image_generation.rs
@@ -127,7 +127,10 @@ where
 
         match serde_json::from_str::<ApiResponse<ImageGenerationResponse>>(&text)? {
             ApiResponse::Ok(response) => response.try_into(),
-            ApiResponse::Err(err) => Err(ImageGenerationError::ProviderError(err.message)),
+            ApiResponse::Err(err) => {
+                let _ = err.message;
+                Err(ImageGenerationError::ProviderError(text))
+            }
         }
     }
 }

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -1529,8 +1529,11 @@ where
                 }
                 response.try_into()
             } else {
+                let status = response.status();
                 let text = http_client::text(response).await?;
-                Err(CompletionError::ProviderError(text))
+                Err(CompletionError::HttpError(
+                    http_client::Error::InvalidStatusCodeWithMessage(status, text),
+                ))
             }
         }
         .instrument(span)
@@ -2750,5 +2753,41 @@ mod tests {
         assert_eq!(json["content"][0]["file_id"], "file_abc");
         assert!(json["content"][0].get("file_data").is_none());
         assert!(json["content"][0].get("file_url").is_none());
+    }
+
+    #[tokio::test]
+    async fn responses_completion_http_non_success_preserves_status_and_body() {
+        use crate::client::CompletionClient;
+        use crate::completion::CompletionModel;
+        use crate::providers::openai::Client;
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"error":{"message":"bad image","type":"invalid_request_error","code":"invalid_value"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::BAD_REQUEST, body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model("gpt-4o-mini");
+        let request = model.completion_request("hello").build();
+
+        let error = model
+            .completion(request)
+            .await
+            .expect_err("completion should fail with non-success status");
+
+        assert!(matches!(error, CompletionError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::BAD_REQUEST)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+        let json = error
+            .provider_response_json()
+            .expect("raw body should be valid JSON")
+            .expect("parsed JSON should be present");
+        assert_eq!(json["error"]["code"], "invalid_value");
     }
 }

--- a/crates/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -532,12 +532,19 @@ pub(crate) fn raw_choices_from_sse_body(
                 }
             }
             Some("error") => {
-                let message = value
+                if let Some(message) = value
                     .get("error")
                     .and_then(|error| error.get("message"))
                     .and_then(serde_json::Value::as_str)
-                    .unwrap_or(data);
-                return Err(CompletionError::ProviderError(message.to_owned()));
+                {
+                    tracing::warn!(message, "provider returned a streaming error event");
+                }
+                return Err(CompletionError::ProviderResponse(
+                    crate::provider_response::ProviderResponseError {
+                        status: None,
+                        body: data.to_owned(),
+                    },
+                ));
             }
             _ => {}
         }
@@ -1308,6 +1315,23 @@ mod tests {
             stream.next().await.is_none(),
             "stream should terminate after HTTP non-success"
         );
+    }
+
+    #[test]
+    fn streaming_error_event_preserves_full_payload() {
+        let payload = r#"{"type":"error","error":{"message":"boom","code":"server_error","type":"server_error"}}"#;
+        let body = format!("data: {payload}\n");
+
+        let err = super::raw_choices_from_sse_body(&body, super::ResponsesUsage::new(), "OpenAI")
+            .expect_err("error event should surface as a provider response error");
+
+        assert_eq!(err.provider_response_status(), None);
+        assert_eq!(err.provider_response_body(), Some(payload));
+        let json = err
+            .provider_response_json()
+            .expect("raw body should be valid JSON")
+            .expect("parsed JSON should be present");
+        assert_eq!(json["error"]["code"], "server_error");
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -1341,10 +1341,8 @@ mod tests {
             err,
             crate::completion::CompletionError::ProviderError(_)
         ));
-        assert_eq!(
-            err.provider_response_body(),
-            Some("Invalid content type was returned: \"application/json\"")
-        );
+        // Rig-generated transport diagnostics are not provider response bodies.
+        assert_eq!(err.provider_response_body(), None);
         assert_eq!(err.provider_response_status(), None);
     }
 

--- a/crates/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -99,41 +99,25 @@ pub enum ResponseChunkKind {
     ResponseIncomplete,
 }
 
-fn response_chunk_error_message(
-    kind: &ResponseChunkKind,
-    response: &CompletionResponse,
-    provider_name: &str,
-) -> Option<String> {
-    match kind {
-        ResponseChunkKind::ResponseFailed => Some(response_error_message(
-            response.error.as_ref(),
-            &format!("{provider_name} response stream returned a failed response"),
-        )),
-        ResponseChunkKind::ResponseIncomplete => {
-            let reason = response
-                .incomplete_details
-                .as_ref()
-                .map(|details| details.reason.as_str())
-                .unwrap_or("unknown reason");
-
-            Some(format!(
-                "{provider_name} response stream was incomplete: {reason}"
-            ))
-        }
-        _ => None,
+fn provider_response_from_responses_error_value(
+    value: &serde_json::Value,
+    data: &str,
+) -> CompletionError {
+    if let Some(message) = value
+        .get("error")
+        .and_then(|error| error.get("message"))
+        .and_then(serde_json::Value::as_str)
+    {
+        tracing::warn!(message, "provider returned a streaming error event");
     }
+
+    crate::provider_response::completion_error_from_body(data)
 }
 
-fn response_error_message(error: Option<&super::ResponseError>, fallback: &str) -> String {
-    if let Some(error) = error {
-        if error.code.is_empty() {
-            error.message.clone()
-        } else {
-            format!("{}: {}", error.code, error.message)
-        }
-    } else {
-        fallback.to_string()
-    }
+fn provider_response_from_responses_sse_data(data: &str) -> Option<CompletionError> {
+    let value = serde_json::from_str::<serde_json::Value>(data).ok()?;
+    (value.get("type").and_then(serde_json::Value::as_str) == Some("error"))
+        .then(|| provider_response_from_responses_error_value(&value, data))
 }
 
 #[derive(Clone, Copy)]
@@ -151,10 +135,6 @@ impl ResponsesStreamOptions {
         Self::StrictWithImmediateToolCalls
     }
 
-    const fn errors_on_terminal_response(self) -> bool {
-        true
-    }
-
     const fn emits_completed_tool_calls_immediately(self) -> bool {
         matches!(self, Self::StrictWithImmediateToolCalls)
     }
@@ -165,7 +145,6 @@ pub(crate) fn parse_sse_completion_body(
     provider_name: &str,
 ) -> Result<CompletionResponse, CompletionError> {
     let mut completed = None;
-    let mut provider_error = None;
 
     for line in body.lines() {
         let data = line
@@ -185,8 +164,7 @@ pub(crate) fn parse_sse_completion_body(
                         break;
                     }
                     ResponseChunkKind::ResponseFailed | ResponseChunkKind::ResponseIncomplete => {
-                        provider_error =
-                            response_chunk_error_message(&kind, &response, provider_name);
+                        return Err(crate::provider_response::completion_error_from_body(data));
                     }
                     _ => {}
                 }
@@ -207,49 +185,19 @@ pub(crate) fn parse_sse_completion_body(
                 }
             }
             Some("response.failed") | Some("response.incomplete") => {
-                provider_error = value
-                    .get("response")
-                    .cloned()
-                    .and_then(|response| {
-                        serde_json::from_value::<CompletionResponse>(response).ok()
-                    })
-                    .and_then(|response| {
-                        let kind = if value.get("type").and_then(serde_json::Value::as_str)
-                            == Some("response.failed")
-                        {
-                            ResponseChunkKind::ResponseFailed
-                        } else {
-                            ResponseChunkKind::ResponseIncomplete
-                        };
-                        response_chunk_error_message(&kind, &response, provider_name)
-                    })
-                    .or_else(|| {
-                        value
-                            .get("error")
-                            .and_then(|error| error.get("message"))
-                            .and_then(serde_json::Value::as_str)
-                            .map(ToOwned::to_owned)
-                    })
-                    .or_else(|| Some(data.to_string()));
+                return Err(crate::provider_response::completion_error_from_body(data));
             }
             Some("error") => {
-                provider_error = value
-                    .get("error")
-                    .and_then(|error| error.get("message"))
-                    .and_then(serde_json::Value::as_str)
-                    .map(ToOwned::to_owned)
-                    .or_else(|| Some(data.to_string()));
+                return Err(provider_response_from_responses_error_value(&value, data));
             }
             _ => {}
         }
     }
 
     completed.ok_or_else(|| {
-        CompletionError::ProviderError(
-            provider_error.unwrap_or_else(|| {
-                format!("{provider_name} stream did not yield response.completed")
-            }),
-        )
+        CompletionError::ProviderError(format!(
+            "{provider_name} stream did not yield response.completed"
+        ))
     })
 }
 
@@ -340,8 +288,7 @@ impl RawChoiceAccumulator {
         &mut self,
         kind: ResponseChunkKind,
         response: CompletionResponse,
-        provider_name: &str,
-        options: ResponsesStreamOptions,
+        raw_event_data: &str,
     ) -> Result<(), CompletionError> {
         match kind {
             ResponseChunkKind::ResponseCompleted => {
@@ -350,18 +297,9 @@ impl RawChoiceAccumulator {
                 }
                 Ok(())
             }
-            ResponseChunkKind::ResponseFailed | ResponseChunkKind::ResponseIncomplete
-                if options.errors_on_terminal_response() =>
-            {
-                let error_message = response_chunk_error_message(&kind, &response, provider_name)
-                    .unwrap_or_else(|| {
-                        format!(
-                            "{provider_name} returned terminal response {:?} without an error message",
-                            kind
-                        )
-                    });
-                Err(CompletionError::ProviderError(error_message))
-            }
+            ResponseChunkKind::ResponseFailed | ResponseChunkKind::ResponseIncomplete => Err(
+                crate::provider_response::completion_error_from_body(raw_event_data),
+            ),
             _ => Ok(()),
         }
     }
@@ -425,7 +363,6 @@ impl RawChoiceAccumulator {
 pub(crate) fn raw_choices_from_sse_body(
     body: &str,
     initial_usage: ResponsesUsage,
-    provider_name: &str,
 ) -> Result<Vec<StreamingRawChoice>, CompletionError> {
     let mut raw_choices = Vec::new();
     let mut accumulator = RawChoiceAccumulator::new(initial_usage);
@@ -447,7 +384,7 @@ pub(crate) fn raw_choices_from_sse_body(
                 }
                 StreamingCompletionChunk::Response(chunk) => {
                     let ResponseChunk { kind, response, .. } = *chunk;
-                    accumulator.record_response_chunk(kind, response, provider_name, options)?;
+                    accumulator.record_response_chunk(kind, response, data)?;
                 }
             }
             continue;
@@ -528,23 +465,11 @@ pub(crate) fn raw_choices_from_sse_body(
                     }) else {
                         continue;
                     };
-                    accumulator.record_response_chunk(kind, response, provider_name, options)?;
+                    accumulator.record_response_chunk(kind, response, data)?;
                 }
             }
             Some("error") => {
-                if let Some(message) = value
-                    .get("error")
-                    .and_then(|error| error.get("message"))
-                    .and_then(serde_json::Value::as_str)
-                {
-                    tracing::warn!(message, "provider returned a streaming error event");
-                }
-                return Err(CompletionError::ProviderResponse(
-                    crate::provider_response::ProviderResponseError {
-                        status: None,
-                        body: data.to_owned(),
-                    },
-                ));
+                return Err(provider_response_from_responses_error_value(&value, data));
             }
             _ => {}
         }
@@ -557,7 +482,6 @@ pub(crate) fn raw_choices_from_sse_body(
 pub(crate) async fn completion_response_from_sse_body(
     body: &str,
     raw_response: CompletionResponse,
-    provider_name: &str,
 ) -> Result<completion::CompletionResponse<CompletionResponse>, CompletionError> {
     let raw_choices = raw_choices_from_sse_body(
         body,
@@ -565,7 +489,6 @@ pub(crate) async fn completion_response_from_sse_body(
             .usage
             .clone()
             .unwrap_or_else(ResponsesUsage::new),
-        provider_name,
     )?;
     let stream = futures::stream::iter(
         raw_choices
@@ -627,24 +550,17 @@ fn usage_from_raw_response(response: &CompletionResponse) -> completion::Usage {
 pub(crate) fn stream_from_event_source<HttpClient, RequestBody>(
     event_source: GenericEventSource<HttpClient, RequestBody>,
     span: tracing::Span,
-    provider_name: &'static str,
 ) -> streaming::StreamingCompletionResponse<StreamingCompletionResponse>
 where
     HttpClient: HttpClientExt + Clone + 'static,
     RequestBody: Into<bytes::Bytes> + Clone + WasmCompatSend + 'static,
 {
-    stream_from_event_source_with_options(
-        event_source,
-        span,
-        provider_name,
-        ResponsesStreamOptions::strict(),
-    )
+    stream_from_event_source_with_options(event_source, span, ResponsesStreamOptions::strict())
 }
 
 pub(crate) fn stream_from_event_source_with_options<HttpClient, RequestBody>(
     mut event_source: GenericEventSource<HttpClient, RequestBody>,
     span: tracing::Span,
-    provider_name: &'static str,
     options: ResponsesStreamOptions,
 ) -> streaming::StreamingCompletionResponse<StreamingCompletionResponse>
 where
@@ -666,6 +582,12 @@ where
                 Ok(Event::Message(evt)) => {
                     if evt.data.trim().is_empty() || evt.data == "[DONE]" {
                         continue;
+                    }
+
+                    if let Some(error) = provider_response_from_responses_sse_data(&evt.data) {
+                        terminated_with_error = true;
+                        yield Err(error);
+                        break;
                     }
 
                     let data = serde_json::from_str::<StreamingCompletionChunk>(&evt.data);
@@ -693,9 +615,11 @@ where
                                 span.record("gen_ai.response.id", response.id.as_str());
                                 span.record("gen_ai.response.model", response.model.as_str());
                             }
-                            if let Err(error) =
-                                accumulator.record_response_chunk(kind, response, provider_name, options)
-                            {
+                            if let Err(error) = accumulator.record_response_chunk(
+                                kind,
+                                response,
+                                &evt.data,
+                            ) {
                                 terminated_with_error = true;
                                 yield Err(error);
                                 break;
@@ -924,7 +848,7 @@ where
         let client = self.client.clone();
         let event_source = GenericEventSource::new(client, req);
 
-        Ok(stream_from_event_source(event_source, span, "OpenAI"))
+        Ok(stream_from_event_source(event_source, span))
     }
 }
 
@@ -1008,6 +932,44 @@ mod tests {
         }
 
         panic!("stream should yield a final response");
+    }
+
+    #[test]
+    fn parse_sse_completion_body_preserves_error_payloads() {
+        let mut response = sample_response(ResponseStatus::Failed);
+        response.error = Some(ResponseError {
+            code: "server_error".to_string(),
+            message: "response failed".to_string(),
+        });
+        let events = [
+            json!({
+                "type": "response.failed",
+                "sequence_number": 1,
+                "response": response,
+            }),
+            json!({
+                "type": "error",
+                "error": {
+                    "message": "boom",
+                    "code": "server_error",
+                    "type": "server_error"
+                }
+            }),
+        ];
+
+        for event in events {
+            let payload = serde_json::to_string(&event).expect("event should serialize");
+            let body = format!("data: {payload}\n");
+            let err = super::parse_sse_completion_body(&body, "ChatGPT")
+                .expect_err("error payload should surface as provider response");
+
+            assert!(matches!(
+                err,
+                crate::completion::CompletionError::ProviderResponse(_)
+            ));
+            assert_eq!(err.provider_response_status(), None);
+            assert_eq!(err.provider_response_body(), Some(payload.as_str()));
+        }
     }
 
     #[test]
@@ -1179,10 +1141,14 @@ mod tests {
 
         let err = first_error_from_event(event).await;
 
-        assert_eq!(
-            err.to_string(),
-            "ProviderError: maximum context length exceeded"
-        );
+        assert!(matches!(
+            err,
+            crate::completion::CompletionError::ProviderResponse(_)
+        ));
+        assert_eq!(err.provider_response_status(), None);
+        assert!(err.provider_response_body().is_some_and(|body| {
+            body.contains("response.failed") && body.contains("maximum context length exceeded")
+        }));
     }
 
     #[tokio::test]
@@ -1201,10 +1167,16 @@ mod tests {
 
         let err = first_error_from_event(event).await;
 
-        assert_eq!(
-            err.to_string(),
-            "ProviderError: context_length_exceeded: maximum context length exceeded"
-        );
+        assert!(matches!(
+            err,
+            crate::completion::CompletionError::ProviderResponse(_)
+        ));
+        assert_eq!(err.provider_response_status(), None);
+        assert!(err.provider_response_body().is_some_and(|body| {
+            body.contains("response.failed")
+                && body.contains("context_length_exceeded")
+                && body.contains("maximum context length exceeded")
+        }));
     }
 
     #[tokio::test]
@@ -1222,10 +1194,14 @@ mod tests {
 
         let err = first_error_from_event(event).await;
 
-        assert_eq!(
-            err.to_string(),
-            "ProviderError: OpenAI response stream was incomplete: max_output_tokens"
-        );
+        assert!(matches!(
+            err,
+            crate::completion::CompletionError::ProviderResponse(_)
+        ));
+        assert_eq!(err.provider_response_status(), None);
+        assert!(err.provider_response_body().is_some_and(|body| {
+            body.contains("response.incomplete") && body.contains("max_output_tokens")
+        }));
     }
 
     #[tokio::test]
@@ -1271,13 +1247,59 @@ mod tests {
             .await
             .expect("stream should yield an item")
             .expect_err("stream should surface a provider error");
-        assert_eq!(
-            err.to_string(),
-            "ProviderError: server_error: response stream failed"
-        );
+        assert!(matches!(
+            err,
+            crate::completion::CompletionError::ProviderResponse(_)
+        ));
+        assert_eq!(err.provider_response_status(), None);
+        assert!(err.provider_response_body().is_some_and(|body| {
+            body.contains("response.failed") && body.contains("response stream failed")
+        }));
         assert!(
             stream.next().await.is_none(),
             "stream should terminate immediately after the first terminal error"
+        );
+    }
+
+    #[tokio::test]
+    async fn streaming_error_event_preserves_full_payload_in_live_loop() {
+        use crate::providers::internal::openai_chat_completions_compatible::test_support::sse_bytes_from_json_events;
+        use crate::test_utils::MockStreamingClient;
+
+        let payload = json!({
+            "type": "error",
+            "error": {
+                "message": "boom",
+                "code": "server_error",
+                "type": "server_error"
+            }
+        });
+
+        let client = openai::Client::builder()
+            .http_client(MockStreamingClient {
+                sse_bytes: sse_bytes_from_json_events(&[payload]),
+            })
+            .api_key("test-key")
+            .build()
+            .expect("client should build");
+        let model = client.completion_model("gpt-5.4");
+        let request = model.completion_request("hello").build();
+        let mut stream = model.stream(request).await.expect("stream should start");
+
+        let err = stream
+            .next()
+            .await
+            .expect("stream should yield an item")
+            .expect_err("stream should surface a provider response error");
+        assert_eq!(err.provider_response_status(), None);
+        assert!(
+            err.provider_response_body().is_some_and(|body| {
+                body.contains("\"type\":\"error\"") && body.contains("boom")
+            })
+        );
+        assert!(
+            stream.next().await.is_none(),
+            "stream should terminate after error event"
         );
     }
 
@@ -1295,7 +1317,7 @@ mod tests {
             .expect("request should build");
         let event_source = GenericEventSource::new(client, req);
         let span = tracing::Span::none();
-        let mut stream = super::stream_from_event_source(event_source, span, "OpenAI");
+        let mut stream = super::stream_from_event_source(event_source, span);
 
         let err = stream
             .next()
@@ -1322,7 +1344,7 @@ mod tests {
         let payload = r#"{"type":"error","error":{"message":"boom","code":"server_error","type":"server_error"}}"#;
         let body = format!("data: {payload}\n");
 
-        let err = super::raw_choices_from_sse_body(&body, super::ResponsesUsage::new(), "OpenAI")
+        let err = super::raw_choices_from_sse_body(&body, super::ResponsesUsage::new())
             .expect_err("error event should surface as a provider response error");
 
         assert_eq!(err.provider_response_status(), None);
@@ -1350,7 +1372,7 @@ mod tests {
             .expect("request should build");
         let event_source = GenericEventSource::new(client, req);
         let span = tracing::Span::none();
-        let mut stream = super::stream_from_event_source(event_source, span, "OpenAI");
+        let mut stream = super::stream_from_event_source(event_source, span);
 
         let err = stream
             .next()

--- a/crates/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -702,7 +702,7 @@ where
                 Err(error) => {
                     tracing::error!(?error, "SSE error");
                     terminated_with_error = true;
-                    yield Err(CompletionError::ProviderError(error.to_string()));
+                    yield Err(CompletionError::from_stream_transport(error));
                     break;
                 }
             }
@@ -1272,6 +1272,80 @@ mod tests {
             stream.next().await.is_none(),
             "stream should terminate immediately after the first terminal error"
         );
+    }
+
+    #[tokio::test]
+    async fn streaming_http_non_success_preserves_status_and_body() {
+        use crate::http_client::sse::GenericEventSource;
+        use crate::test_utils::HttpErrorStreamingClient;
+
+        let body = r#"{"error":{"message":"quota exceeded"}}"#;
+        let client = HttpErrorStreamingClient::new(http::StatusCode::TOO_MANY_REQUESTS, body);
+        let req = http::Request::builder()
+            .method("POST")
+            .uri("http://localhost/v1/responses")
+            .body(Vec::new())
+            .expect("request should build");
+        let event_source = GenericEventSource::new(client, req);
+        let span = tracing::Span::none();
+        let mut stream = super::stream_from_event_source(event_source, span, "OpenAI");
+
+        let err = stream
+            .next()
+            .await
+            .expect("stream should yield transport error")
+            .expect_err("HTTP non-success should surface as a stream error");
+        assert_eq!(
+            err.provider_response_status(),
+            Some(http::StatusCode::TOO_MANY_REQUESTS)
+        );
+        assert_eq!(err.provider_response_body(), Some(body));
+        assert_eq!(
+            err.provider_response_json().expect("valid JSON body"),
+            Some(serde_json::json!({"error": {"message": "quota exceeded"}}))
+        );
+        assert!(
+            stream.next().await.is_none(),
+            "stream should terminate after HTTP non-success"
+        );
+    }
+
+    #[tokio::test]
+    async fn streaming_non_http_transport_error_stays_provider_error() {
+        use crate::http_client::sse::GenericEventSource;
+        use crate::test_utils::SequencedStreamingHttpClient;
+
+        let chunks = vec![Err(crate::http_client::Error::InvalidContentType(
+            http::HeaderValue::from_static("application/json"),
+        ))];
+        let client = SequencedStreamingHttpClient::new(chunks);
+        let req = http::Request::builder()
+            .method("POST")
+            .uri("http://localhost/v1/responses")
+            .body(Vec::new())
+            .expect("request should build");
+        let event_source = GenericEventSource::new(client, req);
+        let span = tracing::Span::none();
+        let mut stream = super::stream_from_event_source(event_source, span, "OpenAI");
+
+        let err = stream
+            .next()
+            .await
+            .expect("stream should yield transport error")
+            .expect_err("non-HTTP transport failure should surface as provider error");
+        assert_eq!(
+            err.to_string(),
+            "ProviderError: Invalid content type was returned: \"application/json\""
+        );
+        assert!(matches!(
+            err,
+            crate::completion::CompletionError::ProviderError(_)
+        ));
+        assert_eq!(
+            err.provider_response_body(),
+            Some("Invalid content type was returned: \"application/json\"")
+        );
+        assert_eq!(err.provider_response_status(), None);
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/providers/openai/responses_api/websocket.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/websocket.rs
@@ -846,6 +846,7 @@ mod tests {
             output: Vec::new(),
             tools: Vec::new(),
             additional_parameters: Default::default(),
+            provider_reasoning: None,
         }
     }
 

--- a/crates/rig-core/src/providers/openai/transcription.rs
+++ b/crates/rig-core/src/providers/openai/transcription.rs
@@ -111,14 +111,19 @@ where
                 ApiResponse::Ok(response) => response.try_into(),
                 ApiResponse::Err(api_error_response) => {
                     let _ = api_error_response.message;
-                    Err(TranscriptionError::ProviderError(
-                        String::from_utf8_lossy(&response_body).into_owned(),
+                    Err(TranscriptionError::ProviderResponse(
+                        crate::provider_response::ProviderResponseError {
+                            status: Some(status),
+                            body: String::from_utf8_lossy(&response_body).into_owned(),
+                        },
                     ))
                 }
             }
         } else {
             let str = String::from_utf8_lossy(&response_body).to_string();
-            Err(TranscriptionError::ProviderError(str))
+            Err(TranscriptionError::HttpError(
+                crate::http_client::Error::InvalidStatusCodeWithMessage(status, str),
+            ))
         }
     }
 }

--- a/crates/rig-core/src/providers/openai/transcription.rs
+++ b/crates/rig-core/src/providers/openai/transcription.rs
@@ -110,7 +110,7 @@ where
             match serde_json::from_slice::<ApiResponse<TranscriptionResponse>>(&response_body)? {
                 ApiResponse::Ok(response) => response.try_into(),
                 ApiResponse::Err(api_error_response) => {
-                    let _ = api_error_response.message;
+                    tracing::warn!(message = %api_error_response.message, "provider returned an error response");
                     Err(TranscriptionError::ProviderResponse(
                         crate::provider_response::ProviderResponseError {
                             status: Some(status),

--- a/crates/rig-core/src/providers/openai/transcription.rs
+++ b/crates/rig-core/src/providers/openai/transcription.rs
@@ -109,9 +109,12 @@ where
         if status.is_success() {
             match serde_json::from_slice::<ApiResponse<TranscriptionResponse>>(&response_body)? {
                 ApiResponse::Ok(response) => response.try_into(),
-                ApiResponse::Err(api_error_response) => Err(TranscriptionError::ProviderError(
-                    api_error_response.message,
-                )),
+                ApiResponse::Err(api_error_response) => {
+                    let _ = api_error_response.message;
+                    Err(TranscriptionError::ProviderError(
+                        String::from_utf8_lossy(&response_body).into_owned(),
+                    ))
+                }
             }
         } else {
             let str = String::from_utf8_lossy(&response_body).to_string();

--- a/crates/rig-core/src/providers/openai/transcription.rs
+++ b/crates/rig-core/src/providers/openai/transcription.rs
@@ -127,3 +127,41 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::transcription::TranscriptionClient;
+    use crate::test_utils::RecordingHttpClient;
+    use crate::transcription::TranscriptionModel as _;
+
+    #[tokio::test]
+    async fn transcription_http_non_success_preserves_status_and_body() {
+        let body = r#"{"error":{"message":"bad audio","type":"invalid_request_error"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::BAD_REQUEST, body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.transcription_model(WHISPER_1);
+
+        let error = match model
+            .transcription_request()
+            .data(vec![0u8; 16])
+            .send()
+            .await
+        {
+            Err(error) => error,
+            Ok(_) => panic!("transcription should fail with non-success status"),
+        };
+
+        assert!(matches!(error, TranscriptionError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::BAD_REQUEST)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+}

--- a/crates/rig-core/src/providers/openrouter/completion.rs
+++ b/crates/rig-core/src/providers/openrouter/completion.rs
@@ -2019,7 +2019,12 @@ where
                             "OpenRouter response: {response:?}");
                         response.try_into()
                     }
-                    ApiResponse::Err(err) => Err(CompletionError::ProviderError(err.message)),
+                    ApiResponse::Err(err) => {
+                        let _ = err.message;
+                        Err(CompletionError::ProviderError(
+                            String::from_utf8_lossy(&response_body).into_owned(),
+                        ))
+                    }
                 }
             } else {
                 Err(CompletionError::ProviderError(

--- a/crates/rig-core/src/providers/openrouter/completion.rs
+++ b/crates/rig-core/src/providers/openrouter/completion.rs
@@ -2021,14 +2021,20 @@ where
                     }
                     ApiResponse::Err(err) => {
                         let _ = err.message;
-                        Err(CompletionError::ProviderError(
-                            String::from_utf8_lossy(&response_body).into_owned(),
+                        Err(CompletionError::ProviderResponse(
+                            crate::provider_response::ProviderResponseError {
+                                status: Some(status),
+                                body: String::from_utf8_lossy(&response_body).into_owned(),
+                            },
                         ))
                     }
                 }
             } else {
-                Err(CompletionError::ProviderError(
-                    String::from_utf8_lossy(&response_body).to_string(),
+                Err(CompletionError::HttpError(
+                    crate::http_client::Error::InvalidStatusCodeWithMessage(
+                        status,
+                        String::from_utf8_lossy(&response_body).to_string(),
+                    ),
                 ))
             }
         }

--- a/crates/rig-core/src/providers/openrouter/completion.rs
+++ b/crates/rig-core/src/providers/openrouter/completion.rs
@@ -2020,7 +2020,7 @@ where
                         response.try_into()
                     }
                     ApiResponse::Err(err) => {
-                        let _ = err.message;
+                        tracing::warn!(message = %err.message, "provider returned an error response");
                         Err(CompletionError::ProviderResponse(
                             crate::provider_response::ProviderResponseError {
                                 status: Some(status),

--- a/crates/rig-core/src/providers/openrouter/embedding.rs
+++ b/crates/rig-core/src/providers/openrouter/embedding.rs
@@ -145,7 +145,7 @@ where
                         .collect())
                 }
                 ApiResponse::Err(err) => {
-                    let _ = err.message;
+                    tracing::warn!(message = %err.message, "provider returned an error response");
                     Err(EmbeddingError::ProviderResponse(
                         crate::provider_response::ProviderResponseError {
                             status: Some(status),

--- a/crates/rig-core/src/providers/openrouter/embedding.rs
+++ b/crates/rig-core/src/providers/openrouter/embedding.rs
@@ -112,7 +112,8 @@ where
 
         let response = self.client.send(req).await?;
 
-        if response.status().is_success() {
+        let status = response.status();
+        if status.is_success() {
             let response_body: Vec<u8> = response.into_body().await?;
             let parsed: ApiResponse<EmbeddingResponse> = serde_json::from_slice(&response_body)?;
 
@@ -145,14 +146,19 @@ where
                 }
                 ApiResponse::Err(err) => {
                     let _ = err.message;
-                    Err(EmbeddingError::ProviderError(
-                        String::from_utf8_lossy(&response_body).into_owned(),
+                    Err(EmbeddingError::ProviderResponse(
+                        crate::provider_response::ProviderResponseError {
+                            status: Some(status),
+                            body: String::from_utf8_lossy(&response_body).into_owned(),
+                        },
                     ))
                 }
             }
         } else {
             let text = http_client::text(response).await?;
-            Err(EmbeddingError::ProviderError(text))
+            Err(EmbeddingError::HttpError(
+                http_client::Error::InvalidStatusCodeWithMessage(status, text),
+            ))
         }
     }
 }

--- a/crates/rig-core/src/providers/openrouter/embedding.rs
+++ b/crates/rig-core/src/providers/openrouter/embedding.rs
@@ -113,10 +113,10 @@ where
         let response = self.client.send(req).await?;
 
         if response.status().is_success() {
-            let body: Vec<u8> = response.into_body().await?;
-            let body: ApiResponse<EmbeddingResponse> = serde_json::from_slice(&body)?;
+            let response_body: Vec<u8> = response.into_body().await?;
+            let parsed: ApiResponse<EmbeddingResponse> = serde_json::from_slice(&response_body)?;
 
-            match body {
+            match parsed {
                 ApiResponse::Ok(response) => {
                     tracing::info!(target: "rig",
                         "OpenRouter embedding token usage: {:?}",
@@ -143,7 +143,12 @@ where
                         })
                         .collect())
                 }
-                ApiResponse::Err(err) => Err(EmbeddingError::ProviderError(err.message)),
+                ApiResponse::Err(err) => {
+                    let _ = err.message;
+                    Err(EmbeddingError::ProviderError(
+                        String::from_utf8_lossy(&response_body).into_owned(),
+                    ))
+                }
             }
         } else {
             let text = http_client::text(response).await?;

--- a/crates/rig-core/src/providers/perplexity.rs
+++ b/crates/rig-core/src/providers/perplexity.rs
@@ -427,7 +427,7 @@ where
                         Ok(response.try_into()?)
                     }
                     ApiResponse::Err(error) => {
-                        let _ = error.message;
+                        tracing::warn!(message = %error.message, "provider returned an error response");
                         Err(CompletionError::ProviderResponse(
                             crate::provider_response::ProviderResponseError {
                                 status: Some(status),

--- a/crates/rig-core/src/providers/perplexity.rs
+++ b/crates/rig-core/src/providers/perplexity.rs
@@ -426,7 +426,12 @@ where
                         }
                         Ok(response.try_into()?)
                     }
-                    ApiResponse::Err(error) => Err(CompletionError::ProviderError(error.message)),
+                    ApiResponse::Err(error) => {
+                        let _ = error.message;
+                        Err(CompletionError::ProviderError(
+                            String::from_utf8_lossy(&response_body).into_owned(),
+                        ))
+                    }
                 }
             } else {
                 Err(CompletionError::ProviderError(

--- a/crates/rig-core/src/providers/perplexity.rs
+++ b/crates/rig-core/src/providers/perplexity.rs
@@ -428,14 +428,20 @@ where
                     }
                     ApiResponse::Err(error) => {
                         let _ = error.message;
-                        Err(CompletionError::ProviderError(
-                            String::from_utf8_lossy(&response_body).into_owned(),
+                        Err(CompletionError::ProviderResponse(
+                            crate::provider_response::ProviderResponseError {
+                                status: Some(status),
+                                body: String::from_utf8_lossy(&response_body).into_owned(),
+                            },
                         ))
                     }
                 }
             } else {
-                Err(CompletionError::ProviderError(
-                    String::from_utf8_lossy(&response_body).to_string(),
+                Err(CompletionError::HttpError(
+                    http_client::Error::InvalidStatusCodeWithMessage(
+                        status,
+                        String::from_utf8_lossy(&response_body).to_string(),
+                    ),
                 ))
             }
         };

--- a/crates/rig-core/src/providers/together/completion.rs
+++ b/crates/rig-core/src/providers/together/completion.rs
@@ -300,7 +300,12 @@ where
                         }
                         response.try_into()
                     }
-                    ApiResponse::Error(err) => Err(CompletionError::ProviderError(err.error)),
+                    ApiResponse::Error(err) => {
+                        let _ = (&err.error, &err.code);
+                        Err(CompletionError::ProviderError(
+                            String::from_utf8_lossy(&response_body).into_owned(),
+                        ))
+                    }
                 }
             } else {
                 Err(CompletionError::ProviderError(

--- a/crates/rig-core/src/providers/together/completion.rs
+++ b/crates/rig-core/src/providers/together/completion.rs
@@ -301,7 +301,11 @@ where
                         response.try_into()
                     }
                     ApiResponse::Error(err) => {
-                        let _ = (&err.error, &err.code);
+                        tracing::warn!(
+                            message = %err.error,
+                            code = %err.code,
+                            "provider returned an error response"
+                        );
                         Err(CompletionError::ProviderResponse(
                             crate::provider_response::ProviderResponseError {
                                 status: Some(status),

--- a/crates/rig-core/src/providers/together/completion.rs
+++ b/crates/rig-core/src/providers/together/completion.rs
@@ -302,14 +302,20 @@ where
                     }
                     ApiResponse::Error(err) => {
                         let _ = (&err.error, &err.code);
-                        Err(CompletionError::ProviderError(
-                            String::from_utf8_lossy(&response_body).into_owned(),
+                        Err(CompletionError::ProviderResponse(
+                            crate::provider_response::ProviderResponseError {
+                                status: Some(status),
+                                body: String::from_utf8_lossy(&response_body).into_owned(),
+                            },
                         ))
                     }
                 }
             } else {
-                Err(CompletionError::ProviderError(
-                    String::from_utf8_lossy(&response_body).to_string(),
+                Err(CompletionError::HttpError(
+                    crate::http_client::Error::InvalidStatusCodeWithMessage(
+                        status,
+                        String::from_utf8_lossy(&response_body).to_string(),
+                    ),
                 ))
             }
         }

--- a/crates/rig-core/src/providers/together/completion.rs
+++ b/crates/rig-core/src/providers/together/completion.rs
@@ -303,7 +303,6 @@ where
                     ApiResponse::Error(err) => {
                         tracing::warn!(
                             message = %err.error,
-                            code = %err.code,
                             "provider returned an error response"
                         );
                         Err(CompletionError::ProviderResponse(
@@ -378,7 +377,48 @@ pub enum ToolChoiceFunctionKind {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::client::CompletionClient;
+    use crate::completion::{CompletionError, CompletionModel};
+    use crate::test_utils::RecordingHttpClient;
     use crate::{OneOrMany, message};
+
+    #[tokio::test]
+    async fn completion_preserves_raw_provider_error_json_on_api_error_envelope() {
+        let body = r#"{"error":"model unavailable","code":"model_overloaded"}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::ACCEPTED, body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model("meta-llama/Meta-Llama-3-70B-Instruct-Turbo");
+        let request = model.completion_request("hello").build();
+
+        let error = model
+            .completion(request)
+            .await
+            .expect_err("completion should fail with provider error envelope");
+
+        match &error {
+            CompletionError::ProviderResponse(stored) => {
+                assert_eq!(stored.body, body);
+                assert_eq!(stored.status, Some(http::StatusCode::ACCEPTED));
+                assert_eq!(error.provider_response_body(), Some(body));
+                assert_eq!(
+                    error.provider_response_status(),
+                    Some(http::StatusCode::ACCEPTED)
+                );
+                let json = error
+                    .provider_response_json()
+                    .expect("raw body should be valid JSON")
+                    .expect("parsed JSON should be present");
+                assert_eq!(json["code"], "model_overloaded");
+                assert_eq!(json["error"], "model unavailable");
+            }
+            other => panic!("expected ProviderResponse, got {other:?}"),
+        }
+    }
 
     #[test]
     fn together_request_conversion_errors_when_all_messages_are_filtered() {

--- a/crates/rig-core/src/providers/together/embedding.rs
+++ b/crates/rig-core/src/providers/together/embedding.rs
@@ -106,7 +106,8 @@ where
 
         let response = self.client.send(req).await?;
 
-        if response.status().is_success() {
+        let status = response.status();
+        if status.is_success() {
             let response_body: Vec<u8> = response.into_body().await?;
             let parsed: ApiResponse<EmbeddingResponse> = serde_json::from_slice(&response_body)?;
 
@@ -134,14 +135,19 @@ where
                 }
                 ApiResponse::Error(err) => {
                     let _ = (&err.error, &err.code);
-                    Err(EmbeddingError::ProviderError(
-                        String::from_utf8_lossy(&response_body).into_owned(),
+                    Err(EmbeddingError::ProviderResponse(
+                        crate::provider_response::ProviderResponseError {
+                            status: Some(status),
+                            body: String::from_utf8_lossy(&response_body).into_owned(),
+                        },
                     ))
                 }
             }
         } else {
             let text = http_client::text(response).await?;
-            Err(EmbeddingError::ProviderError(text))
+            Err(EmbeddingError::HttpError(
+                http_client::Error::InvalidStatusCodeWithMessage(status, text),
+            ))
         }
     }
 }

--- a/crates/rig-core/src/providers/together/embedding.rs
+++ b/crates/rig-core/src/providers/together/embedding.rs
@@ -107,10 +107,10 @@ where
         let response = self.client.send(req).await?;
 
         if response.status().is_success() {
-            let body: Vec<u8> = response.into_body().await?;
-            let body: ApiResponse<EmbeddingResponse> = serde_json::from_slice(&body)?;
+            let response_body: Vec<u8> = response.into_body().await?;
+            let parsed: ApiResponse<EmbeddingResponse> = serde_json::from_slice(&response_body)?;
 
-            match body {
+            match parsed {
                 ApiResponse::Ok(response) => {
                     if response.data.len() != documents.len() {
                         return Err(EmbeddingError::ResponseError(
@@ -132,7 +132,12 @@ where
                         })
                         .collect())
                 }
-                ApiResponse::Error(err) => Err(EmbeddingError::ProviderError(err.message())),
+                ApiResponse::Error(err) => {
+                    let _ = (&err.error, &err.code);
+                    Err(EmbeddingError::ProviderError(
+                        String::from_utf8_lossy(&response_body).into_owned(),
+                    ))
+                }
             }
         } else {
             let text = http_client::text(response).await?;

--- a/crates/rig-core/src/providers/together/embedding.rs
+++ b/crates/rig-core/src/providers/together/embedding.rs
@@ -134,7 +134,11 @@ where
                         .collect())
                 }
                 ApiResponse::Error(err) => {
-                    let _ = (&err.error, &err.code);
+                    tracing::warn!(
+                        message = %err.error,
+                        code = %err.code,
+                        "provider returned an error response"
+                    );
                     Err(EmbeddingError::ProviderResponse(
                         crate::provider_response::ProviderResponseError {
                             status: Some(status),

--- a/crates/rig-core/src/providers/together/embedding.rs
+++ b/crates/rig-core/src/providers/together/embedding.rs
@@ -11,10 +11,7 @@ use crate::{
     http_client::{self, HttpClientExt},
 };
 
-use super::{
-    Client,
-    client::together_ai_api_types::{ApiErrorResponse, ApiResponse},
-};
+use super::{Client, client::together_ai_api_types::ApiResponse};
 
 // ================================================================
 // Together AI Embedding API
@@ -34,21 +31,6 @@ pub struct EmbeddingResponse {
     pub model: String,
     pub object: String,
     pub data: Vec<EmbeddingData>,
-}
-
-impl From<ApiErrorResponse> for EmbeddingError {
-    fn from(err: ApiErrorResponse) -> Self {
-        EmbeddingError::ProviderError(err.message())
-    }
-}
-
-impl From<ApiResponse<EmbeddingResponse>> for Result<EmbeddingResponse, EmbeddingError> {
-    fn from(value: ApiResponse<EmbeddingResponse>) -> Self {
-        match value {
-            ApiResponse::Ok(response) => Ok(response),
-            ApiResponse::Error(err) => Err(EmbeddingError::ProviderError(err.message())),
-        }
-    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -136,7 +118,6 @@ where
                 ApiResponse::Error(err) => {
                     tracing::warn!(
                         message = %err.error,
-                        code = %err.code,
                         "provider returned an error response"
                     );
                     Err(EmbeddingError::ProviderResponse(

--- a/crates/rig-core/src/providers/voyageai.rs
+++ b/crates/rig-core/src/providers/voyageai.rs
@@ -269,7 +269,12 @@ where
 
                     Ok(embeddings::EmbeddingResponse { embeddings, usage })
                 }
-                ApiResponse::Err(err) => Err(EmbeddingError::ProviderError(err.message)),
+                ApiResponse::Err(err) => {
+                    let _ = err.message;
+                    Err(EmbeddingError::ProviderError(
+                        String::from_utf8_lossy(&response_body).into_owned(),
+                    ))
+                }
             }
         } else {
             Err(EmbeddingError::ProviderError(

--- a/crates/rig-core/src/providers/voyageai.rs
+++ b/crates/rig-core/src/providers/voyageai.rs
@@ -270,7 +270,7 @@ where
                     Ok(embeddings::EmbeddingResponse { embeddings, usage })
                 }
                 ApiResponse::Err(err) => {
-                    let _ = err.message;
+                    tracing::warn!(message = %err.message, "provider returned an error response");
                     Err(EmbeddingError::ProviderResponse(
                         crate::provider_response::ProviderResponseError {
                             status: Some(status),

--- a/crates/rig-core/src/providers/voyageai.rs
+++ b/crates/rig-core/src/providers/voyageai.rs
@@ -271,14 +271,20 @@ where
                 }
                 ApiResponse::Err(err) => {
                     let _ = err.message;
-                    Err(EmbeddingError::ProviderError(
-                        String::from_utf8_lossy(&response_body).into_owned(),
+                    Err(EmbeddingError::ProviderResponse(
+                        crate::provider_response::ProviderResponseError {
+                            status: Some(status),
+                            body: String::from_utf8_lossy(&response_body).into_owned(),
+                        },
                     ))
                 }
             }
         } else {
-            Err(EmbeddingError::ProviderError(
-                String::from_utf8_lossy(&response_body).to_string(),
+            Err(EmbeddingError::HttpError(
+                crate::http_client::Error::InvalidStatusCodeWithMessage(
+                    status,
+                    String::from_utf8_lossy(&response_body).to_string(),
+                ),
             ))
         }
     }

--- a/crates/rig-core/src/providers/xai/streaming.rs
+++ b/crates/rig-core/src/providers/xai/streaming.rs
@@ -88,7 +88,6 @@ where
     Ok(stream_from_event_source_with_options(
         event_source,
         span,
-        "xAI",
         ResponsesStreamOptions::strict_with_immediate_tool_calls(),
     ))
 }
@@ -213,10 +212,14 @@ mod tests {
             .await
             .expect("stream should yield terminal error")
             .expect_err("stream should surface a provider error");
-        assert_eq!(
-            err.to_string(),
-            "ProviderError: server_error: response stream failed"
-        );
+        assert!(matches!(
+            err,
+            crate::completion::CompletionError::ProviderResponse(_)
+        ));
+        assert_eq!(err.provider_response_status(), None);
+        assert!(err.provider_response_body().is_some_and(|body| {
+            body.contains("response.failed") && body.contains("response stream failed")
+        }));
         assert!(
             stream.next().await.is_none(),
             "stream should terminate immediately after the first terminal error"

--- a/crates/rig-core/src/test_utils/http.rs
+++ b/crates/rig-core/src/test_utils/http.rs
@@ -115,6 +115,33 @@ impl RecordingHttpClient {
             Err(poisoned) => poisoned.into_inner(),
         }
     }
+
+    fn record_request(&self, uri: String, headers: http::HeaderMap, body: Bytes) {
+        self.requests_guard()
+            .push(CapturedHttpRequest { uri, headers, body });
+    }
+
+    fn build_unary_response<U>(
+        response: MockHttpResponse,
+    ) -> http_client::Result<Response<LazyBody<U>>>
+    where
+        U: From<Bytes> + WasmCompatSend + 'static,
+    {
+        let (status, response_body) = match response {
+            MockHttpResponse::Success(response_body) => (http::StatusCode::OK, response_body),
+            MockHttpResponse::Error(status, message) => {
+                return Err(http_client::Error::InvalidStatusCodeWithMessage(
+                    status, message,
+                ));
+            }
+            MockHttpResponse::ErrorResponse(status, response_body) => (status, response_body),
+        };
+        let body: LazyBody<U> = Box::pin(async move { Ok(U::from(response_body)) });
+        Response::builder()
+            .status(status)
+            .body(body)
+            .map_err(http_client::Error::Protocol)
+    }
 }
 
 impl HttpClientExt for RecordingHttpClient {
@@ -126,48 +153,25 @@ impl HttpClientExt for RecordingHttpClient {
         T: Into<Bytes> + WasmCompatSend,
         U: From<Bytes> + WasmCompatSend + 'static,
     {
-        let requests = Arc::clone(&self.requests);
         let response = self.response_guard().clone();
         let (parts, body) = req.into_parts();
-        let uri = parts.uri.to_string();
-        let headers = parts.headers;
-        let body = body.into();
+        self.record_request(parts.uri.to_string(), parts.headers, body.into());
 
-        match requests.lock() {
-            Ok(mut guard) => guard.push(CapturedHttpRequest { uri, headers, body }),
-            Err(poisoned) => poisoned
-                .into_inner()
-                .push(CapturedHttpRequest { uri, headers, body }),
-        }
-
-        async move {
-            let (status, response_body) = match response {
-                MockHttpResponse::Success(response_body) => (http::StatusCode::OK, response_body),
-                MockHttpResponse::Error(status, message) => {
-                    return Err(http_client::Error::InvalidStatusCodeWithMessage(
-                        status, message,
-                    ));
-                }
-                MockHttpResponse::ErrorResponse(status, response_body) => (status, response_body),
-            };
-            let body: LazyBody<U> = Box::pin(async move { Ok(U::from(response_body)) });
-            Response::builder()
-                .status(status)
-                .body(body)
-                .map_err(http_client::Error::Protocol)
-        }
+        async move { Self::build_unary_response(response) }
     }
 
     fn send_multipart<U>(
         &self,
-        _req: Request<MultipartForm>,
+        req: Request<MultipartForm>,
     ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
     where
         U: From<Bytes> + WasmCompatSend + 'static,
     {
-        future::ready(Err(http_client::Error::InvalidStatusCode(
-            http::StatusCode::NOT_IMPLEMENTED,
-        )))
+        let response = self.response_guard().clone();
+        let (parts, _body) = req.into_parts();
+        self.record_request(parts.uri.to_string(), parts.headers, Bytes::new());
+
+        async move { Self::build_unary_response(response) }
     }
 
     fn send_streaming<T>(

--- a/crates/rig-core/src/test_utils/http.rs
+++ b/crates/rig-core/src/test_utils/http.rs
@@ -32,6 +32,9 @@ pub enum MockHttpResponse {
     Success(Bytes),
     /// Return a status-code error with the given body text.
     Error(http::StatusCode, String),
+    /// Return an HTTP response with the given (typically non-success) status
+    /// and body, instead of a transport-level error.
+    ErrorResponse(http::StatusCode, Bytes),
 }
 
 impl MockHttpResponse {
@@ -74,6 +77,18 @@ impl RecordingHttpClient {
         Self {
             requests: Arc::new(Mutex::new(Vec::new())),
             response: Arc::new(Mutex::new(MockHttpResponse::error(status, message))),
+        }
+    }
+
+    /// Create a client that returns a non-success HTTP response (status and body)
+    /// for unary requests, instead of a transport-level error.
+    pub fn with_error_response(status: http::StatusCode, body: impl Into<Bytes>) -> Self {
+        Self {
+            requests: Arc::new(Mutex::new(Vec::new())),
+            response: Arc::new(Mutex::new(MockHttpResponse::ErrorResponse(
+                status,
+                body.into(),
+            ))),
         }
     }
 
@@ -126,17 +141,18 @@ impl HttpClientExt for RecordingHttpClient {
         }
 
         async move {
-            let response_body = match response {
-                MockHttpResponse::Success(response_body) => response_body,
+            let (status, response_body) = match response {
+                MockHttpResponse::Success(response_body) => (http::StatusCode::OK, response_body),
                 MockHttpResponse::Error(status, message) => {
                     return Err(http_client::Error::InvalidStatusCodeWithMessage(
                         status, message,
                     ));
                 }
+                MockHttpResponse::ErrorResponse(status, response_body) => (status, response_body),
             };
             let body: LazyBody<U> = Box::pin(async move { Ok(U::from(response_body)) });
             Response::builder()
-                .status(http::StatusCode::OK)
+                .status(status)
                 .body(body)
                 .map_err(http_client::Error::Protocol)
         }

--- a/crates/rig-core/src/test_utils/http.rs
+++ b/crates/rig-core/src/test_utils/http.rs
@@ -224,6 +224,67 @@ impl HttpClientExt for MockStreamingClient {
     }
 }
 
+/// An [`HttpClientExt`] implementation whose `send_streaming` fails immediately
+/// with a non-success HTTP status and response body.
+#[derive(Debug, Clone)]
+pub struct HttpErrorStreamingClient {
+    pub status: http::StatusCode,
+    pub body: String,
+}
+
+impl HttpErrorStreamingClient {
+    /// Create a streaming client that fails `send_streaming` with the given status and body.
+    pub fn new(status: http::StatusCode, body: impl Into<String>) -> Self {
+        Self {
+            status,
+            body: body.into(),
+        }
+    }
+}
+
+impl HttpClientExt for HttpErrorStreamingClient {
+    fn send<T, U>(
+        &self,
+        _req: Request<T>,
+    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+    where
+        T: Into<Bytes> + WasmCompatSend,
+        U: From<Bytes> + WasmCompatSend + 'static,
+    {
+        future::ready(Err(http_client::Error::InvalidStatusCode(
+            http::StatusCode::NOT_IMPLEMENTED,
+        )))
+    }
+
+    fn send_multipart<U>(
+        &self,
+        _req: Request<MultipartForm>,
+    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+    where
+        U: From<Bytes> + WasmCompatSend + 'static,
+    {
+        future::ready(Err(http_client::Error::InvalidStatusCode(
+            http::StatusCode::NOT_IMPLEMENTED,
+        )))
+    }
+
+    fn send_streaming<T>(
+        &self,
+        _req: Request<T>,
+    ) -> impl Future<Output = http_client::Result<StreamingResponse>> + WasmCompatSend
+    where
+        T: Into<Bytes> + WasmCompatSend,
+    {
+        let status = self.status;
+        let body = self.body.clone();
+        async move {
+            Err(http_client::Error::InvalidStatusCodeWithMessage(
+                status, body,
+            ))
+        }
+    }
+}
+
 /// An [`HttpClientExt`] implementation that returns one scripted stream of byte
 /// chunks from `send_streaming`.
 #[derive(Debug, Clone, Default)]

--- a/crates/rig-core/src/test_utils/mod.rs
+++ b/crates/rig-core/src/test_utils/mod.rs
@@ -14,8 +14,8 @@ mod tools;
 pub use completion::{MockCompletionModel, MockError, MockTurn};
 pub use embeddings::{MockEmbeddingModel, MockMultiTextDocument, MockTextDocument};
 pub use http::{
-    CapturedHttpRequest, MockHttpResponse, MockStreamingClient, RecordingHttpClient,
-    SequencedStreamingHttpClient,
+    CapturedHttpRequest, HttpErrorStreamingClient, MockHttpResponse, MockStreamingClient,
+    RecordingHttpClient, SequencedStreamingHttpClient,
 };
 pub use memory::{AppendFailingMemory, CountingMemory, FailingMemory};
 pub use model_listing::MockModelLister;

--- a/crates/rig-core/src/transcription.rs
+++ b/crates/rig-core/src/transcription.rs
@@ -9,6 +9,10 @@ use std::{fs, path::Path};
 use thiserror::Error;
 
 // Errors
+/// Errors returned by transcription models.
+///
+/// Inspect provider failures with [`Self::provider_response_body`],
+/// [`Self::provider_response_json`], and [`Self::provider_response_status`].
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum TranscriptionError {

--- a/crates/rig-core/src/transcription.rs
+++ b/crates/rig-core/src/transcription.rs
@@ -47,40 +47,7 @@ pub enum TranscriptionError {
     ProviderResponse(provider_response::ProviderResponseError),
 }
 
-impl TranscriptionError {
-    /// Returns the raw provider response body when available.
-    ///
-    /// This is available for:
-    /// - [`TranscriptionError::ProviderResponse`] using its preserved body.
-    /// - [`TranscriptionError::HttpError`] when it wraps an HTTP non-success response that carries a body.
-    pub fn provider_response_body(&self) -> Option<&str> {
-        match self {
-            Self::ProviderResponse(response) => Some(response.body.as_str()),
-            Self::HttpError(error) => error.non_success_body(),
-            _ => None,
-        }
-    }
-
-    /// Parses the provider response body as JSON.
-    ///
-    /// Returns:
-    /// - `Ok(Some(value))` when a body is present and valid JSON.
-    /// - `Ok(None)` when no provider response body is available.
-    /// - `Err(error)` when a body is present but isn't valid JSON.
-    pub fn provider_response_json(&self) -> Result<Option<serde_json::Value>, serde_json::Error> {
-        provider_response::json(self.provider_response_body())
-    }
-
-    /// Returns the HTTP status code when this error preserves one, either from a
-    /// non-success HTTP response or from a preserved provider response.
-    pub fn provider_response_status(&self) -> Option<http::StatusCode> {
-        match self {
-            Self::ProviderResponse(response) => response.status,
-            Self::HttpError(error) => error.non_success_status(),
-            _ => None,
-        }
-    }
-}
+crate::provider_response::impl_provider_response_helpers!(TranscriptionError);
 
 /// Trait defining a low-level LLM transcription interface
 pub trait Transcription<M>

--- a/crates/rig-core/src/transcription.rs
+++ b/crates/rig-core/src/transcription.rs
@@ -3,7 +3,7 @@
 //! handling transcription responses, and defining transcription models.
 use crate::markers::{Missing, Provided};
 use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
-use crate::{http_client, json_utils};
+use crate::{http_client, json_utils, provider_response};
 use std::io;
 use std::{fs, path::Path};
 use thiserror::Error;
@@ -37,6 +37,39 @@ pub enum TranscriptionError {
     /// Error returned by the transcription model provider
     #[error("ProviderError: {0}")]
     ProviderError(String),
+}
+
+impl TranscriptionError {
+    /// Returns the raw provider response body when available.
+    ///
+    /// This is available for:
+    /// - [`TranscriptionError::ProviderError`] using its stored string.
+    /// - [`TranscriptionError::HttpError`] when it wraps an HTTP non-success response that carries a body.
+    pub fn provider_response_body(&self) -> Option<&str> {
+        match self {
+            Self::ProviderError(body) => provider_response::body(Some(body.as_str()), None),
+            Self::HttpError(error) => provider_response::body(None, Some(error)),
+            _ => None,
+        }
+    }
+
+    /// Parses the provider response body as JSON.
+    ///
+    /// Returns:
+    /// - `Ok(Some(value))` when a body is present and valid JSON.
+    /// - `Ok(None)` when no provider response body is available.
+    /// - `Err(error)` when a body is present but isn't valid JSON.
+    pub fn provider_response_json(&self) -> Result<Option<serde_json::Value>, serde_json::Error> {
+        provider_response::json(self.provider_response_body())
+    }
+
+    /// Returns the HTTP status code when this error comes from a non-success HTTP response.
+    pub fn provider_response_status(&self) -> Option<http::StatusCode> {
+        match self {
+            Self::HttpError(error) => provider_response::status(Some(error)),
+            _ => None,
+        }
+    }
 }
 
 /// Trait defining a low-level LLM transcription interface
@@ -294,5 +327,61 @@ where
     pub async fn send(self) -> Result<TranscriptionResponse<M::Response>, TranscriptionError> {
         let model = self.model.clone();
         model.transcription(self.build()).await
+    }
+}
+
+#[cfg(test)]
+mod provider_response_tests {
+    use super::*;
+    use http::StatusCode;
+
+    #[test]
+    fn transcription_error_provider_response_helpers_with_provider_json_body() {
+        let body = r#"{"error":{"message":"rate limited"}}"#;
+        let error = TranscriptionError::ProviderError(body.to_string());
+
+        assert_eq!(error.provider_response_body(), Some(body));
+        assert_eq!(error.provider_response_status(), None);
+        assert_eq!(
+            error.provider_response_json().expect("valid JSON"),
+            Some(serde_json::json!({ "error": { "message": "rate limited" } }))
+        );
+    }
+
+    #[test]
+    fn transcription_error_provider_response_helpers_with_http_non_success() {
+        let body = r#"{"error":{"message":"bad request"}}"#;
+        let error =
+            TranscriptionError::HttpError(http_client::Error::InvalidStatusCodeWithMessage(
+                StatusCode::BAD_REQUEST,
+                body.to_string(),
+            ));
+
+        assert_eq!(error.provider_response_body(), Some(body));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(StatusCode::BAD_REQUEST)
+        );
+        assert_eq!(
+            error.provider_response_json().expect("valid JSON"),
+            Some(serde_json::json!({ "error": { "message": "bad request" } }))
+        );
+    }
+
+    #[test]
+    fn transcription_error_provider_response_helpers_with_plain_text_provider_body() {
+        let error = TranscriptionError::ProviderError("not json".to_string());
+
+        assert_eq!(error.provider_response_body(), Some("not json"));
+        assert!(error.provider_response_json().is_err());
+    }
+
+    #[test]
+    fn transcription_error_provider_response_helpers_with_unrelated_variant() {
+        let error = TranscriptionError::ResponseError("parse failed".to_string());
+
+        assert_eq!(error.provider_response_body(), None);
+        assert_eq!(error.provider_response_status(), None);
+        assert_eq!(error.provider_response_json().expect("no body"), None);
     }
 }

--- a/crates/rig-core/src/transcription.rs
+++ b/crates/rig-core/src/transcription.rs
@@ -41,18 +41,22 @@ pub enum TranscriptionError {
     /// Error returned by the transcription model provider
     #[error("ProviderError: {0}")]
     ProviderError(String),
+
+    /// Raw error response preserved from the transcription model provider
+    #[error("ProviderResponseError: {0}")]
+    ProviderResponse(provider_response::ProviderResponseError),
 }
 
 impl TranscriptionError {
     /// Returns the raw provider response body when available.
     ///
     /// This is available for:
-    /// - [`TranscriptionError::ProviderError`] using its stored string.
+    /// - [`TranscriptionError::ProviderResponse`] using its preserved body.
     /// - [`TranscriptionError::HttpError`] when it wraps an HTTP non-success response that carries a body.
     pub fn provider_response_body(&self) -> Option<&str> {
         match self {
-            Self::ProviderError(body) => provider_response::body(Some(body.as_str()), None),
-            Self::HttpError(error) => provider_response::body(None, Some(error)),
+            Self::ProviderResponse(response) => Some(response.body.as_str()),
+            Self::HttpError(error) => error.non_success_body(),
             _ => None,
         }
     }
@@ -67,10 +71,12 @@ impl TranscriptionError {
         provider_response::json(self.provider_response_body())
     }
 
-    /// Returns the HTTP status code when this error comes from a non-success HTTP response.
+    /// Returns the HTTP status code when this error preserves one, either from a
+    /// non-success HTTP response or from a preserved provider response.
     pub fn provider_response_status(&self) -> Option<http::StatusCode> {
         match self {
-            Self::HttpError(error) => provider_response::status(Some(error)),
+            Self::ProviderResponse(response) => response.status,
+            Self::HttpError(error) => error.non_success_status(),
             _ => None,
         }
     }
@@ -340,9 +346,13 @@ mod provider_response_tests {
     use http::StatusCode;
 
     #[test]
-    fn transcription_error_provider_response_helpers_with_provider_json_body() {
+    fn transcription_error_provider_response_helpers_with_preserved_json_body() {
         let body = r#"{"error":{"message":"rate limited"}}"#;
-        let error = TranscriptionError::ProviderError(body.to_string());
+        let error =
+            TranscriptionError::ProviderResponse(provider_response::ProviderResponseError {
+                status: None,
+                body: body.to_string(),
+            });
 
         assert_eq!(error.provider_response_body(), Some(body));
         assert_eq!(error.provider_response_status(), None);
@@ -373,11 +383,24 @@ mod provider_response_tests {
     }
 
     #[test]
-    fn transcription_error_provider_response_helpers_with_plain_text_provider_body() {
-        let error = TranscriptionError::ProviderError("not json".to_string());
+    fn transcription_error_provider_response_helpers_with_preserved_plain_text_body() {
+        let error =
+            TranscriptionError::ProviderResponse(provider_response::ProviderResponseError {
+                status: None,
+                body: "not json".to_string(),
+            });
 
         assert_eq!(error.provider_response_body(), Some("not json"));
         assert!(error.provider_response_json().is_err());
+    }
+
+    #[test]
+    fn transcription_error_provider_error_is_not_a_provider_response() {
+        let error = TranscriptionError::ProviderError("internal diagnostic".to_string());
+
+        assert_eq!(error.provider_response_body(), None);
+        assert_eq!(error.provider_response_status(), None);
+        assert_eq!(error.provider_response_json().expect("no body"), None);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #1820

## Summary

This PR adds provider error response inspection across Rig capability errors.

Users can read a preserved provider response body, parse it as JSON, and get the HTTP status when Rig captured one, through uniform helpers on capability errors:

- `provider_response_body`
- `provider_response_json`
- `provider_response_status`

## Approach

Preserved provider responses are stored separately from `ProviderError(String)` in the type system:

- A shared `ProviderResponseError { status: Option<StatusCode>, body: String }` type, re-exported at the crate root.
- A `ProviderResponse(ProviderResponseError)` variant on `CompletionError`, `EmbeddingError`, `TranscriptionError`, `ImageGenerationError`, `AudioGenerationError`, and `VerifyError`.

The helpers only report data from two sources that genuinely represent a provider response:

- `ProviderResponse`, for provider-authored API error envelopes.
- `HttpError(InvalidStatusCodeWithMessage(status, body))`, for non-success HTTP responses.

`ProviderError(String)` is never treated as a provider response body because it also carries Rig-generated and internal diagnostics. The helpers return `None` for it.

`PromptError` and `StructuredOutputError` forward these helpers when they wrap a completion failure.

## What Improved

- Uniform helpers across rig-core completion, prompt, structured output, embedding, transcription, image generation, audio generation, and verify errors.
- 2xx API error envelopes are preserved as `ProviderResponse` with captured status and raw body for the touched OpenAI-family and OpenAI-compatible providers.
- Paths that previously flattened `"{status}: {body}"` into `ProviderError` now use `HttpError(InvalidStatusCodeWithMessage(status, body))` in the touched providers, so `provider_response_status()` remains recoverable.
- OpenAI Responses API non-success responses, the default OpenAI completion path, now preserve inspectable status and body.
- `verify()` non-success arms preserve status and body via `InvalidStatusCodeWithMessage`; 401/403 still map to `InvalidAuthentication`.
- OpenAI Chat Completions-compatible streams and OpenAI Responses streaming now surface HTTP transport failures and in-band provider error events with inspectable raw bodies.
- Multipart-capable `RecordingHttpClient` coverage makes transcription provider response branches testable.

## Notes And Limits

- `AudioGenerationError::ProviderResponse` is forward-looking for symmetry. No audio provider path currently constructs it. Only Azure audio failures currently surface as inspectable `HttpError`; other audio providers still return `ProviderError` and remain follow-up work.
- Some providers and transports still have bespoke error envelopes or event formats that should be handled separately: Anthropic, Gemini, Cohere, xAI Responses-style envelopes, Mira, provider-specific SSE event payloads, WebSocket transports, Ollama streaming, and companion `rig-*` provider crates.
- `provider_response_status()` can return a 2xx status for provider-authored error envelopes sent over successful HTTP responses.

## Breaking Changes

- The new `ProviderResponse` variant breaks downstream exhaustive matches on `CompletionError`, `EmbeddingError`, and `VerifyError`. These enums, along with `ImageGenerationError` and `AudioGenerationError`, are now `#[non_exhaustive]`, matching `TranscriptionError`.
- Provider paths that previously returned `ProviderError` for preserved bodies or non-success statuses now return `ProviderResponse` or `HttpError`, which changes which variant downstream `match` arms observe for those failures.
- Streaming HTTP failures now surface as `CompletionError::HttpError` instead of `ProviderError` with a formatted string.

## Tests

- Non-2xx provider responses via `RecordingHttpClient::with_error_response(status, raw_json_body)` for rewritten branches that receive a response object.
- 2xx error envelope coverage retained as a secondary case, now asserting `ProviderResponse` and captured status.
- End-to-end `verify()` failure through `RecordingHttpClient`.
- OpenAI Responses parser, buffered stream, and live stream error-event coverage.
- OpenAI Chat Completions-compatible in-band streaming error coverage.
- Transcription non-success paths through multipart-capable `RecordingHttpClient`.
- Unit tests assert that `ProviderError(String)` and Rig-generated stream transport diagnostics are not reported as provider response bodies.

## Test Plan

- [x] `cargo fmt`
- [x] `cargo clippy -p rig-core --all-targets --all-features`
- [x] `cargo test -p rig-core --all-features` (4 pre-existing epub loader failures unrelated to this change)
- [x] `cargo check --workspace --all-targets`
- [x] `cargo doc -p rig-core --no-deps --all-features`

Latest focused checks after final review cleanup:

- [x] `cargo test -p rig-core provider_response`
- [x] `cargo test -p rig-core streaming_error_event`
- [x] `cargo test -p rig-core test_completion_response_from_sse_body_falls_back_to_streamed_text`
- [x] `cargo test -p rig-core transcription_http_non_success`

## AI Disclosure

I have used an LLM for writing most of the rustdocs and some tests. The shared capability-error helper API and prompt forwarding were implemented by me line by line. For provider raw-body preservation, an agent helped identify low-risk provider paths and talk through the edits, but I made changes myself.

Update: Changes integrated into this PR after review are agent-driven with direction from me.
