### PR TITLE
Fix streaming reasoning history order

### DIFF
--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -243,37 +243,33 @@ fn build_tool_call_validation_history(input: ToolCallValidationHistory<'_>) -> V
         return build_full_history(input.chat_history, messages);
     }
 
-    let mut content_items = Vec::new();
-    if let Some(text) = input.text_delta_response
+    let text_items = if let Some(text) = input.text_delta_response
         && !text.is_empty()
     {
-        content_items.push(AssistantContent::text(text.to_string()));
-    }
-    content_items.extend(
-        input
-            .accumulated_reasoning
-            .iter()
-            .cloned()
-            .map(AssistantContent::Reasoning),
-    );
+        vec![AssistantContent::text(text.to_string())]
+    } else {
+        Vec::new()
+    };
+    let mut reasoning_items = input.accumulated_reasoning.to_vec();
     if input.accumulated_reasoning.is_empty() && !input.pending_reasoning_delta_text.is_empty() {
         let mut reasoning = crate::message::Reasoning::new(input.pending_reasoning_delta_text);
         if let Some(id) = input.pending_reasoning_delta_id.clone() {
             reasoning = reasoning.with_id(id);
         }
-        content_items.push(AssistantContent::Reasoning(reasoning));
+        reasoning_items.push(reasoning);
     }
-    content_items.extend(
-        input
-            .pending_tool_calls
-            .iter()
-            .map(|(tool_call, _)| AssistantContent::ToolCall(tool_call.clone())),
-    );
+    let mut tool_items = input
+        .pending_tool_calls
+        .iter()
+        .map(|(tool_call, _)| AssistantContent::ToolCall(tool_call.clone()))
+        .collect::<Vec<_>>();
     if let Some(tool_call) = input.current_tool_call {
-        content_items.push(AssistantContent::ToolCall(tool_call));
+        tool_items.push(AssistantContent::ToolCall(tool_call));
     }
 
-    if let Some(content) = OneOrMany::from_iter_optional(content_items) {
+    if let Some(content) =
+        ordered_streaming_assistant_content(reasoning_items, text_items, tool_items)
+    {
         messages.push(Message::Assistant {
             id: input.assistant_message_id.clone(),
             content,
@@ -281,6 +277,30 @@ fn build_tool_call_validation_history(input: ToolCallValidationHistory<'_>) -> V
     }
 
     build_full_history(input.chat_history, messages)
+}
+
+fn ordered_streaming_assistant_content(
+    reasoning_items: impl IntoIterator<Item = crate::message::Reasoning>,
+    text_items: impl IntoIterator<Item = AssistantContent>,
+    tool_items: impl IntoIterator<Item = AssistantContent>,
+) -> Option<OneOrMany<AssistantContent>> {
+    let mut content_items = reasoning_items
+        .into_iter()
+        .map(AssistantContent::Reasoning)
+        .collect::<Vec<_>>();
+    content_items.extend(text_items);
+    content_items.extend(tool_items);
+
+    OneOrMany::from_iter_optional(content_items)
+}
+
+fn pending_tool_call_content_items(
+    pending_tool_calls: &[(ToolCall, String)],
+) -> Vec<AssistantContent> {
+    pending_tool_calls
+        .iter()
+        .map(|(tool_call, _)| AssistantContent::ToolCall(tool_call.clone()))
+        .collect()
 }
 
 async fn drain_recovered_stream_usage<R>(
@@ -394,26 +414,21 @@ fn invalid_streaming_tool_retry_messages(
     invalid_tool_call: ToolCall,
     feedback: String,
 ) -> Option<(Message, Message)> {
-    let mut assistant_content = Vec::new();
-    if let Some(text) = text_delta_response
+    let text_items = if let Some(text) = text_delta_response
         && !text.is_empty()
     {
-        assistant_content.push(AssistantContent::text(text.to_string()));
-    }
-    assistant_content.extend(
-        accumulated_reasoning
-            .iter()
-            .cloned()
-            .map(AssistantContent::Reasoning),
-    );
-    assistant_content.extend(
-        pending_tool_calls
-            .iter()
-            .map(|(tool_call, _)| AssistantContent::ToolCall(tool_call.clone())),
-    );
-    assistant_content.push(AssistantContent::ToolCall(invalid_tool_call.clone()));
+        vec![AssistantContent::text(text.to_string())]
+    } else {
+        Vec::new()
+    };
+    let mut tool_items = pending_tool_call_content_items(pending_tool_calls);
+    tool_items.push(AssistantContent::ToolCall(invalid_tool_call.clone()));
 
-    let assistant_content = OneOrMany::from_iter_optional(assistant_content)?;
+    let assistant_content = ordered_streaming_assistant_content(
+        accumulated_reasoning.iter().cloned(),
+        text_items,
+        tool_items,
+    )?;
     let assistant_message = Message::Assistant {
         id: assistant_message_id.clone(),
         content: assistant_content,
@@ -450,28 +465,23 @@ fn invalid_streaming_name_delta_retry_messages(
     invalid_tool_call: ToolCall,
     feedback: String,
 ) -> Option<(Message, Message)> {
-    let mut assistant_content = Vec::new();
-    if let Some(text) = text_delta_response
+    let text_items = if let Some(text) = text_delta_response
         && !text.is_empty()
     {
-        assistant_content.push(AssistantContent::text(text.to_string()));
-    }
-    assistant_content.extend(
-        accumulated_reasoning
-            .iter()
-            .cloned()
-            .map(AssistantContent::Reasoning),
-    );
-    assistant_content.extend(
-        pending_tool_calls
-            .iter()
-            .map(|(tool_call, _)| AssistantContent::ToolCall(tool_call.clone())),
-    );
-    assistant_content.push(AssistantContent::ToolCall(invalid_tool_call.clone()));
+        vec![AssistantContent::text(text.to_string())]
+    } else {
+        Vec::new()
+    };
+    let mut tool_items = pending_tool_call_content_items(pending_tool_calls);
+    tool_items.push(AssistantContent::ToolCall(invalid_tool_call.clone()));
 
     let assistant_message = Message::Assistant {
         id: assistant_message_id.clone(),
-        content: OneOrMany::from_iter_optional(assistant_content)?,
+        content: ordered_streaming_assistant_content(
+            accumulated_reasoning.iter().cloned(),
+            text_items,
+            tool_items,
+        )?,
     };
     let mut retry_results = pending_tool_calls
         .iter()
@@ -1594,21 +1604,16 @@ where
                     }
                 }
 
-                // Add text, reasoning, and tool calls to chat history.
-                // OpenAI Responses API requires reasoning items to precede function_call items.
+                // Add reasoning, text, and tool calls to chat history in the
+                // provider-native order expected by OpenAI Responses replay.
                 let mut assistant_turn_added_to_history = false;
                 if !tool_calls.is_empty() || !accumulated_reasoning.is_empty() {
-                    // Text before tool calls so the model sees its own prior output.
-                    let mut content_items = assistant_text_items_from_choice(&final_turn_content);
-
-                    // Reasoning must come before tool calls (OpenAI requirement)
-                    for reasoning in accumulated_reasoning.drain(..) {
-                        content_items.push(rig::message::AssistantContent::Reasoning(reasoning));
-                    }
-
-                    content_items.extend(tool_calls.clone());
-
-                    if let Some(content) = OneOrMany::from_iter_optional(content_items) {
+                    let text_items = assistant_text_items_from_choice(&final_turn_content);
+                    if let Some(content) = ordered_streaming_assistant_content(
+                        accumulated_reasoning.drain(..),
+                        text_items,
+                        tool_calls.clone(),
+                    ) {
                         new_messages.push(Message::Assistant {
                             id: stream.message_id.clone(),
                             content,
@@ -2048,6 +2053,50 @@ mod tests {
             });
 
             matches!((reasoning_index, tool_index), (Some(reasoning), Some(tool)) if reasoning < tool)
+        })
+    }
+
+    fn assistant_reasoning_precedes_text_and_tool_call(
+        history: &[Message],
+        expected_reasoning: &str,
+        expected_text: &str,
+        tool_name: &str,
+    ) -> bool {
+        history.iter().any(|message| {
+            let Message::Assistant { content, .. } = message else {
+                return false;
+            };
+
+            let reasoning_index = content.iter().position(|item| {
+                matches!(
+                    item,
+                    AssistantContent::Reasoning(reasoning)
+                        if reasoning.content.iter().any(|content| matches!(
+                            content,
+                            ReasoningContent::Text { text, .. }
+                                if text == expected_reasoning
+                        ))
+                )
+            });
+            let text_index = content.iter().position(|item| {
+                matches!(
+                    item,
+                    AssistantContent::Text(text) if text.text == expected_text
+                )
+            });
+            let tool_index = content.iter().position(|item| {
+                matches!(
+                    item,
+                    AssistantContent::ToolCall(tool_call)
+                        if tool_call.function.name == tool_name
+                )
+            });
+
+            matches!(
+                (reasoning_index, text_index, tool_index),
+                (Some(reasoning), Some(text), Some(tool))
+                    if reasoning < text && text < tool
+            )
         })
     }
 
@@ -3420,6 +3469,15 @@ mod tests {
             "reasoned step",
             "default_api"
         ));
+        assert!(
+            assistant_reasoning_precedes_text_and_tool_call(
+                &follow_up_history,
+                "reasoned step",
+                "checking ",
+                "default_api"
+            ),
+            "{follow_up_history:?}"
+        );
     }
 
     #[tokio::test]
@@ -5724,6 +5782,18 @@ mod tests {
                         ReasoningContent::Text { text, .. } if text == "reasoned step"
                     ))
         )));
+        let reasoning_index = assistant_content
+            .iter()
+            .position(|item| matches!(item, AssistantContent::Reasoning(_)))
+            .expect("assistant history should contain reasoning");
+        let text_index = assistant_content
+            .iter()
+            .position(|item| matches!(item, AssistantContent::Text(_)))
+            .expect("assistant history should contain text");
+        assert!(
+            reasoning_index < text_index,
+            "assistant reasoning must be stored before assistant text: {assistant_content:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -236,10 +236,12 @@ fn build_tool_call_validation_history(input: ToolCallValidationHistory<'_>) -> V
     if let Some(final_turn_content) = input.final_turn_content
         && !is_empty_assistant_choice(final_turn_content)
     {
-        messages.push(Message::Assistant {
-            id: input.assistant_message_id.clone(),
-            content: final_turn_content.clone(),
-        });
+        if let Some(content) = ordered_streaming_assistant_content_from_choice(final_turn_content) {
+            messages.push(Message::Assistant {
+                id: input.assistant_message_id.clone(),
+                content,
+            });
+        }
         return build_full_history(input.chat_history, messages);
     }
 
@@ -282,16 +284,41 @@ fn build_tool_call_validation_history(input: ToolCallValidationHistory<'_>) -> V
 fn ordered_streaming_assistant_content(
     reasoning_items: impl IntoIterator<Item = crate::message::Reasoning>,
     text_items: impl IntoIterator<Item = AssistantContent>,
-    tool_items: impl IntoIterator<Item = AssistantContent>,
+    trailing_items: impl IntoIterator<Item = AssistantContent>,
 ) -> Option<OneOrMany<AssistantContent>> {
     let mut content_items = reasoning_items
         .into_iter()
         .map(AssistantContent::Reasoning)
         .collect::<Vec<_>>();
     content_items.extend(text_items);
-    content_items.extend(tool_items);
+    content_items.extend(trailing_items);
 
     OneOrMany::from_iter_optional(content_items)
+}
+
+fn ordered_streaming_assistant_content_from_choice(
+    choice: &OneOrMany<AssistantContent>,
+) -> Option<OneOrMany<AssistantContent>> {
+    let mut reasoning_items = Vec::new();
+    let mut text_items = Vec::new();
+    let mut trailing_items = Vec::new();
+
+    for item in choice.iter().cloned() {
+        match item {
+            AssistantContent::Reasoning(reasoning) => reasoning_items.push(reasoning),
+            AssistantContent::Text(text) => {
+                if !text.text.is_empty() || text.additional_params.is_some() {
+                    text_items.push(AssistantContent::Text(text));
+                }
+            }
+            AssistantContent::ToolCall(tool_call) => {
+                trailing_items.push(AssistantContent::ToolCall(tool_call));
+            }
+            AssistantContent::Image(image) => trailing_items.push(AssistantContent::Image(image)),
+        }
+    }
+
+    ordered_streaming_assistant_content(reasoning_items, text_items, trailing_items)
 }
 
 fn pending_tool_call_content_items(
@@ -1604,8 +1631,7 @@ where
                     }
                 }
 
-                // Add reasoning, text, and tool calls to chat history in the
-                // provider-native order expected by OpenAI Responses replay.
+                // Add assistant turn content to chat history in canonical replay order.
                 let mut assistant_turn_added_to_history = false;
                 if !tool_calls.is_empty() || !accumulated_reasoning.is_empty() {
                     let text_items = assistant_text_items_from_choice(&final_turn_content);

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -2605,6 +2605,62 @@ mod tests {
     }
 
     #[test]
+    fn assistant_reasoning_text_tool_call_convert_in_responses_replay_order() {
+        let assistant = completion::Message::Assistant {
+            id: Some("msg_123".to_string()),
+            content: OneOrMany::many(vec![
+                message::AssistantContent::Reasoning(message::Reasoning {
+                    id: Some("rs_123".to_string()),
+                    content: vec![message::ReasoningContent::Summary(
+                        "structured summary".to_string(),
+                    )],
+                }),
+                message::AssistantContent::Text(Text::new("final answer")),
+                message::AssistantContent::tool_call_with_call_id(
+                    "fc_123",
+                    "call_123".to_string(),
+                    "lookup",
+                    json!({"query": "rig"}),
+                ),
+            ])
+            .expect("assistant content should be non-empty"),
+        };
+
+        let converted =
+            Vec::<InputItem>::try_from(assistant).expect("assistant history should convert");
+
+        assert_eq!(converted.len(), 3);
+        assert!(converted[0].role.is_none());
+        assert!(matches!(
+            &converted[0].input,
+            InputContent::Reasoning(OpenAIReasoning { id, .. }) if id == "rs_123"
+        ));
+
+        assert!(matches!(converted[1].role, Some(Role::Assistant)));
+        let InputContent::Message(Message::Assistant { content, id, .. }) = &converted[1].input
+        else {
+            panic!("expected assistant output message");
+        };
+        assert_eq!(id, "msg_123");
+        assert!(matches!(
+            content.first_ref(),
+            AssistantContentType::Text(AssistantContent::OutputText(Text { text, .. }))
+                if text == "final answer"
+        ));
+
+        assert!(converted[2].role.is_none());
+        let InputContent::FunctionCall(OutputFunctionCall {
+            id, call_id, name, ..
+        }) = &converted[2].input
+        else {
+            panic!("expected function call input item");
+        };
+        assert_eq!(id, "fc_123");
+        assert_eq!(call_id, "call_123");
+        assert_eq!(name, "lookup");
+    }
+
+    #[test]
     fn mocked_second_turn_request_omits_unreplayable_reasoning() {
         let request = crate::completion::CompletionRequest {
             model: None,

--- a/tests/cassettes/anthropic/reasoning_tool_roundtrip/streaming.yaml
+++ b/tests/cassettes/anthropic/reasoning_tool_roundtrip/streaming.yaml
@@ -41,7 +41,7 @@ then:
     data: {"content_block":{"text":"","type":"text"},"index":1,"type":"content_block_start"}
 
     event: content_block_delta
-    data: {"delta":{"text":"Sure! Let me check the current weather in Tokyo for you right away!","type":"text_delta"},"index":1,"type":"content_block_delta"}
+    data: {"delta":{"text":"Sure! Let me check the current weather in Tokyo right away!","type":"text_delta"},"index":1,"type":"content_block_delta"}
 
     event: content_block_stop
     data: {"index":1,"type":"content_block_stop"}
@@ -53,25 +53,19 @@ then:
     data: {"delta":{"partial_json":"","type":"input_json_delta"},"index":2,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"partial_json":"{\"","type":"input_json_delta"},"index":2,"type":"content_block_delta"}
+    data: {"delta":{"partial_json":"{\"city\": \"T","type":"input_json_delta"},"index":2,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"partial_json":"cit","type":"input_json_delta"},"index":2,"type":"content_block_delta"}
+    data: {"delta":{"partial_json":"okyo, ","type":"input_json_delta"},"index":2,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"partial_json":"y\": ","type":"input_json_delta"},"index":2,"type":"content_block_delta"}
-
-    event: content_block_delta
-    data: {"delta":{"partial_json":"\"Tok","type":"input_json_delta"},"index":2,"type":"content_block_delta"}
-
-    event: content_block_delta
-    data: {"delta":{"partial_json":"yo\"}","type":"input_json_delta"},"index":2,"type":"content_block_delta"}
+    data: {"delta":{"partial_json":"Japan\"}","type":"input_json_delta"},"index":2,"type":"content_block_delta"}
 
     event: content_block_stop
     data: {"index":2,"type":"content_block_stop"}
 
     event: message_delta
-    data: {"delta":{"stop_details":null,"stop_reason":"tool_use","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":671,"output_tokens":113}}
+    data: {"delta":{"stop_details":null,"stop_reason":"tool_use","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":671,"output_tokens":113,"output_tokens_details":{"thinking_tokens":41}}}
 
     event: message_stop
     data: {"type":"message_stop"}
@@ -88,7 +82,7 @@ when:
     value: application/json
   - name: anthropic-version
     value: 2023-06-01
-  body: '{"max_tokens":16384,"messages":[{"content":[{"text":"I''m planning a trip. What is the current weather in Tokyo, Japan? Based on the weather conditions, should I pack an umbrella or sunscreen? Use the get_weather tool to check before answering.","type":"text"}],"role":"user"},{"content":[{"text":"Sure! Let me check the current weather in Tokyo for you right away!","type":"text"},{"signature":"signature_REDACTED_2","thinking":"The user wants to know the current weather in Tokyo, Japan. I''ll call the get_weather tool with \"Tokyo\" as the city.","type":"thinking"},{"id":"toolu_REDACTED_1","input":{"city":"Tokyo"},"name":"get_weather","type":"tool_use"}],"role":"assistant"},{"content":[{"content":[{"text":"Weather in Tokyo: 72F (22C), sunny with light clouds, humidity 45%, wind 8 mph NW","type":"text"}],"tool_use_id":"toolu_REDACTED_1","type":"tool_result"}],"role":"user"}],"model":"claude-sonnet-4-6","stream":true,"system":[{"text":"You are a weather assistant. You have access to a get_weather tool. You must call the get_weather tool for any weather question and never guess weather data. After receiving the tool result, provide a concise summary of the weather.","type":"text"}],"thinking":{"type":"adaptive"},"tool_choice":{"type":"auto"},"tools":[{"description":"Get the current weather for a city. Must be called for weather questions.","input_schema":{"properties":{"city":{"description":"City name to get weather for","type":"string"}},"required":["city"],"type":"object"},"name":"get_weather"}]}'
+  body: '{"max_tokens":16384,"messages":[{"content":[{"text":"I''m planning a trip. What is the current weather in Tokyo, Japan? Based on the weather conditions, should I pack an umbrella or sunscreen? Use the get_weather tool to check before answering.","type":"text"}],"role":"user"},{"content":[{"signature":"signature_REDACTED_2","thinking":"The user wants to know the current weather in Tokyo, Japan. I''ll call the get_weather tool with \"Tokyo\" as the city.","type":"thinking"},{"text":"Sure! Let me check the current weather in Tokyo right away!","type":"text"},{"id":"toolu_REDACTED_1","input":{"city":"Tokyo, Japan"},"name":"get_weather","type":"tool_use"}],"role":"assistant"},{"content":[{"content":[{"text":"Weather in Tokyo, Japan: 72F (22C), sunny with light clouds, humidity 45%, wind 8 mph NW","type":"text"}],"tool_use_id":"toolu_REDACTED_1","type":"tool_result"}],"role":"user"}],"model":"claude-sonnet-4-6","stream":true,"system":[{"text":"You are a weather assistant. You have access to a get_weather tool. You must call the get_weather tool for any weather question and never guess weather data. After receiving the tool result, provide a concise summary of the weather.","type":"text"}],"thinking":{"type":"adaptive"},"tool_choice":{"type":"auto"},"tools":[{"description":"Get the current weather for a city. Must be called for weather questions.","input_schema":{"properties":{"city":{"description":"City name to get weather for","type":"string"}},"required":["city"],"type":"object"},"name":"get_weather"}]}'
 then:
   status: 200
   header:
@@ -96,7 +90,7 @@ then:
     value: text/event-stream; charset=utf-8
   body: |+
     event: message_start
-    data: {"message":{"content":[],"id":"msg_REDACTED_2","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":822,"output_tokens":1,"service_tier":"standard"}},"type":"message_start"}
+    data: {"message":{"content":[],"id":"msg_REDACTED_2","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":825,"output_tokens":1,"service_tier":"standard"}},"type":"message_start"}
 
     event: content_block_start
     data: {"content_block":{"text":"","type":"text"},"index":0,"type":"content_block_start"}
@@ -108,49 +102,49 @@ then:
     data: {"delta":{"text":"Here","type":"text_delta"},"index":0,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"text":"'s the current weather report for **Tokyo, Japan** 🇯🇵:\n\n| Detail | Condition","type":"text_delta"},"index":0,"type":"content_block_delta"}
+    data: {"delta":{"text":"'s the current weather report for **Tokyo, Japan** 🗼:\n\n| Detail |","type":"text_delta"},"index":0,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"text":" |\n|---|---|\n| 🌡️ Temperature | 72°F (22°C) |\n| ☀️ Sky | Sunny with light clouds |\n| ","type":"text_delta"},"index":0,"type":"content_block_delta"}
+    data: {"delta":{"text":" Condition |\n|---|---|\n| 🌡️ Temperature | 72°F (22°C) |\n| ☁","type":"text_delta"},"index":0,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"text":"💧 Humidity | 45% |\n| 💨 Wind | 8 mph, Northwest |\n\n---\n\n### ","type":"text_delta"},"index":0,"type":"content_block_delta"}
+    data: {"delta":{"text":"️ Sky | Sunny with light clouds |\n| 💧 Humidity | 45% |\n| 💨 Wind | 8 mph, Northwest","type":"text_delta"},"index":0,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"text":"🧳 Packing Recommendation: **Sunscreen!** ","type":"text_delta"},"index":0,"type":"content_block_delta"}
+    data: {"delta":{"text":" |\n\n---\n\n### 🧳 Packing Recommendation: **","type":"text_delta"},"index":0,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"text":"☀️\n\nBased on the current conditions, here's my advice:\n\n- **✅ Pack","type":"text_delta"},"index":0,"type":"content_block_delta"}
+    data: {"delta":{"text":"Sunscreen!** ☀️\n\nBased on the current conditions, here's what I","type":"text_delta"},"index":0,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"text":" Sunscreen** – Tokyo is currently sunny with only light cloud cover and a comfortable","type":"text_delta"},"index":0,"type":"content_block_delta"}
+    data: {"delta":{"text":" suggest:\n\n- **✅ Pack Sunscreen** – Tokyo is currently","type":"text_delta"},"index":0,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"text":" humidity of 45%. UV exposure is a real concern on","type":"text_delta"},"index":0,"type":"content_block_delta"}
+    data: {"delta":{"text":" experiencing sunny skies with only light clouds. With comfortable","type":"text_delta"},"index":0,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"text":" days like this, so sunscreen is a must!","type":"text_delta"},"index":0,"type":"content_block_delta"}
+    data: {"delta":{"text":" temperatures and moderate humidity, you'll likely be spending time outdoors, so sun protection is a","type":"text_delta"},"index":0,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"text":"\n- **❌ Skip the Umbrella (for now)** – There's no rain in the","type":"text_delta"},"index":0,"type":"content_block_delta"}
+    data: {"delta":{"text":" must!\n- **🌂 Skip the Umbrella (for now)** – There's no rain","type":"text_delta"},"index":0,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"text":" current conditions, so an umbrella isn't immediately necessary. However, weather can change, so if you're","type":"text_delta"},"index":0,"type":"content_block_delta"}
+    data: {"delta":{"text":" in the current conditions, so an umbrella isn't immediately necessary. However, weather","type":"text_delta"},"index":0,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"text":" staying for multiple days, a compact travel umbrella wouldn","type":"text_delta"},"index":0,"type":"content_block_delta"}
+    data: {"delta":{"text":" can change, so if you're staying for multiple days, a compact","type":"text_delta"},"index":0,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"text":"'t hurt as a backup.\n\n**Overall**, it sounds like a lovely day","type":"text_delta"},"index":0,"type":"content_block_delta"}
+    data: {"delta":{"text":" travel umbrella wouldn't hurt as a backup.\n\n**Overall**, it sounds","type":"text_delta"},"index":0,"type":"content_block_delta"}
 
     event: content_block_delta
-    data: {"delta":{"text":" in Tokyo! Great weather for sightseeing. Enjoy your trip! 🗼😊","type":"text_delta"},"index":0,"type":"content_block_delta"}
+    data: {"delta":{"text":" like a lovely day in Tokyo! Enjoy your trip! 🎌","type":"text_delta"},"index":0,"type":"content_block_delta"}
 
     event: content_block_stop
     data: {"index":0,"type":"content_block_stop"}
 
     event: message_delta
-    data: {"delta":{"stop_details":null,"stop_reason":"end_turn","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":822,"output_tokens":275}}
+    data: {"delta":{"stop_details":null,"stop_reason":"end_turn","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":825,"output_tokens":264,"output_tokens_details":{"thinking_tokens":0}}}
 
     event: message_stop
     data: {"type":"message_stop"}


### PR DESCRIPTION
## Summary

Fixes #1892 by storing streaming assistant history in OpenAI Responses replay order: reasoning items first, then assistant text, then tool calls.

The streaming path previously persisted text before reasoning when providers emitted text deltas before reasoning items. That could replay multi-turn Responses histories as `Text -> Reasoning -> ToolCall`, while OpenAI Responses expects prior reasoning output before assistant output and function calls.

This change centralizes streaming assistant-content assembly and applies the same order to final history plus invalid tool-call retry/repair history.

## Validation

- `cargo fmt`
- `cargo test -p rig-core streaming_reasoning_without_tools_does_not_duplicate_final_history -- --nocapture`
- `cargo test -p rig-core invalid_completed_tool_call_skip_preserves_streaming_reasoning_history -- --nocapture`
- `cargo test -p rig-core agent::prompt_request::streaming -- --nocapture`
- `cargo test -p rig-core providers::openai::responses_api -- --nocapture`
- `git diff --check`