### PR TITLE
test(agent): cassette-backed AgentRun coverage against real Gemini turns

### DIFF
--- a/tests/cassettes/gemini/agent_run_recovery/fail_resolution_returns_unknown_tool_call.yaml
+++ b/tests/cassettes/gemini/agent_run_recovery/fail_resolution_returns_unknown_tool_call.yaml
@@ -1,0 +1,18 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"What is 21 + 21? Use the add tool.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":{"functionCallingConfig":{"mode":"ANY"}},"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":21,"y":21},"name":"add"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":20,"promptTokenCount":109,"promptTokensDetails":[{"modality":"TEXT","tokenCount":109}],"serviceTier":"standard","thoughtsTokenCount":69,"totalTokenCount":198}}'

--- a/tests/cassettes/gemini/agent_run_recovery/repair_renames_tool_call_and_executes_it.yaml
+++ b/tests/cassettes/gemini/agent_run_recovery/repair_renames_tool_call_and_executes_it.yaml
@@ -1,0 +1,37 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the add tool to compute 2 + 3, then state the result.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Add x and y together (alias of add)","name":"sum","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":2,"y":3},"name":"add"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":18,"promptTokenCount":166,"promptTokensDetails":[{"modality":"TEXT","tokenCount":166}],"serviceTier":"standard","thoughtsTokenCount":37,"totalTokenCount":221}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the add tool to compute 2 + 3, then state the result.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":2,"y":3},"name":"sum"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":5}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Add x and y together (alias of add)","name":"sum","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"5"}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_2","usageMetadata":{"candidatesTokenCount":1,"promptTokenCount":197,"promptTokensDetails":[{"modality":"TEXT","tokenCount":197}],"serviceTier":"standard","totalTokenCount":198}}'

--- a/tests/cassettes/gemini/agent_run_recovery/repair_to_disallowed_name_fails_with_unknown_tool_call.yaml
+++ b/tests/cassettes/gemini/agent_run_recovery/repair_to_disallowed_name_fails_with_unknown_tool_call.yaml
@@ -1,0 +1,18 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"What is 21 + 21? Use the add tool.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":{"functionCallingConfig":{"mode":"ANY"}},"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":21,"y":21},"name":"add"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":20,"promptTokenCount":109,"promptTokensDetails":[{"modality":"TEXT","tokenCount":109}],"serviceTier":"standard","thoughtsTokenCount":65,"totalTokenCount":194}}'

--- a/tests/cassettes/gemini/agent_run_recovery/retry_with_exhausted_budget_fails_with_unknown_tool_call.yaml
+++ b/tests/cassettes/gemini/agent_run_recovery/retry_with_exhausted_budget_fails_with_unknown_tool_call.yaml
@@ -1,0 +1,18 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"What is 21 + 21? Use the add tool.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":{"functionCallingConfig":{"mode":"ANY"}},"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":21,"y":21},"name":"add"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":20,"promptTokenCount":109,"promptTokensDetails":[{"modality":"TEXT","tokenCount":109}],"serviceTier":"standard","thoughtsTokenCount":47,"totalTokenCount":176}}'

--- a/tests/cassettes/gemini/agent_run_recovery/skip_suppresses_every_call_in_the_turn.yaml
+++ b/tests/cassettes/gemini/agent_run_recovery/skip_suppresses_every_call_in_the_turn.yaml
@@ -1,0 +1,37 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Compute 3 + 5 and 10 - 4. You MUST call the add tool and the subtract tool together in your first response, as two parallel function calls, then report both results.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":3,"y":5},"name":"add"},"thoughtSignature":"signature_REDACTED_1"},{"functionCall":{"args":{"x":10,"y":4},"name":"subtract"}}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":37,"promptTokenCount":193,"promptTokensDetails":[{"modality":"TEXT","tokenCount":193}],"serviceTier":"standard","thoughtsTokenCount":63,"totalTokenCount":293}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Compute 3 + 5 and 10 - 4. You MUST call the add tool and the subtract tool together in your first response, as two parallel function calls, then report both results.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":3,"y":5},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"},{"functionCall":{"args":{"x":10,"y":4},"name":"subtract"},"thought":false}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":"The add tool is disabled for this request."}},"thought":false},{"functionResponse":{"name":"subtract","response":{"result":"Tool not executed because another tool call in the same assistant turn was invalid."}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"I''m sorry, I wasn''t able to compute 3 + 5 and 10 - 4 because the add and subtract tools are currently disabled.","thoughtSignature":"signature_REDACTED_2"}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_2","usageMetadata":{"candidatesTokenCount":34,"promptTokenCount":276,"promptTokensDetails":[{"modality":"TEXT","tokenCount":276}],"serviceTier":"standard","thoughtsTokenCount":74,"totalTokenCount":384}}'

--- a/tests/cassettes/gemini/agent_run_resume/resume_after_invalid_tool_call_retry_rollback.yaml
+++ b/tests/cassettes/gemini/agent_run_resume/resume_after_invalid_tool_call_retry_rollback.yaml
@@ -1,0 +1,37 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"What is 21 + 21?","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":21,"y":21},"name":"add"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":20,"promptTokenCount":104,"promptTokensDetails":[{"modality":"TEXT","tokenCount":104}],"serviceTier":"standard","thoughtsTokenCount":55,"totalTokenCount":179}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"What is 21 + 21?","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":21,"y":21},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":"Tools are temporarily unavailable. Answer the question directly in plain text without calling any tools."}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"21 + 21 = 42. So the answer is 42.\nThe tools are temporarily unavailable. I cannot answer the question at this time.","thoughtSignature":"signature_REDACTED_2"},{"text":"42"}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_2","usageMetadata":{"candidatesTokenCount":38,"promptTokenCount":153,"promptTokensDetails":[{"modality":"TEXT","tokenCount":153}],"serviceTier":"standard","thoughtsTokenCount":56,"totalTokenCount":247}}'

--- a/tests/cassettes/gemini/agent_run_resume/resume_from_serialized_state_mid_tool_execution.yaml
+++ b/tests/cassettes/gemini/agent_run_resume/resume_from_serialized_state_mid_tool_execution.yaml
@@ -1,0 +1,37 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"What is 21 + 21? Use the add tool.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":21,"y":21},"name":"add"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":20,"promptTokenCount":109,"promptTokensDetails":[{"modality":"TEXT","tokenCount":109}],"serviceTier":"standard","thoughtsTokenCount":47,"totalTokenCount":176}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"What is 21 + 21? Use the add tool.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":21,"y":21},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":42}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"42"}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_2","usageMetadata":{"candidatesTokenCount":2,"promptTokenCount":143,"promptTokensDetails":[{"modality":"TEXT","tokenCount":143}],"serviceTier":"standard","totalTokenCount":145}}'

--- a/tests/cassettes/gemini/agent_run_resume/resume_while_invalid_tool_call_awaits_resolution.yaml
+++ b/tests/cassettes/gemini/agent_run_resume/resume_while_invalid_tool_call_awaits_resolution.yaml
@@ -1,0 +1,37 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"What is 21 + 21? Use the add tool.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":21,"y":21},"name":"add"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":20,"promptTokenCount":109,"promptTokensDetails":[{"modality":"TEXT","tokenCount":109}],"serviceTier":"standard","thoughtsTokenCount":47,"totalTokenCount":176}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"What is 21 + 21? Use the add tool.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":21,"y":21},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":"The add tool is disabled for this request."}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"I''m sorry, the add tool is disabled for this request. Therefore, I cannot calculate 21 + 21.","thoughtSignature":"signature_REDACTED_2"}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_2","usageMetadata":{"candidatesTokenCount":27,"promptTokenCount":150,"promptTokensDetails":[{"modality":"TEXT","tokenCount":150}],"serviceTier":"standard","thoughtsTokenCount":24,"totalTokenCount":201}}'

--- a/tests/cassettes/gemini/agent_run_stepping/hand_driven_multi_turn_tool_run_completes.yaml
+++ b/tests/cassettes/gemini/agent_run_stepping/hand_driven_multi_turn_tool_run_completes.yaml
@@ -1,0 +1,56 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the tools to compute (7 + 4) - 2: first compute 7 + 4 with the add tool, then subtract 2 from that result with the subtract tool, then state the final result.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":7,"y":4},"name":"add"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":18,"promptTokenCount":197,"promptTokensDetails":[{"modality":"TEXT","tokenCount":197}],"serviceTier":"standard","thoughtsTokenCount":55,"totalTokenCount":270}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the tools to compute (7 + 4) - 2: first compute 7 + 4 with the add tool, then subtract 2 from that result with the subtract tool, then state the final result.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":7,"y":4},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":11}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":11,"y":2},"name":"subtract"},"thoughtSignature":"signature_REDACTED_2"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_2","usageMetadata":{"candidatesTokenCount":19,"promptTokenCount":229,"promptTokensDetails":[{"modality":"TEXT","tokenCount":229}],"serviceTier":"standard","thoughtsTokenCount":33,"totalTokenCount":281}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the tools to compute (7 + 4) - 2: first compute 7 + 4 with the add tool, then subtract 2 from that result with the subtract tool, then state the final result.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":7,"y":4},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":11}},"thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":11,"y":2},"name":"subtract"},"thought":false,"thoughtSignature":"signature_REDACTED_2"}],"role":"model"},{"parts":[{"functionResponse":{"name":"subtract","response":{"result":9}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"9","thoughtSignature":"signature_REDACTED_3"}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_3","usageMetadata":{"candidatesTokenCount":1,"promptTokenCount":261,"promptTokensDetails":[{"modality":"TEXT","tokenCount":261}],"serviceTier":"standard","thoughtsTokenCount":20,"totalTokenCount":282}}'

--- a/tests/cassettes/gemini/agent_run_stepping/hand_driven_parallel_tool_calls_arrive_in_one_step.yaml
+++ b/tests/cassettes/gemini/agent_run_stepping/hand_driven_parallel_tool_calls_arrive_in_one_step.yaml
@@ -1,0 +1,37 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Compute 3 + 5 and 10 - 4. You MUST call the add tool and the subtract tool together in your first response, as two parallel function calls, then report both results.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":3,"y":5},"name":"add"},"thoughtSignature":"signature_REDACTED_1"},{"functionCall":{"args":{"x":10,"y":4},"name":"subtract"}}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":37,"promptTokenCount":193,"promptTokensDetails":[{"modality":"TEXT","tokenCount":193}],"serviceTier":"standard","thoughtsTokenCount":99,"totalTokenCount":329}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Compute 3 + 5 and 10 - 4. You MUST call the add tool and the subtract tool together in your first response, as two parallel function calls, then report both results.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":3,"y":5},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"},{"functionCall":{"args":{"x":10,"y":4},"name":"subtract"},"thought":false}],"role":"model"},{"parts":[{"functionResponse":{"name":"subtract","response":{"result":6}},"thought":false},{"functionResponse":{"name":"add","response":{"result":8}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"8\n6","thoughtSignature":"signature_REDACTED_2"}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_2","usageMetadata":{"candidatesTokenCount":3,"promptTokenCount":254,"promptTokensDetails":[{"modality":"TEXT","tokenCount":254}],"serviceTier":"standard","thoughtsTokenCount":53,"totalTokenCount":310}}'

--- a/tests/cassettes/gemini/agent_run_stepping/hand_driven_single_turn_completes.yaml
+++ b/tests/cassettes/gemini/agent_run_stepping/hand_driven_single_turn_completes.yaml
@@ -1,0 +1,18 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"In one or two sentences, explain what Rust programming language is and why memory safety matters.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a concise assistant. Answer directly.","thought":false}],"role":"model"},"toolConfig":null}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"Rust is a systems programming language focused on performance, reliability, and productivity, achieving memory safety without a garbage collector. Memory safety is crucial as it prevents common, severe bugs like buffer overflows and data races that lead to crashes, undefined behavior, and security vulnerabilities."}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":52,"promptTokenCount":29,"promptTokensDetails":[{"modality":"TEXT","tokenCount":29}],"serviceTier":"standard","thoughtsTokenCount":172,"totalTokenCount":253}}'

--- a/tests/cassettes/gemini/agent_run_stepping/max_turns_error_carries_pending_tool_results_message.yaml
+++ b/tests/cassettes/gemini/agent_run_stepping/max_turns_error_carries_pending_tool_results_message.yaml
@@ -1,0 +1,37 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"What is 21 + 21? Use the add tool.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":{"functionCallingConfig":{"mode":"ANY"}},"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":21,"y":21},"name":"add"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":20,"promptTokenCount":109,"promptTokensDetails":[{"modality":"TEXT","tokenCount":109}],"serviceTier":"standard","thoughtsTokenCount":66,"totalTokenCount":195}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"What is 21 + 21? Use the add tool.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":21,"y":21},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":42}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":{"functionCallingConfig":{"mode":"ANY"}},"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":21,"y":21},"name":"add"},"thoughtSignature":"signature_REDACTED_2"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_2","usageMetadata":{"candidatesTokenCount":20,"promptTokenCount":143,"promptTokensDetails":[{"modality":"TEXT","tokenCount":143}],"serviceTier":"standard","thoughtsTokenCount":65,"totalTokenCount":228}}'

--- a/tests/cassettes/gemini/agent_run_streamed/builtin_streaming_cancellation_history_includes_assistant_turn.yaml
+++ b/tests/cassettes/gemini/agent_run_streamed/builtin_streaming_cancellation_history_includes_assistant_turn.yaml
@@ -1,0 +1,20 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"What is 21 + 21? Use the add tool.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":{"functionCallingConfig":{"mode":"ANY"}},"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"args\":{\"x\":21,\"y\":21},\"name\":\"add\"},\"thoughtSignature\":\"signature_REDACTED_1\"}],\"role\":\"model\"},\"finishMessage\":\"Model generated function call(s).\",\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_1\",\"usageMetadata\":{\"candidatesTokenCount\":20,\"promptTokenCount\":109,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":109}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":68,\"totalTokenCount\":197}}\r\n\r\n"

--- a/tests/cassettes/gemini/agent_run_streamed/builtin_streaming_max_turns_error_carries_pending_message.yaml
+++ b/tests/cassettes/gemini/agent_run_streamed/builtin_streaming_max_turns_error_carries_pending_message.yaml
@@ -1,0 +1,41 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"What is 21 + 21? Use the add tool.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":{"functionCallingConfig":{"mode":"ANY"}},"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"args\":{\"x\":21,\"y\":21},\"name\":\"add\"},\"thoughtSignature\":\"signature_REDACTED_1\"}],\"role\":\"model\"},\"finishMessage\":\"Model generated function call(s).\",\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_1\",\"usageMetadata\":{\"candidatesTokenCount\":20,\"promptTokenCount\":109,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":109}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":50,\"totalTokenCount\":179}}\r\n\r\n"
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"What is 21 + 21? Use the add tool.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":21,"y":21},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":42}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":{"functionCallingConfig":{"mode":"ANY"}},"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"args\":{\"x\":21,\"y\":21},\"name\":\"add\"},\"thoughtSignature\":\"signature_REDACTED_2\"}],\"role\":\"model\"},\"finishMessage\":\"Model generated function call(s).\",\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_2\",\"usageMetadata\":{\"candidatesTokenCount\":20,\"promptTokenCount\":193,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":193}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":67,\"totalTokenCount\":280}}\r\n\r\n"

--- a/tests/cassettes/gemini/agent_run_streamed/streamed_hand_driven_multi_turn_run_completes.yaml
+++ b/tests/cassettes/gemini/agent_run_streamed/streamed_hand_driven_multi_turn_run_completes.yaml
@@ -1,0 +1,62 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the tools to compute (7 + 4) - 2: first compute 7 + 4 with the add tool, then subtract 2 from that result with the subtract tool, then state the final result.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"args\":{\"x\":7,\"y\":4},\"name\":\"add\"},\"thoughtSignature\":\"signature_REDACTED_1\"}],\"role\":\"model\"},\"finishMessage\":\"Model generated function call(s).\",\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_1\",\"usageMetadata\":{\"candidatesTokenCount\":18,\"promptTokenCount\":197,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":197}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":114,\"totalTokenCount\":329}}\r\n\r\n"
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the tools to compute (7 + 4) - 2: first compute 7 + 4 with the add tool, then subtract 2 from that result with the subtract tool, then state the final result.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":7,"y":4},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":11}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"args\":{\"x\":11,\"y\":2},\"name\":\"subtract\"},\"thoughtSignature\":\"signature_REDACTED_2\"}],\"role\":\"model\"},\"finishMessage\":\"Model generated function call(s).\",\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_2\",\"usageMetadata\":{\"candidatesTokenCount\":19,\"promptTokenCount\":343,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":343}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":47,\"totalTokenCount\":409}}\r\n\r\n"
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the tools to compute (7 + 4) - 2: first compute 7 + 4 with the add tool, then subtract 2 from that result with the subtract tool, then state the final result.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":7,"y":4},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":11}},"thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":11,"y":2},"name":"subtract"},"thought":false,"thoughtSignature":"signature_REDACTED_2"}],"role":"model"},{"parts":[{"functionResponse":{"name":"subtract","response":{"result":9}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"9\",\"thoughtSignature\":\"signature_REDACTED_3\"}],\"role\":\"model\"},\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_3\",\"usageMetadata\":{\"candidatesTokenCount\":1,\"promptTokenCount\":422,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":422}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":19,\"totalTokenCount\":442}}\r\n\r\n"

--- a/tests/cassettes/gemini/agent_run_streamed/streamed_invalid_tool_call_fails_fast_mid_stream.yaml
+++ b/tests/cassettes/gemini/agent_run_streamed/streamed_invalid_tool_call_fails_fast_mid_stream.yaml
@@ -1,0 +1,20 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"What is 21 + 21? Use the add tool.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":{"functionCallingConfig":{"mode":"ANY"}},"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"args\":{\"x\":21,\"y\":21},\"name\":\"add\"},\"thoughtSignature\":\"signature_REDACTED_1\"}],\"role\":\"model\"},\"finishMessage\":\"Model generated function call(s).\",\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_1\",\"usageMetadata\":{\"candidatesTokenCount\":20,\"promptTokenCount\":109,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":109}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":51,\"totalTokenCount\":180}}\r\n\r\n"

--- a/tests/cassettes/gemini/agent_run_streamed/streamed_repair_continues_the_same_stream.yaml
+++ b/tests/cassettes/gemini/agent_run_streamed/streamed_repair_continues_the_same_stream.yaml
@@ -1,0 +1,41 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the add tool to compute 2 + 3, then state the result.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Add x and y together (alias of add)","name":"sum","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"args\":{\"x\":2,\"y\":3},\"name\":\"add\"},\"thoughtSignature\":\"signature_REDACTED_1\"}],\"role\":\"model\"},\"finishMessage\":\"Model generated function call(s).\",\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_1\",\"usageMetadata\":{\"candidatesTokenCount\":18,\"promptTokenCount\":166,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":166}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":37,\"totalTokenCount\":221}}\r\n\r\n"
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the add tool to compute 2 + 3, then state the result.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":2,"y":3},"name":"sum"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":5}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Add x and y together (alias of add)","name":"sum","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"5\"}],\"role\":\"model\"},\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_2\",\"usageMetadata\":{\"candidatesTokenCount\":1,\"promptTokenCount\":234,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":234}],\"serviceTier\":\"standard\",\"totalTokenCount\":235}}\r\n\r\ndata: {\"candidates\":[{\"content\":{\"role\":\"model\"},\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_2\",\"usageMetadata\":{\"candidatesTokenCount\":1,\"promptTokenCount\":234,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":234}],\"serviceTier\":\"standard\",\"totalTokenCount\":235}}\r\n\r\n"

--- a/tests/cassettes/gemini/agent_run_streamed/streamed_skip_abandons_the_turn_and_recovers.yaml
+++ b/tests/cassettes/gemini/agent_run_streamed/streamed_skip_abandons_the_turn_and_recovers.yaml
@@ -1,0 +1,41 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"What is 21 + 21? Use the add tool.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"args\":{\"x\":21,\"y\":21},\"name\":\"add\"},\"thoughtSignature\":\"signature_REDACTED_1\"}],\"role\":\"model\"},\"finishMessage\":\"Model generated function call(s).\",\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_1\",\"usageMetadata\":{\"candidatesTokenCount\":20,\"promptTokenCount\":109,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":109}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":50,\"totalTokenCount\":179}}\r\n\r\n"
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"What is 21 + 21? Use the add tool.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":21,"y":21},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":"The add tool is disabled for this request."}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"The add tool is disabled for this request. I cannot calculate 21 + 21.\",\"thoughtSignature\":\"signature_REDACTED_2\"}],\"role\":\"model\"},\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_2\",\"usageMetadata\":{\"candidatesTokenCount\":20,\"promptTokenCount\":200,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":200}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":23,\"totalTokenCount\":243}}\r\n\r\n"

--- a/tests/providers/gemini/agent_run_support.rs
+++ b/tests/providers/gemini/agent_run_support.rs
@@ -1,0 +1,254 @@
+//! Shared fixtures for the `agent_run` cassette suites: the arithmetic tools
+//! advertised to Gemini and helpers for hand-driving the sans-IO
+//! [`AgentRun`](rig::agent::run::AgentRun) state machine.
+#![allow(dead_code)]
+
+use std::collections::BTreeSet;
+
+use rig::agent::CompletionCall;
+use rig::agent::run::{ModelTurn, PendingToolCall};
+use rig::completion::{Completion, ToolDefinition, Usage};
+use rig::message::{AssistantContent, Message, ToolResultContent, UserContent};
+use rig::providers::gemini;
+use rig::tool::Tool;
+use serde::Deserialize;
+use serde_json::json;
+
+pub(crate) type GeminiAgent = rig::agent::Agent<gemini::completion::CompletionModel>;
+
+pub(crate) const FORCE_TOOLS_PREAMBLE: &str = "You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Once you have all the tool results you need, reply with the final numeric answer in plain text.";
+
+#[derive(Deserialize)]
+pub(crate) struct OperationArgs {
+    x: i64,
+    y: i64,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("math error")]
+pub(crate) struct MathError;
+
+fn operation_definition(name: &str, description: &str) -> ToolDefinition {
+    ToolDefinition {
+        name: name.to_string(),
+        description: description.to_string(),
+        parameters: json!({
+            "type": "object",
+            "properties": {
+                "x": { "type": "number", "description": "The first operand" },
+                "y": { "type": "number", "description": "The second operand" }
+            },
+            "required": ["x", "y"]
+        }),
+    }
+}
+
+pub(crate) struct Add;
+
+impl Tool for Add {
+    const NAME: &'static str = "add";
+    type Error = MathError;
+    type Args = OperationArgs;
+    type Output = i64;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        operation_definition(Self::NAME, "Add x and y together")
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        Ok(args.x + args.y)
+    }
+}
+
+pub(crate) struct Subtract;
+
+impl Tool for Subtract {
+    const NAME: &'static str = "subtract";
+    type Error = MathError;
+    type Args = OperationArgs;
+    type Output = i64;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        operation_definition(Self::NAME, "Subtract y from x (i.e. x - y)")
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        Ok(args.x - args.y)
+    }
+}
+
+/// Alias of `add` registered alongside it so invalid tool-call repairs can
+/// rename `add` to `sum` while the recorded wire history stays coherent.
+pub(crate) struct Sum;
+
+impl Tool for Sum {
+    const NAME: &'static str = "sum";
+    type Error = MathError;
+    type Args = OperationArgs;
+    type Output = i64;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        operation_definition(Self::NAME, "Add x and y together (alias of add)")
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        Ok(args.x + args.y)
+    }
+}
+
+pub(crate) fn tool_names(names: &[&str]) -> BTreeSet<String> {
+    names.iter().map(|name| (*name).to_string()).collect()
+}
+
+/// Execute one arithmetic tool call by name, the way a driver would.
+pub(crate) fn execute_arithmetic(name: &str, arguments: &serde_json::Value) -> String {
+    let operand = |key: &str| {
+        arguments
+            .get(key)
+            .and_then(serde_json::Value::as_f64)
+            .unwrap_or_else(|| panic!("tool args should carry `{key}`: {arguments}")) as i64
+    };
+    let (x, y) = (operand("x"), operand("y"));
+    let result = match name {
+        "add" | "sum" => x + y,
+        "subtract" => x - y,
+        other => panic!("unexpected tool `{other}`"),
+    };
+    result.to_string()
+}
+
+/// Answer every pending call: preresolved results pass through unexecuted,
+/// the rest run the arithmetic tools.
+pub(crate) fn execute_pending_calls(calls: &[PendingToolCall]) -> Vec<UserContent> {
+    calls
+        .iter()
+        .map(|call| {
+            if let Some(result) = call.preresolved_result.clone() {
+                return result;
+            }
+            let output = execute_arithmetic(
+                &call.tool_call.function.name,
+                &call.tool_call.function.arguments,
+            );
+            let content = ToolResultContent::from_tool_output(output);
+            match call.tool_call.call_id.clone() {
+                Some(call_id) => UserContent::tool_result_with_call_id(
+                    call.tool_call.id.clone(),
+                    call_id,
+                    content,
+                ),
+                None => UserContent::tool_result(call.tool_call.id.clone(), content),
+            }
+        })
+        .collect()
+}
+
+/// One hand-driven, non-streamed model call: send the step's prompt and
+/// history through the agent's completion builder and shape the response into
+/// a [`ModelTurn`] with the given advertised tool names.
+pub(crate) async fn call_model(
+    agent: &GeminiAgent,
+    prompt: Message,
+    history: Vec<Message>,
+    executable: &BTreeSet<String>,
+    allowed: &BTreeSet<String>,
+) -> ModelTurn {
+    let response = agent
+        .completion(prompt, history)
+        .await
+        .expect("completion request should build")
+        .send()
+        .await
+        .expect("gemini completion should succeed");
+    ModelTurn::new(
+        response.message_id.clone(),
+        response.choice.clone(),
+        response.usage,
+        executable.clone(),
+        allowed.clone(),
+    )
+}
+
+pub(crate) fn assistant_tool_call_names(message: &Message) -> Vec<String> {
+    match message {
+        Message::Assistant { content, .. } => content
+            .iter()
+            .filter_map(|item| match item {
+                AssistantContent::ToolCall(tool_call) => Some(tool_call.function.name.clone()),
+                _ => None,
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+pub(crate) fn history_has_assistant_tool_call(history: &[Message], tool_name: &str) -> bool {
+    history.iter().any(|message| {
+        assistant_tool_call_names(message)
+            .iter()
+            .any(|n| n == tool_name)
+    })
+}
+
+/// Texts of every tool result carried by a user message.
+pub(crate) fn tool_result_texts(message: &Message) -> Vec<String> {
+    let Message::User { content } = message else {
+        return Vec::new();
+    };
+    content
+        .iter()
+        .flat_map(user_content_tool_result_texts)
+        .collect()
+}
+
+pub(crate) fn user_content_tool_result_texts(content: &UserContent) -> Vec<String> {
+    let UserContent::ToolResult(tool_result) = content else {
+        return Vec::new();
+    };
+    tool_result
+        .content
+        .iter()
+        .filter_map(|item| match item {
+            ToolResultContent::Text(text) => Some(text.text.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+pub(crate) fn is_tool_result_user_message(message: &Message) -> bool {
+    matches!(
+        message,
+        Message::User { content }
+            if content.iter().any(|item| matches!(item, UserContent::ToolResult(_)))
+    )
+}
+
+pub(crate) fn sum_completion_call_usage(calls: &[CompletionCall]) -> Usage {
+    let mut total = Usage::new();
+    for call in calls {
+        total += call.usage;
+    }
+    total
+}
+
+/// Assert each assistant message in `messages` records content in canonical
+/// replay order: reasoning blocks, then text, then tool calls.
+pub(crate) fn assert_canonical_assistant_order(messages: &[Message]) {
+    for message in messages {
+        let Message::Assistant { content, .. } = message else {
+            continue;
+        };
+        let kind_rank = |item: &AssistantContent| match item {
+            AssistantContent::Reasoning(_) => 0_u8,
+            AssistantContent::ToolCall(_) => 2,
+            _ => 1,
+        };
+        let ranks: Vec<u8> = content.iter().map(kind_rank).collect();
+        let mut sorted = ranks.clone();
+        sorted.sort_unstable();
+        assert_eq!(
+            ranks, sorted,
+            "assistant content should be in canonical reasoning → text → tool-call order: {message:?}"
+        );
+    }
+}

--- a/tests/providers/gemini/cassette/agent_run_recovery.rs
+++ b/tests/providers/gemini/cassette/agent_run_recovery.rs
@@ -1,0 +1,329 @@
+//! Invalid tool-call recovery on [`AgentRun`] exercised against real Gemini
+//! turns: the model's `add` call is recorded normally on the wire, while the
+//! machine is fed restricted allowed-tool sets to trigger each recovery path
+//! (fail, repair, skip, retry-budget exhaustion, bad repair).
+
+use rig::agent::InvalidToolCallHookAction;
+use rig::agent::run::{AgentRun, AgentRunStep, ModelTurnOutcome};
+use rig::client::CompletionClient;
+use rig::completion::PromptError;
+use rig::message::ToolChoice;
+use rig::providers::gemini;
+
+use super::super::agent_run_support::{
+    Add, FORCE_TOOLS_PREAMBLE, Subtract, Sum, assistant_tool_call_names, call_model,
+    execute_pending_calls, history_has_assistant_tool_call, tool_names,
+    user_content_tool_result_texts,
+};
+use super::super::support::with_gemini_cassette;
+use crate::support::{assert_mentions_expected_number, assert_nonempty_response};
+
+const SKIP_REASON: &str = "The add tool is disabled for this request.";
+
+/// Drive a fresh single-tool run to its first `NeedsResolution`, returning
+/// the run mid-resolution.
+async fn run_until_invalid_add_call(
+    agent: &super::super::agent_run_support::GeminiAgent,
+    allowed: &std::collections::BTreeSet<String>,
+    retries: usize,
+) -> AgentRun {
+    let executable = tool_names(&["add"]);
+    let mut run = AgentRun::new("What is 21 + 21? Use the add tool.")
+        .max_turns(2)
+        .max_invalid_tool_call_retries(retries);
+    let AgentRunStep::CallModel {
+        prompt, history, ..
+    } = run.next_step().expect("run should advance")
+    else {
+        panic!("a fresh run starts with a model call");
+    };
+    let outcome = run
+        .model_response(call_model(agent, prompt, history, &executable, allowed).await)
+        .expect("model turn should be ingested");
+    let ModelTurnOutcome::NeedsResolution(context) = outcome else {
+        panic!("the add call must be rejected for this turn: {outcome:?}");
+    };
+    assert_eq!(context.tool_name, "add");
+    run
+}
+
+#[tokio::test]
+async fn fail_resolution_returns_unknown_tool_call() {
+    with_gemini_cassette(
+        "agent_run_recovery/fail_resolution_returns_unknown_tool_call",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .preamble(FORCE_TOOLS_PREAMBLE)
+                .tool(Add)
+                .tool_choice(ToolChoice::Required)
+                .build();
+
+            let mut run = run_until_invalid_add_call(&agent, &tool_names(&[]), 0).await;
+            let error = run
+                .resolve_invalid_tool_call(InvalidToolCallHookAction::fail())
+                .expect_err("fail resolution must error the run");
+
+            let PromptError::UnknownToolCall {
+                tool_name,
+                available_tools,
+                allowed_tools,
+                chat_history,
+            } = error
+            else {
+                panic!("expected UnknownToolCall, got {error:?}");
+            };
+            assert_eq!(tool_name, "add");
+            assert_eq!(available_tools, vec!["add".to_string()]);
+            assert!(allowed_tools.is_empty());
+            assert!(
+                history_has_assistant_tool_call(&chat_history, "add"),
+                "the diagnostic history must include the rejected assistant turn: {chat_history:?}"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn repair_renames_tool_call_and_executes_it() {
+    with_gemini_cassette(
+        "agent_run_recovery/repair_renames_tool_call_and_executes_it",
+        |client| async move {
+            // `sum` is registered alongside `add` so the post-repair wire
+            // history references a tool Gemini saw advertised.
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .preamble(FORCE_TOOLS_PREAMBLE)
+                .tool(Add)
+                .tool(Sum)
+                .build();
+            let machine_names = tool_names(&["sum"]);
+
+            let mut run =
+                AgentRun::new("Use the add tool to compute 2 + 3, then state the result.")
+                    .max_turns(3);
+            let mut repaired_calls = 0_usize;
+
+            let response = loop {
+                match run.next_step().expect("run should advance") {
+                    AgentRunStep::CallModel {
+                        prompt, history, ..
+                    } => {
+                        let repaired_before = repaired_calls;
+                        let mut outcome = run
+                            .model_response(
+                                call_model(&agent, prompt, history, &machine_names, &machine_names)
+                                    .await,
+                            )
+                            .expect("model turn should be ingested");
+                        while let ModelTurnOutcome::NeedsResolution(context) = outcome {
+                            assert_eq!(context.tool_name, "add");
+                            outcome = run
+                                .resolve_invalid_tool_call(InvalidToolCallHookAction::repair("sum"))
+                                .expect("repair to an allowed tool should be accepted");
+                            repaired_calls += 1;
+                            assert!(repaired_calls < 6, "repair loop did not converge");
+                        }
+                        let ModelTurnOutcome::Continue {
+                            response_hook_suppressed,
+                        } = outcome
+                        else {
+                            panic!("repaired turns continue: {outcome:?}");
+                        };
+                        assert_eq!(
+                            response_hook_suppressed,
+                            repaired_calls > repaired_before,
+                            "exactly the recovered turns suppress the response hook"
+                        );
+                    }
+                    AgentRunStep::CallTools { calls } => {
+                        for call in &calls {
+                            assert_eq!(
+                                call.tool_call.function.name, "sum",
+                                "the repaired name must reach the driver"
+                            );
+                            assert!(call.preresolved_result.is_none());
+                        }
+                        run.tool_results(execute_pending_calls(&calls))
+                            .expect("tool results should be accepted");
+                    }
+                    AgentRunStep::Done(response) => break response,
+                }
+            };
+
+            assert!(repaired_calls >= 1, "at least one call should be repaired");
+            assert_mentions_expected_number(&response.output, 5);
+
+            // The repaired name is what history records; the original name
+            // never reaches the conversation.
+            let messages = response.messages.clone().expect("run reports its messages");
+            let recorded: Vec<String> = messages
+                .iter()
+                .flat_map(assistant_tool_call_names)
+                .collect();
+            assert!(recorded.iter().any(|name| name == "sum"), "{recorded:?}");
+            assert!(
+                !recorded.iter().any(|name| name == "add"),
+                "the unrepaired name must not be recorded: {recorded:?}"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn skip_suppresses_every_call_in_the_turn() {
+    with_gemini_cassette(
+        "agent_run_recovery/skip_suppresses_every_call_in_the_turn",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .preamble(FORCE_TOOLS_PREAMBLE)
+                .tool(Add)
+                .tool(Subtract)
+                .build();
+            let executable = tool_names(&["add", "subtract"]);
+            // `add` is disallowed for the first turn.
+            let restricted = tool_names(&["subtract"]);
+
+            let mut run = AgentRun::new(
+                "Compute 3 + 5 and 10 - 4. You MUST call the add tool and the subtract tool together in your first response, as two parallel function calls, then report both results.",
+            )
+            .max_turns(3);
+            let mut skipped_turn_calls: Option<Vec<String>> = None;
+
+            let response = loop {
+                match run.next_step().expect("run should advance") {
+                    AgentRunStep::CallModel {
+                        prompt, history, ..
+                    } => {
+                        let (allowed, expect_invalid) = if skipped_turn_calls.is_none() {
+                            (&restricted, true)
+                        } else {
+                            (&executable, false)
+                        };
+                        let mut outcome = run
+                            .model_response(
+                                call_model(&agent, prompt, history, &executable, allowed).await,
+                            )
+                            .expect("model turn should be ingested");
+                        if let ModelTurnOutcome::NeedsResolution(context) = outcome {
+                            assert!(expect_invalid, "only the first turn restricts tools");
+                            assert_eq!(context.tool_name, "add");
+                            outcome = run
+                                .resolve_invalid_tool_call(InvalidToolCallHookAction::skip(
+                                    SKIP_REASON,
+                                ))
+                                .expect("skip should be accepted");
+                        }
+                        assert!(matches!(outcome, ModelTurnOutcome::Continue { .. }));
+                    }
+                    AgentRunStep::CallTools { calls } => {
+                        if skipped_turn_calls.is_none() {
+                            // Recovery skipped `add`, so no call in this turn
+                            // may execute: each one is preresolved.
+                            let mut names = Vec::new();
+                            for call in &calls {
+                                names.push(call.tool_call.function.name.clone());
+                                let preresolved = call
+                                    .preresolved_result
+                                    .clone()
+                                    .expect("every call in a skipped turn is preresolved");
+                                let texts = user_content_tool_result_texts(&preresolved);
+                                if call.tool_call.function.name == "add" {
+                                    assert!(
+                                        texts.iter().any(|text| text.contains(SKIP_REASON)),
+                                        "the skipped call carries the hook reason: {texts:?}"
+                                    );
+                                } else {
+                                    assert!(
+                                        texts.iter().any(|text| text
+                                            .contains("another tool call in the same assistant turn was invalid")),
+                                        "peers carry the not-executed marker: {texts:?}"
+                                    );
+                                }
+                            }
+                            skipped_turn_calls = Some(names);
+                        }
+                        run.tool_results(execute_pending_calls(&calls))
+                            .expect("tool results should be accepted");
+                    }
+                    AgentRunStep::Done(response) => break response,
+                }
+            };
+
+            let first_turn = skipped_turn_calls.expect("the model should call tools");
+            assert!(
+                first_turn.iter().any(|name| name == "add"),
+                "the skipped add call still reaches the driver: {first_turn:?}"
+            );
+            assert_nonempty_response(&response.output);
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn retry_with_exhausted_budget_fails_with_unknown_tool_call() {
+    with_gemini_cassette(
+        "agent_run_recovery/retry_with_exhausted_budget_fails_with_unknown_tool_call",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .preamble(FORCE_TOOLS_PREAMBLE)
+                .tool(Add)
+                .tool_choice(ToolChoice::Required)
+                .build();
+
+            // Zero retry budget: the first retry resolution must fail.
+            let mut run = run_until_invalid_add_call(&agent, &tool_names(&[]), 0).await;
+            let error = run
+                .resolve_invalid_tool_call(InvalidToolCallHookAction::retry(
+                    "Try a different tool.",
+                ))
+                .expect_err("retry without budget must error the run");
+
+            let PromptError::UnknownToolCall { tool_name, .. } = error else {
+                panic!("expected UnknownToolCall, got {error:?}");
+            };
+            assert_eq!(tool_name, "add");
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn repair_to_disallowed_name_fails_with_unknown_tool_call() {
+    with_gemini_cassette(
+        "agent_run_recovery/repair_to_disallowed_name_fails_with_unknown_tool_call",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .preamble(FORCE_TOOLS_PREAMBLE)
+                .tool(Add)
+                .tool_choice(ToolChoice::Required)
+                .build();
+
+            let mut run = run_until_invalid_add_call(&agent, &tool_names(&["subtract"]), 0).await;
+            let error = run
+                .resolve_invalid_tool_call(InvalidToolCallHookAction::repair("multiply"))
+                .expect_err("repairing to a disallowed name must error the run");
+
+            let PromptError::UnknownToolCall {
+                tool_name,
+                allowed_tools,
+                ..
+            } = error
+            else {
+                panic!("expected UnknownToolCall, got {error:?}");
+            };
+            assert_eq!(
+                tool_name, "multiply",
+                "the error names the rejected repair target"
+            );
+            assert_eq!(allowed_tools, vec!["subtract".to_string()]);
+        },
+    )
+    .await;
+}

--- a/tests/providers/gemini/cassette/agent_run_resume.rs
+++ b/tests/providers/gemini/cassette/agent_run_resume.rs
@@ -1,0 +1,321 @@
+//! The "serialized state alone" guarantee: an [`AgentRun`] suspended at any
+//! point can be serialized, dropped, deserialized in a fresh context, and
+//! driven to completion against real Gemini turns.
+
+use rig::agent::InvalidToolCallHookAction;
+use rig::agent::run::{AgentRun, AgentRunStep, ModelTurnOutcome};
+use rig::client::CompletionClient;
+use rig::providers::gemini;
+
+use super::super::agent_run_support::{
+    Add, FORCE_TOOLS_PREAMBLE, call_model, execute_pending_calls, history_has_assistant_tool_call,
+    is_tool_result_user_message, tool_names, tool_result_texts,
+};
+use super::super::support::with_gemini_cassette;
+use crate::support::{assert_mentions_expected_number, assert_nonempty_response};
+
+/// Serialize the run, drop it, and bring it back from the JSON alone.
+fn roundtrip(run: AgentRun) -> AgentRun {
+    let suspended = serde_json::to_string(&run).expect("run state should serialize");
+    drop(run);
+    serde_json::from_str(&suspended).expect("run state should deserialize")
+}
+
+#[tokio::test]
+async fn resume_from_serialized_state_mid_tool_execution() {
+    with_gemini_cassette(
+        "agent_run_resume/resume_from_serialized_state_mid_tool_execution",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .preamble(FORCE_TOOLS_PREAMBLE)
+                .tool(Add)
+                .build();
+            let names = tool_names(&["add"]);
+
+            let mut run = AgentRun::new("What is 21 + 21? Use the add tool.").max_turns(2);
+            let pending_calls = loop {
+                match run.next_step().expect("run should advance") {
+                    AgentRunStep::CallModel {
+                        prompt, history, ..
+                    } => {
+                        let outcome = run
+                            .model_response(
+                                call_model(&agent, prompt, history, &names, &names).await,
+                            )
+                            .expect("model turn should be accepted");
+                        assert!(matches!(outcome, ModelTurnOutcome::Continue { .. }));
+                    }
+                    AgentRunStep::CallTools { calls } => break calls,
+                    AgentRunStep::Done(response) => {
+                        panic!("the model should call the add tool before answering: {response:?}")
+                    }
+                }
+            };
+
+            // Suspend while tool calls are pending; resume from the JSON alone.
+            let mut resumed = roundtrip(run);
+            assert!(!resumed.is_done());
+            assert_eq!(resumed.turn(), 1);
+            assert_eq!(resumed.completion_calls().len(), 1);
+
+            // The resumed run re-emits the pending calls from its own state,
+            // idempotently.
+            for attempt in 0..2 {
+                let AgentRunStep::CallTools { calls } =
+                    resumed.next_step().expect("resumed run should advance")
+                else {
+                    panic!("resumed run must re-emit the pending tool calls");
+                };
+                assert_eq!(
+                    calls.len(),
+                    pending_calls.len(),
+                    "attempt {attempt}: resumed pending calls must match the suspended ones"
+                );
+                for (resumed_call, original) in calls.iter().zip(&pending_calls) {
+                    assert_eq!(resumed_call.tool_call.id, original.tool_call.id);
+                    assert_eq!(
+                        resumed_call.tool_call.function.name,
+                        original.tool_call.function.name
+                    );
+                    assert_eq!(
+                        resumed_call.tool_call.function.arguments,
+                        original.tool_call.function.arguments
+                    );
+                }
+            }
+
+            let AgentRunStep::CallTools { calls } =
+                resumed.next_step().expect("resumed run should advance")
+            else {
+                panic!("resumed run must still be executing tools");
+            };
+            resumed
+                .tool_results(execute_pending_calls(&calls))
+                .expect("tool results should be accepted");
+
+            let response = loop {
+                match resumed.next_step().expect("resumed run should advance") {
+                    AgentRunStep::CallModel {
+                        prompt, history, ..
+                    } => {
+                        assert!(
+                            history_has_assistant_tool_call(&history, "add"),
+                            "resumed history must thread the pre-suspension tool call: {history:?}"
+                        );
+                        let outcome = resumed
+                            .model_response(
+                                call_model(&agent, prompt, history, &names, &names).await,
+                            )
+                            .expect("model turn should be accepted");
+                        assert!(matches!(outcome, ModelTurnOutcome::Continue { .. }));
+                    }
+                    AgentRunStep::CallTools { calls } => {
+                        resumed
+                            .tool_results(execute_pending_calls(&calls))
+                            .expect("tool results should be accepted");
+                    }
+                    AgentRunStep::Done(response) => break response,
+                }
+            };
+
+            assert_mentions_expected_number(&response.output, 42);
+            assert_eq!(resumed.completion_calls().len(), resumed.turn());
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn resume_while_invalid_tool_call_awaits_resolution() {
+    with_gemini_cassette(
+        "agent_run_resume/resume_while_invalid_tool_call_awaits_resolution",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .preamble(FORCE_TOOLS_PREAMBLE)
+                .tool(Add)
+                .build();
+            let executable = tool_names(&["add"]);
+            // Machine-side restriction: the model's `add` call is disallowed
+            // for this turn even though it was advertised on the wire.
+            let restricted = tool_names(&["subtract"]);
+
+            let mut run = AgentRun::new("What is 21 + 21? Use the add tool.").max_turns(2);
+            let AgentRunStep::CallModel {
+                prompt, history, ..
+            } = run.next_step().expect("run should advance")
+            else {
+                panic!("a fresh run starts with a model call");
+            };
+            let outcome = run
+                .model_response(call_model(&agent, prompt, history, &executable, &restricted).await)
+                .expect("model turn should be ingested");
+            let ModelTurnOutcome::NeedsResolution(context) = outcome else {
+                panic!("the add call must be rejected for this turn: {outcome:?}");
+            };
+            assert_eq!(context.tool_name, "add");
+            assert!(!context.is_streaming);
+
+            // Suspend mid-resolution; the resumed run re-derives the pending
+            // invalid call from its own state.
+            let mut resumed = roundtrip(run);
+            let rederived = resumed
+                .pending_invalid_tool_call()
+                .expect("resumed run re-derives the pending invalid tool call");
+            assert_eq!(rederived.tool_name, "add");
+            assert_eq!(rederived.available_tools, vec!["add".to_string()]);
+            assert_eq!(rederived.allowed_tools, vec!["subtract".to_string()]);
+
+            let outcome = resumed
+                .resolve_invalid_tool_call(InvalidToolCallHookAction::skip(
+                    "The add tool is disabled for this request.",
+                ))
+                .expect("skip resolution should be accepted");
+            assert!(
+                matches!(
+                    outcome,
+                    ModelTurnOutcome::Continue {
+                        response_hook_suppressed: true
+                    }
+                ),
+                "recovered turns suppress the response hook"
+            );
+
+            // The skipped call comes back preresolved; the driver must not
+            // execute it.
+            let AgentRunStep::CallTools { calls } =
+                resumed.next_step().expect("resumed run should advance")
+            else {
+                panic!("the skipped call must still be answered via CallTools");
+            };
+            assert_eq!(calls.len(), 1);
+            let preresolved = calls
+                .first()
+                .and_then(|call| call.preresolved_result.clone())
+                .expect("skipped calls carry a preresolved result");
+            resumed
+                .tool_results(vec![preresolved])
+                .expect("preresolved results should be accepted");
+
+            let response = loop {
+                match resumed.next_step().expect("resumed run should advance") {
+                    AgentRunStep::CallModel {
+                        prompt, history, ..
+                    } => {
+                        let outcome = resumed
+                            .model_response(
+                                call_model(&agent, prompt, history, &executable, &executable).await,
+                            )
+                            .expect("model turn should be accepted");
+                        assert!(matches!(outcome, ModelTurnOutcome::Continue { .. }));
+                    }
+                    AgentRunStep::CallTools { calls } => {
+                        resumed
+                            .tool_results(execute_pending_calls(&calls))
+                            .expect("tool results should be accepted");
+                    }
+                    AgentRunStep::Done(response) => break response,
+                }
+            };
+            assert_nonempty_response(&response.output);
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn resume_after_invalid_tool_call_retry_rollback() {
+    with_gemini_cassette(
+        "agent_run_resume/resume_after_invalid_tool_call_retry_rollback",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .preamble(FORCE_TOOLS_PREAMBLE)
+                .tool(Add)
+                .build();
+            let executable = tool_names(&["add"]);
+            let nothing_allowed = tool_names(&[]);
+            const FEEDBACK: &str = "Tools are temporarily unavailable. Answer the question directly in plain text without calling any tools.";
+
+            let mut run = AgentRun::new("What is 21 + 21?")
+                .max_turns(3)
+                .max_invalid_tool_call_retries(1);
+            let AgentRunStep::CallModel {
+                prompt, history, ..
+            } = run.next_step().expect("run should advance")
+            else {
+                panic!("a fresh run starts with a model call");
+            };
+            let outcome = run
+                .model_response(
+                    call_model(&agent, prompt, history, &executable, &nothing_allowed).await,
+                )
+                .expect("model turn should be ingested");
+            let ModelTurnOutcome::NeedsResolution(_) = outcome else {
+                panic!("the tool call must be rejected for this turn: {outcome:?}");
+            };
+
+            let outcome = run
+                .resolve_invalid_tool_call(InvalidToolCallHookAction::retry(FEEDBACK))
+                .expect("retry should be accepted within budget");
+            assert!(matches!(outcome, ModelTurnOutcome::TurnRetried));
+
+            // Suspend right after the rollback; resume and take the retry turn.
+            let mut resumed = roundtrip(run);
+            let AgentRunStep::CallModel {
+                prompt,
+                history,
+                turn,
+            } = resumed.next_step().expect("resumed run should advance")
+            else {
+                panic!("a rolled-back run must retry with a model call");
+            };
+            assert_eq!(turn, 2, "the retry consumes multi-turn depth");
+            assert!(
+                history_has_assistant_tool_call(&history, "add"),
+                "the rolled-back assistant turn stays in history: {history:?}"
+            );
+            assert!(
+                is_tool_result_user_message(&prompt),
+                "the retry prompt is the corrective tool-results message: {prompt:?}"
+            );
+            assert!(
+                tool_result_texts(&prompt).iter().any(|text| text.contains(FEEDBACK)),
+                "the retry prompt must carry the hook feedback: {prompt:?}"
+            );
+
+            // Take the retry turn with the full allowed set, then drive the
+            // run to completion normally.
+            let outcome = resumed
+                .model_response(call_model(&agent, prompt, history, &executable, &executable).await)
+                .expect("retry model turn should be accepted");
+            assert!(matches!(outcome, ModelTurnOutcome::Continue { .. }));
+
+            let response = loop {
+                match resumed.next_step().expect("resumed run should advance") {
+                    AgentRunStep::CallModel {
+                        prompt, history, ..
+                    } => {
+                        let outcome = resumed
+                            .model_response(
+                                call_model(&agent, prompt, history, &executable, &executable).await,
+                            )
+                            .expect("model turn should be accepted");
+                        assert!(matches!(outcome, ModelTurnOutcome::Continue { .. }));
+                    }
+                    AgentRunStep::CallTools { calls } => {
+                        resumed
+                            .tool_results(execute_pending_calls(&calls))
+                            .expect("tool results should be accepted");
+                    }
+                    AgentRunStep::Done(response) => break response,
+                }
+            };
+
+            assert_nonempty_response(&response.output);
+            assert!(resumed.completion_calls().len() >= 2);
+        },
+    )
+    .await;
+}

--- a/tests/providers/gemini/cassette/agent_run_stepping.rs
+++ b/tests/providers/gemini/cassette/agent_run_stepping.rs
@@ -1,0 +1,326 @@
+//! Hand-driving the sans-IO [`AgentRun`] state machine against real Gemini
+//! turns: stepping protocol, multi-turn tool threading, parallel tool calls,
+//! and `max_turns` exhaustion.
+
+use rig::agent::run::{AgentRun, AgentRunStep, ModelTurnOutcome};
+use rig::client::CompletionClient;
+use rig::completion::PromptError;
+use rig::message::{Message, ToolChoice, UserContent};
+use rig::providers::gemini;
+
+use super::super::agent_run_support::{
+    Add, FORCE_TOOLS_PREAMBLE, Subtract, call_model, execute_pending_calls,
+    history_has_assistant_tool_call, is_tool_result_user_message, sum_completion_call_usage,
+    tool_names,
+};
+use super::super::support::with_gemini_cassette;
+use crate::support::{
+    BASIC_PREAMBLE, BASIC_PROMPT, assert_mentions_expected_number, assert_nonempty_response,
+};
+
+#[tokio::test]
+async fn hand_driven_single_turn_completes() {
+    with_gemini_cassette(
+        "agent_run_stepping/hand_driven_single_turn_completes",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .preamble(BASIC_PREAMBLE)
+                .build();
+            let names = tool_names(&[]);
+
+            let mut run = AgentRun::new(BASIC_PROMPT);
+            let response = loop {
+                match run.next_step().expect("run should advance") {
+                    AgentRunStep::CallModel {
+                        prompt,
+                        history,
+                        turn,
+                    } => {
+                        assert_eq!(turn, 1, "a tool-free run makes exactly one model call");
+                        assert!(
+                            history.is_empty(),
+                            "first turn of a history-free run starts empty: {history:?}"
+                        );
+                        let outcome = run
+                            .model_response(
+                                call_model(&agent, prompt, history, &names, &names).await,
+                            )
+                            .expect("model turn should be accepted");
+                        assert!(
+                            matches!(
+                                outcome,
+                                ModelTurnOutcome::Continue {
+                                    response_hook_suppressed: false
+                                }
+                            ),
+                            "unrecovered turns must not suppress the response hook"
+                        );
+                    }
+                    AgentRunStep::CallTools { calls } => {
+                        panic!("tool-free run must not request tool execution: {calls:?}")
+                    }
+                    AgentRunStep::Done(response) => break response,
+                }
+            };
+
+            assert_nonempty_response(&response.output);
+            assert!(run.is_done());
+            assert_eq!(
+                run.response()
+                    .expect("done run exposes its response")
+                    .output,
+                response.output
+            );
+            assert_eq!(run.turn(), 1);
+            assert_eq!(response.completion_calls.len(), 1);
+            assert_eq!(run.usage(), response.usage);
+            assert_eq!(
+                sum_completion_call_usage(&response.completion_calls),
+                response.usage,
+                "aggregate usage must equal the sum of per-call usage"
+            );
+            assert!(
+                response.usage.total_tokens > 0,
+                "cassette-recorded usage should be non-zero"
+            );
+
+            let messages = response.messages.clone().expect("run reports its messages");
+            assert_eq!(messages.as_slice(), run.messages());
+            assert_eq!(
+                messages.len(),
+                2,
+                "single turn accumulates [user prompt, assistant reply]: {messages:?}"
+            );
+            assert!(matches!(messages.first(), Some(Message::User { .. })));
+            assert!(matches!(messages.last(), Some(Message::Assistant { .. })));
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn hand_driven_multi_turn_tool_run_completes() {
+    with_gemini_cassette(
+        "agent_run_stepping/hand_driven_multi_turn_tool_run_completes",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .preamble(FORCE_TOOLS_PREAMBLE)
+                .tool(Add)
+                .tool(Subtract)
+                .build();
+            let names = tool_names(&["add", "subtract"]);
+
+            let mut run = AgentRun::new(
+                "Use the tools to compute (7 + 4) - 2: first compute 7 + 4 with the add tool, then subtract 2 from that result with the subtract tool, then state the final result.",
+            )
+            .max_turns(5);
+            let mut executed_tools: Vec<String> = Vec::new();
+
+            let response = loop {
+                match run.next_step().expect("run should advance") {
+                    AgentRunStep::CallModel {
+                        prompt,
+                        history,
+                        turn,
+                    } => {
+                        if turn > 1 {
+                            assert!(
+                                is_tool_result_user_message(&prompt),
+                                "follow-up turns are prompted by the pending tool results: {prompt:?}"
+                            );
+                            assert!(
+                                history.iter().any(|m| matches!(m, Message::Assistant { .. })),
+                                "follow-up history threads the prior assistant turn: {history:?}"
+                            );
+                        }
+                        let outcome = run
+                            .model_response(call_model(&agent, prompt, history, &names, &names).await)
+                            .expect("model turn should be accepted");
+                        assert!(matches!(outcome, ModelTurnOutcome::Continue { .. }));
+                    }
+                    AgentRunStep::CallTools { calls } => {
+                        for call in &calls {
+                            assert!(
+                                call.preresolved_result.is_none(),
+                                "no recovery happened, so no call should be preresolved"
+                            );
+                            assert!(
+                                call.internal_call_id.is_none(),
+                                "non-streamed turns carry no internal call ids"
+                            );
+                            executed_tools.push(call.tool_call.function.name.clone());
+                        }
+                        run.tool_results(execute_pending_calls(&calls))
+                            .expect("tool results should be accepted");
+                    }
+                    AgentRunStep::Done(response) => break response,
+                }
+            };
+
+            assert!(
+                executed_tools.iter().any(|name| name == "add"),
+                "the add tool should run: {executed_tools:?}"
+            );
+            assert!(
+                executed_tools.iter().any(|name| name == "subtract"),
+                "the subtract tool should run: {executed_tools:?}"
+            );
+            assert_mentions_expected_number(&response.output, 9);
+            assert!(run.turn() >= 2, "tool use forces at least two model calls");
+            assert_eq!(
+                response.completion_calls.len(),
+                run.turn(),
+                "every model call records exactly one completion call"
+            );
+            assert_eq!(
+                sum_completion_call_usage(&response.completion_calls),
+                response.usage
+            );
+
+            let messages = response.messages.clone().expect("run reports its messages");
+            assert!(history_has_assistant_tool_call(&messages, "add"));
+            assert!(history_has_assistant_tool_call(&messages, "subtract"));
+            assert!(
+                messages.iter().any(is_tool_result_user_message),
+                "tool results must be threaded into history: {messages:?}"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn hand_driven_parallel_tool_calls_arrive_in_one_step() {
+    with_gemini_cassette(
+        "agent_run_stepping/hand_driven_parallel_tool_calls_arrive_in_one_step",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .preamble(FORCE_TOOLS_PREAMBLE)
+                .tool(Add)
+                .tool(Subtract)
+                .build();
+            let names = tool_names(&["add", "subtract"]);
+
+            let mut run = AgentRun::new(
+                "Compute 3 + 5 and 10 - 4. You MUST call the add tool and the subtract tool together in your first response, as two parallel function calls, then report both results.",
+            )
+            .max_turns(3);
+            let mut first_tool_step: Option<Vec<String>> = None;
+
+            let response = loop {
+                match run.next_step().expect("run should advance") {
+                    AgentRunStep::CallModel {
+                        prompt, history, ..
+                    } => {
+                        let outcome = run
+                            .model_response(call_model(&agent, prompt, history, &names, &names).await)
+                            .expect("model turn should be accepted");
+                        assert!(matches!(outcome, ModelTurnOutcome::Continue { .. }));
+                    }
+                    AgentRunStep::CallTools { calls } => {
+                        if first_tool_step.is_none() {
+                            first_tool_step = Some(
+                                calls
+                                    .iter()
+                                    .map(|call| call.tool_call.function.name.clone())
+                                    .collect(),
+                            );
+                        }
+                        // Deliver results in reverse emission order: the
+                        // machine accepts them in any order.
+                        let mut results = execute_pending_calls(&calls);
+                        results.reverse();
+                        run.tool_results(results)
+                            .expect("tool results in any order should be accepted");
+                    }
+                    AgentRunStep::Done(response) => break response,
+                }
+            };
+
+            let first_step = first_tool_step.expect("the model should call tools");
+            assert_eq!(
+                first_step.len(),
+                2,
+                "both calls should arrive in a single CallTools step: {first_step:?}"
+            );
+            assert!(first_step.iter().any(|name| name == "add"));
+            assert!(first_step.iter().any(|name| name == "subtract"));
+            assert_mentions_expected_number(&response.output, 8);
+            assert_mentions_expected_number(&response.output, 6);
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn max_turns_error_carries_pending_tool_results_message() {
+    with_gemini_cassette(
+        "agent_run_stepping/max_turns_error_carries_pending_tool_results_message",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .preamble(FORCE_TOOLS_PREAMBLE)
+                .tool(Add)
+                .tool_choice(ToolChoice::Required)
+                .build();
+            let names = tool_names(&["add"]);
+
+            // max_turns 0: the run errors once tool results demand a second
+            // model call.
+            let mut run = AgentRun::new("What is 21 + 21? Use the add tool.");
+            let error = loop {
+                match run.next_step() {
+                    Ok(AgentRunStep::CallModel {
+                        prompt, history, ..
+                    }) => {
+                        let outcome = run
+                            .model_response(call_model(&agent, prompt, history, &names, &names).await)
+                            .expect("model turn should be accepted");
+                        assert!(matches!(outcome, ModelTurnOutcome::Continue { .. }));
+                    }
+                    Ok(AgentRunStep::CallTools { calls }) => {
+                        run.tool_results(execute_pending_calls(&calls))
+                            .expect("tool results should be accepted");
+                    }
+                    Ok(AgentRunStep::Done(response)) => {
+                        panic!("run should exhaust max_turns before completing: {response:?}")
+                    }
+                    Err(error) => break error,
+                }
+            };
+
+            let PromptError::MaxTurnsError {
+                max_turns,
+                chat_history,
+                prompt,
+            } = error
+            else {
+                panic!("expected MaxTurnsError, got {error:?}");
+            };
+            assert_eq!(max_turns, 0);
+            // Pins the divergence resolved by #1899: the error carries the
+            // actual pending message (the tool-results user message), not a
+            // reconstruction of its text.
+            assert!(
+                is_tool_result_user_message(&prompt),
+                "MaxTurnsError must carry the pending tool-results message: {prompt:?}"
+            );
+            assert!(
+                matches!(
+                    &*prompt,
+                    Message::User { content }
+                        if content.iter().all(|item| matches!(item, UserContent::ToolResult(_)))
+                ),
+                "the pending message should consist of tool results only: {prompt:?}"
+            );
+            assert!(
+                history_has_assistant_tool_call(&chat_history, "add"),
+                "the error history must include the recorded assistant tool-call turn: {chat_history:?}"
+            );
+        },
+    )
+    .await;
+}

--- a/tests/providers/gemini/cassette/agent_run_streamed.rs
+++ b/tests/providers/gemini/cassette/agent_run_streamed.rs
@@ -1,0 +1,595 @@
+//! Streamed-turn coverage for [`AgentRun`]: hand-driving
+//! [`StreamedTurnAssembler`] over real Gemini SSE streams, mid-stream invalid
+//! tool-call recovery, per-call usage recording, and the built-in streaming
+//! driver divergences pinned by #1899.
+
+use std::collections::{BTreeSet, VecDeque};
+
+use futures::StreamExt;
+use rig::agent::run::{
+    AgentRun, AgentRunStep, StreamedInvalidToolCall, StreamedResolution, StreamedTurnAssembler,
+    StreamedTurnEvent,
+};
+use rig::agent::{
+    HookAction, InvalidToolCallHookAction, MultiTurnStreamItem, PromptHook, StreamingError,
+    ToolCallHookAction,
+};
+use rig::client::CompletionClient;
+use rig::completion::{GetTokenUsage, PromptError, Usage};
+use rig::message::{Message, ToolChoice, ToolResult};
+use rig::providers::gemini;
+use rig::streaming::{StreamedAssistantContent, StreamingCompletion, StreamingPrompt};
+
+use super::super::agent_run_support::{
+    Add, FORCE_TOOLS_PREAMBLE, GeminiAgent, Subtract, Sum, assert_canonical_assistant_order,
+    assistant_tool_call_names, execute_pending_calls, history_has_assistant_tool_call,
+    is_tool_result_user_message, sum_completion_call_usage, tool_names,
+};
+use super::super::support::with_gemini_cassette;
+use crate::support::{assert_mentions_expected_number, assert_nonempty_response};
+
+/// How one hand-driven streamed turn ended.
+#[derive(Debug)]
+enum TurnEnd {
+    /// The turn was assembled and fed to the machine.
+    Finished,
+    /// Mid-stream recovery abandoned the turn (retry or skip).
+    Abandoned {
+        skipped_tool_result: Option<ToolResult>,
+    },
+}
+
+/// Hand-drive one streamed model turn through [`StreamedTurnAssembler`],
+/// mirroring the built-in streaming driver's protocol. Invalid tool calls are
+/// resolved with `on_invalid`'s action; streamed text accumulates into
+/// `collected_text`.
+#[allow(clippy::too_many_arguments)]
+async fn run_streamed_turn(
+    agent: &GeminiAgent,
+    run: &mut AgentRun,
+    prompt: Message,
+    history: Vec<Message>,
+    executable: &BTreeSet<String>,
+    allowed: &BTreeSet<String>,
+    on_invalid: impl Fn(&StreamedInvalidToolCall) -> InvalidToolCallHookAction,
+    collected_text: &mut String,
+) -> Result<TurnEnd, PromptError> {
+    let mut stream = agent
+        .stream_completion(prompt, &history)
+        .await
+        .expect("stream request should build")
+        .stream()
+        .await
+        .expect("gemini stream should open");
+    let mut assembler = StreamedTurnAssembler::new(executable.clone(), allowed.clone());
+    let mut recorded = false;
+
+    while let Some(item) = stream.next().await {
+        let item = item.expect("stream item should be ok");
+        let mut events: VecDeque<StreamedTurnEvent> = assembler
+            .ingest(&item)
+            .expect("ingest should succeed")
+            .into();
+        while let Some(event) = events.pop_front() {
+            match event {
+                StreamedTurnEvent::EmitIngested => {
+                    if let StreamedAssistantContent::Text(text) = &item {
+                        collected_text.push_str(&text.text);
+                    }
+                }
+                StreamedTurnEvent::EmitToolCallDelta { .. } => {}
+                StreamedTurnEvent::Completed { usage, .. } => {
+                    if !recorded {
+                        run.record_streamed_completion_call(usage)
+                            .expect("completion call should record while the turn is pending");
+                        recorded = true;
+                    }
+                }
+                StreamedTurnEvent::InvalidToolCall(invalid) => {
+                    let partial = assembler.partial_turn(stream.message_id.clone());
+                    let context = run.streamed_invalid_tool_call_context(&partial, &invalid);
+                    assert!(context.is_streaming);
+                    assert_eq!(context.tool_name, invalid.tool_call.function.name);
+                    let action = on_invalid(&invalid);
+                    match run.resolve_streamed_invalid_tool_call(&partial, &invalid, action) {
+                        Err(error) => {
+                            // Drain so record mode captures a complete body.
+                            while stream.next().await.is_some() {}
+                            return Err(error);
+                        }
+                        Ok(resolution) => {
+                            let replayed = assembler.resolve_pending_invalid(&resolution);
+                            match resolution {
+                                StreamedResolution::Repaired { .. } => {
+                                    events.extend(replayed);
+                                }
+                                StreamedResolution::TurnAbandoned {
+                                    skipped_tool_result,
+                                } => {
+                                    let drained_usage = drain_stream_usage(&mut stream).await;
+                                    if !recorded {
+                                        run.record_streamed_completion_call(drained_usage).expect(
+                                            "abandoned turns may still record their completion call",
+                                        );
+                                    }
+                                    return Ok(TurnEnd::Abandoned {
+                                        skipped_tool_result,
+                                    });
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(
+        assembler.pending_delta_error().is_none(),
+        "the provider stream should end consistently"
+    );
+    if !recorded {
+        run.record_streamed_completion_call(Usage::new())
+            .expect("turns without provider usage still record a completion call");
+    }
+    let streamed_turn = assembler.finish(stream.message_id.clone(), &stream.choice);
+    run.streamed_turn(streamed_turn)?;
+    Ok(TurnEnd::Finished)
+}
+
+async fn drain_stream_usage<R>(stream: &mut rig::streaming::StreamingCompletionResponse<R>) -> Usage
+where
+    R: Clone + Unpin + GetTokenUsage,
+{
+    while let Some(item) = stream.next().await {
+        if let Ok(StreamedAssistantContent::Final(final_response)) = item {
+            return final_response.token_usage();
+        }
+    }
+    Usage::new()
+}
+
+#[tokio::test]
+async fn streamed_hand_driven_multi_turn_run_completes() {
+    with_gemini_cassette(
+        "agent_run_streamed/streamed_hand_driven_multi_turn_run_completes",
+        |client| async move {
+            // Machine-only guard, no IO: a fresh run has no model call to
+            // record against.
+            let mut fresh = AgentRun::new("unused");
+            assert!(
+                fresh.record_streamed_completion_call(Usage::new()).is_err(),
+                "a phantom completion call must be rejected on a fresh run"
+            );
+
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .preamble(FORCE_TOOLS_PREAMBLE)
+                .tool(Add)
+                .tool(Subtract)
+                .build();
+            let names = tool_names(&["add", "subtract"]);
+
+            let mut run = AgentRun::new(
+                "Use the tools to compute (7 + 4) - 2: first compute 7 + 4 with the add tool, then subtract 2 from that result with the subtract tool, then state the final result.",
+            )
+            .max_turns(5);
+            let mut streamed_text = String::new();
+
+            let response = loop {
+                match run.next_step().expect("run should advance") {
+                    AgentRunStep::CallModel {
+                        prompt, history, ..
+                    } => {
+                        let end = run_streamed_turn(
+                            &agent,
+                            &mut run,
+                            prompt,
+                            history,
+                            &names,
+                            &names,
+                            |invalid| {
+                                panic!("no invalid tool calls expected: {invalid:?}")
+                            },
+                            &mut streamed_text,
+                        )
+                        .await
+                        .expect("streamed turn should be accepted");
+                        assert!(matches!(end, TurnEnd::Finished));
+                    }
+                    AgentRunStep::CallTools { calls } => {
+                        for call in &calls {
+                            assert!(
+                                call.internal_call_id.is_some(),
+                                "streamed turns persist internal call ids: {call:?}"
+                            );
+                        }
+                        run.tool_results(execute_pending_calls(&calls))
+                            .expect("tool results should be accepted");
+                    }
+                    AgentRunStep::Done(response) => break response,
+                }
+            };
+
+            assert_mentions_expected_number(&streamed_text, 9);
+            assert_mentions_expected_number(&response.output, 9);
+            assert!(run.turn() >= 2, "tool use forces at least two model calls");
+            assert_eq!(
+                response.completion_calls.len(),
+                run.turn(),
+                "every streamed model call records exactly one completion call"
+            );
+            assert_eq!(
+                sum_completion_call_usage(&response.completion_calls),
+                response.usage
+            );
+            assert!(
+                response.usage.total_tokens > 0,
+                "cassette-recorded usage should be non-zero"
+            );
+
+            let messages = response.messages.clone().expect("run reports its messages");
+            assert!(history_has_assistant_tool_call(&messages, "add"));
+            assert!(history_has_assistant_tool_call(&messages, "subtract"));
+            // The assembler records streamed turns in canonical replay order.
+            assert_canonical_assistant_order(&messages);
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn streamed_invalid_tool_call_fails_fast_mid_stream() {
+    with_gemini_cassette(
+        "agent_run_streamed/streamed_invalid_tool_call_fails_fast_mid_stream",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .preamble(FORCE_TOOLS_PREAMBLE)
+                .tool(Add)
+                .tool_choice(ToolChoice::Required)
+                .build();
+            let executable = tool_names(&["add"]);
+            let nothing_allowed = tool_names(&[]);
+
+            let mut run = AgentRun::new("What is 21 + 21? Use the add tool.").max_turns(2);
+            let AgentRunStep::CallModel {
+                prompt, history, ..
+            } = run.next_step().expect("run should advance")
+            else {
+                panic!("a fresh run starts with a model call");
+            };
+            let mut streamed_text = String::new();
+            let error = run_streamed_turn(
+                &agent,
+                &mut run,
+                prompt,
+                history,
+                &executable,
+                &nothing_allowed,
+                |invalid| {
+                    assert_eq!(invalid.tool_call.function.name, "add");
+                    InvalidToolCallHookAction::fail()
+                },
+                &mut streamed_text,
+            )
+            .await
+            .expect_err("the disallowed call must fail the run mid-stream");
+
+            let PromptError::UnknownToolCall {
+                tool_name,
+                available_tools,
+                allowed_tools,
+                chat_history,
+            } = error
+            else {
+                panic!("expected UnknownToolCall, got {error:?}");
+            };
+            assert_eq!(tool_name, "add");
+            assert_eq!(available_tools, vec!["add".to_string()]);
+            assert!(allowed_tools.is_empty());
+            assert!(
+                history_has_assistant_tool_call(&chat_history, "add"),
+                "the streamed diagnostic history must include the partial assistant turn: {chat_history:?}"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn streamed_repair_continues_the_same_stream() {
+    with_gemini_cassette(
+        "agent_run_streamed/streamed_repair_continues_the_same_stream",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .preamble(FORCE_TOOLS_PREAMBLE)
+                .tool(Add)
+                .tool(Sum)
+                .build();
+            let machine_names = tool_names(&["sum"]);
+
+            let mut run =
+                AgentRun::new("Use the add tool to compute 2 + 3, then state the result.")
+                    .max_turns(3);
+            let mut streamed_text = String::new();
+            let mut repaired = false;
+
+            let response = loop {
+                match run.next_step().expect("run should advance") {
+                    AgentRunStep::CallModel {
+                        prompt, history, ..
+                    } => {
+                        let end = run_streamed_turn(
+                            &agent,
+                            &mut run,
+                            prompt,
+                            history,
+                            &machine_names,
+                            &machine_names,
+                            |invalid| {
+                                assert_eq!(invalid.tool_call.function.name, "add");
+                                InvalidToolCallHookAction::repair("sum")
+                            },
+                            &mut streamed_text,
+                        )
+                        .await
+                        .expect("the repaired turn should be accepted");
+                        assert!(matches!(end, TurnEnd::Finished));
+                    }
+                    AgentRunStep::CallTools { calls } => {
+                        for call in &calls {
+                            assert_eq!(
+                                call.tool_call.function.name, "sum",
+                                "the repaired name must reach the driver"
+                            );
+                            repaired = true;
+                        }
+                        run.tool_results(execute_pending_calls(&calls))
+                            .expect("tool results should be accepted");
+                    }
+                    AgentRunStep::Done(response) => break response,
+                }
+            };
+
+            assert!(repaired, "the model should call a tool that gets repaired");
+            assert_mentions_expected_number(&response.output, 5);
+            let messages = response.messages.clone().expect("run reports its messages");
+            let recorded: Vec<String> = messages
+                .iter()
+                .flat_map(assistant_tool_call_names)
+                .collect();
+            assert!(
+                !recorded.iter().any(|name| name == "add"),
+                "the unrepaired name must not be recorded: {recorded:?}"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn streamed_skip_abandons_the_turn_and_recovers() {
+    with_gemini_cassette(
+        "agent_run_streamed/streamed_skip_abandons_the_turn_and_recovers",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .preamble(FORCE_TOOLS_PREAMBLE)
+                .tool(Add)
+                .build();
+            let executable = tool_names(&["add"]);
+            let nothing_allowed = tool_names(&[]);
+            const SKIP_REASON: &str = "The add tool is disabled for this request.";
+
+            let mut run = AgentRun::new("What is 21 + 21? Use the add tool.").max_turns(3);
+            let mut streamed_text = String::new();
+            let mut abandoned = false;
+
+            let response = loop {
+                match run.next_step().expect("run should advance") {
+                    AgentRunStep::CallModel {
+                        prompt,
+                        history,
+                        turn,
+                    } => {
+                        let (allowed, expect_abandon) = if abandoned {
+                            (&executable, false)
+                        } else {
+                            (&nothing_allowed, true)
+                        };
+                        if abandoned {
+                            // The rollback messages from the skipped turn are
+                            // already threaded into the retry request.
+                            assert!(
+                                history_has_assistant_tool_call(&history, "add"),
+                                "turn {turn} history should include the abandoned assistant turn: {history:?}"
+                            );
+                            assert!(
+                                is_tool_result_user_message(&prompt),
+                                "the retry prompt is the synthetic tool-results message: {prompt:?}"
+                            );
+                        }
+                        let end = run_streamed_turn(
+                            &agent,
+                            &mut run,
+                            prompt,
+                            history,
+                            &executable,
+                            allowed,
+                            |invalid| {
+                                assert!(expect_abandon, "only the first turn restricts tools");
+                                assert_eq!(invalid.tool_call.function.name, "add");
+                                InvalidToolCallHookAction::skip(SKIP_REASON)
+                            },
+                            &mut streamed_text,
+                        )
+                        .await
+                        .expect("the streamed turn should be accepted");
+                        match end {
+                            TurnEnd::Abandoned {
+                                skipped_tool_result,
+                            } => {
+                                assert!(expect_abandon, "only the first turn should abandon");
+                                let tool_result = skipped_tool_result
+                                    .expect("a skipped call surfaces its synthetic tool result");
+                                assert!(!tool_result.id.is_empty());
+                                abandoned = true;
+                            }
+                            TurnEnd::Finished => {
+                                assert!(!expect_abandon, "the first turn must abandon");
+                            }
+                        }
+                    }
+                    AgentRunStep::CallTools { calls } => {
+                        run.tool_results(execute_pending_calls(&calls))
+                            .expect("tool results should be accepted");
+                    }
+                    AgentRunStep::Done(response) => break response,
+                }
+            };
+
+            assert!(abandoned, "the restricted first turn should be abandoned");
+            assert_nonempty_response(&response.output);
+            assert!(
+                run.completion_calls().len() >= 2,
+                "the abandoned turn still records its completion call"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn builtin_streaming_max_turns_error_carries_pending_message() {
+    with_gemini_cassette(
+        "agent_run_streamed/builtin_streaming_max_turns_error_carries_pending_message",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .preamble(FORCE_TOOLS_PREAMBLE)
+                .tool(Add)
+                .tool_choice(ToolChoice::Required)
+                .build();
+
+            let mut stream = agent
+                .stream_prompt("What is 21 + 21? Use the add tool.")
+                .multi_turn(0)
+                .await;
+
+            let mut prompt_error = None;
+            while let Some(item) = stream.next().await {
+                match item {
+                    Ok(_) => {}
+                    Err(StreamingError::Prompt(error)) => {
+                        prompt_error = Some(*error);
+                        break;
+                    }
+                    Err(other) => panic!("expected a prompt error, got {other:?}"),
+                }
+            }
+
+            let PromptError::MaxTurnsError {
+                max_turns,
+                chat_history,
+                prompt,
+            } = prompt_error.expect("the stream should surface MaxTurnsError")
+            else {
+                panic!("expected MaxTurnsError");
+            };
+            assert_eq!(max_turns, 0);
+            // Pins the divergence resolved by #1899: the streaming error
+            // carries the actual pending tool-results message, not a rag-text
+            // reconstruction of it.
+            assert!(
+                is_tool_result_user_message(&prompt),
+                "MaxTurnsError must carry the pending tool-results message: {prompt:?}"
+            );
+            assert!(
+                history_has_assistant_tool_call(&chat_history, "add"),
+                "the error history must include the assistant tool-call turn: {chat_history:?}"
+            );
+        },
+    )
+    .await;
+}
+
+#[derive(Clone)]
+struct CancelOnToolCall;
+
+impl PromptHook<gemini::completion::CompletionModel> for CancelOnToolCall {
+    async fn on_tool_call(
+        &self,
+        _tool_name: &str,
+        _tool_call_id: Option<String>,
+        _internal_call_id: &str,
+        _args: &str,
+    ) -> ToolCallHookAction {
+        ToolCallHookAction::Terminate {
+            reason: "cancelled by test hook".to_string(),
+        }
+    }
+
+    async fn on_completion_call(&self, _prompt: &Message, _history: &[Message]) -> HookAction {
+        HookAction::cont()
+    }
+}
+
+#[tokio::test]
+async fn builtin_streaming_cancellation_history_includes_assistant_turn() {
+    with_gemini_cassette(
+        "agent_run_streamed/builtin_streaming_cancellation_history_includes_assistant_turn",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .preamble(FORCE_TOOLS_PREAMBLE)
+                .tool(Add)
+                .tool_choice(ToolChoice::Required)
+                .build();
+
+            let mut stream = agent
+                .stream_prompt("What is 21 + 21? Use the add tool.")
+                .with_hook(CancelOnToolCall)
+                .multi_turn(2)
+                .await;
+
+            let mut prompt_error = None;
+            let mut saw_final = false;
+            while let Some(item) = stream.next().await {
+                match item {
+                    Ok(MultiTurnStreamItem::FinalResponse(_)) => saw_final = true,
+                    Ok(_) => {}
+                    Err(StreamingError::Prompt(error)) => {
+                        prompt_error = Some(*error);
+                        break;
+                    }
+                    Err(other) => panic!("expected a prompt error, got {other:?}"),
+                }
+            }
+            assert!(
+                !saw_final,
+                "a cancelled run must not produce a final response"
+            );
+
+            let PromptError::PromptCancelled {
+                chat_history,
+                reason,
+            } = prompt_error.expect("the hook should cancel the run")
+            else {
+                panic!("expected PromptCancelled");
+            };
+            assert!(
+                reason.contains("cancelled by test hook"),
+                "the hook reason must surface: {reason}"
+            );
+            // Pins the divergence resolved by #1899: mid-run cancellation
+            // history includes the already-recorded assistant turn.
+            assert!(
+                history_has_assistant_tool_call(&chat_history, "add"),
+                "cancellation history must include the recorded assistant turn: {chat_history:?}"
+            );
+        },
+    )
+    .await;
+}

--- a/tests/providers/gemini/mod.rs
+++ b/tests/providers/gemini/mod.rs
@@ -1,7 +1,12 @@
+mod agent_run_support;
 mod support;
 
 mod cassette {
     mod agent;
+    mod agent_run_recovery;
+    mod agent_run_resume;
+    mod agent_run_stepping;
+    mod agent_run_streamed;
     mod chat_history;
     mod document_ordering;
     mod embeddings;


### PR DESCRIPTION
Follow-up to #1899, tests only — no production code changes.

#1899 introduced the sans-IO `AgentRun` state machine with unit tests built on synthetic turns. This PR adds 18 cassette-backed tests (Gemini only for now) that exercise the machine and `StreamedTurnAssembler` against real recorded provider traffic — actual parallel function calls, thinking deltas, streaming chunk boundaries, and usage metadata — using the existing `tests/providers/<provider>/cassette` infrastructure.

## Coverage

**`agent_run_stepping`** — hand-driven stepping protocol:
- single- and multi-turn runs driven via `next_step`/`model_response`/`tool_results`, with usage, completion-call, and history-threading assertions
- Gemini parallel tool calls arriving in one `CallTools` step, with results delivered in reverse order (the machine accepts any order)
- `MaxTurnsError` carrying the **actual pending tool-results message** (pins one of the divergences resolved by #1899)

**`agent_run_resume`** — the "serialized state alone" guarantee: serialize the run to JSON, drop it, deserialize in a fresh context, and finish the run, at three suspension points:
- mid-`ExecutingTools`: pending calls re-emitted idempotently from the resumed state
- mid-invalid-resolution: context re-derived via `pending_invalid_tool_call()` after deserialize, then resolved by skip
- after a retry rollback: the corrective feedback message is verified in the retry prompt

**`agent_run_recovery`** — every invalid tool-call recovery path against a real recorded `add` call, triggered by feeding the machine restricted allowed-tool sets while the wire recording stays coherent:
- fail → `UnknownToolCall` with the rejected assistant turn in the diagnostic history
- repair → renamed call reaches the driver and executes; the unrepaired name never enters history; `response_hook_suppressed` is exact per turn
- skip on a parallel-call turn → the skipped call carries the hook reason and the peer call is preresolved with the not-executed marker
- retry with exhausted budget and repair to a disallowed name → `UnknownToolCall`

**`agent_run_streamed`** — hand-driving `StreamedTurnAssembler` over real Gemini SSE, mirroring the built-in driver's protocol:
- full multi-turn streamed run: canonical reasoning → text → tool-call turn assembly, per-call usage recording summing to the run total, internal call IDs persisted into `CallTools`
- mid-stream fail-fast, repair continuing the same stream, and skip abandoning the turn (stream drained for usage, completion call still recorded)
- built-in streaming driver: `MaxTurnsError` carries the pending message instead of a rag-text reconstruction, and mid-run hook cancellation history includes the recorded assistant turn (pins the remaining #1899 divergences)

## Recording / replay

All cassettes were recorded live against `gemini-2.5-flash` and are scrubbed by the existing cassette safety tooling (API key, thought signatures, and response IDs redacted; verified by the committed cassette-safety tests). Replay needs no provider keys:

```bash
cargo test -p rig --all-features --test gemini agent_run -- --test-threads=1
```

Re-record with `RIG_PROVIDER_TEST_MODE=record` and `GEMINI_API_KEY` set.

Verified locally: full gemini target (87 tests) green in replay, `cargo test -p rig --all-features --test core` green, `cargo clippy --workspace --all-targets` and `cargo clippy -p rig --all-features --all-targets` clean.

Happy to extend the same suites to OpenAI/Anthropic cassettes in a follow-up if useful.