### PR TITLE
refactor(tool): back ToolSet with an IndexMap instead of HashMap + order Vec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9063,6 +9063,7 @@ dependencies = [
  "glob",
  "http 1.4.0",
  "hyper-util",
+ "indexmap 2.14.0",
  "lopdf",
  "mime",
  "mime_guess",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ google-cloud-aiplatform-v1 = { version = "1.11.0", default-features = false, fea
 http = "1.3.1"
 httpmock = "0.8.3"
 hyper-util = "0.1.14"
+indexmap = "2.14.0"
 indoc = "2.0.6"
 lancedb = { version = "0.30", default-features = false }
 log = "0.4.27"

--- a/crates/rig-core/Cargo.toml
+++ b/crates/rig-core/Cargo.toml
@@ -27,6 +27,7 @@ bytes = { workspace = true }
 epub = { workspace = true, optional = true }
 futures = { workspace = true }
 glob = { workspace = true }
+indexmap = { workspace = true }
 lopdf = { workspace = true, optional = true }
 mime_guess = { workspace = true }
 ordered-float = { workspace = true }

--- a/crates/rig-core/src/tool/mod.rs
+++ b/crates/rig-core/src/tool/mod.rs
@@ -15,6 +15,7 @@ use std::fmt;
 use std::sync::Arc;
 
 use futures::Future;
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -296,15 +297,15 @@ pub enum ToolSetError {
     Interrupted,
 }
 
-/// A struct that holds a set of tools
+/// A struct that holds a set of tools.
+///
+/// Tools are stored in an [`IndexMap`] keyed by name, so iteration
+/// (definitions, documents, schemas) follows registration order and the tool
+/// list sent to providers is deterministic across processes. Re-registering an
+/// existing name replaces the implementation but keeps its original position.
 #[derive(Default)]
 pub struct ToolSet {
-    pub(crate) tools: HashMap<String, ToolType>,
-    /// Tool names in registration order. Iteration (definitions, documents,
-    /// schemas) follows this order so the tool list sent to providers is
-    /// deterministic across processes. Re-registering an existing name
-    /// replaces the implementation but keeps its original position.
-    pub(crate) order: Vec<String>,
+    pub(crate) tools: IndexMap<String, ToolType>,
 }
 
 impl ToolSet {
@@ -348,9 +349,10 @@ impl ToolSet {
 
     pub(crate) fn insert(&mut self, tool: ToolType) {
         let name = tool.name();
-        if self.tools.insert(name.clone(), tool).is_none() {
-            self.order.push(name);
-        } else {
+        // `IndexMap::insert` replaces the value while keeping the existing
+        // slot position, and returns the previous value when the name was
+        // already registered.
+        if self.tools.insert(name.clone(), tool).is_some() {
             tracing::warn!(
                 tool_name = %name,
                 "a tool named {name:?} was already registered; replacing it with the new registration"
@@ -360,19 +362,16 @@ impl ToolSet {
 
     /// Remove a tool by name. Missing tools are ignored.
     pub fn delete_tool(&mut self, tool_name: &str) {
-        if self.tools.remove(tool_name).is_some() {
-            self.order.retain(|name| name != tool_name);
-        }
+        // `shift_remove` preserves the order of the remaining tools;
+        // `swap_remove` would not.
+        self.tools.shift_remove(tool_name);
     }
 
     /// Merge another toolset into this one. Tools keep `toolset`'s
     /// registration order; names that already exist are replaced in place.
     pub fn add_tools(&mut self, toolset: ToolSet) {
-        let ToolSet { mut tools, order } = toolset;
-        for name in order {
-            if let Some(tool) = tools.remove(&name) {
-                self.insert(tool);
-            }
+        for (_, tool) in toolset.tools {
+            self.insert(tool);
         }
     }
 
@@ -382,12 +381,12 @@ impl ToolSet {
 
     /// Tool names in registration order.
     pub(crate) fn ordered_names(&self) -> impl Iterator<Item = &String> {
-        self.order.iter()
+        self.tools.keys()
     }
 
     /// Tools in registration order.
     fn ordered_tools(&self) -> impl Iterator<Item = &ToolType> {
-        self.order.iter().filter_map(|name| self.tools.get(name))
+        self.tools.values()
     }
 
     /// Return definitions for all tools currently registered in the set, in
@@ -528,7 +527,10 @@ mod tests {
         toolset.delete_tool("add");
         assert!(!toolset.contains("add"));
         assert_eq!(toolset.tools.len(), 1);
-        assert_eq!(toolset.order, vec!["subtract".to_string()]);
+        assert_eq!(
+            toolset.ordered_names().cloned().collect::<Vec<_>>(),
+            vec!["subtract".to_string()]
+        );
     }
 
     /// A tool whose name and definition are chosen at runtime, for ordering

--- a/crates/rig-core/src/tool/mod.rs
+++ b/crates/rig-core/src/tool/mod.rs
@@ -594,8 +594,9 @@ mod tests {
 
     #[tokio::test]
     async fn tool_definitions_follow_registration_order() {
-        // Enough names that HashMap iteration order would almost surely
-        // differ from insertion order if ordering regressed.
+        // Enough names that any non-order-preserving storage would almost
+        // surely surface a regression: its iteration order would differ from
+        // insertion order.
         let names: Vec<String> = (0..32).map(|i| format!("tool_{i:02}")).collect();
         let mut toolset = ToolSet::default();
         for name in &names {

--- a/crates/rig-core/src/tool/mod.rs
+++ b/crates/rig-core/src/tool/mod.rs
@@ -533,6 +533,30 @@ mod tests {
         );
     }
 
+    #[test]
+    fn deleting_a_middle_tool_preserves_order_of_survivors() {
+        // Guards the `shift_remove` (not `swap_remove`) choice in `delete_tool`.
+        // `swap_remove` would move the last tool into the deleted slot, so this
+        // only catches a regression with 3+ tools and a non-last deletion: here
+        // a `swap_remove("beta")` would yield [alpha, delta, gamma].
+        let mut toolset = ToolSet::default();
+        for name in ["alpha", "beta", "gamma", "delta"] {
+            toolset.add_tool(named_tool(name, "test tool"));
+        }
+
+        toolset.delete_tool("beta");
+
+        assert_eq!(
+            toolset.ordered_names().cloned().collect::<Vec<_>>(),
+            vec![
+                "alpha".to_string(),
+                "gamma".to_string(),
+                "delta".to_string()
+            ],
+            "survivors must keep their registration order after a middle deletion"
+        );
+    }
+
     /// A tool whose name and definition are chosen at runtime, for ordering
     /// and duplicate-registration tests.
     struct NamedTool {


### PR DESCRIPTION
## Description

`ToolSet` kept a `HashMap<String, ToolType>` alongside a parallel `Vec<String>` (`order`) to make iteration (definitions, documents, schemas) follow registration order. Every mutation — `insert`, `delete_tool`, `add_tools` — was responsible for keeping the two fields in sync, and `ordered_tools` used a `filter_map(|name| self.tools.get(name))` that silently tolerated any drift between them.

This PR replaces both fields with a single `IndexMap<String, ToolType>`, which is an insertion-ordered map by construction. The hand-maintained sync invariant becomes structurally impossible to violate, and the code shrinks.

Behavior is preserved exactly:
- iteration follows registration order;
- duplicate registration replaces the value **in place**, keeping its original position (and still emits the existing `tracing::warn!`);
- `delete_tool` uses `shift_remove` (not `swap_remove`) so the order of the remaining tools is preserved.

`indexmap` is already compiled transitively in the workspace (`2.14.0` per `Cargo.lock`), so promoting it to a direct dependency of `rig-core` adds no new crate to the build graph. There are no public API changes — `tools` stays `pub(crate)` and the only out-of-module consumer (`tool/server.rs`, via `ordered_names()`) is unaffected.

## Type of change

- [x] Refactor / internal change (no functional or API change)

## Testing

- [x] `cargo test -p rig-core tool::` — all 19 tool tests pass (including `tool_definitions_follow_registration_order`, `duplicate_registration_replaces_in_place`, `add_tools_merges_in_order_and_replaces_existing`, `test_tool_deletion`)
- [x] `cargo clippy -p rig-core` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `cargo build -p rig-core --target wasm32-unknown-unknown --no-default-features --features wasm,derive` — builds (IndexMap is no_std/wasm-friendly)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] Existing unit tests pass locally with my changes
- [x] WASM compatibility verified

## Notes

The duplicate-safe, deterministic-ordering behavior this builds on was introduced in #1913; this is purely an internal simplification of how that ordering is stored. Happy to open a tracking issue if the maintainers would prefer one per CONTRIBUTING.md.