### PR TITLE
[codex] cover Anthropic streaming tool result batching

### DIFF
--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -351,22 +351,6 @@ async fn cancelled_prompt_error(
     )
 }
 
-fn tool_result_to_user_message(
-    id: String,
-    call_id: Option<String>,
-    tool_result: String,
-) -> Message {
-    let content = ToolResultContent::from_tool_output(tool_result);
-    let user_content = match call_id {
-        Some(call_id) => UserContent::tool_result_with_call_id(id, call_id, content),
-        None => UserContent::tool_result(id, content),
-    };
-
-    Message::User {
-        content: OneOrMany::one(user_content),
-    }
-}
-
 fn tool_result_user_content(
     id: String,
     call_id: Option<String>,
@@ -1864,8 +1848,8 @@ mod tests {
     }
 
     #[test]
-    fn tool_result_to_user_message_preserves_multimodal_tool_output() {
-        let message = tool_result_to_user_message(
+    fn tool_result_user_content_preserves_multimodal_tool_output() {
+        let user_content = tool_result_user_content(
             "tool_call_1".to_string(),
             Some("call_1".to_string()),
             serde_json::json!({
@@ -1883,12 +1867,9 @@ mod tests {
             .to_string(),
         );
 
-        let tool_result = match message {
-            Message::User { content } => match content.first() {
-                UserContent::ToolResult(tool_result) => tool_result,
-                other => panic!("expected tool result content, got {other:?}"),
-            },
-            other => panic!("expected user message, got {other:?}"),
+        let tool_result = match user_content {
+            UserContent::ToolResult(tool_result) => tool_result,
+            other => panic!("expected tool result content, got {other:?}"),
         };
 
         assert_eq!(tool_result.id, "tool_call_1");

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -1594,8 +1594,20 @@ where
                     }
                 }
 
-                for (id, call_id, tool_result) in tool_results {
-                    new_messages.push(tool_result_to_user_message(id, call_id, tool_result));
+                // Combine all tool results into a single User message (required by Anthropic)
+                let tool_result_contents: Vec<UserContent> = tool_results
+                    .into_iter()
+                    .map(|(id, call_id, tool_result)| {
+                        let content = ToolResultContent::from_tool_output(tool_result);
+                        match call_id {
+                            Some(call_id) => UserContent::tool_result_with_call_id(id, call_id, content),
+                            None => UserContent::tool_result(id, content),
+                        }
+                    })
+                    .collect();
+
+                if let Some(content) = OneOrMany::from_iter_optional(tool_result_contents) {
+                    new_messages.push(Message::User { content });
                 }
 
                 if !saw_tool_call_this_turn {

--- a/tests/cassettes/anthropic/multi_turn_streaming/multi_turn_streaming_tools.yaml
+++ b/tests/cassettes/anthropic/multi_turn_streaming/multi_turn_streaming_tools.yaml
@@ -17,7 +17,7 @@ then:
     value: text/event-stream; charset=utf-8
   body: |+
     event: message_start
-    data: {"message":{"content":[],"id":"msg_REDACTED_1","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":1001,"output_tokens":3,"service_tier":"standard"}},"type":"message_start"}
+    data: {"message":{"content":[],"id":"msg_REDACTED_1","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":1001,"output_tokens":2,"service_tier":"standard"}},"type":"message_start"}
 
     event: content_block_start
     data: {"content_block":{"text":"","type":"text"},"index":0,"type":"content_block_start"}
@@ -26,13 +26,13 @@ then:
     data: {"type":"ping"}
 
     event: content_block_delta
-    data: {"delta":{"text":"I'll solve","type":"text_delta"},"index":0,"type":"content_block_delta"}
+    data: {"delta":{"text":"I'll","type":"text_delta"},"index":0,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"text":" this step by step! Let me start by computing the two independent sub-expressions **(10 - 4)","type":"text_delta"},"index":0,"type":"content_block_delta"}
+    data: {"delta":{"text":" solve this step by step! Let me start by computing the two independent sub-expressions *","type":"text_delta"},"index":0,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"text":"** and **(3 + 5)** simultaneously.","type":"text_delta"},"index":0,"type":"content_block_delta"}
+    data: {"delta":{"text":"*(10 - 4)** and **(3 + 5)** simultaneously first.","type":"text_delta"},"index":0,"type":"content_block_delta"}
 
     event: content_block_stop
     data: {"index":0,"type":"content_block_stop"}
@@ -47,7 +47,10 @@ then:
     data: {"delta":{"partial_json":"{\"x\": 10","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"partial_json":", \"y\": 4}","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+    data: {"delta":{"partial_json":", \"y\":","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":" 4}","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
 
     event: content_block_stop
     data: {"index":1,"type":"content_block_stop"}
@@ -65,16 +68,13 @@ then:
     data: {"delta":{"partial_json":", \"y","type":"input_json_delta"},"index":2,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"partial_json":"\":","type":"input_json_delta"},"index":2,"type":"content_block_delta"}
-
-    event: content_block_delta
-    data: {"delta":{"partial_json":" 5}","type":"input_json_delta"},"index":2,"type":"content_block_delta"}
+    data: {"delta":{"partial_json":"\": 5}","type":"input_json_delta"},"index":2,"type":"content_block_delta"}
 
     event: content_block_stop
     data: {"index":2,"type":"content_block_stop"}
 
     event: message_delta
-    data: {"delta":{"stop_details":null,"stop_reason":"tool_use","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":1001,"output_tokens":160}}
+    data: {"delta":{"stop_details":null,"stop_reason":"tool_use","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":1001,"output_tokens":161}}
 
     event: message_stop
     data: {"type":"message_stop"}
@@ -91,7 +91,7 @@ when:
     value: application/json
   - name: anthropic-version
     value: 2023-06-01
-  body: '{"max_tokens":64000,"messages":[{"content":[{"text":"Calculate ((10 - 4) * (3 + 5)) / 3 and describe the result in one short paragraph.","type":"text"}],"role":"user"},{"content":[{"text":"I''ll solve this step by step! Let me start by computing the two independent sub-expressions **(10 - 4)** and **(3 + 5)** simultaneously.","type":"text"},{"id":"toolu_REDACTED_1","input":{"x":10,"y":4},"name":"subtract","type":"tool_use"},{"id":"toolu_REDACTED_2","input":{"x":3,"y":5},"name":"add","type":"tool_use"}],"role":"assistant"},{"content":[{"content":[{"text":"6","type":"text"}],"tool_use_id":"toolu_REDACTED_1","type":"tool_result"}],"role":"user"},{"content":[{"content":[{"text":"8","type":"text"}],"tool_use_id":"toolu_REDACTED_2","type":"tool_result"}],"role":"user"}],"model":"claude-sonnet-4-6","stream":true,"system":[{"text":"You must use tools for arithmetic.","type":"text"}],"tool_choice":{"type":"auto"},"tools":[{"description":"Add x and y together","input_schema":{"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"x":{"format":"int32","type":"integer"},"y":{"format":"int32","type":"integer"}},"required":["x","y"],"title":"OperationArgs","type":"object"},"name":"add"},{"description":"Subtract y from x (i.e.: x - y)","input_schema":{"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"x":{"format":"int32","type":"integer"},"y":{"format":"int32","type":"integer"}},"required":["x","y"],"title":"OperationArgs","type":"object"},"name":"subtract"},{"description":"Compute the product of x and y (i.e.: x * y).","input_schema":{"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"x":{"format":"int32","type":"integer"},"y":{"format":"int32","type":"integer"}},"required":["x","y"],"title":"OperationArgs","type":"object"},"name":"multiply"},{"description":"Compute the quotient of x and y.","input_schema":{"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"x":{"format":"int32","type":"integer"},"y":{"format":"int32","type":"integer"}},"required":["x","y"],"title":"OperationArgs","type":"object"},"name":"divide"}]}'
+  body: '{"max_tokens":64000,"messages":[{"content":[{"text":"Calculate ((10 - 4) * (3 + 5)) / 3 and describe the result in one short paragraph.","type":"text"}],"role":"user"},{"content":[{"text":"I''ll solve this step by step! Let me start by computing the two independent sub-expressions **(10 - 4)** and **(3 + 5)** simultaneously first.","type":"text"},{"id":"toolu_REDACTED_1","input":{"x":10,"y":4},"name":"subtract","type":"tool_use"},{"id":"toolu_REDACTED_2","input":{"x":3,"y":5},"name":"add","type":"tool_use"}],"role":"assistant"},{"content":[{"content":[{"text":"6","type":"text"}],"tool_use_id":"toolu_REDACTED_1","type":"tool_result"},{"content":[{"text":"8","type":"text"}],"tool_use_id":"toolu_REDACTED_2","type":"tool_result"}],"role":"user"}],"model":"claude-sonnet-4-6","stream":true,"system":[{"text":"You must use tools for arithmetic.","type":"text"}],"tool_choice":{"type":"auto"},"tools":[{"description":"Add x and y together","input_schema":{"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"x":{"format":"int32","type":"integer"},"y":{"format":"int32","type":"integer"}},"required":["x","y"],"title":"OperationArgs","type":"object"},"name":"add"},{"description":"Subtract y from x (i.e.: x - y)","input_schema":{"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"x":{"format":"int32","type":"integer"},"y":{"format":"int32","type":"integer"}},"required":["x","y"],"title":"OperationArgs","type":"object"},"name":"subtract"},{"description":"Compute the product of x and y (i.e.: x * y).","input_schema":{"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"x":{"format":"int32","type":"integer"},"y":{"format":"int32","type":"integer"}},"required":["x","y"],"title":"OperationArgs","type":"object"},"name":"multiply"},{"description":"Compute the quotient of x and y.","input_schema":{"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"x":{"format":"int32","type":"integer"},"y":{"format":"int32","type":"integer"}},"required":["x","y"],"title":"OperationArgs","type":"object"},"name":"divide"}]}'
 then:
   status: 200
   header:
@@ -99,7 +99,7 @@ then:
     value: text/event-stream; charset=utf-8
   body: |+
     event: message_start
-    data: {"message":{"content":[],"id":"msg_REDACTED_2","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":1222,"output_tokens":1,"service_tier":"standard"}},"type":"message_start"}
+    data: {"message":{"content":[],"id":"msg_REDACTED_2","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":1223,"output_tokens":1,"service_tier":"standard"}},"type":"message_start"}
 
     event: content_block_start
     data: {"content_block":{"text":"","type":"text"},"index":0,"type":"content_block_start"}
@@ -108,10 +108,10 @@ then:
     data: {"type":"ping"}
 
     event: content_block_delta
-    data: {"delta":{"text":"Great","type":"text_delta"},"index":0,"type":"content_block_delta"}
+    data: {"delta":{"text":"Got","type":"text_delta"},"index":0,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"text":"! Now I'll multiply the two results **(6 * 8)**.","type":"text_delta"},"index":0,"type":"content_block_delta"}
+    data: {"delta":{"text":" **6** and **8**! Now I'll multiply them together.","type":"text_delta"},"index":0,"type":"content_block_delta"}
 
     event: content_block_stop
     data: {"index":0,"type":"content_block_stop"}
@@ -123,19 +123,25 @@ then:
     data: {"delta":{"partial_json":"","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"partial_json":"{\"x\": 6","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+    data: {"delta":{"partial_json":"{\"x","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"partial_json":", ","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+    data: {"delta":{"partial_json":"\":","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"partial_json":"\"y\": 8}","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+    data: {"delta":{"partial_json":" 6","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":", \"y\":","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":" 8}","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
 
     event: content_block_stop
     data: {"index":1,"type":"content_block_stop"}
 
     event: message_delta
-    data: {"delta":{"stop_details":null,"stop_reason":"tool_use","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":1222,"output_tokens":87}}
+    data: {"delta":{"stop_details":null,"stop_reason":"tool_use","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":1223,"output_tokens":85}}
 
     event: message_stop
     data: {"type":"message_stop"}
@@ -152,7 +158,7 @@ when:
     value: application/json
   - name: anthropic-version
     value: 2023-06-01
-  body: '{"max_tokens":64000,"messages":[{"content":[{"text":"Calculate ((10 - 4) * (3 + 5)) / 3 and describe the result in one short paragraph.","type":"text"}],"role":"user"},{"content":[{"text":"I''ll solve this step by step! Let me start by computing the two independent sub-expressions **(10 - 4)** and **(3 + 5)** simultaneously.","type":"text"},{"id":"toolu_REDACTED_1","input":{"x":10,"y":4},"name":"subtract","type":"tool_use"},{"id":"toolu_REDACTED_2","input":{"x":3,"y":5},"name":"add","type":"tool_use"}],"role":"assistant"},{"content":[{"content":[{"text":"6","type":"text"}],"tool_use_id":"toolu_REDACTED_1","type":"tool_result"}],"role":"user"},{"content":[{"content":[{"text":"8","type":"text"}],"tool_use_id":"toolu_REDACTED_2","type":"tool_result"}],"role":"user"},{"content":[{"text":"Great! Now I''ll multiply the two results **(6 * 8)**.","type":"text"},{"id":"toolu_REDACTED_3","input":{"x":6,"y":8},"name":"multiply","type":"tool_use"}],"role":"assistant"},{"content":[{"content":[{"text":"48","type":"text"}],"tool_use_id":"toolu_REDACTED_3","type":"tool_result"}],"role":"user"}],"model":"claude-sonnet-4-6","stream":true,"system":[{"text":"You must use tools for arithmetic.","type":"text"}],"tool_choice":{"type":"auto"},"tools":[{"description":"Add x and y together","input_schema":{"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"x":{"format":"int32","type":"integer"},"y":{"format":"int32","type":"integer"}},"required":["x","y"],"title":"OperationArgs","type":"object"},"name":"add"},{"description":"Subtract y from x (i.e.: x - y)","input_schema":{"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"x":{"format":"int32","type":"integer"},"y":{"format":"int32","type":"integer"}},"required":["x","y"],"title":"OperationArgs","type":"object"},"name":"subtract"},{"description":"Compute the product of x and y (i.e.: x * y).","input_schema":{"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"x":{"format":"int32","type":"integer"},"y":{"format":"int32","type":"integer"}},"required":["x","y"],"title":"OperationArgs","type":"object"},"name":"multiply"},{"description":"Compute the quotient of x and y.","input_schema":{"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"x":{"format":"int32","type":"integer"},"y":{"format":"int32","type":"integer"}},"required":["x","y"],"title":"OperationArgs","type":"object"},"name":"divide"}]}'
+  body: '{"max_tokens":64000,"messages":[{"content":[{"text":"Calculate ((10 - 4) * (3 + 5)) / 3 and describe the result in one short paragraph.","type":"text"}],"role":"user"},{"content":[{"text":"I''ll solve this step by step! Let me start by computing the two independent sub-expressions **(10 - 4)** and **(3 + 5)** simultaneously first.","type":"text"},{"id":"toolu_REDACTED_1","input":{"x":10,"y":4},"name":"subtract","type":"tool_use"},{"id":"toolu_REDACTED_2","input":{"x":3,"y":5},"name":"add","type":"tool_use"}],"role":"assistant"},{"content":[{"content":[{"text":"6","type":"text"}],"tool_use_id":"toolu_REDACTED_1","type":"tool_result"},{"content":[{"text":"8","type":"text"}],"tool_use_id":"toolu_REDACTED_2","type":"tool_result"}],"role":"user"},{"content":[{"text":"Got **6** and **8**! Now I''ll multiply them together.","type":"text"},{"id":"toolu_REDACTED_3","input":{"x":6,"y":8},"name":"multiply","type":"tool_use"}],"role":"assistant"},{"content":[{"content":[{"text":"48","type":"text"}],"tool_use_id":"toolu_REDACTED_3","type":"tool_result"}],"role":"user"}],"model":"claude-sonnet-4-6","stream":true,"system":[{"text":"You must use tools for arithmetic.","type":"text"}],"tool_choice":{"type":"auto"},"tools":[{"description":"Add x and y together","input_schema":{"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"x":{"format":"int32","type":"integer"},"y":{"format":"int32","type":"integer"}},"required":["x","y"],"title":"OperationArgs","type":"object"},"name":"add"},{"description":"Subtract y from x (i.e.: x - y)","input_schema":{"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"x":{"format":"int32","type":"integer"},"y":{"format":"int32","type":"integer"}},"required":["x","y"],"title":"OperationArgs","type":"object"},"name":"subtract"},{"description":"Compute the product of x and y (i.e.: x * y).","input_schema":{"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"x":{"format":"int32","type":"integer"},"y":{"format":"int32","type":"integer"}},"required":["x","y"],"title":"OperationArgs","type":"object"},"name":"multiply"},{"description":"Compute the quotient of x and y.","input_schema":{"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"x":{"format":"int32","type":"integer"},"y":{"format":"int32","type":"integer"}},"required":["x","y"],"title":"OperationArgs","type":"object"},"name":"divide"}]}'
 then:
   status: 200
   header:
@@ -160,7 +166,7 @@ then:
     value: text/event-stream; charset=utf-8
   body: |+
     event: message_start
-    data: {"message":{"content":[],"id":"msg_REDACTED_3","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":1322,"output_tokens":1,"service_tier":"standard"}},"type":"message_start"}
+    data: {"message":{"content":[],"id":"msg_REDACTED_3","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":1321,"output_tokens":1,"service_tier":"standard"}},"type":"message_start"}
 
     event: content_block_start
     data: {"content_block":{"text":"","type":"text"},"index":0,"type":"content_block_start"}
@@ -169,10 +175,10 @@ then:
     data: {"type":"ping"}
 
     event: content_block_delta
-    data: {"delta":{"text":"Now","type":"text_delta"},"index":0,"type":"content_block_delta"}
+    data: {"delta":{"text":"Got","type":"text_delta"},"index":0,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"text":" I'll divide the product by 3 **(48 / 3)**.","type":"text_delta"},"index":0,"type":"content_block_delta"}
+    data: {"delta":{"text":" **48**! Now for the final step — dividing by 3.","type":"text_delta"},"index":0,"type":"content_block_delta"}
 
     event: content_block_stop
     data: {"index":0,"type":"content_block_stop"}
@@ -184,22 +190,19 @@ then:
     data: {"delta":{"partial_json":"","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"partial_json":"{\"x\"","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+    data: {"delta":{"partial_json":"{\"x\": 48","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"partial_json":": 4","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+    data: {"delta":{"partial_json":", ","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"partial_json":"8","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
-
-    event: content_block_delta
-    data: {"delta":{"partial_json":", \"y\": 3}","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+    data: {"delta":{"partial_json":"\"y\": 3}","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
 
     event: content_block_stop
     data: {"index":1,"type":"content_block_stop"}
 
     event: message_delta
-    data: {"delta":{"stop_details":null,"stop_reason":"tool_use","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":1322,"output_tokens":88}}
+    data: {"delta":{"stop_details":null,"stop_reason":"tool_use","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":1321,"output_tokens":86}}
 
     event: message_stop
     data: {"type":"message_stop"}
@@ -216,7 +219,7 @@ when:
     value: application/json
   - name: anthropic-version
     value: 2023-06-01
-  body: '{"max_tokens":64000,"messages":[{"content":[{"text":"Calculate ((10 - 4) * (3 + 5)) / 3 and describe the result in one short paragraph.","type":"text"}],"role":"user"},{"content":[{"text":"I''ll solve this step by step! Let me start by computing the two independent sub-expressions **(10 - 4)** and **(3 + 5)** simultaneously.","type":"text"},{"id":"toolu_REDACTED_1","input":{"x":10,"y":4},"name":"subtract","type":"tool_use"},{"id":"toolu_REDACTED_2","input":{"x":3,"y":5},"name":"add","type":"tool_use"}],"role":"assistant"},{"content":[{"content":[{"text":"6","type":"text"}],"tool_use_id":"toolu_REDACTED_1","type":"tool_result"}],"role":"user"},{"content":[{"content":[{"text":"8","type":"text"}],"tool_use_id":"toolu_REDACTED_2","type":"tool_result"}],"role":"user"},{"content":[{"text":"Great! Now I''ll multiply the two results **(6 * 8)**.","type":"text"},{"id":"toolu_REDACTED_3","input":{"x":6,"y":8},"name":"multiply","type":"tool_use"}],"role":"assistant"},{"content":[{"content":[{"text":"48","type":"text"}],"tool_use_id":"toolu_REDACTED_3","type":"tool_result"}],"role":"user"},{"content":[{"text":"Now I''ll divide the product by 3 **(48 / 3)**.","type":"text"},{"id":"toolu_REDACTED_4","input":{"x":48,"y":3},"name":"divide","type":"tool_use"}],"role":"assistant"},{"content":[{"content":[{"text":"16","type":"text"}],"tool_use_id":"toolu_REDACTED_4","type":"tool_result"}],"role":"user"}],"model":"claude-sonnet-4-6","stream":true,"system":[{"text":"You must use tools for arithmetic.","type":"text"}],"tool_choice":{"type":"auto"},"tools":[{"description":"Add x and y together","input_schema":{"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"x":{"format":"int32","type":"integer"},"y":{"format":"int32","type":"integer"}},"required":["x","y"],"title":"OperationArgs","type":"object"},"name":"add"},{"description":"Subtract y from x (i.e.: x - y)","input_schema":{"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"x":{"format":"int32","type":"integer"},"y":{"format":"int32","type":"integer"}},"required":["x","y"],"title":"OperationArgs","type":"object"},"name":"subtract"},{"description":"Compute the product of x and y (i.e.: x * y).","input_schema":{"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"x":{"format":"int32","type":"integer"},"y":{"format":"int32","type":"integer"}},"required":["x","y"],"title":"OperationArgs","type":"object"},"name":"multiply"},{"description":"Compute the quotient of x and y.","input_schema":{"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"x":{"format":"int32","type":"integer"},"y":{"format":"int32","type":"integer"}},"required":["x","y"],"title":"OperationArgs","type":"object"},"name":"divide"}]}'
+  body: '{"max_tokens":64000,"messages":[{"content":[{"text":"Calculate ((10 - 4) * (3 + 5)) / 3 and describe the result in one short paragraph.","type":"text"}],"role":"user"},{"content":[{"text":"I''ll solve this step by step! Let me start by computing the two independent sub-expressions **(10 - 4)** and **(3 + 5)** simultaneously first.","type":"text"},{"id":"toolu_REDACTED_1","input":{"x":10,"y":4},"name":"subtract","type":"tool_use"},{"id":"toolu_REDACTED_2","input":{"x":3,"y":5},"name":"add","type":"tool_use"}],"role":"assistant"},{"content":[{"content":[{"text":"6","type":"text"}],"tool_use_id":"toolu_REDACTED_1","type":"tool_result"},{"content":[{"text":"8","type":"text"}],"tool_use_id":"toolu_REDACTED_2","type":"tool_result"}],"role":"user"},{"content":[{"text":"Got **6** and **8**! Now I''ll multiply them together.","type":"text"},{"id":"toolu_REDACTED_3","input":{"x":6,"y":8},"name":"multiply","type":"tool_use"}],"role":"assistant"},{"content":[{"content":[{"text":"48","type":"text"}],"tool_use_id":"toolu_REDACTED_3","type":"tool_result"}],"role":"user"},{"content":[{"text":"Got **48**! Now for the final step — dividing by 3.","type":"text"},{"id":"toolu_REDACTED_4","input":{"x":48,"y":3},"name":"divide","type":"tool_use"}],"role":"assistant"},{"content":[{"content":[{"text":"16","type":"text"}],"tool_use_id":"toolu_REDACTED_4","type":"tool_result"}],"role":"user"}],"model":"claude-sonnet-4-6","stream":true,"system":[{"text":"You must use tools for arithmetic.","type":"text"}],"tool_choice":{"type":"auto"},"tools":[{"description":"Add x and y together","input_schema":{"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"x":{"format":"int32","type":"integer"},"y":{"format":"int32","type":"integer"}},"required":["x","y"],"title":"OperationArgs","type":"object"},"name":"add"},{"description":"Subtract y from x (i.e.: x - y)","input_schema":{"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"x":{"format":"int32","type":"integer"},"y":{"format":"int32","type":"integer"}},"required":["x","y"],"title":"OperationArgs","type":"object"},"name":"subtract"},{"description":"Compute the product of x and y (i.e.: x * y).","input_schema":{"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"x":{"format":"int32","type":"integer"},"y":{"format":"int32","type":"integer"}},"required":["x","y"],"title":"OperationArgs","type":"object"},"name":"multiply"},{"description":"Compute the quotient of x and y.","input_schema":{"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"x":{"format":"int32","type":"integer"},"y":{"format":"int32","type":"integer"}},"required":["x","y"],"title":"OperationArgs","type":"object"},"name":"divide"}]}'
 then:
   status: 200
   header:
@@ -224,7 +227,7 @@ then:
     value: text/event-stream; charset=utf-8
   body: |+
     event: message_start
-    data: {"message":{"content":[],"id":"msg_REDACTED_4","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":1423,"output_tokens":1,"service_tier":"standard"}},"type":"message_start"}
+    data: {"message":{"content":[],"id":"msg_REDACTED_4","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":1420,"output_tokens":2,"service_tier":"standard"}},"type":"message_start"}
 
     event: content_block_start
     data: {"content_block":{"text":"","type":"text"},"index":0,"type":"content_block_start"}
@@ -233,28 +236,31 @@ then:
     data: {"type":"ping"}
 
     event: content_block_delta
-    data: {"delta":{"text":"Here","type":"text_delta"},"index":0,"type":"content_block_delta"}
+    data: {"delta":{"text":"**The","type":"text_delta"},"index":0,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"text":"'s a summary of the result:\n\nThe expression **((10 - 4) × (3 + 5)) / 3** evalu","type":"text_delta"},"index":0,"type":"content_block_delta"}
+    data: {"delta":{"text":" result is 16.** Here's a summary of the calculation:\n\nStarting with the two parent","type":"text_delta"},"index":0,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"text":"ates to **16**. Starting with the parentheses, **10 - 4 = 6**","type":"text_delta"},"index":0,"type":"content_block_delta"}
+    data: {"delta":{"text":"hetical expressions, subtracting 4 from 10 gives 6, and adding 3 and","type":"text_delta"},"index":0,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"text":" and **3 + 5 = 8**; multiplying those gives **48**, which when","type":"text_delta"},"index":0,"type":"content_block_delta"}
+    data: {"delta":{"text":" 5 gives 8. Multiplying those two results together yields 48, which when","type":"text_delta"},"index":0,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"text":" divided by **3** yields a clean, whole number result of **16**","type":"text_delta"},"index":0,"type":"content_block_delta"}
+    data: {"delta":{"text":" divided by 3 produces a clean, whole-number answer of **","type":"text_delta"},"index":0,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"text":" — a perfect power of 2 (2⁴).","type":"text_delta"},"index":0,"type":"content_block_delta"}
+    data: {"delta":{"text":"16** — a perfect power of 2 (2⁴), making it a satisf","type":"text_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"text":"ying and tidy result!","type":"text_delta"},"index":0,"type":"content_block_delta"}
 
     event: content_block_stop
     data: {"index":0,"type":"content_block_stop"}
 
     event: message_delta
-    data: {"delta":{"stop_details":null,"stop_reason":"end_turn","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":1423,"output_tokens":111}}
+    data: {"delta":{"stop_details":null,"stop_reason":"end_turn","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":1420,"output_tokens":110}}
 
     event: message_stop
     data: {"type":"message_stop"}

--- a/tests/cassettes/anthropic/streaming_tools/streaming_tools_batches_multiple_tool_results_in_one_followup_message.yaml
+++ b/tests/cassettes/anthropic/streaming_tools/streaming_tools_batches_multiple_tool_results_in_one_followup_message.yaml
@@ -1,0 +1,103 @@
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":64000,"messages":[{"content":[{"text":"Call `lookup_harbor_label` and `lookup_orchard_label` exactly once each before answering. After both tool results are available, stop calling tools and respond in one short sentence that includes both exact tool outputs.","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","stream":true,"system":[{"text":"You are a precise assistant. When tools are available, you must use them instead of guessing. Call both `lookup_harbor_label` and `lookup_orchard_label` before writing any normal text. Never call the same tool twice once you already have its result.","type":"text"}],"tool_choice":{"type":"auto"},"tools":[{"description":"Return the alpha signal marker.","input_schema":{"properties":{},"required":[],"type":"object"},"name":"lookup_harbor_label"},{"description":"Return the beta signal marker.","input_schema":{"properties":{},"required":[],"type":"object"},"name":"lookup_orchard_label"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream; charset=utf-8
+  body: |+
+    event: message_start
+    data: {"message":{"content":[],"id":"msg_REDACTED_1","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":700,"output_tokens":5,"service_tier":"standard"}},"type":"message_start"}
+
+    event: content_block_start
+    data: {"content_block":{"text":"","type":"text"},"index":0,"type":"content_block_start"}
+
+    event: ping
+    data: {"type":"ping"}
+
+    event: content_block_delta
+    data: {"delta":{"text":"I'll call both tools","type":"text_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"text":" simultaneously right away!","type":"text_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_stop
+    data: {"index":0,"type":"content_block_stop"}
+
+    event: content_block_start
+    data: {"content_block":{"caller":{"type":"direct"},"id":"toolu_REDACTED_1","input":{},"name":"lookup_harbor_label","type":"tool_use"},"index":1,"type":"content_block_start"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+
+    event: content_block_stop
+    data: {"index":1,"type":"content_block_stop"}
+
+    event: content_block_start
+    data: {"content_block":{"caller":{"type":"direct"},"id":"toolu_REDACTED_2","input":{},"name":"lookup_orchard_label","type":"tool_use"},"index":2,"type":"content_block_start"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"","type":"input_json_delta"},"index":2,"type":"content_block_delta"}
+
+    event: content_block_stop
+    data: {"index":2,"type":"content_block_stop"}
+
+    event: message_delta
+    data: {"delta":{"stop_details":null,"stop_reason":"tool_use","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":700,"output_tokens":70}}
+
+    event: message_stop
+    data: {"type":"message_stop"}
+
+---
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":64000,"messages":[{"content":[{"text":"Call `lookup_harbor_label` and `lookup_orchard_label` exactly once each before answering. After both tool results are available, stop calling tools and respond in one short sentence that includes both exact tool outputs.","type":"text"}],"role":"user"},{"content":[{"text":"I''ll call both tools simultaneously right away!","type":"text"},{"id":"toolu_REDACTED_1","input":{},"name":"lookup_harbor_label","type":"tool_use"},{"id":"toolu_REDACTED_2","input":{},"name":"lookup_orchard_label","type":"tool_use"}],"role":"assistant"},{"content":[{"content":[{"text":"crimson-harbor","type":"text"}],"tool_use_id":"toolu_REDACTED_1","type":"tool_result"},{"content":[{"text":"silver-orchard","type":"text"}],"tool_use_id":"toolu_REDACTED_2","type":"tool_result"}],"role":"user"}],"model":"claude-sonnet-4-6","stream":true,"system":[{"text":"You are a precise assistant. When tools are available, you must use them instead of guessing. Call both `lookup_harbor_label` and `lookup_orchard_label` before writing any normal text. Never call the same tool twice once you already have its result.","type":"text"}],"tool_choice":{"type":"auto"},"tools":[{"description":"Return the alpha signal marker.","input_schema":{"properties":{},"required":[],"type":"object"},"name":"lookup_harbor_label"},{"description":"Return the beta signal marker.","input_schema":{"properties":{},"required":[],"type":"object"},"name":"lookup_orchard_label"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream; charset=utf-8
+  body: |+
+    event: message_start
+    data: {"message":{"content":[],"id":"msg_REDACTED_2","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":846,"output_tokens":1,"service_tier":"standard"}},"type":"message_start"}
+
+    event: content_block_start
+    data: {"content_block":{"text":"","type":"text"},"index":0,"type":"content_block_start"}
+
+    event: ping
+    data: {"type":"ping"}
+
+    event: content_block_delta
+    data: {"delta":{"text":"The","type":"text_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"text":" alpha signal marker is **crimson-harbor** and the beta signal marker is **silver-orchard**.","type":"text_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_stop
+    data: {"index":0,"type":"content_block_stop"}
+
+    event: message_delta
+    data: {"delta":{"stop_details":null,"stop_reason":"end_turn","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":846,"output_tokens":26}}
+
+    event: message_stop
+    data: {"type":"message_stop"}
+

--- a/tests/providers/anthropic/cassette/streaming_tools.rs
+++ b/tests/providers/anthropic/cassette/streaming_tools.rs
@@ -3,11 +3,15 @@
 use rig::client::CompletionClient;
 use rig::providers::anthropic;
 use rig::streaming::StreamingPrompt;
+use serde::Deserialize;
+use serde_json::Value;
 
 use super::super::support::with_anthropic_cassette;
 use crate::support::{
-    Adder, STREAMING_TOOLS_PREAMBLE, STREAMING_TOOLS_PROMPT, Subtract,
-    assert_mentions_expected_number, collect_stream_final_response,
+    ALPHA_SIGNAL_OUTPUT, Adder, AlphaSignal, BETA_SIGNAL_OUTPUT, BetaSignal,
+    STREAMING_TOOLS_PREAMBLE, STREAMING_TOOLS_PROMPT, Subtract, TWO_TOOL_STREAM_PREAMBLE,
+    TWO_TOOL_STREAM_PROMPT, assert_contains_all_case_insensitive, assert_mentions_expected_number,
+    collect_stream_final_response, collect_stream_observation,
 };
 
 #[tokio::test]
@@ -31,4 +35,146 @@ async fn streaming_tools_smoke() {
         },
     )
     .await;
+}
+
+#[tokio::test]
+async fn streaming_tools_batches_multiple_tool_results_in_one_followup_message() {
+    with_anthropic_cassette(
+        "streaming_tools/streaming_tools_batches_multiple_tool_results_in_one_followup_message",
+        |client| async move {
+            let agent = client
+                .agent(anthropic::completion::CLAUDE_SONNET_4_6)
+                .preamble(TWO_TOOL_STREAM_PREAMBLE)
+                .tool(AlphaSignal)
+                .tool(BetaSignal)
+                .build();
+
+            let mut stream = agent
+                .stream_prompt(TWO_TOOL_STREAM_PROMPT)
+                .multi_turn(8)
+                .await;
+            let observation = collect_stream_observation(&mut stream).await;
+
+            assert!(
+                observation.errors.is_empty(),
+                "stream should not emit errors: {:?}",
+                observation.errors
+            );
+            assert!(
+                observation.got_final_response,
+                "stream should emit a final response"
+            );
+            assert!(
+                observation.tool_results >= 2,
+                "expected at least 2 tool-result events, got {}",
+                observation.tool_results
+            );
+            for expected_tool in ["lookup_harbor_label", "lookup_orchard_label"] {
+                assert!(
+                    observation
+                        .tool_calls
+                        .iter()
+                        .any(|tool_call| tool_call == expected_tool),
+                    "expected tool call for {expected_tool}, saw {:?}",
+                    observation.tool_calls
+                );
+            }
+            assert_contains_all_case_insensitive(
+                observation
+                    .final_response_text
+                    .as_deref()
+                    .expect("stream should produce a final response string"),
+                &[ALPHA_SIGNAL_OUTPUT, BETA_SIGNAL_OUTPUT],
+            );
+        },
+    )
+    .await;
+
+    assert_cassette_groups_multiple_tool_results(
+        "streaming_tools/streaming_tools_batches_multiple_tool_results_in_one_followup_message",
+        &["lookup_harbor_label", "lookup_orchard_label"],
+    );
+}
+
+#[derive(Deserialize)]
+struct RecordedInteraction {
+    when: RecordedRequest,
+}
+
+#[derive(Deserialize)]
+struct RecordedRequest {
+    body: Option<String>,
+}
+
+fn assert_cassette_groups_multiple_tool_results(scenario: &str, expected_tools: &[&str]) {
+    let cassette_path = crate::cassettes::cassette_path("anthropic", scenario);
+    let contents = std::fs::read_to_string(&cassette_path).unwrap_or_else(|error| {
+        panic!(
+            "provider cassette {} should be readable after recording: {error}",
+            cassette_path.display()
+        )
+    });
+
+    let request_bodies = serde_yaml::Deserializer::from_str(&contents)
+        .map(|document| {
+            RecordedInteraction::deserialize(document)
+                .expect("cassette interaction should deserialize")
+                .when
+                .body
+        })
+        .filter_map(|body| body.and_then(|body| serde_json::from_str::<Value>(&body).ok()))
+        .collect::<Vec<_>>();
+
+    let grouped = request_bodies.iter().any(|body| {
+        body.get("messages")
+            .and_then(Value::as_array)
+            .is_some_and(|messages| messages_group_tool_results(messages, expected_tools))
+    });
+
+    assert!(
+        grouped,
+        "expected cassette {} to contain an Anthropic request where the two tool_result blocks \
+         from one assistant turn are grouped into one user message",
+        cassette_path.display()
+    );
+}
+
+fn messages_group_tool_results(messages: &[Value], expected_tools: &[&str]) -> bool {
+    messages.windows(2).any(|window| {
+        let assistant = &window[0];
+        let user = &window[1];
+
+        role(assistant) == Some("assistant")
+            && expected_tools
+                .iter()
+                .all(|tool| assistant_tool_use_names(assistant).any(|name| name == *tool))
+            && role(user) == Some("user")
+            && content_type_count(user, "tool_result") >= expected_tools.len()
+    })
+}
+
+fn role(message: &Value) -> Option<&str> {
+    message.get("role").and_then(Value::as_str)
+}
+
+fn assistant_tool_use_names(message: &Value) -> impl Iterator<Item = &str> {
+    content_items(message).filter_map(|content| {
+        (content.get("type").and_then(Value::as_str) == Some("tool_use"))
+            .then(|| content.get("name").and_then(Value::as_str))
+            .flatten()
+    })
+}
+
+fn content_type_count(message: &Value, expected_type: &str) -> usize {
+    content_items(message)
+        .filter(|content| content.get("type").and_then(Value::as_str) == Some(expected_type))
+        .count()
+}
+
+fn content_items(message: &Value) -> impl Iterator<Item = &Value> {
+    message
+        .get("content")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
 }


### PR DESCRIPTION
## Summary

- stack PR #1838's Anthropic streaming tool-result batching fix with original author attribution preserved
- add a cassette-backed Anthropic streaming regression that records two tool results from one assistant turn
- re-record affected Anthropic cassettes so replay expects grouped `tool_result` blocks in one user message
- remove the now-unused streaming helper and keep its multimodal tool-result coverage on the replacement helper

## Why

Anthropic-compatible requests should send all `tool_result` blocks from a single assistant turn in one `user` message. The old streaming path split them across multiple user messages, which is the behavior described in #1838. This PR adds live-recorded cassette coverage for that request shape and refreshes existing affected fixtures.

## Validation

- `cargo fmt`
- `RIG_PROVIDER_TEST_MODE=record cargo test --test anthropic streaming_tools_batches_multiple_tool_results_in_one_followup_message -- --nocapture`
- `RIG_PROVIDER_TEST_MODE=record cargo test --test anthropic multi_turn_streaming_tools -- --nocapture`
- `cargo test --test anthropic cassette`
- `cargo test -p rig-core tool_result_user_content_preserves_multimodal_tool_output`