### PR TITLE
fix(rig-redis): address review comments from #1509 and harden edge cases

### DIFF
--- a/crates/rig-redis/README.md
+++ b/crates/rig-redis/README.md
@@ -6,9 +6,16 @@ Vector store index integration for [Redis](https://redis.io/) using RediSearch v
 
 - Vector similarity search using Redis's RediSearch module
 - Support for KNN (k-nearest neighbors) queries
-- Metadata filtering with Redis query syntax
 - Document insertion with automatic embedding storage
 - Compatible with Redis 7.2+ or Redis Stack
+
+## Filtering
+
+Filters apply to fields that exist in your RediSearch index schema **and** are
+present in the stored hash keys. The `InsertDocuments` implementation only writes
+`document`, `embedded_text`, and the vector field. If you need filterable metadata
+fields, write them to the hash separately or use a custom insertion approach that
+includes the filterable fields in the hash.
 
 ## Prerequisites
 
@@ -38,25 +45,28 @@ Replace `1536` with your embedding model's dimensionality.
 
 ## Usage Example
 
-```rust
+```rust,no_run
 use rig::providers::openai;
 use rig::vector_store::{InsertDocuments, VectorStoreIndex};
 use rig_redis::RedisVectorStore;
 
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
 // Create embedding model
-let openai_client = openai::Client::from_env();
+let openai_client = openai::Client::from_env()?;
 let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_3_SMALL);
 
 // Create Redis client
 let redis_client = redis::Client::open("redis://127.0.0.1:6379")?;
 
-// Create vector store
+// Create vector store — key prefix must match the index PREFIX configuration
 let vector_store = RedisVectorStore::new(
     model,
     redis_client,
     "word_idx".to_string(),      // index name
     "embedding".to_string(),      // vector field name
-);
+)
+.await?
+.with_key_prefix("doc:".to_string());
 
 // Insert documents
 vector_store.insert_documents(documents).await?;
@@ -67,12 +77,14 @@ let results = vector_store
         VectorSearchRequest::builder()
             .query("your search query")
             .samples(5)
-            .build()?
+            .build()
     )
     .await?;
+# Ok(())
+# }
 ```
 
-You can find complete examples [here](https://github.com/0xPlaygrounds/rig/tree/main/rig-integrations/rig-redis/examples).
+You can find complete examples [here](https://github.com/0xPlaygrounds/rig/tree/main/crates/rig-redis/examples).
 
 ## Distance Metrics
 
@@ -88,12 +100,13 @@ Choose the metric that matches your embedding model when creating the index.
 - Requires pre-created RediSearch index
 - Vector dimensionality must match the index definition
 - Embeddings are stored as FLOAT32 (converted from FLOAT64)
+- `InsertDocuments` stores only the serialized document, embedded text, and vector — additional metadata fields for filtering must be written separately
 
 ## Testing
 
 ### Prerequisites
 
-Integration tests require Docker to be running, as they use testcontainers to spin up a Redis Stack instance.
+Integration tests require Docker (or Podman) to be running, as they use testcontainers to spin up a Redis Stack instance.
 
 ### Running Tests
 
@@ -104,8 +117,8 @@ cargo test
 # Run only unit tests
 cargo test --lib
 
-# Run only integration tests
-cargo test --test integration_tests
+# Run only integration tests (requires Docker/Podman)
+cargo test --test integration_tests -- --ignored
 
 # Or use the Makefile
 make test              # All tests
@@ -124,7 +137,7 @@ make redis-local
 docker run -d --name redis-stack -p 6379:6379 redis/redis-stack:latest
 
 # Create a test index
-redis-cli FT.CREATE word_idx ON HASH SCHEMA document TEXT embedded_text TEXT embedding VECTOR FLAT 6 TYPE FLOAT32 DIM 1536 DISTANCE_METRIC COSINE
+redis-cli FT.CREATE word_idx ON HASH PREFIX 1 doc: SCHEMA document TEXT embedded_text TEXT embedding VECTOR FLAT 6 TYPE FLOAT32 DIM 1536 DISTANCE_METRIC COSINE
 
 # Run the example
 make run-example

--- a/crates/rig-redis/README.md
+++ b/crates/rig-redis/README.md
@@ -9,13 +9,43 @@ Vector store index integration for [Redis](https://redis.io/) using RediSearch v
 - Document insertion with automatic embedding storage
 - Compatible with Redis 7.2+ or Redis Stack
 
-## Filtering
+## Metadata Filtering
 
-Filters apply to fields that exist in your RediSearch index schema **and** are
-present in the stored hash keys. The `InsertDocuments` implementation only writes
-`document`, `embedded_text`, and the vector field. If you need filterable metadata
-fields, write them to the hash separately or use a custom insertion approach that
-includes the filterable fields in the hash.
+To filter search results by document fields, configure metadata fields when
+creating the store. These fields are extracted from the serialized document JSON
+during insertion and written as separate hash fields that RediSearch can index.
+
+Your RediSearch index schema must declare these fields (TAG, NUMERIC, TEXT) in
+addition to the core fields (`document`, `embedded_text`, vector field).
+
+```bash
+FT.CREATE products_idx
+  ON HASH
+  PREFIX 1 prod:
+  SCHEMA
+    document TEXT
+    embedded_text TEXT
+    embedding VECTOR FLAT 6 TYPE FLOAT32 DIM 1536 DISTANCE_METRIC COSINE
+    category TAG
+    price NUMERIC
+```
+
+```rust,no_run
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let store = RedisVectorStore::new(model, client, "products_idx".into(), "embedding".into())
+    .await?
+    .with_key_prefix("prod:".to_string())
+    .with_metadata_fields(vec!["category".to_string(), "price".to_string()]);
+
+// Documents with `category` and `price` fields will have those written
+// as hash fields, enabling filter queries like:
+// @category:{Electronics} or @price:[50 100]
+# Ok(())
+# }
+```
+
+Fields that are missing from a document or have null/array/object values are
+silently skipped.
 
 ## Prerequisites
 
@@ -100,7 +130,7 @@ Choose the metric that matches your embedding model when creating the index.
 - Requires pre-created RediSearch index
 - Vector dimensionality must match the index definition
 - Embeddings are stored as FLOAT32 (converted from FLOAT64)
-- `InsertDocuments` stores only the serialized document, embedded text, and vector — additional metadata fields for filtering must be written separately
+- Metadata filtering requires configuring `with_metadata_fields` during store creation; only top-level scalar fields (string/number/bool) are extracted
 
 ## Testing
 

--- a/crates/rig-redis/examples/vector_search_redis.rs
+++ b/crates/rig-redis/examples/vector_search_redis.rs
@@ -1,80 +1,174 @@
-use rig_core::client::ProviderClient;
-use rig_core::vector_store::InsertDocuments;
-use rig_core::vector_store::request::VectorSearchRequest;
+// Redis vector store example demonstrating:
+// - Basic vector similarity search
+// - Metadata field extraction and filtered search
+// - Document round-tripping
+//
+// Prerequisites:
+//   export OPENAI_API_KEY=<your-key>
+//   docker run -d --name redis-stack -p 6379:6379 redis/redis-stack:latest
+//   redis-cli FT.CREATE products_idx ON HASH PREFIX 1 "prod:" SCHEMA \
+//     document TEXT embedded_text TEXT embedding VECTOR FLAT 6 \
+//     TYPE FLOAT32 DIM 1536 DISTANCE_METRIC COSINE \
+//     category TAG price NUMERIC
+//
+// Run:
+//   cargo run --example vector_search_redis --features rig-core/derive
+
+use rig_core::vector_store::request::SearchFilter;
 use rig_core::{
-    Embed, client::EmbeddingsClient, embeddings::EmbeddingsBuilder, vector_store::VectorStoreIndex,
+    Embed,
+    client::{EmbeddingsClient, ProviderClient},
+    embeddings::EmbeddingsBuilder,
+    providers::openai,
+    vector_store::{InsertDocuments, VectorStoreIndex, request::VectorSearchRequest},
 };
+use rig_redis::{Filter, RedisVectorStore, filter::RedisValue};
 use serde::{Deserialize, Serialize};
 
-#[derive(Embed, Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Default)]
-struct WordDefinition {
-    word: String,
-    #[serde(skip)]
+#[derive(Embed, Serialize, Deserialize, Clone, Debug)]
+struct Product {
+    name: String,
+    category: String,
+    price: f64,
     #[embed]
-    definition: String,
-}
-
-impl std::fmt::Display for WordDefinition {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.word)
-    }
+    description: String,
 }
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    let openai_client = rig_core::providers::openai::Client::from_env()?;
-    let model = openai_client.embedding_model(rig_core::providers::openai::TEXT_EMBEDDING_3_SMALL);
+    let openai_client = openai::Client::from_env()?;
+    let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_3_SMALL);
 
     let redis_url =
         std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
     let redis_client = redis::Client::open(redis_url)?;
 
     // Key prefix must match the index PREFIX configuration.
-    // If your index was created with: FT.CREATE word_idx ON HASH PREFIX 1 doc: ...
-    // then use "doc:" as the key prefix.
-    let vector_store = rig_redis::RedisVectorStore::new(
+    // Metadata fields must match the index SCHEMA (category TAG, price NUMERIC).
+    let vector_store = RedisVectorStore::new(
         model.clone(),
         redis_client,
-        "word_idx".to_string(),
+        "products_idx".to_string(),
         "embedding".to_string(),
     )
     .await?
-    .with_key_prefix("doc:".to_string());
+    .with_key_prefix("prod:".to_string())
+    .with_metadata_fields(vec!["category".to_string(), "price".to_string()]);
 
-    let words = vec![
-        WordDefinition {
-            word: "flurbo".to_string(),
-            definition: "1. *flurbo* (name): A fictional digital currency that originated in the animated series Rick and Morty.".to_string()
+    // --- Insert documents ---
+    let products = vec![
+        Product {
+            name: "Gaming Laptop".to_string(),
+            category: "Electronics".to_string(),
+            price: 1500.0,
+            description: "High-performance gaming laptop with RTX 4080 GPU and 32GB RAM"
+                .to_string(),
         },
-        WordDefinition {
-            word: "glarb-glarb".to_string(),
-            definition: "1. *glarb-glarb* (noun): A fictional creature found in the distant, swampy marshlands of the planet Glibbo in the Andromeda galaxy.".to_string()
+        Product {
+            name: "Wool Sweater".to_string(),
+            category: "Clothing".to_string(),
+            price: 75.0,
+            description: "Warm merino wool sweater, perfect for cold winter days".to_string(),
         },
-        WordDefinition {
-            word: "linglingdong".to_string(),
-            definition: "1. *linglingdong* (noun): A term used by inhabitants of the far side of the moon to describe humans.".to_string(),
-        }
+        Product {
+            name: "Mechanical Keyboard".to_string(),
+            category: "Electronics".to_string(),
+            price: 45.0,
+            description: "Compact 65% mechanical keyboard with Cherry MX switches".to_string(),
+        },
+        Product {
+            name: "Running Shoes".to_string(),
+            category: "Clothing".to_string(),
+            price: 120.0,
+            description: "Lightweight running shoes with responsive cushioning for road running"
+                .to_string(),
+        },
     ];
 
     let documents = EmbeddingsBuilder::new(model.clone())
-        .documents(words)?
+        .documents(products)?
         .build()
         .await?;
 
     vector_store.insert_documents(documents).await?;
+    println!("Inserted 4 products\n");
 
-    let query = "What does \"glarb-glarb\" mean?";
-
+    // --- Basic vector search (no filter) ---
+    let query = "computer peripherals";
     let req = VectorSearchRequest::builder()
         .query(query)
         .samples(2)
         .build();
 
-    let results = vector_store.top_n::<WordDefinition>(req).await?;
+    let results = vector_store.top_n::<Product>(req).await?;
 
-    println!("#{} results for query: {}", results.len(), query);
-    for (score, _id, doc) in results.iter() {
-        println!("Result score {score} for word: {doc}");
+    println!("=== Basic search: \"{query}\" (top 2) ===");
+    for (score, id, doc) in &results {
+        println!(
+            "  [{score:.4}] {id} -> {} (${}, {})",
+            doc.name, doc.price, doc.category
+        );
+    }
+    println!();
+
+    // --- Filtered search: only Electronics ---
+    let query = "something for gaming";
+    let filter = Filter::eq("category", RedisValue::String("Electronics".to_string()));
+    let req = VectorSearchRequest::builder()
+        .query(query)
+        .samples(4)
+        .filter(filter)
+        .build();
+
+    let results = vector_store.top_n::<Product>(req).await?;
+
+    println!("=== Filtered search: \"{query}\" (category=Electronics) ===");
+    for (score, id, doc) in &results {
+        println!(
+            "  [{score:.4}] {id} -> {} (${}, {})",
+            doc.name, doc.price, doc.category
+        );
+    }
+    println!();
+
+    // --- Filtered search: price under $100 ---
+    let query = "affordable gear";
+    let filter = Filter::lt("price", RedisValue::Number(100.0));
+    let req = VectorSearchRequest::builder()
+        .query(query)
+        .samples(4)
+        .filter(filter)
+        .build();
+
+    let results = vector_store.top_n::<Product>(req).await?;
+
+    println!("=== Filtered search: \"{query}\" (price < 100) ===");
+    for (score, id, doc) in &results {
+        println!(
+            "  [{score:.4}] {id} -> {} (${}, {})",
+            doc.name, doc.price, doc.category
+        );
+    }
+    println!();
+
+    // --- Combined filter: Electronics AND price > 100 ---
+    let query = "premium tech";
+    let filter = Filter::eq("category", RedisValue::String("Electronics".to_string()))
+        .and(Filter::gt("price", RedisValue::Number(100.0)));
+    let req = VectorSearchRequest::builder()
+        .query(query)
+        .samples(4)
+        .filter(filter)
+        .build();
+
+    let results = vector_store.top_n::<Product>(req).await?;
+
+    println!("=== Combined filter: \"{query}\" (Electronics AND price > 100) ===");
+    for (score, id, doc) in &results {
+        println!(
+            "  [{score:.4}] {id} -> {} (${}, {})",
+            doc.name, doc.price, doc.category
+        );
     }
 
     Ok(())

--- a/crates/rig-redis/examples/vector_search_redis.rs
+++ b/crates/rig-redis/examples/vector_search_redis.rs
@@ -29,13 +29,17 @@ async fn main() -> Result<(), anyhow::Error> {
         std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
     let redis_client = redis::Client::open(redis_url)?;
 
+    // Key prefix must match the index PREFIX configuration.
+    // If your index was created with: FT.CREATE word_idx ON HASH PREFIX 1 doc: ...
+    // then use "doc:" as the key prefix.
     let vector_store = rig_redis::RedisVectorStore::new(
         model.clone(),
         redis_client,
         "word_idx".to_string(),
         "embedding".to_string(),
     )
-    .await?;
+    .await?
+    .with_key_prefix("doc:".to_string());
 
     let words = vec![
         WordDefinition {

--- a/crates/rig-redis/src/filter.rs
+++ b/crates/rig-redis/src/filter.rs
@@ -10,9 +10,83 @@
 //! - **Bool fields**: Treated as numeric TAG (1/0) with tag syntax
 //!
 //! Ensure your RediSearch schema matches the filter types you use.
+//!
+//! # Filtering Limitations
+//!
+//! Filters apply to fields that exist in your RediSearch index schema and are
+//! present in the stored hash keys. Documents inserted via [`InsertDocuments`](crate::RedisVectorStore)
+//! only store `document`, `embedded_text`, and the vector field. To use filters,
+//! you must either write additional hash fields out-of-band or use a custom
+//! insertion approach that includes the filterable fields in the hash.
+//!
+//! # Escaping
+//!
+//! Tag values are automatically escaped for RediSearch special characters.
+//! See [`escape_tag_value`] for the list of escaped characters.
 
 use rig_core::vector_store::request::{Filter as CoreFilter, FilterError, SearchFilter};
 use serde::{Deserialize, Serialize};
+
+/// Characters that must be escaped with a backslash in RediSearch tag queries.
+///
+/// Per the [Redis documentation](https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/tags/),
+/// these characters have special meaning in tag query syntax:
+/// - `'` (single quote)
+/// - `-` (hyphen / negation)
+/// - `(`, `)` (parentheses / grouping)
+/// - `[`, `]`, `{`, `}` (brackets / range/tag delimiters)
+/// - `|` (pipe / OR operator)
+/// - `@` (field prefix)
+/// - `\\` (backslash / escape character itself)
+const TAG_ESCAPE_CHARS: &[char] = &['\'', '-', '(', ')', '[', ']', '{', '}', '|', '@', '\\'];
+
+/// Escapes special characters in a value for use in RediSearch tag queries.
+///
+/// Prepends a backslash to characters that have special meaning in RediSearch
+/// tag syntax to prevent query injection or parse failures.
+///
+/// # Example
+/// ```
+/// use rig_redis::filter::escape_tag_value;
+///
+/// assert_eq!(escape_tag_value("hello-world"), r"hello\-world");
+/// assert_eq!(escape_tag_value("it's"), r"it\'s");
+/// assert_eq!(escape_tag_value("foo|bar"), r"foo\|bar");
+/// ```
+pub fn escape_tag_value(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        if TAG_ESCAPE_CHARS.contains(&ch) {
+            escaped.push('\\');
+        }
+        escaped.push(ch);
+    }
+    escaped
+}
+
+/// Characters that must be escaped with a backslash in RediSearch text field queries.
+///
+/// Per the [Redis tokenization documentation](https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/escaping/),
+/// these punctuation marks are token separators in TEXT fields:
+/// `,.<>{}[]"':;!@#$%^&*()-+=~`
+const TEXT_ESCAPE_CHARS: &[char] = &[
+    ',', '.', '<', '>', '{', '}', '[', ']', '"', '\'', ':', ';', '!', '@', '#', '$', '%', '^', '&',
+    '*', '(', ')', '-', '+', '=', '~', '|', '\\',
+];
+
+/// Escapes special characters in a value for use in RediSearch TEXT field queries.
+///
+/// Prepends a backslash to token-separator characters.
+pub fn escape_text_value(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        if TEXT_ESCAPE_CHARS.contains(&ch) {
+            escaped.push('\\');
+        }
+        escaped.push(ch);
+    }
+    escaped
+}
 
 /// Typed value for Redis filter expressions.
 ///
@@ -29,10 +103,12 @@ pub enum RedisValue {
 
 impl RedisValue {
     /// Formats value for tag-style filters (`@field:{value}` or `@field:{1}`).
+    ///
+    /// Values are escaped for RediSearch special characters.
     fn to_tag_expr(&self) -> String {
         match self {
             RedisValue::Number(n) => n.to_string(),
-            RedisValue::String(s) => s.clone(),
+            RedisValue::String(s) => escape_tag_value(s),
             RedisValue::Bool(b) => {
                 if *b {
                     "1".to_string()
@@ -41,6 +117,11 @@ impl RedisValue {
                 }
             }
         }
+    }
+
+    /// Returns `true` if this value is numeric.
+    fn is_numeric(&self) -> bool {
+        matches!(self, RedisValue::Number(_))
     }
 }
 
@@ -117,12 +198,14 @@ impl SearchFilter for Filter {
     /// Equality filter.
     ///
     /// - Numeric: `@field:[val val]` (exact range match)
-    /// - String: `@field:{value}` (tag match)
+    /// - String: `@field:{value}` (tag match, value is escaped)
     /// - Bool: `@field:{1}` or `@field:{0}` (tag match)
     fn eq(key: impl AsRef<str>, value: Self::Value) -> Self {
         match value {
             RedisValue::Number(n) => Self(format!("@{}:[{} {}]", key.as_ref(), n, n)),
-            RedisValue::String(ref s) => Self(format!("@{}:{{{}}}", key.as_ref(), s)),
+            RedisValue::String(ref s) => {
+                Self(format!("@{}:{{{}}}", key.as_ref(), escape_tag_value(s)))
+            }
             RedisValue::Bool(b) => {
                 let v = if b { "1" } else { "0" };
                 Self(format!("@{}:{{{}}}", key.as_ref(), v))
@@ -132,8 +215,20 @@ impl SearchFilter for Filter {
 
     /// Greater-than filter (exclusive).
     ///
-    /// Numeric: `@field:[(val +inf]`. Non-numeric falls back to tag syntax.
+    /// Numeric: `@field:[(val +inf]`.
+    ///
+    /// Non-numeric values are not meaningful for range comparisons and will
+    /// produce a tag-equality filter with a warning log. Prefer using [`Filter::eq`]
+    /// for non-numeric values.
     fn gt(key: impl AsRef<str>, value: Self::Value) -> Self {
+        if !value.is_numeric() {
+            tracing::warn!(
+                target: "rig",
+                field = %key.as_ref(),
+                "gt() called with non-numeric value; falling back to tag-equality semantics. \
+                 Use eq() for string/bool comparisons."
+            );
+        }
         match value {
             RedisValue::Number(n) => Self(format!("@{}:[({} +inf]", key.as_ref(), n)),
             _ => Self(format!("@{}:{{{}}}", key.as_ref(), value.to_tag_expr())),
@@ -142,8 +237,20 @@ impl SearchFilter for Filter {
 
     /// Less-than filter (exclusive).
     ///
-    /// Numeric: `@field:[-inf (val]`. Non-numeric falls back to tag syntax.
+    /// Numeric: `@field:[-inf (val]`.
+    ///
+    /// Non-numeric values are not meaningful for range comparisons and will
+    /// produce a tag-equality filter with a warning log. Prefer using [`Filter::eq`]
+    /// for non-numeric values.
     fn lt(key: impl AsRef<str>, value: Self::Value) -> Self {
+        if !value.is_numeric() {
+            tracing::warn!(
+                target: "rig",
+                field = %key.as_ref(),
+                "lt() called with non-numeric value; falling back to tag-equality semantics. \
+                 Use eq() for string/bool comparisons."
+            );
+        }
         match value {
             RedisValue::Number(n) => Self(format!("@{}:[-inf ({}]", key.as_ref(), n)),
             _ => Self(format!("@{}:{{{}}}", key.as_ref(), value.to_tag_expr())),
@@ -169,7 +276,16 @@ impl Filter {
     /// Greater than or equal (inclusive).
     ///
     /// Numeric: `@field:[val +inf]`.
+    ///
+    /// Non-numeric values produce a tag-equality filter with a warning.
     pub fn gte(key: impl AsRef<str>, value: <Self as SearchFilter>::Value) -> Self {
+        if !value.is_numeric() {
+            tracing::warn!(
+                target: "rig",
+                field = %key.as_ref(),
+                "gte() called with non-numeric value; falling back to tag-equality semantics."
+            );
+        }
         match value {
             RedisValue::Number(n) => Self(format!("@{}:[{} +inf]", key.as_ref(), n)),
             _ => Self(format!("@{}:{{{}}}", key.as_ref(), value.to_tag_expr())),
@@ -179,7 +295,16 @@ impl Filter {
     /// Less than or equal (inclusive).
     ///
     /// Numeric: `@field:[-inf val]`.
+    ///
+    /// Non-numeric values produce a tag-equality filter with a warning.
     pub fn lte(key: impl AsRef<str>, value: <Self as SearchFilter>::Value) -> Self {
+        if !value.is_numeric() {
+            tracing::warn!(
+                target: "rig",
+                field = %key.as_ref(),
+                "lte() called with non-numeric value; falling back to tag-equality semantics."
+            );
+        }
         match value {
             RedisValue::Number(n) => Self(format!("@{}:[-inf {}]", key.as_ref(), n)),
             _ => Self(format!("@{}:{{{}}}", key.as_ref(), value.to_tag_expr())),
@@ -198,15 +323,32 @@ impl Filter {
 
     /// Tag filter for multiple values (OR).
     ///
-    /// Produces `@field:{val1 | val2 | val3}`.
+    /// Produces `@field:{val1 | val2 | val3}`. Values are escaped for special characters.
     pub fn tag_in(key: impl AsRef<str>, values: Vec<String>) -> Self {
-        let tags = values.join(" | ");
+        let tags = values
+            .iter()
+            .map(|v| escape_tag_value(v))
+            .collect::<Vec<_>>()
+            .join(" | ");
         Self(format!("@{}:{{{}}}", key.as_ref(), tags))
     }
 
     /// Full-text search within a TEXT field.
+    ///
+    /// The text value is escaped for RediSearch text-field special characters.
     pub fn text_contains(key: impl AsRef<str>, text: impl AsRef<str>) -> Self {
-        Self(format!("@{}:{}", key.as_ref(), text.as_ref()))
+        Self(format!(
+            "@{}:{}",
+            key.as_ref(),
+            escape_text_value(text.as_ref())
+        ))
+    }
+
+    /// Creates a filter from a raw RediSearch query string.
+    ///
+    /// No escaping is applied — the caller is responsible for correct syntax.
+    pub fn raw(query: impl Into<String>) -> Self {
+        Self(query.into())
     }
 
     /// Consumes the filter and returns the raw RediSearch query string.

--- a/crates/rig-redis/src/filter.rs
+++ b/crates/rig-redis/src/filter.rs
@@ -14,10 +14,10 @@
 //! # Filtering Limitations
 //!
 //! Filters apply to fields that exist in your RediSearch index schema and are
-//! present in the stored hash keys. Documents inserted via [`InsertDocuments`](crate::RedisVectorStore)
-//! only store `document`, `embedded_text`, and the vector field. To use filters,
-//! you must either write additional hash fields out-of-band or use a custom
-//! insertion approach that includes the filterable fields in the hash.
+//! present in the stored hash keys. Configure [`RedisVectorStore::with_metadata_fields`](crate::RedisVectorStore::with_metadata_fields)
+//! to have metadata fields automatically extracted from documents during insertion.
+//! Only top-level scalar values (string, number, bool) are supported; null, array,
+//! and object values are silently skipped.
 //!
 //! # Escaping
 //!

--- a/crates/rig-redis/src/filter.rs
+++ b/crates/rig-redis/src/filter.rs
@@ -11,13 +11,28 @@
 //!
 //! Ensure your RediSearch schema matches the filter types you use.
 //!
-//! # Filtering Limitations
+//! # Field Names
+//!
+//! Filter field names (the `key` argument) must be valid RediSearch identifiers
+//! matching the fields declared in your index schema. RediSearch field names
+//! are alphanumeric with underscores (`[a-zA-Z_][a-zA-Z0-9_]*`).
+//!
+//! # Filtering with Metadata
 //!
 //! Filters apply to fields that exist in your RediSearch index schema and are
 //! present in the stored hash keys. Configure [`RedisVectorStore::with_metadata_fields`](crate::RedisVectorStore::with_metadata_fields)
 //! to have metadata fields automatically extracted from documents during insertion.
 //! Only top-level scalar values (string, number, bool) are supported; null, array,
 //! and object values are silently skipped.
+//!
+//! # Dynamic API Subset
+//!
+//! The [`VectorStoreIndexDyn`](rig_core::vector_store::VectorStoreIndexDyn) path
+//! only supports the five [`CoreFilter`](rig_core::vector_store::request::Filter)
+//! variants: `Eq`, `Gt`, `Lt`, `And`, `Or`. Redis-specific methods like
+//! [`Filter::gte`], [`Filter::lte`], [`Filter::range`], [`Filter::tag_in`],
+//! [`Filter::text_contains`], and [`Filter::text_phrase`] are only accessible
+//! through the typed [`VectorStoreIndex`](rig_core::vector_store::VectorStoreIndex) API.
 //!
 //! # Escaping
 //!
@@ -131,6 +146,10 @@ impl From<i64> for RedisValue {
     }
 }
 
+/// Converts a `u64` to [`RedisValue::Number`].
+///
+/// Note: values above 2⁵³ (9,007,199,254,740,992) will lose precision
+/// due to the `f64` representation.
 impl From<u64> for RedisValue {
     fn from(value: u64) -> Self {
         Self::Number(value as f64)
@@ -324,7 +343,13 @@ impl Filter {
     /// Tag filter for multiple values (OR).
     ///
     /// Produces `@field:{val1 | val2 | val3}`. Values are escaped for special characters.
+    ///
+    /// If `values` is empty, returns a match-all filter (`*`) to avoid producing
+    /// invalid RediSearch syntax.
     pub fn tag_in(key: impl AsRef<str>, values: Vec<String>) -> Self {
+        if values.is_empty() {
+            return Self::raw("*");
+        }
         let tags = values
             .iter()
             .map(|v| escape_tag_value(v))
@@ -333,9 +358,15 @@ impl Filter {
         Self(format!("@{}:{{{}}}", key.as_ref(), tags))
     }
 
-    /// Full-text search within a TEXT field.
+    /// Full-text token search within a TEXT field.
+    ///
+    /// Performs a token-AND search: all words in `text` must appear in the field,
+    /// but they can appear in any order and at any position. This is **not** a
+    /// phrase search.
     ///
     /// The text value is escaped for RediSearch text-field special characters.
+    ///
+    /// Use [`Filter::text_phrase`] for exact phrase matching (word order preserved).
     pub fn text_contains(key: impl AsRef<str>, text: impl AsRef<str>) -> Self {
         Self(format!(
             "@{}:{}",
@@ -344,9 +375,31 @@ impl Filter {
         ))
     }
 
+    /// Exact phrase search within a TEXT field.
+    ///
+    /// Matches the exact sequence of words in `phrase` (order matters).
+    /// Produces `@field:"phrase"` syntax.
+    ///
+    /// The phrase value is escaped for RediSearch text-field special characters
+    /// (except the wrapping quotes).
+    pub fn text_phrase(key: impl AsRef<str>, phrase: impl AsRef<str>) -> Self {
+        Self(format!(
+            "@{}:\"{}\"",
+            key.as_ref(),
+            escape_text_value(phrase.as_ref())
+        ))
+    }
+
     /// Creates a filter from a raw RediSearch query string.
     ///
     /// No escaping is applied — the caller is responsible for correct syntax.
+    ///
+    /// # Security Warning
+    ///
+    /// Do **not** pass unsanitized user input to this method. Arbitrary RediSearch
+    /// query clauses can be injected, potentially returning unintended results or
+    /// causing query parse errors. Use the typed filter methods (e.g., [`Filter::eq`],
+    /// [`Filter::tag_in`]) for values that originate from user input.
     pub fn raw(query: impl Into<String>) -> Self {
         Self(query.into())
     }

--- a/crates/rig-redis/src/lib.rs
+++ b/crates/rig-redis/src/lib.rs
@@ -233,18 +233,39 @@ where
     }
 
     /// Parses FT.SEARCH response into results with deserialized documents.
+    ///
+    /// Documents with empty or unparseable JSON are skipped with a warning rather
+    /// than aborting the entire result set.
     fn parse_search_response<T>(
         response: redis::Value,
     ) -> Result<Vec<(f64, String, T)>, VectorStoreError>
     where
         T: for<'a> Deserialize<'a>,
     {
-        Self::parse_response_generic(response, true).and_then(|items| {
+        Self::parse_response_generic(response, true).map(|items| {
             items
                 .into_iter()
-                .map(|(score, id, doc_json)| {
-                    let doc = serde_json::from_str::<T>(&doc_json)?;
-                    Ok((score, id, doc))
+                .filter_map(|(score, id, doc_json)| {
+                    if doc_json.is_empty() {
+                        tracing::warn!(
+                            target: "rig",
+                            id = %id,
+                            "Document field missing or empty in hash, skipping"
+                        );
+                        return None;
+                    }
+                    match serde_json::from_str::<T>(&doc_json) {
+                        Ok(doc) => Some((score, id, doc)),
+                        Err(e) => {
+                            tracing::warn!(
+                                target: "rig",
+                                id = %id,
+                                error = %e,
+                                "Failed to deserialize document, skipping"
+                            );
+                            None
+                        }
+                    }
                 })
                 .collect()
         })
@@ -303,6 +324,7 @@ where
                     };
 
                     let mut score = 0.0;
+                    let mut score_found = false;
                     let mut document_json = String::new();
 
                     let mut field_iter = fields_val.chunks(2);
@@ -314,6 +336,7 @@ where
 
                         if field_name == "__vector_score" {
                             score = Self::extract_score(value_val)?;
+                            score_found = true;
                         } else if include_document && field_name == "document" {
                             match Self::extract_string(value_val) {
                                 Some(json) => document_json = json,
@@ -326,6 +349,14 @@ where
                                 }
                             }
                         }
+                    }
+
+                    if !score_found {
+                        tracing::warn!(
+                            target: "rig",
+                            id = %id,
+                            "__vector_score field missing from search result, defaulting to 0.0"
+                        );
                     }
 
                     results.push((score, id, document_json));
@@ -409,6 +440,13 @@ impl<Model> InsertDocuments for RedisVectorStore<Model>
 where
     Model: EmbeddingModel + Send + Sync,
 {
+    /// Inserts documents with their precomputed embeddings into Redis.
+    ///
+    /// Each embedding in [`OneOrMany<Embedding>`] produces a separate Redis hash
+    /// keyed by `{prefix}{uuid}`. All hashes for a given document share the same
+    /// serialized JSON in the `document` field but have distinct `embedded_text`
+    /// values (one per embedding). This means a single logical document may produce
+    /// multiple hash entries if it has multiple embeddings.
     async fn insert_documents<Doc: Serialize + Embed + Send>(
         &self,
         documents: Vec<(Doc, OneOrMany<Embedding>)>,

--- a/crates/rig-redis/src/lib.rs
+++ b/crates/rig-redis/src/lib.rs
@@ -10,6 +10,7 @@
 //! - A `document` field of type TEXT (stores serialized JSON)
 //! - An `embedded_text` field of type TEXT (stores the source text)
 //! - A vector field (configurable name) of type VECTOR with FLOAT32 elements
+//! - Optionally, additional fields for metadata filtering (TAG, NUMERIC, etc.)
 //!
 //! # Distance Metric
 //!
@@ -18,13 +19,15 @@
 //! to cosine similarity (1 = identical, -1 = opposite) via `1.0 - distance`.
 //! Using a different distance metric (L2, IP) will produce incorrect similarity scores.
 //!
-//! # Filtering
+//! # Metadata Filtering
 //!
-//! Filters apply to fields that exist in your RediSearch index schema **and** are
-//! present in the stored hash keys. The [`InsertDocuments`] implementation only
-//! writes `document`, `embedded_text`, and the vector field. If you need filterable
-//! metadata fields, write them to the hash separately or use a custom insertion
-//! approach. See [`filter`] module documentation for details.
+//! To enable filtering on document fields during search, configure metadata fields
+//! via [`RedisVectorStore::with_metadata_fields`]. These fields are extracted from
+//! the serialized document JSON during insertion and written as separate hash fields,
+//! making them available for RediSearch filter queries.
+//!
+//! Your RediSearch index schema must declare these fields with appropriate types
+//! (TAG, NUMERIC, TEXT) for filters to work.
 //!
 //! # Example
 //! ```ignore
@@ -36,7 +39,9 @@
 //!     "my_index".into(),
 //!     "embedding".into(),
 //! )
-//! .await?;
+//! .await?
+//! .with_key_prefix("doc:".to_string())
+//! .with_metadata_fields(vec!["category".to_string(), "price".to_string()]);
 //! ```
 
 pub mod filter;
@@ -64,6 +69,12 @@ use serde::{Deserialize, Serialize};
 /// If your RediSearch index uses a `PREFIX` configuration (e.g., `PREFIX 1 doc:`),
 /// you **must** call [`RedisVectorStore::with_key_prefix`] with the matching prefix
 /// so that inserted documents are discoverable by the index.
+///
+/// # Metadata Fields
+///
+/// Configure metadata fields via [`RedisVectorStore::with_metadata_fields`] to enable
+/// filtering. During insertion, these fields are extracted from the serialized document
+/// and stored as separate hash fields that RediSearch can index and filter on.
 pub struct RedisVectorStore<M>
 where
     M: EmbeddingModel,
@@ -73,6 +84,7 @@ where
     index_name: String,
     vector_field: String,
     key_prefix: Option<String>,
+    metadata_fields: Vec<String>,
 }
 
 impl<M> RedisVectorStore<M>
@@ -108,6 +120,7 @@ where
             index_name,
             vector_field,
             key_prefix: None,
+            metadata_fields: Vec::new(),
         })
     }
 
@@ -118,6 +131,64 @@ where
     /// to be indexed and discoverable by `FT.SEARCH`.
     pub fn with_key_prefix(mut self, prefix: String) -> Self {
         self.key_prefix = Some(prefix);
+        self
+    }
+
+    /// Configures metadata fields to extract from documents during insertion.
+    ///
+    /// When documents are inserted, the specified fields are extracted from the
+    /// serialized JSON representation and written as separate hash fields. This
+    /// makes them available for RediSearch filter queries (TAG, NUMERIC, TEXT).
+    ///
+    /// The field names must match top-level keys in the serialized document JSON
+    /// **and** must be declared in the RediSearch index schema.
+    ///
+    /// Fields that are missing from a document or have null/complex values are
+    /// silently skipped with a warning log.
+    ///
+    /// Reserved field names (`document`, `embedded_text`, and the configured vector
+    /// field) are filtered out with a warning to prevent data corruption.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Given a document struct:
+    /// #[derive(Serialize, Embed)]
+    /// struct Product {
+    ///     name: String,
+    ///     category: String,
+    ///     price: f64,
+    ///     #[embed]
+    ///     description: String,
+    /// }
+    ///
+    /// // And an index created with:
+    /// // FT.CREATE products ON HASH PREFIX 1 prod:
+    /// //   SCHEMA document TEXT embedded_text TEXT embedding VECTOR FLAT 6 ...
+    /// //   category TAG price NUMERIC
+    ///
+    /// let store = RedisVectorStore::new(model, client, "products".into(), "embedding".into())
+    ///     .await?
+    ///     .with_key_prefix("prod:".to_string())
+    ///     .with_metadata_fields(vec!["category".to_string(), "price".to_string()]);
+    /// ```
+    pub fn with_metadata_fields(mut self, fields: Vec<String>) -> Self {
+        let reserved = ["document", "embedded_text", self.vector_field.as_str()];
+        self.metadata_fields = fields
+            .into_iter()
+            .filter(|f| {
+                if reserved.contains(&f.as_str()) {
+                    tracing::warn!(
+                        target: "rig",
+                        field = %f,
+                        "Metadata field name conflicts with reserved hash field, skipping"
+                    );
+                    false
+                } else {
+                    true
+                }
+            })
+            .collect();
         self
     }
 
@@ -316,6 +387,22 @@ where
             .await
             .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))
     }
+
+    /// Converts a JSON value to a string suitable for storage in a Redis hash field.
+    ///
+    /// - Strings are stored as-is (unquoted).
+    /// - Numbers and booleans are converted to their string representation.
+    /// - Null, arrays, and objects return `None` (not storable as flat hash fields).
+    fn json_value_to_hash_field(value: &serde_json::Value) -> Option<String> {
+        match value {
+            serde_json::Value::String(s) => Some(s.clone()),
+            serde_json::Value::Number(n) => Some(n.to_string()),
+            serde_json::Value::Bool(b) => Some(if *b { "1".to_string() } else { "0".to_string() }),
+            serde_json::Value::Null
+            | serde_json::Value::Array(_)
+            | serde_json::Value::Object(_) => None,
+        }
+    }
 }
 
 impl<Model> InsertDocuments for RedisVectorStore<Model>
@@ -330,7 +417,32 @@ where
         let mut pipe = redis::pipe();
 
         for (document, embeddings) in &documents {
-            let json_document = serde_json::to_string(document)?;
+            let json_value = serde_json::to_value(document)?;
+            let json_document = json_value.to_string();
+
+            // Extract metadata fields from the document JSON if configured.
+            let metadata: Vec<(String, String)> = if self.metadata_fields.is_empty() {
+                Vec::new()
+            } else {
+                self.metadata_fields
+                    .iter()
+                    .filter_map(|field_name| {
+                        let value = json_value.get(field_name)?;
+                        match Self::json_value_to_hash_field(value) {
+                            Some(hash_value) => Some((field_name.clone(), hash_value)),
+                            None => {
+                                tracing::warn!(
+                                    target: "rig",
+                                    field = %field_name,
+                                    value_type = %value,
+                                    "Metadata field has unsupported type (null/array/object), skipping"
+                                );
+                                None
+                            }
+                        }
+                    })
+                    .collect()
+            };
 
             for embedding in embeddings.iter() {
                 let id = if let Some(ref prefix) = self.key_prefix {
@@ -340,15 +452,22 @@ where
                 };
                 let embedding_bytes = Self::embedding_to_bytes(&embedding.vec);
 
-                pipe.cmd("HSET")
+                let cmd = pipe
+                    .cmd("HSET")
                     .arg(&id)
                     .arg("document")
                     .arg(json_document.as_bytes())
                     .arg("embedded_text")
                     .arg(embedding.document.as_bytes())
                     .arg(&self.vector_field)
-                    .arg(embedding_bytes)
-                    .ignore();
+                    .arg(embedding_bytes);
+
+                // Write metadata fields as separate hash fields.
+                for (field_name, field_value) in &metadata {
+                    cmd.arg(field_name).arg(field_value.as_bytes());
+                }
+
+                cmd.ignore();
             }
         }
 
@@ -360,6 +479,7 @@ where
             target: "rig",
             index = %self.index_name,
             count = documents.len(),
+            metadata_fields = ?self.metadata_fields,
             "Inserted documents into Redis vector store"
         );
 

--- a/crates/rig-redis/src/lib.rs
+++ b/crates/rig-redis/src/lib.rs
@@ -18,6 +18,14 @@
 //! to cosine similarity (1 = identical, -1 = opposite) via `1.0 - distance`.
 //! Using a different distance metric (L2, IP) will produce incorrect similarity scores.
 //!
+//! # Filtering
+//!
+//! Filters apply to fields that exist in your RediSearch index schema **and** are
+//! present in the stored hash keys. The [`InsertDocuments`] implementation only
+//! writes `document`, `embedded_text`, and the vector field. If you need filterable
+//! metadata fields, write them to the hash separately or use a custom insertion
+//! approach. See [`filter`] module documentation for details.
+//!
 //! # Example
 //! ```ignore
 //! use rig_redis::RedisVectorStore;
@@ -27,7 +35,8 @@
 //!     redis_client,
 //!     "my_index".into(),
 //!     "embedding".into(),
-//! );
+//! )
+//! .await?;
 //! ```
 
 pub mod filter;
@@ -49,6 +58,12 @@ use serde::{Deserialize, Serialize};
 ///
 /// Uses Redis's `FT.SEARCH` command with KNN vector queries for similarity search.
 /// Internally holds a [`ConnectionManager`] for automatic reconnection on transient failures.
+///
+/// # Key Prefix
+///
+/// If your RediSearch index uses a `PREFIX` configuration (e.g., `PREFIX 1 doc:`),
+/// you **must** call [`RedisVectorStore::with_key_prefix`] with the matching prefix
+/// so that inserted documents are discoverable by the index.
 pub struct RedisVectorStore<M>
 where
     M: EmbeddingModel,
@@ -99,7 +114,8 @@ where
     /// Sets a key prefix for document keys.
     ///
     /// Documents stored via [`InsertDocuments`] will be keyed as `{prefix}{uuid}`.
-    /// This prefix should match the index's `PREFIX` configuration.
+    /// This prefix **must** match the index's `PREFIX` configuration for documents
+    /// to be indexed and discoverable by `FT.SEARCH`.
     pub fn with_key_prefix(mut self, prefix: String) -> Self {
         self.key_prefix = Some(prefix);
         self
@@ -293,9 +309,8 @@ where
 
         cmd.arg("DIALECT").arg(2);
 
-        if req.threshold().is_some() {
-            cmd.arg("LIMIT").arg(0).arg(req.samples());
-        }
+        // Always specify LIMIT to override RediSearch's default of 10 results.
+        cmd.arg("LIMIT").arg(0).arg(req.samples());
 
         cmd.query_async(&mut con)
             .await

--- a/crates/rig-redis/tests/filter_tests.rs
+++ b/crates/rig-redis/tests/filter_tests.rs
@@ -229,3 +229,33 @@ fn test_filter_raw() {
     let filter = Filter::raw("@field:{raw value with no escaping}");
     assert_eq!(filter.into_inner(), "@field:{raw value with no escaping}");
 }
+
+// tag_in edge cases
+
+#[test]
+fn test_filter_tag_in_empty_values_returns_match_all() {
+    let filter = Filter::tag_in("tags", vec![]);
+    assert_eq!(filter.into_inner(), "*");
+}
+
+// text_phrase tests
+
+#[test]
+fn test_filter_text_phrase() {
+    let filter = Filter::text_phrase("description", "hello world");
+    assert_eq!(filter.into_inner(), "@description:\"hello world\"");
+}
+
+#[test]
+fn test_filter_text_phrase_with_special_chars() {
+    let filter = Filter::text_phrase("description", "it's a test");
+    assert_eq!(filter.into_inner(), r#"@description:"it\'s a test""#);
+}
+
+#[test]
+fn test_filter_text_contains_is_token_and_not_phrase() {
+    // text_contains escapes spaces but does not wrap in quotes
+    let filter = Filter::text_contains("description", "hello world");
+    // Each word is escaped individually — no quotes means token-AND semantics
+    assert_eq!(filter.into_inner(), "@description:hello world");
+}

--- a/crates/rig-redis/tests/filter_tests.rs
+++ b/crates/rig-redis/tests/filter_tests.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::unwrap_used)]
 
 use rig_core::vector_store::request::{Filter as CoreFilter, SearchFilter};
-use rig_redis::filter::{Filter, RedisValue};
+use rig_redis::filter::{Filter, RedisValue, escape_tag_value, escape_text_value};
 
 #[test]
 fn test_filter_eq_string() {
@@ -12,7 +12,6 @@ fn test_filter_eq_string() {
 #[test]
 fn test_filter_eq_number() {
     let filter = Filter::eq("price", RedisValue::Number(99.99));
-    // Numeric equality uses range syntax: @field:[val val]
     assert_eq!(filter.into_inner(), "@price:[99.99 99.99]");
 }
 
@@ -176,4 +175,57 @@ fn test_filter_gt_non_numeric_uses_tag_syntax() {
 fn test_filter_lt_non_numeric_uses_tag_syntax() {
     let filter = Filter::lt("status", RedisValue::String("inactive".to_string()));
     assert_eq!(filter.into_inner(), "@status:{inactive}");
+}
+
+// Escaping tests
+
+#[test]
+fn test_escape_tag_value_special_chars() {
+    assert_eq!(escape_tag_value("hello-world"), r"hello\-world");
+    assert_eq!(escape_tag_value("it's"), r"it\'s");
+    assert_eq!(escape_tag_value("foo|bar"), r"foo\|bar");
+    assert_eq!(escape_tag_value("test@email"), r"test\@email");
+    assert_eq!(escape_tag_value("a{b}c"), r"a\{b\}c");
+    assert_eq!(escape_tag_value("(group)"), r"\(group\)");
+    assert_eq!(escape_tag_value("[bracket]"), r"\[bracket\]");
+    assert_eq!(escape_tag_value(r"back\slash"), r"back\\slash");
+}
+
+#[test]
+fn test_escape_tag_value_no_special_chars() {
+    assert_eq!(escape_tag_value("simple"), "simple");
+    assert_eq!(escape_tag_value("hello world"), "hello world");
+    assert_eq!(escape_tag_value("123"), "123");
+}
+
+#[test]
+fn test_escape_text_value_special_chars() {
+    assert_eq!(escape_text_value("hello-world"), r"hello\-world");
+    assert_eq!(escape_text_value("foo.bar"), r"foo\.bar");
+    assert_eq!(escape_text_value("a:b"), r"a\:b");
+    assert_eq!(escape_text_value("test@email.com"), r"test\@email\.com");
+}
+
+#[test]
+fn test_filter_eq_string_with_special_chars() {
+    let filter = Filter::eq("category", RedisValue::String("hello-world".to_string()));
+    assert_eq!(filter.into_inner(), r"@category:{hello\-world}");
+}
+
+#[test]
+fn test_filter_eq_string_with_pipe() {
+    let filter = Filter::eq("status", RedisValue::String("on|off".to_string()));
+    assert_eq!(filter.into_inner(), r"@status:{on\|off}");
+}
+
+#[test]
+fn test_filter_tag_in_with_special_chars() {
+    let filter = Filter::tag_in("tags", vec!["it's-new".to_string(), "50% off".to_string()]);
+    assert_eq!(filter.into_inner(), r"@tags:{it\'s\-new | 50% off}");
+}
+
+#[test]
+fn test_filter_raw() {
+    let filter = Filter::raw("@field:{raw value with no escaping}");
+    assert_eq!(filter.into_inner(), "@field:{raw value with no escaping}");
 }

--- a/crates/rig-redis/tests/integration_tests.rs
+++ b/crates/rig-redis/tests/integration_tests.rs
@@ -1,3 +1,11 @@
+//! Integration tests for rig-redis vector store.
+//!
+//! These tests require a Redis Stack instance (with RediSearch module).
+//! They use testcontainers to spin up an isolated Redis Stack container by default.
+//!
+//! Set `REDIS_URL` environment variable to use an external Redis instance instead.
+//!
+//! Run with: `cargo test --test integration_tests -- --ignored`
 #![allow(
     clippy::expect_used,
     clippy::indexing_slicing,
@@ -31,25 +39,28 @@ struct Word {
     definition: String,
 }
 
-/// Check if Redis is already running on localhost:6379
-async fn is_redis_running() -> bool {
-    match redis::Client::open("redis://127.0.0.1:6379") {
-        Ok(client) => client.get_multiplexed_async_connection().await.is_ok(),
-        Err(_) => false,
-    }
-}
-
-/// Get Redis connection info - either from existing instance or new container
+/// Get Redis connection info.
+///
+/// If `REDIS_URL` is set, uses that external instance.
+/// Otherwise, starts an isolated testcontainers Redis Stack instance.
 async fn get_redis_connection() -> (
     String,
     u16,
     Option<testcontainers::ContainerAsync<GenericImage>>,
 ) {
-    if is_redis_running().await {
-        println!("Using existing Redis instance on localhost:6379");
-        ("127.0.0.1".to_string(), REDIS_PORT, None)
+    if let Ok(url) = std::env::var("REDIS_URL") {
+        // Parse host:port from URL like redis://host:port
+        let url = url.strip_prefix("redis://").unwrap_or(&url);
+        let parts: Vec<&str> = url.split(':').collect();
+        let host = parts.first().unwrap_or(&"127.0.0.1").to_string();
+        let port: u16 = parts
+            .get(1)
+            .and_then(|p| p.parse().ok())
+            .unwrap_or(REDIS_PORT);
+        println!("Using external Redis instance at {host}:{port}");
+        (host, port, None)
     } else {
-        println!("Starting new Redis Stack container");
+        println!("Starting new Redis Stack container via testcontainers");
         let container = GenericImage::new("redis/redis-stack", "latest")
             .with_exposed_port(REDIS_PORT.tcp())
             .with_wait_for(WaitFor::Duration {
@@ -57,13 +68,26 @@ async fn get_redis_connection() -> (
             })
             .start()
             .await
-            .expect("Failed to start Redis Stack container");
+            .expect("Failed to start Redis Stack container. Is Docker/Podman running?");
 
         let port = container.get_host_port_ipv4(REDIS_PORT).await.unwrap();
         let host = container.get_host().await.unwrap().to_string();
 
         (host, port, Some(container))
     }
+}
+
+/// Verifies that the Redis instance has RediSearch module loaded.
+async fn verify_redisearch(client: &redis::Client) -> bool {
+    let mut con = match client.get_multiplexed_async_connection().await {
+        Ok(con) => con,
+        Err(_) => return false,
+    };
+
+    // FT._LIST returns an array of index names. If the command errors,
+    // RediSearch is not available.
+    let result: Result<redis::Value, _> = redis::cmd("FT._LIST").query_async(&mut con).await;
+    result.is_ok()
 }
 
 async fn setup_redis_index(
@@ -133,9 +157,18 @@ async fn cleanup_redis_index(
 }
 
 #[tokio::test]
+#[ignore = "requires Docker/Podman for testcontainers"]
 async fn test_vector_search_basic() {
     let (host, port, _container) = get_redis_connection().await;
     let index_name = "test_vector_search_basic";
+
+    let redis_url = format!("redis://{host}:{port}");
+    let redis_client = redis::Client::open(redis_url).unwrap();
+
+    assert!(
+        verify_redisearch(&redis_client).await,
+        "RediSearch module not available on this Redis instance"
+    );
 
     let server = httpmock::MockServer::start();
 
@@ -193,9 +226,6 @@ async fn test_vector_search_basic() {
 
     let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_ADA_002);
 
-    let redis_url = format!("redis://{host}:{port}");
-    let redis_client = redis::Client::open(redis_url).unwrap();
-
     setup_redis_index(&redis_client, index_name, 1536)
         .await
         .unwrap();
@@ -245,8 +275,6 @@ async fn test_vector_search_basic() {
 
     assert_eq!(results.len(), 1);
     let (score, _, doc) = &results[0];
-    // Redis returns cosine distance (0 = identical, higher = more different)
-    // So we just check it's a valid number
     assert!(score.is_finite());
     assert!(doc.definition.contains("linglingdong"));
 
@@ -256,9 +284,18 @@ async fn test_vector_search_basic() {
 }
 
 #[tokio::test]
+#[ignore = "requires Docker/Podman for testcontainers"]
 async fn test_top_n_ids() {
     let (host, port, _container) = get_redis_connection().await;
     let index_name = "test_top_n_ids";
+
+    let redis_url = format!("redis://{host}:{port}");
+    let redis_client = redis::Client::open(redis_url).unwrap();
+
+    assert!(
+        verify_redisearch(&redis_client).await,
+        "RediSearch module not available on this Redis instance"
+    );
 
     let server = httpmock::MockServer::start();
 
@@ -308,9 +345,6 @@ async fn test_top_n_ids() {
 
     let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_ADA_002);
 
-    let redis_url = format!("redis://{host}:{port}");
-    let redis_client = redis::Client::open(redis_url).unwrap();
-
     setup_redis_index(&redis_client, index_name, 1536)
         .await
         .unwrap();
@@ -355,7 +389,6 @@ async fn test_top_n_ids() {
     let results = vector_store.top_n_ids(req).await.unwrap();
 
     assert_eq!(results.len(), 2);
-    // Redis returns cosine distance, so scores can be 0 or positive
     assert!(results[0].0.is_finite());
     assert!(!results[0].1.is_empty());
 
@@ -365,9 +398,18 @@ async fn test_top_n_ids() {
 }
 
 #[tokio::test]
+#[ignore = "requires Docker/Podman for testcontainers"]
 async fn test_threshold_filtering() {
     let (host, port, _container) = get_redis_connection().await;
     let index_name = "test_threshold_filtering";
+
+    let redis_url = format!("redis://{host}:{port}");
+    let redis_client = redis::Client::open(redis_url).unwrap();
+
+    assert!(
+        verify_redisearch(&redis_client).await,
+        "RediSearch module not available on this Redis instance"
+    );
 
     let server = httpmock::MockServer::start();
 
@@ -416,9 +458,6 @@ async fn test_threshold_filtering() {
         .unwrap();
 
     let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_ADA_002);
-
-    let redis_url = format!("redis://{host}:{port}");
-    let redis_client = redis::Client::open(redis_url).unwrap();
 
     setup_redis_index(&redis_client, index_name, 1536)
         .await
@@ -474,9 +513,18 @@ async fn test_threshold_filtering() {
 }
 
 #[tokio::test]
+#[ignore = "requires Docker/Podman for testcontainers"]
 async fn test_insert_multiple_embeddings() {
     let (host, port, _container) = get_redis_connection().await;
     let index_name = "test_insert_multiple_embeddings";
+
+    let redis_url = format!("redis://{host}:{port}");
+    let redis_client = redis::Client::open(redis_url).unwrap();
+
+    assert!(
+        verify_redisearch(&redis_client).await,
+        "RediSearch module not available on this Redis instance"
+    );
 
     let server = httpmock::MockServer::start();
 
@@ -510,9 +558,6 @@ async fn test_insert_multiple_embeddings() {
         .unwrap();
 
     let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_ADA_002);
-
-    let redis_url = format!("redis://{host}:{port}");
-    let redis_client = redis::Client::open(redis_url).unwrap();
 
     setup_redis_index(&redis_client, index_name, 1536)
         .await
@@ -554,18 +599,17 @@ async fn test_insert_multiple_embeddings() {
 
     sleep(Duration::from_millis(500)).await;
 
-    // Verify documents were inserted
+    // Verify documents were inserted by searching
     let mut con = redis_client
         .get_multiplexed_async_connection()
         .await
         .unwrap();
     let keys: Vec<String> = redis::cmd("KEYS")
-        .arg("*")
+        .arg(format!("{index_name}:*"))
         .query_async(&mut con)
         .await
         .unwrap();
 
-    // Should have at least 3 documents (one per embedding)
     assert!(keys.len() >= 3, "Should have inserted at least 3 documents");
 
     cleanup_redis_index(&redis_client, index_name)
@@ -574,9 +618,18 @@ async fn test_insert_multiple_embeddings() {
 }
 
 #[tokio::test]
+#[ignore = "requires Docker/Podman for testcontainers"]
 async fn test_empty_results() {
     let (host, port, _container) = get_redis_connection().await;
     let index_name = "test_empty_results";
+
+    let redis_url = format!("redis://{host}:{port}");
+    let redis_client = redis::Client::open(redis_url).unwrap();
+
+    assert!(
+        verify_redisearch(&redis_client).await,
+        "RediSearch module not available on this Redis instance"
+    );
 
     let server = httpmock::MockServer::start();
 
@@ -604,9 +657,6 @@ async fn test_empty_results() {
         .unwrap();
 
     let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_ADA_002);
-
-    let redis_url = format!("redis://{host}:{port}");
-    let redis_client = redis::Client::open(redis_url).unwrap();
 
     setup_redis_index(&redis_client, index_name, 1536)
         .await

--- a/crates/rig-redis/tests/integration_tests.rs
+++ b/crates/rig-redis/tests/integration_tests.rs
@@ -14,6 +14,7 @@
 )]
 
 use rig_core::client::EmbeddingsClient;
+use rig_core::vector_store::request::SearchFilter;
 use rig_core::{
     Embed,
     embeddings::EmbeddingsBuilder,
@@ -21,6 +22,8 @@ use rig_core::{
     vector_store::{InsertDocuments, VectorStoreIndex, request::VectorSearchRequest},
 };
 use rig_redis::RedisVectorStore;
+use rig_redis::filter::Filter;
+use rig_redis::filter::RedisValue;
 use serde_json::json;
 use testcontainers::{
     GenericImage,
@@ -37,6 +40,17 @@ struct Word {
     id: String,
     #[embed]
     definition: String,
+}
+
+/// A document type with metadata fields for filtering tests.
+#[derive(Embed, Clone, serde::Deserialize, serde::Serialize, Debug, PartialEq)]
+struct Product {
+    name: String,
+    category: String,
+    price: f64,
+    in_stock: bool,
+    #[embed]
+    description: String,
 }
 
 /// Get Redis connection info.
@@ -132,6 +146,58 @@ async fn setup_redis_index(
         .await?;
 
     // Wait for index to be ready
+    sleep(Duration::from_millis(1000)).await;
+
+    Ok(())
+}
+
+/// Creates a RediSearch index with additional metadata fields for filtering.
+async fn setup_redis_index_with_metadata(
+    client: &redis::Client,
+    index_name: &str,
+    dimensions: usize,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut con = client.get_multiplexed_async_connection().await?;
+
+    let _: Result<String, _> = redis::cmd("FT.DROPINDEX")
+        .arg(index_name)
+        .arg("DD")
+        .query_async(&mut con)
+        .await;
+
+    let prefix = format!("{index_name}:");
+    let _: String = redis::cmd("FT.CREATE")
+        .arg(index_name)
+        .arg("ON")
+        .arg("HASH")
+        .arg("PREFIX")
+        .arg(1)
+        .arg(&prefix)
+        .arg("SCHEMA")
+        .arg("document")
+        .arg("TEXT")
+        .arg("embedded_text")
+        .arg("TEXT")
+        .arg(VECTOR_FIELD)
+        .arg("VECTOR")
+        .arg("FLAT")
+        .arg(6)
+        .arg("TYPE")
+        .arg("FLOAT32")
+        .arg("DIM")
+        .arg(dimensions)
+        .arg("DISTANCE_METRIC")
+        .arg("COSINE")
+        // Metadata fields
+        .arg("category")
+        .arg("TAG")
+        .arg("price")
+        .arg("NUMERIC")
+        .arg("in_stock")
+        .arg("TAG")
+        .query_async(&mut con)
+        .await?;
+
     sleep(Duration::from_millis(1000)).await;
 
     Ok(())
@@ -680,6 +746,668 @@ async fn test_empty_results() {
     let results = vector_store.top_n::<Word>(req).await.unwrap();
 
     assert_eq!(results.len(), 0);
+
+    cleanup_redis_index(&redis_client, index_name)
+        .await
+        .unwrap();
+}
+
+// =============================================================================
+// Metadata filtering tests
+// =============================================================================
+
+/// Helper to create a mock embedding server that returns distinct vectors for products.
+fn setup_product_embedding_mocks(server: &httpmock::MockServer) {
+    // Mock for inserting 3 products
+    server.mock(|when, then| {
+        when.method(httpmock::Method::POST)
+            .path("/embeddings")
+            .json_body(json!({
+                "input": [
+                    "A high-end gaming laptop with RTX graphics",
+                    "A cozy wool sweater for winter",
+                    "A budget-friendly mechanical keyboard"
+                ],
+                "model": "text-embedding-ada-002",
+            }));
+        then.status(200).json_body(json!({
+            "object": "list",
+            "data": [
+                {"object": "embedding", "embedding": (0..1536).map(|i| if i < 512 { 1.0 } else { 0.0 }).collect::<Vec<f64>>(), "index": 0},
+                {"object": "embedding", "embedding": (0..1536).map(|i| if (512..1024).contains(&i) { 1.0 } else { 0.0 }).collect::<Vec<f64>>(), "index": 1},
+                {"object": "embedding", "embedding": (0..1536).map(|i| if i >= 1024 { 1.0 } else { 0.0 }).collect::<Vec<f64>>(), "index": 2}
+            ],
+            "model": "text-embedding-ada-002",
+            "usage": {"prompt_tokens": 6, "total_tokens": 6}
+        }));
+    });
+
+    // Mock for search query "electronics"
+    server.mock(|when, then| {
+        when.method(httpmock::Method::POST)
+            .path("/embeddings")
+            .json_body(json!({
+                "input": ["electronics"],
+                "model": "text-embedding-ada-002",
+            }));
+        then.status(200).json_body(json!({
+            "object": "list",
+            "data": [
+                {"object": "embedding", "embedding": (0..1536).map(|i| if i < 512 { 0.9 } else { 0.1 }).collect::<Vec<f64>>(), "index": 0}
+            ],
+            "model": "text-embedding-ada-002",
+            "usage": {"prompt_tokens": 1, "total_tokens": 1}
+        }));
+    });
+
+    // Mock for search query "find products"
+    server.mock(|when, then| {
+        when.method(httpmock::Method::POST)
+            .path("/embeddings")
+            .json_body(json!({
+                "input": ["find products"],
+                "model": "text-embedding-ada-002",
+            }));
+        then.status(200).json_body(json!({
+            "object": "list",
+            "data": [
+                {"object": "embedding", "embedding": vec![0.5; 1536], "index": 0}
+            ],
+            "model": "text-embedding-ada-002",
+            "usage": {"prompt_tokens": 2, "total_tokens": 2}
+        }));
+    });
+}
+
+/// Creates a vector store with metadata fields and inserts test products.
+async fn setup_product_store(
+    redis_client: &redis::Client,
+    index_name: &str,
+    server: &httpmock::MockServer,
+) -> RedisVectorStore<rig_core::providers::openai::EmbeddingModel> {
+    let openai_client = openai::Client::builder()
+        .api_key("TEST")
+        .base_url(server.base_url())
+        .build()
+        .unwrap();
+
+    let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_ADA_002);
+
+    setup_redis_index_with_metadata(redis_client, index_name, 1536)
+        .await
+        .unwrap();
+
+    let vector_store = RedisVectorStore::new(
+        model.clone(),
+        redis_client.clone(),
+        index_name.to_string(),
+        VECTOR_FIELD.to_string(),
+    )
+    .await
+    .unwrap()
+    .with_key_prefix(format!("{}:", index_name))
+    .with_metadata_fields(vec![
+        "category".to_string(),
+        "price".to_string(),
+        "in_stock".to_string(),
+    ]);
+
+    let products = vec![
+        Product {
+            name: "Gaming Laptop".to_string(),
+            category: "Electronics".to_string(),
+            price: 1500.0,
+            in_stock: true,
+            description: "A high-end gaming laptop with RTX graphics".to_string(),
+        },
+        Product {
+            name: "Wool Sweater".to_string(),
+            category: "Clothing".to_string(),
+            price: 75.0,
+            in_stock: true,
+            description: "A cozy wool sweater for winter".to_string(),
+        },
+        Product {
+            name: "Mechanical Keyboard".to_string(),
+            category: "Electronics".to_string(),
+            price: 45.0,
+            in_stock: false,
+            description: "A budget-friendly mechanical keyboard".to_string(),
+        },
+    ];
+
+    let documents = EmbeddingsBuilder::new(model.clone())
+        .documents(products)
+        .unwrap()
+        .build()
+        .await
+        .unwrap();
+
+    vector_store.insert_documents(documents).await.unwrap();
+
+    sleep(Duration::from_millis(500)).await;
+
+    vector_store
+}
+
+#[tokio::test]
+#[ignore = "requires Docker/Podman for testcontainers"]
+async fn test_metadata_filter_by_tag() {
+    let (host, port, _container) = get_redis_connection().await;
+    let index_name = "test_metadata_filter_by_tag";
+
+    let redis_url = format!("redis://{host}:{port}");
+    let redis_client = redis::Client::open(redis_url).unwrap();
+
+    assert!(
+        verify_redisearch(&redis_client).await,
+        "RediSearch module not available on this Redis instance"
+    );
+
+    let server = httpmock::MockServer::start();
+    setup_product_embedding_mocks(&server);
+
+    let vector_store = setup_product_store(&redis_client, index_name, &server).await;
+
+    // Filter by category = "Electronics" — should return 2 results
+    let filter = Filter::eq("category", RedisValue::String("Electronics".to_string()));
+    let req = VectorSearchRequest::builder()
+        .query("find products")
+        .samples(10)
+        .filter(filter)
+        .build();
+
+    let results = vector_store.top_n::<Product>(req).await.unwrap();
+
+    assert_eq!(results.len(), 2, "Should find 2 Electronics products");
+    for (_, _, product) in &results {
+        assert_eq!(product.category, "Electronics");
+    }
+
+    cleanup_redis_index(&redis_client, index_name)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires Docker/Podman for testcontainers"]
+async fn test_metadata_filter_by_numeric_range() {
+    let (host, port, _container) = get_redis_connection().await;
+    let index_name = "test_metadata_filter_numeric";
+
+    let redis_url = format!("redis://{host}:{port}");
+    let redis_client = redis::Client::open(redis_url).unwrap();
+
+    assert!(
+        verify_redisearch(&redis_client).await,
+        "RediSearch module not available on this Redis instance"
+    );
+
+    let server = httpmock::MockServer::start();
+    setup_product_embedding_mocks(&server);
+
+    let vector_store = setup_product_store(&redis_client, index_name, &server).await;
+
+    // Filter by price < 100 — should return Wool Sweater (75) and Keyboard (45)
+    let filter = Filter::lt("price", RedisValue::Number(100.0));
+    let req = VectorSearchRequest::builder()
+        .query("find products")
+        .samples(10)
+        .filter(filter)
+        .build();
+
+    let results = vector_store.top_n::<Product>(req).await.unwrap();
+
+    assert_eq!(results.len(), 2, "Should find 2 products under $100");
+    for (_, _, product) in &results {
+        assert!(product.price < 100.0, "All products should be under $100");
+    }
+
+    cleanup_redis_index(&redis_client, index_name)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires Docker/Podman for testcontainers"]
+async fn test_metadata_filter_by_boolean() {
+    let (host, port, _container) = get_redis_connection().await;
+    let index_name = "test_metadata_filter_boolean";
+
+    let redis_url = format!("redis://{host}:{port}");
+    let redis_client = redis::Client::open(redis_url).unwrap();
+
+    assert!(
+        verify_redisearch(&redis_client).await,
+        "RediSearch module not available on this Redis instance"
+    );
+
+    let server = httpmock::MockServer::start();
+    setup_product_embedding_mocks(&server);
+
+    let vector_store = setup_product_store(&redis_client, index_name, &server).await;
+
+    // Filter by in_stock = true — should return Gaming Laptop and Wool Sweater
+    let filter = Filter::eq("in_stock", RedisValue::Bool(true));
+    let req = VectorSearchRequest::builder()
+        .query("find products")
+        .samples(10)
+        .filter(filter)
+        .build();
+
+    let results = vector_store.top_n::<Product>(req).await.unwrap();
+
+    assert_eq!(results.len(), 2, "Should find 2 in-stock products");
+    for (_, _, product) in &results {
+        assert!(product.in_stock, "All products should be in stock");
+    }
+
+    cleanup_redis_index(&redis_client, index_name)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires Docker/Podman for testcontainers"]
+async fn test_metadata_filter_combined_and() {
+    let (host, port, _container) = get_redis_connection().await;
+    let index_name = "test_metadata_filter_combined";
+
+    let redis_url = format!("redis://{host}:{port}");
+    let redis_client = redis::Client::open(redis_url).unwrap();
+
+    assert!(
+        verify_redisearch(&redis_client).await,
+        "RediSearch module not available on this Redis instance"
+    );
+
+    let server = httpmock::MockServer::start();
+    setup_product_embedding_mocks(&server);
+
+    let vector_store = setup_product_store(&redis_client, index_name, &server).await;
+
+    // Filter: category = "Electronics" AND in_stock = true
+    // Should return only Gaming Laptop (Keyboard is out of stock)
+    let filter = Filter::eq("category", RedisValue::String("Electronics".to_string()))
+        .and(Filter::eq("in_stock", RedisValue::Bool(true)));
+
+    let req = VectorSearchRequest::builder()
+        .query("find products")
+        .samples(10)
+        .filter(filter)
+        .build();
+
+    let results = vector_store.top_n::<Product>(req).await.unwrap();
+
+    assert_eq!(
+        results.len(),
+        1,
+        "Should find 1 in-stock Electronics product"
+    );
+    assert_eq!(results[0].2.name, "Gaming Laptop");
+
+    cleanup_redis_index(&redis_client, index_name)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires Docker/Podman for testcontainers"]
+async fn test_metadata_filter_combined_or() {
+    let (host, port, _container) = get_redis_connection().await;
+    let index_name = "test_metadata_filter_or";
+
+    let redis_url = format!("redis://{host}:{port}");
+    let redis_client = redis::Client::open(redis_url).unwrap();
+
+    assert!(
+        verify_redisearch(&redis_client).await,
+        "RediSearch module not available on this Redis instance"
+    );
+
+    let server = httpmock::MockServer::start();
+    setup_product_embedding_mocks(&server);
+
+    let vector_store = setup_product_store(&redis_client, index_name, &server).await;
+
+    // Filter: category = "Electronics" OR category = "Clothing"
+    // Should return all 3 products
+    let filter = Filter::eq("category", RedisValue::String("Electronics".to_string())).or(
+        Filter::eq("category", RedisValue::String("Clothing".to_string())),
+    );
+
+    let req = VectorSearchRequest::builder()
+        .query("find products")
+        .samples(10)
+        .filter(filter)
+        .build();
+
+    let results = vector_store.top_n::<Product>(req).await.unwrap();
+
+    assert_eq!(results.len(), 3, "Should find all 3 products");
+
+    cleanup_redis_index(&redis_client, index_name)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires Docker/Podman for testcontainers"]
+async fn test_metadata_filter_no_match() {
+    let (host, port, _container) = get_redis_connection().await;
+    let index_name = "test_metadata_filter_no_match";
+
+    let redis_url = format!("redis://{host}:{port}");
+    let redis_client = redis::Client::open(redis_url).unwrap();
+
+    assert!(
+        verify_redisearch(&redis_client).await,
+        "RediSearch module not available on this Redis instance"
+    );
+
+    let server = httpmock::MockServer::start();
+    setup_product_embedding_mocks(&server);
+
+    let vector_store = setup_product_store(&redis_client, index_name, &server).await;
+
+    // Filter by a non-existent category — should return 0 results
+    let filter = Filter::eq("category", RedisValue::String("Books".to_string()));
+    let req = VectorSearchRequest::builder()
+        .query("find products")
+        .samples(10)
+        .filter(filter)
+        .build();
+
+    let results = vector_store.top_n::<Product>(req).await.unwrap();
+
+    assert_eq!(results.len(), 0, "Should find no products");
+
+    cleanup_redis_index(&redis_client, index_name)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires Docker/Podman for testcontainers"]
+async fn test_metadata_filter_numeric_gt() {
+    let (host, port, _container) = get_redis_connection().await;
+    let index_name = "test_metadata_filter_gt";
+
+    let redis_url = format!("redis://{host}:{port}");
+    let redis_client = redis::Client::open(redis_url).unwrap();
+
+    assert!(
+        verify_redisearch(&redis_client).await,
+        "RediSearch module not available on this Redis instance"
+    );
+
+    let server = httpmock::MockServer::start();
+    setup_product_embedding_mocks(&server);
+
+    let vector_store = setup_product_store(&redis_client, index_name, &server).await;
+
+    // Filter: price > 100 — should only return Gaming Laptop (1500)
+    let filter = Filter::gt("price", RedisValue::Number(100.0));
+    let req = VectorSearchRequest::builder()
+        .query("find products")
+        .samples(10)
+        .filter(filter)
+        .build();
+
+    let results = vector_store.top_n::<Product>(req).await.unwrap();
+
+    assert_eq!(results.len(), 1, "Should find 1 product over $100");
+    assert_eq!(results[0].2.name, "Gaming Laptop");
+
+    cleanup_redis_index(&redis_client, index_name)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires Docker/Podman for testcontainers"]
+async fn test_metadata_fields_missing_from_document() {
+    let (host, port, _container) = get_redis_connection().await;
+    let index_name = "test_metadata_missing_field";
+
+    let redis_url = format!("redis://{host}:{port}");
+    let redis_client = redis::Client::open(redis_url).unwrap();
+
+    assert!(
+        verify_redisearch(&redis_client).await,
+        "RediSearch module not available on this Redis instance"
+    );
+
+    let server = httpmock::MockServer::start();
+
+    // Mock for Word insertion (no category/price fields in Word struct)
+    server.mock(|when, then| {
+        when.method(httpmock::Method::POST)
+            .path("/embeddings")
+            .json_body(json!({
+                "input": ["A simple test document"],
+                "model": "text-embedding-ada-002",
+            }));
+        then.status(200).json_body(json!({
+            "object": "list",
+            "data": [
+                {"object": "embedding", "embedding": vec![0.5; 1536], "index": 0}
+            ],
+            "model": "text-embedding-ada-002",
+            "usage": {"prompt_tokens": 2, "total_tokens": 2}
+        }));
+    });
+
+    server.mock(|when, then| {
+        when.method(httpmock::Method::POST)
+            .path("/embeddings")
+            .json_body(json!({
+                "input": ["search query"],
+                "model": "text-embedding-ada-002",
+            }));
+        then.status(200).json_body(json!({
+            "object": "list",
+            "data": [
+                {"object": "embedding", "embedding": vec![0.5; 1536], "index": 0}
+            ],
+            "model": "text-embedding-ada-002",
+            "usage": {"prompt_tokens": 1, "total_tokens": 1}
+        }));
+    });
+
+    let openai_client = openai::Client::builder()
+        .api_key("TEST")
+        .base_url(server.base_url())
+        .build()
+        .unwrap();
+
+    let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_ADA_002);
+
+    setup_redis_index(&redis_client, index_name, 1536)
+        .await
+        .unwrap();
+
+    // Configure metadata_fields that don't exist in the Word struct
+    let vector_store = RedisVectorStore::new(
+        model.clone(),
+        redis_client.clone(),
+        index_name.to_string(),
+        VECTOR_FIELD.to_string(),
+    )
+    .await
+    .unwrap()
+    .with_key_prefix(format!("{}:", index_name))
+    .with_metadata_fields(vec![
+        "category".to_string(),
+        "nonexistent_field".to_string(),
+    ]);
+
+    let words = vec![Word {
+        id: "test1".to_string(),
+        definition: "A simple test document".to_string(),
+    }];
+
+    let documents = EmbeddingsBuilder::new(model.clone())
+        .documents(words)
+        .unwrap()
+        .build()
+        .await
+        .unwrap();
+
+    // Should not panic or error — missing fields are silently skipped
+    vector_store.insert_documents(documents).await.unwrap();
+
+    sleep(Duration::from_millis(500)).await;
+
+    // The document should still be searchable (just without metadata filters)
+    let req = VectorSearchRequest::builder()
+        .query("search query")
+        .samples(5)
+        .build();
+
+    let results = vector_store.top_n::<Word>(req).await.unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].2.id, "test1");
+
+    cleanup_redis_index(&redis_client, index_name)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires Docker/Podman for testcontainers"]
+async fn test_metadata_no_fields_configured() {
+    let (host, port, _container) = get_redis_connection().await;
+    let index_name = "test_metadata_no_fields";
+
+    let redis_url = format!("redis://{host}:{port}");
+    let redis_client = redis::Client::open(redis_url).unwrap();
+
+    assert!(
+        verify_redisearch(&redis_client).await,
+        "RediSearch module not available on this Redis instance"
+    );
+
+    let server = httpmock::MockServer::start();
+
+    server.mock(|when, then| {
+        when.method(httpmock::Method::POST)
+            .path("/embeddings")
+            .json_body(json!({
+                "input": ["A simple test document"],
+                "model": "text-embedding-ada-002",
+            }));
+        then.status(200).json_body(json!({
+            "object": "list",
+            "data": [
+                {"object": "embedding", "embedding": vec![0.5; 1536], "index": 0}
+            ],
+            "model": "text-embedding-ada-002",
+            "usage": {"prompt_tokens": 2, "total_tokens": 2}
+        }));
+    });
+
+    server.mock(|when, then| {
+        when.method(httpmock::Method::POST)
+            .path("/embeddings")
+            .json_body(json!({
+                "input": ["search"],
+                "model": "text-embedding-ada-002",
+            }));
+        then.status(200).json_body(json!({
+            "object": "list",
+            "data": [
+                {"object": "embedding", "embedding": vec![0.5; 1536], "index": 0}
+            ],
+            "model": "text-embedding-ada-002",
+            "usage": {"prompt_tokens": 1, "total_tokens": 1}
+        }));
+    });
+
+    let openai_client = openai::Client::builder()
+        .api_key("TEST")
+        .base_url(server.base_url())
+        .build()
+        .unwrap();
+
+    let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_ADA_002);
+
+    setup_redis_index(&redis_client, index_name, 1536)
+        .await
+        .unwrap();
+
+    // No metadata fields configured — backward compatible
+    let vector_store = RedisVectorStore::new(
+        model.clone(),
+        redis_client.clone(),
+        index_name.to_string(),
+        VECTOR_FIELD.to_string(),
+    )
+    .await
+    .unwrap()
+    .with_key_prefix(format!("{}:", index_name));
+
+    let words = vec![Word {
+        id: "compat".to_string(),
+        definition: "A simple test document".to_string(),
+    }];
+
+    let documents = EmbeddingsBuilder::new(model.clone())
+        .documents(words)
+        .unwrap()
+        .build()
+        .await
+        .unwrap();
+
+    vector_store.insert_documents(documents).await.unwrap();
+
+    sleep(Duration::from_millis(500)).await;
+
+    let req = VectorSearchRequest::builder()
+        .query("search")
+        .samples(5)
+        .build();
+
+    let results = vector_store.top_n::<Word>(req).await.unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].2.id, "compat");
+
+    cleanup_redis_index(&redis_client, index_name)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires Docker/Podman for testcontainers"]
+async fn test_metadata_filter_with_top_n_ids() {
+    let (host, port, _container) = get_redis_connection().await;
+    let index_name = "test_metadata_top_n_ids";
+
+    let redis_url = format!("redis://{host}:{port}");
+    let redis_client = redis::Client::open(redis_url).unwrap();
+
+    assert!(
+        verify_redisearch(&redis_client).await,
+        "RediSearch module not available on this Redis instance"
+    );
+
+    let server = httpmock::MockServer::start();
+    setup_product_embedding_mocks(&server);
+
+    let vector_store = setup_product_store(&redis_client, index_name, &server).await;
+
+    // Filter by category = "Clothing" — should return 1 result
+    let filter = Filter::eq("category", RedisValue::String("Clothing".to_string()));
+    let req = VectorSearchRequest::builder()
+        .query("find products")
+        .samples(10)
+        .filter(filter)
+        .build();
+
+    let results = vector_store.top_n_ids(req).await.unwrap();
+
+    assert_eq!(results.len(), 1, "Should find 1 Clothing product");
+    assert!(!results[0].1.is_empty());
 
     cleanup_redis_index(&redis_client, index_name)
         .await


### PR DESCRIPTION
## Summary

Follow-up to the merged [#1509](https://github.com/0xPlaygrounds/rig/pull/1509) (Redis vector store integration) addressing the [review comments](https://github.com/0xPlaygrounds/rig/pull/1509#issuecomment-4654557758) left by the maintainer. Also relates to the original request in [#1239](https://github.com/0xPlaygrounds/rig/issues/1239).

## Review Comments Addressed

### P1 — Metadata filtering not supported for inserted documents

**Comment:** `InsertDocuments` only writes `document`, `embedded_text`, and the vector field. Filter queries reference fields that never exist in the hash.

**Fix:** Implemented `with_metadata_fields()` builder method. When configured, specified top-level scalar fields (string/number/bool) are extracted from the serialized document JSON during insertion and written as separate hash fields. This enables RediSearch filter queries on those fields. Reserved field names (`document`, `embedded_text`, vector field) are guarded against to prevent data corruption. Null/array/object values are silently skipped with a `tracing::warn`.

---

### P1 — Key prefix mismatch in docs/examples

**Comment:** README creates index with `PREFIX 1 doc:` but the example doesn't use `.with_key_prefix("doc:")`, so inserted documents are invisible to FT.SEARCH.

**Fix:** Added `.with_key_prefix("doc:".to_string())` to the example and README. Added doc comments emphasizing the prefix must match the index configuration.

---

### P1 — No escaping in filter values

**Comment:** Values with special characters (spaces, `|`, braces, `@`) are interpolated directly into RediSearch syntax, risking injection/parse errors.

**Fix:** Added `escape_tag_value()` and `escape_text_value()` functions that escape RediSearch special characters per [official Redis documentation](https://redis.io/docs/latest/develop/ai/search-and-query/advanced-concepts/tags/). Applied escaping in all filter construction methods. Added `Filter::raw()` for pre-escaped queries with security warning. Added regression tests for special characters.

---

### P2 — Range operators on non-numeric values silently degrade

**Comment:** `gt("status", "active")` becomes `@status:{active}` (tag filter) instead of erroring.

**Fix:** The `SearchFilter` trait returns `Self` (not `Result`), so errors cannot be returned. Added `tracing::warn!` when non-numeric values are used with `gt`/`lt`/`gte`/`lte`, and documented the limitation clearly.

---

### P2 — LIMIT not always applied

**Comment:** Without a threshold, RediSearch defaults to `LIMIT 0 10`, so `samples > 10` is silently capped at 10 results.

**Fix:** Now always appends `LIMIT 0 req.samples()` to override RediSearch's default.

---

### P2 — Integration tests panic without Docker

**Fix:** Marked all integration tests with `#[ignore]`. They only run with `cargo test -- --ignored`.

---

### P2 — Tests mutate local Redis with FT.DROPINDEX

**Fix:** Removed auto-detection of local Redis. Tests always use testcontainers unless `REDIS_URL` is explicitly set. Added `verify_redisearch()` capability probe.

---

### P3 — README shows `new()` as sync and links to wrong path

**Fix:** Added `.await?` to README example, fixed link to `crates/rig-redis/examples`.

---

## Additional Hardening

Based on additional review:

- **Empty document JSON handling:** `parse_search_response` now skips documents with empty/unparseable JSON (with `tracing::warn`) instead of aborting the entire result set
- **Empty `tag_in` guard:** `tag_in(field, vec![])` returns match-all `*` instead of invalid `@field:{}`
- **Missing `__vector_score` warning:** emits `tracing::warn` when score field is absent
- **`text_phrase()` method:** added for exact phrase matching (`@field:"phrase"`)
- **`text_contains()` documented:** clarified it performs token-AND, not phrase search
- **`Filter::raw()` security warning:** explicitly warns against unsanitized user input
- **Dynamic API subset documented:** notes that `VectorStoreIndexDyn` only supports Eq/Gt/Lt/And/Or
- **`From<u64>` precision loss:** documented that values above 2⁵³ lose precision

## Example Rewrite

Rewrote `examples/vector_search_redis.rs` from a minimal word-definition demo to a product catalog demonstrating:
- Basic vector similarity search (no filter)
- TAG field filtering (`category = Electronics`)
- NUMERIC range filtering (`price < 100`)
- Combined AND filters (`Electronics AND price > 100`)
- Proper document round-tripping (all fields preserved)
- `with_metadata_fields` and `with_key_prefix` usage

## Test Results

- 34 filter unit tests ✓
- 15 integration tests ✓ (TAG, NUMERIC, boolean, AND/OR, no-match, missing fields, backward compat, top_n_ids)

## Changes

- `crates/rig-redis/src/lib.rs` — metadata fields, LIMIT fix, graceful error handling, docs
- `crates/rig-redis/src/filter.rs` — escaping, `text_phrase`, empty `tag_in` guard, docs
- `crates/rig-redis/tests/integration_tests.rs` — 10 new metadata tests, #[ignore], testcontainers
- `crates/rig-redis/tests/filter_tests.rs` — escaping + edge case tests
- `crates/rig-redis/examples/vector_search_redis.rs` — full rewrite with filtering demos
- `crates/rig-redis/README.md` — metadata filtering docs, fixed examples