### PR TITLE
test: de-flake tracing span tests and deepseek permission_control race

### DIFF
--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -1594,6 +1594,12 @@ mod tests {
     struct CapturedSpans(Arc<Mutex<Vec<CapturedSpan>>>);
 
     impl CapturedSpans {
+        fn clear(&self) {
+            if let Ok(mut spans) = self.0.lock() {
+                spans.clear();
+            }
+        }
+
         fn insert(&self, id: &Id, name: &str, parent_id: Option<u64>) {
             let id = id.into_u64();
             if let Ok(mut spans) = self.0.lock() {
@@ -1663,11 +1669,43 @@ mod tests {
         max_turns: usize,
         expected_usages: &[Usage],
     ) {
+        // Scoped-subscriber tests must not run concurrently; the warm-up
+        // below explains the callsite-interest hazard this guards against.
+        let _isolation = crate::test_utils::scoped_tracing_subscriber_guard().await;
         let spans = CapturedSpans::default();
         let subscriber = Registry::default().with(SpanCaptureLayer {
             spans: spans.clone(),
         });
         let _default = tracing::subscriber::set_default(subscriber);
+
+        // Span callsites in the driver are shared with every other test in
+        // this binary. The FIRST thread to hit a callsite caches its interest
+        // from that thread's dispatcher (`Dispatchers::Rebuilder::JustOne`
+        // consults `dispatcher::get_default`), so a parallel test without a
+        // subscriber can permanently cache `Interest::never` for the very
+        // spans this harness asserts on. Defend in two steps, both under the
+        // isolation guard: (1) warm the whole driver path from THIS thread so
+        // unregistered callsites first-register against this subscriber, then
+        // (2) rebuild the interest cache to heal callsites a foreign thread
+        // already poisoned.
+        let warmup_model = MockCompletionModel::from_stream_turns([[
+            MockStreamEvent::text("warmup"),
+            MockStreamEvent::final_response(Usage::default()),
+        ]]);
+        let warmup_agent = crate::agent::AgentBuilder::new(warmup_model).build();
+        let mut warmup_stream = warmup_agent.stream_prompt("warmup").multi_turn(1).await;
+        while let Some(item) = warmup_stream
+            .try_next()
+            .await
+            .expect("warmup stream should not error")
+        {
+            if matches!(item, MultiTurnStreamItem::FinalResponse(_)) {
+                break;
+            }
+        }
+        tracing::callsite::rebuild_interest_cache();
+        spans.clear();
+
         let empty_history: &[Message] = &[];
         let outer_span = tracing::info_span!("outer");
 

--- a/crates/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -1332,6 +1332,9 @@ mod tests {
             total_tokens: 6,
         });
 
+        // Scoped-subscriber tests must not run concurrently; see
+        // `test_utils::scoped_tracing_subscriber_guard`.
+        let _isolation = crate::test_utils::scoped_tracing_subscriber_guard().await;
         let captured = Arc::new(Mutex::new(Vec::new()));
         let subscriber = tracing_subscriber::fmt()
             .with_max_level(tracing::Level::DEBUG)

--- a/crates/rig-core/src/telemetry/mod.rs
+++ b/crates/rig-core/src/telemetry/mod.rs
@@ -225,6 +225,9 @@ mod tests {
             reasoning_tokens: 5,
         });
 
+        // Scoped-subscriber tests must not run concurrently; see
+        // `test_utils::scoped_tracing_subscriber_guard`.
+        let _isolation = crate::test_utils::scoped_tracing_subscriber_guard_blocking();
         tracing::subscriber::with_default(subscriber, || {
             let span = tracing::info_span!(
                 "usage_recording",

--- a/crates/rig-core/src/test_utils/mod.rs
+++ b/crates/rig-core/src/test_utils/mod.rs
@@ -10,6 +10,7 @@ mod model_listing;
 mod pipeline;
 mod streaming;
 mod tools;
+mod tracing_isolation;
 
 pub use completion::{MockCompletionModel, MockError, MockTurn};
 pub use embeddings::{MockEmbeddingModel, MockMultiTextDocument, MockTextDocument};
@@ -25,4 +26,7 @@ pub use tools::{
     BarrierMockToolIndex, MockAddTool, MockBarrierTool, MockControlledTool, MockExampleTool,
     MockImageGeneratorTool, MockImageOutputTool, MockObjectOutputTool, MockOperationArgs,
     MockStringOutputTool, MockSubtractTool, MockToolError, MockToolIndex, mock_math_toolset,
+};
+pub use tracing_isolation::{
+    scoped_tracing_subscriber_guard, scoped_tracing_subscriber_guard_blocking,
 };

--- a/crates/rig-core/src/test_utils/tracing_isolation.rs
+++ b/crates/rig-core/src/test_utils/tracing_isolation.rs
@@ -1,0 +1,26 @@
+//! Serialization for tests that install scoped tracing subscribers.
+
+use tokio::sync::{Mutex, MutexGuard};
+
+static GUARD: Mutex<()> = Mutex::const_new(());
+
+/// Serializes tests that install scoped tracing subscribers
+/// (`tracing::subscriber::set_default` / `with_default`).
+///
+/// `tracing` caches per-callsite interest globally, and the first thread to
+/// hit a callsite computes that interest from its own thread's dispatcher. A
+/// test running in parallel without a subscriber can therefore cache
+/// `Interest::never` for callsites a span-asserting test relies on, and
+/// dispatcher registration churn rebuilds the cache at arbitrary times. Any
+/// test that installs a scoped subscriber and asserts on captured spans must
+/// hold this guard for the subscriber's whole lifetime (and warm/rebuild the
+/// callsites it asserts on; see `assert_stream_usage_recorded_on_chat_spans`).
+pub async fn scoped_tracing_subscriber_guard() -> MutexGuard<'static, ()> {
+    GUARD.lock().await
+}
+
+/// Blocking variant of [`scoped_tracing_subscriber_guard`] for synchronous
+/// tests.
+pub fn scoped_tracing_subscriber_guard_blocking() -> MutexGuard<'static, ()> {
+    GUARD.blocking_lock()
+}

--- a/tests/providers/deepseek/permission_control.rs
+++ b/tests/providers/deepseek/permission_control.rs
@@ -16,21 +16,30 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use super::support::with_deepseek_cassette_result;
 use crate::support::assert_nonempty_response;
 
-const TEST_FILE: &str = "test.txt";
 const TEST_CONTENT: &str = "hello world\n";
 
-struct FileCleanup;
+/// A per-test fixture file. The two tests in this module run in parallel
+/// within one target, so a shared path would let one test's cleanup race the
+/// other's tool executions. Only the local path is unique; everything on the
+/// wire still says `test.txt`, so the cassettes are unaffected.
+struct FileCleanup {
+    path: std::path::PathBuf,
+}
 
 impl FileCleanup {
-    fn new() -> Result<Self> {
-        std::fs::write(TEST_FILE, TEST_CONTENT)?;
-        Ok(Self)
+    fn new(label: &str) -> Result<Self> {
+        let path = std::env::temp_dir().join(format!(
+            "rig-deepseek-permission-{label}-{}.txt",
+            std::process::id()
+        ));
+        std::fs::write(&path, TEST_CONTENT)?;
+        Ok(Self { path })
     }
 }
 
 impl Drop for FileCleanup {
     fn drop(&mut self) {
-        let _ = std::fs::remove_file(TEST_FILE);
+        let _ = std::fs::remove_file(&self.path);
     }
 }
 
@@ -42,7 +51,10 @@ struct ReadFileArgs {}
 struct FileError;
 
 #[derive(Deserialize, Serialize)]
-struct ReadFileHead;
+struct ReadFileHead {
+    #[serde(skip)]
+    path: std::path::PathBuf,
+}
 
 impl Tool for ReadFileHead {
     const NAME: &'static str = "read_file_head";
@@ -64,7 +76,7 @@ impl Tool for ReadFileHead {
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
         let output = std::process::Command::new("head")
             .arg("-1")
-            .arg(TEST_FILE)
+            .arg(&self.path)
             .output()
             .map_err(|_| FileError)?;
 
@@ -73,7 +85,10 @@ impl Tool for ReadFileHead {
 }
 
 #[derive(Deserialize, Serialize)]
-struct ReadFileTail;
+struct ReadFileTail {
+    #[serde(skip)]
+    path: std::path::PathBuf,
+}
 
 impl Tool for ReadFileTail {
     const NAME: &'static str = "read_file_tail";
@@ -95,7 +110,7 @@ impl Tool for ReadFileTail {
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
         let output = std::process::Command::new("tail")
             .arg("-1")
-            .arg(TEST_FILE)
+            .arg(&self.path)
             .output()
             .map_err(|_| FileError)?;
 
@@ -154,13 +169,17 @@ async fn permission_control_prompt_example() -> Result<()> {
     with_deepseek_cassette_result(
         "permission_control/permission_control_prompt_example",
         |client| async move {
-            let _cleanup = FileCleanup::new()?;
+            let _cleanup = FileCleanup::new("prompt")?;
 
             let agent = client
                 .agent(deepseek::DEEPSEEK_V4_FLASH)
                 .preamble("You are a helpful assistant that can read files using different methods.")
-                .tool(ReadFileHead)
-                .tool(ReadFileTail)
+                .tool(ReadFileHead {
+                    path: _cleanup.path.clone(),
+                })
+                .tool(ReadFileTail {
+                    path: _cleanup.path.clone(),
+                })
                 .build();
 
             let call_count = Arc::new(AtomicUsize::new(0));
@@ -200,13 +219,17 @@ async fn permission_control_streaming_example() -> Result<()> {
     with_deepseek_cassette_result(
         "permission_control/permission_control_streaming_example",
         |client| async move {
-            let _cleanup = FileCleanup::new()?;
+            let _cleanup = FileCleanup::new("streaming")?;
 
             let agent = client
                 .agent(deepseek::DEEPSEEK_V4_FLASH)
                 .preamble("You are a helpful assistant that can read files using different methods.")
-                .tool(ReadFileHead)
-                .tool(ReadFileTail)
+                .tool(ReadFileHead {
+                    path: _cleanup.path.clone(),
+                })
+                .tool(ReadFileTail {
+                    path: _cleanup.path.clone(),
+                })
                 .build();
 
             let call_count = Arc::new(AtomicUsize::new(0));


### PR DESCRIPTION
Two test-reliability fixes carved out of #1902 (a follow-up to #1913). Both are
test-only — no production code, no public API, no runtime behavior change — so
they should be easy to land independently of the larger tool-pipeline work.

## 1. Span-test flakiness from tracing's callsite interest cache

The `stream_prompt_records_*_on_chat_spans_*` tests intermittently captured zero
spans (roughly one full-suite run in three). Root cause: `tracing` computes a
callsite's interest on **first** registration from the registering thread's
dispatcher, so a parallel test running without a subscriber can permanently cache
`Interest::never` for the production callsites these tests assert on.

Fixed by:
- a test-only serialization guard (`scoped_tracing_subscriber_guard` /
  `_blocking`) that every scoped-subscriber test holds for the subscriber's whole
  lifetime, so two such tests never overlap; and
- having the chat-spans harness warm the driver's callsites from its own thread
  and `rebuild_interest_cache()` before asserting, healing any callsite a foreign
  thread already poisoned.

Applied to the affected span/telemetry tests in `agent::prompt_request::streaming`,
`telemetry`, and `providers::openai::responses_api::streaming`.

## 2. deepseek `permission_control` shared-file race

The two `permission_control` tests run in parallel within one target and both used
`./test.txt`, so one test's `FileCleanup` drop could delete the fixture mid-run of
the other. Each test now writes to a unique path under the temp dir. Only the local
path changed; the wire still says `test.txt`, so the cassettes are untouched.

## Test plan

- `cargo test -p rig-core --lib` — 880 passed; ran the full suite 5× back-to-back
  (concurrency stress for the callsite race) with no flakes, and the chat-spans
  test 3× individually.
- `cargo test --test deepseek` — 56 passed in replay, including both
  `permission_control` tests with the new temp paths.
- `cargo clippy -p rig-core --all-targets` and `cargo fmt --check` — clean.
