### PR TITLE
Expose streaming terminal metadata

### DIFF
--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -5,7 +5,7 @@ use crate::{
         HookAction, InvalidToolCallResolution, TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER,
         hooks::PromptHook, resolve_invalid_tool_call, validate_tool_call_name,
     },
-    completion::{Document, GetTokenUsage},
+    completion::{CompletionFinishReason, CompletionTerminalMetadata, Document, GetTokenUsage},
     json_utils,
     memory::ConversationMemory,
     message::{
@@ -78,6 +78,8 @@ pub struct FinalResponse {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     completion_calls: Vec<CompletionCall>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    terminal_metadata: Option<CompletionTerminalMetadata>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     history: Option<Vec<Message>>,
 }
 
@@ -101,6 +103,7 @@ impl FinalResponse {
             response,
             aggregated_usage,
             completion_calls: Vec::new(),
+            terminal_metadata: None,
             history,
         }
     }
@@ -134,6 +137,23 @@ impl FinalResponse {
         &self.completion_calls
     }
 
+    /// Returns provider terminal metadata for the final provider call, when available.
+    pub fn terminal_metadata(&self) -> Option<&CompletionTerminalMetadata> {
+        self.terminal_metadata.as_ref()
+    }
+
+    /// Returns the normalized finish reason for the final provider call, when available.
+    pub fn finish_reason(&self) -> Option<CompletionFinishReason> {
+        self.terminal_metadata()
+            .map(|terminal_metadata| terminal_metadata.reason)
+    }
+
+    /// Returns the provider's raw finish reason for the final provider call, when available.
+    pub fn raw_finish_reason(&self) -> Option<&str> {
+        self.terminal_metadata()
+            .and_then(CompletionTerminalMetadata::raw_reason)
+    }
+
     pub fn history(&self) -> Option<&[Message]> {
         self.history.as_deref()
     }
@@ -164,9 +184,11 @@ impl<R> MultiTurnStreamItem<R> {
         aggregated_usage: crate::completion::Usage,
         completion_calls: Vec<CompletionCall>,
         history: Option<Vec<Message>>,
+        terminal_metadata: Option<CompletionTerminalMetadata>,
     ) -> Self {
         let mut response = FinalResponse::new(content, aggregated_usage, history);
         response.completion_calls = completion_calls;
+        response.terminal_metadata = terminal_metadata;
         Self::FinalResponse(response)
     }
 }
@@ -839,6 +861,7 @@ where
         let mut aggregated_usage = crate::completion::Usage::new();
         let mut completion_calls = Vec::new();
         let mut completion_call_index = 0;
+        let mut last_terminal_metadata = None;
         let mut invalid_tool_call_retries = 0;
 
         // NOTE: We use .instrument(agent_span) instead of span.enter() to avoid
@@ -1418,6 +1441,7 @@ where
                             if let Some(usage) = final_resp.token_usage() {
                                 current_call_usage = reported_usage(usage);
                             }
+                            last_terminal_metadata = final_resp.terminal_metadata();
                             if let Some(usage) = current_call_usage {
                                 aggregated_usage += usage;
                             }
@@ -1674,6 +1698,7 @@ where
                         aggregated_usage,
                         completion_calls,
                         final_messages,
+                        last_terminal_metadata.clone(),
                     ));
                     break;
                 }
@@ -1755,7 +1780,10 @@ mod tests {
     };
     use crate::client::ProviderClient;
     use crate::client::completion::CompletionClient;
-    use crate::completion::{CompletionRequest, PromptError, ToolDefinition, Usage};
+    use crate::completion::{
+        CompletionFinishReason, CompletionRequest, CompletionTerminalMetadata, PromptError,
+        ToolDefinition, Usage,
+    };
     use crate::message::{
         AssistantContent, DocumentSourceKind, ImageMediaType, Message, ReasoningContent,
         ToolChoice, ToolResultContent, UserContent,
@@ -2406,6 +2434,7 @@ mod tests {
                     CompletionCall::new(1, Some(usage(3, 4))),
                 ],
                 None,
+                None,
             );
 
         let value = serde_json::to_value(&item).expect("serialize final response");
@@ -2486,6 +2515,18 @@ mod tests {
     fn streaming_final_only_model() -> MockCompletionModel {
         MockCompletionModel::from_stream_turns([[
             MockStreamEvent::final_response_with_total_tokens(1),
+        ]])
+    }
+
+    fn streaming_text_then_terminal_metadata_model() -> MockCompletionModel {
+        MockCompletionModel::from_stream_turns([[
+            MockStreamEvent::text("partial"),
+            MockStreamEvent::FinalResponse(
+                MockResponse::with_total_tokens(3).with_terminal_metadata(
+                    CompletionTerminalMetadata::new(CompletionFinishReason::Length)
+                        .with_raw_reason("max_output_tokens"),
+                ),
+            ),
         ]])
     }
 
@@ -5442,6 +5483,30 @@ mod tests {
 
         assert!(streamed_text.is_empty());
         assert_eq!(final_response_text.as_deref(), Some(""));
+    }
+
+    #[tokio::test]
+    async fn final_response_retains_provider_terminal_metadata() {
+        let agent = AgentBuilder::new(streaming_text_then_terminal_metadata_model()).build();
+
+        let mut stream = agent.stream_prompt("continue until truncated").await;
+        let mut terminal_metadata = None;
+
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(MultiTurnStreamItem::FinalResponse(res)) => {
+                    terminal_metadata = res.terminal_metadata().cloned();
+                    break;
+                }
+                Ok(_) => {}
+                Err(err) => panic!("unexpected streaming error: {err:?}"),
+            }
+        }
+
+        let terminal_metadata =
+            terminal_metadata.expect("final response should retain terminal metadata");
+        assert_eq!(terminal_metadata.reason, CompletionFinishReason::Length);
+        assert_eq!(terminal_metadata.raw_reason(), Some("max_output_tokens"));
     }
 
     /// Background task that logs periodically to detect span leakage.

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -380,6 +380,11 @@ pub struct CompletionResponse<T> {
 pub trait GetTokenUsage {
     /// Returns token usage when the response type carries it.
     fn token_usage(&self) -> Option<crate::completion::Usage>;
+
+    /// Returns terminal metadata when the response type carries a provider finish reason.
+    fn terminal_metadata(&self) -> Option<CompletionTerminalMetadata> {
+        None
+    }
 }
 
 impl GetTokenUsage for () {
@@ -393,11 +398,60 @@ where
     T: GetTokenUsage,
 {
     fn token_usage(&self) -> Option<crate::completion::Usage> {
-        if let Some(usage) = self {
-            usage.token_usage()
-        } else {
-            None
+        self.as_ref().and_then(GetTokenUsage::token_usage)
+    }
+
+    fn terminal_metadata(&self) -> Option<CompletionTerminalMetadata> {
+        self.as_ref().and_then(GetTokenUsage::terminal_metadata)
+    }
+}
+
+/// Normalized reason a completion stream stopped producing output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum CompletionFinishReason {
+    /// The provider reported a normal stop condition.
+    Stop,
+    /// The provider stopped because the request or model output limit was reached.
+    Length,
+    /// The provider stopped to return one or more tool calls.
+    ToolCalls,
+    /// The provider stopped because content was filtered or blocked by a safety policy.
+    ContentFilter,
+    /// The provider reported a terminal reason that Rig does not recognize.
+    Unknown,
+}
+
+/// Provider terminal metadata from a completion stream.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CompletionTerminalMetadata {
+    /// Normalized finish reason.
+    pub reason: CompletionFinishReason,
+    /// Raw provider finish reason, when available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub raw_reason: Option<String>,
+}
+
+impl CompletionTerminalMetadata {
+    /// Creates terminal metadata with a normalized finish reason.
+    pub fn new(reason: CompletionFinishReason) -> Self {
+        Self {
+            reason,
+            raw_reason: None,
         }
+    }
+
+    /// Attaches the provider's raw finish reason.
+    pub fn with_raw_reason(mut self, raw_reason: impl Into<String>) -> Self {
+        self.raw_reason = Some(raw_reason.into());
+        self
+    }
+
+    /// Returns the provider's raw finish reason, when present.
+    pub fn raw_reason(&self) -> Option<&str> {
+        self.raw_reason.as_deref()
     }
 }
 

--- a/crates/rig-core/src/providers/anthropic/streaming.rs
+++ b/crates/rig-core/src/providers/anthropic/streaming.rs
@@ -11,7 +11,10 @@ use super::completion::{
     resolve_top_level_cache_control, split_system_messages_from_history,
     supports_mid_conversation_system_messages,
 };
-use crate::completion::{CompletionError, CompletionRequest, GetTokenUsage};
+use crate::completion::{
+    CompletionError, CompletionFinishReason, CompletionRequest, CompletionTerminalMetadata,
+    GetTokenUsage,
+};
 use crate::http_client::sse::{Event, GenericEventSource};
 use crate::http_client::{self, HttpClientExt};
 use crate::json_utils::merge_inplace;
@@ -143,6 +146,8 @@ struct ThinkingState {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StreamingCompletionResponse {
     pub usage: PartialUsage,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub terminal_metadata: Option<CompletionTerminalMetadata>,
 }
 
 impl GetTokenUsage for StreamingCompletionResponse {
@@ -159,6 +164,22 @@ impl GetTokenUsage for StreamingCompletionResponse {
 
         Some(usage)
     }
+
+    fn terminal_metadata(&self) -> Option<CompletionTerminalMetadata> {
+        self.terminal_metadata.clone()
+    }
+}
+
+fn terminal_metadata_from_stop_reason(stop_reason: &str) -> CompletionTerminalMetadata {
+    let reason = match stop_reason {
+        "end_turn" | "stop_sequence" => CompletionFinishReason::Stop,
+        "max_tokens" | "model_context_window" => CompletionFinishReason::Length,
+        "tool_use" => CompletionFinishReason::ToolCalls,
+        "refusal" | "safety" | "content_filter" => CompletionFinishReason::ContentFilter,
+        _ => CompletionFinishReason::Unknown,
+    };
+
+    CompletionTerminalMetadata::new(reason).with_raw_reason(stop_reason.to_owned())
 }
 
 impl<Ext, T> GenericCompletionModel<Ext, T>
@@ -322,6 +343,7 @@ where
             let mut sse_stream = Box::pin(stream);
             let mut input_tokens = 0;
             let mut final_usage = None;
+            let mut final_terminal_metadata = None;
 
             let mut text_content = String::new();
 
@@ -341,7 +363,7 @@ where
                                         span.record("gen_ai.response.model", &message.model);
                                     },
                                     StreamingEvent::MessageDelta { delta, usage } => {
-                                        if delta.stop_reason.is_some() {
+                                        if let Some(stop_reason) = delta.stop_reason.as_deref() {
                                             // cache_creation_input_tokens and cache_read_input_tokens
                                             // are cumulative totals on message_delta.usage per the
                                             // Anthropic streaming API spec — use them directly.
@@ -355,6 +377,8 @@ where
                                             let span = tracing::Span::current();
                                             span.record_token_usage(&usage);
                                             final_usage = Some(usage);
+                                            final_terminal_metadata =
+                                                Some(terminal_metadata_from_stop_reason(stop_reason));
                                             break;
                                         }
                                     }
@@ -393,7 +417,8 @@ where
             sse_stream.close();
 
             yield Ok(RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
-                usage: final_usage.unwrap_or_default()
+                usage: final_usage.unwrap_or_default(),
+                terminal_metadata: final_terminal_metadata,
             }))
         }.instrument(span));
 
@@ -589,6 +614,10 @@ fn handle_event(
 mod tests {
     use super::super::completion::{CacheControl, CacheTtl};
     use super::*;
+    use crate::completion::{CompletionModel as _, GetTokenUsage};
+    use crate::providers::internal::openai_chat_completions_compatible::test_support::sse_bytes_from_json_events;
+    use crate::streaming::StreamedAssistantContent;
+    use crate::test_utils::MockStreamingClient;
     use async_stream::stream;
     use futures::StreamExt;
 
@@ -695,6 +724,78 @@ mod tests {
             &mut server_tool_uses,
             current_thinking,
         )
+    }
+
+    #[test]
+    fn terminal_metadata_maps_anthropic_stop_reasons() {
+        let terminal_metadata = terminal_metadata_from_stop_reason("max_tokens");
+        assert_eq!(terminal_metadata.reason, CompletionFinishReason::Length);
+        assert_eq!(terminal_metadata.raw_reason(), Some("max_tokens"));
+
+        let terminal_metadata = terminal_metadata_from_stop_reason("safety");
+        assert_eq!(
+            terminal_metadata.reason,
+            CompletionFinishReason::ContentFilter
+        );
+
+        let terminal_metadata = terminal_metadata_from_stop_reason("end_turn");
+        assert_eq!(terminal_metadata.reason, CompletionFinishReason::Stop);
+    }
+
+    #[tokio::test]
+    async fn streaming_final_response_preserves_anthropic_terminal_metadata() {
+        let message_start = serde_json::json!({
+            "type": "message_start",
+            "message": {
+                "id": "msg_test",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-test",
+                "content": [],
+                "stop_reason": null,
+                "stop_sequence": null,
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 0
+                }
+            }
+        });
+        let message_delta = serde_json::json!({
+            "type": "message_delta",
+            "delta": {
+                "stop_reason": "max_tokens",
+                "stop_sequence": null
+            },
+            "usage": {
+                "output_tokens": 5
+            }
+        });
+
+        let client = super::super::Client::builder()
+            .http_client(MockStreamingClient {
+                sse_bytes: sse_bytes_from_json_events(&[message_start, message_delta]),
+            })
+            .api_key("test-key")
+            .build()
+            .expect("client should build");
+        let model = super::super::completion::CompletionModel::with_model(client, "claude-test");
+        let request = model.completion_request("hello").build();
+        let mut stream = model.stream(request).await.expect("stream should start");
+
+        while let Some(item) = stream.next().await {
+            if let StreamedAssistantContent::Final(response) =
+                item.expect("stream item should be ok")
+            {
+                let terminal_metadata = response
+                    .terminal_metadata()
+                    .expect("final response should include terminal metadata");
+                assert_eq!(terminal_metadata.reason, CompletionFinishReason::Length);
+                assert_eq!(terminal_metadata.raw_reason(), Some("max_tokens"));
+                return;
+            }
+        }
+
+        panic!("stream should yield a final response");
     }
 
     #[test]
@@ -1369,6 +1470,7 @@ mod tests {
 
             yield Ok(RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
                 usage: PartialUsage::default(),
+                terminal_metadata: None,
             }));
         };
 
@@ -1514,6 +1616,7 @@ mod tests {
 
             yield Ok(RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
                 usage: PartialUsage::default(),
+                terminal_metadata: None,
             }));
         };
 

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -26,13 +26,12 @@ use crate::client::{
     self, ApiKey, Capabilities, Capable, DebugExt, ModelLister, Nothing, Provider, ProviderBuilder,
     ProviderClient, Transport,
 };
-use crate::completion::{self, CompletionError, GetTokenUsage};
+use crate::completion::{self, CompletionError, CompletionTerminalMetadata, GetTokenUsage};
 use crate::embeddings::{self, EmbeddingError};
 use crate::http_client::{self, HttpClientExt};
 use crate::model::{Model, ModelList, ModelListingError};
 use crate::providers::internal::openai_chat_completions_compatible::{
-    self, CompatibleChoiceData, CompatibleChunk, CompatibleFinishReason, CompatibleStreamProfile,
-    CompatibleToolCallChunk,
+    self, CompatibleChoiceData, CompatibleChunk, CompatibleStreamProfile, CompatibleToolCallChunk,
 };
 use crate::providers::openai;
 use crate::providers::openai::responses_api::{self, CompletionRequest as ResponsesRequest};
@@ -570,6 +569,13 @@ impl GetTokenUsage for CopilotStreamingResponse {
         match self {
             Self::Chat(response) => response.token_usage(),
             Self::Responses(response) => response.token_usage(),
+        }
+    }
+
+    fn terminal_metadata(&self) -> Option<CompletionTerminalMetadata> {
+        match self {
+            Self::Chat(response) => response.terminal_metadata(),
+            Self::Responses(response) => response.terminal_metadata(),
         }
     }
 }
@@ -1186,7 +1192,10 @@ where
 
                 yield Ok(RawStreamingChoice::FinalResponse(
                     CopilotStreamingResponse::Responses(
-                        responses_api::streaming::StreamingCompletionResponse { usage: final_usage }
+                        responses_api::streaming::StreamingCompletionResponse {
+                            usage: final_usage,
+                            terminal_metadata: None,
+                        }
                     )
                 ));
             },
@@ -1521,6 +1530,16 @@ enum ChatFinishReason {
     Other(String),
 }
 
+fn chat_raw_finish_reason(reason: &ChatFinishReason) -> String {
+    match reason {
+        ChatFinishReason::ToolCalls => "tool_calls".to_owned(),
+        ChatFinishReason::Stop => "stop".to_owned(),
+        ChatFinishReason::ContentFilter => "content_filter".to_owned(),
+        ChatFinishReason::Length => "length".to_owned(),
+        ChatFinishReason::Other(reason) => reason.clone(),
+    }
+}
+
 #[derive(Deserialize, Debug)]
 struct ChatStreamingChoice {
     delta: ChatStreamingDelta,
@@ -1561,26 +1580,33 @@ impl CompatibleStreamProfile for CopilotChatCompatibleProfile {
                 data.model,
                 data.usage,
                 &data.choices,
-                |choice| CompatibleChoiceData {
-                    finish_reason: if choice.finish_reason == Some(ChatFinishReason::ToolCalls) {
-                        CompatibleFinishReason::ToolCalls
-                    } else {
-                        CompatibleFinishReason::Other
-                    },
+                |choice| {
+                    CompatibleChoiceData {
+                    terminal_metadata: choice.finish_reason.as_ref().map(|reason| {
+                        openai_chat_completions_compatible::terminal_metadata_from_raw_finish_reason(
+                            chat_raw_finish_reason(reason),
+                        )
+                    }),
                     text: choice.delta.content.clone(),
                     reasoning: choice.delta.reasoning_content.clone(),
                     tool_calls: openai_chat_completions_compatible::tool_call_chunks(
                         &choice.delta.tool_calls,
                     ),
                     details: Vec::new(),
+                }
                 },
             ),
         ))
     }
 
-    fn build_final_response(&self, usage: Self::Usage) -> Self::FinalResponse {
+    fn build_final_response(
+        &self,
+        usage: Self::Usage,
+        terminal_metadata: Option<CompletionTerminalMetadata>,
+    ) -> Self::FinalResponse {
         CopilotStreamingResponse::Chat(openai::completion::streaming::StreamingCompletionResponse {
             usage,
+            terminal_metadata,
         })
     }
 

--- a/crates/rig-core/src/providers/deepseek.rs
+++ b/crates/rig-core/src/providers/deepseek.rs
@@ -20,12 +20,12 @@ use crate::client::{
     self, BearerAuth, Capabilities, Capable, DebugExt, ModelLister, Nothing, Provider,
     ProviderBuilder, ProviderClient,
 };
-use crate::completion::GetTokenUsage;
+use crate::completion::{CompletionTerminalMetadata, GetTokenUsage};
 use crate::http_client::{self, HttpClientExt};
 use crate::message::{Document, DocumentSourceKind};
 use crate::model::{Model, ModelList, ModelListingError};
 use crate::providers::internal::openai_chat_completions_compatible::{
-    self, CompatibleChoiceData, CompatibleChunk, CompatibleFinishReason, CompatibleStreamProfile,
+    self, CompatibleChoiceData, CompatibleChunk, CompatibleStreamProfile,
 };
 use crate::{
     OneOrMany,
@@ -705,6 +705,7 @@ pub struct StreamingDelta {
 #[derive(Deserialize, Debug)]
 struct StreamingChoice {
     delta: StreamingDelta,
+    finish_reason: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -718,11 +719,17 @@ struct StreamingCompletionChunk {
 #[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct StreamingCompletionResponse {
     pub usage: Usage,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub terminal_metadata: Option<CompletionTerminalMetadata>,
 }
 
 impl GetTokenUsage for StreamingCompletionResponse {
     fn token_usage(&self) -> Option<crate::completion::Usage> {
         self.usage.token_usage()
+    }
+
+    fn terminal_metadata(&self) -> Option<CompletionTerminalMetadata> {
+        self.terminal_metadata.clone()
     }
 }
 
@@ -755,21 +762,32 @@ impl CompatibleStreamProfile for DeepSeekCompatibleProfile {
                 data.model,
                 data.usage,
                 &data.choices,
-                |choice| CompatibleChoiceData {
-                    finish_reason: CompatibleFinishReason::Other,
+                |choice| {
+                    CompatibleChoiceData {
+                    terminal_metadata: choice.finish_reason.clone().map(
+                        openai_chat_completions_compatible::terminal_metadata_from_raw_finish_reason,
+                    ),
                     text: choice.delta.content.clone(),
                     reasoning: choice.delta.reasoning_content.clone(),
                     tool_calls: openai_chat_completions_compatible::tool_call_chunks(
                         &choice.delta.tool_calls,
                     ),
                     details: Vec::new(),
+                }
                 },
             ),
         ))
     }
 
-    fn build_final_response(&self, usage: Self::Usage) -> Self::FinalResponse {
-        StreamingCompletionResponse { usage }
+    fn build_final_response(
+        &self,
+        usage: Self::Usage,
+        terminal_metadata: Option<CompletionTerminalMetadata>,
+    ) -> Self::FinalResponse {
+        StreamingCompletionResponse {
+            usage,
+            terminal_metadata,
+        }
     }
 
     fn uses_distinct_tool_call_eviction(&self) -> bool {

--- a/crates/rig-core/src/providers/gemini/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/streaming.rs
@@ -12,7 +12,10 @@ use super::completion::{
     streaming_endpoint,
 };
 use crate::completion::message::ReasoningContent;
-use crate::completion::{CompletionError, CompletionRequest, GetTokenUsage};
+use crate::completion::{
+    CompletionError, CompletionFinishReason, CompletionRequest, CompletionTerminalMetadata,
+    GetTokenUsage,
+};
 use crate::http_client::HttpClientExt;
 use crate::http_client::sse::{Event, GenericEventSource};
 use crate::streaming;
@@ -79,11 +82,61 @@ pub struct StreamingCompletionResponse {
     pub finish_message: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub terminal_metadata: Option<CompletionTerminalMetadata>,
 }
 
 impl GetTokenUsage for StreamingCompletionResponse {
     fn token_usage(&self) -> Option<crate::completion::Usage> {
         self.usage_metadata.token_usage()
+    }
+
+    fn terminal_metadata(&self) -> Option<CompletionTerminalMetadata> {
+        self.terminal_metadata.clone()
+    }
+}
+
+fn terminal_metadata_from_finish_reason(
+    finish_reason: &FinishReason,
+) -> CompletionTerminalMetadata {
+    let reason = match finish_reason {
+        FinishReason::Stop => CompletionFinishReason::Stop,
+        FinishReason::MaxTokens => CompletionFinishReason::Length,
+        FinishReason::Safety
+        | FinishReason::Recitation
+        | FinishReason::Language
+        | FinishReason::Blocklist
+        | FinishReason::ProhibitedContent
+        | FinishReason::Spii => CompletionFinishReason::ContentFilter,
+        FinishReason::FinishReasonUnspecified
+        | FinishReason::Other
+        | FinishReason::MalformedFunctionCall
+        | FinishReason::UnexpectedToolCall
+        | FinishReason::MissingThoughtSignature
+        | FinishReason::TooManyToolCalls
+        | FinishReason::MalformedResponse => CompletionFinishReason::Unknown,
+    };
+
+    CompletionTerminalMetadata::new(reason).with_raw_reason(raw_finish_reason(finish_reason))
+}
+
+fn raw_finish_reason(finish_reason: &FinishReason) -> &'static str {
+    match finish_reason {
+        FinishReason::FinishReasonUnspecified => "FINISH_REASON_UNSPECIFIED",
+        FinishReason::Stop => "STOP",
+        FinishReason::MaxTokens => "MAX_TOKENS",
+        FinishReason::Safety => "SAFETY",
+        FinishReason::Recitation => "RECITATION",
+        FinishReason::Language => "LANGUAGE",
+        FinishReason::Other => "OTHER",
+        FinishReason::Blocklist => "BLOCKLIST",
+        FinishReason::ProhibitedContent => "PROHIBITED_CONTENT",
+        FinishReason::Spii => "SPII",
+        FinishReason::MalformedFunctionCall => "MALFORMED_FUNCTION_CALL",
+        FinishReason::UnexpectedToolCall => "UNEXPECTED_TOOL_CALL",
+        FinishReason::MissingThoughtSignature => "MISSING_THOUGHT_SIGNATURE",
+        FinishReason::TooManyToolCalls => "TOO_MANY_TOOL_CALLS",
+        FinishReason::MalformedResponse => "MALFORMED_RESPONSE",
     }
 }
 
@@ -148,6 +201,7 @@ where
             let mut final_finish_reason: Option<FinishReason> = None;
             let mut final_finish_message: Option<String> = None;
             let mut final_model_version: Option<String> = None;
+            let mut final_terminal_metadata = None;
             let mut stream_failed = false;
             while let Some(event_result) = event_source.next().await {
                 match event_result {
@@ -194,6 +248,7 @@ where
                         let should_stop = choice.finish_reason.is_some();
                         if let Some(fr) = &choice.finish_reason {
                             final_finish_reason = Some(fr.clone());
+                            final_terminal_metadata = Some(terminal_metadata_from_finish_reason(fr));
                         }
                         if let Some(message) = &choice.finish_message {
                             final_finish_message = Some(message.clone());
@@ -297,6 +352,7 @@ where
                     finish_reason: final_finish_reason,
                     finish_message: final_finish_message,
                     model_version: final_model_version,
+                    terminal_metadata: final_terminal_metadata,
                 }));
             }
         }.instrument(span);
@@ -310,7 +366,68 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::completion::{CompletionModel as _, GetTokenUsage};
+    use crate::providers::internal::openai_chat_completions_compatible::test_support::sse_bytes_from_json_events;
+    use crate::streaming::StreamedAssistantContent;
+    use crate::test_utils::MockStreamingClient;
     use serde_json::json;
+
+    #[test]
+    fn terminal_metadata_maps_gemini_finish_reasons() {
+        let terminal_metadata = terminal_metadata_from_finish_reason(&FinishReason::MaxTokens);
+        assert_eq!(terminal_metadata.reason, CompletionFinishReason::Length);
+        assert_eq!(terminal_metadata.raw_reason(), Some("MAX_TOKENS"));
+
+        let terminal_metadata = terminal_metadata_from_finish_reason(&FinishReason::Safety);
+        assert_eq!(
+            terminal_metadata.reason,
+            CompletionFinishReason::ContentFilter
+        );
+
+        let terminal_metadata = terminal_metadata_from_finish_reason(&FinishReason::Stop);
+        assert_eq!(terminal_metadata.reason, CompletionFinishReason::Stop);
+    }
+
+    #[tokio::test]
+    async fn streaming_final_response_preserves_gemini_terminal_metadata() {
+        let event = json!({
+            "candidates": [{
+                "finishReason": "MAX_TOKENS",
+                "index": 0
+            }],
+            "usageMetadata": {
+                "promptTokenCount": 10,
+                "candidatesTokenCount": 5,
+                "totalTokenCount": 15
+            }
+        });
+
+        let client = super::super::Client::builder()
+            .http_client(MockStreamingClient {
+                sse_bytes: sse_bytes_from_json_events(&[event]),
+            })
+            .api_key("test-key")
+            .build()
+            .expect("client should build");
+        let model = super::super::CompletionModel::with_model(client, "gemini-test");
+        let request = model.completion_request("hello").build();
+        let mut stream = model.stream(request).await.expect("stream should start");
+
+        while let Some(item) = stream.next().await {
+            if let StreamedAssistantContent::Final(response) =
+                item.expect("stream item should be ok")
+            {
+                let terminal_metadata = response
+                    .terminal_metadata()
+                    .expect("final response should include terminal metadata");
+                assert_eq!(terminal_metadata.reason, CompletionFinishReason::Length);
+                assert_eq!(terminal_metadata.raw_reason(), Some("MAX_TOKENS"));
+                return;
+            }
+        }
+
+        panic!("stream should yield a final response");
+    }
 
     #[test]
     fn test_deserialize_stream_response_with_single_text_part() {
@@ -721,6 +838,7 @@ mod tests {
             finish_reason: Some(FinishReason::Stop),
             finish_message: None,
             model_version: Some("gemini-2.5-pro-preview-05-06".to_string()),
+            terminal_metadata: None,
         };
 
         assert!(matches!(response.finish_reason, Some(FinishReason::Stop)));
@@ -760,6 +878,7 @@ mod tests {
             finish_reason: Some(FinishReason::Stop),
             finish_message: None,
             model_version: Some("gemini-2.0-flash-001".to_string()),
+            terminal_metadata: None,
         };
 
         let token_usage = response.token_usage().unwrap();

--- a/crates/rig-core/src/providers/groq.rs
+++ b/crates/rig-core/src/providers/groq.rs
@@ -23,11 +23,11 @@ use crate::client::{
     self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
     ProviderClient,
 };
-use crate::completion::GetTokenUsage;
+use crate::completion::{CompletionTerminalMetadata, GetTokenUsage};
 use crate::http_client::multipart::Part;
 use crate::http_client::{self, HttpClientExt, MultipartForm};
 use crate::providers::internal::openai_chat_completions_compatible::{
-    self, CompatibleChoiceData, CompatibleChunk, CompatibleFinishReason, CompatibleStreamProfile,
+    self, CompatibleChoiceData, CompatibleChunk, CompatibleStreamProfile,
 };
 
 use crate::{
@@ -620,6 +620,7 @@ enum StreamingDelta {
 #[derive(Deserialize, Debug)]
 struct StreamingChoice {
     delta: StreamingDelta,
+    finish_reason: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -633,11 +634,17 @@ struct StreamingCompletionChunk {
 #[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct StreamingCompletionResponse {
     pub usage: Usage,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub terminal_metadata: Option<CompletionTerminalMetadata>,
 }
 
 impl GetTokenUsage for StreamingCompletionResponse {
     fn token_usage(&self) -> Option<crate::completion::Usage> {
         self.usage.token_usage()
+    }
+
+    fn terminal_metadata(&self) -> Option<CompletionTerminalMetadata> {
+        self.terminal_metadata.clone()
     }
 }
 
@@ -670,9 +677,12 @@ impl CompatibleStreamProfile for GroqCompatibleProfile {
                 data.model,
                 data.usage,
                 &data.choices,
-                |choice| match &choice.delta {
+                |choice| {
+                    match &choice.delta {
                     StreamingDelta::Reasoning { reasoning } => CompatibleChoiceData {
-                        finish_reason: CompatibleFinishReason::Other,
+                        terminal_metadata: choice.finish_reason.clone().map(
+                            openai_chat_completions_compatible::terminal_metadata_from_raw_finish_reason,
+                        ),
                         text: None,
                         reasoning: Some(reasoning.clone()),
                         tool_calls: Vec::new(),
@@ -682,7 +692,9 @@ impl CompatibleStreamProfile for GroqCompatibleProfile {
                         content,
                         tool_calls,
                     } => CompatibleChoiceData {
-                        finish_reason: CompatibleFinishReason::Other,
+                        terminal_metadata: choice.finish_reason.clone().map(
+                            openai_chat_completions_compatible::terminal_metadata_from_raw_finish_reason,
+                        ),
                         text: content.clone(),
                         reasoning: None,
                         tool_calls: openai_chat_completions_compatible::tool_call_chunks(
@@ -690,13 +702,21 @@ impl CompatibleStreamProfile for GroqCompatibleProfile {
                         ),
                         details: Vec::new(),
                     },
+                }
                 },
             ),
         ))
     }
 
-    fn build_final_response(&self, usage: Self::Usage) -> Self::FinalResponse {
-        StreamingCompletionResponse { usage }
+    fn build_final_response(
+        &self,
+        usage: Self::Usage,
+        terminal_metadata: Option<CompletionTerminalMetadata>,
+    ) -> Self::FinalResponse {
+        StreamingCompletionResponse {
+            usage,
+            terminal_metadata,
+        }
     }
 
     fn uses_distinct_tool_call_eviction(&self) -> bool {

--- a/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
+++ b/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
@@ -13,7 +13,9 @@ use futures::StreamExt;
 use http::Request;
 use tracing_futures::Instrument;
 
-use crate::completion::{CompletionError, GetTokenUsage};
+use crate::completion::{
+    CompletionError, CompletionFinishReason, CompletionTerminalMetadata, GetTokenUsage,
+};
 use crate::http_client::HttpClientExt;
 use crate::http_client::sse::{Event, GenericEventSource};
 use crate::json_utils;
@@ -22,8 +24,48 @@ use crate::wasm_compat::WasmCompatSend;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CompatibleFinishReason {
+    Stop,
+    Length,
     ToolCalls,
-    Other,
+    ContentFilter,
+    Unknown,
+}
+
+impl From<CompatibleFinishReason> for CompletionFinishReason {
+    fn from(value: CompatibleFinishReason) -> Self {
+        match value {
+            CompatibleFinishReason::Stop => Self::Stop,
+            CompatibleFinishReason::Length => Self::Length,
+            CompatibleFinishReason::ToolCalls => Self::ToolCalls,
+            CompatibleFinishReason::ContentFilter => Self::ContentFilter,
+            CompatibleFinishReason::Unknown => Self::Unknown,
+        }
+    }
+}
+
+pub(crate) fn compatible_finish_reason_from_raw(raw_reason: &str) -> CompatibleFinishReason {
+    match raw_reason.trim().to_ascii_lowercase().as_str() {
+        "stop" | "end_turn" | "stop_sequence" | "completed" => CompatibleFinishReason::Stop,
+        "length"
+        | "max_tokens"
+        | "max_completion_tokens"
+        | "max_output_tokens"
+        | "model_context_window" => CompatibleFinishReason::Length,
+        "tool_calls" | "tool_use" | "function_call" => CompatibleFinishReason::ToolCalls,
+        "content_filter" | "filtered" | "safety" | "refusal" | "recitation" | "language"
+        | "blocklist" | "prohibited_content" | "spii" => CompatibleFinishReason::ContentFilter,
+        _ => CompatibleFinishReason::Unknown,
+    }
+}
+
+pub(crate) fn terminal_metadata_from_raw_finish_reason(
+    raw_reason: impl Into<String>,
+) -> CompletionTerminalMetadata {
+    let raw_reason = raw_reason.into();
+    CompletionTerminalMetadata::new(CompletionFinishReason::from(
+        compatible_finish_reason_from_raw(&raw_reason),
+    ))
+    .with_raw_reason(raw_reason)
 }
 
 #[derive(Debug, Clone)]
@@ -61,7 +103,7 @@ impl CompatibleToolCallChunk {
 
 #[derive(Debug, Clone)]
 pub(crate) struct CompatibleChoice<D> {
-    pub(crate) finish_reason: CompatibleFinishReason,
+    pub(crate) terminal_metadata: Option<CompletionTerminalMetadata>,
     pub(crate) text: Option<String>,
     pub(crate) reasoning: Option<String>,
     pub(crate) tool_calls: Vec<CompatibleToolCallChunk>,
@@ -70,7 +112,7 @@ pub(crate) struct CompatibleChoice<D> {
 
 #[derive(Debug, Clone)]
 pub(crate) struct CompatibleChoiceData<T, D> {
-    pub(crate) finish_reason: CompatibleFinishReason,
+    pub(crate) terminal_metadata: Option<CompletionTerminalMetadata>,
     pub(crate) text: Option<String>,
     pub(crate) reasoning: Option<String>,
     pub(crate) tool_calls: Vec<T>,
@@ -94,7 +136,7 @@ where
 {
     fn from(value: CompatibleChoiceData<T, D>) -> Self {
         Self {
-            finish_reason: value.finish_reason,
+            terminal_metadata: value.terminal_metadata,
             text: value.text,
             reasoning: value.reasoning,
             tool_calls: value.tool_calls.into_iter().map(Into::into).collect(),
@@ -141,7 +183,11 @@ pub(crate) trait CompatibleStreamProfile: WasmCompatSend {
 
     fn normalize_chunk(&self, data: &str) -> NormalizedCompatibleChunk<Self::Usage, Self::Detail>;
 
-    fn build_final_response(&self, usage: Self::Usage) -> Self::FinalResponse;
+    fn build_final_response(
+        &self,
+        usage: Self::Usage,
+        terminal_metadata: Option<CompletionTerminalMetadata>,
+    ) -> Self::FinalResponse;
 
     fn uses_distinct_tool_call_eviction(&self) -> bool {
         false
@@ -210,6 +256,7 @@ where
     let stream = stream! {
         let mut tool_calls: HashMap<usize, RawStreamingToolCall> = HashMap::new();
         let mut final_usage = None;
+        let mut final_terminal_metadata = None;
         let mut terminated_with_error = false;
 
         while let Some(event_result) = event_source.next().await {
@@ -246,6 +293,7 @@ where
                     let Some(choice) = chunk.choice else {
                         continue;
                     };
+                    let choice_terminal_metadata = choice.terminal_metadata.clone();
 
                     for incoming in choice.tool_calls {
                         if let Some(existing) = tool_calls.get(&incoming.index)
@@ -324,13 +372,20 @@ where
                         yield Ok(RawStreamingChoice::Message(content));
                     }
 
-                    if choice.finish_reason == CompatibleFinishReason::ToolCalls {
+                    if choice_terminal_metadata
+                        .as_ref()
+                        .is_some_and(|metadata| metadata.reason == CompletionFinishReason::ToolCalls)
+                    {
                         for tool_call in take_finalized_tool_calls(
                             &mut tool_calls,
                             DroppedToolCallContext::ToolCallsFinishReason,
                         ) {
                             yield Ok(RawStreamingChoice::ToolCall(tool_call));
                         }
+                    }
+
+                    if let Some(terminal_metadata) = choice_terminal_metadata {
+                        final_terminal_metadata = Some(terminal_metadata);
                     }
                 }
                 Err(crate::http_client::Error::StreamEnded) => {
@@ -360,7 +415,7 @@ where
         let final_usage = final_usage.unwrap_or_default();
         record_usage(&span, &final_usage);
         yield Ok(RawStreamingChoice::FinalResponse(
-            profile.build_final_response(final_usage),
+            profile.build_final_response(final_usage, final_terminal_metadata),
         ));
     }
     .instrument(instrument_span);

--- a/crates/rig-core/src/providers/llamafile.rs
+++ b/crates/rig-core/src/providers/llamafile.rs
@@ -26,10 +26,10 @@
 use crate::client::{
     self, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder, ProviderClient,
 };
-use crate::completion::GetTokenUsage;
+use crate::completion::{CompletionTerminalMetadata, GetTokenUsage};
 use crate::http_client::{self, HttpClientExt};
 use crate::providers::internal::openai_chat_completions_compatible::{
-    self, CompatibleChoiceData, CompatibleChunk, CompatibleFinishReason, CompatibleStreamProfile,
+    self, CompatibleChoiceData, CompatibleChunk, CompatibleStreamProfile,
 };
 use crate::providers::openai::{self, StreamingToolCall};
 use crate::{
@@ -536,11 +536,17 @@ struct StreamingCompletionChunk {
 pub struct StreamingCompletionResponse {
     /// Token usage from the streaming response.
     pub usage: openai::Usage,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub terminal_metadata: Option<CompletionTerminalMetadata>,
 }
 
 impl GetTokenUsage for StreamingCompletionResponse {
     fn token_usage(&self) -> Option<crate::completion::Usage> {
         self.usage.token_usage()
+    }
+
+    fn terminal_metadata(&self) -> Option<CompletionTerminalMetadata> {
+        self.terminal_metadata.clone()
     }
 }
 
@@ -573,27 +579,34 @@ impl CompatibleStreamProfile for LlamafileCompatibleProfile {
                 data.model,
                 data.usage,
                 &data.choices,
-                |choice| CompatibleChoiceData {
-                    finish_reason: if choice.finish_reason
-                        == Some(openai::completion::streaming::FinishReason::ToolCalls)
-                    {
-                        CompatibleFinishReason::ToolCalls
-                    } else {
-                        CompatibleFinishReason::Other
-                    },
+                |choice| {
+                    CompatibleChoiceData {
+                    terminal_metadata: choice.finish_reason.as_ref().map(|reason| {
+                        openai_chat_completions_compatible::terminal_metadata_from_raw_finish_reason(
+                            openai::completion::streaming::raw_finish_reason(reason),
+                        )
+                    }),
                     text: choice.delta.content.clone(),
                     reasoning: None,
                     tool_calls: openai_chat_completions_compatible::tool_call_chunks(
                         &choice.delta.tool_calls,
                     ),
                     details: Vec::new(),
+                }
                 },
             ),
         ))
     }
 
-    fn build_final_response(&self, usage: Self::Usage) -> Self::FinalResponse {
-        StreamingCompletionResponse { usage }
+    fn build_final_response(
+        &self,
+        usage: Self::Usage,
+        terminal_metadata: Option<CompletionTerminalMetadata>,
+    ) -> Self::FinalResponse {
+        StreamingCompletionResponse {
+            usage,
+            terminal_metadata,
+        }
     }
 
     fn uses_distinct_tool_call_eviction(&self) -> bool {

--- a/crates/rig-core/src/providers/openai/completion/streaming.rs
+++ b/crates/rig-core/src/providers/openai/completion/streaming.rs
@@ -3,12 +3,13 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tracing::{Level, enabled, info_span};
 
-use crate::completion::{CompletionError, CompletionRequest, GetTokenUsage};
+use crate::completion::{
+    CompletionError, CompletionRequest, CompletionTerminalMetadata, GetTokenUsage,
+};
 use crate::http_client::HttpClientExt;
 use crate::json_utils::{self, merge};
 use crate::providers::internal::openai_chat_completions_compatible::{
-    self, CompatibleChoiceData, CompatibleChunk, CompatibleFinishReason, CompatibleStreamProfile,
-    CompatibleToolCallChunk,
+    self, CompatibleChoiceData, CompatibleChunk, CompatibleStreamProfile, CompatibleToolCallChunk,
 };
 use crate::providers::openai::completion::{GenericCompletionModel, OpenAIRequestParams, Usage};
 use crate::streaming;
@@ -66,6 +67,16 @@ pub enum FinishReason {
     Other(String), // This will handle the deprecated function_call
 }
 
+pub(crate) fn raw_finish_reason(reason: &FinishReason) -> String {
+    match reason {
+        FinishReason::ToolCalls => "tool_calls".to_owned(),
+        FinishReason::Stop => "stop".to_owned(),
+        FinishReason::ContentFilter => "content_filter".to_owned(),
+        FinishReason::Length => "length".to_owned(),
+        FinishReason::Other(reason) => reason.clone(),
+    }
+}
+
 #[derive(Deserialize, Debug)]
 struct StreamingChoice {
     delta: StreamingDelta,
@@ -83,11 +94,17 @@ struct StreamingCompletionChunk {
 #[derive(Clone, Serialize, Deserialize)]
 pub struct StreamingCompletionResponse {
     pub usage: Usage,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub terminal_metadata: Option<CompletionTerminalMetadata>,
 }
 
 impl GetTokenUsage for StreamingCompletionResponse {
     fn token_usage(&self) -> Option<crate::completion::Usage> {
         self.usage.token_usage()
+    }
+
+    fn terminal_metadata(&self) -> Option<CompletionTerminalMetadata> {
+        self.terminal_metadata.clone()
     }
 }
 
@@ -182,25 +199,34 @@ impl CompatibleStreamProfile for OpenAICompatibleProfile {
                 data.model,
                 data.usage,
                 &data.choices,
-                |choice| CompatibleChoiceData {
-                    finish_reason: if choice.finish_reason == Some(FinishReason::ToolCalls) {
-                        CompatibleFinishReason::ToolCalls
-                    } else {
-                        CompatibleFinishReason::Other
-                    },
-                    text: choice.delta.content.clone(),
-                    reasoning: choice.delta.reasoning_content.clone(),
-                    tool_calls: openai_chat_completions_compatible::tool_call_chunks(
-                        &choice.delta.tool_calls,
-                    ),
-                    details: Vec::new(),
+                |choice| {
+                    CompatibleChoiceData {
+                        terminal_metadata: choice.finish_reason.as_ref().map(|reason| {
+                            openai_chat_completions_compatible::terminal_metadata_from_raw_finish_reason(
+                                raw_finish_reason(reason),
+                            )
+                        }),
+                        text: choice.delta.content.clone(),
+                        reasoning: choice.delta.reasoning_content.clone(),
+                        tool_calls: openai_chat_completions_compatible::tool_call_chunks(
+                            &choice.delta.tool_calls,
+                        ),
+                        details: Vec::new(),
+                    }
                 },
             ),
         ))
     }
 
-    fn build_final_response(&self, usage: Self::Usage) -> Self::FinalResponse {
-        StreamingCompletionResponse { usage }
+    fn build_final_response(
+        &self,
+        usage: Self::Usage,
+        terminal_metadata: Option<CompletionTerminalMetadata>,
+    ) -> Self::FinalResponse {
+        StreamingCompletionResponse {
+            usage,
+            terminal_metadata,
+        }
     }
 
     fn uses_distinct_tool_call_eviction(&self) -> bool {
@@ -559,6 +585,44 @@ mod tests {
         assert_eq!(usage.total_tokens, 10);
         let token_usage = usage.token_usage().expect("usage should convert");
         assert_eq!(token_usage.output_tokens, 6);
+    }
+
+    #[tokio::test]
+    async fn test_streaming_final_response_preserves_finish_reason() {
+        use crate::completion::CompletionFinishReason;
+        use crate::test_utils::MockStreamingClient;
+        use futures::StreamExt;
+
+        let client = MockStreamingClient {
+            sse_bytes: sse_bytes_from_data_lines([
+                "{\"choices\":[{\"delta\":{\"content\":\"Hello\",\"tool_calls\":[]},\"finish_reason\":null}],\"usage\":null}",
+                "{\"choices\":[{\"delta\":{\"tool_calls\":[]},\"finish_reason\":\"length\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}",
+                "[DONE]",
+            ]),
+        };
+
+        let req = http::Request::builder()
+            .method("POST")
+            .uri("http://localhost/v1/chat/completions")
+            .body(Vec::new())
+            .unwrap();
+
+        let mut stream = send_compatible_streaming_request(client, req)
+            .await
+            .unwrap();
+
+        let mut terminal_metadata = None;
+        while let Some(chunk) = stream.next().await {
+            if let streaming::StreamedAssistantContent::Final(res) = chunk.unwrap() {
+                terminal_metadata = res.terminal_metadata();
+                break;
+            }
+        }
+
+        let terminal_metadata =
+            terminal_metadata.expect("expected a final response with terminal metadata");
+        assert_eq!(terminal_metadata.reason, CompletionFinishReason::Length);
+        assert_eq!(terminal_metadata.raw_reason(), Some("length"));
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -1,6 +1,8 @@
 //! The streaming module for the OpenAI Responses API.
 //! Please see the `openai_streaming` or `openai_streaming_with_tools` example for more practical usage.
-use crate::completion::{self, CompletionError, GetTokenUsage};
+use crate::completion::{
+    self, CompletionError, CompletionFinishReason, CompletionTerminalMetadata, GetTokenUsage,
+};
 use crate::http_client::HttpClientExt;
 use crate::http_client::sse::{Event, GenericEventSource};
 use crate::message::ReasoningContent;
@@ -38,6 +40,9 @@ pub enum StreamingCompletionChunk {
 pub struct StreamingCompletionResponse {
     /// Token usage
     pub usage: ResponsesUsage,
+    /// Provider terminal metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub terminal_metadata: Option<CompletionTerminalMetadata>,
 }
 
 pub(crate) fn reasoning_choices_from_done_item(
@@ -68,6 +73,10 @@ pub(crate) fn reasoning_choices_from_done_item(
 impl GetTokenUsage for StreamingCompletionResponse {
     fn token_usage(&self) -> Option<crate::completion::Usage> {
         self.usage.token_usage()
+    }
+
+    fn terminal_metadata(&self) -> Option<CompletionTerminalMetadata> {
+        self.terminal_metadata.clone()
     }
 }
 
@@ -136,6 +145,48 @@ fn response_error_message(error: Option<&super::ResponseError>, fallback: &str) 
     }
 }
 
+fn response_terminal_metadata(
+    kind: &ResponseChunkKind,
+    response: &CompletionResponse,
+) -> Option<CompletionTerminalMetadata> {
+    match kind {
+        ResponseChunkKind::ResponseCompleted => Some(
+            CompletionTerminalMetadata::new(CompletionFinishReason::Stop)
+                .with_raw_reason("completed"),
+        ),
+        ResponseChunkKind::ResponseIncomplete => {
+            let raw_reason = response
+                .incomplete_details
+                .as_ref()
+                .map(|details| details.reason.as_str())
+                .unwrap_or("incomplete");
+            Some(
+                CompletionTerminalMetadata::new(incomplete_finish_reason(raw_reason))
+                    .with_raw_reason(raw_reason.to_owned()),
+            )
+        }
+        _ => None,
+    }
+}
+
+fn incomplete_finish_reason(raw_reason: &str) -> CompletionFinishReason {
+    let normalized = raw_reason.trim().to_ascii_lowercase();
+    if normalized.contains("max_output")
+        || normalized.contains("max_token")
+        || normalized == "length"
+    {
+        CompletionFinishReason::Length
+    } else if normalized.contains("filter")
+        || normalized.contains("safety")
+        || normalized.contains("policy")
+        || normalized.contains("blocked")
+    {
+        CompletionFinishReason::ContentFilter
+    } else {
+        CompletionFinishReason::Unknown
+    }
+}
+
 #[derive(Clone, Copy)]
 pub(crate) enum ResponsesStreamOptions {
     Strict,
@@ -151,7 +202,7 @@ impl ResponsesStreamOptions {
         Self::StrictWithImmediateToolCalls
     }
 
-    const fn errors_on_terminal_response(self) -> bool {
+    const fn errors_on_failed_response(self) -> bool {
         true
     }
 
@@ -255,6 +306,7 @@ pub(crate) fn parse_sse_completion_body(
 
 struct RawChoiceAccumulator {
     final_usage: ResponsesUsage,
+    terminal_metadata: Option<CompletionTerminalMetadata>,
     tool_calls: Vec<StreamingRawChoice>,
     tool_call_internal_ids: std::collections::HashMap<String, String>,
 }
@@ -263,6 +315,7 @@ impl RawChoiceAccumulator {
     fn new(initial_usage: ResponsesUsage) -> Self {
         Self {
             final_usage: initial_usage,
+            terminal_metadata: None,
             tool_calls: Vec::new(),
             tool_call_internal_ids: std::collections::HashMap::new(),
         }
@@ -345,14 +398,20 @@ impl RawChoiceAccumulator {
     ) -> Result<(), CompletionError> {
         match kind {
             ResponseChunkKind::ResponseCompleted => {
-                if let Some(usage) = response.usage {
+                if let Some(usage) = response.usage.clone() {
                     self.final_usage = usage;
                 }
+                self.terminal_metadata = response_terminal_metadata(&kind, &response);
                 Ok(())
             }
-            ResponseChunkKind::ResponseFailed | ResponseChunkKind::ResponseIncomplete
-                if options.errors_on_terminal_response() =>
-            {
+            ResponseChunkKind::ResponseIncomplete => {
+                if let Some(usage) = response.usage.clone() {
+                    self.final_usage = usage;
+                }
+                self.terminal_metadata = response_terminal_metadata(&kind, &response);
+                Ok(())
+            }
+            ResponseChunkKind::ResponseFailed if options.errors_on_failed_response() => {
                 let error_message = response_chunk_error_message(&kind, &response, provider_name)
                     .unwrap_or_else(|| {
                         format!(
@@ -416,6 +475,7 @@ impl RawChoiceAccumulator {
         choices.push(RawStreamingChoice::FinalResponse(
             StreamingCompletionResponse {
                 usage: self.final_usage,
+                terminal_metadata: self.terminal_metadata,
             },
         ));
         choices
@@ -924,7 +984,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::{ItemChunkKind, StreamingCompletionChunk, reasoning_choices_from_done_item};
-    use crate::completion::CompletionModel;
+    use crate::completion::{CompletionFinishReason, CompletionModel};
     use crate::message::ReasoningContent;
     use crate::providers::internal::openai_chat_completions_compatible::test_support::sse_bytes_from_json_events;
     use crate::providers::openai::responses_api::{
@@ -981,7 +1041,9 @@ mod tests {
             .expect_err("stream should surface a provider error")
     }
 
-    async fn final_usage_from_event(event: serde_json::Value) -> ResponsesUsage {
+    async fn final_response_from_event(
+        event: serde_json::Value,
+    ) -> super::StreamingCompletionResponse {
         let client = openai::Client::builder()
             .http_client(MockStreamingClient {
                 sse_bytes: sse_bytes_from_json_events(&[event]),
@@ -995,7 +1057,7 @@ mod tests {
 
         while let Some(item) = stream.next().await {
             match item.expect("completed stream should not error") {
-                StreamedAssistantContent::Final(res) => return res.usage,
+                StreamedAssistantContent::Final(res) => return res,
                 _ => continue,
             }
         }
@@ -1201,7 +1263,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn response_incomplete_chunk_uses_incomplete_details_reason() {
+    async fn response_incomplete_chunk_preserves_length_terminal_metadata() {
         let mut response = sample_response(ResponseStatus::Incomplete);
         response.incomplete_details = Some(IncompleteDetailsReason {
             reason: "max_output_tokens".to_string(),
@@ -1213,12 +1275,38 @@ mod tests {
             "response": response,
         });
 
-        let err = first_error_from_event(event).await;
+        let response = final_response_from_event(event).await;
+        let terminal_metadata = response
+            .terminal_metadata
+            .expect("incomplete response should include terminal metadata");
+
+        assert_eq!(terminal_metadata.reason, CompletionFinishReason::Length);
+        assert_eq!(terminal_metadata.raw_reason(), Some("max_output_tokens"));
+    }
+
+    #[tokio::test]
+    async fn response_incomplete_chunk_preserves_filter_terminal_metadata() {
+        let mut response = sample_response(ResponseStatus::Incomplete);
+        response.incomplete_details = Some(IncompleteDetailsReason {
+            reason: "content_filter".to_string(),
+        });
+
+        let event = json!({
+            "type": "response.incomplete",
+            "sequence_number": 1,
+            "response": response,
+        });
+
+        let response = final_response_from_event(event).await;
+        let terminal_metadata = response
+            .terminal_metadata
+            .expect("incomplete response should include terminal metadata");
 
         assert_eq!(
-            err.to_string(),
-            "ProviderError: OpenAI response stream was incomplete: max_output_tokens"
+            terminal_metadata.reason,
+            CompletionFinishReason::ContentFilter
         );
+        assert_eq!(terminal_metadata.raw_reason(), Some("content_filter"));
     }
 
     #[tokio::test]
@@ -1293,10 +1381,17 @@ mod tests {
             "response": response,
         });
 
-        let usage = final_usage_from_event(event).await;
+        let response = final_response_from_event(event).await;
+        let usage = response.usage;
         assert_eq!(usage.input_tokens, 10);
         assert_eq!(usage.output_tokens, 5);
         assert_eq!(usage.total_tokens, 15);
+
+        let terminal_metadata = response
+            .terminal_metadata
+            .expect("completed response should include terminal metadata");
+        assert_eq!(terminal_metadata.reason, CompletionFinishReason::Stop);
+        assert_eq!(terminal_metadata.raw_reason(), Some("completed"));
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/providers/openrouter/streaming.rs
+++ b/crates/rig-core/src/providers/openrouter/streaming.rs
@@ -3,12 +3,13 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tracing::info_span;
 
-use crate::completion::{CompletionError, CompletionRequest, GetTokenUsage};
+use crate::completion::{
+    CompletionError, CompletionRequest, CompletionTerminalMetadata, GetTokenUsage,
+};
 use crate::http_client::HttpClientExt;
 use crate::json_utils;
 use crate::providers::internal::openai_chat_completions_compatible::{
-    self, CompatibleChoiceData, CompatibleChunk, CompatibleFinishReason, CompatibleStreamProfile,
-    CompatibleToolCallChunk,
+    self, CompatibleChoiceData, CompatibleChunk, CompatibleStreamProfile, CompatibleToolCallChunk,
 };
 use crate::providers::openrouter::{
     OpenRouterRequestParams, OpenrouterCompletionRequest, ReasoningDetails,
@@ -18,11 +19,17 @@ use crate::streaming;
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct StreamingCompletionResponse {
     pub usage: Usage,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub terminal_metadata: Option<CompletionTerminalMetadata>,
 }
 
 impl GetTokenUsage for StreamingCompletionResponse {
     fn token_usage(&self) -> Option<crate::completion::Usage> {
         self.usage.token_usage()
+    }
+
+    fn terminal_metadata(&self) -> Option<CompletionTerminalMetadata> {
+        self.terminal_metadata.clone()
     }
 }
 
@@ -36,6 +43,17 @@ pub enum FinishReason {
     Length,
     #[serde(untagged)]
     Other(String),
+}
+
+fn raw_finish_reason(reason: &FinishReason) -> String {
+    match reason {
+        FinishReason::ToolCalls => "tool_calls".to_owned(),
+        FinishReason::Stop => "stop".to_owned(),
+        FinishReason::Error => "error".to_owned(),
+        FinishReason::ContentFilter => "content_filter".to_owned(),
+        FinishReason::Length => "length".to_owned(),
+        FinishReason::Other(reason) => reason.clone(),
+    }
 }
 
 #[derive(Deserialize, Debug)]
@@ -237,25 +255,34 @@ impl CompatibleStreamProfile for OpenRouterCompatibleProfile {
                 Some(data.model),
                 data.usage,
                 &data.choices,
-                |choice| CompatibleChoiceData {
-                    finish_reason: if choice.finish_reason == Some(FinishReason::ToolCalls) {
-                        CompatibleFinishReason::ToolCalls
-                    } else {
-                        CompatibleFinishReason::Other
-                    },
+                |choice| {
+                    CompatibleChoiceData {
+                    terminal_metadata: choice
+                        .native_finish_reason
+                        .clone()
+                        .or_else(|| choice.finish_reason.as_ref().map(raw_finish_reason))
+                        .map(openai_chat_completions_compatible::terminal_metadata_from_raw_finish_reason),
                     text: choice.delta.content.clone(),
                     reasoning: choice.delta.reasoning.clone(),
                     tool_calls: openai_chat_completions_compatible::tool_call_chunks(
                         &choice.delta.tool_calls,
                     ),
                     details: choice.delta.reasoning_details.clone(),
+                }
                 },
             ),
         ))
     }
 
-    fn build_final_response(&self, usage: Self::Usage) -> Self::FinalResponse {
-        StreamingCompletionResponse { usage }
+    fn build_final_response(
+        &self,
+        usage: Self::Usage,
+        terminal_metadata: Option<CompletionTerminalMetadata>,
+    ) -> Self::FinalResponse {
+        StreamingCompletionResponse {
+            usage,
+            terminal_metadata,
+        }
     }
 
     fn decorate_tool_call(

--- a/crates/rig-core/src/test_utils/internal_streaming_profiles.rs
+++ b/crates/rig-core/src/test_utils/internal_streaming_profiles.rs
@@ -1,7 +1,7 @@
 //! Crate-internal streaming profile helpers for compatible provider tests.
 
 use crate::{
-    completion::CompletionError,
+    completion::{CompletionError, CompletionTerminalMetadata},
     providers::internal::openai_chat_completions_compatible::{
         CompatibleChoice, CompatibleChunk, CompatibleFinishReason, CompatibleStreamProfile,
         CompatibleToolCallChunk,
@@ -20,11 +20,13 @@ fn test_chunk(choice: CompatibleChoice<()>) -> CompatibleChunk<MockResponse, ()>
 }
 
 fn tool_call_choice(
-    finish_reason: CompatibleFinishReason,
+    finish_reason: Option<CompatibleFinishReason>,
     tool_calls: Vec<CompatibleToolCallChunk>,
 ) -> CompatibleChoice<()> {
     CompatibleChoice {
-        finish_reason,
+        terminal_metadata: finish_reason.map(|reason| {
+            CompletionTerminalMetadata::new(reason.into()).with_raw_reason(format!("{reason:?}"))
+        }),
         text: None,
         reasoning: None,
         tool_calls,
@@ -61,7 +63,7 @@ impl CompatibleStreamProfile for ErrorAfterPendingToolCallProfile {
     ) -> Result<Option<CompatibleChunk<Self::Usage, Self::Detail>>, CompletionError> {
         match data {
             "start" => Ok(Some(test_chunk(tool_call_choice(
-                CompatibleFinishReason::Other,
+                None,
                 vec![tool_call_chunk(0, Some("call_123"), Some("ping"), Some(""))],
             )))),
             "bad" => Err(CompletionError::ProviderError(
@@ -71,8 +73,17 @@ impl CompatibleStreamProfile for ErrorAfterPendingToolCallProfile {
         }
     }
 
-    fn build_final_response(&self, _usage: Self::Usage) -> Self::FinalResponse {
-        MockResponse::new()
+    fn build_final_response(
+        &self,
+        _usage: Self::Usage,
+        terminal_metadata: Option<CompletionTerminalMetadata>,
+    ) -> Self::FinalResponse {
+        let response = MockResponse::new();
+        if let Some(metadata) = terminal_metadata {
+            response.with_terminal_metadata(metadata)
+        } else {
+            response
+        }
     }
 }
 
@@ -91,7 +102,7 @@ impl CompatibleStreamProfile for DistinctToolCallEvictionProfile {
     ) -> Result<Option<CompatibleChunk<Self::Usage, Self::Detail>>, CompletionError> {
         let choice = match data {
             "first_start" => Some(tool_call_choice(
-                CompatibleFinishReason::Other,
+                None,
                 vec![tool_call_chunk(
                     0,
                     Some("call_aaa"),
@@ -100,11 +111,11 @@ impl CompatibleStreamProfile for DistinctToolCallEvictionProfile {
                 )],
             )),
             "first_args" => Some(tool_call_choice(
-                CompatibleFinishReason::Other,
+                None,
                 vec![tool_call_chunk(0, None, None, Some("{\"query\":\"one\"}"))],
             )),
             "second_start" => Some(tool_call_choice(
-                CompatibleFinishReason::Other,
+                None,
                 vec![tool_call_chunk(
                     0,
                     Some("call_bbb"),
@@ -113,11 +124,11 @@ impl CompatibleStreamProfile for DistinctToolCallEvictionProfile {
                 )],
             )),
             "second_args" => Some(tool_call_choice(
-                CompatibleFinishReason::Other,
+                None,
                 vec![tool_call_chunk(0, None, None, Some("{\"query\":\"two\"}"))],
             )),
             "finish" => Some(tool_call_choice(
-                CompatibleFinishReason::ToolCalls,
+                Some(CompatibleFinishReason::ToolCalls),
                 Vec::new(),
             )),
             _ => None,
@@ -126,8 +137,17 @@ impl CompatibleStreamProfile for DistinctToolCallEvictionProfile {
         Ok(choice.map(test_chunk))
     }
 
-    fn build_final_response(&self, _usage: Self::Usage) -> Self::FinalResponse {
-        MockResponse::new()
+    fn build_final_response(
+        &self,
+        _usage: Self::Usage,
+        terminal_metadata: Option<CompletionTerminalMetadata>,
+    ) -> Self::FinalResponse {
+        let response = MockResponse::new();
+        if let Some(metadata) = terminal_metadata {
+            response.with_terminal_metadata(metadata)
+        } else {
+            response
+        }
     }
 
     fn uses_distinct_tool_call_eviction(&self) -> bool {
@@ -150,7 +170,7 @@ impl CompatibleStreamProfile for FinishReasonCleanupProfile {
     ) -> Result<Option<CompatibleChunk<Self::Usage, Self::Detail>>, CompletionError> {
         let choice = match data {
             "start" => Some(tool_call_choice(
-                CompatibleFinishReason::Other,
+                None,
                 vec![tool_call_chunk(
                     0,
                     Some("call_123"),
@@ -159,7 +179,7 @@ impl CompatibleStreamProfile for FinishReasonCleanupProfile {
                 )],
             )),
             "finish" => Some(tool_call_choice(
-                CompatibleFinishReason::ToolCalls,
+                Some(CompatibleFinishReason::ToolCalls),
                 Vec::new(),
             )),
             _ => None,
@@ -168,7 +188,16 @@ impl CompatibleStreamProfile for FinishReasonCleanupProfile {
         Ok(choice.map(test_chunk))
     }
 
-    fn build_final_response(&self, _usage: Self::Usage) -> Self::FinalResponse {
-        MockResponse::new()
+    fn build_final_response(
+        &self,
+        _usage: Self::Usage,
+        terminal_metadata: Option<CompletionTerminalMetadata>,
+    ) -> Self::FinalResponse {
+        let response = MockResponse::new();
+        if let Some(metadata) = terminal_metadata {
+            response.with_terminal_metadata(metadata)
+        } else {
+            response
+        }
     }
 }

--- a/crates/rig-core/src/test_utils/streaming.rs
+++ b/crates/rig-core/src/test_utils/streaming.rs
@@ -1,7 +1,7 @@
 //! Streaming helpers for [`MockCompletionModel`](super::MockCompletionModel).
 
 use crate::{
-    completion::{CompletionError, GetTokenUsage, Usage},
+    completion::{CompletionError, CompletionTerminalMetadata, GetTokenUsage, Usage},
     message::ReasoningContent,
     streaming::{RawStreamingChoice, RawStreamingToolCall, ToolCallDeltaContent},
 };
@@ -11,17 +11,24 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct MockResponse {
     usage: Option<Usage>,
+    terminal_metadata: Option<CompletionTerminalMetadata>,
 }
 
 impl MockResponse {
     /// Create a mock raw response without token usage.
     pub fn new() -> Self {
-        Self { usage: None }
+        Self {
+            usage: None,
+            terminal_metadata: None,
+        }
     }
 
     /// Create a mock raw response carrying token usage.
     pub fn with_usage(usage: Usage) -> Self {
-        Self { usage: Some(usage) }
+        Self {
+            usage: Some(usage),
+            terminal_metadata: None,
+        }
     }
 
     /// Create a mock raw response whose usage has only `total_tokens` set.
@@ -30,11 +37,21 @@ impl MockResponse {
         usage.total_tokens = total_tokens;
         Self::with_usage(usage)
     }
+
+    /// Attach provider terminal metadata.
+    pub fn with_terminal_metadata(mut self, metadata: CompletionTerminalMetadata) -> Self {
+        self.terminal_metadata = Some(metadata);
+        self
+    }
 }
 
 impl GetTokenUsage for MockResponse {
     fn token_usage(&self) -> Option<Usage> {
         self.usage
+    }
+
+    fn terminal_metadata(&self) -> Option<CompletionTerminalMetadata> {
+        self.terminal_metadata.clone()
     }
 }
 


### PR DESCRIPTION
## Summary
- add a small `CompletionFinishReason` / `CompletionTerminalMetadata` API to `rig-core`
- let streaming final responses expose normalized and raw provider terminal reasons via `GetTokenUsage::terminal_metadata()`
- thread terminal metadata through multi-turn `FinalResponse` without changing upstream completion-call usage aggregation
- preserve conservative provider mappings across OpenAI, Anthropic, Gemini, OpenRouter-compatible, Groq, DeepSeek, Copilot, and Llamafile paths

