### PR TITLE
feat(agent)!: sans-IO AgentRun state machine; both agent loops become thin drivers

### DIFF
--- a/crates/rig-bedrock/src/streaming.rs
+++ b/crates/rig-bedrock/src/streaming.rs
@@ -281,23 +281,28 @@ mod tests {
             }),
         };
 
-        let rig_usage = response.token_usage();
-        assert!(rig_usage.is_some());
-
-        let usage = rig_usage.unwrap();
-        assert_eq!(usage.input_tokens, 200);
-        assert_eq!(usage.output_tokens, 75);
-        assert_eq!(usage.total_tokens, 275);
-        assert_eq!(usage.cached_input_tokens, 40);
-        assert_eq!(usage.cache_creation_input_tokens, 10);
+        assert_eq!(
+            response.token_usage(),
+            rig_core::completion::Usage {
+                input_tokens: 200,
+                output_tokens: 75,
+                total_tokens: 275,
+                cached_input_tokens: 40,
+                cache_creation_input_tokens: 10,
+                tool_use_prompt_tokens: 0,
+                reasoning_tokens: 0,
+            }
+        );
     }
 
     #[test]
     fn test_bedrock_streaming_response_without_usage() {
         let response = BedrockStreamingResponse { usage: None };
 
-        let rig_usage = response.token_usage();
-        assert!(rig_usage.is_none());
+        // Zero-valued usage is rig's documented sentinel for "the provider
+        // reported no usage metrics".
+        assert_eq!(response.token_usage(), rig_core::completion::Usage::new());
+        assert!(!response.token_usage().has_values());
     }
 
     #[test]
@@ -313,12 +318,18 @@ mod tests {
         };
 
         // Test that GetTokenUsage trait is properly implemented
-        let usage = response.token_usage().expect("Usage should be present");
-        assert_eq!(usage.input_tokens, 448);
-        assert_eq!(usage.output_tokens, 68);
-        assert_eq!(usage.total_tokens, 516);
-        assert_eq!(usage.cached_input_tokens, 80);
-        assert_eq!(usage.cache_creation_input_tokens, 20);
+        assert_eq!(
+            response.token_usage(),
+            rig_core::completion::Usage {
+                input_tokens: 448,
+                output_tokens: 68,
+                total_tokens: 516,
+                cached_input_tokens: 80,
+                cache_creation_input_tokens: 20,
+                tool_use_prompt_tokens: 0,
+                reasoning_tokens: 0,
+            }
+        );
     }
 
     #[test]

--- a/crates/rig-bedrock/src/streaming.rs
+++ b/crates/rig-bedrock/src/streaming.rs
@@ -31,16 +31,19 @@ pub struct BedrockUsage {
 }
 
 impl GetTokenUsage for BedrockStreamingResponse {
-    fn token_usage(&self) -> Option<rig_core::completion::Usage> {
-        self.usage.as_ref().map(|u| rig_core::completion::Usage {
-            input_tokens: u.input_tokens as u64,
-            output_tokens: u.output_tokens as u64,
-            total_tokens: u.total_tokens as u64,
-            cached_input_tokens: u.cache_read_input_tokens.unwrap_or_default() as u64,
-            cache_creation_input_tokens: u.cache_write_input_tokens.unwrap_or_default() as u64,
-            tool_use_prompt_tokens: 0,
-            reasoning_tokens: 0,
-        })
+    fn token_usage(&self) -> rig_core::completion::Usage {
+        self.usage
+            .as_ref()
+            .map(|u| rig_core::completion::Usage {
+                input_tokens: u.input_tokens as u64,
+                output_tokens: u.output_tokens as u64,
+                total_tokens: u.total_tokens as u64,
+                cached_input_tokens: u.cache_read_input_tokens.unwrap_or_default() as u64,
+                cache_creation_input_tokens: u.cache_write_input_tokens.unwrap_or_default() as u64,
+                tool_use_prompt_tokens: 0,
+                reasoning_tokens: 0,
+            })
+            .unwrap_or_default()
     }
 }
 

--- a/crates/rig-bedrock/src/types/assistant_content.rs
+++ b/crates/rig-bedrock/src/types/assistant_content.rs
@@ -76,8 +76,8 @@ impl ProviderResponseExt for AwsConverseOutput {
 }
 
 impl GetTokenUsage for AwsConverseOutput {
-    fn token_usage(&self) -> Option<completion::Usage> {
-        self.get_usage()
+    fn token_usage(&self) -> completion::Usage {
+        self.get_usage().unwrap_or_default()
     }
 }
 

--- a/crates/rig-bedrock/src/types/assistant_content.rs
+++ b/crates/rig-bedrock/src/types/assistant_content.rs
@@ -329,16 +329,24 @@ mod tests {
     #[test]
     fn get_token_usage_delegates_to_provider_response_ext() {
         let out = make_output("x", Some(make_usage(10, 20, 30)));
-        let usage = out.token_usage().unwrap();
-        assert_eq!(usage.input_tokens, 10);
-        assert_eq!(usage.output_tokens, 20);
-        assert_eq!(usage.total_tokens, 30);
+        assert_eq!(
+            out.token_usage(),
+            completion::Usage {
+                input_tokens: 10,
+                output_tokens: 20,
+                total_tokens: 30,
+                ..completion::Usage::new()
+            }
+        );
     }
 
     #[test]
-    fn get_token_usage_none_when_no_usage() {
+    fn get_token_usage_zero_when_no_usage() {
         let out = make_output("x", None);
-        assert!(out.token_usage().is_none());
+        // Zero-valued usage is rig's documented sentinel for "the provider
+        // reported no usage metrics".
+        assert_eq!(out.token_usage(), completion::Usage::new());
+        assert!(!out.token_usage().has_values());
     }
 
     #[test]

--- a/crates/rig-core/src/agent/mod.rs
+++ b/crates/rig-core/src/agent/mod.rs
@@ -107,6 +107,7 @@
 mod builder;
 mod completion;
 pub(crate) mod prompt_request;
+pub mod run;
 mod tool;
 
 pub use crate::message::Text;
@@ -122,3 +123,4 @@ pub use prompt_request::streaming::{
 pub use prompt_request::{
     CompletionCall, PromptRequest, PromptResponse, TypedPromptRequest, TypedPromptResponse,
 };
+pub use run::{AgentRun, AgentRunStep, ModelTurn, ModelTurnOutcome, PendingToolCall};

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -4,6 +4,7 @@ pub mod streaming;
 use super::{
     Agent,
     completion::{DynamicContextStore, build_prepared_completion_request},
+    run::{AgentRun, AgentRunStep, ModelTurn, ModelTurnOutcome, PendingToolCall},
 };
 use crate::{
     OneOrMany,
@@ -15,12 +16,9 @@ use crate::{
     wasm_compat::{WasmBoxedFuture, WasmCompatSend},
 };
 use futures::{StreamExt, stream};
-use hooks::{
-    HookAction, InvalidToolCallContext, InvalidToolCallHookAction, PromptHook, ToolCallHookAction,
-};
+use hooks::{HookAction, InvalidToolCallHookAction, PromptHook, ToolCallHookAction};
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{BTreeMap, BTreeSet},
     future::IntoFuture,
     marker::PhantomData,
     sync::{
@@ -410,7 +408,7 @@ pub(crate) const TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER: &str =
     "Tool not executed because another tool call in the same assistant turn was invalid.";
 
 /// Combine input history with new messages for building completion requests.
-fn build_history_for_request(
+pub(crate) fn build_history_for_request(
     chat_history: Option<&[Message]>,
     new_messages: &[Message],
 ) -> Vec<Message> {
@@ -419,7 +417,7 @@ fn build_history_for_request(
 }
 
 /// Build the full history for error reporting (input + new messages).
-fn build_full_history(
+pub(crate) fn build_full_history(
     chat_history: Option<&[Message]>,
     new_messages: Vec<Message>,
 ) -> Vec<Message> {
@@ -427,7 +425,7 @@ fn build_full_history(
     input.iter().cloned().chain(new_messages).collect()
 }
 
-fn tool_result_user_content(
+pub(crate) fn tool_result_user_content(
     id: String,
     call_id: Option<String>,
     tool_result: String,
@@ -439,7 +437,7 @@ fn tool_result_user_content(
     }
 }
 
-fn invalid_tool_retry_user_message(
+pub(crate) fn invalid_tool_retry_user_message(
     assistant_content: &OneOrMany<AssistantContent>,
     invalid_tool_call_id: &str,
     feedback: String,
@@ -468,97 +466,7 @@ fn invalid_tool_retry_user_message(
     })
 }
 
-pub(crate) fn validate_tool_call_name(
-    tool_name: &str,
-    executable_tool_names: &BTreeSet<String>,
-    allowed_tool_names: &BTreeSet<String>,
-    chat_history: Vec<Message>,
-) -> Result<(), PromptError> {
-    if allowed_tool_names.contains(tool_name) {
-        return Ok(());
-    }
-
-    Err(PromptError::UnknownToolCall {
-        tool_name: tool_name.to_owned(),
-        available_tools: executable_tool_names.iter().cloned().collect(),
-        allowed_tools: allowed_tool_names.iter().cloned().collect(),
-        chat_history: Box::new(chat_history),
-    })
-}
-
-enum InvalidToolCallResolution {
-    Fail(PromptError),
-    Retry(String),
-    Repair(String),
-    Skip(String),
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn resolve_invalid_tool_call<M, P>(
-    hook: Option<&P>,
-    tool_name: &str,
-    tool_call_id: Option<String>,
-    internal_call_id: Option<String>,
-    args: Option<String>,
-    executable_tool_names: &BTreeSet<String>,
-    allowed_tool_names: &BTreeSet<String>,
-    tool_choice: Option<&ToolChoice>,
-    chat_history: Vec<Message>,
-    is_streaming: bool,
-) -> InvalidToolCallResolution
-where
-    M: CompletionModel,
-    P: PromptHook<M>,
-{
-    let err = PromptError::UnknownToolCall {
-        tool_name: tool_name.to_owned(),
-        available_tools: executable_tool_names.iter().cloned().collect(),
-        allowed_tools: allowed_tool_names.iter().cloned().collect(),
-        chat_history: Box::new(chat_history.clone()),
-    };
-
-    let Some(hook) = hook else {
-        return InvalidToolCallResolution::Fail(err);
-    };
-
-    let context = InvalidToolCallContext {
-        tool_name: tool_name.to_owned(),
-        tool_call_id,
-        internal_call_id,
-        args,
-        available_tools: executable_tool_names.iter().cloned().collect(),
-        allowed_tools: allowed_tool_names.iter().cloned().collect(),
-        tool_choice: tool_choice.cloned(),
-        chat_history,
-        is_streaming,
-    };
-
-    match hook.on_invalid_tool_call(&context).await {
-        InvalidToolCallHookAction::Fail => InvalidToolCallResolution::Fail(err),
-        InvalidToolCallHookAction::Retry { feedback } => InvalidToolCallResolution::Retry(feedback),
-        InvalidToolCallHookAction::Repair { tool_name } => {
-            if allowed_tool_names.contains(&tool_name) {
-                InvalidToolCallResolution::Repair(tool_name)
-            } else {
-                InvalidToolCallResolution::Fail(PromptError::UnknownToolCall {
-                    tool_name,
-                    available_tools: executable_tool_names.iter().cloned().collect(),
-                    allowed_tools: allowed_tool_names.iter().cloned().collect(),
-                    chat_history: Box::new(context.chat_history),
-                })
-            }
-        }
-        InvalidToolCallHookAction::Skip { reason } => {
-            if matches!(tool_choice, Some(ToolChoice::None)) {
-                InvalidToolCallResolution::Fail(err)
-            } else {
-                InvalidToolCallResolution::Skip(reason)
-            }
-        }
-    }
-}
-
-fn is_empty_assistant_turn(choice: &OneOrMany<AssistantContent>) -> bool {
+pub(crate) fn is_empty_assistant_turn(choice: &OneOrMany<AssistantContent>) -> bool {
     choice.len() == 1
         && matches!(
             choice.first(),
@@ -566,7 +474,7 @@ fn is_empty_assistant_turn(choice: &OneOrMany<AssistantContent>) -> bool {
         )
 }
 
-fn assistant_text_from_choice(choice: &OneOrMany<AssistantContent>) -> String {
+pub(crate) fn assistant_text_from_choice(choice: &OneOrMany<AssistantContent>) -> String {
     choice
         .iter()
         .filter_map(|content| match content {
@@ -624,469 +532,307 @@ where
                 _ => (None, None),
             },
         };
-        let mut new_messages: Vec<Message> = vec![self.prompt.clone()];
 
-        let mut current_max_turns = 0;
-        let mut usage = Usage::new();
-        let mut completion_calls = Vec::new();
-        let mut completion_call_index = 0;
-        let mut invalid_tool_call_retries = 0;
+        let mut run = AgentRun::new(self.prompt.clone())
+            .max_turns(self.max_turns)
+            .max_invalid_tool_call_retries(self.max_invalid_tool_call_retries);
+        if let Some(history) = chat_history {
+            run = run.with_history(history);
+        }
+        if let Some(tool_choice) = self.tool_choice.clone() {
+            run = run.with_tool_choice(tool_choice);
+        }
+
         let current_span_id: AtomicU64 = AtomicU64::new(0);
 
-        // We need to do at least 2 loops for 1 roundtrip (user expects normal message)
-        let last_prompt = 'prompt_loop: loop {
-            // Get the last message (the current prompt)
-            let Some((prompt_ref, history_for_current_turn)) = new_messages.split_last() else {
-                return Err(PromptError::prompt_cancelled(
-                    build_full_history(chat_history.as_deref(), new_messages),
-                    "prompt loop lost its pending prompt",
-                ));
-            };
-            let prompt = prompt_ref.clone();
-
-            if current_max_turns > self.max_turns + 1 {
-                break prompt;
-            }
-
-            current_max_turns += 1;
-
-            if self.max_turns > 1 {
-                tracing::info!(
-                    "Current conversation depth: {}/{}",
-                    current_max_turns,
-                    self.max_turns
-                );
-            }
-
-            // Build history for hook callback (input + new messages except last)
-            let history_for_hook =
-                build_history_for_request(chat_history.as_deref(), history_for_current_turn);
-
-            if let Some(ref hook) = self.hook
-                && let HookAction::Terminate { reason } =
-                    hook.on_completion_call(&prompt, &history_for_hook).await
-            {
-                return Err(PromptError::prompt_cancelled(
-                    build_full_history(chat_history.as_deref(), new_messages),
-                    reason,
-                ));
-            }
-
-            let span = tracing::Span::current();
-            let chat_span = info_span!(
-                target: "rig::agent_chat",
-                parent: &span,
-                "chat",
-                gen_ai.operation.name = "chat",
-                gen_ai.agent.name = agent_name_for_span.as_deref().unwrap_or(UNKNOWN_AGENT_NAME),
-                gen_ai.system_instructions = self.preamble,
-                gen_ai.provider.name = tracing::field::Empty,
-                gen_ai.request.model = tracing::field::Empty,
-                gen_ai.response.id = tracing::field::Empty,
-                gen_ai.response.model = tracing::field::Empty,
-                gen_ai.usage.output_tokens = tracing::field::Empty,
-                gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
-                gen_ai.usage.tool_use_prompt_tokens = tracing::field::Empty,
-                gen_ai.usage.reasoning_tokens = tracing::field::Empty,
-                gen_ai.input.messages = tracing::field::Empty,
-                gen_ai.output.messages = tracing::field::Empty,
-            );
-
-            let chat_span = if current_span_id.load(Ordering::SeqCst) != 0 {
-                let id = Id::from_u64(current_span_id.load(Ordering::SeqCst));
-                chat_span.follows_from(id).to_owned()
-            } else {
-                chat_span
-            };
-
-            if let Some(id) = chat_span.id() {
-                current_span_id.store(id.into_u64(), Ordering::SeqCst);
-            };
-
-            // Build history for completion request (input + new messages except last)
-            let history_for_request =
-                build_history_for_request(chat_history.as_deref(), history_for_current_turn);
-
-            let prepared_request = build_prepared_completion_request(
-                &self.model,
-                prompt.clone(),
-                &history_for_request,
-                self.preamble.as_deref(),
-                &self.static_context,
-                self.temperature,
-                self.max_tokens,
-                self.additional_params.as_ref(),
-                self.tool_choice.as_ref(),
-                &self.tool_server_handle,
-                &self.dynamic_context,
-                self.output_schema.as_ref(),
-            )
-            .await?;
-            let executable_tool_names = prepared_request.executable_tool_names.clone();
-            let allowed_tool_names = prepared_request.allowed_tool_names.clone();
-
-            let resp = prepared_request
-                .builder
-                .send()
-                .instrument(chat_span.clone())
-                .await?;
-
-            completion_calls.push(CompletionCall::from_reported_usage(
-                completion_call_index,
-                resp.usage,
-            ));
-            completion_call_index += 1;
-            usage += resp.usage;
-
-            let mut response_choice = resp.choice.clone();
-            let has_tool_calls = response_choice
-                .iter()
-                .any(|choice| matches!(choice, AssistantContent::ToolCall(_)));
-
-            // Some providers normalize textless terminal turns into a single empty text item
-            // because the generic completion response cannot represent an empty choice. Treat
-            // that sentinel as "no assistant output" so it does not pollute returned history.
-            let mut skipped_tool_results = BTreeMap::new();
-            let mut invalid_tool_call_recovered = false;
-            let mut invalid_tool_call_skipped = false;
-            if has_tool_calls {
-                for choice in response_choice.iter_mut() {
-                    let AssistantContent::ToolCall(tool_call) = choice else {
-                        continue;
-                    };
-
-                    if allowed_tool_names.contains(&tool_call.function.name) {
-                        continue;
+        loop {
+            match run.next_step()? {
+                AgentRunStep::CallModel {
+                    prompt,
+                    history,
+                    turn,
+                } => {
+                    if self.max_turns > 1 {
+                        tracing::info!("Current conversation depth: {}/{}", turn, self.max_turns);
                     }
 
-                    let mut diagnostic_messages = new_messages.clone();
-                    diagnostic_messages.push(Message::Assistant {
-                        id: resp.message_id.clone(),
-                        content: resp.choice.clone(),
-                    });
-                    let diagnostic_history =
-                        build_full_history(chat_history.as_deref(), diagnostic_messages);
-                    let args = json_utils::value_to_json_string(&tool_call.function.arguments);
-                    let emitted_tool_name = tool_call.function.name.clone();
-
-                    match resolve_invalid_tool_call::<M, P>(
-                        self.hook.as_ref(),
-                        &emitted_tool_name,
-                        Some(tool_call.id.clone()),
-                        None,
-                        Some(args),
-                        &executable_tool_names,
-                        &allowed_tool_names,
-                        self.tool_choice.as_ref(),
-                        diagnostic_history.clone(),
-                        false,
-                    )
-                    .await
+                    if let Some(ref hook) = self.hook
+                        && let HookAction::Terminate { reason } =
+                            hook.on_completion_call(&prompt, &history).await
                     {
-                        InvalidToolCallResolution::Fail(err) => return Err(err),
-                        InvalidToolCallResolution::Retry(feedback) => {
-                            if invalid_tool_call_retries >= self.max_invalid_tool_call_retries {
-                                return Err(PromptError::UnknownToolCall {
-                                    tool_name: emitted_tool_name,
-                                    available_tools: executable_tool_names
-                                        .iter()
-                                        .cloned()
-                                        .collect(),
-                                    allowed_tools: allowed_tool_names.iter().cloned().collect(),
-                                    chat_history: Box::new(diagnostic_history.clone()),
-                                });
-                            }
-
-                            invalid_tool_call_retries += 1;
-                            new_messages.push(Message::Assistant {
-                                id: resp.message_id.clone(),
-                                content: resp.choice.clone(),
-                            });
-                            let Some(user_message) = invalid_tool_retry_user_message(
-                                &resp.choice,
-                                &tool_call.id,
-                                feedback,
-                            ) else {
-                                return Err(PromptError::prompt_cancelled(
-                                    diagnostic_history,
-                                    "invalid tool call retry produced no retry messages",
-                                ));
-                            };
-                            new_messages.push(user_message);
-                            continue 'prompt_loop;
-                        }
-                        InvalidToolCallResolution::Repair(repaired_name) => {
-                            tool_call.function.name = repaired_name;
-                            invalid_tool_call_recovered = true;
-                        }
-                        InvalidToolCallResolution::Skip(reason) => {
-                            let user_content = if let Some(call_id) = tool_call.call_id.clone() {
-                                UserContent::tool_result_with_call_id(
-                                    tool_call.id.clone(),
-                                    call_id,
-                                    OneOrMany::one(reason.into()),
-                                )
-                            } else {
-                                UserContent::tool_result(
-                                    tool_call.id.clone(),
-                                    OneOrMany::one(reason.into()),
-                                )
-                            };
-                            skipped_tool_results.insert(tool_call.id.clone(), user_content);
-                            invalid_tool_call_recovered = true;
-                            invalid_tool_call_skipped = true;
-                        }
+                        return Err(run.cancel_error(reason));
                     }
-                }
-            }
 
-            if invalid_tool_call_skipped {
-                for choice in response_choice.iter() {
-                    let AssistantContent::ToolCall(tool_call) = choice else {
-                        continue;
-                    };
-
-                    skipped_tool_results
-                        .entry(tool_call.id.clone())
-                        .or_insert_with(|| {
-                            tool_result_user_content(
-                                tool_call.id.clone(),
-                                tool_call.call_id.clone(),
-                                TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER.to_string(),
-                            )
-                        });
-                }
-            }
-
-            let assistant_response_message =
-                (!is_empty_assistant_turn(&response_choice)).then(|| Message::Assistant {
-                    id: resp.message_id.clone(),
-                    content: response_choice.clone(),
-                });
-
-            if !invalid_tool_call_recovered
-                && let Some(ref hook) = self.hook
-                && let HookAction::Terminate { reason } =
-                    hook.on_completion_response(&prompt, &resp).await
-            {
-                return Err(PromptError::prompt_cancelled(
-                    build_full_history(chat_history.as_deref(), new_messages),
-                    reason,
-                ));
-            }
-
-            if let Some(message) = assistant_response_message {
-                new_messages.push(message);
-            }
-
-            if !has_tool_calls {
-                let merged_texts = assistant_text_from_choice(&response_choice);
-
-                if self.max_turns > 1 {
-                    tracing::info!("Depth reached: {}/{}", current_max_turns, self.max_turns);
-                }
-
-                agent_span.record("gen_ai.completion", &merged_texts);
-                agent_span.record("gen_ai.usage.input_tokens", usage.input_tokens);
-                agent_span.record("gen_ai.usage.output_tokens", usage.output_tokens);
-                agent_span.record(
-                    "gen_ai.usage.cache_read.input_tokens",
-                    usage.cached_input_tokens,
-                );
-                agent_span.record(
-                    "gen_ai.usage.cache_creation.input_tokens",
-                    usage.cache_creation_input_tokens,
-                );
-                agent_span.record(
-                    "gen_ai.usage.tool_use_prompt_tokens",
-                    usage.tool_use_prompt_tokens,
-                );
-                agent_span.record("gen_ai.usage.reasoning_tokens", usage.reasoning_tokens);
-
-                if let Some((memory, id)) = memory_handle.as_ref()
-                    && let Err(err) = memory.append(id, new_messages.clone()).await
-                {
-                    tracing::warn!(
-                        error = %err,
-                        conversation_id = %id,
-                        "conversation memory append failed; returning model response anyway"
-                    );
-                }
-
-                return Ok(PromptResponse::new(merged_texts, usage)
-                    .with_messages(new_messages)
-                    .with_completion_calls(completion_calls));
-            }
-
-            let hook = self.hook.clone();
-            let tool_server_handle = self.tool_server_handle.clone();
-            let skipped_tool_results = Arc::new(skipped_tool_results);
-
-            // For error handling in concurrent tool execution, we need to build full history
-            let full_history_for_errors =
-                build_full_history(chat_history.as_deref(), new_messages.clone());
-
-            let tool_calls: Vec<AssistantContent> = response_choice
-                .iter()
-                .filter(|choice| matches!(choice, AssistantContent::ToolCall(_)))
-                .cloned()
-                .collect();
-            let tool_content = stream::iter(tool_calls)
-                .map(|choice| {
-                    let hook1 = hook.clone();
-                    let hook2 = hook.clone();
-                    let tool_server_handle = tool_server_handle.clone();
-                    let skipped_tool_results = skipped_tool_results.clone();
-
-                    let tool_span = info_span!(
-                        "execute_tool",
-                        gen_ai.operation.name = "execute_tool",
-                        gen_ai.tool.type = "function",
-                        gen_ai.tool.name = tracing::field::Empty,
-                        gen_ai.tool.call.id = tracing::field::Empty,
-                        gen_ai.tool.call.arguments = tracing::field::Empty,
-                        gen_ai.tool.call.result = tracing::field::Empty
+                    let span = tracing::Span::current();
+                    let chat_span = info_span!(
+                        target: "rig::agent_chat",
+                        parent: &span,
+                        "chat",
+                        gen_ai.operation.name = "chat",
+                        gen_ai.agent.name = agent_name_for_span.as_deref().unwrap_or(UNKNOWN_AGENT_NAME),
+                        gen_ai.system_instructions = self.preamble,
+                        gen_ai.provider.name = tracing::field::Empty,
+                        gen_ai.request.model = tracing::field::Empty,
+                        gen_ai.response.id = tracing::field::Empty,
+                        gen_ai.response.model = tracing::field::Empty,
+                        gen_ai.usage.output_tokens = tracing::field::Empty,
+                        gen_ai.usage.input_tokens = tracing::field::Empty,
+                        gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
+                        gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
+                        gen_ai.usage.tool_use_prompt_tokens = tracing::field::Empty,
+                        gen_ai.usage.reasoning_tokens = tracing::field::Empty,
+                        gen_ai.input.messages = tracing::field::Empty,
+                        gen_ai.output.messages = tracing::field::Empty,
                     );
 
-                    let tool_span = if current_span_id.load(Ordering::SeqCst) != 0 {
+                    let chat_span = if current_span_id.load(Ordering::SeqCst) != 0 {
                         let id = Id::from_u64(current_span_id.load(Ordering::SeqCst));
-                        tool_span.follows_from(id).to_owned()
+                        chat_span.follows_from(id).to_owned()
                     } else {
-                        tool_span
+                        chat_span
                     };
 
-                    if let Some(id) = tool_span.id() {
+                    if let Some(id) = chat_span.id() {
                         current_span_id.store(id.into_u64(), Ordering::SeqCst);
                     };
 
-                    // Clone full history for error reporting in concurrent tool execution
-                    let cloned_history_for_error = full_history_for_errors.clone();
+                    let prepared_request = build_prepared_completion_request(
+                        &self.model,
+                        prompt.clone(),
+                        &history,
+                        self.preamble.as_deref(),
+                        &self.static_context,
+                        self.temperature,
+                        self.max_tokens,
+                        self.additional_params.as_ref(),
+                        self.tool_choice.as_ref(),
+                        &self.tool_server_handle,
+                        &self.dynamic_context,
+                        self.output_schema.as_ref(),
+                    )
+                    .await?;
 
-                    async move {
-                        if let AssistantContent::ToolCall(tool_call) = choice {
-                            let tool_name = &tool_call.function.name;
-                            let args =
-                                json_utils::value_to_json_string(&tool_call.function.arguments);
-                            let internal_call_id = nanoid::nanoid!();
-                            if let Some(result) = skipped_tool_results.get(&tool_call.id) {
-                                return Ok(result.clone());
+                    let resp = prepared_request
+                        .builder
+                        .send()
+                        .instrument(chat_span.clone())
+                        .await?;
+
+                    let mut outcome = run.model_response(ModelTurn::new(
+                        resp.message_id.clone(),
+                        resp.choice.clone(),
+                        resp.usage,
+                        prepared_request.executable_tool_names,
+                        prepared_request.allowed_tool_names,
+                    ))?;
+
+                    loop {
+                        match outcome {
+                            ModelTurnOutcome::NeedsResolution(context) => {
+                                let action = match self.hook.as_ref() {
+                                    Some(hook) => hook.on_invalid_tool_call(&context).await,
+                                    None => InvalidToolCallHookAction::fail(),
+                                };
+                                outcome = run.resolve_invalid_tool_call(action)?;
                             }
-                            let tool_span = tracing::Span::current();
-                            tool_span.record("gen_ai.tool.name", tool_name);
-                            tool_span.record("gen_ai.tool.call.id", &tool_call.id);
-                            tool_span.record("gen_ai.tool.call.arguments", &args);
-                            if let Some(hook) = hook1 {
-                                let action = hook
-                                    .on_tool_call(
-                                        tool_name,
-                                        tool_call.call_id.clone(),
-                                        &internal_call_id,
-                                        &args,
-                                    )
-                                    .await;
+                            ModelTurnOutcome::TurnRetried => break,
+                            ModelTurnOutcome::Continue {
+                                response_hook_suppressed,
+                            } => {
+                                if !response_hook_suppressed
+                                    && let Some(ref hook) = self.hook
+                                    && let HookAction::Terminate { reason } =
+                                        hook.on_completion_response(&prompt, &resp).await
+                                {
+                                    return Err(run.cancel_error(reason));
+                                }
+                                break;
+                            }
+                        }
+                    }
+                }
+                AgentRunStep::CallTools { calls } => {
+                    let hook = self.hook.clone();
+                    let tool_server_handle = self.tool_server_handle.clone();
 
-                                if let ToolCallHookAction::Terminate { reason } = action {
+                    // For error handling in concurrent tool execution, we need to build full history
+                    let full_history_for_errors = run.full_history();
+
+                    let tool_content = stream::iter(calls)
+                        .map(|pending| {
+                            let hook1 = hook.clone();
+                            let hook2 = hook.clone();
+                            let tool_server_handle = tool_server_handle.clone();
+
+                            let tool_span = info_span!(
+                                "execute_tool",
+                                gen_ai.operation.name = "execute_tool",
+                                gen_ai.tool.type = "function",
+                                gen_ai.tool.name = tracing::field::Empty,
+                                gen_ai.tool.call.id = tracing::field::Empty,
+                                gen_ai.tool.call.arguments = tracing::field::Empty,
+                                gen_ai.tool.call.result = tracing::field::Empty
+                            );
+
+                            let tool_span = if current_span_id.load(Ordering::SeqCst) != 0 {
+                                let id = Id::from_u64(current_span_id.load(Ordering::SeqCst));
+                                tool_span.follows_from(id).to_owned()
+                            } else {
+                                tool_span
+                            };
+
+                            if let Some(id) = tool_span.id() {
+                                current_span_id.store(id.into_u64(), Ordering::SeqCst);
+                            };
+
+                            // Clone full history for error reporting in concurrent tool execution
+                            let cloned_history_for_error = full_history_for_errors.clone();
+
+                            async move {
+                                let PendingToolCall {
+                                    tool_call,
+                                    preresolved_result,
+                                } = pending;
+                                let tool_name = &tool_call.function.name;
+                                let args =
+                                    json_utils::value_to_json_string(&tool_call.function.arguments);
+                                let internal_call_id = nanoid::nanoid!();
+                                if let Some(result) = preresolved_result {
+                                    return Ok(result);
+                                }
+                                let tool_span = tracing::Span::current();
+                                tool_span.record("gen_ai.tool.name", tool_name);
+                                tool_span.record("gen_ai.tool.call.id", &tool_call.id);
+                                tool_span.record("gen_ai.tool.call.arguments", &args);
+                                if let Some(hook) = hook1 {
+                                    let action = hook
+                                        .on_tool_call(
+                                            tool_name,
+                                            tool_call.call_id.clone(),
+                                            &internal_call_id,
+                                            &args,
+                                        )
+                                        .await;
+
+                                    if let ToolCallHookAction::Terminate { reason } = action {
+                                        return Err(PromptError::prompt_cancelled(
+                                            cloned_history_for_error,
+                                            reason,
+                                        ));
+                                    }
+
+                                    if let ToolCallHookAction::Skip { reason } = action {
+                                        // Tool execution rejected, return rejection message as tool result
+                                        tracing::info!(
+                                            tool_name = tool_name,
+                                            reason = reason,
+                                            "Tool call rejected"
+                                        );
+                                        if let Some(call_id) = tool_call.call_id.clone() {
+                                            return Ok(UserContent::tool_result_with_call_id(
+                                                tool_call.id.clone(),
+                                                call_id,
+                                                OneOrMany::one(reason.into()),
+                                            ));
+                                        } else {
+                                            return Ok(UserContent::tool_result(
+                                                tool_call.id.clone(),
+                                                OneOrMany::one(reason.into()),
+                                            ));
+                                        }
+                                    }
+                                }
+                                let output =
+                                    match tool_server_handle.call_tool(tool_name, &args).await {
+                                        Ok(res) => res,
+                                        Err(e) => {
+                                            tracing::warn!("Error while executing tool: {e}");
+                                            e.to_string()
+                                        }
+                                    };
+                                if let Some(hook) = hook2
+                                    && let HookAction::Terminate { reason } = hook
+                                        .on_tool_result(
+                                            tool_name,
+                                            tool_call.call_id.clone(),
+                                            &internal_call_id,
+                                            &args,
+                                            &output.to_string(),
+                                        )
+                                        .await
+                                {
                                     return Err(PromptError::prompt_cancelled(
                                         cloned_history_for_error,
                                         reason,
                                     ));
                                 }
 
-                                if let ToolCallHookAction::Skip { reason } = action {
-                                    // Tool execution rejected, return rejection message as tool result
-                                    tracing::info!(
-                                        tool_name = tool_name,
-                                        reason = reason,
-                                        "Tool call rejected"
-                                    );
-                                    if let Some(call_id) = tool_call.call_id.clone() {
-                                        return Ok(UserContent::tool_result_with_call_id(
-                                            tool_call.id.clone(),
-                                            call_id,
-                                            OneOrMany::one(reason.into()),
-                                        ));
-                                    } else {
-                                        return Ok(UserContent::tool_result(
-                                            tool_call.id.clone(),
-                                            OneOrMany::one(reason.into()),
-                                        ));
-                                    }
+                                tool_span.record("gen_ai.tool.call.result", &output);
+                                tracing::info!(
+                                    "executed tool {tool_name} with args {args}. result: {output}"
+                                );
+                                if let Some(call_id) = tool_call.call_id.clone() {
+                                    Ok(UserContent::tool_result_with_call_id(
+                                        tool_call.id.clone(),
+                                        call_id,
+                                        ToolResultContent::from_tool_output(output),
+                                    ))
+                                } else {
+                                    Ok(UserContent::tool_result(
+                                        tool_call.id.clone(),
+                                        ToolResultContent::from_tool_output(output),
+                                    ))
                                 }
                             }
-                            let output = match tool_server_handle.call_tool(tool_name, &args).await
-                            {
-                                Ok(res) => res,
-                                Err(e) => {
-                                    tracing::warn!("Error while executing tool: {e}");
-                                    e.to_string()
-                                }
-                            };
-                            if let Some(hook) = hook2
-                                && let HookAction::Terminate { reason } = hook
-                                    .on_tool_result(
-                                        tool_name,
-                                        tool_call.call_id.clone(),
-                                        &internal_call_id,
-                                        &args,
-                                        &output.to_string(),
-                                    )
-                                    .await
-                            {
-                                return Err(PromptError::prompt_cancelled(
-                                    cloned_history_for_error,
-                                    reason,
-                                ));
-                            }
+                            .instrument(tool_span)
+                        })
+                        .buffer_unordered(self.concurrency)
+                        .collect::<Vec<Result<UserContent, PromptError>>>()
+                        .await
+                        .into_iter()
+                        .collect::<Result<Vec<_>, _>>()?;
 
-                            tool_span.record("gen_ai.tool.call.result", &output);
-                            tracing::info!(
-                                "executed tool {tool_name} with args {args}. result: {output}"
-                            );
-                            if let Some(call_id) = tool_call.call_id.clone() {
-                                Ok(UserContent::tool_result_with_call_id(
-                                    tool_call.id.clone(),
-                                    call_id,
-                                    ToolResultContent::from_tool_output(output),
-                                ))
-                            } else {
-                                Ok(UserContent::tool_result(
-                                    tool_call.id.clone(),
-                                    ToolResultContent::from_tool_output(output),
-                                ))
-                            }
-                        } else {
-                            Err(PromptError::prompt_cancelled(
-                                Vec::new(),
-                                "tool execution received non-tool assistant content",
-                            ))
-                        }
+                    run.tool_results(tool_content)?;
+                }
+                AgentRunStep::Done(response) => {
+                    if self.max_turns > 1 {
+                        tracing::info!("Depth reached: {}/{}", run.turn(), self.max_turns);
                     }
-                    .instrument(tool_span)
-                })
-                .buffer_unordered(self.concurrency)
-                .collect::<Vec<Result<UserContent, PromptError>>>()
-                .await
-                .into_iter()
-                .collect::<Result<Vec<_>, _>>()?;
 
-            let Some(content) = OneOrMany::from_iter_optional(tool_content) else {
-                return Err(PromptError::prompt_cancelled(
-                    build_full_history(chat_history.as_deref(), new_messages),
-                    "tool execution produced no tool results",
-                ));
-            };
+                    let usage = response.usage;
+                    agent_span.record("gen_ai.completion", &response.output);
+                    agent_span.record("gen_ai.usage.input_tokens", usage.input_tokens);
+                    agent_span.record("gen_ai.usage.output_tokens", usage.output_tokens);
+                    agent_span.record(
+                        "gen_ai.usage.cache_read.input_tokens",
+                        usage.cached_input_tokens,
+                    );
+                    agent_span.record(
+                        "gen_ai.usage.cache_creation.input_tokens",
+                        usage.cache_creation_input_tokens,
+                    );
+                    agent_span.record(
+                        "gen_ai.usage.tool_use_prompt_tokens",
+                        usage.tool_use_prompt_tokens,
+                    );
+                    agent_span.record("gen_ai.usage.reasoning_tokens", usage.reasoning_tokens);
 
-            new_messages.push(Message::User { content });
-        };
+                    if let Some((memory, id)) = memory_handle.as_ref()
+                        && let Err(err) = memory
+                            .append(id, response.messages.clone().unwrap_or_default())
+                            .await
+                    {
+                        tracing::warn!(
+                            error = %err,
+                            conversation_id = %id,
+                            "conversation memory append failed; returning model response anyway"
+                        );
+                    }
 
-        // If we reach here, we exceeded max turns without a final response
-        Err(PromptError::MaxTurnsError {
-            max_turns: self.max_turns,
-            chat_history: build_full_history(chat_history.as_deref(), new_messages).into(),
-            prompt: last_prompt.into(),
-        })
+                    return Ok(response);
+                }
+            }
+        }
     }
 }
 

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -290,27 +290,29 @@ where
 pub struct CompletionCall {
     /// Zero-based index of the completion request within this agent run.
     pub call_index: usize,
-    /// Token usage reported for this completion request, when the provider supplied it.
+    /// Token usage reported for this completion request.
     ///
-    /// Rig normalizes zero-valued [`Usage`] to `None` because zero-valued usage
-    /// is the existing sentinel for missing provider usage metrics.
-    #[serde(default)]
-    pub usage: Option<Usage>,
+    /// Zero-valued usage is [`Usage`]'s documented sentinel for missing
+    /// provider usage metrics; rig does not distinguish "reported all zeros"
+    /// from "unreported".
+    #[serde(default, deserialize_with = "usage_null_as_default")]
+    pub usage: Usage,
 }
 
 impl CompletionCall {
     /// Create details for one completion request in an agent run.
-    pub fn new(call_index: usize, usage: Option<Usage>) -> Self {
+    pub fn new(call_index: usize, usage: Usage) -> Self {
         Self { call_index, usage }
-    }
-
-    pub(crate) fn from_reported_usage(call_index: usize, usage: Usage) -> Self {
-        Self::new(call_index, reported_usage(usage))
     }
 }
 
-pub(crate) fn reported_usage(usage: Usage) -> Option<Usage> {
-    (usage != Usage::new()).then_some(usage)
+/// Tolerate `null` usage from data serialized before rig dropped the
+/// `Option<Usage>` encoding of missing provider usage metrics.
+fn usage_null_as_default<'de, D>(deserializer: D) -> Result<Usage, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(Option::<Usage>::deserialize(deserializer)?.unwrap_or_default())
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -318,12 +320,12 @@ pub(crate) fn reported_usage(usage: Usage) -> Option<Usage> {
 pub struct PromptResponse {
     pub output: String,
     pub usage: Usage,
-    /// Successfully completed completion requests made by this agent run, with token usage when available.
+    /// Successfully completed completion requests made by this agent run.
     ///
-    /// `usage` remains the aggregate across the whole run. Use the last entry's
-    /// usage, when present, to inspect the final completion request's
-    /// prompt/context length.
-    /// If a provider does not report token usage, its entry contains `None`.
+    /// `usage` remains the aggregate across the whole run. Use the last
+    /// entry's usage to inspect the final completion request's prompt/context
+    /// length. Zero-valued entry usage means the provider reported no usage
+    /// metrics for that request.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub completion_calls: Vec<CompletionCall>,
     pub messages: Option<Vec<Message>>,
@@ -356,11 +358,17 @@ impl PromptResponse {
         self
     }
 
-    /// Returns successfully completed completion requests made by this agent run, with token usage when available.
+    /// Returns successfully completed completion requests made by this agent run.
     ///
-    /// If a provider does not report token usage, its entry contains `None`.
+    /// Zero-valued entry usage means the provider reported no usage metrics
+    /// for that request.
     pub fn completion_calls(&self) -> &[CompletionCall] {
         &self.completion_calls
+    }
+
+    /// Number of completion requests this agent run made.
+    pub fn requests(&self) -> usize {
+        self.completion_calls.len()
     }
 }
 
@@ -369,12 +377,12 @@ impl PromptResponse {
 pub struct TypedPromptResponse<T> {
     pub output: T,
     pub usage: Usage,
-    /// Successfully completed completion requests made by this agent run, with token usage when available.
+    /// Successfully completed completion requests made by this agent run.
     ///
-    /// `usage` remains the aggregate across the whole run. Use the last entry's
-    /// usage, when present, to inspect the final completion request's
-    /// prompt/context length.
-    /// If a provider does not report token usage, its entry contains `None`.
+    /// `usage` remains the aggregate across the whole run. Use the last
+    /// entry's usage to inspect the final completion request's prompt/context
+    /// length. Zero-valued entry usage means the provider reported no usage
+    /// metrics for that request.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub completion_calls: Vec<CompletionCall>,
 }
@@ -394,9 +402,10 @@ impl<T> TypedPromptResponse<T> {
         self
     }
 
-    /// Returns successfully completed completion requests made by this agent run, with token usage when available.
+    /// Returns successfully completed completion requests made by this agent run.
     ///
-    /// If a provider does not report token usage, its entry contains `None`.
+    /// Zero-valued entry usage means the provider reported no usage metrics
+    /// for that request.
     pub fn completion_calls(&self) -> &[CompletionCall] {
         &self.completion_calls
     }
@@ -1307,18 +1316,29 @@ mod tests {
     fn prompt_response_serializes_completion_calls_with_missing_usage() {
         let reported_usage = usage(3, 4);
         let response = PromptResponse::new("ok", reported_usage).with_completion_calls(vec![
-            CompletionCall::new(0, None),
-            CompletionCall::new(1, Some(reported_usage)),
+            CompletionCall::new(0, Usage::new()),
+            CompletionCall::new(1, reported_usage),
         ]);
 
         let value = serde_json::to_value(&response).expect("serialize prompt response");
 
+        // Unreported usage serializes as a plain zero-valued object: zero is
+        // Usage's documented sentinel for missing provider metrics, so there
+        // is no null encoding to keep in sync.
         assert_eq!(
             value.get("completion_calls"),
             Some(&json!([
                 {
                     "call_index": 0,
-                    "usage": null,
+                    "usage": {
+                        "input_tokens": 0,
+                        "output_tokens": 0,
+                        "total_tokens": 0,
+                        "cached_input_tokens": 0,
+                        "cache_creation_input_tokens": 0,
+                        "tool_use_prompt_tokens": 0,
+                        "reasoning_tokens": 0,
+                    }
                 },
                 {
                     "call_index": 1,
@@ -1340,8 +1360,26 @@ mod tests {
         assert_eq!(
             response.completion_calls(),
             &[
-                CompletionCall::new(0, None),
-                CompletionCall::new(1, Some(reported_usage))
+                CompletionCall::new(0, Usage::new()),
+                CompletionCall::new(1, reported_usage)
+            ]
+        );
+        assert_eq!(response.requests(), 2);
+    }
+
+    #[test]
+    fn prompt_response_deserializes_pre_monoid_null_usage_format() {
+        // Fixture captured from rig before CompletionCall.usage dropped its
+        // Option encoding; `"usage": null` must map to zero-valued usage.
+        let fixture = r#"{"output":"ok","usage":{"input_tokens":3,"output_tokens":4,"total_tokens":7,"cached_input_tokens":0,"cache_creation_input_tokens":0,"tool_use_prompt_tokens":0,"reasoning_tokens":0},"completion_calls":[{"call_index":0,"usage":null},{"call_index":1,"usage":{"input_tokens":3,"output_tokens":4,"total_tokens":7,"cached_input_tokens":0,"cache_creation_input_tokens":0,"tool_use_prompt_tokens":0,"reasoning_tokens":0}}],"messages":[{"role":"user","content":[{"type":"text","text":"add things"}]}]}"#;
+
+        let response: PromptResponse =
+            serde_json::from_str(fixture).expect("old-format response should deserialize");
+        assert_eq!(
+            response.completion_calls(),
+            &[
+                CompletionCall::new(0, Usage::new()),
+                CompletionCall::new(1, usage(3, 4))
             ]
         );
     }
@@ -1359,7 +1397,10 @@ mod tests {
 
         assert_eq!(response.output, "ok");
         assert_eq!(response.usage, Usage::new());
-        assert_eq!(response.completion_calls(), &[CompletionCall::new(0, None)]);
+        assert_eq!(
+            response.completion_calls(),
+            &[CompletionCall::new(0, Usage::new())]
+        );
     }
 
     #[tokio::test]
@@ -1392,7 +1433,7 @@ mod tests {
         assert_eq!(response.usage, call_usage);
         assert_eq!(
             response.completion_calls(),
-            &[CompletionCall::new(0, Some(call_usage))]
+            &[CompletionCall::new(0, call_usage)]
         );
     }
 
@@ -2243,8 +2284,8 @@ mod tests {
         assert_eq!(
             response.completion_calls(),
             &[
-                CompletionCall::new(0, Some(first_call_usage)),
-                CompletionCall::new(1, Some(second_call_usage))
+                CompletionCall::new(0, first_call_usage),
+                CompletionCall::new(1, second_call_usage)
             ]
         );
 

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -692,6 +692,7 @@ where
                                 let PendingToolCall {
                                     tool_call,
                                     preresolved_result,
+                                    ..
                                 } = pending;
                                 let tool_name = &tool_call.function.name;
                                 let args =

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -308,6 +308,10 @@ impl CompletionCall {
 
 /// Tolerate `null` usage from data serialized before rig dropped the
 /// `Option<Usage>` encoding of missing provider usage metrics.
+///
+/// This tolerance requires a self-describing format such as JSON; data
+/// serialized with non-self-describing formats (e.g. bincode) from before the
+/// change cannot round-trip.
 fn usage_null_as_default<'de, D>(deserializer: D) -> Result<Usage, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -408,6 +412,11 @@ impl<T> TypedPromptResponse<T> {
     /// for that request.
     pub fn completion_calls(&self) -> &[CompletionCall] {
         &self.completion_calls
+    }
+
+    /// Number of completion requests this agent run made.
+    pub fn requests(&self) -> usize {
+        self.completion_calls.len()
     }
 }
 
@@ -1306,6 +1315,7 @@ mod tests {
         )
         .expect("deserialize typed prompt response");
 
+        assert_eq!(response.requests(), 0);
         assert_eq!(response.output.value, "ok");
         assert_eq!(response.usage.input_tokens, 1);
         assert_eq!(response.usage.output_tokens, 2);

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -136,6 +136,11 @@ impl FinalResponse {
         &self.completion_calls
     }
 
+    /// Number of completion requests this agent run made.
+    pub fn requests(&self) -> usize {
+        self.completion_calls.len()
+    }
+
     pub fn history(&self) -> Option<&[Message]> {
         self.history.as_deref()
     }
@@ -678,7 +683,7 @@ where
                                     }
                                     StreamedTurnEvent::Completed { usage, emit_final } => {
                                         if !completion_call_emitted {
-                                            if usage != crate::completion::Usage::new() {
+                                            if usage.has_values() {
                                                 record_usage_on_span(&chat_stream_span, usage);
                                             }
                                             let completion_call =
@@ -771,9 +776,7 @@ where
                                                         }
                                                     };
                                                 if !completion_call_emitted {
-                                                    if drained_usage
-                                                        != crate::completion::Usage::new()
-                                                    {
+                                                    if drained_usage.has_values() {
                                                         record_usage_on_span(
                                                             &chat_stream_span,
                                                             drained_usage,
@@ -1825,6 +1828,10 @@ mod tests {
                 ],
                 None,
             );
+
+        if let MultiTurnStreamItem::FinalResponse(response) = &item {
+            assert_eq!(response.requests(), 2);
+        }
 
         let value = serde_json::to_value(&item).expect("serialize final response");
 

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -57,7 +57,10 @@ pub enum MultiTurnStreamItem<R> {
     /// ```rust,ignore
     /// match item {
     ///     MultiTurnStreamItem::CompletionCall(completion_call) => {
-    ///         let context_tokens = completion_call.usage.map(|usage| usage.input_tokens);
+    ///         // Zero-valued usage means the provider reported no metrics.
+    ///         if completion_call.usage.has_values() {
+    ///             let context_tokens = completion_call.usage.input_tokens;
+    ///         }
     ///     }
     ///     _ => {}
     /// }

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -2,23 +2,29 @@ use crate::{
     OneOrMany,
     agent::completion::{DynamicContextStore, build_prepared_completion_request},
     agent::prompt_request::{
-        HookAction, InvalidToolCallResolution, TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER,
-        hooks::PromptHook, resolve_invalid_tool_call, validate_tool_call_name,
+        HookAction, assistant_text_from_choice,
+        hooks::{InvalidToolCallHookAction, PromptHook},
+        is_empty_assistant_turn, tool_result_user_content,
+    },
+    agent::run::{
+        AgentRun, AgentRunStep,
+        streamed::{StreamedResolution, StreamedTurnAssembler, StreamedTurnEvent},
     },
     completion::{Document, GetTokenUsage},
     json_utils,
     memory::ConversationMemory,
-    message::{
-        AssistantContent, ToolCall, ToolChoice, ToolFunction, ToolResult, ToolResultContent,
-        UserContent,
-    },
+    message::{AssistantContent, ToolChoice, ToolResult, ToolResultContent, UserContent},
     streaming::{StreamedAssistantContent, StreamedUserContent, ToolCallDeltaContent},
     tool::server::ToolServerHandle,
     wasm_compat::{WasmBoxedFuture, WasmCompatSend},
 };
 use futures::{Stream, StreamExt};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, pin::Pin, sync::Arc};
+use std::{
+    collections::{BTreeMap, VecDeque},
+    pin::Pin,
+    sync::Arc,
+};
 use tracing::info_span;
 use tracing_futures::Instrument;
 
@@ -171,216 +177,29 @@ impl<R> MultiTurnStreamItem<R> {
     }
 }
 
-fn merge_reasoning_blocks(
-    accumulated_reasoning: &mut Vec<crate::message::Reasoning>,
-    incoming: &crate::message::Reasoning,
-) {
-    let ids_match = |existing: &crate::message::Reasoning| {
-        matches!(
-            (&existing.id, &incoming.id),
-            (Some(existing_id), Some(incoming_id)) if existing_id == incoming_id
-        )
-    };
-
-    if let Some(existing) = accumulated_reasoning
-        .iter_mut()
-        .rev()
-        .find(|existing| ids_match(existing))
-    {
-        existing.content.extend(incoming.content.clone());
-    } else {
-        accumulated_reasoning.push(incoming.clone());
-    }
-}
-
-fn flush_pending_reasoning_delta(
-    accumulated_reasoning: &mut Vec<crate::message::Reasoning>,
-    pending_reasoning_delta_text: &mut String,
-    pending_reasoning_delta_id: &mut Option<String>,
-) {
-    if accumulated_reasoning.is_empty() && !pending_reasoning_delta_text.is_empty() {
-        let mut assembled = crate::message::Reasoning::new(&*pending_reasoning_delta_text);
-        if let Some(id) = pending_reasoning_delta_id.take() {
-            assembled = assembled.with_id(id);
-        }
-        accumulated_reasoning.push(assembled);
-        pending_reasoning_delta_text.clear();
-    }
-}
-
-/// Build full history for error reporting (input + new messages).
-fn build_full_history(
-    chat_history: Option<&[Message]>,
-    new_messages: Vec<Message>,
-) -> Vec<Message> {
-    let input = chat_history.unwrap_or(&[]);
-    input.iter().cloned().chain(new_messages).collect()
-}
-
-struct ToolCallValidationHistory<'a> {
-    chat_history: Option<&'a [Message]>,
-    new_messages: &'a [Message],
-    assistant_message_id: &'a Option<String>,
-    final_turn_content: Option<&'a OneOrMany<AssistantContent>>,
-    text_delta_response: Option<&'a str>,
-    accumulated_reasoning: &'a [crate::message::Reasoning],
-    pending_reasoning_delta_text: &'a str,
-    pending_reasoning_delta_id: &'a Option<String>,
-    pending_tool_calls: &'a [(ToolCall, String)],
-    current_tool_call: Option<ToolCall>,
-}
-
-fn build_tool_call_validation_history(input: ToolCallValidationHistory<'_>) -> Vec<Message> {
-    let mut messages = input.new_messages.to_vec();
-
-    if let Some(final_turn_content) = input.final_turn_content
-        && !is_empty_assistant_choice(final_turn_content)
-    {
-        if let Some(content) = ordered_streaming_assistant_content_from_choice(final_turn_content) {
-            messages.push(Message::Assistant {
-                id: input.assistant_message_id.clone(),
-                content,
-            });
-        }
-        return build_full_history(input.chat_history, messages);
-    }
-
-    let text_items = if let Some(text) = input.text_delta_response
-        && !text.is_empty()
-    {
-        vec![AssistantContent::text(text.to_string())]
-    } else {
-        Vec::new()
-    };
-    let mut reasoning_items = input.accumulated_reasoning.to_vec();
-    if input.accumulated_reasoning.is_empty() && !input.pending_reasoning_delta_text.is_empty() {
-        let mut reasoning = crate::message::Reasoning::new(input.pending_reasoning_delta_text);
-        if let Some(id) = input.pending_reasoning_delta_id.clone() {
-            reasoning = reasoning.with_id(id);
-        }
-        reasoning_items.push(reasoning);
-    }
-    let mut tool_items = input
-        .pending_tool_calls
-        .iter()
-        .map(|(tool_call, _)| AssistantContent::ToolCall(tool_call.clone()))
-        .collect::<Vec<_>>();
-    if let Some(tool_call) = input.current_tool_call {
-        tool_items.push(AssistantContent::ToolCall(tool_call));
-    }
-
-    if let Some(content) =
-        ordered_streaming_assistant_content(reasoning_items, text_items, tool_items)
-    {
-        messages.push(Message::Assistant {
-            id: input.assistant_message_id.clone(),
-            content,
-        });
-    }
-
-    build_full_history(input.chat_history, messages)
-}
-
-fn ordered_streaming_assistant_content(
-    reasoning_items: impl IntoIterator<Item = crate::message::Reasoning>,
-    text_items: impl IntoIterator<Item = AssistantContent>,
-    trailing_items: impl IntoIterator<Item = AssistantContent>,
-) -> Option<OneOrMany<AssistantContent>> {
-    let mut content_items = reasoning_items
-        .into_iter()
-        .map(AssistantContent::Reasoning)
-        .collect::<Vec<_>>();
-    content_items.extend(text_items);
-    content_items.extend(trailing_items);
-
-    OneOrMany::from_iter_optional(content_items)
-}
-
-fn ordered_streaming_assistant_content_from_choice(
-    choice: &OneOrMany<AssistantContent>,
-) -> Option<OneOrMany<AssistantContent>> {
-    let mut reasoning_items = Vec::new();
-    let mut text_items = Vec::new();
-    let mut trailing_items = Vec::new();
-
-    for item in choice.iter().cloned() {
-        match item {
-            AssistantContent::Reasoning(reasoning) => reasoning_items.push(reasoning),
-            AssistantContent::Text(text) => {
-                if !text.text.is_empty() || text.additional_params.is_some() {
-                    text_items.push(AssistantContent::Text(text));
-                }
-            }
-            AssistantContent::ToolCall(tool_call) => {
-                trailing_items.push(AssistantContent::ToolCall(tool_call));
-            }
-            AssistantContent::Image(image) => trailing_items.push(AssistantContent::Image(image)),
-        }
-    }
-
-    ordered_streaming_assistant_content(reasoning_items, text_items, trailing_items)
-}
-
-fn pending_tool_call_content_items(
-    pending_tool_calls: &[(ToolCall, String)],
-) -> Vec<AssistantContent> {
-    pending_tool_calls
-        .iter()
-        .map(|(tool_call, _)| AssistantContent::ToolCall(tool_call.clone()))
-        .collect()
-}
-
-async fn drain_recovered_stream_usage<R>(
+/// Drain a provider stream abandoned by invalid tool-call recovery so the
+/// reported usage for the recovered completion call is not lost.
+async fn drain_stream_usage<R>(
     stream: &mut crate::streaming::StreamingCompletionResponse<R>,
-    tool_call_delta_states: &HashMap<(String, String), ToolCallDeltaState>,
-    current_call_usage: &mut Option<crate::completion::Usage>,
-    aggregated_usage: &mut crate::completion::Usage,
-) -> Result<(), StreamingError>
+) -> Result<Option<crate::completion::Usage>, StreamingError>
 where
     R: Clone + Unpin + GetTokenUsage,
 {
-    if let Some(err) = pending_tool_call_delta_error(tool_call_delta_states) {
-        return Err(err.into());
-    }
-
+    let mut usage = None;
     while let Some(content) = stream.next().await {
         match content {
             Ok(StreamedAssistantContent::Final(final_resp)) => {
-                if let Some(usage) = final_resp.token_usage() {
-                    *current_call_usage = reported_usage(usage);
+                if let Some(reported) = final_resp.token_usage() {
+                    usage = reported_usage(reported);
                 }
-                if let Some(usage) = *current_call_usage {
-                    *aggregated_usage += usage;
-                }
-                return Ok(());
+                return Ok(usage);
             }
             Ok(_) => {}
             Err(err) => return Err(err.into()),
         }
     }
 
-    Ok(())
-}
-
-fn record_completion_call_if_needed(
-    completion_calls: &mut Vec<CompletionCall>,
-    completion_call_emitted: &mut bool,
-    call_index: usize,
-    current_call_usage: Option<crate::completion::Usage>,
-    chat_stream_span: &tracing::Span,
-) -> Option<CompletionCall> {
-    if *completion_call_emitted {
-        return None;
-    }
-
-    if let Some(usage) = current_call_usage {
-        record_usage_on_span(chat_stream_span, usage);
-    }
-
-    let completion_call = CompletionCall::new(call_index, current_call_usage);
-    completion_calls.push(completion_call);
-    *completion_call_emitted = true;
-    Some(completion_call)
+    Ok(usage)
 }
 
 fn record_usage_on_span(span: &tracing::Span, usage: crate::completion::Usage) {
@@ -399,188 +218,6 @@ fn record_usage_on_span(span: &tracing::Span, usage: crate::completion::Usage) {
         usage.tool_use_prompt_tokens,
     );
     span.record("gen_ai.usage.reasoning_tokens", usage.reasoning_tokens);
-}
-
-/// Combine input history with new messages for building completion requests.
-fn build_history_for_request(
-    chat_history: Option<&[Message]>,
-    new_messages: &[Message],
-) -> Vec<Message> {
-    let input = chat_history.unwrap_or(&[]);
-    input.iter().chain(new_messages.iter()).cloned().collect()
-}
-
-async fn cancelled_prompt_error(
-    chat_history: Option<&[Message]>,
-    new_messages: Vec<Message>,
-    reason: String,
-) -> StreamingError {
-    StreamingError::Prompt(
-        PromptError::prompt_cancelled(build_full_history(chat_history, new_messages), reason)
-            .into(),
-    )
-}
-
-fn tool_result_user_content(
-    id: String,
-    call_id: Option<String>,
-    tool_result: String,
-) -> UserContent {
-    let content = ToolResultContent::from_tool_output(tool_result);
-    match call_id {
-        Some(call_id) => UserContent::tool_result_with_call_id(id, call_id, content),
-        None => UserContent::tool_result(id, content),
-    }
-}
-
-fn invalid_streaming_tool_retry_messages(
-    assistant_message_id: &Option<String>,
-    text_delta_response: Option<&str>,
-    accumulated_reasoning: &[crate::message::Reasoning],
-    pending_tool_calls: &[(ToolCall, String)],
-    invalid_tool_call: ToolCall,
-    feedback: String,
-) -> Option<(Message, Message)> {
-    let text_items = if let Some(text) = text_delta_response
-        && !text.is_empty()
-    {
-        vec![AssistantContent::text(text.to_string())]
-    } else {
-        Vec::new()
-    };
-    let mut tool_items = pending_tool_call_content_items(pending_tool_calls);
-    tool_items.push(AssistantContent::ToolCall(invalid_tool_call.clone()));
-
-    let assistant_content = ordered_streaming_assistant_content(
-        accumulated_reasoning.iter().cloned(),
-        text_items,
-        tool_items,
-    )?;
-    let assistant_message = Message::Assistant {
-        id: assistant_message_id.clone(),
-        content: assistant_content,
-    };
-
-    let mut retry_results = pending_tool_calls
-        .iter()
-        .map(|(tool_call, _)| {
-            tool_result_user_content(
-                tool_call.id.clone(),
-                tool_call.call_id.clone(),
-                TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER.to_string(),
-            )
-        })
-        .collect::<Vec<_>>();
-    retry_results.push(tool_result_user_content(
-        invalid_tool_call.id,
-        invalid_tool_call.call_id,
-        feedback,
-    ));
-
-    let user_message = Message::User {
-        content: OneOrMany::from_iter_optional(retry_results)?,
-    };
-
-    Some((assistant_message, user_message))
-}
-
-fn invalid_streaming_name_delta_retry_messages(
-    assistant_message_id: &Option<String>,
-    text_delta_response: Option<&str>,
-    accumulated_reasoning: &[crate::message::Reasoning],
-    pending_tool_calls: &[(ToolCall, String)],
-    invalid_tool_call: ToolCall,
-    feedback: String,
-) -> Option<(Message, Message)> {
-    let text_items = if let Some(text) = text_delta_response
-        && !text.is_empty()
-    {
-        vec![AssistantContent::text(text.to_string())]
-    } else {
-        Vec::new()
-    };
-    let mut tool_items = pending_tool_call_content_items(pending_tool_calls);
-    tool_items.push(AssistantContent::ToolCall(invalid_tool_call.clone()));
-
-    let assistant_message = Message::Assistant {
-        id: assistant_message_id.clone(),
-        content: ordered_streaming_assistant_content(
-            accumulated_reasoning.iter().cloned(),
-            text_items,
-            tool_items,
-        )?,
-    };
-    let mut retry_results = pending_tool_calls
-        .iter()
-        .map(|(tool_call, _)| {
-            tool_result_user_content(
-                tool_call.id.clone(),
-                tool_call.call_id.clone(),
-                TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER.to_string(),
-            )
-        })
-        .collect::<Vec<_>>();
-    retry_results.push(tool_result_user_content(
-        invalid_tool_call.id,
-        invalid_tool_call.call_id,
-        feedback,
-    ));
-    let user_message = Message::User {
-        content: OneOrMany::from_iter_optional(retry_results)?,
-    };
-
-    Some((assistant_message, user_message))
-}
-
-fn assistant_text_from_choice(choice: &OneOrMany<AssistantContent>) -> String {
-    choice
-        .iter()
-        .filter_map(|content| match content {
-            AssistantContent::Text(text) => Some(text.text.as_str()),
-            _ => None,
-        })
-        .collect()
-}
-
-fn assistant_text_items_from_choice(choice: &OneOrMany<AssistantContent>) -> Vec<AssistantContent> {
-    choice
-        .iter()
-        .filter_map(|content| match content {
-            AssistantContent::Text(text) => (!text.text.is_empty()
-                || text.additional_params.is_some())
-            .then(|| AssistantContent::Text(text.clone())),
-            _ => None,
-        })
-        .collect()
-}
-
-fn is_empty_assistant_choice(choice: &OneOrMany<AssistantContent>) -> bool {
-    choice.len() == 1
-        && matches!(
-            choice.first(),
-            AssistantContent::Text(text)
-                if text.text.is_empty() && text.additional_params.is_none()
-        )
-}
-
-#[derive(Default)]
-struct ToolCallDeltaState {
-    name_validated: bool,
-    buffered_arguments: Vec<String>,
-}
-
-fn pending_tool_call_delta_error(
-    states: &HashMap<(String, String), ToolCallDeltaState>,
-) -> Option<CompletionError> {
-    states
-        .iter()
-        .find(|(_, state)| !state.name_validated && !state.buffered_arguments.is_empty())
-        .map(|((id, internal_call_id), state)| {
-            CompletionError::ResponseError(format!(
-                "streamed tool call arguments received before a validated tool name for id `{id}` and internal_call_id `{internal_call_id}` ({} buffered argument delta(s))",
-                state.buffered_arguments.len()
-            ))
-        })
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -843,6 +480,7 @@ where
         let dynamic_context = self.dynamic_context.clone();
         let tool_choice = self.tool_choice.clone();
         let agent_name = self.agent_name.clone();
+        let output_schema = self.output_schema;
         // When the caller passes explicit history, memory is fully bypassed for
         // this request (no load AND no save). Otherwise, if a memory backend and
         // conversation id are both configured, load prior history; if either is
@@ -863,20 +501,16 @@ where
             },
         };
         let has_history = chat_history.is_some();
-        let mut new_messages: Vec<Message> = vec![prompt.clone()];
 
-        let mut current_max_turns = 0;
-        let mut last_prompt_error = String::new();
-
-        let mut text_delta_response = String::new();
-        let mut saw_text_this_turn = false;
-        let mut max_turns_reached = false;
-        let output_schema = self.output_schema;
-
-        let mut aggregated_usage = crate::completion::Usage::new();
-        let mut completion_calls = Vec::new();
-        let mut completion_call_index = 0;
-        let mut invalid_tool_call_retries = 0;
+        let mut run = AgentRun::new(prompt.clone())
+            .max_turns(self.max_turns)
+            .max_invalid_tool_call_retries(self.max_invalid_tool_call_retries);
+        if let Some(history) = chat_history {
+            run = run.with_history(history);
+        }
+        if let Some(tool_choice) = tool_choice.clone() {
+            run = run.with_tool_choice(tool_choice);
+        }
 
         // NOTE: We use .instrument(agent_span) instead of span.enter() to avoid
         // span context leaking to other concurrent tasks. Using span.enter() inside
@@ -885,837 +519,518 @@ where
         // See: https://docs.rs/tracing/latest/tracing/span/struct.Span.html#in-asynchronous-code
         // See also: https://github.com/rust-lang/rust-clippy/issues/8722
         let stream = async_stream::stream! {
+            // The raw provider choice of the most recent turn; the final
+            // response surfaces it as-is, even when canonical reordering was
+            // recorded in history.
+            let mut last_final_choice: OneOrMany<AssistantContent> =
+                OneOrMany::one(AssistantContent::text(""));
+            let mut last_message_id: Option<String> = None;
+            let mut internal_call_ids: BTreeMap<String, String> = BTreeMap::new();
+
             'outer: loop {
-                let Some((current_prompt_ref, previous_messages)) = new_messages.split_last() else {
-                    yield Err(cancelled_prompt_error(
-                        chat_history.as_deref(),
-                        new_messages.clone(),
-                        "streaming loop lost its pending prompt".to_string(),
-                    ).await);
-                    break 'outer;
+                let step = match run.next_step() {
+                    Ok(step) => step,
+                    Err(err) => {
+                        yield Err(Box::new(err).into());
+                        break 'outer;
+                    }
                 };
-                let current_prompt = current_prompt_ref.clone();
 
-                if current_max_turns > self.max_turns + 1 {
-                    last_prompt_error = current_prompt.rag_text().unwrap_or_default();
-                    max_turns_reached = true;
-                    break;
-                }
+                match step {
+                    AgentRunStep::CallModel { prompt: current_prompt, history, turn } => {
+                        if self.max_turns > 1 {
+                            tracing::info!(
+                                "Current conversation Turns: {}/{}",
+                                turn,
+                                self.max_turns
+                            );
+                        }
 
-                current_max_turns += 1;
+                        if let Some(ref hook) = self.hook
+                            && let HookAction::Terminate { reason } =
+                                hook.on_completion_call(&current_prompt, &history).await
+                        {
+                            yield Err(StreamingError::Prompt(Box::new(run.cancel_error(reason))));
+                            break 'outer;
+                        }
 
-                if self.max_turns > 1 {
-                    tracing::info!(
-                        "Current conversation Turns: {}/{}",
-                        current_max_turns,
-                        self.max_turns
-                    );
-                }
+                        let chat_stream_span = info_span!(
+                            target: "rig::agent_chat",
+                            parent: tracing::Span::current(),
+                            "chat_streaming",
+                            gen_ai.operation.name = "chat",
+                            gen_ai.agent.name = agent_name.as_deref().unwrap_or(UNKNOWN_AGENT_NAME),
+                            gen_ai.system_instructions = preamble,
+                            gen_ai.provider.name = tracing::field::Empty,
+                            gen_ai.request.model = tracing::field::Empty,
+                            gen_ai.response.id = tracing::field::Empty,
+                            gen_ai.response.model = tracing::field::Empty,
+                            gen_ai.usage.output_tokens = tracing::field::Empty,
+                            gen_ai.usage.input_tokens = tracing::field::Empty,
+                            gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
+                            gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
+                            gen_ai.usage.tool_use_prompt_tokens = tracing::field::Empty,
+                            gen_ai.usage.reasoning_tokens = tracing::field::Empty,
+                            gen_ai.input.messages = tracing::field::Empty,
+                            gen_ai.output.messages = tracing::field::Empty,
+                        );
 
-                let history_snapshot: Vec<Message> = build_history_for_request(
-                    chat_history.as_deref(),
-                    previous_messages,
-                );
+                        let prepared_request = build_prepared_completion_request(
+                            &model,
+                            current_prompt.clone(),
+                            &history,
+                            preamble.as_deref(),
+                            &static_context,
+                            temperature,
+                            max_tokens,
+                            additional_params.as_ref(),
+                            tool_choice.as_ref(),
+                            &tool_server_handle,
+                            &dynamic_context,
+                            output_schema.as_ref(),
+                        )
+                        .await?;
 
-                if let Some(ref hook) = self.hook
-                    && let HookAction::Terminate { reason } =
-                        hook.on_completion_call(&current_prompt, &history_snapshot).await
-                {
-                    yield Err(
-                        cancelled_prompt_error(chat_history.as_deref(), new_messages.clone(), reason)
-                            .await,
-                    );
-                    break 'outer;
-                }
+                        let mut stream = prepared_request
+                            .builder
+                            .stream()
+                            .instrument(chat_stream_span.clone())
+                            .await?;
 
-                let chat_stream_span = info_span!(
-                    target: "rig::agent_chat",
-                    parent: tracing::Span::current(),
-                    "chat_streaming",
-                    gen_ai.operation.name = "chat",
-                    gen_ai.agent.name = agent_name.as_deref().unwrap_or(UNKNOWN_AGENT_NAME),
-                    gen_ai.system_instructions = preamble,
-                    gen_ai.provider.name = tracing::field::Empty,
-                    gen_ai.request.model = tracing::field::Empty,
-                    gen_ai.response.id = tracing::field::Empty,
-                    gen_ai.response.model = tracing::field::Empty,
-                    gen_ai.usage.output_tokens = tracing::field::Empty,
-                    gen_ai.usage.input_tokens = tracing::field::Empty,
-                    gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
-                    gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
-                    gen_ai.usage.tool_use_prompt_tokens = tracing::field::Empty,
-                    gen_ai.usage.reasoning_tokens = tracing::field::Empty,
-                    gen_ai.input.messages = tracing::field::Empty,
-                    gen_ai.output.messages = tracing::field::Empty,
-                );
+                        let mut assembler = StreamedTurnAssembler::new(
+                            prepared_request.executable_tool_names.clone(),
+                            prepared_request.allowed_tool_names.clone(),
+                        );
+                        let mut completion_call_emitted = false;
+                        let mut turn_abandoned = false;
 
-                let prepared_request = build_prepared_completion_request(
-                    &model,
-                    current_prompt.clone(),
-                    &history_snapshot,
-                    preamble.as_deref(),
-                    &static_context,
-                    temperature,
-                    max_tokens,
-                    additional_params.as_ref(),
-                    tool_choice.as_ref(),
-                    &tool_server_handle,
-                    &dynamic_context,
-                    output_schema.as_ref(),
-                )
-                .await?;
-                let executable_tool_names = prepared_request.executable_tool_names.clone();
-                let allowed_tool_names = prepared_request.allowed_tool_names.clone();
-
-                let mut stream = prepared_request
-                    .builder
-                    .stream()
-                    .instrument(chat_stream_span.clone())
-                    .await?;
-
-                let call_index = completion_call_index;
-                completion_call_index += 1;
-                let mut current_call_usage = None;
-                let mut completion_call_emitted = false;
-                let mut pending_tool_calls: Vec<(ToolCall, String)> = vec![];
-                let mut tool_calls = vec![];
-                let mut tool_results = vec![];
-                let mut accumulated_reasoning: Vec<rig::message::Reasoning> = vec![];
-                // Kept separate from accumulated_reasoning so providers requiring
-                // signatures (e.g. Anthropic) never see unsigned blocks.
-                let mut pending_reasoning_delta_text = String::new();
-                let mut pending_reasoning_delta_id: Option<String> = None;
-                let mut tool_call_delta_states: HashMap<(String, String), ToolCallDeltaState> =
-                    HashMap::new();
-                let mut saw_tool_call_this_turn = false;
-
-                while let Some(content) = stream.next().await {
-                    match content {
-                        Ok(StreamedAssistantContent::Text(text)) => {
-                            if !saw_text_this_turn {
-                                text_delta_response.clear();
-                                saw_text_this_turn = true;
-                            }
-                            text_delta_response.push_str(&text.text);
-                            if let Some(ref hook) = self.hook &&
-                                let HookAction::Terminate { reason } = hook.on_text_delta(&text.text, &text_delta_response).await {
-                                    yield Err(cancelled_prompt_error(chat_history.as_deref(), new_messages.clone(), reason).await);
+                        'turn: while let Some(item) = stream.next().await {
+                            let item = match item {
+                                Ok(item) => item,
+                                Err(err) => {
+                                    yield Err(err.into());
                                     break 'outer;
-                            }
-
-                            yield Ok(MultiTurnStreamItem::stream_item(StreamedAssistantContent::Text(text)));
-                        },
-                        Ok(StreamedAssistantContent::ToolCall { mut tool_call, internal_call_id }) => {
-                            let diagnostic_history =
-                                build_tool_call_validation_history(ToolCallValidationHistory {
-                                    chat_history: chat_history.as_deref(),
-                                    new_messages: &new_messages,
-                                    assistant_message_id: &stream.message_id,
-                                    final_turn_content: None,
-                                    text_delta_response: saw_text_this_turn
-                                        .then_some(text_delta_response.as_str()),
-                                    accumulated_reasoning: &accumulated_reasoning,
-                                    pending_reasoning_delta_text: &pending_reasoning_delta_text,
-                                    pending_reasoning_delta_id: &pending_reasoning_delta_id,
-                                    pending_tool_calls: &pending_tool_calls,
-                                    current_tool_call: Some(tool_call.clone()),
-                                });
-
-                            if !allowed_tool_names.contains(&tool_call.function.name) {
-                                let args = json_utils::value_to_json_string(&tool_call.function.arguments);
-                                let emitted_tool_name = tool_call.function.name.clone();
-                                match resolve_invalid_tool_call::<M, P>(
-                                    self.hook.as_ref(),
-                                    &emitted_tool_name,
-                                    Some(tool_call.id.clone()),
-                                    Some(internal_call_id.clone()),
-                                    Some(args),
-                                    &executable_tool_names,
-                                    &allowed_tool_names,
-                                    self.tool_choice.as_ref(),
-                                    diagnostic_history.clone(),
-                                    true,
-                                ).await {
-                                    InvalidToolCallResolution::Fail(err) => {
-                                        yield Err(Box::new(err).into());
+                                }
+                            };
+                            let mut events: VecDeque<StreamedTurnEvent> =
+                                match assembler.ingest(&item) {
+                                    Ok(events) => events.into(),
+                                    Err(err) => {
+                                        yield Err(err.into());
                                         break 'outer;
                                     }
-                                    InvalidToolCallResolution::Retry(feedback) => {
-                                        if invalid_tool_call_retries >= self.max_invalid_tool_call_retries {
-                                            yield Err(Box::new(PromptError::UnknownToolCall {
-                                                tool_name: emitted_tool_name,
-                                                available_tools: executable_tool_names.iter().cloned().collect(),
-                                                allowed_tools: allowed_tool_names.iter().cloned().collect(),
-                                                chat_history: Box::new(diagnostic_history),
-                                            }).into());
+                                };
+                            while let Some(event) = events.pop_front() {
+                                match event {
+                                    StreamedTurnEvent::EmitIngested => {
+                                        if let StreamedAssistantContent::Text(text) = &item
+                                            && let Some(ref hook) = self.hook
+                                            && let HookAction::Terminate { reason } = hook
+                                                .on_text_delta(
+                                                    &text.text,
+                                                    assembler.aggregated_text(),
+                                                )
+                                                .await
+                                        {
+                                            yield Err(StreamingError::Prompt(Box::new(
+                                                run.cancel_error(reason),
+                                            )));
                                             break 'outer;
+                                        }
+                                        yield Ok(MultiTurnStreamItem::stream_item(item.clone()));
+                                    }
+                                    StreamedTurnEvent::EmitToolCallDelta {
+                                        id,
+                                        internal_call_id,
+                                        content,
+                                    } => {
+                                        if let Some(ref hook) = self.hook {
+                                            let (name, delta) = match &content {
+                                                ToolCallDeltaContent::Name(name) => {
+                                                    (Some(name.as_str()), "")
+                                                }
+                                                ToolCallDeltaContent::Delta(delta) => {
+                                                    (None, delta.as_str())
+                                                }
+                                            };
+
+                                            if let HookAction::Terminate { reason } = hook
+                                                .on_tool_call_delta(
+                                                    &id,
+                                                    &internal_call_id,
+                                                    name,
+                                                    delta,
+                                                )
+                                                .await
+                                            {
+                                                yield Err(StreamingError::Prompt(Box::new(
+                                                    run.cancel_error(reason),
+                                                )));
+                                                break 'outer;
+                                            }
                                         }
 
-                                        invalid_tool_call_retries += 1;
-                                        flush_pending_reasoning_delta(
-                                            &mut accumulated_reasoning,
-                                            &mut pending_reasoning_delta_text,
-                                            &mut pending_reasoning_delta_id,
-                                        );
-                                        let Some((assistant_message, user_message)) =
-                                            invalid_streaming_tool_retry_messages(
-                                                &stream.message_id,
-                                                saw_text_this_turn.then_some(text_delta_response.as_str()),
-                                                &accumulated_reasoning,
-                                                &pending_tool_calls,
-                                                tool_call,
-                                                feedback,
-                                            )
-                                        else {
-                                            yield Err(cancelled_prompt_error(
-                                                chat_history.as_deref(),
-                                                new_messages.clone(),
-                                                "invalid tool call retry produced no retry messages".to_string(),
-                                            ).await);
-                                            break 'outer;
-                                        };
-                                        new_messages.push(assistant_message);
-                                        new_messages.push(user_message);
-                                        if let Err(err) = drain_recovered_stream_usage(
-                                            &mut stream,
-                                            &tool_call_delta_states,
-                                            &mut current_call_usage,
-                                            &mut aggregated_usage,
-                                        )
-                                        .await
-                                        {
-                                            yield Err(err);
-                                            break 'outer;
-                                        }
-                                        if let Some(completion_call) = record_completion_call_if_needed(
-                                            &mut completion_calls,
-                                            &mut completion_call_emitted,
-                                            call_index,
-                                            current_call_usage,
-                                            &chat_stream_span,
-                                        ) {
-                                            yield Ok(MultiTurnStreamItem::CompletionCall(
-                                                completion_call,
-                                            ));
-                                        }
-                                        text_delta_response.clear();
-                                        saw_text_this_turn = false;
-                                        continue 'outer;
-                                    }
-                                    InvalidToolCallResolution::Repair(repaired_name) => {
-                                        tool_call.function.name = repaired_name;
-                                    }
-                                    InvalidToolCallResolution::Skip(reason) => {
-                                        let skipped_tool_result = ToolResult {
-                                            id: tool_call.id.clone(),
-                                            call_id: tool_call.call_id.clone(),
-                                            content: ToolResultContent::from_tool_output(
-                                                reason.clone(),
-                                            ),
-                                        };
-                                        flush_pending_reasoning_delta(
-                                            &mut accumulated_reasoning,
-                                            &mut pending_reasoning_delta_text,
-                                            &mut pending_reasoning_delta_id,
-                                        );
-                                        let Some((assistant_message, user_message)) =
-                                            invalid_streaming_tool_retry_messages(
-                                                &stream.message_id,
-                                                saw_text_this_turn
-                                                    .then_some(text_delta_response.as_str()),
-                                                &accumulated_reasoning,
-                                                &pending_tool_calls,
-                                                tool_call,
-                                                reason,
-                                            )
-                                        else {
-                                            yield Err(cancelled_prompt_error(
-                                                chat_history.as_deref(),
-                                                new_messages.clone(),
-                                                "invalid tool call skip produced no recovery messages".to_string(),
-                                            ).await);
-                                            break 'outer;
-                                        };
-                                        new_messages.push(assistant_message);
-                                        new_messages.push(user_message);
-                                        let tool_result = ToolResult {
-                                            id: skipped_tool_result.id,
-                                            call_id: skipped_tool_result.call_id,
-                                            content: skipped_tool_result.content,
-                                        };
-                                        if let Err(err) = drain_recovered_stream_usage(
-                                            &mut stream,
-                                            &tool_call_delta_states,
-                                            &mut current_call_usage,
-                                            &mut aggregated_usage,
-                                        )
-                                        .await
-                                        {
-                                            yield Err(err);
-                                            break 'outer;
-                                        }
-                                        if let Some(completion_call) = record_completion_call_if_needed(
-                                            &mut completion_calls,
-                                            &mut completion_call_emitted,
-                                            call_index,
-                                            current_call_usage,
-                                            &chat_stream_span,
-                                        ) {
-                                            yield Ok(MultiTurnStreamItem::CompletionCall(
-                                                completion_call,
-                                            ));
-                                        }
-                                        yield Ok(MultiTurnStreamItem::StreamUserItem(
-                                            StreamedUserContent::ToolResult {
-                                                tool_result,
+                                        yield Ok(MultiTurnStreamItem::StreamAssistantItem(
+                                            StreamedAssistantContent::ToolCallDelta {
+                                                id,
                                                 internal_call_id,
+                                                content,
                                             },
                                         ));
-                                        text_delta_response.clear();
-                                        saw_text_this_turn = false;
-                                        continue 'outer;
                                     }
-                                }
-                            }
+                                    StreamedTurnEvent::Completed { usage, emit_final } => {
+                                        if !completion_call_emitted {
+                                            if let Some(usage) = usage {
+                                                record_usage_on_span(&chat_stream_span, usage);
+                                            }
+                                            let completion_call =
+                                                match run.record_streamed_completion_call(usage) {
+                                                    Ok(call) => call,
+                                                    Err(err) => {
+                                                        yield Err(Box::new(err).into());
+                                                        break 'outer;
+                                                    }
+                                                };
+                                            completion_call_emitted = true;
+                                            yield Ok(MultiTurnStreamItem::CompletionCall(
+                                                completion_call,
+                                            ));
+                                        }
 
-                            pending_tool_calls.push((tool_call, internal_call_id));
-                        },
-                        Ok(StreamedAssistantContent::ToolCallDelta {
-                            id,
-                            internal_call_id,
-                            content,
-                        }) => {
-                            let key = (id.clone(), internal_call_id.clone());
-                            let mut deltas_to_emit = Vec::new();
+                                        if emit_final
+                                            && let StreamedAssistantContent::Final(final_resp) =
+                                                &item
+                                        {
+                                            if let Some(ref hook) = self.hook
+                                                && let HookAction::Terminate { reason } = hook
+                                                    .on_stream_completion_response_finish(
+                                                        &current_prompt,
+                                                        final_resp,
+                                                    )
+                                                    .await
+                                            {
+                                                yield Err(StreamingError::Prompt(Box::new(
+                                                    run.cancel_error(reason),
+                                                )));
+                                                break 'outer;
+                                            }
+                                            yield Ok(MultiTurnStreamItem::stream_item(
+                                                item.clone(),
+                                            ));
+                                        }
+                                    }
+                                    StreamedTurnEvent::InvalidToolCall(invalid) => {
+                                        let partial =
+                                            assembler.partial_turn(stream.message_id.clone());
+                                        let action = match self.hook.as_ref() {
+                                            Some(hook) => {
+                                                let context = run
+                                                    .streamed_invalid_tool_call_context(
+                                                        &partial, &invalid,
+                                                    );
+                                                hook.on_invalid_tool_call(&context).await
+                                            }
+                                            None => InvalidToolCallHookAction::fail(),
+                                        };
 
-                            match content {
-                                ToolCallDeltaContent::Name(mut name) => {
-                                    let buffered_args = tool_call_delta_states
-                                        .get(&key)
-                                        .map(|state| state.buffered_arguments.join(""))
-                                        .unwrap_or_default();
-                                    let diagnostic_args = if buffered_args.trim().is_empty() {
-                                        serde_json::Value::Null
-                                    } else {
-                                        serde_json::from_str(&buffered_args)
-                                            .unwrap_or(serde_json::Value::Null)
-                                    };
-                                    let diagnostic_tool_call = ToolCall::new(
-                                        id.clone(),
-                                        ToolFunction::new(name.clone(), diagnostic_args),
-                                    );
-                                    let diagnostic_history =
-                                        build_tool_call_validation_history(ToolCallValidationHistory {
-                                            chat_history: chat_history.as_deref(),
-                                            new_messages: &new_messages,
-                                            assistant_message_id: &stream.message_id,
-                                            final_turn_content: None,
-                                            text_delta_response: saw_text_this_turn
-                                                .then_some(text_delta_response.as_str()),
-                                            accumulated_reasoning: &accumulated_reasoning,
-                                            pending_reasoning_delta_text: &pending_reasoning_delta_text,
-                                            pending_reasoning_delta_id: &pending_reasoning_delta_id,
-                                            pending_tool_calls: &pending_tool_calls,
-                                            current_tool_call: Some(diagnostic_tool_call.clone()),
-                                        });
-
-                                    if !allowed_tool_names.contains(&name) {
-                                        let emitted_tool_name = name.clone();
-                                        match resolve_invalid_tool_call::<M, P>(
-                                            self.hook.as_ref(),
-                                            &emitted_tool_name,
-                                            Some(id.clone()),
-                                            Some(internal_call_id.clone()),
-                                            Some(buffered_args.clone()),
-                                            &executable_tool_names,
-                                            &allowed_tool_names,
-                                            self.tool_choice.as_ref(),
-                                            diagnostic_history.clone(),
-                                            true,
-                                        ).await {
-                                            InvalidToolCallResolution::Fail(err) => {
+                                        let resolution = match run
+                                            .resolve_streamed_invalid_tool_call(
+                                                &partial, &invalid, action,
+                                            ) {
+                                            Ok(resolution) => resolution,
+                                            Err(err) => {
                                                 yield Err(Box::new(err).into());
                                                 break 'outer;
                                             }
-                                            InvalidToolCallResolution::Skip(reason) => {
-                                                tool_call_delta_states.remove(&key);
-                                                flush_pending_reasoning_delta(
-                                                    &mut accumulated_reasoning,
-                                                    &mut pending_reasoning_delta_text,
-                                                    &mut pending_reasoning_delta_id,
-                                                );
-                                                let Some((assistant_message, user_message)) =
-                                                    invalid_streaming_name_delta_retry_messages(
-                                                        &stream.message_id,
-                                                        saw_text_this_turn
-                                                            .then_some(text_delta_response.as_str()),
-                                                        &accumulated_reasoning,
-                                                        &pending_tool_calls,
-                                                        diagnostic_tool_call.clone(),
-                                                        reason.clone(),
-                                                    )
-                                                else {
-                                                    yield Err(cancelled_prompt_error(
-                                                        chat_history.as_deref(),
-                                                        new_messages.clone(),
-                                                        "invalid tool call skip produced no recovery messages".to_string(),
-                                                    ).await);
-                                                    break 'outer;
-                                                };
-                                                new_messages.push(assistant_message);
-                                                new_messages.push(user_message);
-                                                let tool_result = ToolResult {
-                                                    id,
-                                                    call_id: None,
-                                                    content: ToolResultContent::from_tool_output(
-                                                        reason,
-                                                    ),
-                                                };
-                                                if let Err(err) = drain_recovered_stream_usage(
-                                                    &mut stream,
-                                                    &tool_call_delta_states,
-                                                    &mut current_call_usage,
-                                                    &mut aggregated_usage,
-                                                )
-                                                .await
-                                                {
-                                                    yield Err(err);
-                                                    break 'outer;
-                                                }
-                                                if let Some(completion_call) = record_completion_call_if_needed(
-                                                    &mut completion_calls,
-                                                    &mut completion_call_emitted,
-                                                    call_index,
-                                                    current_call_usage,
-                                                    &chat_stream_span,
-                                                ) {
-                                                    yield Ok(MultiTurnStreamItem::CompletionCall(
-                                                        completion_call,
-                                                    ));
-                                                }
-                                                yield Ok(MultiTurnStreamItem::StreamUserItem(
-                                                    StreamedUserContent::ToolResult {
-                                                        tool_result,
-                                                        internal_call_id,
-                                                    },
-                                                ));
-                                                text_delta_response.clear();
-                                                saw_text_this_turn = false;
-                                                continue 'outer;
-                                            }
-                                            InvalidToolCallResolution::Retry(feedback) => {
-                                                tool_call_delta_states.remove(&key);
-                                                if invalid_tool_call_retries >= self.max_invalid_tool_call_retries {
-                                                    yield Err(Box::new(PromptError::UnknownToolCall {
-                                                        tool_name: emitted_tool_name,
-                                                        available_tools: executable_tool_names.iter().cloned().collect(),
-                                                        allowed_tools: allowed_tool_names.iter().cloned().collect(),
-                                                        chat_history: Box::new(diagnostic_history),
-                                                    }).into());
-                                                    break 'outer;
-                                                }
+                                        };
 
-                                                invalid_tool_call_retries += 1;
-                                                flush_pending_reasoning_delta(
-                                                    &mut accumulated_reasoning,
-                                                    &mut pending_reasoning_delta_text,
-                                                    &mut pending_reasoning_delta_id,
+                                        match resolution {
+                                            StreamedResolution::Repaired { .. } => {
+                                                // Replayed name/argument deltas flow through
+                                                // the same event handling above.
+                                                events.extend(
+                                                    assembler.resolve_pending_invalid(&resolution),
                                                 );
-                                                let Some((assistant_message, user_message)) =
-                                                    invalid_streaming_name_delta_retry_messages(
-                                                        &stream.message_id,
-                                                        saw_text_this_turn
-                                                            .then_some(text_delta_response.as_str()),
-                                                        &accumulated_reasoning,
-                                                        &pending_tool_calls,
-                                                        diagnostic_tool_call.clone(),
-                                                        feedback,
-                                                    )
-                                                else {
-                                                    yield Err(cancelled_prompt_error(
-                                                        chat_history.as_deref(),
-                                                        new_messages.clone(),
-                                                        "invalid tool call retry produced no retry messages".to_string(),
-                                                    ).await);
-                                                    break 'outer;
-                                                };
-                                                new_messages.push(assistant_message);
-                                                new_messages.push(user_message);
-                                                if let Err(err) = drain_recovered_stream_usage(
-                                                    &mut stream,
-                                                    &tool_call_delta_states,
-                                                    &mut current_call_usage,
-                                                    &mut aggregated_usage,
-                                                )
-                                                .await
-                                                {
-                                                    yield Err(err);
+                                            }
+                                            StreamedResolution::TurnAbandoned {
+                                                ref skipped_tool_result,
+                                            } => {
+                                                let skipped_tool_result =
+                                                    skipped_tool_result.clone();
+                                                assembler.resolve_pending_invalid(&resolution);
+
+                                                if let Some(err) = assembler.pending_delta_error() {
+                                                    yield Err(err.into());
                                                     break 'outer;
                                                 }
-                                                if let Some(completion_call) = record_completion_call_if_needed(
-                                                    &mut completion_calls,
-                                                    &mut completion_call_emitted,
-                                                    call_index,
-                                                    current_call_usage,
-                                                    &chat_stream_span,
-                                                ) {
+                                                let drained_usage =
+                                                    match drain_stream_usage(&mut stream).await {
+                                                        Ok(usage) => usage,
+                                                        Err(err) => {
+                                                            yield Err(err);
+                                                            break 'outer;
+                                                        }
+                                                    };
+                                                if !completion_call_emitted {
+                                                    if let Some(usage) = drained_usage {
+                                                        record_usage_on_span(
+                                                            &chat_stream_span,
+                                                            usage,
+                                                        );
+                                                    }
+                                                    let completion_call = match run
+                                                        .record_streamed_completion_call(
+                                                            drained_usage,
+                                                        ) {
+                                                        Ok(call) => call,
+                                                        Err(err) => {
+                                                            yield Err(Box::new(err).into());
+                                                            break 'outer;
+                                                        }
+                                                    };
+                                                    completion_call_emitted = true;
                                                     yield Ok(MultiTurnStreamItem::CompletionCall(
                                                         completion_call,
                                                     ));
                                                 }
-                                                text_delta_response.clear();
-                                                saw_text_this_turn = false;
-                                                continue 'outer;
-                                            }
-                                            InvalidToolCallResolution::Repair(repaired_name) => {
-                                                name = repaired_name;
+                                                if let Some(tool_result) = skipped_tool_result {
+                                                    yield Ok(MultiTurnStreamItem::StreamUserItem(
+                                                        StreamedUserContent::ToolResult {
+                                                            tool_result,
+                                                            internal_call_id: invalid
+                                                                .internal_call_id
+                                                                .clone(),
+                                                        },
+                                                    ));
+                                                }
+                                                turn_abandoned = true;
+                                                break 'turn;
                                             }
                                         }
                                     }
-
-                                    let state =
-                                        tool_call_delta_states.entry(key.clone()).or_default();
-                                    state.name_validated = true;
-                                    let buffered_arguments =
-                                        std::mem::take(&mut state.buffered_arguments);
-
-                                    deltas_to_emit.push(ToolCallDeltaContent::Name(name));
-                                    deltas_to_emit.extend(
-                                        buffered_arguments
-                                            .into_iter()
-                                            .map(ToolCallDeltaContent::Delta),
-                                    );
                                 }
-                                ToolCallDeltaContent::Delta(arguments) => {
-                                    let state =
-                                        tool_call_delta_states.entry(key.clone()).or_default();
-                                    if state.name_validated {
-                                        deltas_to_emit.push(ToolCallDeltaContent::Delta(arguments));
-                                    } else {
-                                        state.buffered_arguments.push(arguments);
-                                    }
-                                }
-                            }
-
-                            for content in deltas_to_emit {
-                                if let Some(ref hook) = self.hook {
-                                    let (name, delta) = match &content {
-                                        ToolCallDeltaContent::Name(n) => (Some(n.as_str()), ""),
-                                        ToolCallDeltaContent::Delta(d) => (None, d.as_str()),
-                                    };
-
-                                    if let HookAction::Terminate { reason } = hook
-                                        .on_tool_call_delta(
-                                            &id,
-                                            &internal_call_id,
-                                            name,
-                                            delta,
-                                        )
-                                        .await
-                                    {
-                                        yield Err(cancelled_prompt_error(chat_history.as_deref(), new_messages.clone(), reason).await);
-                                        break 'outer;
-                                    }
-                                }
-
-                                yield Ok(MultiTurnStreamItem::StreamAssistantItem(
-                                    StreamedAssistantContent::ToolCallDelta {
-                                        id: id.clone(),
-                                        internal_call_id: internal_call_id.clone(),
-                                        content,
-                                    },
-                                ));
                             }
                         }
-                        Ok(StreamedAssistantContent::Reasoning(reasoning)) => {
-                            // Accumulate reasoning for inclusion in chat history with tool calls.
-                            // OpenAI Responses API requires reasoning items to be sent back
-                            // alongside function_call items in multi-turn conversations.
-                            merge_reasoning_blocks(&mut accumulated_reasoning, &reasoning);
-                            yield Ok(MultiTurnStreamItem::stream_item(StreamedAssistantContent::Reasoning(reasoning)));
-                        },
-                        Ok(StreamedAssistantContent::ReasoningDelta { reasoning, id }) => {
-                            // Deltas lack signatures/encrypted content that full
-                            // blocks carry; mixing them into accumulated_reasoning
-                            // causes Anthropic to reject with "signature required".
-                            pending_reasoning_delta_text.push_str(&reasoning);
-                            if pending_reasoning_delta_id.is_none() {
-                                pending_reasoning_delta_id = id.clone();
-                            }
-                            yield Ok(MultiTurnStreamItem::stream_item(StreamedAssistantContent::ReasoningDelta { reasoning, id }));
-                        },
-                        Ok(StreamedAssistantContent::Final(final_resp)) => {
-                            if let Some(err) =
-                                pending_tool_call_delta_error(&tool_call_delta_states)
-                            {
-                                yield Err(err.into());
-                                break 'outer;
-                            }
 
-                            if let Some(usage) = final_resp.token_usage() {
-                                current_call_usage = reported_usage(usage);
-                            }
-                            if let Some(usage) = current_call_usage {
-                                aggregated_usage += usage;
-                            }
-                            if let Some(completion_call) = record_completion_call_if_needed(
-                                &mut completion_calls,
-                                &mut completion_call_emitted,
-                                call_index,
-                                current_call_usage,
-                                &chat_stream_span,
-                            ) {
-                                yield Ok(MultiTurnStreamItem::CompletionCall(completion_call));
-                            }
-
-                            if saw_text_this_turn {
-                                if let Some(ref hook) = self.hook &&
-                                     let HookAction::Terminate { reason } = hook.on_stream_completion_response_finish(&current_prompt, &final_resp).await {
-                                        yield Err(cancelled_prompt_error(chat_history.as_deref(), new_messages.clone(), reason).await);
-                                        break 'outer;
-                                    }
-
-                                yield Ok(MultiTurnStreamItem::stream_item(StreamedAssistantContent::Final(final_resp)));
-                                saw_text_this_turn = false;
-                            }
+                        if turn_abandoned {
+                            continue 'outer;
                         }
-                        Err(e) => {
-                            yield Err(e.into());
+
+                        if let Some(err) = assembler.pending_delta_error() {
+                            yield Err(err.into());
                             break 'outer;
                         }
+
+                        if !completion_call_emitted {
+                            let completion_call =
+                                match run.record_streamed_completion_call(None) {
+                                    Ok(call) => call,
+                                    Err(err) => {
+                                        yield Err(Box::new(err).into());
+                                        break 'outer;
+                                    }
+                                };
+                            yield Ok(MultiTurnStreamItem::CompletionCall(completion_call));
+                        }
+
+                        let final_turn_content = stream.choice.clone();
+                        tracing::Span::current().record(
+                            "gen_ai.completion",
+                            assistant_text_from_choice(&final_turn_content),
+                        );
+
+                        internal_call_ids = assembler.internal_call_ids();
+                        last_message_id = stream.message_id.clone();
+                        let streamed_turn =
+                            assembler.finish(stream.message_id.clone(), &final_turn_content);
+                        if let Err(err) = run.streamed_turn(streamed_turn) {
+                            yield Err(Box::new(err).into());
+                            break 'outer;
+                        }
+                        last_final_choice = final_turn_content;
                     }
-                }
+                    AgentRunStep::CallTools { calls } => {
+                        let full_history_for_errors = run.full_history();
+                        let mut results: Vec<UserContent> = Vec::with_capacity(calls.len());
 
-                if let Some(err) = pending_tool_call_delta_error(&tool_call_delta_states) {
-                    yield Err(err.into());
-                    break 'outer;
-                }
+                        for pending in calls {
+                            let tool_call = pending.tool_call;
+                            if let Some(result) = pending.preresolved_result {
+                                // Pre-resolved results only occur when invalid
+                                // tool-call recovery suppressed execution; the
+                                // streamed path abandons such turns instead, so
+                                // this arm only serves machine-level drivers
+                                // mixing streamed and non-streamed turns.
+                                results.push(result);
+                                continue;
+                            }
+                            let internal_call_id = internal_call_ids
+                                .get(&tool_call.id)
+                                .cloned()
+                                .unwrap_or_else(|| nanoid::nanoid!());
 
-                if let Some(completion_call) = record_completion_call_if_needed(
-                    &mut completion_calls,
-                    &mut completion_call_emitted,
-                    call_index,
-                    current_call_usage,
-                    &chat_stream_span,
-                ) {
-                    yield Ok(MultiTurnStreamItem::CompletionCall(completion_call));
-                }
+                            let tool_span = info_span!(
+                                parent: tracing::Span::current(),
+                                "execute_tool",
+                                gen_ai.operation.name = "execute_tool",
+                                gen_ai.tool.type = "function",
+                                gen_ai.tool.name = tracing::field::Empty,
+                                gen_ai.tool.call.id = tracing::field::Empty,
+                                gen_ai.tool.call.arguments = tracing::field::Empty,
+                                gen_ai.tool.call.result = tracing::field::Empty
+                            );
 
-                // Providers like Gemini emit thinking as incremental deltas
-                // without signatures; assemble into a single block so
-                // reasoning survives into the next turn's chat history.
-                flush_pending_reasoning_delta(
-                    &mut accumulated_reasoning,
-                    &mut pending_reasoning_delta_text,
-                    &mut pending_reasoning_delta_id,
-                );
+                            yield Ok(MultiTurnStreamItem::stream_item(
+                                StreamedAssistantContent::ToolCall {
+                                    tool_call: tool_call.clone(),
+                                    internal_call_id: internal_call_id.clone(),
+                                },
+                            ));
 
-                let final_turn_content = stream.choice.clone();
-                let turn_text_response = assistant_text_from_choice(&final_turn_content);
-                tracing::Span::current().record("gen_ai.completion", &turn_text_response);
+                            let tc_result = async {
+                                let tool_span = tracing::Span::current();
+                                let tool_args =
+                                    json_utils::value_to_json_string(&tool_call.function.arguments);
+                                if let Some(ref hook) = self.hook {
+                                    let action = hook
+                                        .on_tool_call(
+                                            &tool_call.function.name,
+                                            tool_call.call_id.clone(),
+                                            &internal_call_id,
+                                            &tool_args,
+                                        )
+                                        .await;
 
-                if !pending_tool_calls.is_empty() {
-                    let diagnostic_history =
-                        build_tool_call_validation_history(ToolCallValidationHistory {
-                            chat_history: chat_history.as_deref(),
-                            new_messages: &new_messages,
-                            assistant_message_id: &stream.message_id,
-                            final_turn_content: Some(&final_turn_content),
-                            text_delta_response: None,
-                            accumulated_reasoning: &accumulated_reasoning,
-                            pending_reasoning_delta_text: "",
-                            pending_reasoning_delta_id: &None,
-                            pending_tool_calls: &pending_tool_calls,
-                            current_tool_call: None,
-                        });
+                                    if let ToolCallHookAction::Terminate { reason } = action {
+                                        return Err(StreamingError::Prompt(Box::new(
+                                            PromptError::prompt_cancelled(
+                                                full_history_for_errors.clone(),
+                                                reason,
+                                            ),
+                                        )));
+                                    }
 
-                    for (tool_call, _) in &pending_tool_calls {
-                        if let Err(err) = validate_tool_call_name(
-                            &tool_call.function.name,
-                            &executable_tool_names,
-                            &allowed_tool_names,
-                            diagnostic_history.clone(),
-                        ) {
+                                    if let ToolCallHookAction::Skip { reason } = action {
+                                        // Tool execution rejected, return rejection message as tool result
+                                        tracing::info!(
+                                            tool_name = tool_call.function.name.as_str(),
+                                            reason = reason,
+                                            "Tool call rejected"
+                                        );
+                                        return Ok(reason);
+                                    }
+                                }
+
+                                tool_span.record("gen_ai.tool.name", &tool_call.function.name);
+                                tool_span.record("gen_ai.tool.call.arguments", &tool_args);
+
+                                let tool_result = match tool_server_handle
+                                    .call_tool(&tool_call.function.name, &tool_args)
+                                    .await
+                                {
+                                    Ok(result) => result,
+                                    Err(err) => {
+                                        tracing::warn!("Error while calling tool: {err}");
+                                        err.to_string()
+                                    }
+                                };
+
+                                tool_span.record("gen_ai.tool.call.result", &tool_result);
+
+                                if let Some(ref hook) = self.hook
+                                    && let HookAction::Terminate { reason } = hook
+                                        .on_tool_result(
+                                            &tool_call.function.name,
+                                            tool_call.call_id.clone(),
+                                            &internal_call_id,
+                                            &tool_args,
+                                            &tool_result.to_string(),
+                                        )
+                                        .await
+                                {
+                                    return Err(StreamingError::Prompt(Box::new(
+                                        PromptError::prompt_cancelled(
+                                            full_history_for_errors.clone(),
+                                            reason,
+                                        ),
+                                    )));
+                                }
+
+                                Ok(tool_result)
+                            }
+                            .instrument(tool_span)
+                            .await;
+
+                            match tc_result {
+                                Ok(text) => {
+                                    results.push(tool_result_user_content(
+                                        tool_call.id.clone(),
+                                        tool_call.call_id.clone(),
+                                        text.clone(),
+                                    ));
+                                    let tool_result = ToolResult {
+                                        id: tool_call.id,
+                                        call_id: tool_call.call_id,
+                                        content: ToolResultContent::from_tool_output(text),
+                                    };
+                                    yield Ok(MultiTurnStreamItem::StreamUserItem(
+                                        StreamedUserContent::ToolResult {
+                                            tool_result,
+                                            internal_call_id,
+                                        },
+                                    ));
+                                }
+                                Err(err) => {
+                                    yield Err(err);
+                                    break 'outer;
+                                }
+                            }
+                        }
+
+                        if let Err(err) = run.tool_results(results) {
                             yield Err(Box::new(err).into());
                             break 'outer;
                         }
                     }
-
-                    for (tool_call, internal_call_id) in pending_tool_calls {
-                        let tool_span = info_span!(
-                            parent: tracing::Span::current(),
-                            "execute_tool",
-                            gen_ai.operation.name = "execute_tool",
-                            gen_ai.tool.type = "function",
-                            gen_ai.tool.name = tracing::field::Empty,
-                            gen_ai.tool.call.id = tracing::field::Empty,
-                            gen_ai.tool.call.arguments = tracing::field::Empty,
-                            gen_ai.tool.call.result = tracing::field::Empty
-                        );
-
-                        yield Ok(MultiTurnStreamItem::stream_item(StreamedAssistantContent::ToolCall { tool_call: tool_call.clone(), internal_call_id: internal_call_id.clone() }));
-
-                        let tc_result = async {
-                            let tool_span = tracing::Span::current();
-                            let tool_args = json_utils::value_to_json_string(&tool_call.function.arguments);
-                            if let Some(ref hook) = self.hook {
-                                let action = hook
-                                    .on_tool_call(&tool_call.function.name, tool_call.call_id.clone(), &internal_call_id, &tool_args)
-                                    .await;
-
-                                if let ToolCallHookAction::Terminate { reason } = action {
-                                    return Err(cancelled_prompt_error(chat_history.as_deref(), new_messages.clone(), reason).await);
-                                }
-
-                                if let ToolCallHookAction::Skip { reason } = action {
-                                    // Tool execution rejected, return rejection message as tool result
-                                    tracing::info!(
-                                        tool_name = tool_call.function.name.as_str(),
-                                        reason = reason,
-                                        "Tool call rejected"
-                                    );
-                                    let tool_call_msg = AssistantContent::ToolCall(tool_call.clone());
-                                    tool_calls.push(tool_call_msg);
-                                    tool_results.push((tool_call.id.clone(), tool_call.call_id.clone(), reason.clone()));
-                                    saw_tool_call_this_turn = true;
-                                    return Ok(reason);
-                                }
-                            }
-
-                            tool_span.record("gen_ai.tool.name", &tool_call.function.name);
-                            tool_span.record("gen_ai.tool.call.arguments", &tool_args);
-
-                            let tool_result = match
-                            tool_server_handle.call_tool(&tool_call.function.name, &tool_args).await {
-                                Ok(thing) => thing,
-                                Err(e) => {
-                                    tracing::warn!("Error while calling tool: {e}");
-                                    e.to_string()
-                                }
-                            };
-
-                            tool_span.record("gen_ai.tool.call.result", &tool_result);
-
-                            if let Some(ref hook) = self.hook &&
-                                let HookAction::Terminate { reason } =
-                                hook.on_tool_result(
-                                    &tool_call.function.name,
-                                    tool_call.call_id.clone(),
-                                    &internal_call_id,
-                                    &tool_args,
-                                    &tool_result.to_string()
-                                )
-                                .await {
-                                    return Err(cancelled_prompt_error(chat_history.as_deref(), new_messages.clone(), reason).await);
-                                }
-
-                            let tool_call_msg = AssistantContent::ToolCall(tool_call.clone());
-
-                            tool_calls.push(tool_call_msg);
-                            tool_results.push((tool_call.id.clone(), tool_call.call_id.clone(), tool_result.clone()));
-
-                            saw_tool_call_this_turn = true;
-                            Ok(tool_result)
-                        }.instrument(tool_span).await;
-
-                        match tc_result {
-                            Ok(text) => {
-                                let tr = ToolResult { id: tool_call.id, call_id: tool_call.call_id, content: ToolResultContent::from_tool_output(text) };
-                                yield Ok(MultiTurnStreamItem::StreamUserItem(StreamedUserContent::ToolResult{ tool_result: tr, internal_call_id }));
-                            }
-                            Err(e) => {
-                                yield Err(e);
-                                break 'outer;
-                            }
+                    AgentRunStep::Done(response) => {
+                        if is_empty_assistant_turn(&last_final_choice) {
+                            tracing::warn!(
+                                agent_name = agent_name.as_deref().unwrap_or(UNKNOWN_AGENT_NAME),
+                                message_id = ?last_message_id,
+                                "Streaming turn completed without assistant text; final response will be empty"
+                            );
                         }
-                    }
-                }
 
-                // Add assistant turn content to chat history in canonical replay order.
-                let mut assistant_turn_added_to_history = false;
-                if !tool_calls.is_empty() || !accumulated_reasoning.is_empty() {
-                    let text_items = assistant_text_items_from_choice(&final_turn_content);
-                    if let Some(content) = ordered_streaming_assistant_content(
-                        accumulated_reasoning.drain(..),
-                        text_items,
-                        tool_calls.clone(),
-                    ) {
-                        new_messages.push(Message::Assistant {
-                            id: stream.message_id.clone(),
-                            content,
-                        });
-                        assistant_turn_added_to_history = true;
-                    }
-                }
-
-                // Combine all tool results into a single User message (required by Anthropic)
-                let tool_result_contents: Vec<UserContent> = tool_results
-                    .into_iter()
-                    .map(|(id, call_id, tool_result)| {
-                        let content = ToolResultContent::from_tool_output(tool_result);
-                        match call_id {
-                            Some(call_id) => UserContent::tool_result_with_call_id(id, call_id, content),
-                            None => UserContent::tool_result(id, content),
+                        if created_agent_span {
+                            let current_span = tracing::Span::current();
+                            record_usage_on_span(&current_span, response.usage);
                         }
-                    })
-                    .collect();
-
-                if let Some(content) = OneOrMany::from_iter_optional(tool_result_contents) {
-                    new_messages.push(Message::User { content });
+                        tracing::info!("Agent multi-turn stream finished");
+                        if let Some((memory, id)) = memory_handle.as_ref()
+                            && let Err(err) = memory
+                                .append(id, response.messages.clone().unwrap_or_default())
+                                .await
+                        {
+                            tracing::warn!(
+                                error = %err,
+                                conversation_id = %id,
+                                "conversation memory append failed; yielding final response anyway"
+                            );
+                        }
+                        let final_messages: Option<Vec<Message>> = if has_history {
+                            Some(response.messages.clone().unwrap_or_default())
+                        } else {
+                            None
+                        };
+                        yield Ok(MultiTurnStreamItem::final_response_with_completion_calls(
+                            last_final_choice.clone(),
+                            response.usage,
+                            response.completion_calls.clone(),
+                            final_messages,
+                        ));
+                        break 'outer;
+                    }
                 }
-
-                if !saw_tool_call_this_turn {
-                    // Add user message and assistant response to history before finishing
-                    let should_add_final_assistant = !assistant_turn_added_to_history
-                        && !is_empty_assistant_choice(&final_turn_content);
-                    if should_add_final_assistant {
-                        new_messages.push(Message::Assistant {
-                            id: stream.message_id.clone(),
-                            content: final_turn_content.clone(),
-                        });
-                    } else if !assistant_turn_added_to_history {
-                        tracing::warn!(
-                            agent_name = agent_name.as_deref().unwrap_or(UNKNOWN_AGENT_NAME),
-                            message_id = ?stream.message_id,
-                            "Streaming turn completed without assistant text; final response will be empty"
-                        );
-                    }
-
-                    if created_agent_span {
-                        let current_span = tracing::Span::current();
-                        record_usage_on_span(&current_span, aggregated_usage);
-                    }
-                    tracing::info!("Agent multi-turn stream finished");
-                    if let Some((memory, id)) = memory_handle.as_ref()
-                        && let Err(err) = memory.append(id, new_messages.clone()).await
-                    {
-                        tracing::warn!(
-                            error = %err,
-                            conversation_id = %id,
-                            "conversation memory append failed; yielding final response anyway"
-                        );
-                    }
-                    let final_messages: Option<Vec<Message>> = if has_history {
-                        Some(new_messages.clone())
-                    } else {
-                        None
-                    };
-                    yield Ok(MultiTurnStreamItem::final_response_with_completion_calls(
-                        final_turn_content,
-                        aggregated_usage,
-                        completion_calls,
-                        final_messages,
-                    ));
-                    break;
-                }
-            }
-
-            if max_turns_reached {
-                yield Err(Box::new(PromptError::MaxTurnsError {
-                    max_turns: self.max_turns,
-                    chat_history: build_full_history(chat_history.as_deref(), new_messages.clone()).into(),
-                    prompt: Box::new(last_prompt_error.clone().into()),
-                }).into());
             }
         };
 
@@ -1781,9 +1096,11 @@ pub async fn stream_to_stdout<R>(
 mod tests {
     use super::*;
     use crate::agent::AgentBuilder;
+    use crate::agent::prompt_request::TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER;
     use crate::agent::prompt_request::hooks::{
         InvalidToolCallContext, InvalidToolCallHookAction, PromptHook, ToolCallHookAction,
     };
+    use crate::agent::run::streamed::merge_reasoning_blocks;
     use crate::client::ProviderClient;
     use crate::client::completion::CompletionClient;
     use crate::completion::{CompletionRequest, PromptError, ToolDefinition, Usage};

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -521,7 +521,6 @@ where
             let mut last_final_choice: OneOrMany<AssistantContent> =
                 OneOrMany::one(AssistantContent::text(""));
             let mut last_message_id: Option<String> = None;
-            let mut internal_call_ids: Vec<(String, String)> = Vec::new();
 
             'outer: loop {
                 let step = match run.next_step() {
@@ -843,7 +842,6 @@ where
                             assistant_text_from_choice(&final_turn_content),
                         );
 
-                        internal_call_ids = assembler.internal_call_ids();
                         last_message_id = stream.message_id.clone();
                         let streamed_turn =
                             assembler.finish(stream.message_id.clone(), &final_turn_content);
@@ -868,13 +866,8 @@ where
                                 results.push(result);
                                 continue;
                             }
-                            // Consume pairs positionally so calls stay
-                            // distinguishable even if a provider reuses a tool
-                            // call ID within one turn.
-                            let internal_call_id = internal_call_ids
-                                .iter()
-                                .position(|(id, _)| *id == tool_call.id)
-                                .map(|index| internal_call_ids.remove(index).1)
+                            let internal_call_id = pending
+                                .internal_call_id
                                 .unwrap_or_else(|| nanoid::nanoid!());
 
                             let tool_span = info_span!(

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -20,11 +20,7 @@ use crate::{
 };
 use futures::{Stream, StreamExt};
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::{BTreeMap, VecDeque},
-    pin::Pin,
-    sync::Arc,
-};
+use std::{collections::VecDeque, pin::Pin, sync::Arc};
 use tracing::info_span;
 use tracing_futures::Instrument;
 
@@ -525,7 +521,7 @@ where
             let mut last_final_choice: OneOrMany<AssistantContent> =
                 OneOrMany::one(AssistantContent::text(""));
             let mut last_message_id: Option<String> = None;
-            let mut internal_call_ids: BTreeMap<String, String> = BTreeMap::new();
+            let mut internal_call_ids: Vec<(String, String)> = Vec::new();
 
             'outer: loop {
                 let step = match run.next_step() {
@@ -620,10 +616,15 @@ where
                                         break 'outer;
                                     }
                                 };
+                            // At most one event per ingested item forwards the
+                            // item itself; moving it out of the slot avoids a
+                            // clone per streamed delta.
+                            let mut item_slot = Some(item);
                             while let Some(event) = events.pop_front() {
                                 match event {
                                     StreamedTurnEvent::EmitIngested => {
-                                        if let StreamedAssistantContent::Text(text) = &item
+                                        if let Some(StreamedAssistantContent::Text(text)) =
+                                            item_slot.as_ref()
                                             && let Some(ref hook) = self.hook
                                             && let HookAction::Terminate { reason } = hook
                                                 .on_text_delta(
@@ -637,7 +638,9 @@ where
                                             )));
                                             break 'outer;
                                         }
-                                        yield Ok(MultiTurnStreamItem::stream_item(item.clone()));
+                                        if let Some(item) = item_slot.take() {
+                                            yield Ok(MultiTurnStreamItem::stream_item(item));
+                                        }
                                     }
                                     StreamedTurnEvent::EmitToolCallDelta {
                                         id,
@@ -698,8 +701,9 @@ where
                                         }
 
                                         if emit_final
-                                            && let StreamedAssistantContent::Final(final_resp) =
-                                                &item
+                                            && let Some(StreamedAssistantContent::Final(
+                                                final_resp,
+                                            )) = item_slot.as_ref()
                                         {
                                             if let Some(ref hook) = self.hook
                                                 && let HookAction::Terminate { reason } = hook
@@ -714,9 +718,9 @@ where
                                                 )));
                                                 break 'outer;
                                             }
-                                            yield Ok(MultiTurnStreamItem::stream_item(
-                                                item.clone(),
-                                            ));
+                                            if let Some(item) = item_slot.take() {
+                                                yield Ok(MultiTurnStreamItem::stream_item(item));
+                                            }
                                         }
                                     }
                                     StreamedTurnEvent::InvalidToolCall(invalid) => {
@@ -864,9 +868,13 @@ where
                                 results.push(result);
                                 continue;
                             }
+                            // Consume pairs positionally so calls stay
+                            // distinguishable even if a provider reuses a tool
+                            // call ID within one turn.
                             let internal_call_id = internal_call_ids
-                                .get(&tool_call.id)
-                                .cloned()
+                                .iter()
+                                .position(|(id, _)| *id == tool_call.id)
+                                .map(|index| internal_call_ids.remove(index).1)
                                 .unwrap_or_else(|| nanoid::nanoid!());
 
                             let tool_span = info_span!(

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -24,7 +24,7 @@ use std::{collections::VecDeque, pin::Pin, sync::Arc};
 use tracing::info_span;
 use tracing_futures::Instrument;
 
-use super::{CompletionCall, ToolCallHookAction, reported_usage};
+use super::{CompletionCall, ToolCallHookAction};
 use crate::{
     agent::Agent,
     completion::{CompletionError, CompletionModel, PromptError},
@@ -128,10 +128,10 @@ impl FinalResponse {
 
     /// Returns successfully completed completion requests made by this agent stream, with usage when available.
     ///
-    /// Each entry represents one provider completion request. When present,
-    /// usage is a whole-request provider snapshot, not incremental usage per
-    /// streamed token. Streaming providers may omit usage for some calls; those
-    /// calls have an entry with `None` usage.
+    /// Each entry represents one provider completion request. Usage is a
+    /// whole-request provider snapshot, not incremental usage per streamed
+    /// token. Streaming providers may omit usage for some calls; those calls
+    /// have an entry with zero-valued usage.
     pub fn completion_calls(&self) -> &[CompletionCall] {
         &self.completion_calls
     }
@@ -177,25 +177,21 @@ impl<R> MultiTurnStreamItem<R> {
 /// reported usage for the recovered completion call is not lost.
 async fn drain_stream_usage<R>(
     stream: &mut crate::streaming::StreamingCompletionResponse<R>,
-) -> Result<Option<crate::completion::Usage>, StreamingError>
+) -> Result<crate::completion::Usage, StreamingError>
 where
     R: Clone + Unpin + GetTokenUsage,
 {
-    let mut usage = None;
     while let Some(content) = stream.next().await {
         match content {
             Ok(StreamedAssistantContent::Final(final_resp)) => {
-                if let Some(reported) = final_resp.token_usage() {
-                    usage = reported_usage(reported);
-                }
-                return Ok(usage);
+                return Ok(final_resp.token_usage());
             }
             Ok(_) => {}
             Err(err) => return Err(err.into()),
         }
     }
 
-    Ok(usage)
+    Ok(crate::completion::Usage::new())
 }
 
 fn record_usage_on_span(span: &tracing::Span, usage: crate::completion::Usage) {
@@ -682,7 +678,7 @@ where
                                     }
                                     StreamedTurnEvent::Completed { usage, emit_final } => {
                                         if !completion_call_emitted {
-                                            if let Some(usage) = usage {
+                                            if usage != crate::completion::Usage::new() {
                                                 record_usage_on_span(&chat_stream_span, usage);
                                             }
                                             let completion_call =
@@ -775,10 +771,12 @@ where
                                                         }
                                                     };
                                                 if !completion_call_emitted {
-                                                    if let Some(usage) = drained_usage {
+                                                    if drained_usage
+                                                        != crate::completion::Usage::new()
+                                                    {
                                                         record_usage_on_span(
                                                             &chat_stream_span,
-                                                            usage,
+                                                            drained_usage,
                                                         );
                                                     }
                                                     let completion_call = match run
@@ -826,7 +824,9 @@ where
 
                         if !completion_call_emitted {
                             let completion_call =
-                                match run.record_streamed_completion_call(None) {
+                                match run
+                                    .record_streamed_completion_call(crate::completion::Usage::new())
+                                {
                                     Ok(call) => call,
                                     Err(err) => {
                                         yield Err(Box::new(err).into());
@@ -1744,7 +1744,7 @@ mod tests {
     #[test]
     fn completion_calls_stream_item_serializes_and_deserializes_expected_shape() {
         let item: MultiTurnStreamItem<MockResponse> =
-            MultiTurnStreamItem::CompletionCall(CompletionCall::new(2, Some(usage(3, 4))));
+            MultiTurnStreamItem::CompletionCall(CompletionCall::new(2, usage(3, 4)));
 
         let value = serde_json::to_value(&item).expect("serialize completion call event");
 
@@ -1769,23 +1769,48 @@ mod tests {
             serde_json::from_value(value).expect("deserialize completion call event");
         match item {
             MultiTurnStreamItem::CompletionCall(call_usage) => {
-                assert_eq!(call_usage, CompletionCall::new(2, Some(usage(3, 4))));
+                assert_eq!(call_usage, CompletionCall::new(2, usage(3, 4)));
             }
             other => panic!("expected completion call event, got {other:?}"),
         }
 
         let item: MultiTurnStreamItem<MockResponse> =
-            MultiTurnStreamItem::CompletionCall(CompletionCall::new(3, None));
+            MultiTurnStreamItem::CompletionCall(CompletionCall::new(3, Usage::new()));
         let value = serde_json::to_value(&item).expect("serialize missing usage event");
 
+        // Unreported usage serializes as a plain zero-valued object (Usage's
+        // documented sentinel for missing provider metrics).
         assert_eq!(
             value,
             serde_json::json!({
                 "type": "completionCall",
                 "call_index": 3,
-                "usage": null
+                "usage": {
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "total_tokens": 0,
+                    "cached_input_tokens": 0,
+                    "cache_creation_input_tokens": 0,
+                    "tool_use_prompt_tokens": 0,
+                    "reasoning_tokens": 0,
+                }
             })
         );
+
+        // Stream items serialized before the Option encoding was dropped used
+        // `"usage": null`; they must still deserialize.
+        let legacy: MultiTurnStreamItem<MockResponse> = serde_json::from_value(serde_json::json!({
+            "type": "completionCall",
+            "call_index": 3,
+            "usage": null
+        }))
+        .expect("legacy null-usage event should deserialize");
+        match legacy {
+            MultiTurnStreamItem::CompletionCall(call) => {
+                assert_eq!(call, CompletionCall::new(3, Usage::new()));
+            }
+            other => panic!("expected completion call event, got {other:?}"),
+        }
     }
 
     #[test]
@@ -1795,8 +1820,8 @@ mod tests {
                 OneOrMany::one(AssistantContent::text("done")),
                 usage(3, 4),
                 vec![
-                    CompletionCall::new(0, None),
-                    CompletionCall::new(1, Some(usage(3, 4))),
+                    CompletionCall::new(0, Usage::new()),
+                    CompletionCall::new(1, usage(3, 4)),
                 ],
                 None,
             );
@@ -1808,7 +1833,15 @@ mod tests {
             Some(&serde_json::json!([
                 {
                     "call_index": 0,
-                    "usage": null,
+                    "usage": {
+                        "input_tokens": 0,
+                        "output_tokens": 0,
+                        "total_tokens": 0,
+                        "cached_input_tokens": 0,
+                        "cache_creation_input_tokens": 0,
+                        "tool_use_prompt_tokens": 0,
+                        "reasoning_tokens": 0,
+                    }
                 },
                 {
                     "call_index": 1,
@@ -2592,8 +2625,8 @@ mod tests {
         let mut second_usage = Usage::new();
         second_usage.total_tokens = 6;
         let expected_completion_calls = vec![
-            CompletionCall::new(0, Some(first_usage)),
-            CompletionCall::new(1, Some(second_usage)),
+            CompletionCall::new(0, first_usage),
+            CompletionCall::new(1, second_usage),
         ];
         assert_eq!(completion_call_events, expected_completion_calls);
         assert_eq!(final_completion_calls, expected_completion_calls);
@@ -2992,8 +3025,8 @@ mod tests {
         let mut second_usage = Usage::new();
         second_usage.total_tokens = 6;
         let expected_completion_calls = vec![
-            CompletionCall::new(0, Some(first_usage)),
-            CompletionCall::new(1, Some(second_usage)),
+            CompletionCall::new(0, first_usage),
+            CompletionCall::new(1, second_usage),
         ];
         assert_eq!(completion_call_events, expected_completion_calls);
         assert_eq!(final_completion_calls, expected_completion_calls);
@@ -4526,8 +4559,8 @@ mod tests {
         assert_eq!(
             completion_calls_events,
             vec![
-                CompletionCall::new(0, Some(first_call_usage)),
-                CompletionCall::new(1, Some(second_call_usage))
+                CompletionCall::new(0, first_call_usage),
+                CompletionCall::new(1, second_call_usage)
             ]
         );
 
@@ -4547,8 +4580,8 @@ mod tests {
         assert_eq!(
             final_response.completion_calls(),
             &[
-                CompletionCall::new(0, Some(first_call_usage)),
-                CompletionCall::new(1, Some(second_call_usage))
+                CompletionCall::new(0, first_call_usage),
+                CompletionCall::new(1, second_call_usage)
             ]
         );
     }
@@ -4627,10 +4660,7 @@ mod tests {
             }
         }
 
-        assert_eq!(
-            completion_calls,
-            vec![CompletionCall::new(0, Some(call_usage))]
-        );
+        assert_eq!(completion_calls, vec![CompletionCall::new(0, call_usage)]);
         assert!(saw_error);
     }
 
@@ -4677,8 +4707,8 @@ mod tests {
         }
 
         let expected_usage = vec![
-            CompletionCall::new(0, None),
-            CompletionCall::new(1, Some(second_call_usage)),
+            CompletionCall::new(0, Usage::new()),
+            CompletionCall::new(1, second_call_usage),
         ];
         assert_eq!(completion_calls_events, expected_usage);
 

--- a/crates/rig-core/src/agent/run/mod.rs
+++ b/crates/rig-core/src/agent/run/mod.rs
@@ -218,8 +218,10 @@ enum RunState {
     /// The turn was accepted; ready to emit [`AgentRunStep::CallTools`] or
     /// [`AgentRunStep::Done`].
     AwaitingAdvance(Box<TurnState>),
-    /// Waiting for [`AgentRun::tool_results`].
-    ExecutingTools,
+    /// Waiting for [`AgentRun::tool_results`] for these pending tool calls.
+    /// Carrying the calls in the state keeps a serialized run self-contained:
+    /// a resumed process re-obtains them from [`AgentRun::next_step`].
+    ExecutingTools(Vec<PendingToolCall>),
     /// Terminal: the run completed successfully.
     Done(Box<PromptResponse>),
     /// Terminal: the run returned an error.
@@ -435,7 +437,7 @@ impl AgentRun {
                 }
 
                 if has_tool_calls {
-                    let calls = items
+                    let calls: Vec<PendingToolCall> = items
                         .iter()
                         .filter_map(|item| match item {
                             AssistantContent::ToolCall(tool_call) => Some(PendingToolCall {
@@ -445,7 +447,7 @@ impl AgentRun {
                             _ => None,
                         })
                         .collect();
-                    self.state = RunState::ExecutingTools;
+                    self.state = RunState::ExecutingTools(calls.clone());
                     Ok(AgentRunStep::CallTools { calls })
                 } else {
                     let response =
@@ -456,23 +458,27 @@ impl AgentRun {
                     Ok(AgentRunStep::Done(response))
                 }
             }
+            RunState::ExecutingTools(calls) => {
+                // Idempotent, like Done: a process resuming a serialized run
+                // re-obtains the pending tool calls from the state itself.
+                let step = AgentRunStep::CallTools {
+                    calls: calls.clone(),
+                };
+                self.state = RunState::ExecutingTools(calls);
+                Ok(step)
+            }
             RunState::Done(response) => {
                 let step = AgentRunStep::Done((*response).clone());
                 self.state = RunState::Done(response);
                 Ok(step)
             }
-            state @ (RunState::AwaitingModel
-            | RunState::ResolvingToolCalls(_)
-            | RunState::ExecutingTools) => {
+            state @ (RunState::AwaitingModel | RunState::ResolvingToolCalls(_)) => {
                 let reason = match &state {
                     RunState::AwaitingModel => {
                         "next_step called while a model response is pending; feed it via model_response first"
                     }
-                    RunState::ResolvingToolCalls(_) => {
-                        "next_step called while an invalid tool-call resolution is pending; answer it via resolve_invalid_tool_call first"
-                    }
                     _ => {
-                        "next_step called while tool results are pending; feed them via tool_results first"
+                        "next_step called while an invalid tool-call resolution is pending; answer it via resolve_invalid_tool_call first"
                     }
                 };
                 self.state = state;
@@ -659,12 +665,48 @@ impl AgentRun {
     /// Feed the tool results for the pending [`AgentRunStep::CallTools`].
     ///
     /// Results may be in any order; they are appended as a single user
-    /// message, matching what providers expect for parallel tool calls.
+    /// message, matching what providers expect for parallel tool calls. Each
+    /// result must be a tool result answering one of the pending calls, and
+    /// every pending call must be answered — exactly what providers require
+    /// to accept the next request.
     pub fn tool_results(&mut self, results: Vec<UserContent>) -> Result<(), PromptError> {
-        if !matches!(self.state, RunState::ExecutingTools) {
+        let RunState::ExecutingTools(pending) = &self.state else {
             return Err(
                 self.protocol_violation("tool_results called without a pending CallTools step")
             );
+        };
+        // Match results against pending calls by tool call ID as a multiset,
+        // so duplicate provider IDs within one turn stay answerable.
+        let mut unanswered: Vec<String> = pending
+            .iter()
+            .map(|call| call.tool_call.id.clone())
+            .collect();
+
+        if results.is_empty() {
+            self.state = RunState::Failed;
+            return Err(PromptError::prompt_cancelled(
+                self.full_history(),
+                "tool execution produced no tool results",
+            ));
+        }
+        for result in &results {
+            let UserContent::ToolResult(tool_result) = result else {
+                return Err(self.protocol_violation(
+                    "tool_results received content that is not a tool result",
+                ));
+            };
+            let Some(index) = unanswered.iter().position(|id| *id == tool_result.id) else {
+                return Err(self.protocol_violation(&format!(
+                    "tool_results received a result for unknown or already-answered tool call id `{}`",
+                    tool_result.id
+                )));
+            };
+            unanswered.swap_remove(index);
+        }
+        if !unanswered.is_empty() {
+            return Err(self.protocol_violation(&format!(
+                "tool_results left pending tool call id(s) unanswered: {unanswered:?}"
+            )));
         }
 
         let Some(content) = OneOrMany::from_iter_optional(results) else {
@@ -1451,6 +1493,84 @@ mod tests {
         );
         assert_eq!(expect_done(&mut run).output, "hi");
         assert_eq!(expect_done(&mut run).output, "hi");
+    }
+
+    #[test]
+    fn serialized_run_alone_carries_pending_tool_calls() {
+        let mut run = AgentRun::new("add things").max_turns(2);
+        expect_call_model(&mut run);
+        expect_continue(
+            run.model_response(tool_call_turn("call_1", "add"))
+                .expect("model_response should succeed"),
+        );
+        expect_call_tools(&mut run);
+
+        // A fresh process receives only the serialized run: the pending tool
+        // calls must be recoverable from the state itself.
+        let serialized = serde_json::to_string(&run).expect("mid-run state should serialize");
+        drop(run);
+        let mut resumed: AgentRun =
+            serde_json::from_str(&serialized).expect("mid-run state should deserialize");
+
+        let calls = expect_call_tools(&mut resumed);
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].tool_call.function.name, "add");
+        // Re-emission is idempotent while results are pending.
+        let calls_again = expect_call_tools(&mut resumed);
+        assert_eq!(calls_again[0].tool_call.id, calls[0].tool_call.id);
+
+        // Answer using only IDs learned from the re-emitted step.
+        let results = calls
+            .iter()
+            .map(|call| tool_result(&call.tool_call.id, "2"))
+            .collect::<Vec<_>>();
+        resumed
+            .tool_results(results)
+            .expect("tool_results should succeed");
+        expect_call_model(&mut resumed);
+        expect_continue(
+            resumed
+                .model_response(text_turn("done"))
+                .expect("model_response should succeed"),
+        );
+        assert_eq!(expect_done(&mut resumed).output, "done");
+    }
+
+    #[test]
+    fn tool_results_validates_against_pending_calls() {
+        let drive_to_pending_tools = || {
+            let mut run = AgentRun::new("add things").max_turns(2);
+            expect_call_model(&mut run);
+            expect_continue(
+                run.model_response(tool_call_turn("call_1", "add"))
+                    .expect("model_response should succeed"),
+            );
+            expect_call_tools(&mut run);
+            run
+        };
+
+        // A result for an unknown call ID is rejected without corrupting the run.
+        let mut run = drive_to_pending_tools();
+        let err = run
+            .tool_results(vec![tool_result("call_unknown", "2")])
+            .expect_err("unknown tool call id must be rejected");
+        assert!(matches!(err, PromptError::PromptCancelled { .. }));
+        run.tool_results(vec![tool_result("call_1", "2")])
+            .expect("valid results should still be accepted after a rejection");
+
+        // Leaving a pending call unanswered is rejected.
+        let mut run = drive_to_pending_tools();
+        let err = run
+            .tool_results(vec![tool_result("call_1", "2"), tool_result("call_1", "3")])
+            .expect_err("answering one call twice must be rejected");
+        assert!(matches!(err, PromptError::PromptCancelled { .. }));
+
+        // Non-tool-result content is rejected.
+        let mut run = drive_to_pending_tools();
+        let err = run
+            .tool_results(vec![UserContent::text("not a tool result")])
+            .expect_err("non-tool-result content must be rejected");
+        assert!(matches!(err, PromptError::PromptCancelled { .. }));
     }
 
     #[test]

--- a/crates/rig-core/src/agent/run/mod.rs
+++ b/crates/rig-core/src/agent/run/mod.rs
@@ -1,0 +1,1509 @@
+//! A sans-IO, steppable, serializable state machine for the agent prompt loop.
+//!
+//! [`AgentRun`] owns every *decision* the agent loop makes — turn counting,
+//! tool-call validation, invalid tool-call recovery, chat-history threading,
+//! usage aggregation and final response construction — without performing any
+//! IO itself. A driver advances the machine by calling [`AgentRun::next_step`]
+//! and acting on the returned [`AgentRunStep`]:
+//!
+//! - [`AgentRunStep::CallModel`]: send a completion request to the model and
+//!   feed the result back via [`AgentRun::model_response`].
+//! - [`AgentRunStep::CallTools`]: execute the listed tool calls (with whatever
+//!   concurrency the driver chooses) and feed the results back via
+//!   [`AgentRun::tool_results`].
+//! - [`AgentRunStep::Done`]: the run is complete.
+//!
+//! Because the machine never awaits anything, it is runtime-agnostic and the
+//! whole run state is `Serialize + Deserialize`: a driver can serialize a run
+//! between steps (for example while tool calls are pending), persist it, and
+//! resume it later in another process.
+//!
+//! [`crate::completion::Prompt::prompt`] on [`crate::agent::Agent`] drives
+//! this machine internally; the same machine can be driven by hand for custom
+//! control flow:
+//!
+//! ```rust,no_run
+//! use rig_core::agent::run::{AgentRun, AgentRunStep, ModelTurn, ModelTurnOutcome};
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let mut run = AgentRun::new("What is 2+2?").max_turns(3);
+//! loop {
+//!     match run.next_step()? {
+//!         AgentRunStep::CallModel { prompt, history, .. } => {
+//!             // Send `prompt` + `history` to a model, then:
+//!             // run.model_response(ModelTurn { ... })?;
+//!             # let _ = (prompt, history);
+//!             # break;
+//!         }
+//!         AgentRunStep::CallTools { calls } => {
+//!             // Execute `calls`, then: run.tool_results(results)?;
+//!             # let _ = calls;
+//!         }
+//!         AgentRunStep::Done(response) => {
+//!             println!("{}", response.output);
+//!             break;
+//!         }
+//!     }
+//! }
+//! # Ok(())
+//! # }
+//! ```
+
+pub mod streamed;
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    OneOrMany,
+    agent::prompt_request::{
+        CompletionCall, PromptResponse, TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER,
+        assistant_text_from_choice, build_full_history, build_history_for_request,
+        hooks::{InvalidToolCallContext, InvalidToolCallHookAction},
+        invalid_tool_retry_user_message, is_empty_assistant_turn, tool_result_user_content,
+    },
+    completion::{Message, PromptError, Usage},
+    json_utils,
+    message::{AssistantContent, ToolCall, ToolChoice, ToolResult, ToolResultContent, UserContent},
+};
+
+pub use streamed::{
+    PartialStreamedTurn, StreamedInvalidToolCall, StreamedResolution, StreamedTurn,
+    StreamedTurnAssembler, StreamedTurnEvent,
+};
+
+/// What a driver must do next to advance an [`AgentRun`].
+///
+/// Deliberately exhaustive: a driver must handle every step, so adding a
+/// variant is a breaking change by design.
+#[derive(Debug, Clone)]
+pub enum AgentRunStep {
+    /// Send a completion request to the model and feed the result back via
+    /// [`AgentRun::model_response`].
+    CallModel {
+        /// The prompt message for this turn (the latest message in the run).
+        prompt: Message,
+        /// The chat history preceding `prompt`: the caller-provided input
+        /// history followed by messages accumulated by earlier turns.
+        history: Vec<Message>,
+        /// One-based index of this model call within the run.
+        turn: usize,
+    },
+    /// Execute these tool calls and feed the results back via
+    /// [`AgentRun::tool_results`].
+    CallTools {
+        /// The tool calls of the current assistant turn, in emission order.
+        calls: Vec<PendingToolCall>,
+    },
+    /// The run is complete.
+    Done(PromptResponse),
+}
+
+/// One tool call awaiting execution by the driver.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct PendingToolCall {
+    /// The tool call emitted by the model (with any repaired tool name applied).
+    pub tool_call: ToolCall,
+    /// Pre-resolved result for tool calls suppressed by invalid tool-call
+    /// recovery. When set, the driver must return this content as the tool
+    /// result without executing the tool or invoking tool hooks.
+    pub preresolved_result: Option<UserContent>,
+}
+
+/// A completed model turn fed back to [`AgentRun::model_response`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ModelTurn {
+    /// Provider-assigned assistant message ID, when available.
+    pub message_id: Option<String>,
+    /// The assistant content returned by the model.
+    pub choice: OneOrMany<AssistantContent>,
+    /// Token usage reported by the provider for this completion request.
+    pub usage: Usage,
+    /// Executable Rig tools advertised to the provider for this turn.
+    pub executable_tool_names: BTreeSet<String>,
+    /// Tools allowed by the active [`ToolChoice`] for this turn.
+    pub allowed_tool_names: BTreeSet<String>,
+}
+
+impl ModelTurn {
+    /// Create a model turn from response parts and the tool names advertised
+    /// for the turn.
+    pub fn new(
+        message_id: Option<String>,
+        choice: OneOrMany<AssistantContent>,
+        usage: Usage,
+        executable_tool_names: BTreeSet<String>,
+        allowed_tool_names: BTreeSet<String>,
+    ) -> Self {
+        Self {
+            message_id,
+            choice,
+            usage,
+            executable_tool_names,
+            allowed_tool_names,
+        }
+    }
+}
+
+/// Result of feeding a model turn (or an invalid tool-call resolution) into
+/// the machine.
+///
+/// Deliberately exhaustive: a driver must handle every outcome, so adding a
+/// variant is a breaking change by design.
+#[derive(Debug)]
+pub enum ModelTurnOutcome {
+    /// The turn was accepted. Unless `response_hook_suppressed` is set, the
+    /// driver should run its completion-response hook now, then call
+    /// [`AgentRun::next_step`].
+    ///
+    /// `response_hook_suppressed` is set when invalid tool-call recovery
+    /// (repair or skip) modified the turn, matching the agent loop's behavior
+    /// of not invoking `on_completion_response` for recovered turns.
+    Continue {
+        /// Whether the driver should suppress its completion-response hook.
+        response_hook_suppressed: bool,
+    },
+    /// The model emitted a tool call that is unknown or disallowed for this
+    /// turn. The driver must decide how to recover (typically by asking its
+    /// invalid tool-call hook) and answer via
+    /// [`AgentRun::resolve_invalid_tool_call`].
+    NeedsResolution(InvalidToolCallContext),
+    /// The turn was rolled back with corrective feedback appended to the
+    /// history. Call [`AgentRun::next_step`] to obtain the retry
+    /// [`AgentRunStep::CallModel`].
+    TurnRetried,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ResolvingState {
+    message_id: Option<String>,
+    /// The unmodified model output, used for diagnostic histories and retry
+    /// messages (repairs are never reflected in those).
+    original_choice: OneOrMany<AssistantContent>,
+    /// Working copy of the assistant content; repairs rename tool calls here.
+    items: Vec<AssistantContent>,
+    /// Index of the next item to validate.
+    next_index: usize,
+    executable_tool_names: BTreeSet<String>,
+    allowed_tool_names: BTreeSet<String>,
+    /// Synthetic tool results for skipped tool calls, keyed by tool call ID.
+    skipped: BTreeMap<String, UserContent>,
+    recovered: bool,
+    any_skipped: bool,
+    has_tool_calls: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct TurnState {
+    message_id: Option<String>,
+    items: Vec<AssistantContent>,
+    has_tool_calls: bool,
+    skipped: BTreeMap<String, UserContent>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+enum RunState {
+    /// Ready to emit [`AgentRunStep::CallModel`].
+    PreparingRequest,
+    /// Waiting for [`AgentRun::model_response`].
+    AwaitingModel,
+    /// Scanning the model turn's tool calls for validity; may be waiting for
+    /// [`AgentRun::resolve_invalid_tool_call`].
+    ResolvingToolCalls(Box<ResolvingState>),
+    /// The turn was accepted; ready to emit [`AgentRunStep::CallTools`] or
+    /// [`AgentRunStep::Done`].
+    AwaitingAdvance(Box<TurnState>),
+    /// Waiting for [`AgentRun::tool_results`].
+    ExecutingTools,
+    /// Terminal: the run completed successfully.
+    Done(Box<PromptResponse>),
+    /// Terminal: the run returned an error.
+    Failed,
+}
+
+/// The sans-IO agent loop state machine. See the [module docs](self) for the
+/// driving protocol.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentRun {
+    max_turns: usize,
+    max_invalid_tool_call_retries: usize,
+    tool_choice: Option<ToolChoice>,
+    chat_history: Option<Vec<Message>>,
+    new_messages: Vec<Message>,
+    current_turn: usize,
+    usage: Usage,
+    completion_calls: Vec<CompletionCall>,
+    completion_call_index: usize,
+    invalid_tool_call_retries: usize,
+    state: RunState,
+}
+
+impl AgentRun {
+    /// Create a run for one prompt with no input history, no multi-turn depth
+    /// and no invalid tool-call retries.
+    pub fn new(prompt: impl Into<Message>) -> Self {
+        Self {
+            max_turns: 0,
+            max_invalid_tool_call_retries: 0,
+            tool_choice: None,
+            chat_history: None,
+            new_messages: vec![prompt.into()],
+            current_turn: 0,
+            usage: Usage::new(),
+            completion_calls: Vec::new(),
+            completion_call_index: 0,
+            invalid_tool_call_retries: 0,
+            state: RunState::PreparingRequest,
+        }
+    }
+
+    /// Set the input chat history preceding the prompt.
+    pub fn with_history(mut self, history: Vec<Message>) -> Self {
+        self.chat_history = Some(history);
+        self
+    }
+
+    /// Set the maximum multi-turn depth. Exceeding it makes
+    /// [`AgentRun::next_step`] return [`PromptError::MaxTurnsError`].
+    pub fn max_turns(mut self, max_turns: usize) -> Self {
+        self.max_turns = max_turns;
+        self
+    }
+
+    /// Set the retry budget for [`InvalidToolCallHookAction::Retry`]
+    /// resolutions. Invalid tool-call retries also consume multi-turn depth.
+    pub fn max_invalid_tool_call_retries(mut self, retries: usize) -> Self {
+        self.max_invalid_tool_call_retries = retries;
+        self
+    }
+
+    /// Set the tool choice active for this run. Used to reject
+    /// [`InvalidToolCallHookAction::Skip`] resolutions under
+    /// [`ToolChoice::None`] and reported in invalid tool-call contexts.
+    pub fn with_tool_choice(mut self, tool_choice: ToolChoice) -> Self {
+        self.tool_choice = Some(tool_choice);
+        self
+    }
+
+    /// Aggregated token usage across all completed model calls so far.
+    pub fn usage(&self) -> Usage {
+        self.usage
+    }
+
+    /// Number of model calls emitted so far (including retries).
+    pub fn turn(&self) -> usize {
+        self.current_turn
+    }
+
+    /// Details for each completed model call so far.
+    pub fn completion_calls(&self) -> &[CompletionCall] {
+        &self.completion_calls
+    }
+
+    /// Messages accumulated by this run (the prompt plus all assistant turns
+    /// and tool results), excluding the input history.
+    pub fn messages(&self) -> &[Message] {
+        &self.new_messages
+    }
+
+    /// The full conversation: input history followed by [`Self::messages`].
+    pub fn full_history(&self) -> Vec<Message> {
+        build_full_history(self.chat_history.as_deref(), self.new_messages.clone())
+    }
+
+    /// Whether the run reached [`AgentRunStep::Done`].
+    pub fn is_done(&self) -> bool {
+        matches!(self.state, RunState::Done(_))
+    }
+
+    /// Build the cancellation error a driver should return when one of its
+    /// hooks terminates the run, carrying the current full history.
+    pub fn cancel_error(&self, reason: impl Into<String>) -> PromptError {
+        PromptError::prompt_cancelled(self.full_history(), reason)
+    }
+
+    /// The invalid tool call currently awaiting
+    /// [`AgentRun::resolve_invalid_tool_call`], if any. Useful to re-derive
+    /// the resolution context after deserializing a suspended run.
+    pub fn pending_invalid_tool_call(&self) -> Option<InvalidToolCallContext> {
+        let RunState::ResolvingToolCalls(resolving) = &self.state else {
+            return None;
+        };
+        let AssistantContent::ToolCall(tool_call) = resolving.items.get(resolving.next_index)?
+        else {
+            return None;
+        };
+        if resolving
+            .allowed_tool_names
+            .contains(&tool_call.function.name)
+        {
+            return None;
+        }
+
+        Some(InvalidToolCallContext {
+            tool_name: tool_call.function.name.clone(),
+            tool_call_id: Some(tool_call.id.clone()),
+            internal_call_id: None,
+            args: Some(json_utils::value_to_json_string(
+                &tool_call.function.arguments,
+            )),
+            available_tools: resolving.executable_tool_names.iter().cloned().collect(),
+            allowed_tools: resolving.allowed_tool_names.iter().cloned().collect(),
+            tool_choice: self.tool_choice.clone(),
+            chat_history: self.diagnostic_history(resolving),
+            is_streaming: false,
+        })
+    }
+
+    /// Advance the machine and return the next action for the driver.
+    ///
+    /// # Errors
+    /// - [`PromptError::MaxTurnsError`] when the multi-turn depth is exhausted.
+    /// - [`PromptError::PromptCancelled`] when the machine is driven out of
+    ///   protocol (for example, calling this while a model response is
+    ///   pending).
+    pub fn next_step(&mut self) -> Result<AgentRunStep, PromptError> {
+        match std::mem::replace(&mut self.state, RunState::Failed) {
+            RunState::PreparingRequest => {
+                let Some((prompt_ref, history_for_turn)) = self.new_messages.split_last() else {
+                    return Err(PromptError::prompt_cancelled(
+                        self.full_history(),
+                        "prompt loop lost its pending prompt",
+                    ));
+                };
+                let prompt = prompt_ref.clone();
+
+                if self.current_turn > self.max_turns + 1 {
+                    return Err(PromptError::MaxTurnsError {
+                        max_turns: self.max_turns,
+                        chat_history: self.full_history().into(),
+                        prompt: prompt.into(),
+                    });
+                }
+
+                let history =
+                    build_history_for_request(self.chat_history.as_deref(), history_for_turn);
+                self.current_turn += 1;
+                self.state = RunState::AwaitingModel;
+                Ok(AgentRunStep::CallModel {
+                    prompt,
+                    history,
+                    turn: self.current_turn,
+                })
+            }
+            RunState::AwaitingAdvance(turn_state) => {
+                let TurnState {
+                    message_id,
+                    items,
+                    has_tool_calls,
+                    skipped,
+                } = *turn_state;
+                let Some(choice) = OneOrMany::from_iter_optional(items.clone()) else {
+                    return Err(PromptError::prompt_cancelled(
+                        self.full_history(),
+                        "model turn lost its assistant content",
+                    ));
+                };
+
+                if !is_empty_assistant_turn(&choice) {
+                    self.new_messages.push(Message::Assistant {
+                        id: message_id,
+                        content: choice.clone(),
+                    });
+                }
+
+                if has_tool_calls {
+                    let calls = items
+                        .iter()
+                        .filter_map(|item| match item {
+                            AssistantContent::ToolCall(tool_call) => Some(PendingToolCall {
+                                tool_call: tool_call.clone(),
+                                preresolved_result: skipped.get(&tool_call.id).cloned(),
+                            }),
+                            _ => None,
+                        })
+                        .collect();
+                    self.state = RunState::ExecutingTools;
+                    Ok(AgentRunStep::CallTools { calls })
+                } else {
+                    let response =
+                        PromptResponse::new(assistant_text_from_choice(&choice), self.usage)
+                            .with_messages(self.new_messages.clone())
+                            .with_completion_calls(self.completion_calls.clone());
+                    self.state = RunState::Done(Box::new(response.clone()));
+                    Ok(AgentRunStep::Done(response))
+                }
+            }
+            RunState::Done(response) => {
+                let step = AgentRunStep::Done((*response).clone());
+                self.state = RunState::Done(response);
+                Ok(step)
+            }
+            state @ (RunState::AwaitingModel
+            | RunState::ResolvingToolCalls(_)
+            | RunState::ExecutingTools) => {
+                let reason = match &state {
+                    RunState::AwaitingModel => {
+                        "next_step called while a model response is pending; feed it via model_response first"
+                    }
+                    RunState::ResolvingToolCalls(_) => {
+                        "next_step called while an invalid tool-call resolution is pending; answer it via resolve_invalid_tool_call first"
+                    }
+                    _ => {
+                        "next_step called while tool results are pending; feed them via tool_results first"
+                    }
+                };
+                self.state = state;
+                Err(self.protocol_violation(reason))
+            }
+            RunState::Failed => Err(self.protocol_violation(
+                "next_step called after the run already failed or was misdriven",
+            )),
+        }
+    }
+
+    /// Feed the model's response for the pending [`AgentRunStep::CallModel`].
+    ///
+    /// Records the completion call and aggregates usage, then validates the
+    /// turn's tool calls against the advertised tool names. See
+    /// [`ModelTurnOutcome`] for what the driver must do next.
+    pub fn model_response(&mut self, turn: ModelTurn) -> Result<ModelTurnOutcome, PromptError> {
+        if !matches!(self.state, RunState::AwaitingModel) {
+            return Err(
+                self.protocol_violation("model_response called without a pending CallModel step")
+            );
+        }
+
+        self.completion_calls
+            .push(CompletionCall::from_reported_usage(
+                self.completion_call_index,
+                turn.usage,
+            ));
+        self.completion_call_index += 1;
+        self.usage += turn.usage;
+
+        let items: Vec<AssistantContent> = turn.choice.iter().cloned().collect();
+        let has_tool_calls = items
+            .iter()
+            .any(|item| matches!(item, AssistantContent::ToolCall(_)));
+
+        self.state = RunState::ResolvingToolCalls(Box::new(ResolvingState {
+            message_id: turn.message_id,
+            original_choice: turn.choice,
+            items,
+            next_index: 0,
+            executable_tool_names: turn.executable_tool_names,
+            allowed_tool_names: turn.allowed_tool_names,
+            skipped: BTreeMap::new(),
+            recovered: false,
+            any_skipped: false,
+            has_tool_calls,
+        }));
+
+        self.advance_resolution()
+    }
+
+    /// Answer a pending [`ModelTurnOutcome::NeedsResolution`].
+    ///
+    /// Applies the agent loop's recovery semantics:
+    /// - [`InvalidToolCallHookAction::Fail`] fails the run with
+    ///   [`PromptError::UnknownToolCall`].
+    /// - [`InvalidToolCallHookAction::Retry`] rolls the turn back with
+    ///   corrective feedback while budget remains, consuming multi-turn depth.
+    /// - [`InvalidToolCallHookAction::Repair`] renames the tool call; the
+    ///   repaired name is revalidated against the allowed tools.
+    /// - [`InvalidToolCallHookAction::Skip`] records a synthetic tool result
+    ///   and suppresses execution of every tool call in the turn. Rejected
+    ///   under [`ToolChoice::None`].
+    pub fn resolve_invalid_tool_call(
+        &mut self,
+        action: InvalidToolCallHookAction,
+    ) -> Result<ModelTurnOutcome, PromptError> {
+        // Take the resolving state; rejection paths below restore it so an
+        // out-of-protocol call does not corrupt a drivable run.
+        let mut resolving = match std::mem::replace(&mut self.state, RunState::Failed) {
+            RunState::ResolvingToolCalls(resolving) => resolving,
+            other => {
+                self.state = other;
+                return Err(self.protocol_violation(
+                    "resolve_invalid_tool_call called without a pending invalid tool call",
+                ));
+            }
+        };
+        let tool_call = match resolving.items.get(resolving.next_index) {
+            Some(AssistantContent::ToolCall(tool_call))
+                if !resolving
+                    .allowed_tool_names
+                    .contains(&tool_call.function.name) =>
+            {
+                tool_call.clone()
+            }
+            _ => {
+                self.state = RunState::ResolvingToolCalls(resolving);
+                return Err(self.protocol_violation(
+                    "resolve_invalid_tool_call called without a pending invalid tool call",
+                ));
+            }
+        };
+
+        let diagnostic_history = self.diagnostic_history(&resolving);
+        let executable_tool_names: Vec<String> =
+            resolving.executable_tool_names.iter().cloned().collect();
+        let allowed_tool_names: Vec<String> =
+            resolving.allowed_tool_names.iter().cloned().collect();
+
+        match action {
+            InvalidToolCallHookAction::Fail => Err(PromptError::UnknownToolCall {
+                tool_name: tool_call.function.name,
+                available_tools: executable_tool_names,
+                allowed_tools: allowed_tool_names,
+                chat_history: Box::new(diagnostic_history),
+            }),
+            InvalidToolCallHookAction::Retry { feedback } => {
+                if self.invalid_tool_call_retries >= self.max_invalid_tool_call_retries {
+                    return Err(PromptError::UnknownToolCall {
+                        tool_name: tool_call.function.name,
+                        available_tools: executable_tool_names,
+                        allowed_tools: allowed_tool_names,
+                        chat_history: Box::new(diagnostic_history),
+                    });
+                }
+                self.invalid_tool_call_retries += 1;
+
+                self.new_messages.push(Message::Assistant {
+                    id: resolving.message_id.clone(),
+                    content: resolving.original_choice.clone(),
+                });
+                let Some(user_message) = invalid_tool_retry_user_message(
+                    &resolving.original_choice,
+                    &tool_call.id,
+                    feedback,
+                ) else {
+                    return Err(PromptError::prompt_cancelled(
+                        diagnostic_history,
+                        "invalid tool call retry produced no retry messages",
+                    ));
+                };
+                self.new_messages.push(user_message);
+                self.state = RunState::PreparingRequest;
+                Ok(ModelTurnOutcome::TurnRetried)
+            }
+            InvalidToolCallHookAction::Repair { tool_name } => {
+                if !allowed_tool_names.contains(&tool_name) {
+                    return Err(PromptError::UnknownToolCall {
+                        tool_name,
+                        available_tools: executable_tool_names,
+                        allowed_tools: allowed_tool_names,
+                        chat_history: Box::new(diagnostic_history),
+                    });
+                }
+                if let Some(AssistantContent::ToolCall(tool_call)) =
+                    resolving.items.get_mut(resolving.next_index)
+                {
+                    tool_call.function.name = tool_name;
+                }
+                resolving.recovered = true;
+                self.state = RunState::ResolvingToolCalls(resolving);
+                self.advance_resolution()
+            }
+            InvalidToolCallHookAction::Skip { reason } => {
+                if matches!(self.tool_choice, Some(ToolChoice::None)) {
+                    return Err(PromptError::UnknownToolCall {
+                        tool_name: tool_call.function.name,
+                        available_tools: executable_tool_names,
+                        allowed_tools: allowed_tool_names,
+                        chat_history: Box::new(diagnostic_history),
+                    });
+                }
+                let user_content = if let Some(call_id) = tool_call.call_id.clone() {
+                    UserContent::tool_result_with_call_id(
+                        tool_call.id.clone(),
+                        call_id,
+                        OneOrMany::one(reason.into()),
+                    )
+                } else {
+                    UserContent::tool_result(tool_call.id.clone(), OneOrMany::one(reason.into()))
+                };
+                resolving.skipped.insert(tool_call.id.clone(), user_content);
+                resolving.recovered = true;
+                resolving.any_skipped = true;
+                resolving.next_index += 1;
+                self.state = RunState::ResolvingToolCalls(resolving);
+                self.advance_resolution()
+            }
+        }
+    }
+
+    /// Feed the tool results for the pending [`AgentRunStep::CallTools`].
+    ///
+    /// Results may be in any order; they are appended as a single user
+    /// message, matching what providers expect for parallel tool calls.
+    pub fn tool_results(&mut self, results: Vec<UserContent>) -> Result<(), PromptError> {
+        if !matches!(self.state, RunState::ExecutingTools) {
+            return Err(
+                self.protocol_violation("tool_results called without a pending CallTools step")
+            );
+        }
+
+        let Some(content) = OneOrMany::from_iter_optional(results) else {
+            self.state = RunState::Failed;
+            return Err(PromptError::prompt_cancelled(
+                self.full_history(),
+                "tool execution produced no tool results",
+            ));
+        };
+
+        self.new_messages.push(Message::User { content });
+        self.state = RunState::PreparingRequest;
+        Ok(())
+    }
+
+    /// Scan forward for the next invalid tool call; finish the turn when the
+    /// scan completes.
+    fn advance_resolution(&mut self) -> Result<ModelTurnOutcome, PromptError> {
+        let mut resolving = match std::mem::replace(&mut self.state, RunState::Failed) {
+            RunState::ResolvingToolCalls(resolving) => resolving,
+            other => {
+                self.state = other;
+                return Err(self.protocol_violation(
+                    "internal: advance_resolution outside of tool-call resolution",
+                ));
+            }
+        };
+        while let Some(item) = resolving.items.get(resolving.next_index) {
+            match item {
+                AssistantContent::ToolCall(tool_call)
+                    if !resolving
+                        .allowed_tool_names
+                        .contains(&tool_call.function.name) =>
+                {
+                    break;
+                }
+                _ => resolving.next_index += 1,
+            }
+        }
+
+        if resolving.next_index < resolving.items.len() {
+            self.state = RunState::ResolvingToolCalls(resolving);
+            return match self.pending_invalid_tool_call() {
+                Some(context) => Ok(ModelTurnOutcome::NeedsResolution(context)),
+                None => Err(self.protocol_violation(
+                    "internal: pending invalid tool call could not be derived",
+                )),
+            };
+        }
+
+        let ResolvingState {
+            message_id,
+            items,
+            mut skipped,
+            recovered,
+            any_skipped,
+            has_tool_calls,
+            ..
+        } = *resolving;
+
+        // When any tool call was skipped, none of the turn's tool calls
+        // execute: peers get a synthetic "not executed" result.
+        if any_skipped {
+            for item in &items {
+                if let AssistantContent::ToolCall(tool_call) = item {
+                    skipped.entry(tool_call.id.clone()).or_insert_with(|| {
+                        tool_result_user_content(
+                            tool_call.id.clone(),
+                            tool_call.call_id.clone(),
+                            TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER.to_string(),
+                        )
+                    });
+                }
+            }
+        }
+
+        self.state = RunState::AwaitingAdvance(Box::new(TurnState {
+            message_id,
+            items,
+            has_tool_calls,
+            skipped,
+        }));
+        Ok(ModelTurnOutcome::Continue {
+            response_hook_suppressed: recovered,
+        })
+    }
+
+    // ── Streamed-turn entry points ──────────────────────────────────────
+    // Paired with [`streamed::StreamedTurnAssembler`]; see that module's
+    // docs for the full driving protocol.
+
+    /// Record one provider completion call for a streamed turn.
+    ///
+    /// Streamed turns learn usage from the provider's final stream event —
+    /// including for turns abandoned by invalid tool-call recovery, where the
+    /// stream is drained for usage after the rollback — so recording is
+    /// decoupled from turn ingestion. Valid while a model response is pending
+    /// or right after a turn rollback; aggregates `usage` into the run total.
+    pub fn record_streamed_completion_call(
+        &mut self,
+        usage: Option<Usage>,
+    ) -> Result<CompletionCall, PromptError> {
+        if !matches!(
+            self.state,
+            RunState::AwaitingModel | RunState::PreparingRequest
+        ) {
+            return Err(self.protocol_violation(
+                "record_streamed_completion_call called without a pending or rolled-back CallModel step",
+            ));
+        }
+
+        let call = CompletionCall::new(self.completion_call_index, usage);
+        self.completion_call_index += 1;
+        self.completion_calls.push(call);
+        if let Some(usage) = usage {
+            self.usage += usage;
+        }
+        Ok(call)
+    }
+
+    /// The recovery-hook context for an invalid tool call surfaced
+    /// mid-stream by a [`streamed::StreamedTurnAssembler`].
+    pub fn streamed_invalid_tool_call_context(
+        &self,
+        partial: &PartialStreamedTurn,
+        invalid: &StreamedInvalidToolCall,
+    ) -> InvalidToolCallContext {
+        InvalidToolCallContext {
+            tool_name: invalid.tool_call.function.name.clone(),
+            tool_call_id: Some(invalid.tool_call.id.clone()),
+            internal_call_id: Some(invalid.internal_call_id.clone()),
+            args: invalid.args.clone(),
+            available_tools: invalid.executable_tool_names.iter().cloned().collect(),
+            allowed_tools: invalid.allowed_tool_names.iter().cloned().collect(),
+            tool_choice: self.tool_choice.clone(),
+            chat_history: self
+                .streamed_diagnostic_history(partial, Some(invalid.tool_call.clone())),
+            is_streaming: true,
+        }
+    }
+
+    /// Resolve an invalid tool call surfaced mid-stream.
+    ///
+    /// Applies the same recovery semantics as
+    /// [`AgentRun::resolve_invalid_tool_call`], but rollback messages are
+    /// assembled from the partial streamed turn — exactly what the model has
+    /// produced so far — and a successful retry or skip abandons the turn
+    /// (see [`StreamedResolution`]) instead of finishing it.
+    pub fn resolve_streamed_invalid_tool_call(
+        &mut self,
+        partial: &PartialStreamedTurn,
+        invalid: &StreamedInvalidToolCall,
+        action: InvalidToolCallHookAction,
+    ) -> Result<StreamedResolution, PromptError> {
+        if !matches!(self.state, RunState::AwaitingModel) {
+            return Err(self.protocol_violation(
+                "resolve_streamed_invalid_tool_call called without a pending CallModel step",
+            ));
+        }
+
+        let diagnostic_history =
+            self.streamed_diagnostic_history(partial, Some(invalid.tool_call.clone()));
+        let executable_tool_names: Vec<String> =
+            invalid.executable_tool_names.iter().cloned().collect();
+        let allowed_tool_names: Vec<String> = invalid.allowed_tool_names.iter().cloned().collect();
+
+        match action {
+            InvalidToolCallHookAction::Fail => {
+                self.state = RunState::Failed;
+                Err(PromptError::UnknownToolCall {
+                    tool_name: invalid.tool_call.function.name.clone(),
+                    available_tools: executable_tool_names,
+                    allowed_tools: allowed_tool_names,
+                    chat_history: Box::new(diagnostic_history),
+                })
+            }
+            InvalidToolCallHookAction::Retry { feedback } => {
+                if self.invalid_tool_call_retries >= self.max_invalid_tool_call_retries {
+                    self.state = RunState::Failed;
+                    return Err(PromptError::UnknownToolCall {
+                        tool_name: invalid.tool_call.function.name.clone(),
+                        available_tools: executable_tool_names,
+                        allowed_tools: allowed_tool_names,
+                        chat_history: Box::new(diagnostic_history),
+                    });
+                }
+                self.invalid_tool_call_retries += 1;
+
+                let Some((assistant_message, user_message)) =
+                    partial.rollback_messages(invalid.tool_call.clone(), feedback)
+                else {
+                    self.state = RunState::Failed;
+                    return Err(PromptError::prompt_cancelled(
+                        diagnostic_history,
+                        "invalid tool call retry produced no retry messages",
+                    ));
+                };
+                self.new_messages.push(assistant_message);
+                self.new_messages.push(user_message);
+                self.state = RunState::PreparingRequest;
+                Ok(StreamedResolution::TurnAbandoned {
+                    skipped_tool_result: None,
+                })
+            }
+            InvalidToolCallHookAction::Repair { tool_name } => {
+                if !invalid.allowed_tool_names.contains(&tool_name) {
+                    self.state = RunState::Failed;
+                    return Err(PromptError::UnknownToolCall {
+                        tool_name,
+                        available_tools: executable_tool_names,
+                        allowed_tools: allowed_tool_names,
+                        chat_history: Box::new(diagnostic_history),
+                    });
+                }
+                Ok(StreamedResolution::Repaired { tool_name })
+            }
+            InvalidToolCallHookAction::Skip { reason } => {
+                if matches!(self.tool_choice, Some(ToolChoice::None)) {
+                    self.state = RunState::Failed;
+                    return Err(PromptError::UnknownToolCall {
+                        tool_name: invalid.tool_call.function.name.clone(),
+                        available_tools: executable_tool_names,
+                        allowed_tools: allowed_tool_names,
+                        chat_history: Box::new(diagnostic_history),
+                    });
+                }
+
+                let skipped_tool_result = ToolResult {
+                    id: invalid.tool_call.id.clone(),
+                    call_id: invalid.tool_call.call_id.clone(),
+                    content: ToolResultContent::from_tool_output(reason.clone()),
+                };
+                let Some((assistant_message, user_message)) =
+                    partial.rollback_messages(invalid.tool_call.clone(), reason)
+                else {
+                    self.state = RunState::Failed;
+                    return Err(PromptError::prompt_cancelled(
+                        diagnostic_history,
+                        "invalid tool call skip produced no recovery messages",
+                    ));
+                };
+                self.new_messages.push(assistant_message);
+                self.new_messages.push(user_message);
+                self.state = RunState::PreparingRequest;
+                Ok(StreamedResolution::TurnAbandoned {
+                    skipped_tool_result: Some(skipped_tool_result),
+                })
+            }
+        }
+    }
+
+    /// Feed the assembled streamed turn for the pending
+    /// [`AgentRunStep::CallModel`].
+    ///
+    /// Remaining tool calls are validated fail-fast — mid-stream resolution
+    /// already had recovery-hook access — and the turn then advances through
+    /// [`AgentRun::next_step`] exactly like a non-streamed one.
+    pub fn streamed_turn(&mut self, turn: StreamedTurn) -> Result<(), PromptError> {
+        if !matches!(self.state, RunState::AwaitingModel) {
+            return Err(
+                self.protocol_violation("streamed_turn called without a pending CallModel step")
+            );
+        }
+
+        let items: Vec<AssistantContent> = turn.choice.iter().cloned().collect();
+        let has_tool_calls = items
+            .iter()
+            .any(|item| matches!(item, AssistantContent::ToolCall(_)));
+
+        for item in &items {
+            let AssistantContent::ToolCall(tool_call) = item else {
+                continue;
+            };
+            if !turn.allowed_tool_names.contains(&tool_call.function.name) {
+                let mut diagnostic_messages = self.new_messages.clone();
+                if !is_empty_assistant_turn(&turn.choice) {
+                    diagnostic_messages.push(Message::Assistant {
+                        id: turn.message_id.clone(),
+                        content: turn.choice.clone(),
+                    });
+                }
+                let diagnostic_history =
+                    build_full_history(self.chat_history.as_deref(), diagnostic_messages);
+                self.state = RunState::Failed;
+                return Err(PromptError::UnknownToolCall {
+                    tool_name: tool_call.function.name.clone(),
+                    available_tools: turn.executable_tool_names.iter().cloned().collect(),
+                    allowed_tools: turn.allowed_tool_names.iter().cloned().collect(),
+                    chat_history: Box::new(diagnostic_history),
+                });
+            }
+        }
+
+        self.state = RunState::AwaitingAdvance(Box::new(TurnState {
+            message_id: turn.message_id,
+            items,
+            has_tool_calls,
+            skipped: BTreeMap::new(),
+        }));
+        Ok(())
+    }
+
+    /// Diagnostic history for a streamed turn: the run's messages plus the
+    /// partial assistant turn under inspection.
+    fn streamed_diagnostic_history(
+        &self,
+        partial: &PartialStreamedTurn,
+        current_tool_call: Option<ToolCall>,
+    ) -> Vec<Message> {
+        let mut messages = self.new_messages.clone();
+        if let Some(assistant) = partial.assistant_message(current_tool_call) {
+            messages.push(assistant);
+        }
+        build_full_history(self.chat_history.as_deref(), messages)
+    }
+
+    /// History used for invalid tool-call diagnostics: the run's messages plus
+    /// the unmodified assistant turn under inspection.
+    fn diagnostic_history(&self, resolving: &ResolvingState) -> Vec<Message> {
+        let mut diagnostic_messages = self.new_messages.clone();
+        diagnostic_messages.push(Message::Assistant {
+            id: resolving.message_id.clone(),
+            content: resolving.original_choice.clone(),
+        });
+        build_full_history(self.chat_history.as_deref(), diagnostic_messages)
+    }
+
+    fn protocol_violation(&self, reason: &str) -> PromptError {
+        PromptError::prompt_cancelled(
+            self.full_history(),
+            format!("agent run driver protocol violation: {reason}"),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message::{ToolFunction, ToolResultContent};
+    use serde_json::json;
+
+    fn tool_names(names: &[&str]) -> BTreeSet<String> {
+        names.iter().map(|name| (*name).to_string()).collect()
+    }
+
+    fn usage(input_tokens: u64, output_tokens: u64) -> Usage {
+        Usage {
+            input_tokens,
+            output_tokens,
+            total_tokens: input_tokens + output_tokens,
+            ..Usage::new()
+        }
+    }
+
+    fn text_turn(text: &str) -> ModelTurn {
+        ModelTurn::new(
+            None,
+            OneOrMany::one(AssistantContent::text(text)),
+            Usage::new(),
+            tool_names(&["add"]),
+            tool_names(&["add"]),
+        )
+    }
+
+    fn tool_call(id: &str, name: &str) -> AssistantContent {
+        AssistantContent::ToolCall(ToolCall::new(
+            id.to_string(),
+            ToolFunction::new(name.to_string(), json!({"x": 1})),
+        ))
+    }
+
+    fn tool_call_turn(id: &str, name: &str) -> ModelTurn {
+        ModelTurn::new(
+            None,
+            OneOrMany::one(tool_call(id, name)),
+            Usage::new(),
+            tool_names(&["add"]),
+            tool_names(&["add"]),
+        )
+    }
+
+    fn tool_result(id: &str, output: &str) -> UserContent {
+        UserContent::tool_result(
+            id.to_string(),
+            ToolResultContent::from_tool_output(output.to_string()),
+        )
+    }
+
+    fn expect_call_model(run: &mut AgentRun) -> (Message, Vec<Message>, usize) {
+        match run.next_step().expect("next_step should succeed") {
+            AgentRunStep::CallModel {
+                prompt,
+                history,
+                turn,
+            } => (prompt, history, turn),
+            step => panic!("expected CallModel, got {step:?}"),
+        }
+    }
+
+    fn expect_call_tools(run: &mut AgentRun) -> Vec<PendingToolCall> {
+        match run.next_step().expect("next_step should succeed") {
+            AgentRunStep::CallTools { calls } => calls,
+            step => panic!("expected CallTools, got {step:?}"),
+        }
+    }
+
+    fn expect_done(run: &mut AgentRun) -> PromptResponse {
+        match run.next_step().expect("next_step should succeed") {
+            AgentRunStep::Done(response) => response,
+            step => panic!("expected Done, got {step:?}"),
+        }
+    }
+
+    fn expect_continue(outcome: ModelTurnOutcome) -> bool {
+        match outcome {
+            ModelTurnOutcome::Continue {
+                response_hook_suppressed,
+            } => response_hook_suppressed,
+            outcome => panic!("expected Continue, got {outcome:?}"),
+        }
+    }
+
+    fn expect_needs_resolution(outcome: ModelTurnOutcome) -> InvalidToolCallContext {
+        match outcome {
+            ModelTurnOutcome::NeedsResolution(context) => context,
+            outcome => panic!("expected NeedsResolution, got {outcome:?}"),
+        }
+    }
+
+    #[test]
+    fn text_only_run_completes_in_one_turn() {
+        let mut run = AgentRun::new("hello");
+
+        let (prompt, history, turn) = expect_call_model(&mut run);
+        assert_eq!(prompt, Message::user("hello"));
+        assert!(history.is_empty());
+        assert_eq!(turn, 1);
+
+        let suppressed = expect_continue(
+            run.model_response(text_turn("hi there"))
+                .expect("model_response should succeed"),
+        );
+        assert!(!suppressed);
+
+        let response = expect_done(&mut run);
+        assert_eq!(response.output, "hi there");
+        let messages = response.messages.expect("messages should be recorded");
+        assert_eq!(messages.len(), 2);
+        assert!(run.is_done());
+    }
+
+    #[test]
+    fn input_history_prefixes_request_history() {
+        let mut run = AgentRun::new("question")
+            .with_history(vec![Message::user("earlier"), Message::assistant("reply")]);
+
+        let (_, history, _) = expect_call_model(&mut run);
+        assert_eq!(
+            history,
+            vec![Message::user("earlier"), Message::assistant("reply")]
+        );
+
+        expect_continue(
+            run.model_response(text_turn("answer"))
+                .expect("model_response should succeed"),
+        );
+        let response = expect_done(&mut run);
+        // Returned messages exclude the input history.
+        assert_eq!(
+            response
+                .messages
+                .expect("messages should be recorded")
+                .len(),
+            2
+        );
+    }
+
+    #[test]
+    fn tool_roundtrip_threads_history_and_usage() {
+        let mut run = AgentRun::new("add things").max_turns(2);
+
+        expect_call_model(&mut run);
+        expect_continue(
+            run.model_response(tool_call_turn("call_1", "add").with_usage_for_test(usage(10, 5)))
+                .expect("model_response should succeed"),
+        );
+
+        let calls = expect_call_tools(&mut run);
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].tool_call.function.name, "add");
+        assert!(calls[0].preresolved_result.is_none());
+
+        run.tool_results(vec![tool_result("call_1", "2")])
+            .expect("tool_results should succeed");
+
+        let (prompt, history, turn) = expect_call_model(&mut run);
+        assert_eq!(turn, 2);
+        // The tool-result user message becomes the new prompt; the assistant
+        // turn is part of the history.
+        assert!(matches!(prompt, Message::User { .. }));
+        assert_eq!(history.len(), 2);
+
+        expect_continue(
+            run.model_response(text_turn("the answer is 2").with_usage_for_test(usage(20, 7)))
+                .expect("model_response should succeed"),
+        );
+
+        let response = expect_done(&mut run);
+        assert_eq!(response.output, "the answer is 2");
+        assert_eq!(response.usage, usage(30, 12));
+        assert_eq!(response.completion_calls.len(), 2);
+        assert_eq!(response.completion_calls[0].call_index, 0);
+        assert_eq!(response.completion_calls[0].usage, Some(usage(10, 5)));
+        assert_eq!(response.completion_calls[1].usage, Some(usage(20, 7)));
+        // prompt, assistant tool call, tool result, final assistant text
+        assert_eq!(
+            response
+                .messages
+                .expect("messages should be recorded")
+                .len(),
+            4
+        );
+    }
+
+    #[test]
+    fn parallel_tool_calls_surface_in_emission_order() {
+        let mut run = AgentRun::new("do both").max_turns(2);
+
+        expect_call_model(&mut run);
+        let turn = ModelTurn::new(
+            None,
+            OneOrMany::many(vec![tool_call("call_1", "add"), tool_call("call_2", "add")])
+                .expect("two items"),
+            Usage::new(),
+            tool_names(&["add"]),
+            tool_names(&["add"]),
+        );
+        expect_continue(
+            run.model_response(turn)
+                .expect("model_response should succeed"),
+        );
+
+        let calls = expect_call_tools(&mut run);
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].tool_call.id, "call_1");
+        assert_eq!(calls[1].tool_call.id, "call_2");
+
+        // Results fed out of order still land in one user message.
+        run.tool_results(vec![tool_result("call_2", "b"), tool_result("call_1", "a")])
+            .expect("tool_results should succeed");
+        let messages = run.messages();
+        assert!(matches!(
+            messages.last(),
+            Some(Message::User { content }) if content.len() == 2
+        ));
+    }
+
+    #[test]
+    fn max_turns_exhaustion_returns_max_turns_error() {
+        let mut run = AgentRun::new("loop forever");
+
+        for turn_id in ["call_1", "call_2"] {
+            expect_call_model(&mut run);
+            expect_continue(
+                run.model_response(tool_call_turn(turn_id, "add"))
+                    .expect("model_response should succeed"),
+            );
+            expect_call_tools(&mut run);
+            run.tool_results(vec![tool_result(turn_id, "0")])
+                .expect("tool_results should succeed");
+        }
+
+        let err = run.next_step().expect_err("depth should be exhausted");
+        assert!(matches!(
+            err,
+            PromptError::MaxTurnsError { max_turns: 0, .. }
+        ));
+    }
+
+    #[test]
+    fn invalid_tool_call_fail_returns_unknown_tool_call() {
+        let mut run = AgentRun::new("call something");
+
+        expect_call_model(&mut run);
+        let context = expect_needs_resolution(
+            run.model_response(tool_call_turn("call_1", "unknown"))
+                .expect("model_response should succeed"),
+        );
+        assert_eq!(context.tool_name, "unknown");
+        assert_eq!(context.available_tools, vec!["add".to_string()]);
+        assert!(!context.is_streaming);
+        // Diagnostic history includes the rejected assistant turn.
+        assert_eq!(context.chat_history.len(), 2);
+
+        let err = run
+            .resolve_invalid_tool_call(InvalidToolCallHookAction::fail())
+            .expect_err("fail action should error");
+        assert!(matches!(
+            err,
+            PromptError::UnknownToolCall { tool_name, .. } if tool_name == "unknown"
+        ));
+    }
+
+    #[test]
+    fn invalid_tool_call_retry_rolls_back_with_feedback() {
+        let mut run = AgentRun::new("call something")
+            .max_turns(2)
+            .max_invalid_tool_call_retries(1);
+
+        expect_call_model(&mut run);
+        expect_needs_resolution(
+            run.model_response(tool_call_turn("call_1", "unknown"))
+                .expect("model_response should succeed"),
+        );
+        let outcome = run
+            .resolve_invalid_tool_call(InvalidToolCallHookAction::retry("use add instead"))
+            .expect("retry should be accepted");
+        assert!(matches!(outcome, ModelTurnOutcome::TurnRetried));
+
+        // The rolled-back turn appended the assistant message and feedback.
+        assert_eq!(run.messages().len(), 3);
+        let (prompt, _, turn) = expect_call_model(&mut run);
+        assert_eq!(turn, 2);
+        assert!(matches!(
+            prompt,
+            Message::User { ref content }
+                if matches!(content.first(), UserContent::ToolResult(_))
+        ));
+
+        // Budget of one: a second retry fails with UnknownToolCall.
+        expect_needs_resolution(
+            run.model_response(tool_call_turn("call_2", "unknown"))
+                .expect("model_response should succeed"),
+        );
+        let err = run
+            .resolve_invalid_tool_call(InvalidToolCallHookAction::retry("again"))
+            .expect_err("budget exhausted");
+        assert!(matches!(err, PromptError::UnknownToolCall { .. }));
+    }
+
+    #[test]
+    fn invalid_tool_call_repair_renames_and_suppresses_response_hook() {
+        let mut run = AgentRun::new("call something").max_turns(2);
+
+        expect_call_model(&mut run);
+        expect_needs_resolution(
+            run.model_response(tool_call_turn("call_1", "default_api"))
+                .expect("model_response should succeed"),
+        );
+        let suppressed = expect_continue(
+            run.resolve_invalid_tool_call(InvalidToolCallHookAction::repair("add"))
+                .expect("repair should be accepted"),
+        );
+        assert!(suppressed);
+
+        let calls = expect_call_tools(&mut run);
+        assert_eq!(calls[0].tool_call.function.name, "add");
+        assert!(calls[0].preresolved_result.is_none());
+    }
+
+    #[test]
+    fn invalid_tool_call_repair_to_disallowed_name_fails() {
+        let mut run = AgentRun::new("call something");
+
+        expect_call_model(&mut run);
+        expect_needs_resolution(
+            run.model_response(tool_call_turn("call_1", "unknown"))
+                .expect("model_response should succeed"),
+        );
+        let err = run
+            .resolve_invalid_tool_call(InvalidToolCallHookAction::repair("also_unknown"))
+            .expect_err("repair to disallowed name should fail");
+        assert!(matches!(
+            err,
+            PromptError::UnknownToolCall { tool_name, .. } if tool_name == "also_unknown"
+        ));
+    }
+
+    #[test]
+    fn invalid_tool_call_skip_suppresses_all_peer_executions() {
+        let mut run = AgentRun::new("call things").max_turns(2);
+
+        expect_call_model(&mut run);
+        let turn = ModelTurn::new(
+            None,
+            OneOrMany::many(vec![
+                tool_call("call_1", "unknown"),
+                tool_call("call_2", "add"),
+            ])
+            .expect("two items"),
+            Usage::new(),
+            tool_names(&["add"]),
+            tool_names(&["add"]),
+        );
+        expect_needs_resolution(
+            run.model_response(turn)
+                .expect("model_response should succeed"),
+        );
+        let suppressed = expect_continue(
+            run.resolve_invalid_tool_call(InvalidToolCallHookAction::skip("not available"))
+                .expect("skip should be accepted"),
+        );
+        assert!(suppressed);
+
+        let calls = expect_call_tools(&mut run);
+        assert_eq!(calls.len(), 2);
+        // Both the skipped call and its valid peer carry preresolved results.
+        assert!(calls.iter().all(|call| call.preresolved_result.is_some()));
+    }
+
+    #[test]
+    fn skip_under_tool_choice_none_fails() {
+        let mut run = AgentRun::new("call something").with_tool_choice(ToolChoice::None);
+
+        expect_call_model(&mut run);
+        expect_needs_resolution(
+            run.model_response(ModelTurn::new(
+                None,
+                OneOrMany::one(tool_call("call_1", "add")),
+                Usage::new(),
+                tool_names(&["add"]),
+                BTreeSet::new(),
+            ))
+            .expect("model_response should succeed"),
+        );
+        let err = run
+            .resolve_invalid_tool_call(InvalidToolCallHookAction::skip("nope"))
+            .expect_err("skip under ToolChoice::None should fail");
+        assert!(matches!(err, PromptError::UnknownToolCall { .. }));
+    }
+
+    #[test]
+    fn empty_tool_results_cancel_the_run() {
+        let mut run = AgentRun::new("call something").max_turns(2);
+
+        expect_call_model(&mut run);
+        expect_continue(
+            run.model_response(tool_call_turn("call_1", "add"))
+                .expect("model_response should succeed"),
+        );
+        expect_call_tools(&mut run);
+
+        let err = run
+            .tool_results(Vec::new())
+            .expect_err("empty results should cancel");
+        assert!(matches!(
+            err,
+            PromptError::PromptCancelled { reason, .. }
+                if reason.contains("tool execution produced no tool results")
+        ));
+    }
+
+    #[test]
+    fn out_of_protocol_calls_are_rejected_without_corrupting_state() {
+        let mut run = AgentRun::new("hello");
+
+        let err = run
+            .tool_results(vec![tool_result("call_1", "x")])
+            .expect_err("no CallTools pending");
+        assert!(matches!(err, PromptError::PromptCancelled { .. }));
+
+        // The run is still drivable after a rejected out-of-protocol call.
+        expect_call_model(&mut run);
+        let err = run
+            .next_step()
+            .expect_err("model response is pending, next_step must be rejected");
+        assert!(matches!(err, PromptError::PromptCancelled { .. }));
+        expect_continue(
+            run.model_response(text_turn("hi"))
+                .expect("model_response should still succeed"),
+        );
+        assert_eq!(expect_done(&mut run).output, "hi");
+    }
+
+    #[test]
+    fn done_step_is_idempotent() {
+        let mut run = AgentRun::new("hello");
+        expect_call_model(&mut run);
+        expect_continue(
+            run.model_response(text_turn("hi"))
+                .expect("model_response should succeed"),
+        );
+        assert_eq!(expect_done(&mut run).output, "hi");
+        assert_eq!(expect_done(&mut run).output, "hi");
+    }
+
+    #[test]
+    fn serde_round_trip_mid_run_resumes_identically() {
+        let drive_to_pending_tools = || {
+            let mut run = AgentRun::new("add things").max_turns(2);
+            expect_call_model(&mut run);
+            expect_continue(
+                run.model_response(
+                    tool_call_turn("call_1", "add").with_usage_for_test(usage(10, 5)),
+                )
+                .expect("model_response should succeed"),
+            );
+            expect_call_tools(&mut run);
+            run
+        };
+
+        let finish = |mut run: AgentRun| {
+            run.tool_results(vec![tool_result("call_1", "2")])
+                .expect("tool_results should succeed");
+            expect_call_model(&mut run);
+            expect_continue(
+                run.model_response(text_turn("done").with_usage_for_test(usage(3, 4)))
+                    .expect("model_response should succeed"),
+            );
+            expect_done(&mut run)
+        };
+
+        let uninterrupted = finish(drive_to_pending_tools());
+
+        let suspended = drive_to_pending_tools();
+        let serialized = serde_json::to_string(&suspended).expect("mid-run state should serialize");
+        let restored: AgentRun =
+            serde_json::from_str(&serialized).expect("mid-run state should deserialize");
+        let resumed = finish(restored);
+
+        assert_eq!(resumed.output, uninterrupted.output);
+        assert_eq!(resumed.usage, uninterrupted.usage);
+        assert_eq!(resumed.completion_calls, uninterrupted.completion_calls);
+        // Compare messages by their serialized form: deserializing a message
+        // normalizes absent `additional_params` to an empty map, which is
+        // semantically identical and serializes identically.
+        assert_eq!(
+            serde_json::to_value(&resumed.messages).expect("messages should serialize"),
+            serde_json::to_value(&uninterrupted.messages).expect("messages should serialize"),
+        );
+    }
+
+    #[test]
+    fn pending_invalid_tool_call_survives_serde_round_trip() {
+        let mut run = AgentRun::new("call something");
+        expect_call_model(&mut run);
+        let context = expect_needs_resolution(
+            run.model_response(tool_call_turn("call_1", "unknown"))
+                .expect("model_response should succeed"),
+        );
+
+        let serialized = serde_json::to_string(&run).expect("state should serialize");
+        let restored: AgentRun =
+            serde_json::from_str(&serialized).expect("state should deserialize");
+        let restored_context = restored
+            .pending_invalid_tool_call()
+            .expect("pending resolution should survive serialization");
+        assert_eq!(restored_context.tool_name, context.tool_name);
+        assert_eq!(
+            restored_context.chat_history.len(),
+            context.chat_history.len()
+        );
+    }
+
+    impl ModelTurn {
+        fn with_usage_for_test(mut self, usage: Usage) -> Self {
+            self.usage = usage;
+            self
+        }
+    }
+}

--- a/crates/rig-core/src/agent/run/mod.rs
+++ b/crates/rig-core/src/agent/run/mod.rs
@@ -538,10 +538,7 @@ impl AgentRun {
         }
 
         self.completion_calls
-            .push(CompletionCall::from_reported_usage(
-                self.completion_call_index,
-                turn.usage,
-            ));
+            .push(CompletionCall::new(self.completion_call_index, turn.usage));
         self.completion_call_index += 1;
         self.usage += turn.usage;
 
@@ -840,10 +837,11 @@ impl AgentRun {
     /// stream is drained for usage after the rollback — so recording is
     /// decoupled from turn ingestion. Valid while a model response is pending
     /// or between a turn rollback and the next [`AgentRunStep::CallModel`];
-    /// aggregates `usage` into the run total.
+    /// aggregates `usage` into the run total. Zero-valued usage means the
+    /// provider reported no usage metrics.
     pub fn record_streamed_completion_call(
         &mut self,
-        usage: Option<Usage>,
+        usage: Usage,
     ) -> Result<CompletionCall, PromptError> {
         let recordable = matches!(self.state, RunState::AwaitingModel)
             || (matches!(self.state, RunState::PreparingRequest) && self.rollback_pending);
@@ -862,9 +860,7 @@ impl AgentRun {
         let call = CompletionCall::new(self.completion_call_index, usage);
         self.completion_call_index += 1;
         self.completion_calls.push(call);
-        if let Some(usage) = usage {
-            self.usage += usage;
-        }
+        self.usage += usage;
         Ok(call)
     }
 
@@ -1018,8 +1014,10 @@ impl AgentRun {
         // never learned usage (no record before the turn completed) still get
         // the call recorded, with no reported usage.
         if !self.streamed_completion_call_recorded {
-            self.completion_calls
-                .push(CompletionCall::new(self.completion_call_index, None));
+            self.completion_calls.push(CompletionCall::new(
+                self.completion_call_index,
+                Usage::new(),
+            ));
             self.completion_call_index += 1;
             self.streamed_completion_call_recorded = true;
         }
@@ -1273,8 +1271,8 @@ mod tests {
         assert_eq!(response.usage, usage(30, 12));
         assert_eq!(response.completion_calls.len(), 2);
         assert_eq!(response.completion_calls[0].call_index, 0);
-        assert_eq!(response.completion_calls[0].usage, Some(usage(10, 5)));
-        assert_eq!(response.completion_calls[1].usage, Some(usage(20, 7)));
+        assert_eq!(response.completion_calls[0].usage, usage(10, 5));
+        assert_eq!(response.completion_calls[1].usage, usage(20, 7));
         // prompt, assistant tool call, tool result, final assistant text
         assert_eq!(
             response
@@ -1539,7 +1537,7 @@ mod tests {
     fn model_response_rejected_after_streamed_completion_call_record() {
         let mut run = AgentRun::new("hello");
         expect_call_model(&mut run);
-        run.record_streamed_completion_call(None)
+        run.record_streamed_completion_call(Usage::new())
             .expect("record should succeed");
 
         let err = run
@@ -1638,6 +1636,25 @@ mod tests {
             .tool_results(vec![UserContent::text("not a tool result")])
             .expect_err("non-tool-result content must be rejected");
         assert!(matches!(err, PromptError::PromptCancelled { .. }));
+    }
+
+    #[test]
+    fn agent_run_deserializes_pre_monoid_suspended_state() {
+        // Fixture captured from rig before CompletionCall.usage dropped its
+        // Option encoding, suspended at ExecutingTools with a null-usage
+        // completion call. It must deserialize and resume.
+        let fixture = r#"{"max_turns":2,"max_invalid_tool_call_retries":0,"tool_choice":null,"chat_history":null,"new_messages":[{"role":"user","content":[{"type":"text","text":"add things"}]},{"role":"assistant","id":null,"content":[{"id":"call_1","call_id":null,"function":{"name":"add","arguments":{"x":1}},"signature":null,"additional_params":null}]}],"current_turn":1,"usage":{"input_tokens":10,"output_tokens":5,"total_tokens":15,"cached_input_tokens":0,"cache_creation_input_tokens":0,"tool_use_prompt_tokens":0,"reasoning_tokens":0},"completion_calls":[{"call_index":0,"usage":null}],"completion_call_index":1,"invalid_tool_call_retries":0,"rollback_pending":false,"streamed_completion_call_recorded":false,"state":{"ExecutingTools":[{"tool_call":{"id":"call_1","call_id":null,"function":{"name":"add","arguments":{"x":1}},"signature":null,"additional_params":null},"preresolved_result":null,"internal_call_id":null}]}}"#;
+
+        let mut restored: AgentRun =
+            serde_json::from_str(fixture).expect("old-format suspended run should deserialize");
+        assert_eq!(restored.completion_calls()[0].usage, Usage::new());
+
+        let calls = expect_call_tools(&mut restored);
+        assert_eq!(calls.len(), 1);
+        restored
+            .tool_results(vec![tool_result("call_1", "2")])
+            .expect("tool_results should succeed");
+        expect_call_model(&mut restored);
     }
 
     #[test]

--- a/crates/rig-core/src/agent/run/mod.rs
+++ b/crates/rig-core/src/agent/run/mod.rs
@@ -16,7 +16,9 @@
 //! Because the machine never awaits anything, it is runtime-agnostic and the
 //! whole run state is `Serialize + Deserialize`: a driver can serialize a run
 //! between steps (for example while tool calls are pending), persist it, and
-//! resume it later in another process.
+//! resume it later in another process. Note that serialized run state embeds
+//! the full conversation accumulated so far — persisting it inherits whatever
+//! sensitivity the conversation content has.
 //!
 //! [`crate::completion::Prompt::prompt`] on [`crate::agent::Agent`] drives
 //! this machine internally; the same machine can be driven by hand for custom
@@ -238,6 +240,10 @@ pub struct AgentRun {
     completion_calls: Vec<CompletionCall>,
     completion_call_index: usize,
     invalid_tool_call_retries: usize,
+    /// Set while a streamed turn rollback awaits its completion-call record;
+    /// see [`AgentRun::record_streamed_completion_call`].
+    #[serde(default)]
+    rollback_pending: bool,
     state: RunState,
 }
 
@@ -256,6 +262,7 @@ impl AgentRun {
             completion_calls: Vec::new(),
             completion_call_index: 0,
             invalid_tool_call_retries: 0,
+            rollback_pending: false,
             state: RunState::PreparingRequest,
         }
     }
@@ -317,6 +324,17 @@ impl AgentRun {
     /// Whether the run reached [`AgentRunStep::Done`].
     pub fn is_done(&self) -> bool {
         matches!(self.state, RunState::Done(_))
+    }
+
+    /// The final response once the run is done, without cloning it.
+    /// [`AgentRun::next_step`] in the done state returns an owned clone
+    /// (including the full accumulated message history); prefer this when
+    /// only inspecting the result.
+    pub fn response(&self) -> Option<&PromptResponse> {
+        match &self.state {
+            RunState::Done(response) => Some(response),
+            _ => None,
+        }
     }
 
     /// Build the cancellation error a driver should return when one of its
@@ -387,6 +405,7 @@ impl AgentRun {
                 let history =
                     build_history_for_request(self.chat_history.as_deref(), history_for_turn);
                 self.current_turn += 1;
+                self.rollback_pending = false;
                 self.state = RunState::AwaitingModel;
                 Ok(AgentRunStep::CallModel {
                     prompt,
@@ -743,15 +762,15 @@ impl AgentRun {
     /// including for turns abandoned by invalid tool-call recovery, where the
     /// stream is drained for usage after the rollback — so recording is
     /// decoupled from turn ingestion. Valid while a model response is pending
-    /// or right after a turn rollback; aggregates `usage` into the run total.
+    /// or between a turn rollback and the next [`AgentRunStep::CallModel`];
+    /// aggregates `usage` into the run total.
     pub fn record_streamed_completion_call(
         &mut self,
         usage: Option<Usage>,
     ) -> Result<CompletionCall, PromptError> {
-        if !matches!(
-            self.state,
-            RunState::AwaitingModel | RunState::PreparingRequest
-        ) {
+        let recordable = matches!(self.state, RunState::AwaitingModel)
+            || (matches!(self.state, RunState::PreparingRequest) && self.rollback_pending);
+        if !recordable {
             return Err(self.protocol_violation(
                 "record_streamed_completion_call called without a pending or rolled-back CallModel step",
             ));
@@ -845,6 +864,7 @@ impl AgentRun {
                 };
                 self.new_messages.push(assistant_message);
                 self.new_messages.push(user_message);
+                self.rollback_pending = true;
                 self.state = RunState::PreparingRequest;
                 Ok(StreamedResolution::TurnAbandoned {
                     skipped_tool_result: None,
@@ -889,6 +909,7 @@ impl AgentRun {
                 };
                 self.new_messages.push(assistant_message);
                 self.new_messages.push(user_message);
+                self.rollback_pending = true;
                 self.state = RunState::PreparingRequest;
                 Ok(StreamedResolution::TurnAbandoned {
                     skipped_tool_result: Some(skipped_tool_result),

--- a/crates/rig-core/src/agent/run/mod.rs
+++ b/crates/rig-core/src/agent/run/mod.rs
@@ -112,6 +112,12 @@ pub struct PendingToolCall {
     /// recovery. When set, the driver must return this content as the tool
     /// result without executing the tool or invoking tool hooks.
     pub preresolved_result: Option<UserContent>,
+    /// Rig-generated identifier correlating this call's stream items, when
+    /// the call arrived via a streamed turn. Persisted with the run state so
+    /// a resumed process keeps emitting the IDs consumers already saw in
+    /// tool-call deltas. Drivers generate a fresh ID when absent.
+    #[serde(default)]
+    pub internal_call_id: Option<String>,
 }
 
 /// A completed model turn fed back to [`AgentRun::model_response`].
@@ -204,6 +210,10 @@ struct TurnState {
     items: Vec<AssistantContent>,
     has_tool_calls: bool,
     skipped: BTreeMap<String, UserContent>,
+    /// `(tool_call_id, internal_call_id)` pairs for streamed turns, in
+    /// emission order; empty for non-streamed turns.
+    #[serde(default)]
+    internal_call_ids: Vec<(String, String)>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -246,6 +256,11 @@ pub struct AgentRun {
     /// see [`AgentRun::record_streamed_completion_call`].
     #[serde(default)]
     rollback_pending: bool,
+    /// Set once the current streamed model turn's completion call has been
+    /// recorded, rejecting duplicate records; reset when the next
+    /// [`AgentRunStep::CallModel`] is emitted.
+    #[serde(default)]
+    streamed_completion_call_recorded: bool,
     state: RunState,
 }
 
@@ -265,6 +280,7 @@ impl AgentRun {
             completion_call_index: 0,
             invalid_tool_call_retries: 0,
             rollback_pending: false,
+            streamed_completion_call_recorded: false,
             state: RunState::PreparingRequest,
         }
     }
@@ -408,6 +424,7 @@ impl AgentRun {
                     build_history_for_request(self.chat_history.as_deref(), history_for_turn);
                 self.current_turn += 1;
                 self.rollback_pending = false;
+                self.streamed_completion_call_recorded = false;
                 self.state = RunState::AwaitingModel;
                 Ok(AgentRunStep::CallModel {
                     prompt,
@@ -421,6 +438,7 @@ impl AgentRun {
                     items,
                     has_tool_calls,
                     skipped,
+                    mut internal_call_ids,
                 } = *turn_state;
                 let Some(choice) = OneOrMany::from_iter_optional(items.clone()) else {
                     return Err(PromptError::prompt_cancelled(
@@ -440,10 +458,20 @@ impl AgentRun {
                     let calls: Vec<PendingToolCall> = items
                         .iter()
                         .filter_map(|item| match item {
-                            AssistantContent::ToolCall(tool_call) => Some(PendingToolCall {
-                                tool_call: tool_call.clone(),
-                                preresolved_result: skipped.get(&tool_call.id).cloned(),
-                            }),
+                            AssistantContent::ToolCall(tool_call) => {
+                                // Consume pairs positionally so duplicate
+                                // provider IDs within one turn stay
+                                // distinguishable.
+                                let internal_call_id = internal_call_ids
+                                    .iter()
+                                    .position(|(id, _)| *id == tool_call.id)
+                                    .map(|index| internal_call_ids.remove(index).1);
+                                Some(PendingToolCall {
+                                    tool_call: tool_call.clone(),
+                                    preresolved_result: skipped.get(&tool_call.id).cloned(),
+                                    internal_call_id,
+                                })
+                            }
                             _ => None,
                         })
                         .collect();
@@ -788,6 +816,7 @@ impl AgentRun {
             items,
             has_tool_calls,
             skipped,
+            internal_call_ids: Vec::new(),
         }));
         Ok(ModelTurnOutcome::Continue {
             response_hook_suppressed: recovered,
@@ -817,6 +846,12 @@ impl AgentRun {
                 "record_streamed_completion_call called without a pending or rolled-back CallModel step",
             ));
         }
+        if self.streamed_completion_call_recorded {
+            return Err(self.protocol_violation(
+                "record_streamed_completion_call called twice for the same model turn",
+            ));
+        }
+        self.streamed_completion_call_recorded = true;
 
         let call = CompletionCall::new(self.completion_call_index, usage);
         self.completion_call_index += 1;
@@ -1007,6 +1042,7 @@ impl AgentRun {
             items,
             has_tool_calls,
             skipped: BTreeMap::new(),
+            internal_call_ids: turn.internal_call_ids,
         }));
         Ok(())
     }

--- a/crates/rig-core/src/agent/run/mod.rs
+++ b/crates/rig-core/src/agent/run/mod.rs
@@ -18,7 +18,9 @@
 //! between steps (for example while tool calls are pending), persist it, and
 //! resume it later in another process. Note that serialized run state embeds
 //! the full conversation accumulated so far — persisting it inherits whatever
-//! sensitivity the conversation content has.
+//! sensitivity the conversation content has — and the serialization format
+//! carries no cross-version stability guarantee yet: resume with the same rig
+//! version that suspended the run.
 //!
 //! [`crate::completion::Prompt::prompt`] on [`crate::agent::Agent`] drives
 //! this machine internally; the same machine can be driven by hand for custom
@@ -529,6 +531,11 @@ impl AgentRun {
                 self.protocol_violation("model_response called without a pending CallModel step")
             );
         }
+        if self.streamed_completion_call_recorded {
+            return Err(self.protocol_violation(
+                "model_response called after record_streamed_completion_call for the same turn; feed streamed turns via streamed_turn",
+            ));
+        }
 
         self.completion_calls
             .push(CompletionCall::from_reported_usage(
@@ -737,12 +744,11 @@ impl AgentRun {
             )));
         }
 
+        // `results` is non-empty (checked above), so construction succeeds.
         let Some(content) = OneOrMany::from_iter_optional(results) else {
-            self.state = RunState::Failed;
-            return Err(PromptError::prompt_cancelled(
-                self.full_history(),
-                "tool execution produced no tool results",
-            ));
+            return Err(
+                self.protocol_violation("internal: tool results vanished during validation")
+            );
         };
 
         self.new_messages.push(Message::User { content });
@@ -1006,6 +1012,16 @@ impl AgentRun {
             return Err(
                 self.protocol_violation("streamed_turn called without a pending CallModel step")
             );
+        }
+
+        // Guarantee exactly one CompletionCall per model call: drivers that
+        // never learned usage (no record before the turn completed) still get
+        // the call recorded, with no reported usage.
+        if !self.streamed_completion_call_recorded {
+            self.completion_calls
+                .push(CompletionCall::new(self.completion_call_index, None));
+            self.completion_call_index += 1;
+            self.streamed_completion_call_recorded = true;
         }
 
         let items: Vec<AssistantContent> = turn.choice.iter().cloned().collect();
@@ -1517,6 +1533,21 @@ mod tests {
                 .expect("model_response should still succeed"),
         );
         assert_eq!(expect_done(&mut run).output, "hi");
+    }
+
+    #[test]
+    fn model_response_rejected_after_streamed_completion_call_record() {
+        let mut run = AgentRun::new("hello");
+        expect_call_model(&mut run);
+        run.record_streamed_completion_call(None)
+            .expect("record should succeed");
+
+        let err = run
+            .model_response(text_turn("hi"))
+            .expect_err("mixed streamed/non-streamed ingestion must be rejected");
+        assert!(matches!(err, PromptError::PromptCancelled { .. }));
+        // No duplicate completion call was appended.
+        assert_eq!(run.completion_calls().len(), 1);
     }
 
     #[test]

--- a/crates/rig-core/src/agent/run/streamed.rs
+++ b/crates/rig-core/src/agent/run/streamed.rs
@@ -1,0 +1,1067 @@
+//! Streamed-turn assembly for [`AgentRun`](super::AgentRun).
+//!
+//! A streamed model turn arrives as incremental [`StreamedAssistantContent`]
+//! items. [`StreamedTurnAssembler`] is the sans-IO accumulator that turns that
+//! item stream into the same canonical complete turn the non-streaming path
+//! feeds the machine — while telling the driver what to forward to its
+//! consumer and surfacing invalid tool calls the moment they appear, so a
+//! driver can stop paying for a doomed provider stream early.
+//!
+//! The protocol, paired with the streamed entry points on
+//! [`AgentRun`](super::AgentRun):
+//!
+//! 1. On [`AgentRunStep::CallModel`](super::AgentRunStep::CallModel), open a
+//!    provider stream and create one assembler per turn with the tool names
+//!    advertised for that turn.
+//! 2. Feed every stream item to [`StreamedTurnAssembler::ingest`] and act on
+//!    the returned [`StreamedTurnEvent`]s: forward items to the consumer, and
+//!    on [`StreamedTurnEvent::InvalidToolCall`] consult
+//!    [`AgentRun::resolve_streamed_invalid_tool_call`](super::AgentRun::resolve_streamed_invalid_tool_call) —
+//!    [`StreamedResolution::Repaired`] continues the same stream via
+//!    [`StreamedTurnAssembler::resolve_pending_invalid`];
+//!    [`StreamedResolution::TurnAbandoned`] means drain the provider stream
+//!    for usage and re-enter
+//!    [`AgentRun::next_step`](super::AgentRun::next_step).
+//! 3. When the provider stream ends, call [`StreamedTurnAssembler::finish`]
+//!    and feed the result to
+//!    [`AgentRun::streamed_turn`](super::AgentRun::streamed_turn); the run
+//!    then proceeds exactly like a non-streamed one
+//!    ([`CallTools`](super::AgentRunStep::CallTools) /
+//!    [`Done`](super::AgentRunStep::Done)).
+//!
+//! [`crate::streaming::StreamingPrompt::stream_prompt`] drives this protocol
+//! internally; hand-driven runs can use it to stream any
+//! [`AgentRun`](super::AgentRun).
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    OneOrMany,
+    agent::prompt_request::{TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER, tool_result_user_content},
+    completion::{CompletionError, GetTokenUsage, Message, Usage},
+    json_utils,
+    message::{AssistantContent, Reasoning, ToolCall, ToolFunction, ToolResult},
+    streaming::{StreamedAssistantContent, ToolCallDeltaContent},
+};
+
+/// Merge an incoming reasoning block into the accumulated reasoning,
+/// extending an existing block when provider-assigned IDs match.
+pub(crate) fn merge_reasoning_blocks(
+    accumulated_reasoning: &mut Vec<Reasoning>,
+    incoming: &Reasoning,
+) {
+    let ids_match = |existing: &Reasoning| {
+        matches!(
+            (&existing.id, &incoming.id),
+            (Some(existing_id), Some(incoming_id)) if existing_id == incoming_id
+        )
+    };
+
+    if let Some(existing) = accumulated_reasoning
+        .iter_mut()
+        .rev()
+        .find(|existing| ids_match(existing))
+    {
+        existing.content.extend(incoming.content.clone());
+    } else {
+        accumulated_reasoning.push(incoming.clone());
+    }
+}
+
+/// Assemble assistant content in canonical replay order: reasoning blocks,
+/// then text, then trailing items (tool calls, images).
+pub(crate) fn ordered_streaming_assistant_content(
+    reasoning_items: impl IntoIterator<Item = Reasoning>,
+    text_items: impl IntoIterator<Item = AssistantContent>,
+    trailing_items: impl IntoIterator<Item = AssistantContent>,
+) -> Option<OneOrMany<AssistantContent>> {
+    let mut content_items = reasoning_items
+        .into_iter()
+        .map(AssistantContent::Reasoning)
+        .collect::<Vec<_>>();
+    content_items.extend(text_items);
+    content_items.extend(trailing_items);
+
+    OneOrMany::from_iter_optional(content_items)
+}
+
+pub(crate) fn assistant_text_items_from_choice(
+    choice: &OneOrMany<AssistantContent>,
+) -> Vec<AssistantContent> {
+    choice
+        .iter()
+        .filter_map(|content| match content {
+            AssistantContent::Text(text) => (!text.text.is_empty()
+                || text.additional_params.is_some())
+            .then(|| AssistantContent::Text(text.clone())),
+            _ => None,
+        })
+        .collect()
+}
+
+/// One invalid tool call surfaced mid-stream, awaiting a resolution from
+/// [`AgentRun::resolve_streamed_invalid_tool_call`](super::AgentRun::resolve_streamed_invalid_tool_call).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct StreamedInvalidToolCall {
+    /// The rejected tool call. For a name delta this is a diagnostic call
+    /// assembled from the streamed name and any buffered argument deltas.
+    pub tool_call: ToolCall,
+    /// Rig-generated identifier correlating this call's stream items.
+    pub internal_call_id: String,
+    /// Raw argument payload for diagnostics, when available.
+    pub args: Option<String>,
+    /// Executable Rig tools advertised to the provider for this turn.
+    pub executable_tool_names: BTreeSet<String>,
+    /// Tools allowed by the active tool choice for this turn.
+    pub allowed_tool_names: BTreeSet<String>,
+}
+
+/// Snapshot of a streamed turn at the moment an invalid tool call appeared.
+/// Used by the machine to build diagnostics and rollback messages from
+/// exactly what the model has produced so far.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct PartialStreamedTurn {
+    /// Provider-assigned assistant message ID, when already known.
+    pub message_id: Option<String>,
+    /// Aggregated assistant text, when any text was streamed this turn.
+    pub text: Option<String>,
+    /// Accumulated reasoning, with any pending unsigned delta text assembled
+    /// into a block.
+    pub reasoning: Vec<Reasoning>,
+    /// Tool calls already validated (or repaired) this turn.
+    pub pending_tool_calls: Vec<ToolCall>,
+}
+
+impl PartialStreamedTurn {
+    /// The assistant message representing this partial turn, in canonical
+    /// order, including `current_tool_call` when provided. `None` when the
+    /// turn has produced no representable content.
+    pub(crate) fn assistant_message(&self, current_tool_call: Option<ToolCall>) -> Option<Message> {
+        let text_items = match &self.text {
+            Some(text) if !text.is_empty() => vec![AssistantContent::text(text.clone())],
+            _ => Vec::new(),
+        };
+        let mut tool_items = self
+            .pending_tool_calls
+            .iter()
+            .cloned()
+            .map(AssistantContent::ToolCall)
+            .collect::<Vec<_>>();
+        if let Some(tool_call) = current_tool_call {
+            tool_items.push(AssistantContent::ToolCall(tool_call));
+        }
+
+        let content = ordered_streaming_assistant_content(
+            self.reasoning.iter().cloned(),
+            text_items,
+            tool_items,
+        )?;
+        Some(Message::Assistant {
+            id: self.message_id.clone(),
+            content,
+        })
+    }
+
+    /// Rollback messages for a retried or skipped streamed turn: the partial
+    /// assistant turn plus a user message carrying `feedback` for the invalid
+    /// call and a synthetic "not executed" result for each validated peer.
+    pub(crate) fn rollback_messages(
+        &self,
+        invalid_tool_call: ToolCall,
+        feedback: String,
+    ) -> Option<(Message, Message)> {
+        let assistant_message = self.assistant_message(Some(invalid_tool_call.clone()))?;
+
+        let mut retry_results = self
+            .pending_tool_calls
+            .iter()
+            .map(|tool_call| {
+                tool_result_user_content(
+                    tool_call.id.clone(),
+                    tool_call.call_id.clone(),
+                    TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER.to_string(),
+                )
+            })
+            .collect::<Vec<_>>();
+        retry_results.push(tool_result_user_content(
+            invalid_tool_call.id,
+            invalid_tool_call.call_id,
+            feedback,
+        ));
+
+        let user_message = Message::User {
+            content: OneOrMany::from_iter_optional(retry_results)?,
+        };
+
+        Some((assistant_message, user_message))
+    }
+}
+
+/// The assembled streamed turn, fed to
+/// [`AgentRun::streamed_turn`](super::AgentRun::streamed_turn).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct StreamedTurn {
+    /// Provider-assigned assistant message ID, when available.
+    pub message_id: Option<String>,
+    /// The assistant content to record in history: canonical
+    /// (reasoning → text → tool calls) when the turn produced reasoning or
+    /// tool calls, otherwise the provider's aggregated choice as-is.
+    pub choice: OneOrMany<AssistantContent>,
+    /// Executable Rig tools advertised to the provider for this turn.
+    pub executable_tool_names: BTreeSet<String>,
+    /// Tools allowed by the active tool choice for this turn.
+    pub allowed_tool_names: BTreeSet<String>,
+}
+
+/// What the machine decided about a mid-stream invalid tool call.
+///
+/// Deliberately exhaustive: a driver must handle every resolution, so adding
+/// a variant is a breaking change by design.
+#[derive(Debug)]
+pub enum StreamedResolution {
+    /// The tool name was repaired. Apply it via
+    /// [`StreamedTurnAssembler::resolve_pending_invalid`] and keep consuming
+    /// the provider stream.
+    Repaired {
+        /// The validated replacement tool name.
+        tool_name: String,
+    },
+    /// The turn was rolled back (retry) or the call skipped; corrective
+    /// messages are already in the history. Drain the provider stream for
+    /// usage, record the completion call, then call
+    /// [`AgentRun::next_step`](super::AgentRun::next_step).
+    TurnAbandoned {
+        /// For a skipped call, the synthetic tool result to surface to the
+        /// consumer stream.
+        skipped_tool_result: Option<ToolResult>,
+    },
+}
+
+/// What a driver must do with one ingested stream item.
+///
+/// Deliberately exhaustive: a driver must handle every event, so adding a
+/// variant is a breaking change by design.
+#[derive(Debug, Clone)]
+pub enum StreamedTurnEvent {
+    /// Forward the ingested item to the consumer as-is (text, reasoning, or
+    /// reasoning deltas, after accumulation).
+    EmitIngested,
+    /// Forward this tool-call delta. Argument deltas buffered while the tool
+    /// name awaited validation are replayed through this event.
+    EmitToolCallDelta {
+        /// Provider-supplied tool call ID.
+        id: String,
+        /// Rig-generated identifier correlating this call's stream items.
+        internal_call_id: String,
+        /// The (possibly repaired) name or argument delta.
+        content: ToolCallDeltaContent,
+    },
+    /// The model emitted an unknown or disallowed tool call. Resolve it via
+    /// [`AgentRun::resolve_streamed_invalid_tool_call`](super::AgentRun::resolve_streamed_invalid_tool_call),
+    /// then apply the outcome with
+    /// [`StreamedTurnAssembler::resolve_pending_invalid`].
+    InvalidToolCall(StreamedInvalidToolCall),
+    /// The provider reported the end of this completion call. Record it (see
+    /// [`AgentRun::record_streamed_completion_call`](super::AgentRun::record_streamed_completion_call));
+    /// when `emit_final` is set, the turn streamed text and the driver should
+    /// run its stream-finish hook and forward the final item.
+    Completed {
+        /// Provider-reported usage for this call, normalized to `None` when
+        /// absent or zero-valued.
+        usage: Option<Usage>,
+        /// Whether the ingested final item should be forwarded to the
+        /// consumer (set when the turn streamed text).
+        emit_final: bool,
+    },
+}
+
+#[derive(Default)]
+struct ToolCallDeltaState {
+    name_validated: bool,
+    buffered_arguments: Vec<String>,
+}
+
+enum PendingInvalid {
+    /// A complete tool call with a disallowed name.
+    FullCall {
+        tool_call: ToolCall,
+        internal_call_id: String,
+    },
+    /// A streamed tool-name delta with a disallowed name.
+    NameDelta {
+        id: String,
+        internal_call_id: String,
+    },
+}
+
+/// Sans-IO accumulator that assembles one streamed model turn. See the
+/// [module docs](self) for the driving protocol.
+pub struct StreamedTurnAssembler {
+    executable_tool_names: BTreeSet<String>,
+    allowed_tool_names: BTreeSet<String>,
+    text: String,
+    saw_text: bool,
+    accumulated_reasoning: Vec<Reasoning>,
+    pending_reasoning_delta_text: String,
+    pending_reasoning_delta_id: Option<String>,
+    pending_tool_calls: Vec<(ToolCall, String)>,
+    delta_states: HashMap<(String, String), ToolCallDeltaState>,
+    pending_invalid: Option<PendingInvalid>,
+}
+
+impl StreamedTurnAssembler {
+    /// Create an assembler for one streamed turn with the tool names
+    /// advertised to the provider for that turn.
+    pub fn new(
+        executable_tool_names: BTreeSet<String>,
+        allowed_tool_names: BTreeSet<String>,
+    ) -> Self {
+        Self {
+            executable_tool_names,
+            allowed_tool_names,
+            text: String::new(),
+            saw_text: false,
+            accumulated_reasoning: Vec::new(),
+            pending_reasoning_delta_text: String::new(),
+            pending_reasoning_delta_id: None,
+            pending_tool_calls: Vec::new(),
+            delta_states: HashMap::new(),
+            pending_invalid: None,
+        }
+    }
+
+    /// Aggregated assistant text streamed so far this turn (empty until the
+    /// first text delta).
+    pub fn aggregated_text(&self) -> &str {
+        &self.text
+    }
+
+    /// Ingest one provider stream item and return what the driver must do.
+    ///
+    /// # Errors
+    /// Returns an error when the provider stream is inconsistent (argument
+    /// deltas finishing without a validated tool name) or when an invalid
+    /// tool call is still awaiting resolution.
+    pub fn ingest<R>(
+        &mut self,
+        item: &StreamedAssistantContent<R>,
+    ) -> Result<Vec<StreamedTurnEvent>, CompletionError>
+    where
+        R: Clone + Unpin + GetTokenUsage,
+    {
+        if self.pending_invalid.is_some() {
+            return Err(CompletionError::ResponseError(
+                "streamed turn ingested while an invalid tool call awaits resolution".to_string(),
+            ));
+        }
+
+        match item {
+            StreamedAssistantContent::Text(text) => {
+                if !self.saw_text {
+                    self.text.clear();
+                    self.saw_text = true;
+                }
+                self.text.push_str(&text.text);
+                Ok(vec![StreamedTurnEvent::EmitIngested])
+            }
+            StreamedAssistantContent::Reasoning(reasoning) => {
+                merge_reasoning_blocks(&mut self.accumulated_reasoning, reasoning);
+                Ok(vec![StreamedTurnEvent::EmitIngested])
+            }
+            StreamedAssistantContent::ReasoningDelta { reasoning, id } => {
+                // Deltas lack signatures/encrypted content that full blocks
+                // carry; mixing them into accumulated reasoning causes
+                // providers like Anthropic to reject with "signature required",
+                // so they are kept aside until the turn ends.
+                self.pending_reasoning_delta_text.push_str(reasoning);
+                if self.pending_reasoning_delta_id.is_none() {
+                    self.pending_reasoning_delta_id = id.clone();
+                }
+                Ok(vec![StreamedTurnEvent::EmitIngested])
+            }
+            StreamedAssistantContent::ToolCall {
+                tool_call,
+                internal_call_id,
+            } => {
+                if !self.allowed_tool_names.contains(&tool_call.function.name) {
+                    let invalid = StreamedInvalidToolCall {
+                        tool_call: tool_call.clone(),
+                        internal_call_id: internal_call_id.clone(),
+                        args: Some(json_utils::value_to_json_string(
+                            &tool_call.function.arguments,
+                        )),
+                        executable_tool_names: self.executable_tool_names.clone(),
+                        allowed_tool_names: self.allowed_tool_names.clone(),
+                    };
+                    self.pending_invalid = Some(PendingInvalid::FullCall {
+                        tool_call: tool_call.clone(),
+                        internal_call_id: internal_call_id.clone(),
+                    });
+                    return Ok(vec![StreamedTurnEvent::InvalidToolCall(invalid)]);
+                }
+
+                self.pending_tool_calls
+                    .push((tool_call.clone(), internal_call_id.clone()));
+                Ok(Vec::new())
+            }
+            StreamedAssistantContent::ToolCallDelta {
+                id,
+                internal_call_id,
+                content,
+            } => {
+                let key = (id.clone(), internal_call_id.clone());
+                match content {
+                    ToolCallDeltaContent::Name(name) => {
+                        if !self.allowed_tool_names.contains(name) {
+                            let buffered_args = self
+                                .delta_states
+                                .get(&key)
+                                .map(|state| state.buffered_arguments.join(""))
+                                .unwrap_or_default();
+                            let invalid = StreamedInvalidToolCall {
+                                tool_call: self.name_delta_diagnostic_tool_call(
+                                    id,
+                                    name,
+                                    &buffered_args,
+                                ),
+                                internal_call_id: internal_call_id.clone(),
+                                args: Some(buffered_args),
+                                executable_tool_names: self.executable_tool_names.clone(),
+                                allowed_tool_names: self.allowed_tool_names.clone(),
+                            };
+                            self.pending_invalid = Some(PendingInvalid::NameDelta {
+                                id: id.clone(),
+                                internal_call_id: internal_call_id.clone(),
+                            });
+                            return Ok(vec![StreamedTurnEvent::InvalidToolCall(invalid)]);
+                        }
+
+                        Ok(self.validate_delta_name(&key, name.clone()))
+                    }
+                    ToolCallDeltaContent::Delta(arguments) => {
+                        let state = self.delta_states.entry(key.clone()).or_default();
+                        if state.name_validated {
+                            Ok(vec![StreamedTurnEvent::EmitToolCallDelta {
+                                id: id.clone(),
+                                internal_call_id: internal_call_id.clone(),
+                                content: ToolCallDeltaContent::Delta(arguments.clone()),
+                            }])
+                        } else {
+                            state.buffered_arguments.push(arguments.clone());
+                            Ok(Vec::new())
+                        }
+                    }
+                }
+            }
+            StreamedAssistantContent::Final(final_response) => {
+                if let Some(err) = self.pending_delta_error() {
+                    return Err(err);
+                }
+
+                let usage = final_response
+                    .token_usage()
+                    .and_then(crate::agent::prompt_request::reported_usage);
+                let emit_final = self.saw_text;
+                self.saw_text = false;
+                Ok(vec![StreamedTurnEvent::Completed { usage, emit_final }])
+            }
+        }
+    }
+
+    /// Apply the machine's resolution for the invalid tool call surfaced by
+    /// the last [`StreamedTurnEvent::InvalidToolCall`]. For a repaired name
+    /// this returns the deltas to forward (the repaired name plus any
+    /// buffered argument deltas).
+    pub fn resolve_pending_invalid(
+        &mut self,
+        resolution: &StreamedResolution,
+    ) -> Vec<StreamedTurnEvent> {
+        let Some(pending) = self.pending_invalid.take() else {
+            return Vec::new();
+        };
+
+        match (resolution, pending) {
+            (
+                StreamedResolution::Repaired { tool_name },
+                PendingInvalid::FullCall {
+                    mut tool_call,
+                    internal_call_id,
+                },
+            ) => {
+                tool_call.function.name = tool_name.clone();
+                self.pending_tool_calls.push((tool_call, internal_call_id));
+                Vec::new()
+            }
+            (
+                StreamedResolution::Repaired { tool_name },
+                PendingInvalid::NameDelta {
+                    id,
+                    internal_call_id,
+                },
+            ) => {
+                let key = (id, internal_call_id);
+                self.validate_delta_name(&key, tool_name.clone())
+            }
+            (
+                StreamedResolution::TurnAbandoned { .. },
+                PendingInvalid::NameDelta {
+                    id,
+                    internal_call_id,
+                },
+            ) => {
+                // The abandoned call's buffered state must not trip the
+                // pending-delta consistency check while usage is drained.
+                self.delta_states.remove(&(id, internal_call_id));
+                Vec::new()
+            }
+            (StreamedResolution::TurnAbandoned { .. }, PendingInvalid::FullCall { .. }) => {
+                Vec::new()
+            }
+        }
+    }
+
+    /// Error when argument deltas were buffered for a tool call whose name
+    /// never validated — a provider-stream consistency violation.
+    pub fn pending_delta_error(&self) -> Option<CompletionError> {
+        self.delta_states
+            .iter()
+            .find(|(_, state)| !state.name_validated && !state.buffered_arguments.is_empty())
+            .map(|((id, internal_call_id), state)| {
+                CompletionError::ResponseError(format!(
+                    "streamed tool call arguments received before a validated tool name for id `{id}` and internal_call_id `{internal_call_id}` ({} buffered argument delta(s))",
+                    state.buffered_arguments.len()
+                ))
+            })
+    }
+
+    /// Snapshot of the turn so far, for diagnostics and rollback messages.
+    pub fn partial_turn(&self, message_id: Option<String>) -> PartialStreamedTurn {
+        let mut reasoning = self.accumulated_reasoning.clone();
+        if reasoning.is_empty() && !self.pending_reasoning_delta_text.is_empty() {
+            let mut assembled = Reasoning::new(&self.pending_reasoning_delta_text);
+            if let Some(id) = self.pending_reasoning_delta_id.clone() {
+                assembled = assembled.with_id(id);
+            }
+            reasoning.push(assembled);
+        }
+
+        PartialStreamedTurn {
+            message_id,
+            text: self.saw_text.then(|| self.text.clone()),
+            reasoning,
+            pending_tool_calls: self
+                .pending_tool_calls
+                .iter()
+                .map(|(tool_call, _)| tool_call.clone())
+                .collect(),
+        }
+    }
+
+    /// Internal call IDs for this turn's validated tool calls, keyed by tool
+    /// call ID. Drivers use these to correlate tool execution stream items.
+    pub fn internal_call_ids(&self) -> BTreeMap<String, String> {
+        self.pending_tool_calls
+            .iter()
+            .map(|(tool_call, internal_call_id)| (tool_call.id.clone(), internal_call_id.clone()))
+            .collect()
+    }
+
+    /// Assemble the completed turn. `final_choice` is the provider's
+    /// aggregated choice for the turn
+    /// ([`crate::streaming::StreamingCompletionResponse::choice`]).
+    pub fn finish(
+        mut self,
+        message_id: Option<String>,
+        final_choice: &OneOrMany<AssistantContent>,
+    ) -> StreamedTurn {
+        // Providers like Gemini emit thinking as incremental deltas without
+        // signatures; assemble them into a single block so reasoning survives
+        // into the next turn's chat history.
+        if self.accumulated_reasoning.is_empty() && !self.pending_reasoning_delta_text.is_empty() {
+            let mut assembled = Reasoning::new(&self.pending_reasoning_delta_text);
+            if let Some(id) = self.pending_reasoning_delta_id.take() {
+                assembled = assembled.with_id(id);
+            }
+            self.accumulated_reasoning.push(assembled);
+        }
+
+        // Canonical replay order when the turn produced reasoning or tool
+        // calls; otherwise the provider's aggregated choice is recorded as-is.
+        let choice =
+            if !self.pending_tool_calls.is_empty() || !self.accumulated_reasoning.is_empty() {
+                let text_items = assistant_text_items_from_choice(final_choice);
+                let tool_items = self
+                    .pending_tool_calls
+                    .iter()
+                    .map(|(tool_call, _)| AssistantContent::ToolCall(tool_call.clone()))
+                    .collect::<Vec<_>>();
+                ordered_streaming_assistant_content(
+                    self.accumulated_reasoning.drain(..),
+                    text_items,
+                    tool_items,
+                )
+                .unwrap_or_else(|| final_choice.clone())
+            } else {
+                final_choice.clone()
+            };
+
+        StreamedTurn {
+            message_id,
+            choice,
+            executable_tool_names: self.executable_tool_names,
+            allowed_tool_names: self.allowed_tool_names,
+        }
+    }
+
+    fn name_delta_diagnostic_tool_call(
+        &self,
+        id: &str,
+        name: &str,
+        buffered_args: &str,
+    ) -> ToolCall {
+        let diagnostic_args = if buffered_args.trim().is_empty() {
+            serde_json::Value::Null
+        } else {
+            serde_json::from_str(buffered_args).unwrap_or(serde_json::Value::Null)
+        };
+        ToolCall::new(
+            id.to_string(),
+            ToolFunction::new(name.to_string(), diagnostic_args),
+        )
+    }
+
+    fn validate_delta_name(
+        &mut self,
+        key: &(String, String),
+        name: String,
+    ) -> Vec<StreamedTurnEvent> {
+        let state = self.delta_states.entry(key.clone()).or_default();
+        state.name_validated = true;
+        let buffered_arguments = std::mem::take(&mut state.buffered_arguments);
+
+        let mut events = vec![StreamedTurnEvent::EmitToolCallDelta {
+            id: key.0.clone(),
+            internal_call_id: key.1.clone(),
+            content: ToolCallDeltaContent::Name(name),
+        }];
+        events.extend(buffered_arguments.into_iter().map(|arguments| {
+            StreamedTurnEvent::EmitToolCallDelta {
+                id: key.0.clone(),
+                internal_call_id: key.1.clone(),
+                content: ToolCallDeltaContent::Delta(arguments),
+            }
+        }));
+        events
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::prompt_request::hooks::InvalidToolCallHookAction;
+    use crate::agent::run::{AgentRun, AgentRunStep};
+    use crate::completion::PromptError;
+    use crate::message::{Text, ToolResultContent, UserContent};
+    use crate::test_utils::MockResponse;
+    use serde_json::json;
+
+    fn tool_names(names: &[&str]) -> BTreeSet<String> {
+        names.iter().map(|name| (*name).to_string()).collect()
+    }
+
+    fn assembler() -> StreamedTurnAssembler {
+        StreamedTurnAssembler::new(tool_names(&["add"]), tool_names(&["add"]))
+    }
+
+    fn text_item(text: &str) -> StreamedAssistantContent<MockResponse> {
+        StreamedAssistantContent::Text(Text::new(text.to_string()))
+    }
+
+    fn tool_call(id: &str, name: &str) -> ToolCall {
+        ToolCall::new(
+            id.to_string(),
+            ToolFunction::new(name.to_string(), json!({"x": 1})),
+        )
+    }
+
+    fn tool_call_item(id: &str, name: &str) -> StreamedAssistantContent<MockResponse> {
+        StreamedAssistantContent::ToolCall {
+            tool_call: tool_call(id, name),
+            internal_call_id: format!("internal_{id}"),
+        }
+    }
+
+    fn final_item() -> StreamedAssistantContent<MockResponse> {
+        StreamedAssistantContent::Final(MockResponse::with_usage(Usage::new()))
+    }
+
+    fn name_delta(id: &str, name: &str) -> StreamedAssistantContent<MockResponse> {
+        StreamedAssistantContent::ToolCallDelta {
+            id: id.to_string(),
+            internal_call_id: format!("internal_{id}"),
+            content: ToolCallDeltaContent::Name(name.to_string()),
+        }
+    }
+
+    fn args_delta(id: &str, arguments: &str) -> StreamedAssistantContent<MockResponse> {
+        StreamedAssistantContent::ToolCallDelta {
+            id: id.to_string(),
+            internal_call_id: format!("internal_{id}"),
+            content: ToolCallDeltaContent::Delta(arguments.to_string()),
+        }
+    }
+
+    fn expect_invalid(events: Vec<StreamedTurnEvent>) -> StreamedInvalidToolCall {
+        match events.into_iter().next() {
+            Some(StreamedTurnEvent::InvalidToolCall(invalid)) => invalid,
+            other => panic!("expected InvalidToolCall, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn text_accumulates_and_emits() {
+        let mut asm = assembler();
+        let events = asm
+            .ingest(&text_item("hel"))
+            .expect("ingest should succeed");
+        assert!(matches!(
+            events.as_slice(),
+            [StreamedTurnEvent::EmitIngested]
+        ));
+        asm.ingest(&text_item("lo")).expect("ingest should succeed");
+        assert_eq!(asm.aggregated_text(), "hello");
+    }
+
+    #[test]
+    fn argument_deltas_buffer_until_name_validates() {
+        let mut asm = assembler();
+
+        let events = asm
+            .ingest(&args_delta("tc_1", "{\"x\""))
+            .expect("ingest should succeed");
+        assert!(events.is_empty(), "arguments must buffer before the name");
+
+        let events = asm
+            .ingest(&name_delta("tc_1", "add"))
+            .expect("ingest should succeed");
+        let contents: Vec<_> = events
+            .iter()
+            .map(|event| match event {
+                StreamedTurnEvent::EmitToolCallDelta { content, .. } => content.clone(),
+                other => panic!("expected EmitToolCallDelta, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(
+            contents,
+            vec![
+                ToolCallDeltaContent::Name("add".to_string()),
+                ToolCallDeltaContent::Delta("{\"x\"".to_string()),
+            ]
+        );
+
+        // Subsequent argument deltas now pass straight through.
+        let events = asm
+            .ingest(&args_delta("tc_1", ":1}"))
+            .expect("ingest should succeed");
+        assert_eq!(events.len(), 1);
+    }
+
+    #[test]
+    fn buffered_arguments_without_validated_name_error_at_final() {
+        let mut asm = assembler();
+        asm.ingest(&args_delta("tc_1", "{\"x\":1}"))
+            .expect("ingest should succeed");
+
+        assert!(asm.pending_delta_error().is_some());
+        assert!(asm.ingest(&final_item()).is_err());
+    }
+
+    #[test]
+    fn finish_orders_reasoning_text_then_tool_calls() {
+        let mut asm = assembler();
+        asm.ingest(&StreamedAssistantContent::<MockResponse>::ReasoningDelta {
+            id: Some("rs_1".to_string()),
+            reasoning: "think".to_string(),
+        })
+        .expect("ingest should succeed");
+        asm.ingest(&tool_call_item("tc_1", "add"))
+            .expect("ingest should succeed");
+
+        // Provider aggregation order differs deliberately.
+        let final_choice = OneOrMany::many(vec![
+            AssistantContent::text("answer"),
+            AssistantContent::ToolCall(tool_call("tc_1", "add")),
+        ])
+        .expect("two items");
+
+        let turn = asm.finish(Some("msg_1".to_string()), &final_choice);
+        let kinds: Vec<&'static str> = turn
+            .choice
+            .iter()
+            .map(|item| match item {
+                AssistantContent::Reasoning(_) => "reasoning",
+                AssistantContent::Text(_) => "text",
+                AssistantContent::ToolCall(_) => "tool_call",
+                _ => "other",
+            })
+            .collect();
+        assert_eq!(kinds, vec!["reasoning", "text", "tool_call"]);
+    }
+
+    #[test]
+    fn finish_passes_raw_choice_through_for_plain_text_turns() {
+        let mut asm = assembler();
+        asm.ingest(&text_item("hi")).expect("ingest should succeed");
+
+        let final_choice = OneOrMany::one(AssistantContent::text("hi"));
+        let turn = asm.finish(None, &final_choice);
+        assert_eq!(
+            serde_json::to_value(&turn.choice).expect("serialize"),
+            serde_json::to_value(&final_choice).expect("serialize"),
+        );
+    }
+
+    #[test]
+    fn streamed_run_completes_a_tool_roundtrip() {
+        let mut run = AgentRun::new("add things").max_turns(2);
+
+        // Turn 1: the model streams one tool call.
+        let AgentRunStep::CallModel { .. } = run.next_step().expect("next_step") else {
+            panic!("expected CallModel");
+        };
+        let mut asm = assembler();
+        assert!(
+            asm.ingest(&tool_call_item("tc_1", "add"))
+                .expect("ingest should succeed")
+                .is_empty()
+        );
+        let usage = Usage {
+            input_tokens: 5,
+            output_tokens: 7,
+            total_tokens: 12,
+            ..Usage::new()
+        };
+        run.record_streamed_completion_call(Some(usage))
+            .expect("record should succeed");
+        assert_eq!(
+            asm.internal_call_ids().get("tc_1").map(String::as_str),
+            Some("internal_tc_1")
+        );
+        let final_choice = OneOrMany::one(AssistantContent::ToolCall(tool_call("tc_1", "add")));
+        run.streamed_turn(asm.finish(Some("msg_1".to_string()), &final_choice))
+            .expect("streamed_turn should succeed");
+
+        let AgentRunStep::CallTools { calls } = run.next_step().expect("next_step") else {
+            panic!("expected CallTools");
+        };
+        assert_eq!(calls.len(), 1);
+        run.tool_results(vec![UserContent::tool_result(
+            "tc_1".to_string(),
+            ToolResultContent::from_tool_output("2".to_string()),
+        )])
+        .expect("tool_results should succeed");
+
+        // Turn 2: plain text finishes the run.
+        let AgentRunStep::CallModel { .. } = run.next_step().expect("next_step") else {
+            panic!("expected CallModel");
+        };
+        let asm = assembler();
+        run.record_streamed_completion_call(None)
+            .expect("record should succeed");
+        let final_choice = OneOrMany::one(AssistantContent::text("done"));
+        run.streamed_turn(asm.finish(None, &final_choice))
+            .expect("streamed_turn should succeed");
+
+        let AgentRunStep::Done(response) = run.next_step().expect("next_step") else {
+            panic!("expected Done");
+        };
+        assert_eq!(response.output, "done");
+        assert_eq!(response.usage, usage);
+        assert_eq!(response.completion_calls.len(), 2);
+        assert_eq!(response.completion_calls[0].usage, Some(usage));
+        assert_eq!(response.completion_calls[1].usage, None);
+        // prompt, assistant tool call, tool result, final assistant text
+        assert_eq!(
+            response
+                .messages
+                .expect("messages should be recorded")
+                .len(),
+            4
+        );
+    }
+
+    #[test]
+    fn streamed_invalid_tool_call_retry_rolls_back_with_partial_turn() {
+        let mut run = AgentRun::new("use the tool")
+            .max_turns(2)
+            .max_invalid_tool_call_retries(1);
+        run.next_step().expect("next_step");
+
+        let mut asm = assembler();
+        asm.ingest(&text_item("thinking ")).expect("ingest");
+        let invalid = expect_invalid(
+            asm.ingest(&tool_call_item("tc_1", "default_api"))
+                .expect("ingest should succeed"),
+        );
+        let partial = asm.partial_turn(Some("msg_1".to_string()));
+        assert_eq!(partial.text.as_deref(), Some("thinking "));
+
+        let context = run.streamed_invalid_tool_call_context(&partial, &invalid);
+        assert!(context.is_streaming);
+        assert_eq!(context.tool_name, "default_api");
+        assert_eq!(context.internal_call_id.as_deref(), Some("internal_tc_1"));
+
+        let resolution = run
+            .resolve_streamed_invalid_tool_call(
+                &partial,
+                &invalid,
+                InvalidToolCallHookAction::retry("use add instead"),
+            )
+            .expect("retry should be accepted");
+        assert!(matches!(
+            resolution,
+            StreamedResolution::TurnAbandoned {
+                skipped_tool_result: None
+            }
+        ));
+        asm.resolve_pending_invalid(&resolution);
+
+        // Usage from the drained stream is recorded after the rollback.
+        run.record_streamed_completion_call(None)
+            .expect("record after rollback should succeed");
+
+        // The rollback appended the partial assistant turn and feedback.
+        assert_eq!(run.messages().len(), 3);
+        let AgentRunStep::CallModel { turn, .. } = run.next_step().expect("next_step") else {
+            panic!("expected CallModel retry");
+        };
+        assert_eq!(turn, 2);
+    }
+
+    #[test]
+    fn streamed_invalid_tool_call_skip_returns_synthetic_result() {
+        let mut run = AgentRun::new("use the tool").max_turns(2);
+        run.next_step().expect("next_step");
+
+        let mut asm = assembler();
+        let invalid = expect_invalid(
+            asm.ingest(&tool_call_item("tc_1", "default_api"))
+                .expect("ingest should succeed"),
+        );
+        let partial = asm.partial_turn(None);
+
+        let resolution = run
+            .resolve_streamed_invalid_tool_call(
+                &partial,
+                &invalid,
+                InvalidToolCallHookAction::skip("not available"),
+            )
+            .expect("skip should be accepted");
+        let StreamedResolution::TurnAbandoned {
+            skipped_tool_result: Some(tool_result),
+        } = &resolution
+        else {
+            panic!("expected skipped tool result");
+        };
+        assert_eq!(tool_result.id, "tc_1");
+    }
+
+    #[test]
+    fn streamed_invalid_name_delta_repair_replays_buffered_arguments() {
+        let mut run = AgentRun::new("use the tool").max_turns(2);
+        run.next_step().expect("next_step");
+
+        let mut asm = assembler();
+        asm.ingest(&args_delta("tc_1", "{\"x\":1}"))
+            .expect("ingest should succeed");
+        let invalid = expect_invalid(
+            asm.ingest(&name_delta("tc_1", "default_api"))
+                .expect("ingest should succeed"),
+        );
+        assert_eq!(invalid.args.as_deref(), Some("{\"x\":1}"));
+
+        let partial = asm.partial_turn(None);
+        let resolution = run
+            .resolve_streamed_invalid_tool_call(
+                &partial,
+                &invalid,
+                InvalidToolCallHookAction::repair("add"),
+            )
+            .expect("repair should be accepted");
+        assert!(matches!(
+            resolution,
+            StreamedResolution::Repaired { ref tool_name } if tool_name == "add"
+        ));
+
+        let events = asm.resolve_pending_invalid(&resolution);
+        let contents: Vec<_> = events
+            .iter()
+            .map(|event| match event {
+                StreamedTurnEvent::EmitToolCallDelta { content, .. } => content.clone(),
+                other => panic!("expected EmitToolCallDelta, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(
+            contents,
+            vec![
+                ToolCallDeltaContent::Name("add".to_string()),
+                ToolCallDeltaContent::Delta("{\"x\":1}".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn streamed_turn_rejects_unknown_tool_calls_fail_fast() {
+        let mut run = AgentRun::new("use the tool");
+        run.next_step().expect("next_step");
+
+        let turn = StreamedTurn {
+            message_id: None,
+            choice: OneOrMany::one(AssistantContent::ToolCall(tool_call("tc_1", "unknown"))),
+            executable_tool_names: tool_names(&["add"]),
+            allowed_tool_names: tool_names(&["add"]),
+        };
+        let err = run
+            .streamed_turn(turn)
+            .expect_err("unknown tool should fail fast");
+        assert!(matches!(
+            err,
+            PromptError::UnknownToolCall { tool_name, .. } if tool_name == "unknown"
+        ));
+    }
+
+    #[test]
+    fn streamed_run_serde_round_trips_while_tools_pend() {
+        let mut run = AgentRun::new("add things").max_turns(2);
+        run.next_step().expect("next_step");
+
+        let mut asm = assembler();
+        asm.ingest(&tool_call_item("tc_1", "add"))
+            .expect("ingest should succeed");
+        run.record_streamed_completion_call(None)
+            .expect("record should succeed");
+        let final_choice = OneOrMany::one(AssistantContent::ToolCall(tool_call("tc_1", "add")));
+        run.streamed_turn(asm.finish(None, &final_choice))
+            .expect("streamed_turn should succeed");
+        run.next_step().expect("CallTools step");
+
+        let serialized = serde_json::to_string(&run).expect("serialize mid-run");
+        let mut restored: AgentRun =
+            serde_json::from_str(&serialized).expect("deserialize mid-run");
+        restored
+            .tool_results(vec![UserContent::tool_result(
+                "tc_1".to_string(),
+                ToolResultContent::from_tool_output("2".to_string()),
+            )])
+            .expect("tool_results should succeed");
+        assert!(matches!(
+            restored.next_step().expect("next turn"),
+            AgentRunStep::CallModel { turn: 2, .. }
+        ));
+    }
+}

--- a/crates/rig-core/src/agent/run/streamed.rs
+++ b/crates/rig-core/src/agent/run/streamed.rs
@@ -276,9 +276,9 @@ pub enum StreamedTurnEvent {
     /// when `emit_final` is set, the turn streamed text and the driver should
     /// run its stream-finish hook and forward the final item.
     Completed {
-        /// Provider-reported usage for this call, normalized to `None` when
-        /// absent or zero-valued.
-        usage: Option<Usage>,
+        /// Provider-reported usage for this call. Zero-valued usage means the
+        /// provider reported no usage metrics.
+        usage: Usage,
         /// Whether the ingested final item should be forwarded to the
         /// consumer (set when the turn streamed text).
         emit_final: bool,
@@ -468,9 +468,7 @@ impl StreamedTurnAssembler {
                     return Err(err);
                 }
 
-                let usage = final_response
-                    .token_usage()
-                    .and_then(crate::agent::prompt_request::reported_usage);
+                let usage = final_response.token_usage();
                 let emit_final = self.saw_text;
                 self.saw_text = false;
                 Ok(vec![StreamedTurnEvent::Completed { usage, emit_final }])
@@ -848,7 +846,7 @@ mod tests {
             total_tokens: 12,
             ..Usage::new()
         };
-        run.record_streamed_completion_call(Some(usage))
+        run.record_streamed_completion_call(usage)
             .expect("record should succeed");
         let final_choice = OneOrMany::one(AssistantContent::ToolCall(tool_call("tc_1", "add")));
         run.streamed_turn(asm.finish(Some("msg_1".to_string()), &final_choice))
@@ -870,7 +868,7 @@ mod tests {
             panic!("expected CallModel");
         };
         let asm = assembler();
-        run.record_streamed_completion_call(None)
+        run.record_streamed_completion_call(Usage::new())
             .expect("record should succeed");
         let final_choice = OneOrMany::one(AssistantContent::text("done"));
         run.streamed_turn(asm.finish(None, &final_choice))
@@ -882,8 +880,8 @@ mod tests {
         assert_eq!(response.output, "done");
         assert_eq!(response.usage, usage);
         assert_eq!(response.completion_calls.len(), 2);
-        assert_eq!(response.completion_calls[0].usage, Some(usage));
-        assert_eq!(response.completion_calls[1].usage, None);
+        assert_eq!(response.completion_calls[0].usage, usage);
+        assert_eq!(response.completion_calls[1].usage, Usage::new());
         // prompt, assistant tool call, tool result, final assistant text
         assert_eq!(
             response
@@ -931,7 +929,7 @@ mod tests {
         asm.resolve_pending_invalid(&resolution);
 
         // Usage from the drained stream is recorded after the rollback.
-        run.record_streamed_completion_call(None)
+        run.record_streamed_completion_call(Usage::new())
             .expect("record after rollback should succeed");
 
         // The rollback appended the partial assistant turn and feedback.
@@ -1041,13 +1039,13 @@ mod tests {
         // even though the machine is in its initial PreparingRequest state.
         let mut run = AgentRun::new("hello");
         let err = run
-            .record_streamed_completion_call(None)
+            .record_streamed_completion_call(Usage::new())
             .expect_err("recording before any model call must be rejected");
         assert!(matches!(err, PromptError::PromptCancelled { .. }));
 
         // The run stays drivable.
         run.next_step().expect("next_step should still succeed");
-        run.record_streamed_completion_call(None)
+        run.record_streamed_completion_call(Usage::new())
             .expect("recording during a pending model call succeeds");
     }
 
@@ -1067,7 +1065,7 @@ mod tests {
             internal_call_id: "internal_b".to_string(),
         })
         .expect("ingest should succeed");
-        run.record_streamed_completion_call(None)
+        run.record_streamed_completion_call(Usage::new())
             .expect("record should succeed");
 
         let final_choice = OneOrMany::many(vec![
@@ -1103,7 +1101,7 @@ mod tests {
         // Exactly one CompletionCall per model call, even without an explicit
         // record; usage is simply unreported.
         assert_eq!(run.completion_calls().len(), 1);
-        assert_eq!(run.completion_calls()[0].usage, None);
+        assert_eq!(run.completion_calls()[0].usage, Usage::new());
     }
 
     #[test]
@@ -1111,10 +1109,10 @@ mod tests {
         let mut run = AgentRun::new("hello");
         run.next_step().expect("next_step");
 
-        run.record_streamed_completion_call(None)
+        run.record_streamed_completion_call(Usage::new())
             .expect("first record succeeds");
         let err = run
-            .record_streamed_completion_call(None)
+            .record_streamed_completion_call(Usage::new())
             .expect_err("second record for the same turn must be rejected");
         assert!(matches!(err, PromptError::PromptCancelled { .. }));
         assert_eq!(run.completion_calls().len(), 1);
@@ -1128,7 +1126,7 @@ mod tests {
         let mut asm = assembler();
         asm.ingest(&tool_call_item("tc_1", "add"))
             .expect("ingest should succeed");
-        run.record_streamed_completion_call(None)
+        run.record_streamed_completion_call(Usage::new())
             .expect("record should succeed");
         let final_choice = OneOrMany::one(AssistantContent::ToolCall(tool_call("tc_1", "add")));
         run.streamed_turn(asm.finish(None, &final_choice))

--- a/crates/rig-core/src/agent/run/streamed.rs
+++ b/crates/rig-core/src/agent/run/streamed.rs
@@ -216,6 +216,11 @@ pub struct StreamedTurn {
     pub executable_tool_names: BTreeSet<String>,
     /// Tools allowed by the active tool choice for this turn.
     pub allowed_tool_names: BTreeSet<String>,
+    /// `(tool_call_id, internal_call_id)` pairs for this turn's tool calls,
+    /// in emission order. Carried into the run state so a resumed process
+    /// keeps the IDs consumers already saw in tool-call deltas.
+    #[serde(default)]
+    pub internal_call_ids: Vec<(String, String)>,
 }
 
 /// What the machine decided about a mid-stream invalid tool call.
@@ -562,18 +567,6 @@ impl StreamedTurnAssembler {
         }
     }
 
-    /// `(tool_call_id, internal_call_id)` pairs for this turn's validated
-    /// tool calls, in emission order. Drivers use these to correlate tool
-    /// execution stream items; pairs are returned positionally (not as a
-    /// map) so calls remain distinguishable even if a provider reuses a tool
-    /// call ID within one turn.
-    pub fn internal_call_ids(&self) -> Vec<(String, String)> {
-        self.pending_tool_calls
-            .iter()
-            .map(|(tool_call, internal_call_id)| (tool_call.id.clone(), internal_call_id.clone()))
-            .collect()
-    }
-
     /// Assemble the completed turn. `final_choice` is the provider's
     /// aggregated choice for the turn
     /// ([`crate::streaming::StreamingCompletionResponse::choice`]).
@@ -582,6 +575,11 @@ impl StreamedTurnAssembler {
         message_id: Option<String>,
         final_choice: &OneOrMany<AssistantContent>,
     ) -> StreamedTurn {
+        let internal_call_ids: Vec<(String, String)> = self
+            .pending_tool_calls
+            .iter()
+            .map(|(tool_call, internal_call_id)| (tool_call.id.clone(), internal_call_id.clone()))
+            .collect();
         // Providers like Gemini emit thinking as incremental deltas without
         // signatures; assemble them into a single block so reasoning survives
         // into the next turn's chat history.
@@ -618,6 +616,7 @@ impl StreamedTurnAssembler {
             choice,
             executable_tool_names: self.executable_tool_names,
             allowed_tool_names: self.allowed_tool_names,
+            internal_call_ids,
         }
     }
 
@@ -851,10 +850,6 @@ mod tests {
         };
         run.record_streamed_completion_call(Some(usage))
             .expect("record should succeed");
-        assert_eq!(
-            asm.internal_call_ids(),
-            vec![("tc_1".to_string(), "internal_tc_1".to_string())]
-        );
         let final_choice = OneOrMany::one(AssistantContent::ToolCall(tool_call("tc_1", "add")));
         run.streamed_turn(asm.finish(Some("msg_1".to_string()), &final_choice))
             .expect("streamed_turn should succeed");
@@ -863,6 +858,7 @@ mod tests {
             panic!("expected CallTools");
         };
         assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].internal_call_id.as_deref(), Some("internal_tc_1"));
         run.tool_results(vec![UserContent::tool_result(
             "tc_1".to_string(),
             ToolResultContent::from_tool_output("2".to_string()),
@@ -1028,6 +1024,7 @@ mod tests {
             choice: OneOrMany::one(AssistantContent::ToolCall(tool_call("tc_1", "unknown"))),
             executable_tool_names: tool_names(&["add"]),
             allowed_tool_names: tool_names(&["add"]),
+            internal_call_ids: Vec::new(),
         };
         let err = run
             .streamed_turn(turn)
@@ -1055,7 +1052,10 @@ mod tests {
     }
 
     #[test]
-    fn internal_call_ids_keep_duplicate_tool_call_ids_distinguishable() {
+    fn duplicate_tool_call_ids_keep_distinct_internal_ids_through_the_run() {
+        let mut run = AgentRun::new("do both").max_turns(2);
+        run.next_step().expect("next_step");
+
         let mut asm = assembler();
         asm.ingest(&StreamedAssistantContent::<MockResponse>::ToolCall {
             tool_call: tool_call("tc_1", "add"),
@@ -1067,14 +1067,41 @@ mod tests {
             internal_call_id: "internal_b".to_string(),
         })
         .expect("ingest should succeed");
+        run.record_streamed_completion_call(None)
+            .expect("record should succeed");
 
-        assert_eq!(
-            asm.internal_call_ids(),
-            vec![
-                ("tc_1".to_string(), "internal_a".to_string()),
-                ("tc_1".to_string(), "internal_b".to_string()),
-            ]
-        );
+        let final_choice = OneOrMany::many(vec![
+            AssistantContent::ToolCall(tool_call("tc_1", "add")),
+            AssistantContent::ToolCall(tool_call("tc_1", "add")),
+        ])
+        .expect("two items");
+        run.streamed_turn(asm.finish(None, &final_choice))
+            .expect("streamed_turn should succeed");
+
+        // The internal IDs survive in the run state itself: a serde round
+        // trip must keep both calls distinguishable.
+        let serialized = serde_json::to_string(&run).expect("serialize");
+        let mut restored: AgentRun = serde_json::from_str(&serialized).expect("deserialize");
+        let AgentRunStep::CallTools { calls } = restored.next_step().expect("next_step") else {
+            panic!("expected CallTools");
+        };
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].internal_call_id.as_deref(), Some("internal_a"));
+        assert_eq!(calls[1].internal_call_id.as_deref(), Some("internal_b"));
+    }
+
+    #[test]
+    fn streamed_completion_call_is_recorded_once_per_turn() {
+        let mut run = AgentRun::new("hello");
+        run.next_step().expect("next_step");
+
+        run.record_streamed_completion_call(None)
+            .expect("first record succeeds");
+        let err = run
+            .record_streamed_completion_call(None)
+            .expect_err("second record for the same turn must be rejected");
+        assert!(matches!(err, PromptError::PromptCancelled { .. }));
+        assert_eq!(run.completion_calls().len(), 1);
     }
 
     #[test]

--- a/crates/rig-core/src/agent/run/streamed.rs
+++ b/crates/rig-core/src/agent/run/streamed.rs
@@ -1091,6 +1091,22 @@ mod tests {
     }
 
     #[test]
+    fn streamed_turn_records_the_completion_call_when_the_driver_did_not() {
+        let mut run = AgentRun::new("hello");
+        run.next_step().expect("next_step");
+
+        let asm = assembler();
+        let final_choice = OneOrMany::one(AssistantContent::text("done"));
+        run.streamed_turn(asm.finish(None, &final_choice))
+            .expect("streamed_turn should succeed");
+
+        // Exactly one CompletionCall per model call, even without an explicit
+        // record; usage is simply unreported.
+        assert_eq!(run.completion_calls().len(), 1);
+        assert_eq!(run.completion_calls()[0].usage, None);
+    }
+
+    #[test]
     fn streamed_completion_call_is_recorded_once_per_turn() {
         let mut run = AgentRun::new("hello");
         run.next_step().expect("next_step");

--- a/crates/rig-core/src/agent/run/streamed.rs
+++ b/crates/rig-core/src/agent/run/streamed.rs
@@ -33,7 +33,7 @@
 //! internally; hand-driven runs can use it to stream any
 //! [`AgentRun`](super::AgentRun).
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap};
 
 use serde::{Deserialize, Serialize};
 
@@ -562,9 +562,12 @@ impl StreamedTurnAssembler {
         }
     }
 
-    /// Internal call IDs for this turn's validated tool calls, keyed by tool
-    /// call ID. Drivers use these to correlate tool execution stream items.
-    pub fn internal_call_ids(&self) -> BTreeMap<String, String> {
+    /// `(tool_call_id, internal_call_id)` pairs for this turn's validated
+    /// tool calls, in emission order. Drivers use these to correlate tool
+    /// execution stream items; pairs are returned positionally (not as a
+    /// map) so calls remain distinguishable even if a provider reuses a tool
+    /// call ID within one turn.
+    pub fn internal_call_ids(&self) -> Vec<(String, String)> {
         self.pending_tool_calls
             .iter()
             .map(|(tool_call, internal_call_id)| (tool_call.id.clone(), internal_call_id.clone()))
@@ -849,8 +852,8 @@ mod tests {
         run.record_streamed_completion_call(Some(usage))
             .expect("record should succeed");
         assert_eq!(
-            asm.internal_call_ids().get("tc_1").map(String::as_str),
-            Some("internal_tc_1")
+            asm.internal_call_ids(),
+            vec![("tc_1".to_string(), "internal_tc_1".to_string())]
         );
         let final_choice = OneOrMany::one(AssistantContent::ToolCall(tool_call("tc_1", "add")));
         run.streamed_turn(asm.finish(Some("msg_1".to_string()), &final_choice))
@@ -1033,6 +1036,45 @@ mod tests {
             err,
             PromptError::UnknownToolCall { tool_name, .. } if tool_name == "unknown"
         ));
+    }
+
+    #[test]
+    fn streamed_completion_call_record_requires_a_model_call() {
+        // A fresh run has emitted no CallModel: recording must be rejected
+        // even though the machine is in its initial PreparingRequest state.
+        let mut run = AgentRun::new("hello");
+        let err = run
+            .record_streamed_completion_call(None)
+            .expect_err("recording before any model call must be rejected");
+        assert!(matches!(err, PromptError::PromptCancelled { .. }));
+
+        // The run stays drivable.
+        run.next_step().expect("next_step should still succeed");
+        run.record_streamed_completion_call(None)
+            .expect("recording during a pending model call succeeds");
+    }
+
+    #[test]
+    fn internal_call_ids_keep_duplicate_tool_call_ids_distinguishable() {
+        let mut asm = assembler();
+        asm.ingest(&StreamedAssistantContent::<MockResponse>::ToolCall {
+            tool_call: tool_call("tc_1", "add"),
+            internal_call_id: "internal_a".to_string(),
+        })
+        .expect("ingest should succeed");
+        asm.ingest(&StreamedAssistantContent::<MockResponse>::ToolCall {
+            tool_call: tool_call("tc_1", "add"),
+            internal_call_id: "internal_b".to_string(),
+        })
+        .expect("ingest should succeed");
+
+        assert_eq!(
+            asm.internal_call_ids(),
+            vec![
+                ("tc_1".to_string(), "internal_a".to_string()),
+                ("tc_1".to_string(), "internal_b".to_string()),
+            ]
+        );
     }
 
     #[test]

--- a/crates/rig-core/src/agent/run/streamed.rs
+++ b/crates/rig-core/src/agent/run/streamed.rs
@@ -265,7 +265,7 @@ pub enum StreamedTurnEvent {
     /// [`AgentRun::resolve_streamed_invalid_tool_call`](super::AgentRun::resolve_streamed_invalid_tool_call),
     /// then apply the outcome with
     /// [`StreamedTurnAssembler::resolve_pending_invalid`].
-    InvalidToolCall(StreamedInvalidToolCall),
+    InvalidToolCall(Box<StreamedInvalidToolCall>),
     /// The provider reported the end of this completion call. Record it (see
     /// [`AgentRun::record_streamed_completion_call`](super::AgentRun::record_streamed_completion_call));
     /// when `emit_final` is set, the turn streamed text and the driver should
@@ -289,7 +289,7 @@ struct ToolCallDeltaState {
 enum PendingInvalid {
     /// A complete tool call with a disallowed name.
     FullCall {
-        tool_call: ToolCall,
+        tool_call: Box<ToolCall>,
         internal_call_id: String,
     },
     /// A streamed tool-name delta with a disallowed name.
@@ -399,10 +399,10 @@ impl StreamedTurnAssembler {
                         allowed_tool_names: self.allowed_tool_names.clone(),
                     };
                     self.pending_invalid = Some(PendingInvalid::FullCall {
-                        tool_call: tool_call.clone(),
+                        tool_call: Box::new(tool_call.clone()),
                         internal_call_id: internal_call_id.clone(),
                     });
-                    return Ok(vec![StreamedTurnEvent::InvalidToolCall(invalid)]);
+                    return Ok(vec![StreamedTurnEvent::InvalidToolCall(Box::new(invalid))]);
                 }
 
                 self.pending_tool_calls
@@ -438,7 +438,7 @@ impl StreamedTurnAssembler {
                                 id: id.clone(),
                                 internal_call_id: internal_call_id.clone(),
                             });
-                            return Ok(vec![StreamedTurnEvent::InvalidToolCall(invalid)]);
+                            return Ok(vec![StreamedTurnEvent::InvalidToolCall(Box::new(invalid))]);
                         }
 
                         Ok(self.validate_delta_name(&key, name.clone()))
@@ -494,7 +494,7 @@ impl StreamedTurnAssembler {
                 },
             ) => {
                 tool_call.function.name = tool_name.clone();
-                self.pending_tool_calls.push((tool_call, internal_call_id));
+                self.pending_tool_calls.push((*tool_call, internal_call_id));
                 Vec::new()
             }
             (
@@ -718,7 +718,7 @@ mod tests {
 
     fn expect_invalid(events: Vec<StreamedTurnEvent>) -> StreamedInvalidToolCall {
         match events.into_iter().next() {
-            Some(StreamedTurnEvent::InvalidToolCall(invalid)) => invalid,
+            Some(StreamedTurnEvent::InvalidToolCall(invalid)) => *invalid,
             other => panic!("expected InvalidToolCall, got {other:?}"),
         }
     }

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -438,6 +438,14 @@ impl Usage {
             reasoning_tokens: 0,
         }
     }
+
+    /// Whether any usage values are set and non-zero.
+    ///
+    /// Zero-valued usage is this type's documented sentinel for "the provider
+    /// supplied no usage metrics", so `false` means usage was not reported.
+    pub fn has_values(&self) -> bool {
+        *self != Self::new()
+    }
 }
 
 impl Default for Usage {
@@ -947,6 +955,16 @@ impl<M: CompletionModel> CompletionRequestBuilder<M> {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn usage_has_values_reflects_the_zero_sentinel() {
+        use super::Usage;
+
+        assert!(!Usage::new().has_values());
+
+        let mut usage = Usage::new();
+        usage.reasoning_tokens = 1;
+        assert!(usage.has_values());
+    }
 
     use super::*;
     use crate::test_utils::MockCompletionModel;

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -378,13 +378,15 @@ pub struct CompletionResponse<T> {
 ///
 /// Primarily designed for streamed completion responses in streamed multi-turn, as otherwise it would be impossible to do.
 pub trait GetTokenUsage {
-    /// Returns token usage when the response type carries it.
-    fn token_usage(&self) -> Option<crate::completion::Usage>;
+    /// Returns token usage for this response. Zero-valued usage is
+    /// [`Usage`]'s documented sentinel for missing provider usage metrics;
+    /// response types that carry no usage return [`Usage::new`].
+    fn token_usage(&self) -> crate::completion::Usage;
 }
 
 impl GetTokenUsage for () {
-    fn token_usage(&self) -> Option<crate::completion::Usage> {
-        None
+    fn token_usage(&self) -> crate::completion::Usage {
+        crate::completion::Usage::new()
     }
 }
 
@@ -392,11 +394,11 @@ impl<T> GetTokenUsage for Option<T>
 where
     T: GetTokenUsage,
 {
-    fn token_usage(&self) -> Option<crate::completion::Usage> {
+    fn token_usage(&self) -> crate::completion::Usage {
         if let Some(usage) = self {
             usage.token_usage()
         } else {
-            None
+            crate::completion::Usage::new()
         }
     }
 }

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -131,7 +131,7 @@ impl std::fmt::Display for Usage {
 }
 
 impl GetTokenUsage for Usage {
-    fn token_usage(&self) -> Option<crate::completion::Usage> {
+    fn token_usage(&self) -> crate::completion::Usage {
         let mut usage = crate::completion::Usage::new();
 
         usage.input_tokens = self.input_tokens;
@@ -143,7 +143,7 @@ impl GetTokenUsage for Usage {
             + self.cache_creation_input_tokens.unwrap_or_default()
             + self.output_tokens;
 
-        Some(usage)
+        usage
     }
 }
 

--- a/crates/rig-core/src/providers/anthropic/streaming.rs
+++ b/crates/rig-core/src/providers/anthropic/streaming.rs
@@ -205,7 +205,7 @@ pub struct PartialUsage {
 }
 
 impl GetTokenUsage for PartialUsage {
-    fn token_usage(&self) -> Option<crate::completion::Usage> {
+    fn token_usage(&self) -> crate::completion::Usage {
         let mut usage = crate::completion::Usage::new();
 
         usage.input_tokens = self.input_tokens.unwrap_or_default() as u64;
@@ -216,7 +216,7 @@ impl GetTokenUsage for PartialUsage {
             + usage.cached_input_tokens
             + usage.cache_creation_input_tokens
             + usage.output_tokens;
-        Some(usage)
+        usage
     }
 }
 
@@ -247,7 +247,7 @@ pub struct StreamingCompletionResponse {
 }
 
 impl GetTokenUsage for StreamingCompletionResponse {
-    fn token_usage(&self) -> Option<crate::completion::Usage> {
+    fn token_usage(&self) -> crate::completion::Usage {
         let mut usage = crate::completion::Usage::new();
         usage.input_tokens = self.usage.input_tokens.unwrap_or(0) as u64;
         usage.output_tokens = self.usage.output_tokens as u64;
@@ -258,7 +258,7 @@ impl GetTokenUsage for StreamingCompletionResponse {
             + usage.cache_creation_input_tokens
             + usage.output_tokens;
 
-        Some(usage)
+        usage
     }
 }
 

--- a/crates/rig-core/src/providers/azure.rs
+++ b/crates/rig-core/src/providers/azure.rs
@@ -407,14 +407,14 @@ pub struct Usage {
 }
 
 impl GetTokenUsage for Usage {
-    fn token_usage(&self) -> Option<crate::completion::Usage> {
+    fn token_usage(&self) -> crate::completion::Usage {
         let mut usage = crate::completion::Usage::new();
 
         usage.input_tokens = self.prompt_tokens as u64;
         usage.total_tokens = self.total_tokens as u64;
         usage.output_tokens = usage.total_tokens - usage.input_tokens;
 
-        Some(usage)
+        usage
     }
 }
 

--- a/crates/rig-core/src/providers/cohere/completion.rs
+++ b/crates/rig-core/src/providers/cohere/completion.rs
@@ -104,7 +104,7 @@ pub struct Usage {
 }
 
 impl GetTokenUsage for Usage {
-    fn token_usage(&self) -> Option<crate::completion::Usage> {
+    fn token_usage(&self) -> crate::completion::Usage {
         let mut usage = crate::completion::Usage::new();
 
         if let Some(ref billed_units) = self.billed_units {
@@ -113,7 +113,7 @@ impl GetTokenUsage for Usage {
             usage.total_tokens = usage.input_tokens + usage.output_tokens;
         }
 
-        Some(usage)
+        usage
     }
 }
 

--- a/crates/rig-core/src/providers/cohere/streaming.rs
+++ b/crates/rig-core/src/providers/cohere/streaming.rs
@@ -67,7 +67,7 @@ pub struct StreamingCompletionResponse {
 }
 
 impl GetTokenUsage for StreamingCompletionResponse {
-    fn token_usage(&self) -> Option<crate::completion::Usage> {
+    fn token_usage(&self) -> crate::completion::Usage {
         let tokens = self
             .usage
             .clone()
@@ -79,14 +79,14 @@ impl GetTokenUsage for StreamingCompletionResponse {
                 )
             });
         let Some((Some(input), Some(output))) = tokens else {
-            return None;
+            return crate::completion::Usage::new();
         };
         let mut usage = crate::completion::Usage::new();
         usage.input_tokens = input;
         usage.output_tokens = output;
         usage.total_tokens = input + output;
 
-        Some(usage)
+        usage
     }
 }
 

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -566,7 +566,7 @@ pub enum CopilotStreamingResponse {
 }
 
 impl GetTokenUsage for CopilotStreamingResponse {
-    fn token_usage(&self) -> Option<completion::Usage> {
+    fn token_usage(&self) -> completion::Usage {
         match self {
             Self::Chat(response) => response.token_usage(),
             Self::Responses(response) => response.token_usage(),

--- a/crates/rig-core/src/providers/deepseek.rs
+++ b/crates/rig-core/src/providers/deepseek.rs
@@ -152,8 +152,8 @@ pub struct Usage {
 }
 
 impl GetTokenUsage for Usage {
-    fn token_usage(&self) -> Option<crate::completion::Usage> {
-        Some(crate::providers::internal::completion_usage(
+    fn token_usage(&self) -> crate::completion::Usage {
+        crate::providers::internal::completion_usage(
             self.prompt_tokens as u64,
             self.completion_tokens as u64,
             self.total_tokens as u64,
@@ -162,7 +162,7 @@ impl GetTokenUsage for Usage {
                 .and_then(|details| details.cached_tokens)
                 .map(u64::from)
                 .unwrap_or(0),
-        ))
+        )
     }
 }
 
@@ -715,7 +715,7 @@ pub struct StreamingCompletionResponse {
 }
 
 impl GetTokenUsage for StreamingCompletionResponse {
-    fn token_usage(&self) -> Option<crate::completion::Usage> {
+    fn token_usage(&self) -> crate::completion::Usage {
         self.usage.token_usage()
     }
 }

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -518,7 +518,7 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse<Generat
         let usage = response
             .usage_metadata
             .as_ref()
-            .and_then(GetTokenUsage::token_usage)
+            .map(GetTokenUsage::token_usage)
             .unwrap_or_default();
 
         Ok(completion::CompletionResponse {
@@ -1403,7 +1403,7 @@ pub mod gemini_api_types {
     }
 
     impl GetTokenUsage for UsageMetadata {
-        fn token_usage(&self) -> Option<crate::completion::Usage> {
+        fn token_usage(&self) -> crate::completion::Usage {
             let mut usage = crate::completion::Usage::new();
 
             usage.input_tokens = self.prompt_token_count as u64;
@@ -1414,7 +1414,7 @@ pub mod gemini_api_types {
                 self.tool_use_prompt_token_count.unwrap_or_default() as u64;
             usage.total_tokens = self.total_token_count as u64;
 
-            Some(usage)
+            usage
         }
     }
 

--- a/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
@@ -503,7 +503,7 @@ impl TryFrom<Interaction> for completion::CompletionResponse<Interaction> {
         let usage = response
             .usage
             .as_ref()
-            .and_then(|usage| usage.token_usage())
+            .map(|usage| usage.token_usage())
             .unwrap_or_default();
 
         Ok(completion::CompletionResponse {
@@ -749,8 +749,11 @@ pub mod interactions_api_types {
     }
 
     impl GetTokenUsage for Interaction {
-        fn token_usage(&self) -> Option<Usage> {
-            self.usage.as_ref().and_then(|usage| usage.token_usage())
+        fn token_usage(&self) -> Usage {
+            self.usage
+                .as_ref()
+                .map(|usage| usage.token_usage())
+                .unwrap_or_default()
         }
     }
 
@@ -1298,14 +1301,14 @@ pub mod interactions_api_types {
     }
 
     impl GetTokenUsage for InteractionUsage {
-        fn token_usage(&self) -> Option<Usage> {
+        fn token_usage(&self) -> Usage {
             let mut usage = Usage::new();
             usage.input_tokens = self.total_input_tokens.unwrap_or_default();
             usage.output_tokens = self.total_output_tokens.unwrap_or_default();
             usage.total_tokens = self
                 .total_tokens
                 .unwrap_or(usage.input_tokens + usage.output_tokens);
-            Some(usage)
+            usage
         }
     }
 

--- a/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
@@ -41,8 +41,11 @@ pub type InteractionEventStream =
     Pin<Box<dyn Stream<Item = Result<InteractionSseEvent, CompletionError>>>>;
 
 impl GetTokenUsage for StreamingCompletionResponse {
-    fn token_usage(&self) -> Option<crate::completion::Usage> {
-        self.usage.as_ref().and_then(|usage| usage.token_usage())
+    fn token_usage(&self) -> crate::completion::Usage {
+        self.usage
+            .as_ref()
+            .map(|usage| usage.token_usage())
+            .unwrap_or_default()
     }
 }
 

--- a/crates/rig-core/src/providers/gemini/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/streaming.rs
@@ -45,7 +45,7 @@ pub struct PartialUsage {
 }
 
 impl GetTokenUsage for PartialUsage {
-    fn token_usage(&self) -> Option<crate::completion::Usage> {
+    fn token_usage(&self) -> crate::completion::Usage {
         let mut usage = crate::completion::Usage::new();
 
         usage.input_tokens = self.prompt_token_count as u64;
@@ -55,7 +55,7 @@ impl GetTokenUsage for PartialUsage {
         usage.tool_use_prompt_tokens = self.tool_use_prompt_token_count.unwrap_or_default() as u64;
         usage.total_tokens = self.total_token_count as u64;
 
-        Some(usage)
+        usage
     }
 }
 
@@ -82,7 +82,7 @@ pub struct StreamingCompletionResponse {
 }
 
 impl GetTokenUsage for StreamingCompletionResponse {
-    fn token_usage(&self) -> Option<crate::completion::Usage> {
+    fn token_usage(&self) -> crate::completion::Usage {
         self.usage_metadata.token_usage()
     }
 }
@@ -433,7 +433,7 @@ mod tests {
         let usage = response
             .usage_metadata
             .as_ref()
-            .and_then(GetTokenUsage::token_usage)
+            .map(GetTokenUsage::token_usage)
             .unwrap();
         assert_eq!(usage.input_tokens, 10);
         assert_eq!(usage.output_tokens, 5);
@@ -679,7 +679,7 @@ mod tests {
             traffic_type: None,
         };
 
-        let token_usage = usage.token_usage().unwrap();
+        let token_usage = usage.token_usage();
         assert_eq!(token_usage.input_tokens, 40);
         assert_eq!(token_usage.cached_input_tokens, 20);
         assert_eq!(token_usage.output_tokens, 30);
@@ -704,7 +704,7 @@ mod tests {
             traffic_type: None,
         };
 
-        let token_usage = usage.token_usage().unwrap();
+        let token_usage = usage.token_usage();
         assert_eq!(token_usage.input_tokens, 20);
         assert_eq!(token_usage.cached_input_tokens, 0);
         assert_eq!(token_usage.output_tokens, 30);
@@ -762,7 +762,7 @@ mod tests {
             model_version: Some("gemini-2.0-flash-001".to_string()),
         };
 
-        let token_usage = response.token_usage().unwrap();
+        let token_usage = response.token_usage();
         assert_eq!(token_usage.input_tokens, 75);
         assert_eq!(token_usage.output_tokens, 75);
         assert_eq!(token_usage.reasoning_tokens, 0);
@@ -817,7 +817,7 @@ mod tests {
             Some(TrafficType::ProvisionedThroughput)
         ));
 
-        let token_usage = usage.token_usage().unwrap();
+        let token_usage = usage.token_usage();
         assert_eq!(token_usage.input_tokens, 100);
         assert_eq!(token_usage.cached_input_tokens, 25);
         assert_eq!(token_usage.output_tokens, 50);

--- a/crates/rig-core/src/providers/groq.rs
+++ b/crates/rig-core/src/providers/groq.rs
@@ -634,7 +634,7 @@ pub struct StreamingCompletionResponse {
 }
 
 impl GetTokenUsage for StreamingCompletionResponse {
-    fn token_usage(&self) -> Option<crate::completion::Usage> {
+    fn token_usage(&self) -> crate::completion::Usage {
         self.usage.token_usage()
     }
 }

--- a/crates/rig-core/src/providers/huggingface/completion.rs
+++ b/crates/rig-core/src/providers/huggingface/completion.rs
@@ -468,13 +468,13 @@ pub struct Usage {
 }
 
 impl GetTokenUsage for Usage {
-    fn token_usage(&self) -> Option<crate::completion::Usage> {
+    fn token_usage(&self) -> crate::completion::Usage {
         let mut usage = crate::completion::Usage::new();
         usage.input_tokens = self.prompt_tokens as u64;
         usage.output_tokens = self.completion_tokens as u64;
         usage.total_tokens = self.total_tokens as u64;
 
-        Some(usage)
+        usage
     }
 }
 

--- a/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
+++ b/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
@@ -378,9 +378,12 @@ where
         return;
     }
 
-    let Some(usage) = usage.token_usage() else {
+    let usage = usage.token_usage();
+    if usage == crate::completion::Usage::new() {
+        // Zero-valued usage is the documented sentinel for missing provider
+        // usage metrics; leave the span fields unset.
         return;
-    };
+    }
 
     span.record("gen_ai.usage.input_tokens", usage.input_tokens);
     span.record("gen_ai.usage.output_tokens", usage.output_tokens);

--- a/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
+++ b/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
@@ -379,7 +379,7 @@ where
     }
 
     let usage = usage.token_usage();
-    if usage == crate::completion::Usage::new() {
+    if !usage.has_values() {
         // Zero-valued usage is the documented sentinel for missing provider
         // usage metrics; leave the span fields unset.
         return;

--- a/crates/rig-core/src/providers/llamafile.rs
+++ b/crates/rig-core/src/providers/llamafile.rs
@@ -533,7 +533,7 @@ pub struct StreamingCompletionResponse {
 }
 
 impl GetTokenUsage for StreamingCompletionResponse {
-    fn token_usage(&self) -> Option<crate::completion::Usage> {
+    fn token_usage(&self) -> crate::completion::Usage {
         self.usage.token_usage()
     }
 }

--- a/crates/rig-core/src/providers/mistral/completion.rs
+++ b/crates/rig-core/src/providers/mistral/completion.rs
@@ -469,8 +469,10 @@ impl crate::telemetry::ProviderResponseExt for CompletionResponse {
 }
 
 impl GetTokenUsage for CompletionResponse {
-    fn token_usage(&self) -> Option<crate::completion::Usage> {
-        let api_usage = self.usage.as_ref()?;
+    fn token_usage(&self) -> crate::completion::Usage {
+        let Some(api_usage) = self.usage.as_ref() else {
+            return crate::completion::Usage::new();
+        };
 
         let mut usage = crate::completion::Usage::new();
         usage.input_tokens = api_usage.prompt_tokens as u64;
@@ -478,7 +480,7 @@ impl GetTokenUsage for CompletionResponse {
         usage.total_tokens = api_usage.total_tokens as u64;
         usage.cached_input_tokens = api_usage.cached_tokens();
 
-        Some(usage)
+        usage
     }
 }
 
@@ -799,7 +801,7 @@ mod tests {
             }
         }"#;
         let response: CompletionResponse = serde_json::from_str(json).unwrap();
-        let usage = response.token_usage().unwrap();
+        let usage = response.token_usage();
         assert_eq!(usage.input_tokens, 100);
         assert_eq!(usage.output_tokens, 20);
         assert_eq!(usage.total_tokens, 120);

--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -581,7 +581,7 @@ pub struct StreamingCompletionResponse {
 }
 
 impl GetTokenUsage for StreamingCompletionResponse {
-    fn token_usage(&self) -> Option<crate::completion::Usage> {
+    fn token_usage(&self) -> crate::completion::Usage {
         let mut usage = crate::completion::Usage::new();
         let input_tokens = self.prompt_eval_count.unwrap_or_default();
         let output_tokens = self.eval_count.unwrap_or_default();
@@ -589,7 +589,7 @@ impl GetTokenUsage for StreamingCompletionResponse {
         usage.output_tokens = output_tokens;
         usage.total_tokens = input_tokens + output_tokens;
 
-        Some(usage)
+        usage
     }
 }
 

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -1111,8 +1111,8 @@ impl fmt::Display for Usage {
 }
 
 impl GetTokenUsage for Usage {
-    fn token_usage(&self) -> Option<crate::completion::Usage> {
-        Some(crate::providers::internal::completion_usage(
+    fn token_usage(&self) -> crate::completion::Usage {
+        crate::providers::internal::completion_usage(
             self.prompt_tokens as u64,
             (self.total_tokens - self.prompt_tokens) as u64,
             self.total_tokens as u64,
@@ -1120,7 +1120,7 @@ impl GetTokenUsage for Usage {
                 .as_ref()
                 .map(|d| d.cached_tokens as u64)
                 .unwrap_or(0),
-        ))
+        )
     }
 }
 

--- a/crates/rig-core/src/providers/openai/completion/streaming.rs
+++ b/crates/rig-core/src/providers/openai/completion/streaming.rs
@@ -86,7 +86,7 @@ pub struct StreamingCompletionResponse {
 }
 
 impl GetTokenUsage for StreamingCompletionResponse {
-    fn token_usage(&self) -> Option<crate::completion::Usage> {
+    fn token_usage(&self) -> crate::completion::Usage {
         self.usage.token_usage()
     }
 }
@@ -557,7 +557,7 @@ mod tests {
         let usage = final_usage.expect("expected final usage");
         assert_eq!(usage.prompt_tokens, 4);
         assert_eq!(usage.total_tokens, 10);
-        let token_usage = usage.token_usage().expect("usage should convert");
+        let token_usage = usage.token_usage();
         assert_eq!(token_usage.output_tokens, 6);
     }
 
@@ -606,7 +606,7 @@ mod tests {
         );
 
         // Verify core Usage also has cached_input_tokens via GetTokenUsage
-        let core_usage = res.token_usage().expect("token_usage should return Some");
+        let core_usage = res.token_usage();
         assert_eq!(core_usage.cached_input_tokens, 80);
         assert_eq!(core_usage.input_tokens, 100);
         assert_eq!(core_usage.total_tokens, 110);

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -711,8 +711,8 @@ impl ResponsesUsage {
 }
 
 impl GetTokenUsage for ResponsesUsage {
-    fn token_usage(&self) -> Option<crate::completion::Usage> {
-        Some(crate::completion::Usage {
+    fn token_usage(&self) -> crate::completion::Usage {
+        crate::completion::Usage {
             input_tokens: self.input_tokens,
             output_tokens: self.output_tokens,
             total_tokens: self.total_tokens,
@@ -728,7 +728,7 @@ impl GetTokenUsage for ResponsesUsage {
                 .as_ref()
                 .map(|details| details.reasoning_tokens)
                 .unwrap_or(0),
-        })
+        }
     }
 }
 
@@ -1591,7 +1591,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
         let usage = response
             .usage
             .as_ref()
-            .and_then(GetTokenUsage::token_usage)
+            .map(GetTokenUsage::token_usage)
             .unwrap_or_default();
 
         Ok(completion::CompletionResponse {
@@ -2200,7 +2200,7 @@ mod tests {
             total_tokens: 150,
         };
 
-        let token_usage = usage.token_usage().expect("usage should be present");
+        let token_usage = usage.token_usage();
 
         assert_eq!(token_usage.input_tokens, 100);
         assert_eq!(token_usage.cached_input_tokens, 25);
@@ -2223,7 +2223,7 @@ mod tests {
 
         assert!(usage.output_tokens_details.is_none());
 
-        let token_usage = usage.token_usage().expect("usage should be present");
+        let token_usage = usage.token_usage();
 
         assert_eq!(token_usage.input_tokens, 100);
         assert_eq!(token_usage.cached_input_tokens, 25);
@@ -2755,7 +2755,7 @@ mod tests {
         };
 
         let usage = lhs + rhs;
-        let token_usage = usage.token_usage().expect("usage should be present");
+        let token_usage = usage.token_usage();
 
         assert_eq!(token_usage.input_tokens, 13);
         assert_eq!(token_usage.cached_input_tokens, 2);

--- a/crates/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -66,7 +66,7 @@ pub(crate) fn reasoning_choices_from_done_item(
 }
 
 impl GetTokenUsage for StreamingCompletionResponse {
-    fn token_usage(&self) -> Option<crate::completion::Usage> {
+    fn token_usage(&self) -> crate::completion::Usage {
         self.usage.token_usage()
     }
 }
@@ -582,7 +582,7 @@ pub(crate) async fn completion_response_from_sse_body(
         usage: stream
             .response
             .as_ref()
-            .and_then(GetTokenUsage::token_usage)
+            .map(GetTokenUsage::token_usage)
             .unwrap_or_else(|| usage_from_raw_response(&raw_response)),
         message_id: stream
             .message_id
@@ -613,7 +613,7 @@ fn usage_from_raw_response(response: &CompletionResponse) -> completion::Usage {
     response
         .usage
         .as_ref()
-        .and_then(GetTokenUsage::token_usage)
+        .map(GetTokenUsage::token_usage)
         .unwrap_or_default()
 }
 

--- a/crates/rig-core/src/providers/openrouter/client.rs
+++ b/crates/rig-core/src/providers/openrouter/client.rs
@@ -134,13 +134,13 @@ impl std::fmt::Display for Usage {
 }
 
 impl GetTokenUsage for Usage {
-    fn token_usage(&self) -> Option<crate::completion::Usage> {
+    fn token_usage(&self) -> crate::completion::Usage {
         let (cached_input, cache_creation) = self
             .prompt_tokens_details
             .as_ref()
             .map(|d| (d.cached_tokens as u64, d.cache_write_tokens as u64))
             .unwrap_or((0, 0));
-        Some(crate::completion::Usage {
+        crate::completion::Usage {
             input_tokens: self.prompt_tokens as u64,
             output_tokens: self.completion_tokens as u64,
             total_tokens: self.total_tokens as u64,
@@ -148,7 +148,7 @@ impl GetTokenUsage for Usage {
             cache_creation_input_tokens: cache_creation,
             tool_use_prompt_tokens: 0,
             reasoning_tokens: 0,
-        })
+        }
     }
 }
 impl<ApiKey, H> client::ClientBuilder<OpenRouterExtBuilder, ApiKey, H> {

--- a/crates/rig-core/src/providers/openrouter/streaming.rs
+++ b/crates/rig-core/src/providers/openrouter/streaming.rs
@@ -21,7 +21,7 @@ pub struct StreamingCompletionResponse {
 }
 
 impl GetTokenUsage for StreamingCompletionResponse {
-    fn token_usage(&self) -> Option<crate::completion::Usage> {
+    fn token_usage(&self) -> crate::completion::Usage {
         self.usage.token_usage()
     }
 }
@@ -100,13 +100,13 @@ pub struct PromptTokensDetails {
 }
 
 impl GetTokenUsage for Usage {
-    fn token_usage(&self) -> Option<crate::completion::Usage> {
+    fn token_usage(&self) -> crate::completion::Usage {
         let (cached_input, cache_creation) = self
             .prompt_tokens_details
             .as_ref()
             .map(|d| (d.cached_tokens as u64, d.cache_write_tokens as u64))
             .unwrap_or((0, 0));
-        Some(crate::completion::Usage {
+        crate::completion::Usage {
             input_tokens: self.prompt_tokens as u64,
             output_tokens: self.completion_tokens as u64,
             total_tokens: self.total_tokens as u64,
@@ -114,7 +114,7 @@ impl GetTokenUsage for Usage {
             cache_creation_input_tokens: cache_creation,
             tool_use_prompt_tokens: 0,
             reasoning_tokens: 0,
-        })
+        }
     }
 }
 
@@ -424,7 +424,7 @@ mod tests {
 
         let chunk: StreamingCompletionChunk = serde_json::from_value(json).unwrap();
         let usage = chunk.usage.unwrap();
-        let token_usage = usage.token_usage().unwrap();
+        let token_usage = usage.token_usage();
 
         assert_eq!(token_usage.input_tokens, 500);
         assert_eq!(token_usage.output_tokens, 20);
@@ -451,7 +451,7 @@ mod tests {
 
         let chunk: StreamingCompletionChunk = serde_json::from_value(json).unwrap();
         let usage = chunk.usage.unwrap();
-        let token_usage = usage.token_usage().unwrap();
+        let token_usage = usage.token_usage();
 
         assert_eq!(token_usage.cached_input_tokens, 0);
         assert_eq!(token_usage.cache_creation_input_tokens, 0);

--- a/crates/rig-core/src/telemetry/mod.rs
+++ b/crates/rig-core/src/telemetry/mod.rs
@@ -80,7 +80,7 @@ impl SpanCombinator for tracing::Span {
         let usage = usage.token_usage();
         // Zero-valued usage is the documented sentinel for missing provider
         // usage metrics; leave the span fields unset.
-        if usage != crate::completion::Usage::new() {
+        if usage.has_values() {
             self.record("gen_ai.usage.input_tokens", usage.input_tokens);
             self.record("gen_ai.usage.output_tokens", usage.output_tokens);
             self.record(

--- a/crates/rig-core/src/telemetry/mod.rs
+++ b/crates/rig-core/src/telemetry/mod.rs
@@ -77,7 +77,10 @@ impl SpanCombinator for tracing::Span {
             return;
         }
 
-        if let Some(usage) = usage.token_usage() {
+        let usage = usage.token_usage();
+        // Zero-valued usage is the documented sentinel for missing provider
+        // usage metrics; leave the span fields unset.
+        if usage != crate::completion::Usage::new() {
             self.record("gen_ai.usage.input_tokens", usage.input_tokens);
             self.record("gen_ai.usage.output_tokens", usage.output_tokens);
             self.record(
@@ -154,8 +157,8 @@ mod tests {
     struct TestUsage(Usage);
 
     impl GetTokenUsage for TestUsage {
-        fn token_usage(&self) -> Option<Usage> {
-            Some(self.0)
+        fn token_usage(&self) -> Usage {
+            self.0
         }
     }
 

--- a/crates/rig-core/src/test_utils/completion.rs
+++ b/crates/rig-core/src/test_utils/completion.rs
@@ -415,10 +415,10 @@ mod tests {
                 StreamedAssistantContent::Final(response) => {
                     saw_final = matches!(
                         response.token_usage(),
-                        Some(Usage {
+                        Usage {
                             total_tokens: 7,
                             ..
-                        })
+                        }
                     );
                 }
                 _ => {}

--- a/crates/rig-core/src/test_utils/streaming.rs
+++ b/crates/rig-core/src/test_utils/streaming.rs
@@ -10,18 +10,21 @@ use serde::{Deserialize, Serialize};
 /// Raw mock response used by completion and streaming test utilities.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct MockResponse {
-    usage: Option<Usage>,
+    usage: Usage,
 }
 
 impl MockResponse {
-    /// Create a mock raw response without token usage.
+    /// Create a mock raw response without token usage (zero-valued usage,
+    /// [`Usage`]'s documented sentinel for missing provider metrics).
     pub fn new() -> Self {
-        Self { usage: None }
+        Self {
+            usage: Usage::new(),
+        }
     }
 
     /// Create a mock raw response carrying token usage.
     pub fn with_usage(usage: Usage) -> Self {
-        Self { usage: Some(usage) }
+        Self { usage }
     }
 
     /// Create a mock raw response whose usage has only `total_tokens` set.
@@ -33,7 +36,7 @@ impl MockResponse {
 }
 
 impl GetTokenUsage for MockResponse {
-    fn token_usage(&self) -> Option<Usage> {
+    fn token_usage(&self) -> Usage {
         self.usage
     }
 }

--- a/crates/rig-gemini-grpc/src/lib.rs
+++ b/crates/rig-gemini-grpc/src/lib.rs
@@ -38,7 +38,7 @@ pub use proto::{
 
 // Implement GetTokenUsage for proto::GenerateContentResponse to support streaming
 impl rig_core::completion::GetTokenUsage for proto::GenerateContentResponse {
-    fn token_usage(&self) -> Option<rig_core::completion::Usage> {
+    fn token_usage(&self) -> rig_core::completion::Usage {
         self.usage_metadata
             .as_ref()
             .map(|u| rig_core::completion::Usage {
@@ -50,5 +50,6 @@ impl rig_core::completion::GetTokenUsage for proto::GenerateContentResponse {
                 tool_use_prompt_tokens: 0,
                 reasoning_tokens: 0,
             })
+            .unwrap_or_default()
     }
 }

--- a/crates/rig-vertexai/src/completion.rs
+++ b/crates/rig-vertexai/src/completion.rs
@@ -38,8 +38,8 @@ pub struct CompletionModel {
 pub struct PlaceholderStreamingResponse;
 
 impl GetTokenUsage for PlaceholderStreamingResponse {
-    fn token_usage(&self) -> Option<rig_core::completion::Usage> {
-        None
+    fn token_usage(&self) -> rig_core::completion::Usage {
+        rig_core::completion::Usage::new()
     }
 }
 

--- a/examples/agent_run_stepping.rs
+++ b/examples/agent_run_stepping.rs
@@ -104,11 +104,16 @@ async fn main() -> Result<()> {
                     outcome = run.resolve_invalid_tool_call(InvalidToolCallHookAction::fail())?;
                 }
             }
-            AgentRunStep::CallTools { calls } => {
+            AgentRunStep::CallTools { .. } => {
                 // The whole run is serializable while tool calls are pending:
-                // persist it here to pause for approval and resume later.
+                // persist it here to pause for approval and resume later —
+                // even in a process that never saw this step. The resumed run
+                // re-emits the pending tool calls from its own state.
                 let suspended = serde_json::to_string(&run)?;
                 let mut run_resumed: AgentRun = serde_json::from_str(&suspended)?;
+                let AgentRunStep::CallTools { calls } = run_resumed.next_step()? else {
+                    anyhow::bail!("resumed run must re-emit the pending tool calls");
+                };
 
                 let mut results = Vec::new();
                 for call in calls {

--- a/examples/agent_run_stepping.rs
+++ b/examples/agent_run_stepping.rs
@@ -1,0 +1,146 @@
+//! Drives the agent loop by hand with the sans-IO [`AgentRun`] state machine.
+//!
+//! `agent.prompt(...)` runs this machine internally; stepping it yourself lets
+//! you inspect every model call, execute tools with your own policy, and —
+//! because the machine is fully serializable between steps — pause a run while
+//! tool calls are pending and resume it later (even in another process).
+//!
+//! Requires `OPENAI_API_KEY`.
+
+use std::collections::BTreeSet;
+
+use anyhow::Result;
+use rig::agent::InvalidToolCallHookAction;
+use rig::agent::run::{AgentRun, AgentRunStep, ModelTurn, ModelTurnOutcome};
+use rig::client::{CompletionClient, ProviderClient};
+use rig::completion::{Completion, ToolDefinition};
+use rig::message::{ToolResultContent, UserContent};
+use rig::providers::openai;
+use rig::tool::Tool;
+use serde::Deserialize;
+use serde_json::json;
+
+#[derive(Deserialize)]
+struct OperationArgs {
+    x: i32,
+    y: i32,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("math error")]
+struct MathError;
+
+struct Add;
+
+impl Tool for Add {
+    const NAME: &'static str = "add";
+    type Error = MathError;
+    type Args = OperationArgs;
+    type Output = i32;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: "add".to_string(),
+            description: "Add x and y together".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "x": { "type": "number", "description": "The first number to add" },
+                    "y": { "type": "number", "description": "The second number to add" }
+                },
+                "required": ["x", "y"]
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        Ok(args.x + args.y)
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let openai = openai::Client::from_env()?;
+    let agent = openai
+        .agent(openai::GPT_4O)
+        .preamble("You are a calculator. Always use the provided tools to compute results.")
+        .tool(Add)
+        .build();
+
+    let mut run = AgentRun::new("What is 2 + 5?").max_turns(2);
+
+    loop {
+        match run.next_step()? {
+            AgentRunStep::CallModel {
+                prompt,
+                history,
+                turn,
+            } => {
+                println!("→ model call #{turn}");
+                let response = agent.completion(prompt, history).await?.send().await?;
+
+                // The tools advertised to the provider for this turn. With
+                // static tools these are the agent's registered tools; agents
+                // with dynamic (RAG) tools would resolve them per turn.
+                let tool_names: BTreeSet<String> = agent
+                    .tool_server_handle
+                    .get_tool_defs(None)
+                    .await?
+                    .into_iter()
+                    .map(|def| def.name)
+                    .collect();
+
+                let mut outcome = run.model_response(ModelTurn::new(
+                    response.message_id.clone(),
+                    response.choice.clone(),
+                    response.usage,
+                    tool_names.clone(),
+                    tool_names,
+                ))?;
+                while let ModelTurnOutcome::NeedsResolution(context) = outcome {
+                    eprintln!("model called unknown tool `{}`", context.tool_name);
+                    // Preserve the agent loop's default fail-fast behavior; a
+                    // driver could instead retry, repair, or skip here.
+                    outcome = run.resolve_invalid_tool_call(InvalidToolCallHookAction::fail())?;
+                }
+            }
+            AgentRunStep::CallTools { calls } => {
+                // The whole run is serializable while tool calls are pending:
+                // persist it here to pause for approval and resume later.
+                let suspended = serde_json::to_string(&run)?;
+                let mut run_resumed: AgentRun = serde_json::from_str(&suspended)?;
+
+                let mut results = Vec::new();
+                for call in calls {
+                    // Tool calls suppressed by invalid tool-call recovery come
+                    // with a pre-resolved result and must not be executed.
+                    if let Some(result) = call.preresolved_result {
+                        results.push(result);
+                        continue;
+                    }
+                    let name = &call.tool_call.function.name;
+                    let args = call.tool_call.function.arguments.to_string();
+                    println!("→ executing {name}({args})");
+                    let output = agent.tool_server_handle.call_tool(name, &args).await?;
+                    results.push(UserContent::tool_result(
+                        call.tool_call.id.clone(),
+                        ToolResultContent::from_tool_output(output),
+                    ));
+                }
+                run_resumed.tool_results(results)?;
+                run = run_resumed;
+            }
+            AgentRunStep::Done(response) => {
+                println!("✓ {}", response.output);
+                println!(
+                    "  {} model call(s), {} total tokens",
+                    response.completion_calls.len(),
+                    response.usage.total_tokens
+                );
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/examples/openai_streaming_per_call_usage.rs
+++ b/examples/openai_streaming_per_call_usage.rs
@@ -127,15 +127,18 @@ async fn main() -> Result<()> {
                     println!();
                     printed_streamed_text = false;
                 }
-                match completion_call.usage {
-                    Some(usage) => print_usage(
+                // Zero-valued usage is Usage's documented sentinel for
+                // "the provider reported no usage metrics".
+                if completion_call.usage != Usage::new() {
+                    print_usage(
                         &format!("completion call {} usage", completion_call.call_index),
-                        usage,
-                    ),
-                    None => println!(
+                        completion_call.usage,
+                    );
+                } else {
+                    println!(
                         "completion call {} usage: not reported",
                         completion_call.call_index
-                    ),
+                    );
                 }
             }
             MultiTurnStreamItem::FinalResponse(response) => {
@@ -151,7 +154,8 @@ async fn main() -> Result<()> {
     print_usage("aggregate agent usage", response.usage());
 
     if let Some(final_completion_call) = response.completion_calls().last().copied() {
-        if let Some(usage) = final_completion_call.usage {
+        let usage = final_completion_call.usage;
+        if usage != Usage::new() {
             print_usage("final completion call usage", usage);
             println!("final prompt/context token length: {}", usage.input_tokens);
         } else {

--- a/examples/openai_streaming_per_call_usage.rs
+++ b/examples/openai_streaming_per_call_usage.rs
@@ -129,7 +129,7 @@ async fn main() -> Result<()> {
                 }
                 // Zero-valued usage is Usage's documented sentinel for
                 // "the provider reported no usage metrics".
-                if completion_call.usage != Usage::new() {
+                if completion_call.usage.has_values() {
                     print_usage(
                         &format!("completion call {} usage", completion_call.call_index),
                         completion_call.usage,
@@ -155,7 +155,7 @@ async fn main() -> Result<()> {
 
     if let Some(final_completion_call) = response.completion_calls().last().copied() {
         let usage = final_completion_call.usage;
-        if usage != Usage::new() {
+        if usage.has_values() {
             print_usage("final completion call usage", usage);
             println!("final prompt/context token length: {}", usage.input_tokens);
         } else {

--- a/tests/providers/anthropic/cassette/prompt_caching.rs
+++ b/tests/providers/anthropic/cassette/prompt_caching.rs
@@ -185,7 +185,7 @@ async fn send_streaming_cache_probe(
         match item.expect("streaming prompt-cached Anthropic item should succeed") {
             StreamedAssistantContent::Text(delta) => text.push_str(&delta.text),
             StreamedAssistantContent::Final(response) => {
-                usage = response.token_usage();
+                usage = Some(response.token_usage());
             }
             _ => {}
         }

--- a/tests/providers/gemini/cassette/interactions_api.rs
+++ b/tests/providers/gemini/cassette/interactions_api.rs
@@ -225,7 +225,7 @@ async fn streaming_interaction() {
                 match chunk.expect("stream chunk should succeed") {
                     StreamedAssistantContent::Text(delta) => text.push_str(&delta.text),
                     StreamedAssistantContent::Final(response) => {
-                        saw_usage = response.token_usage() != rig::completion::Usage::new();
+                        saw_usage = response.token_usage().has_values();
                     }
                     _ => {}
                 }
@@ -262,7 +262,7 @@ async fn streaming_final_metadata_exposes_model_version() {
                     StreamedAssistantContent::Text(delta) => text.push_str(&delta.text),
                     StreamedAssistantContent::Final(response) => {
                         final_response_count += 1;
-                        saw_usage = response.token_usage() != rig::completion::Usage::new();
+                        saw_usage = response.token_usage().has_values();
                         final_model_version = response.model_version.clone();
                     }
                     _ => {}

--- a/tests/providers/gemini/cassette/interactions_api.rs
+++ b/tests/providers/gemini/cassette/interactions_api.rs
@@ -225,7 +225,7 @@ async fn streaming_interaction() {
                 match chunk.expect("stream chunk should succeed") {
                     StreamedAssistantContent::Text(delta) => text.push_str(&delta.text),
                     StreamedAssistantContent::Final(response) => {
-                        saw_usage = response.token_usage().is_some();
+                        saw_usage = response.token_usage() != rig::completion::Usage::new();
                     }
                     _ => {}
                 }
@@ -262,7 +262,7 @@ async fn streaming_final_metadata_exposes_model_version() {
                     StreamedAssistantContent::Text(delta) => text.push_str(&delta.text),
                     StreamedAssistantContent::Final(response) => {
                         final_response_count += 1;
-                        saw_usage = response.token_usage().is_some();
+                        saw_usage = response.token_usage() != rig::completion::Usage::new();
                         final_model_version = response.model_version.clone();
                     }
                     _ => {}

--- a/tests/providers/gemini/cassette/streaming.rs
+++ b/tests/providers/gemini/cassette/streaming.rs
@@ -121,8 +121,9 @@ async fn final_metadata_exposes_finish_reason_and_model_version() {
                 Some(gemini::completion::GEMINI_2_5_FLASH),
                 "expected resolved Gemini model version to be surfaced"
             );
-            assert!(
-                final_response.token_usage().is_some(),
+            assert_ne!(
+                final_response.token_usage(),
+                rig::completion::Usage::new(),
                 "expected final response to expose token usage"
             );
         },
@@ -172,9 +173,7 @@ async fn final_metadata_handles_terminal_finish_reason_chunk() {
                 Some(gemini::completion::GEMINI_2_5_FLASH),
                 "expected modelVersion from terminal chunks to be retained"
             );
-            let usage = final_response
-                .token_usage()
-                .expect("expected final response to expose token usage");
+            let usage = final_response.token_usage();
             assert!(
                 usage.input_tokens > 0,
                 "expected positive input token usage, got {usage:?}"

--- a/tests/providers/gemini/cassette/streaming.rs
+++ b/tests/providers/gemini/cassette/streaming.rs
@@ -121,9 +121,8 @@ async fn final_metadata_exposes_finish_reason_and_model_version() {
                 Some(gemini::completion::GEMINI_2_5_FLASH),
                 "expected resolved Gemini model version to be surfaced"
             );
-            assert_ne!(
-                final_response.token_usage(),
-                rig::completion::Usage::new(),
+            assert!(
+                final_response.token_usage().has_values(),
                 "expected final response to expose token usage"
             );
         },


### PR DESCRIPTION
## Summary

Rig currently maintains two parallel hand-written agent loops — the non-streaming one in `PromptRequest::send()` and the streaming one in `StreamingPromptRequest::send()` — which duplicate every turn-level decision (turn counting, invalid tool-call recovery, retry budgets, history threading, usage/completion-call records, memory append) and had already drifted apart.

This PR extracts those decisions into one explicit, steppable, **sans-IO state machine** (`agent::run::AgentRun`) and rewrites both paths as thin drivers over it. The design follows the architecture popularized by pydantic-ai's `pydantic_graph`/`agent.iter()`: the loop is an inspectable, serializable machine rather than a black box, and streaming is the same machine fed by a turn accumulator rather than a second loop.

## Implementation

**`agent::run::AgentRun`** owns every loop *decision* and performs no IO:

- `next_step()` returns `CallModel { prompt, history, turn }` / `CallTools { calls }` / `Done(response)`; drivers perform the IO and feed results back via `model_response(...)` / `tool_results(...)`.
- Invalid tool calls surface as `NeedsResolution(InvalidToolCallContext)` so the async recovery hook stays driver-side while the machine owns fail/retry/repair/skip semantics, the retry budget, `ToolChoice::None` rejection, repair revalidation, and rollback message construction.
- Hooks, conversation memory, GenAI tracing spans, and tool-execution concurrency remain in the drivers at the machine's transition points.
- All inter-step state is `Serialize + Deserialize`: a run can be suspended while tool calls are pending, persisted, and resumed in another process — the building block for human-in-the-loop approval and durable execution. This works for streamed runs too, since the streamed path reuses the same machine states.

**`agent::run::streamed::StreamedTurnAssembler`** is the sans-IO accumulator for streamed turns. It ingests `StreamedAssistantContent` items, tells the driver what to forward to the consumer, buffers argument deltas until tool names validate (replaying them after), quarantines unsigned reasoning deltas, and assembles the same canonical complete turn the non-streaming path feeds the machine. Invalid tool calls still surface mid-stream, so a doomed provider stream is abandoned early exactly as before; the machine's streamed entry points (`resolve_streamed_invalid_tool_call`, `streamed_turn`, `record_streamed_completion_call`) apply the shared recovery semantics with rollback messages built from the partial turn.

Both modules are public: `AgentRun` can be driven by hand (new example `examples/agent_run_stepping.rs`, which also demonstrates pause-by-serialization before tool execution), and any hand-driven run can stream by using `.stream()` plus an assembler on the `CallModel` step.

## Behavior preservation

The full existing test suite passes unchanged — including the entire streaming suite — except two test-`use` lines that moved with relocated helpers. 26 new unit tests drive the machine and assembler directly with no IO, including mid-run serde round-trips for both paths.

Three divergences between the two old loops were resolved toward non-streaming semantics; none were pinned by any test:

- mid-run cancellation errors now carry history including the already-recorded assistant turn;
- streaming `MaxTurnsError::prompt` is the actual pending `Message` instead of a rag-text reconstruction;
- the lost-pending-prompt error string is unified.

Also not replicated: the old streaming loop could double-add usage if a provider emitted two `Final` events (the completion-call record was guarded but the usage aggregation was not).

## Breaking change: usage sentinel removed

This PR now also carries a breaking redesign of usage reporting (commit `3a14497d`), motivated by a review finding on the new machine API. `Usage` already documents zero-valued metrics as the sentinel for "provider supplied no usage", so the `Option<Usage>` layer on `CompletionCall` was a second encoding of the same fact, kept consistent only by a normalization convention that call sites had to remember — and one forgot. Following pydantic-ai's usage design (plain integer monoids; zero is the empty value; request count carried by the per-call records):

- `CompletionCall.usage` is plain `Usage` (zero = unreported). Legacy `"usage": null` payloads still deserialize (JSON-compatible formats only; binary formats that encoded the `Option` tag cannot round-trip pre-change data) — covered by fixtures captured from the previous format, including a suspended `AgentRun` that deserializes and resumes — but the serialized form is now a zero-valued object.
- `GetTokenUsage::token_usage()` returns `Usage` (default when the response carries none) across all providers.
- `reported_usage()` / `CompletionCall::from_reported_usage()` are removed; `AgentRun::record_streamed_completion_call` and `StreamedTurnEvent::Completed` carry plain `Usage`; `PromptResponse::requests()` exposes the request count.
- Telemetry/span recording skips zero-valued usage, preserving the previous unset-fields behavior for unreported metrics.
- Companion-crate tests were migrated too (rig-bedrock's usage tests now assert full equality against constructed `Usage` values, pydantic-ai style). Reviewers should note upstream CI does not build member-crate test targets — the workspace root is itself a package, so root-level cargo commands cover only the `rig` facade; adding `--workspace` to the CI clippy/test jobs is worth a follow-up issue.

If you'd prefer this in its own PR (it is the only breaking part), the usage commits (`3a14497d` and its follow-ups at the tip of the branch) split off cleanly as a unit.

## Size

- streaming implementation: 1,780 → 1,095 lines (tests untouched)
- non-streaming `send()`: ~500-line loop → ~370-line driver
- net: the duplicated loop logic is replaced by one serializable core (`run/mod.rs` + `run/streamed.rs`, ~1,650 lines implementation incl. docs, plus ~900 lines of new unit tests)

## Verification

- `cargo test -p rig-core`: 865 lib + 96 doc tests green
- `cargo clippy -p rig-core --all-targets`: clean (including the deny-level `unreachable`/`indexing_slicing` lints)
- `cargo doc -p rig-core --no-deps`: clean; `cargo fmt --check`: clean
- `--all-features` is broken on current `main` (missing `provider_reasoning` field in OpenAI responses-API test code) independent of this PR; verified against a clean checkout.

Note for maintainers: per CONTRIBUTING this should have a tracking issue — happy to open one with the design write-up if you'd like, or split this into machine + non-streaming and streaming-port PRs if that's easier to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


