### PR TITLE
Improve Redis vector store filters and tests

### DIFF
--- a/crates/rig-redis/README.md
+++ b/crates/rig-redis/README.md
@@ -6,7 +6,7 @@ Vector store index integration for [Redis](https://redis.io/) using RediSearch v
 
 - Vector similarity search using Redis's RediSearch module
 - Support for KNN (k-nearest neighbors) queries
-- Metadata filtering with Redis query syntax
+- RediSearch filtering for fields that already exist in your Redis hashes and index schema
 - Document insertion with automatic embedding storage
 - Compatible with Redis 7.2+ or Redis Stack
 
@@ -56,7 +56,9 @@ let vector_store = RedisVectorStore::new(
     redis_client,
     "word_idx".to_string(),      // index name
     "embedding".to_string(),      // vector field name
-);
+)
+.await?
+.with_key_prefix("doc:".to_string());
 
 // Insert documents
 vector_store.insert_documents(documents).await?;
@@ -72,7 +74,23 @@ let results = vector_store
     .await?;
 ```
 
-You can find complete examples [here](https://github.com/0xPlaygrounds/rig/tree/main/rig-integrations/rig-redis/examples).
+You can find complete examples [here](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-redis/examples).
+
+## Filtering
+
+Redis filters target fields that already exist in your Redis hashes and are declared in your RediSearch schema. `InsertDocuments` writes `document`, `embedded_text`, and the configured vector field; it does not automatically expand document metadata into separate Redis hash fields.
+
+When constructing Redis filters directly, use the fallible numeric range constructors so runtime values are rejected before Redis execution:
+
+```rust
+use rig_redis::filter::{Filter, RedisValue};
+
+let price_filter = Filter::gte("price", RedisValue::Number(50.0))?;
+let category_filter = Filter::eq("category", RedisValue::String("books".to_string()))?;
+let filter = price_filter.and(category_filter);
+```
+
+Use `Filter::eq` or `Filter::tag_in` for tag/string matching. Numeric range filters return an error for strings and booleans instead of converting them into tag matches.
 
 ## Distance Metrics
 
@@ -88,12 +106,13 @@ Choose the metric that matches your embedding model when creating the index.
 - Requires pre-created RediSearch index
 - Vector dimensionality must match the index definition
 - Embeddings are stored as FLOAT32 (converted from FLOAT64)
+- `InsertDocuments` stores only `document`, `embedded_text`, and the configured vector field. Filters work only for fields that are present in the Redis hash and declared in the RediSearch schema.
 
 ## Testing
 
 ### Prerequisites
 
-Integration tests require Docker to be running, as they use testcontainers to spin up a Redis Stack instance.
+Integration tests use Redis Stack. By default they try to start Redis Stack with testcontainers and skip cleanly if Docker is unavailable. Set `REDIS_URL` to run against an explicit Redis Stack instance; the tests probe for RediSearch support before running.
 
 ### Running Tests
 

--- a/crates/rig-redis/examples/vector_search_redis.rs
+++ b/crates/rig-redis/examples/vector_search_redis.rs
@@ -35,7 +35,8 @@ async fn main() -> Result<(), anyhow::Error> {
         "word_idx".to_string(),
         "embedding".to_string(),
     )
-    .await?;
+    .await?
+    .with_key_prefix("doc:".to_string());
 
     let words = vec![
         WordDefinition {

--- a/crates/rig-redis/src/filter.rs
+++ b/crates/rig-redis/src/filter.rs
@@ -5,43 +5,215 @@
 //!
 //! # Field Type Expectations
 //!
-//! - **Numeric fields**: `eq`, `gt`, `lt`, `gte`, `lte`, `range` produce range syntax (`@field:[min max]`)
+//! - **Numeric fields**: `eq`, `gt`, `lt`, `gte`, `lte`, and `range` produce range syntax (`@field:[min max]`)
 //! - **Tag fields**: String equality uses tag syntax (`@field:{value}`)
-//! - **Bool fields**: Treated as numeric TAG (1/0) with tag syntax
+//! - **Bool fields**: Equality uses numeric TAG values (`1` or `0`) with tag syntax
+//! - **Range filters**: Redis-specific range constructors reject non-numeric values instead of converting them into tag matches
 //!
-//! Ensure your RediSearch schema matches the filter types you use.
+//! The generic [`SearchFilter`] implementation is numeric-only because Rig's
+//! shared trait is infallible. Use the inherent [`Filter`] constructors when
+//! building Redis filters directly, especially for tag values and fallible
+//! numeric range filters. Ensure your RediSearch schema matches the filter
+//! types you use.
 
 use rig_core::vector_store::request::{Filter as CoreFilter, FilterError, SearchFilter};
 use serde::{Deserialize, Serialize};
 
-/// Typed value for Redis filter expressions.
+/// Typed value for Redis-specific filter expressions.
 ///
 /// Determines how the value is formatted in the RediSearch query syntax.
 #[derive(Debug, Clone, PartialEq)]
 pub enum RedisValue {
-    /// Numeric value — produces range syntax for all comparisons.
+    /// Numeric value. Equality produces range syntax; range constructors use
+    /// this as the only supported value kind.
     Number(f64),
-    /// String/tag value — produces tag syntax `{value}`.
+    /// String/tag value. Equality and tag filters produce tag syntax.
     String(String),
-    /// Boolean value — treated as numeric TAG (`1` or `0`).
+    /// Boolean value. Equality treats this as a TAG value (`1` or `0`).
     Bool(bool),
 }
 
-impl RedisValue {
-    /// Formats value for tag-style filters (`@field:{value}` or `@field:{1}`).
-    fn to_tag_expr(&self) -> String {
-        match self {
-            RedisValue::Number(n) => n.to_string(),
-            RedisValue::String(s) => s.clone(),
-            RedisValue::Bool(b) => {
-                if *b {
-                    "1".to_string()
-                } else {
-                    "0".to_string()
-                }
-            }
+/// Finite numeric value for Redis range-syntax filters.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RedisNumber(f64);
+
+impl RedisNumber {
+    /// Creates a finite Redis numeric filter value.
+    pub fn new(value: f64) -> Result<Self, FilterError> {
+        if value.is_finite() {
+            Ok(Self(value))
+        } else {
+            Err(FilterError::Expected {
+                expected: "finite numeric value for Redis numeric filter".into(),
+                got: value.to_string(),
+            })
         }
     }
+
+    fn get(self) -> f64 {
+        self.0
+    }
+}
+
+impl TryFrom<f64> for RedisNumber {
+    type Error = FilterError;
+
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<i64> for RedisNumber {
+    fn from(value: i64) -> Self {
+        Self(value as f64)
+    }
+}
+
+impl From<u64> for RedisNumber {
+    fn from(value: u64) -> Self {
+        Self(value as f64)
+    }
+}
+
+fn numeric_bound(value: RedisValue, operation: &'static str) -> Result<RedisNumber, FilterError> {
+    match value {
+        RedisValue::Number(n) if n.is_finite() => Ok(RedisNumber(n)),
+        RedisValue::Number(n) => Err(FilterError::Expected {
+            expected: format!("finite numeric value for Redis {operation} filter"),
+            got: n.to_string(),
+        }),
+        other => Err(FilterError::Expected {
+            expected: format!("numeric value for Redis {operation} filter"),
+            got: format!("{other:?}"),
+        }),
+    }
+}
+
+fn numeric_eq_filter(key: impl AsRef<str>, value: RedisNumber) -> Filter {
+    let value = value.get();
+    Filter(format!("@{}:[{value} {value}]", field_name(key)))
+}
+
+fn gt_number_filter(key: impl AsRef<str>, value: RedisNumber) -> Filter {
+    let value = value.get();
+    Filter(format!("@{}:[({value} +inf]", field_name(key)))
+}
+
+fn lt_number_filter(key: impl AsRef<str>, value: RedisNumber) -> Filter {
+    let value = value.get();
+    Filter(format!("@{}:[-inf ({value}]", field_name(key)))
+}
+
+fn gte_number_filter(key: impl AsRef<str>, value: RedisNumber) -> Filter {
+    let value = value.get();
+    Filter(format!("@{}:[{value} +inf]", field_name(key)))
+}
+
+fn lte_number_filter(key: impl AsRef<str>, value: RedisNumber) -> Filter {
+    let value = value.get();
+    Filter(format!("@{}:[-inf {value}]", field_name(key)))
+}
+
+fn field_name(key: impl AsRef<str>) -> String {
+    key.as_ref()
+        .split('.')
+        .map(escape_field_segment)
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
+fn escape_field_segment(segment: &str) -> String {
+    let mut escaped = String::with_capacity(segment.len());
+    for ch in segment.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' {
+            escaped.push(ch);
+        } else {
+            escaped.push('\\');
+            escaped.push(ch);
+        }
+    }
+    escaped
+}
+
+fn escape_tag_value(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        if matches!(
+            ch,
+            '\\' | ' '
+                | ','
+                | '.'
+                | '<'
+                | '>'
+                | '{'
+                | '}'
+                | '['
+                | ']'
+                | '"'
+                | '\''
+                | ':'
+                | ';'
+                | '!'
+                | '@'
+                | '#'
+                | '$'
+                | '%'
+                | '^'
+                | '&'
+                | '*'
+                | '('
+                | ')'
+                | '-'
+                | '+'
+                | '='
+                | '~'
+                | '|'
+                | '/'
+        ) {
+            escaped.push('\\');
+        }
+        escaped.push(ch);
+    }
+    escaped
+}
+
+fn escape_text_query(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        if matches!(
+            ch,
+            '\\' | '<'
+                | '>'
+                | '{'
+                | '}'
+                | '['
+                | ']'
+                | '"'
+                | '\''
+                | ':'
+                | ';'
+                | '!'
+                | '@'
+                | '#'
+                | '$'
+                | '%'
+                | '^'
+                | '&'
+                | '*'
+                | '('
+                | ')'
+                | '-'
+                | '+'
+                | '='
+                | '~'
+                | '|'
+                | '/'
+        ) {
+            escaped.push('\\');
+        }
+        escaped.push(ch);
+    }
+    escaped
 }
 
 impl From<i64> for RedisValue {
@@ -105,61 +277,79 @@ impl TryFrom<serde_json::Value> for RedisValue {
 
 /// Redis filter for FT.SEARCH queries.
 ///
-/// Wraps a raw RediSearch query string. Combine filters with [`SearchFilter::and`]
-/// and [`SearchFilter::or`], or use the additional helpers like [`Filter::range`]
-/// and [`Filter::tag_in`].
+/// Wraps a raw RediSearch query string. Use the inherent constructors on this
+/// type for Redis-specific filters, including fallible numeric range filters
+/// and tag filters.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Filter(String);
 
 impl SearchFilter for Filter {
-    type Value = RedisValue;
+    type Value = RedisNumber;
 
+    /// Numeric equality filter.
+    ///
+    /// Redis-specific string and boolean equality are available through the
+    /// inherent [`Filter::eq`] constructor.
+    fn eq(key: impl AsRef<str>, value: Self::Value) -> Self {
+        numeric_eq_filter(key, value)
+    }
+
+    fn gt(key: impl AsRef<str>, value: Self::Value) -> Self {
+        gt_number_filter(key, value)
+    }
+
+    fn lt(key: impl AsRef<str>, value: Self::Value) -> Self {
+        lt_number_filter(key, value)
+    }
+
+    fn and(self, rhs: Self) -> Self {
+        self.and(rhs)
+    }
+
+    fn or(self, rhs: Self) -> Self {
+        self.or(rhs)
+    }
+}
+
+impl Filter {
     /// Equality filter.
     ///
     /// - Numeric: `@field:[val val]` (exact range match)
     /// - String: `@field:{value}` (tag match)
     /// - Bool: `@field:{1}` or `@field:{0}` (tag match)
-    fn eq(key: impl AsRef<str>, value: Self::Value) -> Self {
-        match value {
-            RedisValue::Number(n) => Self(format!("@{}:[{} {}]", key.as_ref(), n, n)),
-            RedisValue::String(ref s) => Self(format!("@{}:{{{}}}", key.as_ref(), s)),
+    pub fn eq(key: impl AsRef<str>, value: impl Into<RedisValue>) -> Result<Self, FilterError> {
+        let key = field_name(key);
+        let filter = match value.into() {
+            RedisValue::Number(n) => numeric_eq_filter(key, RedisNumber::new(n)?),
+            RedisValue::String(ref s) => Self(format!("@{key}:{{{}}}", escape_tag_value(s))),
             RedisValue::Bool(b) => {
                 let v = if b { "1" } else { "0" };
-                Self(format!("@{}:{{{}}}", key.as_ref(), v))
+                Self(format!("@{key}:{{{v}}}"))
             }
-        }
+        };
+        Ok(filter)
     }
 
     /// Greater-than filter (exclusive).
     ///
-    /// Numeric: `@field:[(val +inf]`. Non-numeric falls back to tag syntax.
-    fn gt(key: impl AsRef<str>, value: Self::Value) -> Self {
-        match value {
-            RedisValue::Number(n) => Self(format!("@{}:[({} +inf]", key.as_ref(), n)),
-            _ => Self(format!("@{}:{{{}}}", key.as_ref(), value.to_tag_expr())),
-        }
+    /// Produces `@field:[(val +inf]` for numeric values and returns an error
+    /// for strings or booleans. Use [`Filter::eq`] or [`Filter::tag_in`] for
+    /// tag comparisons.
+    pub fn gt(key: impl AsRef<str>, value: impl Into<RedisValue>) -> Result<Self, FilterError> {
+        let value = numeric_bound(value.into(), "greater-than")?;
+        Ok(gt_number_filter(key, value))
     }
 
     /// Less-than filter (exclusive).
     ///
-    /// Numeric: `@field:[-inf (val]`. Non-numeric falls back to tag syntax.
-    fn lt(key: impl AsRef<str>, value: Self::Value) -> Self {
-        match value {
-            RedisValue::Number(n) => Self(format!("@{}:[-inf ({}]", key.as_ref(), n)),
-            _ => Self(format!("@{}:{{{}}}", key.as_ref(), value.to_tag_expr())),
-        }
+    /// Produces `@field:[-inf (val]` for numeric values and returns an error
+    /// for strings or booleans. Use [`Filter::eq`] or [`Filter::tag_in`] for
+    /// tag comparisons.
+    pub fn lt(key: impl AsRef<str>, value: impl Into<RedisValue>) -> Result<Self, FilterError> {
+        let value = numeric_bound(value.into(), "less-than")?;
+        Ok(lt_number_filter(key, value))
     }
 
-    fn and(self, rhs: Self) -> Self {
-        Self(format!("({} {})", self.0, rhs.0))
-    }
-
-    fn or(self, rhs: Self) -> Self {
-        Self(format!("({} | {})", self.0, rhs.0))
-    }
-}
-
-impl Filter {
     /// Negates this filter expression.
     #[allow(clippy::should_implement_trait)]
     pub fn not(self) -> Self {
@@ -168,45 +358,67 @@ impl Filter {
 
     /// Greater than or equal (inclusive).
     ///
-    /// Numeric: `@field:[val +inf]`.
-    pub fn gte(key: impl AsRef<str>, value: <Self as SearchFilter>::Value) -> Self {
-        match value {
-            RedisValue::Number(n) => Self(format!("@{}:[{} +inf]", key.as_ref(), n)),
-            _ => Self(format!("@{}:{{{}}}", key.as_ref(), value.to_tag_expr())),
-        }
+    /// Produces `@field:[val +inf]` for numeric values and returns an error
+    /// for strings or booleans. Use [`Filter::eq`] or [`Filter::tag_in`] for
+    /// tag comparisons.
+    pub fn gte(key: impl AsRef<str>, value: impl Into<RedisValue>) -> Result<Self, FilterError> {
+        let value = numeric_bound(value.into(), "greater-than-or-equal")?;
+        Ok(gte_number_filter(key, value))
     }
 
     /// Less than or equal (inclusive).
     ///
-    /// Numeric: `@field:[-inf val]`.
-    pub fn lte(key: impl AsRef<str>, value: <Self as SearchFilter>::Value) -> Self {
-        match value {
-            RedisValue::Number(n) => Self(format!("@{}:[-inf {}]", key.as_ref(), n)),
-            _ => Self(format!("@{}:{{{}}}", key.as_ref(), value.to_tag_expr())),
-        }
+    /// Produces `@field:[-inf val]` for numeric values and returns an error
+    /// for strings or booleans. Use [`Filter::eq`] or [`Filter::tag_in`] for
+    /// tag comparisons.
+    pub fn lte(key: impl AsRef<str>, value: impl Into<RedisValue>) -> Result<Self, FilterError> {
+        let value = numeric_bound(value.into(), "less-than-or-equal")?;
+        Ok(lte_number_filter(key, value))
+    }
+
+    /// Combines this filter with another using RediSearch AND semantics.
+    pub fn and(self, rhs: Self) -> Self {
+        Self(format!("({} {})", self.0, rhs.0))
+    }
+
+    /// Combines this filter with another using RediSearch OR semantics.
+    pub fn or(self, rhs: Self) -> Self {
+        Self(format!("({} | {})", self.0, rhs.0))
     }
 
     /// Numeric range filter (inclusive on both ends).
-    pub fn range(key: impl AsRef<str>, min: f64, max: f64) -> Self {
-        Self(format!("@{}:[{} {}]", key.as_ref(), min, max))
+    pub fn range(key: impl AsRef<str>, min: f64, max: f64) -> Result<Self, FilterError> {
+        let min = RedisNumber::new(min)?.get();
+        let max = RedisNumber::new(max)?.get();
+        Ok(Self(format!("@{}:[{} {}]", field_name(key), min, max)))
     }
 
     /// Numeric range filter (exclusive on both ends).
-    pub fn range_exclusive(key: impl AsRef<str>, min: f64, max: f64) -> Self {
-        Self(format!("@{}:[({} ({}]", key.as_ref(), min, max))
+    pub fn range_exclusive(key: impl AsRef<str>, min: f64, max: f64) -> Result<Self, FilterError> {
+        let min = RedisNumber::new(min)?.get();
+        let max = RedisNumber::new(max)?.get();
+        Ok(Self(format!("@{}:[({} ({}]", field_name(key), min, max)))
     }
 
     /// Tag filter for multiple values (OR).
     ///
     /// Produces `@field:{val1 | val2 | val3}`.
     pub fn tag_in(key: impl AsRef<str>, values: Vec<String>) -> Self {
-        let tags = values.join(" | ");
-        Self(format!("@{}:{{{}}}", key.as_ref(), tags))
+        let tags = values
+            .iter()
+            .map(|value| escape_tag_value(value))
+            .collect::<Vec<_>>()
+            .join(" | ");
+        Self(format!("@{}:{{{}}}", field_name(key), tags))
     }
 
     /// Full-text search within a TEXT field.
     pub fn text_contains(key: impl AsRef<str>, text: impl AsRef<str>) -> Self {
-        Self(format!("@{}:{}", key.as_ref(), text.as_ref()))
+        Self(format!(
+            "@{}:({})",
+            field_name(key),
+            escape_text_query(text.as_ref())
+        ))
     }
 
     /// Consumes the filter and returns the raw RediSearch query string.
@@ -220,9 +432,9 @@ impl TryFrom<CoreFilter<serde_json::Value>> for Filter {
 
     fn try_from(value: CoreFilter<serde_json::Value>) -> Result<Self, Self::Error> {
         let filter = match value {
-            CoreFilter::Eq(k, val) => Filter::eq(k, val.try_into()?),
-            CoreFilter::Gt(k, val) => Filter::gt(k, val.try_into()?),
-            CoreFilter::Lt(k, val) => Filter::lt(k, val.try_into()?),
+            CoreFilter::Eq(k, val) => Filter::eq(k, RedisValue::try_from(val)?)?,
+            CoreFilter::Gt(k, val) => Filter::gt(k, RedisValue::try_from(val)?)?,
+            CoreFilter::Lt(k, val) => Filter::lt(k, RedisValue::try_from(val)?)?,
             CoreFilter::And(l, r) => Self::try_from(*l)?.and(Self::try_from(*r)?),
             CoreFilter::Or(l, r) => Self::try_from(*l)?.or(Self::try_from(*r)?),
         };

--- a/crates/rig-redis/src/lib.rs
+++ b/crates/rig-redis/src/lib.rs
@@ -27,7 +27,9 @@
 //!     redis_client,
 //!     "my_index".into(),
 //!     "embedding".into(),
-//! );
+//! )
+//! .await?
+//! .with_key_prefix("doc:".to_string());
 //! ```
 
 pub mod filter;
@@ -291,11 +293,11 @@ where
             cmd.arg(1).arg("__vector_score");
         }
 
-        cmd.arg("DIALECT").arg(2);
-
-        if req.threshold().is_some() {
-            cmd.arg("LIMIT").arg(0).arg(req.samples());
-        }
+        cmd.arg("LIMIT")
+            .arg(0)
+            .arg(req.samples())
+            .arg("DIALECT")
+            .arg(2);
 
         cmd.query_async(&mut con)
             .await

--- a/crates/rig-redis/tests/filter_tests.rs
+++ b/crates/rig-redis/tests/filter_tests.rs
@@ -1,61 +1,118 @@
 #![allow(clippy::unwrap_used)]
 
 use rig_core::vector_store::request::{Filter as CoreFilter, SearchFilter};
-use rig_redis::filter::{Filter, RedisValue};
+use rig_redis::filter::{Filter, RedisNumber, RedisValue};
 
 #[test]
 fn test_filter_eq_string() {
-    let filter = Filter::eq("category", RedisValue::String("electronics".to_string()));
+    let filter = Filter::eq("category", RedisValue::String("electronics".to_string())).unwrap();
     assert_eq!(filter.into_inner(), "@category:{electronics}");
 }
 
 #[test]
+fn test_filter_eq_string_escapes_tag_value() {
+    let filter = Filter::eq(
+        "category",
+        RedisValue::String("audio | video - {new}, @home".to_string()),
+    )
+    .unwrap();
+    assert_eq!(
+        filter.into_inner(),
+        r"@category:{audio\ \|\ video\ \-\ \{new\}\,\ \@home}"
+    );
+}
+
+#[test]
+fn test_filter_escapes_field_name_segments() {
+    let filter = Filter::eq(
+        "metadata.category-name",
+        RedisValue::String("electronics".to_string()),
+    )
+    .unwrap();
+    assert_eq!(
+        filter.into_inner(),
+        r"@metadata.category\-name:{electronics}"
+    );
+}
+
+#[test]
 fn test_filter_eq_number() {
-    let filter = Filter::eq("price", RedisValue::Number(99.99));
+    let filter = Filter::eq("price", RedisValue::Number(99.99)).unwrap();
     // Numeric equality uses range syntax: @field:[val val]
     assert_eq!(filter.into_inner(), "@price:[99.99 99.99]");
 }
 
 #[test]
+fn test_filter_eq_nan_errors() {
+    let err = Filter::eq("price", RedisValue::Number(f64::NAN)).unwrap_err();
+    assert!(err.to_string().contains("finite numeric value"));
+}
+
+#[test]
 fn test_filter_gt() {
-    let filter = Filter::gt("price", RedisValue::Number(50.0));
+    let filter = Filter::gt("price", RedisValue::Number(50.0)).unwrap();
     assert_eq!(filter.into_inner(), "@price:[(50 +inf]");
 }
 
 #[test]
+fn test_search_filter_trait_gt_is_numeric() {
+    let filter = <Filter as SearchFilter>::gt("price", RedisNumber::new(50.0).unwrap());
+    assert_eq!(filter.into_inner(), "@price:[(50 +inf]");
+}
+
+#[test]
+fn test_redis_number_rejects_non_finite_values() {
+    assert!(RedisNumber::new(f64::NAN).is_err());
+    assert!(RedisNumber::new(f64::INFINITY).is_err());
+    assert!(RedisNumber::new(f64::NEG_INFINITY).is_err());
+}
+
+#[test]
 fn test_filter_lt() {
-    let filter = Filter::lt("price", RedisValue::Number(100.0));
+    let filter = Filter::lt("price", RedisValue::Number(100.0)).unwrap();
     assert_eq!(filter.into_inner(), "@price:[-inf (100]");
 }
 
 #[test]
 fn test_filter_gte() {
-    let filter = Filter::gte("price", RedisValue::Number(50.0));
+    let filter = Filter::gte("price", RedisValue::Number(50.0)).unwrap();
     assert_eq!(filter.into_inner(), "@price:[50 +inf]");
 }
 
 #[test]
 fn test_filter_lte() {
-    let filter = Filter::lte("price", RedisValue::Number(100.0));
+    let filter = Filter::lte("price", RedisValue::Number(100.0)).unwrap();
     assert_eq!(filter.into_inner(), "@price:[-inf 100]");
 }
 
 #[test]
 fn test_filter_range() {
-    let filter = Filter::range("price", 50.0, 100.0);
+    let filter = Filter::range("price", 50.0, 100.0).unwrap();
     assert_eq!(filter.into_inner(), "@price:[50 100]");
 }
 
 #[test]
+fn test_filter_range_rejects_non_finite_min() {
+    let err = Filter::range("price", f64::NAN, 100.0).unwrap_err();
+    assert!(err.to_string().contains("finite numeric value"));
+}
+
+#[test]
 fn test_filter_range_exclusive() {
-    let filter = Filter::range_exclusive("price", 50.0, 100.0);
+    let filter = Filter::range_exclusive("price", 50.0, 100.0).unwrap();
     assert_eq!(filter.into_inner(), "@price:[(50 (100]");
 }
 
 #[test]
+fn test_filter_range_exclusive_rejects_non_finite_max() {
+    let err = Filter::range_exclusive("price", 50.0, f64::INFINITY).unwrap_err();
+    assert!(err.to_string().contains("finite numeric value"));
+}
+
+#[test]
 fn test_filter_and() {
-    let filter1 = Filter::eq("category", RedisValue::String("electronics".to_string()));
-    let filter2 = Filter::gt("price", RedisValue::Number(50.0));
+    let filter1 = Filter::eq("category", RedisValue::String("electronics".to_string())).unwrap();
+    let filter2 = Filter::gt("price", RedisValue::Number(50.0)).unwrap();
     let combined = filter1.and(filter2);
     assert_eq!(
         combined.into_inner(),
@@ -65,8 +122,8 @@ fn test_filter_and() {
 
 #[test]
 fn test_filter_or() {
-    let filter1 = Filter::eq("category", RedisValue::String("electronics".to_string()));
-    let filter2 = Filter::eq("category", RedisValue::String("books".to_string()));
+    let filter1 = Filter::eq("category", RedisValue::String("electronics".to_string())).unwrap();
+    let filter2 = Filter::eq("category", RedisValue::String("books".to_string())).unwrap();
     let combined = filter1.or(filter2);
     assert_eq!(
         combined.into_inner(),
@@ -76,7 +133,7 @@ fn test_filter_or() {
 
 #[test]
 fn test_filter_not() {
-    let filter = Filter::eq("category", RedisValue::String("electronics".to_string()));
+    let filter = Filter::eq("category", RedisValue::String("electronics".to_string())).unwrap();
     let negated = filter.not();
     assert_eq!(negated.into_inner(), "-@category:{electronics}");
 }
@@ -88,16 +145,57 @@ fn test_filter_tag_in() {
 }
 
 #[test]
+fn test_filter_tag_in_escapes_values() {
+    let filter = Filter::tag_in(
+        "tags",
+        vec![
+            "new items".to_string(),
+            "sale|clearance".to_string(),
+            "a,b.c".to_string(),
+        ],
+    );
+    assert_eq!(
+        filter.into_inner(),
+        r"@tags:{new\ items | sale\|clearance | a\,b\.c}"
+    );
+}
+
+#[test]
 fn test_filter_text_contains() {
     let filter = Filter::text_contains("description", "laptop");
-    assert_eq!(filter.into_inner(), "@description:laptop");
+    assert_eq!(filter.into_inner(), "@description:(laptop)");
+}
+
+#[test]
+fn test_filter_text_contains_groups_multi_word_query() {
+    let filter = Filter::text_contains("description", "gaming laptop");
+    assert_eq!(filter.into_inner(), "@description:(gaming laptop)");
+}
+
+#[test]
+fn test_filter_text_contains_escapes_query_syntax_inside_group() {
+    let filter = Filter::text_contains("description", "laptop - @home | office");
+    assert_eq!(
+        filter.into_inner(),
+        r"@description:(laptop \- \@home \| office)"
+    );
+}
+
+#[test]
+fn test_filter_text_contains_escapes_parentheses_and_quotes_inside_group() {
+    let filter = Filter::text_contains("description", r#"laptop ("portable")"#);
+    assert_eq!(
+        filter.into_inner(),
+        r#"@description:(laptop \(\"portable\"\))"#
+    );
 }
 
 #[test]
 fn test_complex_filter() {
-    let category_filter = Filter::eq("category", RedisValue::String("electronics".to_string()));
-    let price_min = Filter::gte("price", RedisValue::Number(50.0));
-    let price_max = Filter::lte("price", RedisValue::Number(200.0));
+    let category_filter =
+        Filter::eq("category", RedisValue::String("electronics".to_string())).unwrap();
+    let price_min = Filter::gte("price", RedisValue::Number(50.0)).unwrap();
+    let price_max = Filter::lte("price", RedisValue::Number(200.0)).unwrap();
 
     let combined = category_filter.and(price_min).and(price_max);
 
@@ -126,6 +224,22 @@ fn test_core_filter_gt_conversion() {
 }
 
 #[test]
+fn test_core_filter_gt_rejects_non_numeric_value() {
+    let core_filter: CoreFilter<serde_json::Value> =
+        CoreFilter::gt("status", serde_json::json!("active"));
+
+    assert!(Filter::try_from(core_filter).is_err());
+}
+
+#[test]
+fn test_core_filter_lt_rejects_non_numeric_value() {
+    let core_filter: CoreFilter<serde_json::Value> =
+        CoreFilter::lt("status", serde_json::json!("inactive"));
+
+    assert!(Filter::try_from(core_filter).is_err());
+}
+
+#[test]
 fn test_core_filter_eq_numeric_conversion() {
     let core_filter: CoreFilter<serde_json::Value> =
         CoreFilter::eq("price", serde_json::json!(99.99));
@@ -150,7 +264,7 @@ fn test_core_filter_and_conversion() {
 
 #[test]
 fn test_redis_value_bool() {
-    let filter = Filter::eq("in_stock", RedisValue::Bool(true));
+    let filter = Filter::eq("in_stock", RedisValue::Bool(true)).unwrap();
     assert_eq!(filter.into_inner(), "@in_stock:{1}");
 }
 
@@ -167,13 +281,43 @@ fn test_filter_tag_in_single_value() {
 }
 
 #[test]
-fn test_filter_gt_non_numeric_uses_tag_syntax() {
-    let filter = Filter::gt("status", RedisValue::String("active".to_string()));
-    assert_eq!(filter.into_inner(), "@status:{active}");
+fn test_filter_gt_non_numeric_errors() {
+    let err = Filter::gt("status", RedisValue::String("active".to_string())).unwrap_err();
+    assert!(err.to_string().contains("greater-than filter"));
 }
 
 #[test]
-fn test_filter_lt_non_numeric_uses_tag_syntax() {
-    let filter = Filter::lt("status", RedisValue::String("inactive".to_string()));
-    assert_eq!(filter.into_inner(), "@status:{inactive}");
+fn test_filter_gt_nan_errors() {
+    let err = Filter::gt("price", RedisValue::Number(f64::NAN)).unwrap_err();
+    assert!(err.to_string().contains("finite numeric value"));
+}
+
+#[test]
+fn test_filter_gte_infinity_errors() {
+    let err = Filter::gte("price", RedisValue::Number(f64::INFINITY)).unwrap_err();
+    assert!(err.to_string().contains("finite numeric value"));
+}
+
+#[test]
+fn test_filter_lte_negative_infinity_errors() {
+    let err = Filter::lte("price", RedisValue::Number(f64::NEG_INFINITY)).unwrap_err();
+    assert!(err.to_string().contains("finite numeric value"));
+}
+
+#[test]
+fn test_filter_lt_non_numeric_errors() {
+    let err = Filter::lt("status", RedisValue::String("inactive".to_string())).unwrap_err();
+    assert!(err.to_string().contains("less-than filter"));
+}
+
+#[test]
+fn test_filter_gte_bool_errors() {
+    let err = Filter::gte("enabled", RedisValue::Bool(true)).unwrap_err();
+    assert!(err.to_string().contains("greater-than-or-equal filter"));
+}
+
+#[test]
+fn test_filter_lte_bool_errors() {
+    let err = Filter::lte("enabled", RedisValue::Bool(false)).unwrap_err();
+    assert!(err.to_string().contains("less-than-or-equal filter"));
 }

--- a/crates/rig-redis/tests/integration_tests.rs
+++ b/crates/rig-redis/tests/integration_tests.rs
@@ -31,39 +31,97 @@ struct Word {
     definition: String,
 }
 
-/// Check if Redis is already running on localhost:6379
-async fn is_redis_running() -> bool {
-    match redis::Client::open("redis://127.0.0.1:6379") {
-        Ok(client) => client.get_multiplexed_async_connection().await.is_ok(),
-        Err(_) => false,
-    }
+struct TestRedis {
+    client: redis::Client,
+    _container: Option<testcontainers::ContainerAsync<GenericImage>>,
 }
 
-/// Get Redis connection info - either from existing instance or new container
-async fn get_redis_connection() -> (
-    String,
-    u16,
-    Option<testcontainers::ContainerAsync<GenericImage>>,
-) {
-    if is_redis_running().await {
-        println!("Using existing Redis instance on localhost:6379");
-        ("127.0.0.1".to_string(), REDIS_PORT, None)
-    } else {
-        println!("Starting new Redis Stack container");
-        let container = GenericImage::new("redis/redis-stack", "latest")
-            .with_exposed_port(REDIS_PORT.tcp())
-            .with_wait_for(WaitFor::Duration {
-                length: std::time::Duration::from_secs(3),
-            })
-            .start()
-            .await
-            .expect("Failed to start Redis Stack container");
+async fn redis_has_search(client: &redis::Client) -> bool {
+    let Ok(mut con) = client.get_multiplexed_async_connection().await else {
+        return false;
+    };
 
-        let port = container.get_host_port_ipv4(REDIS_PORT).await.unwrap();
-        let host = container.get_host().await.unwrap().to_string();
+    redis::cmd("FT._LIST")
+        .query_async::<Vec<String>>(&mut con)
+        .await
+        .is_ok()
+}
 
-        (host, port, Some(container))
+async fn get_redis_connection() -> Option<TestRedis> {
+    if let Ok(redis_url) = std::env::var("REDIS_URL") {
+        let client = match redis::Client::open(redis_url.clone()) {
+            Ok(client) => client,
+            Err(err) => {
+                eprintln!("Skipping Redis integration tests: invalid REDIS_URL ({err})");
+                return None;
+            }
+        };
+
+        if redis_has_search(&client).await {
+            return Some(TestRedis {
+                client,
+                _container: None,
+            });
+        }
+
+        eprintln!("Skipping Redis integration tests: REDIS_URL does not expose RediSearch");
+        return None;
     }
+
+    let container = match GenericImage::new("redis/redis-stack", "latest")
+        .with_exposed_port(REDIS_PORT.tcp())
+        .with_wait_for(WaitFor::Duration {
+            length: std::time::Duration::from_secs(3),
+        })
+        .start()
+        .await
+    {
+        Ok(container) => container,
+        Err(err) => {
+            eprintln!(
+                "Skipping Redis integration tests: could not start Redis Stack container ({err})"
+            );
+            return None;
+        }
+    };
+
+    let port = match container.get_host_port_ipv4(REDIS_PORT).await {
+        Ok(port) => port,
+        Err(err) => {
+            eprintln!("Skipping Redis integration tests: could not read Redis Stack port ({err})");
+            return None;
+        }
+    };
+    let host = match container.get_host().await {
+        Ok(host) => host.to_string(),
+        Err(err) => {
+            eprintln!("Skipping Redis integration tests: could not read Redis Stack host ({err})");
+            return None;
+        }
+    };
+    let client = match redis::Client::open(format!("redis://{host}:{port}")) {
+        Ok(client) => client,
+        Err(err) => {
+            eprintln!("Skipping Redis integration tests: invalid container Redis URL ({err})");
+            return None;
+        }
+    };
+
+    if !redis_has_search(&client).await {
+        eprintln!(
+            "Skipping Redis integration tests: Redis Stack container does not expose RediSearch"
+        );
+        return None;
+    }
+
+    Some(TestRedis {
+        client,
+        _container: Some(container),
+    })
+}
+
+fn unique_index_name(base: &str) -> String {
+    format!("{}_{}", base, uuid::Uuid::new_v4().simple())
 }
 
 async fn setup_redis_index(
@@ -134,8 +192,10 @@ async fn cleanup_redis_index(
 
 #[tokio::test]
 async fn test_vector_search_basic() {
-    let (host, port, _container) = get_redis_connection().await;
-    let index_name = "test_vector_search_basic";
+    let Some(redis) = get_redis_connection().await else {
+        return;
+    };
+    let index_name = unique_index_name("test_vector_search_basic");
 
     let server = httpmock::MockServer::start();
 
@@ -193,17 +253,16 @@ async fn test_vector_search_basic() {
 
     let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_ADA_002);
 
-    let redis_url = format!("redis://{host}:{port}");
-    let redis_client = redis::Client::open(redis_url).unwrap();
+    let redis_client = redis.client;
 
-    setup_redis_index(&redis_client, index_name, 1536)
+    setup_redis_index(&redis_client, &index_name, 1536)
         .await
         .unwrap();
 
     let vector_store = RedisVectorStore::new(
         model.clone(),
         redis_client.clone(),
-        index_name.to_string(),
+        index_name.clone(),
         VECTOR_FIELD.to_string(),
     )
     .await
@@ -250,15 +309,17 @@ async fn test_vector_search_basic() {
     assert!(score.is_finite());
     assert!(doc.definition.contains("linglingdong"));
 
-    cleanup_redis_index(&redis_client, index_name)
+    cleanup_redis_index(&redis_client, &index_name)
         .await
         .unwrap();
 }
 
 #[tokio::test]
 async fn test_top_n_ids() {
-    let (host, port, _container) = get_redis_connection().await;
-    let index_name = "test_top_n_ids";
+    let Some(redis) = get_redis_connection().await else {
+        return;
+    };
+    let index_name = unique_index_name("test_top_n_ids");
 
     let server = httpmock::MockServer::start();
 
@@ -308,17 +369,16 @@ async fn test_top_n_ids() {
 
     let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_ADA_002);
 
-    let redis_url = format!("redis://{host}:{port}");
-    let redis_client = redis::Client::open(redis_url).unwrap();
+    let redis_client = redis.client;
 
-    setup_redis_index(&redis_client, index_name, 1536)
+    setup_redis_index(&redis_client, &index_name, 1536)
         .await
         .unwrap();
 
     let vector_store = RedisVectorStore::new(
         model.clone(),
         redis_client.clone(),
-        index_name.to_string(),
+        index_name.clone(),
         VECTOR_FIELD.to_string(),
     )
     .await
@@ -359,15 +419,17 @@ async fn test_top_n_ids() {
     assert!(results[0].0.is_finite());
     assert!(!results[0].1.is_empty());
 
-    cleanup_redis_index(&redis_client, index_name)
+    cleanup_redis_index(&redis_client, &index_name)
         .await
         .unwrap();
 }
 
 #[tokio::test]
 async fn test_threshold_filtering() {
-    let (host, port, _container) = get_redis_connection().await;
-    let index_name = "test_threshold_filtering";
+    let Some(redis) = get_redis_connection().await else {
+        return;
+    };
+    let index_name = unique_index_name("test_threshold_filtering");
 
     let server = httpmock::MockServer::start();
 
@@ -417,17 +479,16 @@ async fn test_threshold_filtering() {
 
     let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_ADA_002);
 
-    let redis_url = format!("redis://{host}:{port}");
-    let redis_client = redis::Client::open(redis_url).unwrap();
+    let redis_client = redis.client;
 
-    setup_redis_index(&redis_client, index_name, 1536)
+    setup_redis_index(&redis_client, &index_name, 1536)
         .await
         .unwrap();
 
     let vector_store = RedisVectorStore::new(
         model.clone(),
         redis_client.clone(),
-        index_name.to_string(),
+        index_name.clone(),
         VECTOR_FIELD.to_string(),
     )
     .await
@@ -468,15 +529,17 @@ async fn test_threshold_filtering() {
         assert!(score >= &0.5, "All results should meet threshold");
     }
 
-    cleanup_redis_index(&redis_client, index_name)
+    cleanup_redis_index(&redis_client, &index_name)
         .await
         .unwrap();
 }
 
 #[tokio::test]
 async fn test_insert_multiple_embeddings() {
-    let (host, port, _container) = get_redis_connection().await;
-    let index_name = "test_insert_multiple_embeddings";
+    let Some(redis) = get_redis_connection().await else {
+        return;
+    };
+    let index_name = unique_index_name("test_insert_multiple_embeddings");
 
     let server = httpmock::MockServer::start();
 
@@ -511,17 +574,16 @@ async fn test_insert_multiple_embeddings() {
 
     let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_ADA_002);
 
-    let redis_url = format!("redis://{host}:{port}");
-    let redis_client = redis::Client::open(redis_url).unwrap();
+    let redis_client = redis.client;
 
-    setup_redis_index(&redis_client, index_name, 1536)
+    setup_redis_index(&redis_client, &index_name, 1536)
         .await
         .unwrap();
 
     let vector_store = RedisVectorStore::new(
         model.clone(),
         redis_client.clone(),
-        index_name.to_string(),
+        index_name.clone(),
         VECTOR_FIELD.to_string(),
     )
     .await
@@ -560,7 +622,7 @@ async fn test_insert_multiple_embeddings() {
         .await
         .unwrap();
     let keys: Vec<String> = redis::cmd("KEYS")
-        .arg("*")
+        .arg(format!("{index_name}:*"))
         .query_async(&mut con)
         .await
         .unwrap();
@@ -568,15 +630,17 @@ async fn test_insert_multiple_embeddings() {
     // Should have at least 3 documents (one per embedding)
     assert!(keys.len() >= 3, "Should have inserted at least 3 documents");
 
-    cleanup_redis_index(&redis_client, index_name)
+    cleanup_redis_index(&redis_client, &index_name)
         .await
         .unwrap();
 }
 
 #[tokio::test]
 async fn test_empty_results() {
-    let (host, port, _container) = get_redis_connection().await;
-    let index_name = "test_empty_results";
+    let Some(redis) = get_redis_connection().await else {
+        return;
+    };
+    let index_name = unique_index_name("test_empty_results");
 
     let server = httpmock::MockServer::start();
 
@@ -605,17 +669,16 @@ async fn test_empty_results() {
 
     let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_ADA_002);
 
-    let redis_url = format!("redis://{host}:{port}");
-    let redis_client = redis::Client::open(redis_url).unwrap();
+    let redis_client = redis.client;
 
-    setup_redis_index(&redis_client, index_name, 1536)
+    setup_redis_index(&redis_client, &index_name, 1536)
         .await
         .unwrap();
 
     let vector_store = RedisVectorStore::new(
         model.clone(),
         redis_client.clone(),
-        index_name.to_string(),
+        index_name.clone(),
         VECTOR_FIELD.to_string(),
     )
     .await
@@ -631,7 +694,7 @@ async fn test_empty_results() {
 
     assert_eq!(results.len(), 0);
 
-    cleanup_redis_index(&redis_client, index_name)
+    cleanup_redis_index(&redis_client, &index_name)
         .await
         .unwrap();
 }


### PR DESCRIPTION
## Summary
- escape RediSearch field names, tag values, and text query syntax in Redis filters
- reject non-numeric core range filters during Redis filter conversion
- always pass the requested sample count to FT.SEARCH with LIMIT
- make Redis integration tests safer with explicit REDIS_URL opt-in, RediSearch probing, randomized index names, and graceful skip behavior
- update Redis docs and examples for async construction, key prefixes, and filtering limitations

## Testing
- cargo check -p rig-redis
- cargo test -p rig-redis --test filter_tests
- cargo test -p rig-redis --test integration_tests
- cargo test -p rig-redis
- cargo fmt
- git diff --check