### PR TITLE
feat(rig-core): add ToolCallContext for per-call runtime context in tool dispatch

### DIFF
--- a/crates/rig-core/src/lib.rs
+++ b/crates/rig-core/src/lib.rs
@@ -175,6 +175,7 @@ pub mod streaming;
 #[cfg_attr(docsrs, doc(cfg(feature = "test-utils")))]
 pub mod test_utils;
 pub mod tool;
+pub use tool::ToolCallContext;
 pub mod tools;
 pub mod transcription;
 pub mod vector_store;

--- a/crates/rig-core/src/tool/context.rs
+++ b/crates/rig-core/src/tool/context.rs
@@ -1,0 +1,190 @@
+//! Per-call runtime context for tool execution.
+//!
+//! This module provides [`ToolCallContext`], a type-map that allows callers
+//! to attach arbitrary typed values and tools to extract them at call time.
+//! Tools that don't need context simply ignore it.
+
+use std::any::{Any, TypeId};
+use std::collections::HashMap;
+
+// --- CloneableAny helper trait (WASM-gated) ---
+
+#[cfg(not(target_family = "wasm"))]
+trait CloneableAny: Any + Send + Sync {
+    fn clone_box(&self) -> Box<dyn CloneableAny + Send + Sync>;
+    fn as_any(&self) -> &dyn Any;
+}
+
+#[cfg(target_family = "wasm")]
+trait CloneableAny: Any {
+    fn clone_box(&self) -> Box<dyn CloneableAny>;
+    fn as_any(&self) -> &dyn Any;
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl<T: Clone + Send + Sync + 'static> CloneableAny for T {
+    fn clone_box(&self) -> Box<dyn CloneableAny + Send + Sync> {
+        Box::new(self.clone())
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[cfg(target_family = "wasm")]
+impl<T: Clone + 'static> CloneableAny for T {
+    fn clone_box(&self) -> Box<dyn CloneableAny> {
+        Box::new(self.clone())
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl Clone for Box<dyn CloneableAny + Send + Sync> {
+    fn clone(&self) -> Self {
+        // Explicit deref to dispatch via the trait object's vtable, not the
+        // blanket CloneableAny impl on Box itself (which would recurse).
+        (**self).clone_box()
+    }
+}
+
+#[cfg(target_family = "wasm")]
+impl Clone for Box<dyn CloneableAny> {
+    fn clone(&self) -> Self {
+        (**self).clone_box()
+    }
+}
+
+// --- ToolCallContext ---
+
+/// Per-call runtime context for tools.
+///
+/// A type-map that allows callers to attach arbitrary typed values
+/// and tools to extract them. Tools that don't need context ignore it.
+///
+/// # Example
+/// ```
+/// use rig::tool::ToolCallContext;
+///
+/// let mut ctx = ToolCallContext::new();
+/// ctx.insert(42u32);
+/// assert_eq!(ctx.get::<u32>(), Some(&42));
+/// ```
+#[derive(Default, Clone)]
+pub struct ToolCallContext {
+    #[cfg(not(target_family = "wasm"))]
+    map: HashMap<TypeId, Box<dyn CloneableAny + Send + Sync>>,
+    #[cfg(target_family = "wasm")]
+    map: HashMap<TypeId, Box<dyn CloneableAny>>,
+}
+
+impl ToolCallContext {
+    /// Create an empty context.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a typed value. Overwrites any previous value of the same type.
+    #[cfg(not(target_family = "wasm"))]
+    pub fn insert<T: Clone + Send + Sync + 'static>(&mut self, val: T) {
+        self.map.insert(TypeId::of::<T>(), Box::new(val));
+    }
+
+    /// Insert a typed value. Overwrites any previous value of the same type.
+    #[cfg(target_family = "wasm")]
+    pub fn insert<T: Clone + 'static>(&mut self, val: T) {
+        self.map.insert(TypeId::of::<T>(), Box::new(val));
+    }
+
+    /// Get a reference to a value by type. Returns `None` if not present.
+    pub fn get<T: 'static>(&self) -> Option<&T> {
+        self.map
+            .get(&TypeId::of::<T>())
+            // Explicit deref to dispatch via the trait object's vtable, not
+            // the blanket CloneableAny impl that Box itself satisfies.
+            .and_then(|boxed| (**boxed).as_any().downcast_ref::<T>())
+    }
+
+    /// Check if a value of the given type is present.
+    pub fn contains<T: 'static>(&self) -> bool {
+        self.map.contains_key(&TypeId::of::<T>())
+    }
+}
+
+impl std::fmt::Debug for ToolCallContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ToolCallContext")
+            .field("entries", &self.map.len())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insert_and_get_returns_value() {
+        let mut ctx = ToolCallContext::new();
+        ctx.insert(42u32);
+        assert_eq!(ctx.get::<u32>(), Some(&42));
+    }
+
+    #[test]
+    fn get_missing_type_returns_none() {
+        let ctx = ToolCallContext::new();
+        assert_eq!(ctx.get::<u32>(), None);
+    }
+
+    #[test]
+    fn insert_overwrites_same_type() {
+        let mut ctx = ToolCallContext::new();
+        ctx.insert(1u32);
+        ctx.insert(2u32);
+        assert_eq!(ctx.get::<u32>(), Some(&2));
+    }
+
+    #[test]
+    fn different_types_are_independent() {
+        let mut ctx = ToolCallContext::new();
+        ctx.insert(42u32);
+        ctx.insert("hello".to_string());
+        assert_eq!(ctx.get::<u32>(), Some(&42));
+        assert_eq!(ctx.get::<String>(), Some(&"hello".to_string()));
+    }
+
+    #[test]
+    fn contains_returns_true_when_present() {
+        let mut ctx = ToolCallContext::new();
+        ctx.insert(42u32);
+        assert!(ctx.contains::<u32>());
+        assert!(!ctx.contains::<String>());
+    }
+
+    #[test]
+    fn clone_produces_independent_copy() {
+        let mut ctx = ToolCallContext::new();
+        ctx.insert(42u32);
+        let mut cloned = ctx.clone();
+        cloned.insert(99u32);
+        assert_eq!(ctx.get::<u32>(), Some(&42));
+        assert_eq!(cloned.get::<u32>(), Some(&99));
+    }
+
+    #[test]
+    fn debug_shows_entry_count() {
+        let mut ctx = ToolCallContext::new();
+        ctx.insert(42u32);
+        ctx.insert("hi".to_string());
+        let debug = format!("{:?}", ctx);
+        assert!(debug.contains("entries: 2"));
+    }
+
+    #[test]
+    fn empty_context_is_default() {
+        let ctx = ToolCallContext::default();
+        assert!(!ctx.contains::<u32>());
+    }
+}

--- a/crates/rig-core/src/tool/context.rs
+++ b/crates/rig-core/src/tool/context.rs
@@ -3,55 +3,88 @@
 //! This module provides [`ToolCallContext`], a type-map that allows callers
 //! to attach arbitrary typed values and tools to extract them at call time.
 //! Tools that don't need context simply ignore it.
+//!
+//! The implementation follows the `AnyClone` pattern from the [`http::Extensions`]
+//! type in the `http` crate.
 
-use std::any::{Any, TypeId};
+use std::any::{Any, TypeId, type_name};
 use std::collections::HashMap;
 
-// --- CloneableAny helper trait (WASM-gated) ---
+#[cfg(not(target_family = "wasm"))]
+type AnyMap = HashMap<TypeId, Box<dyn AnyClone + Send + Sync>>;
+
+#[cfg(target_family = "wasm")]
+type AnyMap = HashMap<TypeId, Box<dyn AnyClone>>;
+
+// --- AnyClone helper trait (modeled after http::Extensions) ---
 
 #[cfg(not(target_family = "wasm"))]
-trait CloneableAny: Any + Send + Sync {
-    fn clone_box(&self) -> Box<dyn CloneableAny + Send + Sync>;
+trait AnyClone: Any + Send + Sync {
+    fn clone_box(&self) -> Box<dyn AnyClone + Send + Sync>;
     fn as_any(&self) -> &dyn Any;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+    fn into_any(self: Box<Self>) -> Box<dyn Any>;
+    fn type_name(&self) -> &'static str;
 }
 
 #[cfg(target_family = "wasm")]
-trait CloneableAny: Any {
-    fn clone_box(&self) -> Box<dyn CloneableAny>;
+trait AnyClone: Any {
+    fn clone_box(&self) -> Box<dyn AnyClone>;
     fn as_any(&self) -> &dyn Any;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+    fn into_any(self: Box<Self>) -> Box<dyn Any>;
+    fn type_name(&self) -> &'static str;
 }
 
 #[cfg(not(target_family = "wasm"))]
-impl<T: Clone + Send + Sync + 'static> CloneableAny for T {
-    fn clone_box(&self) -> Box<dyn CloneableAny + Send + Sync> {
+impl<T: Clone + Send + Sync + 'static> AnyClone for T {
+    fn clone_box(&self) -> Box<dyn AnyClone + Send + Sync> {
         Box::new(self.clone())
     }
     fn as_any(&self) -> &dyn Any {
         self
     }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+        self
+    }
+    fn type_name(&self) -> &'static str {
+        type_name::<T>()
+    }
 }
 
 #[cfg(target_family = "wasm")]
-impl<T: Clone + 'static> CloneableAny for T {
-    fn clone_box(&self) -> Box<dyn CloneableAny> {
+impl<T: Clone + 'static> AnyClone for T {
+    fn clone_box(&self) -> Box<dyn AnyClone> {
         Box::new(self.clone())
     }
     fn as_any(&self) -> &dyn Any {
         self
     }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+        self
+    }
+    fn type_name(&self) -> &'static str {
+        type_name::<T>()
+    }
 }
 
 #[cfg(not(target_family = "wasm"))]
-impl Clone for Box<dyn CloneableAny + Send + Sync> {
+impl Clone for Box<dyn AnyClone + Send + Sync> {
     fn clone(&self) -> Self {
         // Explicit deref to dispatch via the trait object's vtable, not the
-        // blanket CloneableAny impl on Box itself (which would recurse).
+        // blanket AnyClone impl on Box itself (which would recurse).
         (**self).clone_box()
     }
 }
 
 #[cfg(target_family = "wasm")]
-impl Clone for Box<dyn CloneableAny> {
+impl Clone for Box<dyn AnyClone> {
     fn clone(&self) -> Self {
         (**self).clone_box()
     }
@@ -64,6 +97,10 @@ impl Clone for Box<dyn CloneableAny> {
 /// A type-map that allows callers to attach arbitrary typed values
 /// and tools to extract them. Tools that don't need context ignore it.
 ///
+/// Inspired by [`http::Extensions`](https://docs.rs/http/latest/http/struct.Extensions.html).
+/// Uses `Option<Box<HashMap>>` internally so that empty contexts (the common
+/// case when no caller-provided values are needed) require zero allocation.
+///
 /// # Example
 /// ```
 /// use rig::tool::ToolCallContext;
@@ -74,10 +111,7 @@ impl Clone for Box<dyn CloneableAny> {
 /// ```
 #[derive(Default, Clone)]
 pub struct ToolCallContext {
-    #[cfg(not(target_family = "wasm"))]
-    map: HashMap<TypeId, Box<dyn CloneableAny + Send + Sync>>,
-    #[cfg(target_family = "wasm")]
-    map: HashMap<TypeId, Box<dyn CloneableAny>>,
+    map: Option<Box<AnyMap>>,
 }
 
 impl ToolCallContext {
@@ -89,35 +123,65 @@ impl ToolCallContext {
     /// Insert a typed value. Overwrites any previous value of the same type.
     #[cfg(not(target_family = "wasm"))]
     pub fn insert<T: Clone + Send + Sync + 'static>(&mut self, val: T) {
-        self.map.insert(TypeId::of::<T>(), Box::new(val));
+        self.map
+            .get_or_insert_with(Default::default)
+            .insert(TypeId::of::<T>(), Box::new(val));
     }
 
     /// Insert a typed value. Overwrites any previous value of the same type.
     #[cfg(target_family = "wasm")]
     pub fn insert<T: Clone + 'static>(&mut self, val: T) {
-        self.map.insert(TypeId::of::<T>(), Box::new(val));
+        self.map
+            .get_or_insert_with(Default::default)
+            .insert(TypeId::of::<T>(), Box::new(val));
     }
 
     /// Get a reference to a value by type. Returns `None` if not present.
     pub fn get<T: 'static>(&self) -> Option<&T> {
         self.map
-            .get(&TypeId::of::<T>())
+            .as_ref()
+            .and_then(|map| map.get(&TypeId::of::<T>()))
             // Explicit deref to dispatch via the trait object's vtable, not
-            // the blanket CloneableAny impl that Box itself satisfies.
+            // the blanket AnyClone impl that Box itself satisfies.
             .and_then(|boxed| (**boxed).as_any().downcast_ref::<T>())
+    }
+
+    /// Get a mutable reference to a value by type. Returns `None` if not present.
+    pub fn get_mut<T: 'static>(&mut self) -> Option<&mut T> {
+        self.map
+            .as_mut()
+            .and_then(|map| map.get_mut(&TypeId::of::<T>()))
+            .and_then(|boxed| (**boxed).as_any_mut().downcast_mut::<T>())
+    }
+
+    /// Remove a value by type, returning it if present.
+    pub fn remove<T: 'static>(&mut self) -> Option<T> {
+        self.map
+            .as_mut()
+            .and_then(|map| map.remove(&TypeId::of::<T>()))
+            .and_then(|boxed| boxed.into_any().downcast::<T>().ok())
+            .map(|boxed| *boxed)
     }
 
     /// Check if a value of the given type is present.
     pub fn contains<T: 'static>(&self) -> bool {
-        self.map.contains_key(&TypeId::of::<T>())
+        self.map
+            .as_ref()
+            .is_some_and(|map| map.contains_key(&TypeId::of::<T>()))
     }
 }
 
 impl std::fmt::Debug for ToolCallContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ToolCallContext")
-            .field("entries", &self.map.len())
-            .finish()
+        let mut dbg = f.debug_struct("ToolCallContext");
+        if let Some(map) = &self.map {
+            dbg.field("entries", &map.len());
+            let type_names: Vec<&'static str> = map.values().map(|v| (**v).type_name()).collect();
+            dbg.field("types", &type_names);
+        } else {
+            dbg.field("entries", &0);
+        }
+        dbg.finish()
     }
 }
 
@@ -174,17 +238,49 @@ mod tests {
     }
 
     #[test]
-    fn debug_shows_entry_count() {
+    fn debug_shows_entry_count_and_types() {
         let mut ctx = ToolCallContext::new();
         ctx.insert(42u32);
         ctx.insert("hi".to_string());
         let debug = format!("{:?}", ctx);
         assert!(debug.contains("entries: 2"));
+        assert!(debug.contains("u32"));
+        assert!(debug.contains("String"));
     }
 
     #[test]
     fn empty_context_is_default() {
         let ctx = ToolCallContext::default();
         assert!(!ctx.contains::<u32>());
+    }
+
+    #[test]
+    fn empty_context_has_no_allocation() {
+        let ctx = ToolCallContext::new();
+        assert!(ctx.map.is_none());
+    }
+
+    #[test]
+    fn get_mut_modifies_in_place() {
+        let mut ctx = ToolCallContext::new();
+        ctx.insert(42u32);
+        if let Some(val) = ctx.get_mut::<u32>() {
+            *val = 99;
+        }
+        assert_eq!(ctx.get::<u32>(), Some(&99));
+    }
+
+    #[test]
+    fn remove_returns_value_and_clears_entry() {
+        let mut ctx = ToolCallContext::new();
+        ctx.insert(42u32);
+        assert_eq!(ctx.remove::<u32>(), Some(42));
+        assert!(!ctx.contains::<u32>());
+    }
+
+    #[test]
+    fn remove_missing_type_returns_none() {
+        let mut ctx = ToolCallContext::new();
+        assert_eq!(ctx.remove::<u32>(), None);
     }
 }

--- a/crates/rig-core/src/tool/mod.rs
+++ b/crates/rig-core/src/tool/mod.rs
@@ -9,7 +9,10 @@
 //! The [ToolSet] struct is a collection of tools that can be used by an [Agent](crate::agent::Agent)
 //! and optionally RAGged.
 
+pub mod context;
 pub mod server;
+
+pub use context::ToolCallContext;
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
@@ -140,6 +143,19 @@ pub trait Tool: Sized + WasmCompatSend + WasmCompatSync {
         &self,
         args: Self::Args,
     ) -> impl Future<Output = Result<Self::Output, Self::Error>> + WasmCompatSend;
+
+    /// Tool execution with per-call runtime context.
+    ///
+    /// Override this to access runtime values (auth, session IDs, etc.)
+    /// injected by the caller via [`ToolCallContext`]. The default ignores
+    /// context and delegates to [`Tool::call`].
+    fn call_with_context(
+        &self,
+        args: Self::Args,
+        _ctx: &ToolCallContext,
+    ) -> impl Future<Output = Result<Self::Output, Self::Error>> + WasmCompatSend {
+        self.call(args)
+    }
 }
 
 /// Trait that represents an LLM tool that can be stored in a vector store and RAGged
@@ -180,6 +196,19 @@ pub trait ToolDyn: WasmCompatSend + WasmCompatSync {
 
     /// Calls the tool with JSON-encoded arguments and returns model-facing text.
     fn call<'a>(&'a self, args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>>;
+
+    /// Dynamic dispatch variant of tool execution with per-call runtime context.
+    ///
+    /// The default ignores context and delegates to [`ToolDyn::call`].
+    /// The blanket impl for [`Tool`] types overrides this to thread context
+    /// through to [`Tool::call_with_context`].
+    fn call_with_context<'a>(
+        &'a self,
+        args: String,
+        _ctx: ToolCallContext,
+    ) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
+        self.call(args)
+    }
 }
 
 fn serialize_tool_output(output: impl Serialize) -> serde_json::Result<String> {
@@ -199,6 +228,14 @@ impl<T: Tool> ToolDyn for T {
     }
 
     fn call<'a>(&'a self, args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
+        ToolDyn::call_with_context(self, args, ToolCallContext::new())
+    }
+
+    fn call_with_context<'a>(
+        &'a self,
+        args: String,
+        ctx: ToolCallContext,
+    ) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
         Box::pin(async move {
             // LLMs frequently send `null` for tools whose arguments are all optional.
             // `serde_json::from_str::<T>("null")` fails for struct types even when
@@ -212,7 +249,7 @@ impl<T: Tool> ToolDyn for T {
                 Err(err) => Err(err),
             };
             match args {
-                Ok(args) => <Self as Tool>::call(self, args)
+                Ok(args) => <Self as Tool>::call_with_context(self, args, &ctx)
                     .await
                     .map_err(|e| ToolError::ToolCallError(Box::new(e)))
                     .and_then(|output| serialize_tool_output(output).map_err(ToolError::JsonError)),
@@ -269,10 +306,19 @@ impl ToolType {
         }
     }
 
+    #[allow(dead_code)]
     pub async fn call(&self, args: String) -> Result<String, ToolError> {
+        self.call_with_context(args, ToolCallContext::new()).await
+    }
+
+    pub async fn call_with_context(
+        &self,
+        args: String,
+        ctx: ToolCallContext,
+    ) -> Result<String, ToolError> {
         match self {
-            ToolType::Simple(tool) => tool.call(args).await,
-            ToolType::Embedding(tool) => tool.call(args).await,
+            ToolType::Simple(tool) => tool.call_with_context(args, ctx).await,
+            ToolType::Embedding(tool) => tool.call_with_context(args, ctx).await,
         }
     }
 }
@@ -369,12 +415,26 @@ impl ToolSet {
 
     /// Call a tool with the given name and arguments
     pub async fn call(&self, toolname: &str, args: String) -> Result<String, ToolSetError> {
+        self.call_with_context(toolname, args, ToolCallContext::new())
+            .await
+    }
+
+    /// Call a tool with the given name, arguments, and per-call runtime context.
+    ///
+    /// The context is threaded through to [`Tool::call_with_context`], allowing
+    /// tools to access caller-provided values (auth tokens, session IDs, etc.).
+    pub async fn call_with_context(
+        &self,
+        toolname: &str,
+        args: String,
+        ctx: ToolCallContext,
+    ) -> Result<String, ToolSetError> {
         if let Some(tool) = self.tools.get(toolname) {
             tracing::debug!(target: "rig",
                 "Calling tool {toolname} with args:\n{}",
                 args
             );
-            Ok(tool.call(args).await?)
+            Ok(tool.call_with_context(args, ctx).await?)
         } else {
             Err(ToolSetError::ToolNotFoundError(toolname.to_string()))
         }

--- a/crates/rig-core/src/tool/server.rs
+++ b/crates/rig-core/src/tool/server.rs
@@ -4,7 +4,7 @@ use tokio::sync::RwLock;
 
 use crate::{
     completion::{CompletionError, ToolDefinition},
-    tool::{Tool, ToolDyn, ToolSet, ToolSetError},
+    tool::{Tool, ToolCallContext, ToolDyn, ToolSet, ToolSetError},
     vector_store::{VectorSearchRequest, VectorStoreError, VectorStoreIndexDyn, request::Filter},
 };
 
@@ -146,6 +146,22 @@ impl ToolServerHandle {
     /// The tool handle is cloned under a brief read lock so that
     /// long-running tool executions never block writers.
     pub async fn call_tool(&self, tool_name: &str, args: &str) -> Result<String, ToolServerError> {
+        self.call_tool_with_context(tool_name, args, ToolCallContext::new())
+            .await
+    }
+
+    /// Look up and execute a tool by name with per-call runtime context.
+    ///
+    /// The context is threaded through to [`Tool::call_with_context`], allowing
+    /// tools to access caller-provided values (auth tokens, session IDs, etc.).
+    /// The tool handle is cloned under a brief read lock so that long-running
+    /// tool executions never block writers.
+    pub async fn call_tool_with_context(
+        &self,
+        tool_name: &str,
+        args: &str,
+        ctx: ToolCallContext,
+    ) -> Result<String, ToolServerError> {
         let tool = {
             let state = self.0.read().await;
             state.toolset.get(tool_name).cloned()
@@ -157,7 +173,7 @@ impl ToolServerHandle {
                     "Calling tool {tool_name} with args:\n{}",
                     serde_json::to_string_pretty(&args).unwrap_or_default()
                 );
-                tool.call(args.to_string())
+                tool.call_with_context(args.to_string(), ctx)
                     .await
                     .map_err(|e| ToolSetError::ToolCallError(e).into())
             }
@@ -494,5 +510,89 @@ mod tests {
         let tool_names: Vec<&str> = defs.iter().map(|t| t.name.as_str()).collect();
         assert!(tool_names.contains(&"add"));
         assert!(tool_names.contains(&"subtract"));
+    }
+
+    // --- call_with_context tests ---
+
+    #[derive(Clone)]
+    struct SessionId(String);
+
+    #[derive(serde::Deserialize, serde::Serialize)]
+    struct ContextReader;
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("context reader error")]
+    struct ContextReaderError;
+
+    impl crate::tool::Tool for ContextReader {
+        const NAME: &'static str = "context_reader";
+        type Error = ContextReaderError;
+        type Args = serde_json::Value;
+        type Output = String;
+
+        async fn definition(&self, _prompt: String) -> crate::completion::ToolDefinition {
+            crate::completion::ToolDefinition {
+                name: "context_reader".to_string(),
+                description: "Reads SessionId from context".to_string(),
+                parameters: serde_json::json!({"type": "object", "properties": {}}),
+            }
+        }
+
+        async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
+            Ok("no context".to_string())
+        }
+
+        async fn call_with_context(
+            &self,
+            _args: Self::Args,
+            ctx: &crate::tool::ToolCallContext,
+        ) -> Result<Self::Output, Self::Error> {
+            match ctx.get::<SessionId>() {
+                Some(session) => Ok(format!("session:{}", session.0)),
+                None => Ok("no session".to_string()),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_call_tool_with_context_reaches_tool() {
+        let server = ToolServer::new().tool(ContextReader);
+        let handle = server.run();
+
+        let mut ctx = crate::tool::ToolCallContext::new();
+        ctx.insert(SessionId("abc-123".to_string()));
+
+        let result = handle
+            .call_tool_with_context("context_reader", "{}", ctx)
+            .await
+            .unwrap();
+
+        assert_eq!(result, "\"session:abc-123\"");
+    }
+
+    #[tokio::test]
+    async fn test_call_tool_without_context_uses_default() {
+        let server = ToolServer::new().tool(ContextReader);
+        let handle = server.run();
+
+        let result = handle.call_tool("context_reader", "{}").await.unwrap();
+        assert_eq!(result, "\"no session\"");
+    }
+
+    #[tokio::test]
+    async fn test_tool_ignoring_context_still_works() {
+        let server = ToolServer::new().tool(MockAddTool);
+        let handle = server.run();
+
+        let mut ctx = crate::tool::ToolCallContext::new();
+        ctx.insert(SessionId("ignored".to_string()));
+
+        let args = serde_json::to_string(&serde_json::json!({"x": 3, "y": 7})).unwrap();
+        let result = handle
+            .call_tool_with_context("add", &args, ctx)
+            .await
+            .unwrap();
+
+        assert_eq!(result, "10");
     }
 }


### PR DESCRIPTION
This pull request introduces a new per-call runtime context system for tool execution, enabling tools to access caller-provided values (such as authentication tokens or session IDs) at runtime. The main changes add the `ToolCallContext` type, update the `Tool`, `ToolDyn`, `ToolType`, and `ToolSet` APIs to support context-aware calls, and extend the tool server to thread context through tool invocations. Comprehensive tests demonstrate that context is correctly passed and used.

**Context system for tool execution:**
- Introduced `ToolCallContext`, a type-map for attaching arbitrary typed values to a tool invocation, with a robust implementation and tests.
- Updated the `Tool` and `ToolDyn` traits to support a `call_with_context` method, allowing tools to access the runtime context during execution. Default implementations delegate to the original `call` method if context is not needed. [[1]](diffhunk://#diff-f31a9b871dd43537c0aa9bad6bb40fef0aff7570ed4f7297ee2273968c947ea5R146-R158) [[2]](diffhunk://#diff-f31a9b871dd43537c0aa9bad6bb40fef0aff7570ed4f7297ee2273968c947ea5R199-R211) [[3]](diffhunk://#diff-f31a9b871dd43537c0aa9bad6bb40fef0aff7570ed4f7297ee2273968c947ea5R231-R238) [[4]](diffhunk://#diff-f31a9b871dd43537c0aa9bad6bb40fef0aff7570ed4f7297ee2273968c947ea5L215-R252)
- Refactored `ToolType` and `ToolSet` to add `call_with_context` methods, ensuring context is threaded through all tool invocation paths. [[1]](diffhunk://#diff-f31a9b871dd43537c0aa9bad6bb40fef0aff7570ed4f7297ee2273968c947ea5R309-R321) [[2]](diffhunk://#diff-f31a9b871dd43537c0aa9bad6bb40fef0aff7570ed4f7297ee2273968c947ea5R418-R437)

**Tool server integration:**
- Extended `ToolServerHandle` with `call_tool_with_context`, allowing callers to pass context for each tool execution, and updated the standard `call_tool` method to use an empty context by default. [[1]](diffhunk://#diff-02080ee32f4969ffa03904085fd155ba550f9ed06920ddfa530b18963be039c3R149-R164) [[2]](diffhunk://#diff-02080ee32f4969ffa03904085fd155ba550f9ed06920ddfa530b18963be039c3L160-R176)

**Testing and validation:**
- Added unit tests for context passing, including tools that read from the context and tools that ignore it, ensuring both behaviors are supported and correct.

**API re-exports and organization:**
- Re-exported `ToolCallContext` at the crate root and in the `tool` module for easier access. [[1]](diffhunk://#diff-9342bcbc16fb488e9ea85872b66b977b081468ef46f2eb514129041ca2c26656R178) [[2]](diffhunk://#diff-f31a9b871dd43537c0aa9bad6bb40fef0aff7570ed4f7297ee2273968c947ea5R12-R15)

These changes provide a flexible and efficient way for tools to receive runtime parameters, improving extensibility and enabling advanced use cases such as per-request authentication and session management.

Superseedes https://github.com/0xPlaygrounds/rig/pull/1537