### PR TITLE
fix: correct possessive pronoun typo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Additionally, please ensure that if you are submitting a bug ticket (ie, somethi
 
 ## Pull Requests
 
-Contributions are always encouraged and welcome. Before creating a pull request, create a new issue that tracks that pull request describing the problem in more detail. Pull request descriptions should include information about it's implementation, especially if it makes changes to existing abstractions.
+Contributions are always encouraged and welcome. Before creating a pull request, create a new issue that tracks that pull request describing the problem in more detail. Pull request descriptions should include information about its implementation, especially if it makes changes to existing abstractions.
 
 PRs should be small and focused and should avoid interacting with multiple facets of the library. This may result in a larger PR being split into two or more smaller PRs. Commit messages should follow the [Conventional Commit](https://conventionalcommits.org/en/v1.0.0) format (prefixing with `feat`, `fix`, etc.) as this integrates into our auto-releases via a [release-plz](https://github.com/MarcoIeni/release-plz) Github action.
 


### PR DESCRIPTION
### What
Change `it's` to `its` in the Pull Requests section of `CONTRIBUTING.md`.

### Why
`it's` is a contraction for "it is", but the sentence requires the possessive `its`. This is a grammatical typo.

Small, scoped fix from kcolbchain contrib-bot.