### PR TITLE
[codex] support mistral.rs OpenAI-compatible reasoning

### DIFF
--- a/crates/rig-core/src/providers/openai/completion/streaming.rs
+++ b/crates/rig-core/src/providers/openai/completion/streaming.rs
@@ -506,6 +506,62 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_streaming_reasoning_content_and_text_chunks_are_incremental() {
+        use crate::test_utils::MockStreamingClient;
+        use futures::StreamExt;
+
+        let client = MockStreamingClient {
+            sse_bytes: sse_bytes_from_data_lines([
+                "{\"id\":\"cmpl-1\",\"model\":\"Qwen/Qwen3-4B\",\"choices\":[{\"delta\":{\"reasoning_content\":\"think \",\"tool_calls\":[]},\"finish_reason\":null}],\"usage\":null}",
+                "{\"id\":\"cmpl-1\",\"model\":\"Qwen/Qwen3-4B\",\"choices\":[{\"delta\":{\"reasoning_content\":\"more\",\"tool_calls\":[]},\"finish_reason\":null}],\"usage\":null}",
+                "{\"id\":\"cmpl-1\",\"model\":\"Qwen/Qwen3-4B\",\"choices\":[{\"delta\":{\"content\":\"hel\",\"tool_calls\":[]},\"finish_reason\":null}],\"usage\":null}",
+                "{\"id\":\"cmpl-1\",\"model\":\"Qwen/Qwen3-4B\",\"choices\":[{\"delta\":{\"content\":\"lo\",\"tool_calls\":[]},\"finish_reason\":\"stop\"}],\"usage\":null}",
+                "{\"choices\":[],\"usage\":{\"prompt_tokens\":4,\"completion_tokens\":6,\"total_tokens\":10}}",
+                "[DONE]",
+            ]),
+        };
+
+        let req = http::Request::builder()
+            .method("POST")
+            .uri("http://localhost/v1/chat/completions")
+            .body(Vec::new())
+            .unwrap();
+
+        let mut stream = send_compatible_streaming_request(client, req)
+            .await
+            .unwrap();
+
+        let mut reasoning_chunks = Vec::new();
+        let mut text_chunks = Vec::new();
+        let mut final_usage = None;
+
+        while let Some(chunk) = stream.next().await {
+            match chunk.unwrap() {
+                streaming::StreamedAssistantContent::ReasoningDelta { reasoning, .. } => {
+                    reasoning_chunks.push(reasoning)
+                }
+                streaming::StreamedAssistantContent::Text(text) => text_chunks.push(text.text),
+                streaming::StreamedAssistantContent::Final(response) => {
+                    final_usage = Some(response.usage)
+                }
+                _ => {}
+            }
+        }
+
+        assert_eq!(
+            reasoning_chunks,
+            vec!["think ".to_string(), "more".to_string()]
+        );
+        assert_eq!(text_chunks, vec!["hel".to_string(), "lo".to_string()]);
+
+        let usage = final_usage.expect("expected final usage");
+        assert_eq!(usage.prompt_tokens, 4);
+        assert_eq!(usage.total_tokens, 10);
+        let token_usage = usage.token_usage().expect("usage should convert");
+        assert_eq!(token_usage.output_tokens, 6);
+    }
+
+    #[tokio::test]
     async fn test_streaming_cached_input_tokens_populated() {
         use crate::test_utils::MockStreamingClient;
         use futures::StreamExt;

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -441,18 +441,31 @@ impl TryFrom<crate::completion::Message> for Vec<InputItem> {
             crate::completion::Message::Assistant { id, content } => {
                 let mut reasoning_items = Vec::new();
                 let mut other_items = Vec::new();
+                let content = content.into_iter().collect::<Vec<_>>();
+                let has_unreplayable_reasoning = content.iter().any(|assistant_content| {
+                    matches!(
+                        assistant_content,
+                        crate::message::AssistantContent::Reasoning(reasoning)
+                            if reasoning.id.is_none()
+                    )
+                });
 
                 for assistant_content in content {
                     match assistant_content {
                         crate::message::AssistantContent::Text(Text { text, .. }) => {
-                            let id = id.as_ref().unwrap_or(&String::default()).clone();
+                            if text.is_empty() {
+                                continue;
+                            }
+                            let text = if has_unreplayable_reasoning {
+                                AssistantContent::InputText { text }
+                            } else {
+                                AssistantContent::OutputText(Text::new(text))
+                            };
                             other_items.push(InputItem {
                                 role: Some(Role::Assistant),
                                 input: InputContent::Message(Message::Assistant {
-                                    content: OneOrMany::one(AssistantContentType::Text(
-                                        AssistantContent::OutputText(Text::new(text)),
-                                    )),
-                                    id,
+                                    content: OneOrMany::one(AssistantContentType::Text(text)),
+                                    id: id.clone().unwrap_or_default(),
                                     name: None,
                                     status: ToolStatus::Completed,
                                 }),
@@ -478,10 +491,12 @@ impl TryFrom<crate::completion::Message> for Vec<InputItem> {
                         crate::message::AssistantContent::Reasoning(reasoning) => {
                             let openai_reasoning = openai_reasoning_from_core(&reasoning)
                                 .map_err(|err| CompletionError::ProviderError(err.to_string()))?;
-                            reasoning_items.push(InputItem {
-                                role: None,
-                                input: InputContent::Reasoning(openai_reasoning),
-                            });
+                            if let Some(openai_reasoning) = openai_reasoning {
+                                reasoning_items.push(InputItem {
+                                    role: None,
+                                    input: InputContent::Reasoning(openai_reasoning),
+                                });
+                            }
                         }
                         crate::message::AssistantContent::Image(_) => {
                             return Err(CompletionError::ProviderError(
@@ -516,12 +531,11 @@ fn require_call_id(call_id: Option<String>, context: &str) -> Result<String, Com
 
 fn openai_reasoning_from_core(
     reasoning: &crate::message::Reasoning,
-) -> Result<OpenAIReasoning, MessageError> {
-    let id = reasoning.id.clone().ok_or_else(|| {
-        MessageError::ConversionError(
-            "An OpenAI-generated ID is required when using OpenAI reasoning items".to_string(),
-        )
-    })?;
+) -> Result<Option<OpenAIReasoning>, MessageError> {
+    let Some(id) = reasoning.id.clone() else {
+        return Ok(None);
+    };
+
     let mut summary = Vec::new();
     let mut encrypted_content = None;
     for content in &reasoning.content {
@@ -539,12 +553,24 @@ fn openai_reasoning_from_core(
         }
     }
 
-    Ok(OpenAIReasoning {
+    Ok(Some(OpenAIReasoning {
         id,
         summary,
         encrypted_content,
         status: None,
-    })
+    }))
+}
+
+fn optional_reasoning_string<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(
+        match Option::<serde_json::Value>::deserialize(deserializer)? {
+            Some(serde_json::Value::String(reasoning)) => Some(reasoning),
+            _ => None,
+        },
+    )
 }
 
 /// The definition of a tool response, repurposed for OpenAI's Responses API.
@@ -1044,6 +1070,15 @@ pub struct CompletionResponse {
     pub max_output_tokens: Option<u64>,
     /// The model name
     pub model: String,
+    /// Provider-specific top-level reasoning content returned by some
+    /// OpenAI-compatible Responses implementations.
+    #[serde(
+        default,
+        rename = "reasoning",
+        deserialize_with = "optional_reasoning_string",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub provider_reasoning: Option<String>,
     /// Token usage
     pub usage: Option<ResponsesUsage>,
     /// The model output (messages, etc will go here)
@@ -1517,24 +1552,35 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
     type Error = CompletionError;
 
     fn try_from(response: CompletionResponse) -> Result<Self, Self::Error> {
-        if response.output.is_empty() {
-            return Err(CompletionError::ResponseError(
-                "Response contained no parts".to_owned(),
-            ));
-        }
-
         // Extract the msg_ ID from the first Output::Message item
         let message_id = response.output.iter().find_map(|item| match item {
             Output::Message(msg) => Some(msg.id.clone()),
             _ => None,
         });
 
-        let content: Vec<completion::AssistantContent> = response
+        let output_content: Vec<completion::AssistantContent> = response
             .output
             .iter()
             .cloned()
             .flat_map(<Vec<completion::AssistantContent>>::from)
             .collect();
+        let has_structured_reasoning = response
+            .output
+            .iter()
+            .any(|item| matches!(item, Output::Reasoning { .. }));
+        let content = response
+            .provider_reasoning
+            .as_ref()
+            .filter(|reasoning| !has_structured_reasoning && !reasoning.is_empty())
+            .map(|reasoning| {
+                let mut content = Vec::with_capacity(output_content.len() + 1);
+                content.push(completion::AssistantContent::Reasoning(
+                    message::Reasoning::new(reasoning),
+                ));
+                content.extend(output_content.clone());
+                content
+            })
+            .unwrap_or(output_content);
 
         let choice = OneOrMany::many(content).map_err(|_| {
             CompletionError::ResponseError(
@@ -1611,6 +1657,7 @@ impl Message {
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum AssistantContent {
+    InputText { text: String },
     OutputText(Text),
     Refusal { refusal: String },
 }
@@ -1618,6 +1665,9 @@ pub enum AssistantContent {
 impl From<AssistantContent> for completion::AssistantContent {
     fn from(value: AssistantContent) -> Self {
         match value {
+            AssistantContent::InputText { text } => {
+                completion::AssistantContent::Text(Text::new(text))
+            }
             AssistantContent::Refusal { refusal } => {
                 completion::AssistantContent::Text(Text::new(refusal))
             }
@@ -1863,65 +1913,84 @@ impl TryFrom<message::Message> for Vec<Message> {
                 }
             }
             message::Message::Assistant { content, id } => {
-                let assistant_message_id = id.ok_or_else(|| {
-                    MessageError::ConversionError(
-                        "Assistant message ID is required for OpenAI Responses API".into(),
+                let assistant_message_id = id.unwrap_or_default();
+                let mut messages = Vec::new();
+                let content = content.into_iter().collect::<Vec<_>>();
+                let has_unreplayable_reasoning = content.iter().any(|assistant_content| {
+                    matches!(
+                        assistant_content,
+                        crate::message::AssistantContent::Reasoning(reasoning)
+                            if reasoning.id.is_none()
                     )
-                })?;
+                });
 
-                match content.first() {
-                    crate::message::AssistantContent::Text(Text { text, .. }) => {
-                        Ok(vec![Message::Assistant {
-                            id: assistant_message_id.clone(),
-                            status: ToolStatus::Completed,
-                            content: OneOrMany::one(AssistantContentType::Text(
-                                AssistantContent::OutputText(Text::new(text)),
-                            )),
-                            name: None,
-                        }])
-                    }
-                    crate::message::AssistantContent::ToolCall(crate::message::ToolCall {
-                        id,
-                        call_id,
-                        function,
-                        ..
-                    }) => Ok(vec![Message::Assistant {
-                        content: OneOrMany::one(AssistantContentType::ToolCall(
-                            OutputFunctionCall {
-                                call_id: call_id.ok_or_else(|| {
-                                    MessageError::ConversionError(
-                                        "Tool call `call_id` is required for OpenAI Responses API"
-                                            .into(),
-                                    )
-                                })?,
-                                arguments: function.arguments,
-                                id,
-                                name: function.name,
+                for assistant_content in content {
+                    match assistant_content {
+                        crate::message::AssistantContent::Text(Text { text, .. }) => {
+                            if text.is_empty() {
+                                continue;
+                            }
+                            let text = if has_unreplayable_reasoning {
+                                AssistantContent::InputText { text }
+                            } else {
+                                AssistantContent::OutputText(Text::new(text))
+                            };
+                            messages.push(Message::Assistant {
+                                id: assistant_message_id.clone(),
                                 status: ToolStatus::Completed,
-                            },
-                        )),
-                        id: assistant_message_id.clone(),
-                        name: None,
-                        status: ToolStatus::Completed,
-                    }]),
-                    crate::message::AssistantContent::Reasoning(reasoning) => {
-                        let openai_reasoning = openai_reasoning_from_core(&reasoning)?;
-                        Ok(vec![Message::Assistant {
-                            content: OneOrMany::one(AssistantContentType::Reasoning(
-                                openai_reasoning,
-                            )),
-                            id: assistant_message_id,
-                            name: None,
-                            status: ToolStatus::Completed,
-                        }])
-                    }
-                    crate::message::AssistantContent::Image(_) => {
-                        Err(MessageError::ConversionError(
-                            "Assistant image content is not supported in OpenAI Responses API"
-                                .into(),
-                        ))
+                                content: OneOrMany::one(AssistantContentType::Text(text)),
+                                name: None,
+                            });
+                        }
+                        crate::message::AssistantContent::ToolCall(crate::message::ToolCall {
+                            id,
+                            call_id,
+                            function,
+                            ..
+                        }) => {
+                            messages.push(Message::Assistant {
+                                content: OneOrMany::one(AssistantContentType::ToolCall(
+                                    OutputFunctionCall {
+                                        call_id: call_id.ok_or_else(|| {
+                                            MessageError::ConversionError(
+                                                "Tool call `call_id` is required for OpenAI Responses API"
+                                                    .into(),
+                                            )
+                                        })?,
+                                        arguments: function.arguments,
+                                        id,
+                                        name: function.name,
+                                        status: ToolStatus::Completed,
+                                    },
+                                )),
+                                id: assistant_message_id.clone(),
+                                name: None,
+                                status: ToolStatus::Completed,
+                            });
+                        }
+                        crate::message::AssistantContent::Reasoning(reasoning) => {
+                            if let Some(openai_reasoning) = openai_reasoning_from_core(&reasoning)?
+                            {
+                                messages.push(Message::Assistant {
+                                    content: OneOrMany::one(AssistantContentType::Reasoning(
+                                        openai_reasoning,
+                                    )),
+                                    id: assistant_message_id.clone(),
+                                    name: None,
+                                    status: ToolStatus::Completed,
+                                });
+                            }
+                        }
+                        crate::message::AssistantContent::Image(_) => {
+                            return Err(MessageError::ConversionError(
+                                "Assistant image content is not supported in OpenAI Responses API"
+                                    .into(),
+                            ));
+                        }
                     }
                 }
+
+                Ok(messages)
             }
         }
     }
@@ -2062,6 +2131,402 @@ mod tests {
         assert_eq!(token_usage.output_tokens, 50);
         assert_eq!(token_usage.reasoning_tokens, 0);
         assert_eq!(token_usage.total_tokens, 150);
+    }
+
+    #[test]
+    fn completion_response_accepts_top_level_reasoning_string() {
+        let response: CompletionResponse = serde_json::from_value(json!({
+            "id": "resp_123",
+            "object": "response",
+            "created_at": 0,
+            "status": "completed",
+            "model": "Qwen/Qwen3-4B",
+            "reasoning": "thinking through the answer",
+            "usage": {
+                "input_tokens": 1,
+                "output_tokens": 2,
+                "total_tokens": 3
+            },
+            "output": [{
+                "type": "message",
+                "id": "msg_123",
+                "status": "completed",
+                "role": "assistant",
+                "content": [{
+                    "type": "output_text",
+                    "annotations": [],
+                    "text": "done"
+                }]
+            }],
+            "tools": []
+        }))
+        .expect("mistral.rs-style reasoning string should deserialize");
+
+        assert_eq!(
+            response.provider_reasoning.as_deref(),
+            Some("thinking through the answer")
+        );
+
+        let completion: completion::CompletionResponse<CompletionResponse> =
+            response.try_into().expect("response should convert");
+        let items = completion.choice.iter().collect::<Vec<_>>();
+        assert!(matches!(
+            items[0],
+            completion::AssistantContent::Reasoning(_)
+        ));
+        assert!(matches!(items[1], completion::AssistantContent::Text(_)));
+    }
+
+    #[test]
+    fn completion_response_accepts_reasoning_only_response() {
+        let response: CompletionResponse = serde_json::from_value(json!({
+            "id": "resp_123",
+            "object": "response",
+            "created_at": 0,
+            "status": "completed",
+            "model": "Qwen/Qwen3-4B",
+            "reasoning": "thinking only",
+            "usage": {
+                "input_tokens": 1,
+                "output_tokens": 2,
+                "total_tokens": 3
+            },
+            "output": [],
+            "tools": []
+        }))
+        .expect("reasoning-only response should deserialize");
+
+        let completion: completion::CompletionResponse<CompletionResponse> = response
+            .try_into()
+            .expect("reasoning-only response should convert");
+        let items = completion.choice.iter().collect::<Vec<_>>();
+
+        assert_eq!(items.len(), 1);
+        assert!(matches!(
+            items[0],
+            completion::AssistantContent::Reasoning(_)
+        ));
+    }
+
+    #[test]
+    fn completion_response_rejects_empty_response_without_reasoning() {
+        let response: CompletionResponse = serde_json::from_value(json!({
+            "id": "resp_123",
+            "object": "response",
+            "created_at": 0,
+            "status": "completed",
+            "model": "Qwen/Qwen3-4B",
+            "output": [],
+            "tools": []
+        }))
+        .expect("empty response shape should deserialize");
+
+        let err = completion::CompletionResponse::<CompletionResponse>::try_from(response)
+            .expect_err("empty response without reasoning should be rejected");
+
+        assert!(
+            err.to_string()
+                .contains("Response contained no message or tool call")
+        );
+    }
+
+    #[test]
+    fn completion_response_ignores_top_level_reasoning_object_as_text() {
+        let response: CompletionResponse = serde_json::from_value(json!({
+            "id": "resp_123",
+            "object": "response",
+            "created_at": 0,
+            "status": "completed",
+            "model": "Qwen/Qwen3-4B",
+            "reasoning": {
+                "effort": "high"
+            },
+            "output": [{
+                "type": "message",
+                "id": "msg_123",
+                "status": "completed",
+                "role": "assistant",
+                "content": [{
+                    "type": "output_text",
+                    "annotations": [],
+                    "text": "done"
+                }]
+            }],
+            "tools": []
+        }))
+        .expect("object-shaped reasoning should be tolerated");
+
+        assert!(response.provider_reasoning.is_none());
+
+        let completion: completion::CompletionResponse<CompletionResponse> =
+            response.try_into().expect("response should convert");
+        let items = completion.choice.iter().collect::<Vec<_>>();
+        assert_eq!(items.len(), 1);
+        assert!(matches!(items[0], completion::AssistantContent::Text(_)));
+    }
+
+    #[test]
+    fn completion_response_does_not_duplicate_structured_reasoning() {
+        let response: CompletionResponse = serde_json::from_value(json!({
+            "id": "resp_123",
+            "object": "response",
+            "created_at": 0,
+            "status": "completed",
+            "model": "gpt-5.4",
+            "reasoning": "provider top-level text",
+            "output": [{
+                "type": "reasoning",
+                "id": "rs_123",
+                "summary": [{
+                    "type": "summary_text",
+                    "text": "structured summary"
+                }]
+            }, {
+                "type": "message",
+                "id": "msg_123",
+                "status": "completed",
+                "role": "assistant",
+                "content": [{
+                    "type": "output_text",
+                    "annotations": [],
+                    "text": "done"
+                }]
+            }],
+            "tools": []
+        }))
+        .expect("response should deserialize");
+
+        let completion: completion::CompletionResponse<CompletionResponse> =
+            response.try_into().expect("response should convert");
+        let reasoning_count = completion
+            .choice
+            .iter()
+            .filter(|item| matches!(item, completion::AssistantContent::Reasoning(_)))
+            .count();
+
+        assert_eq!(reasoning_count, 1);
+    }
+
+    #[test]
+    fn idless_reasoning_is_skipped_when_converting_responses_history() {
+        let assistant = message::Message::Assistant {
+            id: Some("msg_123".to_string()),
+            content: OneOrMany::one(message::AssistantContent::Reasoning(
+                message::Reasoning::new("provider reasoning"),
+            )),
+        };
+
+        let converted = Vec::<Message>::try_from(assistant)
+            .expect("idless reasoning should degrade gracefully");
+
+        assert!(converted.is_empty());
+    }
+
+    #[test]
+    fn idless_reasoning_only_is_skipped_without_empty_input_item() {
+        let assistant = completion::Message::Assistant {
+            id: None,
+            content: OneOrMany::one(message::AssistantContent::Reasoning(
+                message::Reasoning::new("provider reasoning"),
+            )),
+        };
+
+        let converted = Vec::<InputItem>::try_from(assistant)
+            .expect("idless reasoning should degrade gracefully");
+
+        assert!(converted.is_empty());
+    }
+
+    #[test]
+    fn idless_reasoning_plus_text_preserves_text_for_responses_history() {
+        let assistant = message::Message::Assistant {
+            id: Some("msg_123".to_string()),
+            content: OneOrMany::many(vec![
+                message::AssistantContent::Reasoning(message::Reasoning::new("provider reasoning")),
+                message::AssistantContent::Text(Text::new("final answer")),
+            ])
+            .expect("assistant content should be non-empty"),
+        };
+
+        let converted =
+            Vec::<Message>::try_from(assistant).expect("assistant history should convert");
+
+        assert_eq!(converted.len(), 1);
+        let Message::Assistant { content, .. } = &converted[0] else {
+            panic!("expected assistant message");
+        };
+        assert!(matches!(
+            content.first_ref(),
+            AssistantContentType::Text(AssistantContent::InputText { text }) if text == "final answer"
+        ));
+    }
+
+    #[test]
+    fn completion_history_idless_reasoning_plus_text_preserves_text_input_item() {
+        let assistant = completion::Message::Assistant {
+            id: Some("msg_123".to_string()),
+            content: OneOrMany::many(vec![
+                message::AssistantContent::Reasoning(message::Reasoning::new("provider reasoning")),
+                message::AssistantContent::Text(Text::new("final answer")),
+            ])
+            .expect("assistant content should be non-empty"),
+        };
+
+        let converted =
+            Vec::<InputItem>::try_from(assistant).expect("assistant history should convert");
+
+        assert_eq!(converted.len(), 1);
+        assert!(matches!(converted[0].role, Some(Role::Assistant)));
+        let InputContent::Message(Message::Assistant { content, .. }) = &converted[0].input else {
+            panic!("expected assistant message input item");
+        };
+        assert!(matches!(
+            content.first_ref(),
+            AssistantContentType::Text(AssistantContent::InputText { text }) if text == "final answer"
+        ));
+    }
+
+    #[test]
+    fn assistant_text_without_idless_reasoning_replays_as_output_text() {
+        let assistant = completion::Message::Assistant {
+            id: Some("msg_123".to_string()),
+            content: OneOrMany::one(message::AssistantContent::Text(Text::new("final answer"))),
+        };
+
+        let converted =
+            Vec::<InputItem>::try_from(assistant).expect("assistant history should convert");
+
+        assert_eq!(converted.len(), 1);
+        let InputContent::Message(Message::Assistant { content, .. }) = &converted[0].input else {
+            panic!("expected assistant message input item");
+        };
+        assert!(matches!(
+            content.first_ref(),
+            AssistantContentType::Text(AssistantContent::OutputText(Text { text, .. })) if text == "final answer"
+        ));
+    }
+
+    #[test]
+    fn structured_reasoning_with_id_still_converts_for_responses_history() {
+        let assistant = message::Message::Assistant {
+            id: Some("msg_123".to_string()),
+            content: OneOrMany::one(message::AssistantContent::Reasoning(message::Reasoning {
+                id: Some("rs_123".to_string()),
+                content: vec![message::ReasoningContent::Summary(
+                    "structured summary".to_string(),
+                )],
+            })),
+        };
+
+        let converted =
+            Vec::<Message>::try_from(assistant).expect("structured reasoning should still convert");
+
+        assert_eq!(converted.len(), 1);
+        let Message::Assistant { content, .. } = &converted[0] else {
+            panic!("expected assistant message");
+        };
+        assert!(matches!(
+            content.first_ref(),
+            AssistantContentType::Reasoning(OpenAIReasoning { id, .. }) if id == "rs_123"
+        ));
+    }
+
+    #[test]
+    fn structured_reasoning_with_id_still_converts_to_input_item() {
+        let assistant = completion::Message::Assistant {
+            id: Some("msg_123".to_string()),
+            content: OneOrMany::one(message::AssistantContent::Reasoning(message::Reasoning {
+                id: Some("rs_123".to_string()),
+                content: vec![message::ReasoningContent::Summary(
+                    "structured summary".to_string(),
+                )],
+            })),
+        };
+
+        let converted =
+            Vec::<InputItem>::try_from(assistant).expect("structured reasoning should convert");
+
+        assert_eq!(converted.len(), 1);
+        assert!(converted[0].role.is_none());
+        assert!(matches!(
+            &converted[0].input,
+            InputContent::Reasoning(OpenAIReasoning { id, .. }) if id == "rs_123"
+        ));
+    }
+
+    #[test]
+    fn mocked_second_turn_request_omits_unreplayable_reasoning() {
+        let request = crate::completion::CompletionRequest {
+            model: None,
+            preamble: Some("You are concise.".to_string()),
+            chat_history: OneOrMany::many(vec![
+                completion::Message::User {
+                    content: OneOrMany::one(message::UserContent::Text(Text::new(
+                        "Think briefly, then answer.",
+                    ))),
+                },
+                completion::Message::Assistant {
+                    id: Some("msg_123".to_string()),
+                    content: OneOrMany::many(vec![
+                        message::AssistantContent::Reasoning(message::Reasoning::new(
+                            "provider reasoning",
+                        )),
+                        message::AssistantContent::Text(Text::new("final answer")),
+                    ])
+                    .expect("assistant content should be non-empty"),
+                },
+                completion::Message::Assistant {
+                    id: None,
+                    content: OneOrMany::many(vec![
+                        message::AssistantContent::Reasoning(message::Reasoning::new(
+                            "provider reasoning only",
+                        )),
+                        message::AssistantContent::Text(Text::new("")),
+                    ])
+                    .expect("assistant content should be non-empty"),
+                },
+                completion::Message::User {
+                    content: OneOrMany::one(message::UserContent::Text(Text::new(
+                        "/no_think Reply with exactly: OK",
+                    ))),
+                },
+            ])
+            .expect("history should be non-empty"),
+            documents: Vec::new(),
+            tools: Vec::new(),
+            temperature: None,
+            max_tokens: Some(64),
+            tool_choice: None,
+            additional_params: None,
+            output_schema: None,
+        };
+
+        let request = CompletionRequest::try_from(("Qwen/Qwen3-4B".to_string(), request))
+            .expect("request should convert");
+        let value = serde_json::to_value(&request).expect("request should serialize");
+        let input = value["input"]
+            .as_array()
+            .expect("mocked multi-turn request should serialize input as an array");
+
+        assert!(!input.iter().any(|item| {
+            item.get("type") == Some(&json!("reasoning")) && item.get("id").is_none()
+        }));
+        assert!(!input.iter().any(|item| {
+            item.get("role") == Some(&json!("assistant"))
+                && item
+                    .get("content")
+                    .and_then(Value::as_array)
+                    .is_some_and(Vec::is_empty)
+        }));
+
+        let assistant_items = input
+            .iter()
+            .filter(|item| item.get("role") == Some(&json!("assistant")))
+            .collect::<Vec<_>>();
+
+        assert_eq!(assistant_items.len(), 1);
+        assert_eq!(assistant_items[0]["content"][0]["type"], "input_text");
+        assert_eq!(assistant_items[0]["content"][0]["text"], "final answer");
     }
 
     #[test]

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -449,6 +449,7 @@ impl TryFrom<crate::completion::Message> for Vec<InputItem> {
                             if reasoning.id.is_none()
                     )
                 });
+                let cannot_replay_as_provider_output = id.is_none() || has_unreplayable_reasoning;
 
                 for assistant_content in content {
                     match assistant_content {
@@ -456,7 +457,7 @@ impl TryFrom<crate::completion::Message> for Vec<InputItem> {
                             if text.is_empty() {
                                 continue;
                             }
-                            let text = if has_unreplayable_reasoning {
+                            let text = if cannot_replay_as_provider_output {
                                 AssistantContent::InputText { text }
                             } else {
                                 AssistantContent::OutputText(Text::new(text))
@@ -1913,6 +1914,7 @@ impl TryFrom<message::Message> for Vec<Message> {
                 }
             }
             message::Message::Assistant { content, id } => {
+                let cannot_replay_without_provider_id = id.is_none();
                 let assistant_message_id = id.unwrap_or_default();
                 let mut messages = Vec::new();
                 let content = content.into_iter().collect::<Vec<_>>();
@@ -1923,6 +1925,8 @@ impl TryFrom<message::Message> for Vec<Message> {
                             if reasoning.id.is_none()
                     )
                 });
+                let cannot_replay_as_provider_output =
+                    cannot_replay_without_provider_id || has_unreplayable_reasoning;
 
                 for assistant_content in content {
                     match assistant_content {
@@ -1930,7 +1934,7 @@ impl TryFrom<message::Message> for Vec<Message> {
                             if text.is_empty() {
                                 continue;
                             }
-                            let text = if has_unreplayable_reasoning {
+                            let text = if cannot_replay_as_provider_output {
                                 AssistantContent::InputText { text }
                             } else {
                                 AssistantContent::OutputText(Text::new(text))
@@ -2404,6 +2408,60 @@ mod tests {
             content.first_ref(),
             AssistantContentType::Text(AssistantContent::OutputText(Text { text, .. })) if text == "final answer"
         ));
+    }
+
+    #[test]
+    fn idless_completion_assistant_text_replays_as_input_text() {
+        let assistant = completion::Message::Assistant {
+            id: None,
+            content: OneOrMany::one(message::AssistantContent::Text(Text::new("final answer"))),
+        };
+
+        let converted =
+            Vec::<InputItem>::try_from(assistant).expect("assistant history should convert");
+
+        assert_eq!(converted.len(), 1);
+        assert!(matches!(converted[0].role, Some(Role::Assistant)));
+        let InputContent::Message(Message::Assistant { content, id, .. }) = &converted[0].input
+        else {
+            panic!("expected assistant message input item");
+        };
+        assert!(id.is_empty());
+        assert!(matches!(
+            content.first_ref(),
+            AssistantContentType::Text(AssistantContent::InputText { text }) if text == "final answer"
+        ));
+
+        let serialized =
+            serde_json::to_value(&converted[0]).expect("input item should serialize to JSON");
+        assert_eq!(serialized["content"][0]["type"], json!("input_text"));
+        assert!(serialized.get("id").is_none());
+    }
+
+    #[test]
+    fn idless_message_assistant_text_replays_as_input_text() {
+        let assistant = message::Message::Assistant {
+            id: None,
+            content: OneOrMany::one(message::AssistantContent::Text(Text::new("final answer"))),
+        };
+
+        let converted =
+            Vec::<Message>::try_from(assistant).expect("assistant history should convert");
+
+        assert_eq!(converted.len(), 1);
+        let Message::Assistant { content, id, .. } = &converted[0] else {
+            panic!("expected assistant message");
+        };
+        assert!(id.is_empty());
+        assert!(matches!(
+            content.first_ref(),
+            AssistantContentType::Text(AssistantContent::InputText { text }) if text == "final answer"
+        ));
+
+        let serialized = serde_json::to_value(&converted[0])
+            .expect("assistant message should serialize to JSON");
+        assert_eq!(serialized["content"][0]["type"], json!("input_text"));
+        assert!(serialized.get("id").is_none());
     }
 
     #[test]

--- a/crates/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -952,6 +952,7 @@ mod tests {
             instructions: None,
             max_output_tokens: None,
             model: "gpt-5.4".to_string(),
+            provider_reasoning: None,
             usage: None,
             output: Vec::new(),
             tools: Vec::new(),

--- a/tests/cassettes/mistralrs/chat_completions/chat_completions_agent_prompt_completes.yaml
+++ b/tests/cassettes/mistralrs/chat_completions/chat_completions_agent_prompt_completes.yaml
@@ -1,0 +1,16 @@
+when:
+  path: /v1/chat/completions
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"max_tokens":128,"messages":[{"content":[{"text":"You are concise. Include a few details so streaming is visible.","type":"text"}],"role":"system"},{"content":"/no_think Explain why a local OpenAI-compatible server should return token usage.","role":"user"}],"model":"Qwen/Qwen3-4B"}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"choices":[{"finish_reason":"stop","index":0,"logprobs":null,"message":{"content":"\n\nA local OpenAI-compatible server should return token usage to help users understand and manage their model''s resource consumption. This data is crucial for cost tracking, optimizing model performance, and ensuring fair usage. It also supports compliance with usage policies and helps in planning for scalability.","reasoning_content":"\n\n","role":"assistant","tool_calls":null}}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion","system_fingerprint":"local","usage":{"avg_compl_tok_per_sec":16.407356,"avg_prompt_tok_per_sec":64.02439,"avg_tok_per_sec":23.849274,"completion_tokens":58,"prompt_tokens":42,"total_completion_time_sec":3.535,"total_prompt_time_sec":0.656,"total_time_sec":4.193,"total_tokens":100}}'

--- a/tests/cassettes/mistralrs/chat_completions/raw_chat_completion_surfaces_reasoning_or_text.yaml
+++ b/tests/cassettes/mistralrs/chat_completions/raw_chat_completion_surfaces_reasoning_or_text.yaml
@@ -1,0 +1,16 @@
+when:
+  path: /v1/chat/completions
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"max_tokens":256,"messages":[{"content":[{"text":"You are concise. Include a few details so streaming is visible.","type":"text"}],"role":"system"},{"content":"Think briefly, then answer in one sentence why token usage should be reported.","role":"user"}],"model":"Qwen/Qwen3-4B"}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"choices":[{"finish_reason":"length","index":0,"logprobs":null,"message":{"content":null,"reasoning_content":"\nOkay, the user is asking why token usage should be reported, and they want a brief, concise answer in one sentence. Let me break this down.\n\nFirst, token usage refers to the number of tokens (like words or characters) a model uses during processing. Reporting this is important for several reasons. One key reason is cost management. Many services charge based on token usage, so tracking it helps in budgeting. Also, it''s crucial for optimizing performance. If you know how many tokens you''re using, you can adjust your prompts or models to be more efficient, reducing costs and improving response times. \n\nAnother angle is transparency. Reporting token usage can help in understanding how resources are being utilized, which is important for scalability and planning. Maybe the user is a developer or a business professional looking to manage costs. They might not want to overspend, so tracking token usage is essential. Also, they might need this data for performance analysis or to demonstrate efficiency to stakeholders. \n\nI should make sure the answer is concise but covers these points. The user wants a single sentence, so I need to combine these ideas without being too verbose. Maybe start with the main reason (cost management) and then mention optimization and resource efficiency. Let me check if that''s accurate","role":"assistant","tool_calls":null}}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion","system_fingerprint":"local","usage":{"avg_compl_tok_per_sec":15.591692,"avg_prompt_tok_per_sec":27.315123,"avg_tok_per_sec":16.57181,"completion_tokens":256,"prompt_tokens":41,"total_completion_time_sec":16.419,"total_prompt_time_sec":1.501,"total_time_sec":17.922,"total_tokens":297}}'

--- a/tests/cassettes/mistralrs/responses_api/responses_api_multi_turn_replays_history.yaml
+++ b/tests/cassettes/mistralrs/responses_api/responses_api_multi_turn_replays_history.yaml
@@ -1,0 +1,33 @@
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"input":[{"content":[{"text":"You are concise. Include a few details so streaming is visible.","type":"input_text"}],"role":"system","type":"message"},{"content":[{"text":"Think briefly, then answer in one sentence why usage accounting matters.","type":"input_text"}],"role":"user","type":"message"}],"max_output_tokens":256,"model":"Qwen/Qwen3-4B"}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"completed_at":0,"created_at":0,"id":"resp_REDACTED_1","max_output_tokens":256,"model":"Qwen/Qwen3-4B","object":"response","output":[{"content":[{"text":"\n\nUsage accounting matters because it ensures fair resource allocation, tracks cost efficiency, and helps optimize spending based on actual consumption.","type":"output_text"}],"id":"msg_REDACTED_1","role":"assistant","status":"completed","type":"message"}],"output_text":"\n\nUsage accounting matters because it ensures fair resource allocation, tracks cost efficiency, and helps optimize spending based on actual consumption.","reasoning":"\nOkay, the user wants a brief answer why usage accounting matters. Let me break it down. Usage accounting tracks resource consumption, right? So why is that important? Well, it helps in managing costs, ensuring fair resource distribution, and optimizing efficiency. Maybe they need to know the main points without going into detail. The user probably wants a clear, concise answer. Let me make sure to include the key benefits: cost management, fairness, efficiency. But keep it to one sentence. Let me check if that''s all. Yeah, that should cover it.\n","status":"completed","usage":{"input_tokens":39,"output_tokens":140,"total_tokens":179}}'
+---
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"input":[{"content":[{"text":"You are concise. Include a few details so streaming is visible.","type":"input_text"}],"role":"system","type":"message"},{"content":[{"text":"Think briefly, then answer in one sentence why usage accounting matters.","type":"input_text"}],"role":"user","type":"message"},{"content":[{"text":"\n\nUsage accounting matters because it ensures fair resource allocation, tracks cost efficiency, and helps optimize spending based on actual consumption.","type":"input_text"}],"id":"msg_REDACTED_1","role":"assistant","status":"completed","type":"message"},{"content":[{"text":"/no_think Reply with exactly: OK","type":"input_text"}],"role":"user","type":"message"}],"max_output_tokens":256,"model":"Qwen/Qwen3-4B"}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"completed_at":0,"created_at":0,"id":"resp_REDACTED_2","max_output_tokens":256,"model":"Qwen/Qwen3-4B","object":"response","output":[{"content":[{"text":"\n\nOK","type":"output_text"}],"id":"msg_REDACTED_2","role":"assistant","status":"completed","type":"message"}],"output_text":"\n\nOK","reasoning":"\n\n","status":"completed","usage":{"input_tokens":80,"output_tokens":6,"total_tokens":86}}'

--- a/tests/cassettes/mistralrs/responses_api/responses_api_no_think_returns_text.yaml
+++ b/tests/cassettes/mistralrs/responses_api/responses_api_no_think_returns_text.yaml
@@ -1,0 +1,16 @@
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"input":[{"content":[{"text":"You are concise. Include a few details so streaming is visible.","type":"input_text"}],"role":"system","type":"message"},{"content":[{"text":"/no_think Explain token usage reporting in one sentence.","type":"input_text"}],"role":"user","type":"message"}],"max_output_tokens":128,"model":"Qwen/Qwen3-4B"}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"completed_at":0,"created_at":0,"id":"resp_REDACTED_1","max_output_tokens":128,"model":"Qwen/Qwen3-4B","object":"response","output":[{"content":[{"text":"\n\nToken usage reporting tracks the number of tokens consumed by AI models during interactions to help optimize costs and resource allocation.","type":"output_text"}],"id":"msg_REDACTED_1","role":"assistant","status":"completed","type":"message"}],"output_text":"\n\nToken usage reporting tracks the number of tokens consumed by AI models during interactions to help optimize costs and resource allocation.","reasoning":"\n\n","status":"completed","usage":{"input_tokens":37,"output_tokens":27,"total_tokens":64}}'

--- a/tests/cassettes/mistralrs/responses_api/responses_api_reasoning_plus_answer_completes.yaml
+++ b/tests/cassettes/mistralrs/responses_api/responses_api_reasoning_plus_answer_completes.yaml
@@ -1,0 +1,16 @@
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"input":[{"content":[{"text":"You are concise. Include a few details so streaming is visible.","type":"input_text"}],"role":"system","type":"message"},{"content":[{"text":"Think briefly, then answer in one sentence why local OpenAI-compatible servers should report token usage.","type":"input_text"}],"role":"user","type":"message"}],"max_output_tokens":512,"model":"Qwen/Qwen3-4B"}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"completed_at":0,"created_at":0,"id":"resp_REDACTED_1","max_output_tokens":512,"model":"Qwen/Qwen3-4B","object":"response","output":[{"content":[{"text":"\n\nLocal OpenAI-compatible servers should report token usage to track costs, optimize resources, and ensure budget compliance for efficient model operation.","type":"output_text"}],"id":"msg_REDACTED_1","role":"assistant","status":"completed","type":"message"}],"output_text":"\n\nLocal OpenAI-compatible servers should report token usage to track costs, optimize resources, and ensure budget compliance for efficient model operation.","reasoning":"\nOkay, the user is asking why local OpenAI-compatible servers should report token usage, and they want a brief, one-sentence answer. Let me start by recalling what token usage reporting entails. It''s about tracking the number of tokens used in model interactions, which is crucial for billing and cost management.\n\nHmm, the user mentioned \"local servers,\" so maybe they''re concerned about cost control. If they''re running their own models, they need to know how much they''re using to avoid unexpected expenses. Also, reporting token usage can help in optimizing model usage, like adjusting the prompt length or model size to stay within budget.\n\nWait, the answer needs to be concise. So the main points are cost tracking, budgeting, and optimization. Maybe also mention resource allocation. But it has to be one sentence. So combining these elements: \"Local OpenAI-compatible servers should report token usage to track costs, optimize resource allocation, and ensure budget compliance for efficient model operation.\" That''s a bit long, but it hits the key points. Let me check if it''s concise enough. Maybe trim some words. \"Local OpenAI-compatible servers should report token usage to track costs, optimize resources, and ensure budget compliance.\" That''s better. Yeah, that covers the main reasons without being too verbose.\n","status":"completed","usage":{"input_tokens":45,"output_tokens":290,"total_tokens":335}}'

--- a/tests/cassettes/mistralrs/streaming/chat_completions_stream_emits_reasoning_and_text_incrementally.yaml
+++ b/tests/cassettes/mistralrs/streaming/chat_completions_stream_emits_reasoning_and_text_incrementally.yaml
@@ -1,0 +1,434 @@
+when:
+  path: /v1/chat/completions
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"max_tokens":512,"messages":[{"content":[{"text":"You are concise. Include a few details so streaming is visible.","type":"text"}],"role":"system"},{"content":"Think briefly, then answer with three short bullet points about token usage reporting.","role":"user"}],"model":"Qwen/Qwen3-4B","stream":true,"stream_options":{"include_usage":true}}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: |+
+    data: {"choices":[{"delta":{"content":null,"role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":"\n","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":"Okay","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":",","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" the","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" user","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" wants","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" a","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" brief","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" answer","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" with","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" three","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" short","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" bullet","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" points","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" about","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" token","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" usage","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" reporting","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":".","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" Let","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" me","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" start","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" by","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" recalling","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" what","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" token","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" usage","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" reporting","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" entails","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":".","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" It","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":"'s","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" about","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" tracking","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" how","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" tokens","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" are","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" used","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" in","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" a","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" system","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":",","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" right","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":"?","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" So","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" first","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":",","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" I","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" need","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" to","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" identify","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" the","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" key","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" aspects","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" of","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" token","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" usage","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" reporting","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":".","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" \n\n","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":"The","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" first","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" point","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" should","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" be","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" about","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" tracking","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" tokens","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" in","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" real","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":"-time","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":".","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" That","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":"'s","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" important","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" for","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" monitoring","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" and","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" optimizing","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" performance","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":".","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" Then","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":",","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" maybe","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" the","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" second","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" point","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" is","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" about","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" reporting","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" on","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" token","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" consumption","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" per","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" user","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" or","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" session","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":".","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" That","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" helps","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" in","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" understanding","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" usage","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" patterns","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" and","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" managing","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" costs","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":".","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" \n\n","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":"Third","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":",","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" I","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" should","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" mention","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" analytics","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" for","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" cost","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" optimization","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":".","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" Using","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" token","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" data","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" to","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" analyze","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" usage","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" and","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" suggest","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" cost","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":"-saving","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" measures","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":".","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" Need","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" to","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" make","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" sure","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" each","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" bullet","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" is","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" concise","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" and","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" covers","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" a","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" distinct","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" aspect","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":".","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" Let","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" me","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" check","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" if","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" these","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" points","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" are","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" accurate","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" and","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" fit","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" the","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" query","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":".","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" Yep","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":",","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" that","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":"'s","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" it","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":".","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" Keep","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" it","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" simple","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" and","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" to","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" the","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":" point","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"reasoning_content":".\n","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":"\n\n","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":"-","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":" Real","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":"-time","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":" tracking","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":" of","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":" token","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":" usage","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":" across","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":" systems","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":".","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":"  \n","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":"-","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":" Per","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":"-user","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":"/session","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":" analytics","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":" for","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":" cost","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":" and","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":" performance","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":" insights","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":".","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":"  \n","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":"-","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":" Historical","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":" data","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":" for","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":" trend","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":" analysis","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":" and","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":" optimization","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":".","role":"assistant","tool_calls":null},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":null}
+
+    data: {"choices":[{"delta":{"content":null,"role":"assistant","tool_calls":null},"finish_reason":"stop","index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion.chunk","system_fingerprint":"local","usage":{"avg_compl_tok_per_sec":15.559545,"avg_prompt_tok_per_sec":26.885244,"avg_tok_per_sec":16.717018,"completion_tokens":208,"prompt_tokens":41,"total_completion_time_sec":13.368,"total_prompt_time_sec":1.525,"total_time_sec":14.895,"total_tokens":249}}
+
+    data: [DONE]
+

--- a/tests/cassettes/mistralrs/tools/raw_chat_completion_emits_requested_tool_call.yaml
+++ b/tests/cassettes/mistralrs/tools/raw_chat_completion_emits_requested_tool_call.yaml
@@ -1,0 +1,16 @@
+when:
+  path: /v1/chat/completions
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"max_tokens":128,"messages":[{"content":"You are concise. Include a few details so streaming is visible.","role":"system"},{"content":"/no_think Call the report_usage tool with reason set to cost_tracking.","role":"user"}],"model":"Qwen/Qwen3-4B","temperature":0.2,"tool_choice":{"function":{"name":"report_usage"},"type":"function"},"tools":[{"function":{"description":"Report why token usage is needed.","name":"report_usage","parameters":{"properties":{"reason":{"type":"string"}},"required":["reason"],"type":"object"}},"type":"function"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"choices":[{"finish_reason":"tool_calls","index":0,"logprobs":null,"message":{"content":"\n\n<tool_call>\n{\"name\": \"report_usage\", \"arguments\": {\"reason\": \"cost_tracking\"}}\n</tool_call>","reasoning_content":"\n\n","role":"assistant","tool_calls":[{"function":{"arguments":"{\"reason\":\"cost_tracking\"}","name":"report_usage"},"id":"call_REDACTED_1","index":0,"type":"function"}]}}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion","system_fingerprint":"local","usage":{"avg_compl_tok_per_sec":16.759777,"avg_prompt_tok_per_sec":29.803186,"avg_tok_per_sec":27.015059,"completion_tokens":24,"prompt_tokens":159,"total_completion_time_sec":1.432,"total_prompt_time_sec":5.335,"total_time_sec":6.774,"total_tokens":183}}'

--- a/tests/cassettes/mistralrs/usage/chat_completion_usage_without_output_tokens_details_deserializes.yaml
+++ b/tests/cassettes/mistralrs/usage/chat_completion_usage_without_output_tokens_details_deserializes.yaml
@@ -1,0 +1,16 @@
+when:
+  path: /v1/chat/completions
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"max_tokens":64,"messages":[{"content":[{"text":"You are concise. Include a few details so streaming is visible.","type":"text"}],"role":"system"},{"content":"/no_think Explain usage accounting in one sentence.","role":"user"}],"model":"Qwen/Qwen3-4B"}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"choices":[{"finish_reason":"stop","index":0,"logprobs":null,"message":{"content":"\n\nUsage accounting is a method of tracking and billing based on actual resource consumption by users or services.","reasoning_content":"\n\n","role":"assistant","tool_calls":null}}],"created":0,"id":"chatcmpl-REDACTED_1","model":"Qwen/Qwen3-4B","object":"chat.completion","system_fingerprint":"local","usage":{"avg_compl_tok_per_sec":17.130621,"avg_prompt_tok_per_sec":26.745914,"avg_tok_per_sec":21.826118,"completion_tokens":24,"prompt_tokens":36,"total_completion_time_sec":1.401,"total_prompt_time_sec":1.346,"total_time_sec":2.749,"total_tokens":60}}'

--- a/tests/common/cassette_safety.rs
+++ b/tests/common/cassette_safety.rs
@@ -65,6 +65,15 @@ const PROVIDER_CASSETTE_SUITES: &[ProviderCassetteSuite] = &[
         source_dir: "tests/providers/deepseek",
         wrapper_names: &["with_deepseek_cassette", "with_deepseek_cassette_result"],
     },
+    ProviderCassetteSuite {
+        provider: "mistralrs",
+        source_dir: "tests/providers/mistralrs/cassette",
+        wrapper_names: &[
+            "with_mistralrs_cassette",
+            "with_mistralrs_completions_cassette",
+            "with_mistralrs_raw_cassette",
+        ],
+    },
 ];
 
 #[test]

--- a/tests/mistralrs.rs
+++ b/tests/mistralrs.rs
@@ -1,0 +1,17 @@
+#![allow(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::unwrap_used,
+    clippy::unreachable
+)]
+
+#[path = "common/cassette_safety.rs"]
+mod cassette_safety;
+#[path = "common/cassettes.rs"]
+mod cassettes;
+#[path = "common/support.rs"]
+mod support;
+
+#[path = "providers/mistralrs/mod.rs"]
+mod mistralrs;

--- a/tests/providers/mistralrs/cassette/chat_completions.rs
+++ b/tests/providers/mistralrs/cassette/chat_completions.rs
@@ -1,0 +1,82 @@
+//! Cassette coverage for mistral.rs `/v1/chat/completions` responses.
+
+use rig::client::CompletionClient;
+use rig::completion::{CompletionModel, Prompt};
+use serde_json::Value;
+
+use super::super::support::{SYSTEM_PROMPT, model_name, with_mistralrs_completions_cassette};
+
+#[tokio::test]
+async fn raw_chat_completion_surfaces_reasoning_or_text() {
+    with_mistralrs_completions_cassette(
+        "chat_completions/raw_chat_completion_surfaces_reasoning_or_text",
+        |client| async move {
+            let response = client
+                .completion_model(model_name())
+                .completion_request(
+                    "Think briefly, then answer in one sentence why token usage should be reported.",
+                )
+                .preamble(SYSTEM_PROMPT.to_string())
+                .max_tokens(256)
+                .send()
+                .await
+                .expect("raw chat completion should succeed");
+            let raw = serde_json::to_value(&response.raw_response)
+                .expect("raw chat completion response should serialize");
+            let message = &raw["choices"][0]["message"];
+            let text = message
+                .get("content")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            let reasoning = message
+                .get("reasoning_content")
+                .and_then(Value::as_str)
+                .or_else(|| message.get("reasoning").and_then(Value::as_str))
+                .unwrap_or_default();
+
+            assert!(
+                !text.is_empty() || !reasoning.is_empty(),
+                "mistral.rs chat response should contain content or reasoning"
+            );
+            let usage = raw
+                .get("usage")
+                .expect("mistral.rs chat response should include usage");
+            assert!(
+                usage.get("prompt_tokens").and_then(Value::as_u64).is_some(),
+                "usage should include prompt_tokens: {usage:?}"
+            );
+            assert!(
+                usage.get("total_tokens").and_then(Value::as_u64).is_some(),
+                "usage should include total_tokens: {usage:?}"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn chat_completions_agent_prompt_completes() {
+    with_mistralrs_completions_cassette(
+        "chat_completions/chat_completions_agent_prompt_completes",
+        |client| async move {
+            let agent = client
+                .agent(model_name())
+                .preamble(SYSTEM_PROMPT)
+                .max_tokens(128)
+                .build();
+
+            let response = agent
+                .prompt(
+                    "/no_think Explain why a local OpenAI-compatible server should return token usage.",
+                )
+                .await
+                .expect("Rig OpenAI Chat Completions API prompt should succeed");
+
+            assert!(
+                !response.trim().is_empty(),
+                "no_think chat-completions prompt should return visible text"
+            );
+        },
+    )
+    .await;
+}

--- a/tests/providers/mistralrs/cassette/responses_api.rs
+++ b/tests/providers/mistralrs/cassette/responses_api.rs
@@ -1,0 +1,90 @@
+//! Cassette coverage for mistral.rs through Rig's OpenAI Responses API client.
+
+use rig::client::CompletionClient;
+use rig::completion::{Chat, Prompt};
+
+use crate::support::{assert_contains_all_case_insensitive, assert_nonempty_response};
+
+use super::super::support::{SYSTEM_PROMPT, model_name, with_mistralrs_cassette};
+
+#[tokio::test]
+async fn responses_api_no_think_returns_text() {
+    with_mistralrs_cassette(
+        "responses_api/responses_api_no_think_returns_text",
+        |client| async move {
+            let agent = client
+                .agent(model_name())
+                .preamble(SYSTEM_PROMPT)
+                .max_tokens(128)
+                .build();
+
+            let response = agent
+                .prompt("/no_think Explain token usage reporting in one sentence.")
+                .await
+                .expect("Responses API /no_think prompt should succeed");
+
+            assert_nonempty_response(&response);
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn responses_api_reasoning_plus_answer_completes() {
+    with_mistralrs_cassette(
+        "responses_api/responses_api_reasoning_plus_answer_completes",
+        |client| async move {
+            let agent = client
+                .agent(model_name())
+                .preamble(SYSTEM_PROMPT)
+                .max_tokens(512)
+                .build();
+
+            let response = agent
+                .prompt(
+                    "Think briefly, then answer in one sentence why local OpenAI-compatible servers should report token usage.",
+                )
+                .await
+                .expect("Responses API reasoning plus answer prompt should succeed");
+
+            assert_nonempty_response(&response);
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn responses_api_multi_turn_replays_history() {
+    with_mistralrs_cassette(
+        "responses_api/responses_api_multi_turn_replays_history",
+        |client| async move {
+            let agent = client
+                .agent(model_name())
+                .preamble(SYSTEM_PROMPT)
+                .max_tokens(256)
+                .build();
+            let mut history = Vec::new();
+
+            let _first = agent
+                .chat(
+                    "Think briefly, then answer in one sentence why usage accounting matters.",
+                    &mut history,
+                )
+                .await
+                .expect("first multi-turn Responses API chat should succeed");
+            let first_history_len = history.len();
+            let second = agent
+                .chat("/no_think Reply with exactly: OK", &mut history)
+                .await
+                .expect("second multi-turn Responses API chat should succeed");
+
+            assert!(
+                first_history_len > 0 && history.len() > first_history_len,
+                "multi-turn history should be updated; first_len={first_history_len}, final_len={}",
+                history.len()
+            );
+            assert_contains_all_case_insensitive(&second, &["OK"]);
+        },
+    )
+    .await;
+}

--- a/tests/providers/mistralrs/cassette/streaming.rs
+++ b/tests/providers/mistralrs/cassette/streaming.rs
@@ -1,0 +1,50 @@
+//! Cassette coverage for mistral.rs chat-completions streaming reasoning chunks.
+
+use rig::client::CompletionClient;
+use rig::streaming::StreamingPrompt;
+
+use crate::support::collect_stream_observation;
+
+use super::super::support::{SYSTEM_PROMPT, model_name, with_mistralrs_completions_cassette};
+
+#[tokio::test]
+async fn chat_completions_stream_emits_reasoning_and_text_incrementally() {
+    with_mistralrs_completions_cassette(
+        "streaming/chat_completions_stream_emits_reasoning_and_text_incrementally",
+        |client| async move {
+            let agent = client
+                .agent(model_name())
+                .preamble(SYSTEM_PROMPT)
+                .max_tokens(512)
+                .build();
+            let mut stream = agent
+                .stream_prompt(
+                    "Think briefly, then answer with three short bullet points about token usage reporting.",
+                )
+                .await;
+            let observation = collect_stream_observation(&mut stream).await;
+
+            assert!(
+                observation.errors.is_empty(),
+                "stream should not emit errors: {:?}",
+                observation.errors
+            );
+            assert!(
+                observation.events.contains(&"reasoning_delta"),
+                "stream should emit reasoning deltas; events={:?}",
+                observation.events
+            );
+            assert!(
+                observation.events.contains(&"text"),
+                "stream should emit text chunks; events={:?}",
+                observation.events
+            );
+            assert!(
+                observation.got_final_response,
+                "stream should emit final response; events={:?}",
+                observation.events
+            );
+        },
+    )
+    .await;
+}

--- a/tests/providers/mistralrs/cassette/tools.rs
+++ b/tests/providers/mistralrs/cassette/tools.rs
@@ -1,0 +1,80 @@
+//! Cassette coverage for mistral.rs OpenAI-compatible tool call responses.
+
+use serde_json::Value;
+
+use super::super::support::{
+    DEFAULT_API_KEY, SYSTEM_PROMPT, model_name, with_mistralrs_raw_cassette,
+};
+
+#[tokio::test]
+async fn raw_chat_completion_emits_requested_tool_call() {
+    with_mistralrs_raw_cassette(
+        "tools/raw_chat_completion_emits_requested_tool_call",
+        |base_url| async move {
+            let raw = reqwest::Client::new()
+                .post(format!("{}/chat/completions", base_url.trim_end_matches('/')))
+                .bearer_auth(
+                    std::env::var("MISTRALRS_API_KEY")
+                        .unwrap_or_else(|_| DEFAULT_API_KEY.to_string()),
+                )
+                .json(&serde_json::json!({
+                    "model": model_name(),
+                    "messages": [
+                        { "role": "system", "content": SYSTEM_PROMPT },
+                        {
+                            "role": "user",
+                            "content": "/no_think Call the report_usage tool with reason set to cost_tracking."
+                        }
+                    ],
+                    "max_tokens": 128,
+                    "temperature": 0.2,
+                    "tools": [{
+                        "type": "function",
+                        "function": {
+                            "name": "report_usage",
+                            "description": "Report why token usage is needed.",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {
+                                    "reason": { "type": "string" }
+                                },
+                                "required": ["reason"]
+                            }
+                        }
+                    }],
+                    "tool_choice": {
+                        "type": "function",
+                        "function": { "name": "report_usage" }
+                    }
+                }))
+                .send()
+                .await
+                .expect("raw tool call request should be sent")
+                .error_for_status()
+                .expect("raw tool call response should be successful")
+                .json::<Value>()
+                .await
+                .expect("raw tool call response should deserialize");
+            let tool_calls = raw["choices"][0]["message"]["tool_calls"]
+                .as_array()
+                .expect("mistral.rs response should include tool_calls");
+
+            assert!(
+                !tool_calls.is_empty(),
+                "mistral.rs tool call response should include at least one tool call: {raw:?}"
+            );
+            assert_eq!(
+                tool_calls[0]["function"]["name"].as_str(),
+                Some("report_usage")
+            );
+            assert!(
+                raw.get("usage")
+                    .and_then(|usage| usage.get("total_tokens"))
+                    .and_then(Value::as_u64)
+                    .is_some(),
+                "tool call response should include usage: {raw:?}"
+            );
+        },
+    )
+    .await;
+}

--- a/tests/providers/mistralrs/cassette/usage.rs
+++ b/tests/providers/mistralrs/cassette/usage.rs
@@ -1,0 +1,41 @@
+//! Cassette coverage for mistral.rs usage without OpenAI `output_tokens_details`.
+
+use rig::client::CompletionClient;
+use rig::completion::CompletionModel;
+use serde_json::Value;
+
+use super::super::support::{SYSTEM_PROMPT, model_name, with_mistralrs_completions_cassette};
+
+#[tokio::test]
+async fn chat_completion_usage_without_output_tokens_details_deserializes() {
+    with_mistralrs_completions_cassette(
+        "usage/chat_completion_usage_without_output_tokens_details_deserializes",
+        |client| async move {
+            let response = client
+                .completion_model(model_name())
+                .completion_request("/no_think Explain usage accounting in one sentence.")
+                .preamble(SYSTEM_PROMPT.to_string())
+                .max_tokens(64)
+                .send()
+                .await
+                .expect("usage check completion should succeed");
+            let raw = serde_json::to_value(&response.raw_response)
+                .expect("raw chat completion response should serialize");
+            let usage = raw
+                .get("usage")
+                .expect("mistral.rs response should include usage");
+
+            for field in ["prompt_tokens", "total_tokens"] {
+                assert!(
+                    usage.get(field).and_then(Value::as_u64).is_some(),
+                    "usage should include numeric {field}: {usage:?}"
+                );
+            }
+            assert!(
+                usage.get("output_tokens_details").is_none(),
+                "mistral.rs compatibility fixture should omit output_tokens_details: {usage:?}"
+            );
+        },
+    )
+    .await;
+}

--- a/tests/providers/mistralrs/mod.rs
+++ b/tests/providers/mistralrs/mod.rs
@@ -1,0 +1,9 @@
+mod support;
+
+mod cassette {
+    mod chat_completions;
+    mod responses_api;
+    mod streaming;
+    mod tools;
+    mod usage;
+}

--- a/tests/providers/mistralrs/support.rs
+++ b/tests/providers/mistralrs/support.rs
@@ -1,0 +1,73 @@
+use std::future::Future;
+use std::panic::AssertUnwindSafe;
+
+use futures::FutureExt;
+use rig::providers::openai;
+
+use crate::cassettes::{CassetteSpec, ProviderCassette};
+
+pub(super) const DEFAULT_BASE_URL: &str = "http://127.0.0.1:1234/v1";
+pub(super) const DEFAULT_API_KEY: &str = "local";
+pub(super) const DEFAULT_MODEL: &str = "Qwen/Qwen3-4B";
+pub(super) const SYSTEM_PROMPT: &str =
+    "You are concise. Include a few details so streaming is visible.";
+
+pub(super) fn model_name() -> String {
+    std::env::var("MISTRALRS_MODEL").unwrap_or_else(|_| DEFAULT_MODEL.to_string())
+}
+
+async fn mistralrs_cassette(spec: impl Into<CassetteSpec>) -> (ProviderCassette, openai::Client) {
+    let real_base_url =
+        std::env::var("MISTRALRS_BASE_URL").unwrap_or_else(|_| DEFAULT_BASE_URL.to_string());
+    let api_key =
+        std::env::var("MISTRALRS_API_KEY").unwrap_or_else(|_| DEFAULT_API_KEY.to_string());
+    let cassette = ProviderCassette::start("mistralrs", spec, &real_base_url).await;
+    let client = openai::Client::builder()
+        .api_key(api_key)
+        .base_url(cassette.base_url())
+        .build()
+        .expect("mistral.rs OpenAI-compatible client should build");
+
+    (cassette, client)
+}
+
+async fn mistralrs_raw_cassette(spec: impl Into<CassetteSpec>) -> (ProviderCassette, String) {
+    let real_base_url =
+        std::env::var("MISTRALRS_BASE_URL").unwrap_or_else(|_| DEFAULT_BASE_URL.to_string());
+    let cassette = ProviderCassette::start("mistralrs", spec, &real_base_url).await;
+    let base_url = cassette.base_url();
+    (cassette, base_url)
+}
+
+pub(super) async fn with_mistralrs_cassette<F, Fut>(spec: impl Into<CassetteSpec>, test_body: F)
+where
+    F: FnOnce(openai::Client) -> Fut,
+    Fut: Future<Output = ()>,
+{
+    let (cassette, client) = mistralrs_cassette(spec).await;
+    let result = AssertUnwindSafe(test_body(client)).catch_unwind().await;
+    cassette.finish_after_test(result).await;
+}
+
+pub(super) async fn with_mistralrs_completions_cassette<F, Fut>(
+    spec: impl Into<CassetteSpec>,
+    test_body: F,
+) where
+    F: FnOnce(openai::CompletionsClient) -> Fut,
+    Fut: Future<Output = ()>,
+{
+    with_mistralrs_cassette(spec, |client| async move {
+        test_body(client.completions_api()).await;
+    })
+    .await;
+}
+
+pub(super) async fn with_mistralrs_raw_cassette<F, Fut>(spec: impl Into<CassetteSpec>, test_body: F)
+where
+    F: FnOnce(String) -> Fut,
+    Fut: Future<Output = ()>,
+{
+    let (cassette, base_url) = mistralrs_raw_cassette(spec).await;
+    let result = AssertUnwindSafe(test_body(base_url)).catch_unwind().await;
+    cassette.finish_after_test(result).await;
+}

--- a/tests/providers/openai/cassette/responses_input_item.rs
+++ b/tests/providers/openai/cassette/responses_input_item.rs
@@ -25,18 +25,16 @@ fn test_input_item_serialization_avoids_duplicate_role() {
 }
 
 #[test]
-fn assistant_reasoning_without_id_returns_error() {
+fn assistant_reasoning_without_id_is_omitted() {
     let message = CompletionMessage::Assistant {
         id: Some("assistant_message_id".to_string()),
         content: OneOrMany::one(AssistantContent::Reasoning(Reasoning::new("thought"))),
     };
 
-    let items: Result<Vec<InputItem>, CompletionError> = message.try_into();
-    assert!(matches!(
-        items,
-        Err(CompletionError::ProviderError(message))
-            if message.contains("OpenAI-generated ID is required")
-    ));
+    let items: Vec<InputItem> = message
+        .try_into()
+        .expect("idless reasoning should be omitted without an error");
+    assert!(items.is_empty());
 }
 
 #[test]
@@ -268,7 +266,7 @@ fn assistant_reasoning_redacted_only_serializes_as_encrypted_content() {
 }
 
 #[test]
-fn openai_responses_request_reasoning_without_id_returns_error_without_panicking() {
+fn openai_responses_request_reasoning_without_id_is_omitted_without_panicking() {
     let panic_result = catch_unwind(AssertUnwindSafe(|| {
         let request = rig::completion::CompletionRequest {
             preamble: None,
@@ -291,8 +289,10 @@ fn openai_responses_request_reasoning_without_id_returns_error_without_panicking
     let conversion = panic_result.expect("request conversion should not panic");
     assert!(matches!(
         conversion,
-        Err(CompletionError::ProviderError(message))
-            if message.contains("OpenAI-generated ID is required")
+        Err(CompletionError::RequestError(error))
+            if error
+                .to_string()
+                .contains("OpenAI Responses request input must contain at least one item")
     ));
 }
 


### PR DESCRIPTION
## What changed

- Accept OpenAI-compatible Responses API payloads where top-level `reasoning` is a string and preserve it as ID-less Rig reasoning content.
- Allow reasoning-only Responses payloads such as `{ "reasoning": "thinking only", "output": [] }` to convert successfully.
- Keep empty Responses payloads with no output and no provider reasoning rejected with a clear empty-response error.
- Ignore object/config-shaped top-level `reasoning` as assistant text reasoning.
- Skip ID-less reasoning when converting OpenAI Responses assistant history back into OpenAI request items, while preserving replay of structured OpenAI reasoning that has an ID.
- Avoid duplicating top-level string reasoning when structured `Output::Reasoning` is already present.
- Add mocked OpenAI chat-completions streaming coverage for `delta.reasoning_content` and normal `delta.content` chunks, verifying both are emitted incrementally through Rig streaming.
- Keep final Responses API usage handling tolerant of missing `output_tokens_details`.

## Why

Local `mistral.rs` servers expose an OpenAI-compatible API, but Qwen3 thinking content can arrive in provider-compatible shapes that differ from OpenAI's structured Responses reasoning object. ID-less provider-compatible reasoning is valid to surface in Rig, but it is not replayable as an OpenAI Responses reasoning input because OpenAI requires its generated reasoning item ID. This change preserves the content where possible without making OpenAI history replay fail.

This PR intentionally does not change Rig's native Mistral AI provider.

## Validation

- `cargo fmt`
- `cargo test -p rig-core providers::openai::responses_api::tests`
- `cargo test -p rig-core providers::openai::responses_api::streaming::tests`
- `cargo test -p rig-core providers::openai::completion::streaming::tests`
- `cargo test -p rig --test openai openai::cassette::chat_history::chat_appends_reasoning_tool_turns_to_caller_history`
- `cargo clippy -p rig-core --all-targets`

## Local repro

Temporarily pointed `rig-mistralrs-1569-repro` at this PR worktree and ran:

- `MISTRALRS_REPRO_COMMAND=rig-openai-responses ./scripts/start-mistralrs.sh --run-repro`
  - Result: `rig openai responses api ok`
- `MISTRALRS_REPRO_COMMAND=rig-openai-stream ./scripts/start-mistralrs.sh --run-repro`
  - Result: `rig openai stream ok: reasoning_chunks=250, text_chunks=4, first_reasoning_at=2.054s, first_text_at=19.300s`
  
  closes #1569 