### PR TITLE
feat(providers): add VoyageAI rerank support

### DIFF
--- a/crates/rig-core/src/client/mod.rs
+++ b/crates/rig-core/src/client/mod.rs
@@ -6,6 +6,7 @@ pub mod completion;
 pub mod embeddings;
 pub mod image_generation;
 pub mod model_listing;
+pub mod rerank;
 pub mod transcription;
 pub mod verify;
 
@@ -14,6 +15,7 @@ pub use completion::CompletionClient;
 pub use embeddings::EmbeddingsClient;
 use http::{HeaderMap, HeaderName, HeaderValue};
 pub use model_listing::{ModelLister, ModelListingClient};
+pub use rerank::RerankingClient;
 use std::{env::VarError, fmt::Debug, marker::PhantomData, sync::Arc};
 use thiserror::Error;
 pub use verify::{VerifyClient, VerifyError};
@@ -36,6 +38,7 @@ use crate::{
     },
     markers::Missing,
     prelude::TranscriptionClient,
+    rerank::RerankModel,
     transcription::TranscriptionModel,
     wasm_compat::{WasmCompatSend, WasmCompatSync},
 };
@@ -286,6 +289,8 @@ pub trait Capabilities<H = reqwest::Client> {
     type Completion: Capability;
     /// Embedding model capability marker.
     type Embeddings: Capability;
+    /// Rerank model capability marker.
+    type Rerank: Capability;
     /// Audio transcription model capability marker.
     type Transcription: Capability;
     /// Model listing capability marker.
@@ -782,6 +787,18 @@ where
         ndims: usize,
     ) -> Self::EmbeddingModel {
         M::make(self, model, Some(ndims))
+    }
+}
+
+impl<M, Ext, H> RerankingClient for Client<Ext, H>
+where
+    Ext: Capabilities<H, Rerank = Capable<M>>,
+    M: RerankModel<Client = Self>,
+{
+    type RerankModel = M;
+
+    fn rerank_model(&self, model: impl Into<String>) -> Self::RerankModel {
+        M::make(self, model)
     }
 }
 

--- a/crates/rig-core/src/client/rerank.rs
+++ b/crates/rig-core/src/client/rerank.rs
@@ -1,0 +1,10 @@
+use crate::rerank::RerankModel;
+
+/// A provider client with reranking capabilities.
+pub trait RerankingClient {
+    /// The type of [`RerankModel`] used by the Client.
+    type RerankModel: RerankModel;
+
+    /// Create a reranking model with the given model identifier.
+    fn rerank_model(&self, model: impl Into<String>) -> Self::RerankModel;
+}

--- a/crates/rig-core/src/lib.rs
+++ b/crates/rig-core/src/lib.rs
@@ -169,6 +169,7 @@ pub mod one_or_many;
 pub mod pipeline;
 pub mod prelude;
 pub mod providers;
+pub mod rerank;
 
 pub mod streaming;
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/rig-core/src/providers/anthropic/client.rs
+++ b/crates/rig-core/src/providers/anthropic/client.rs
@@ -32,6 +32,7 @@ impl<H> Capabilities<H> for AnthropicExt {
     type ImageGeneration = Nothing;
     #[cfg(feature = "audio")]
     type AudioGeneration = Nothing;
+    type Rerank = Nothing;
 }
 
 #[derive(Debug, Clone)]

--- a/crates/rig-core/src/providers/azure.rs
+++ b/crates/rig-core/src/providers/azure.rs
@@ -106,6 +106,7 @@ impl<H> Capabilities<H> for AzureExt {
     type ImageGeneration = Nothing;
     #[cfg(feature = "audio")]
     type AudioGeneration = Capable<AudioGenerationModel<H>>;
+    type Rerank = Nothing;
 }
 
 impl ProviderBuilder for AzureExtBuilder {

--- a/crates/rig-core/src/providers/chatgpt/mod.rs
+++ b/crates/rig-core/src/providers/chatgpt/mod.rs
@@ -167,6 +167,7 @@ impl<H> Capabilities<H> for ChatGPTExt {
     type ImageGeneration = Nothing;
     #[cfg(feature = "audio")]
     type AudioGeneration = Nothing;
+    type Rerank = Nothing;
 }
 
 impl DebugExt for ChatGPTExt {}

--- a/crates/rig-core/src/providers/cohere/client.rs
+++ b/crates/rig-core/src/providers/cohere/client.rs
@@ -43,6 +43,7 @@ impl<H> Capabilities<H> for CohereExt {
 
     #[cfg(feature = "audio")]
     type AudioGeneration = Nothing;
+    type Rerank = Nothing;
 }
 
 impl DebugExt for CohereExt {}

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -200,6 +200,7 @@ impl<H> Capabilities<H> for CopilotExt {
     type ImageGeneration = Nothing;
     #[cfg(feature = "audio")]
     type AudioGeneration = Nothing;
+    type Rerank = Nothing;
 }
 
 impl DebugExt for CopilotExt {}

--- a/crates/rig-core/src/providers/deepseek.rs
+++ b/crates/rig-core/src/providers/deepseek.rs
@@ -63,6 +63,7 @@ impl<H> Capabilities<H> for DeepSeekExt {
     type ImageGeneration = Nothing;
     #[cfg(feature = "audio")]
     type AudioGeneration = Nothing;
+    type Rerank = Nothing;
 }
 
 impl DebugExt for DeepSeekExt {}

--- a/crates/rig-core/src/providers/galadriel.rs
+++ b/crates/rig-core/src/providers/galadriel.rs
@@ -66,6 +66,7 @@ impl<H> Capabilities<H> for GaladrielExt {
     type ImageGeneration = Nothing;
     #[cfg(feature = "audio")]
     type AudioGeneration = Nothing;
+    type Rerank = Nothing;
 }
 
 impl DebugExt for GaladrielExt {

--- a/crates/rig-core/src/providers/gemini/client.rs
+++ b/crates/rig-core/src/providers/gemini/client.rs
@@ -1,6 +1,6 @@
 use crate::client::{
-    self, ApiKey, Capabilities, Capable, DebugExt, Provider, ProviderBuilder, ProviderClient,
-    Transport,
+    self, ApiKey, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
+    ProviderClient, Transport,
 };
 use crate::http_client::{self};
 use crate::providers::gemini::model_listing::{GeminiInteractionsModelLister, GeminiModelLister};
@@ -122,6 +122,7 @@ impl<H> Capabilities<H> for GeminiExt {
     type ImageGeneration = Capable<super::image_generation::ImageGenerationModel<H>>;
     #[cfg(feature = "audio")]
     type AudioGeneration = Nothing;
+    type Rerank = Nothing;
 }
 
 impl<H> Capabilities<H> for GeminiInteractionsExt {
@@ -134,6 +135,7 @@ impl<H> Capabilities<H> for GeminiInteractionsExt {
     type ImageGeneration = Nothing;
     #[cfg(feature = "audio")]
     type AudioGeneration = Nothing;
+    type Rerank = Nothing;
 }
 
 impl ProviderBuilder for GeminiBuilder {

--- a/crates/rig-core/src/providers/gemini/client.rs
+++ b/crates/rig-core/src/providers/gemini/client.rs
@@ -7,9 +7,6 @@ use crate::providers::gemini::model_listing::{GeminiInteractionsModelLister, Gem
 use serde::Deserialize;
 use std::fmt::Debug;
 
-#[cfg(any(feature = "image", feature = "audio"))]
-use crate::client::Nothing;
-
 // ================================================================
 // Google Gemini Client
 // ================================================================

--- a/crates/rig-core/src/providers/groq.rs
+++ b/crates/rig-core/src/providers/groq.rs
@@ -66,6 +66,7 @@ impl<H> Capabilities<H> for GroqExt {
 
     #[cfg(feature = "audio")]
     type AudioGeneration = Nothing;
+    type Rerank = Nothing;
 }
 
 impl DebugExt for GroqExt {}

--- a/crates/rig-core/src/providers/huggingface/client.rs
+++ b/crates/rig-core/src/providers/huggingface/client.rs
@@ -129,6 +129,7 @@ impl<H> Capabilities<H> for HuggingFaceExt {
 
     #[cfg(feature = "audio")]
     type AudioGeneration = Nothing;
+    type Rerank = Nothing;
 }
 
 impl DebugExt for HuggingFaceExt {

--- a/crates/rig-core/src/providers/hyperbolic.rs
+++ b/crates/rig-core/src/providers/hyperbolic.rs
@@ -54,6 +54,7 @@ impl<H> Capabilities<H> for HyperbolicExt {
     type ImageGeneration = Capable<ImageGenerationModel<H>>;
     #[cfg(feature = "audio")]
     type AudioGeneration = Capable<AudioGenerationModel<H>>;
+    type Rerank = Nothing;
 }
 
 impl DebugExt for HyperbolicExt {}

--- a/crates/rig-core/src/providers/llamafile.rs
+++ b/crates/rig-core/src/providers/llamafile.rs
@@ -71,6 +71,7 @@ impl<H> Capabilities<H> for LlamafileExt {
     type ImageGeneration = Nothing;
     #[cfg(feature = "audio")]
     type AudioGeneration = Nothing;
+    type Rerank = Nothing;
 }
 
 impl DebugExt for LlamafileExt {}

--- a/crates/rig-core/src/providers/minimax.rs
+++ b/crates/rig-core/src/providers/minimax.rs
@@ -99,6 +99,7 @@ impl<H> Capabilities<H> for MiniMaxExt {
     type ImageGeneration = Nothing;
     #[cfg(feature = "audio")]
     type AudioGeneration = Nothing;
+    type Rerank = Nothing;
 }
 
 impl<H> Capabilities<H> for MiniMaxAnthropicExt {
@@ -111,6 +112,7 @@ impl<H> Capabilities<H> for MiniMaxAnthropicExt {
     type ImageGeneration = Nothing;
     #[cfg(feature = "audio")]
     type AudioGeneration = Nothing;
+    type Rerank = Nothing;
 }
 
 impl DebugExt for MiniMaxExt {}

--- a/crates/rig-core/src/providers/mira.rs
+++ b/crates/rig-core/src/providers/mira.rs
@@ -50,6 +50,7 @@ impl<H> Capabilities<H> for MiraExt {
 
     #[cfg(feature = "audio")]
     type AudioGeneration = Nothing;
+    type Rerank = Nothing;
 }
 
 impl DebugExt for MiraExt {}

--- a/crates/rig-core/src/providers/mistral/client.rs
+++ b/crates/rig-core/src/providers/mistral/client.rs
@@ -1,8 +1,6 @@
-#[cfg(any(feature = "image", feature = "audio"))]
-use crate::client::Nothing;
 use crate::{
     client::{
-        self, BearerAuth, Capabilities, Capable, DebugExt, Provider, ProviderBuilder,
+        self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
         ProviderClient,
     },
     http_client,
@@ -40,6 +38,7 @@ impl<H> Capabilities<H> for MistralExt {
 
     #[cfg(feature = "audio")]
     type AudioGeneration = Nothing;
+    type Rerank = Nothing;
 }
 
 impl DebugExt for MistralExt {}

--- a/crates/rig-core/src/providers/moonshot.rs
+++ b/crates/rig-core/src/providers/moonshot.rs
@@ -134,6 +134,7 @@ impl<H> Capabilities<H> for MoonshotExt {
     type ImageGeneration = Nothing;
     #[cfg(feature = "audio")]
     type AudioGeneration = Nothing;
+    type Rerank = Nothing;
 }
 
 impl<H> Capabilities<H> for MoonshotAnthropicExt {
@@ -146,6 +147,7 @@ impl<H> Capabilities<H> for MoonshotAnthropicExt {
     type ImageGeneration = Nothing;
     #[cfg(feature = "audio")]
     type AudioGeneration = Nothing;
+    type Rerank = Nothing;
 }
 
 pub type Client<H = reqwest::Client> = client::Client<MoonshotExt, H>;

--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -127,6 +127,7 @@ impl<H> Capabilities<H> for OllamaExt {
 
     #[cfg(feature = "audio")]
     type AudioGeneration = Nothing;
+    type Rerank = Nothing;
 }
 
 impl DebugExt for OllamaExt {}

--- a/crates/rig-core/src/providers/openai/client.rs
+++ b/crates/rig-core/src/providers/openai/client.rs
@@ -1,6 +1,6 @@
 use crate::{
     client::{
-        self, BearerAuth, Capabilities, Capable, DebugExt, Provider, ProviderBuilder,
+        self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
         ProviderClient,
     },
     extractor::ExtractorBuilder,
@@ -66,6 +66,7 @@ impl<H> Capabilities<H> for OpenAIResponsesExt {
     type ImageGeneration = Capable<super::ImageGenerationModel<H>>;
     #[cfg(feature = "audio")]
     type AudioGeneration = Capable<super::audio_generation::AudioGenerationModel<H>>;
+    type Rerank = Nothing;
 }
 
 impl<H> Capabilities<H> for OpenAICompletionsExt {
@@ -77,6 +78,7 @@ impl<H> Capabilities<H> for OpenAICompletionsExt {
     type ImageGeneration = Capable<super::ImageGenerationModel<H>>;
     #[cfg(feature = "audio")]
     type AudioGeneration = Capable<super::audio_generation::AudioGenerationModel<H>>;
+    type Rerank = Nothing;
 }
 
 impl DebugExt for OpenAIResponsesExt {}

--- a/crates/rig-core/src/providers/openrouter/client.rs
+++ b/crates/rig-core/src/providers/openrouter/client.rs
@@ -1,8 +1,6 @@
-#[cfg(feature = "image")]
-use crate::client::Nothing;
 use crate::{
     client::{
-        self, BearerAuth, Capabilities, Capable, DebugExt, Provider, ProviderBuilder,
+        self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
         ProviderClient,
     },
     completion::GetTokenUsage,
@@ -44,6 +42,7 @@ impl<H> Capabilities<H> for OpenRouterExt {
 
     #[cfg(feature = "audio")]
     type AudioGeneration = Capable<super::audio_generation::AudioGenerationModel<H>>;
+    type Rerank = Nothing;
 }
 
 impl DebugExt for OpenRouterExt {}

--- a/crates/rig-core/src/providers/perplexity.rs
+++ b/crates/rig-core/src/providers/perplexity.rs
@@ -58,6 +58,7 @@ impl<H> Capabilities<H> for PerplexityExt {
 
     #[cfg(feature = "audio")]
     type AudioGeneration = Nothing;
+    type Rerank = Nothing;
 }
 
 impl DebugExt for PerplexityExt {}

--- a/crates/rig-core/src/providers/together/client.rs
+++ b/crates/rig-core/src/providers/together/client.rs
@@ -37,6 +37,7 @@ impl<H> Capabilities<H> for TogetherExt {
     type ImageGeneration = Nothing;
     #[cfg(feature = "audio")]
     type AudioGeneration = Nothing;
+    type Rerank = Nothing;
 }
 
 impl ProviderBuilder for TogetherExtBuilder {

--- a/crates/rig-core/src/providers/voyageai.rs
+++ b/crates/rig-core/src/providers/voyageai.rs
@@ -5,6 +5,8 @@ use crate::client::{
 use crate::embeddings;
 use crate::embeddings::EmbeddingError;
 use crate::http_client::{self, HttpClientExt};
+use crate::rerank;
+use crate::rerank::RerankError;
 use bytes::Bytes;
 use serde::Deserialize;
 use serde_json::json;
@@ -32,6 +34,7 @@ impl Provider for VoyageExt {
 impl<H> Capabilities<H> for VoyageExt {
     type Completion = Nothing;
     type Embeddings = Capable<EmbeddingModel<H>>;
+    type Rerank = Capable<RerankModel<H>>;
     type Transcription = Nothing;
     type ModelListing = Nothing;
     #[cfg(feature = "image")]
@@ -278,6 +281,179 @@ where
         }
     }
 }
+
+// ================================================================
+// Voyage AI Rerank API
+// ================================================================
+
+/// `rerank-2.5` reranker model (Voyage AI)
+pub const RERANK_2_5: &str = "rerank-2.5";
+/// `rerank-2.5-lite` reranker model (Voyage AI)
+pub const RERANK_2_5_LITE: &str = "rerank-2.5-lite";
+/// `rerank-2` reranker model (Voyage AI)
+pub const RERANK_2: &str = "rerank-2";
+/// `rerank-2-lite` reranker model (Voyage AI)
+pub const RERANK_2_LITE: &str = "rerank-2-lite";
+/// `rerank-1` reranker model (Voyage AI)
+pub const RERANK_1: &str = "rerank-1";
+/// `rerank-lite-1` reranker model (Voyage AI)
+pub const RERANK_LITE_1: &str = "rerank-lite-1";
+
+#[derive(Debug, Deserialize)]
+pub struct RerankApiResponse {
+    pub data: Vec<RerankApiData>,
+    pub model: String,
+    pub usage: RerankApiUsage,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RerankApiUsage {
+    pub total_tokens: usize,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RerankApiData {
+    pub index: usize,
+    pub relevance_score: f64,
+    #[serde(default)]
+    pub document: Option<String>,
+}
+
+impl From<ApiErrorResponse> for RerankError {
+    fn from(err: ApiErrorResponse) -> Self {
+        RerankError::ProviderError(err.message)
+    }
+}
+
+#[derive(Clone)]
+pub struct RerankModel<T = reqwest::Client> {
+    client: Client<T>,
+    pub model: String,
+    pub top_k: Option<usize>,
+    pub return_documents: bool,
+    pub truncation: Option<bool>,
+}
+
+impl<T> RerankModel<T> {
+    pub fn new(client: Client<T>, model: impl Into<String>) -> Self {
+        Self {
+            client,
+            model: model.into(),
+            top_k: None,
+            return_documents: false,
+            truncation: None,
+        }
+    }
+
+    pub fn top_k(mut self, top_k: usize) -> Self {
+        self.top_k = Some(top_k);
+        self
+    }
+
+    pub fn return_documents(mut self, return_documents: bool) -> Self {
+        self.return_documents = return_documents;
+        self
+    }
+
+    pub fn truncation(mut self, truncation: bool) -> Self {
+        self.truncation = Some(truncation);
+        self
+    }
+}
+
+impl<T> rerank::RerankModel for RerankModel<T>
+where
+    T: HttpClientExt + Clone + std::fmt::Debug + Default + 'static,
+{
+    const MAX_DOCUMENTS: usize = 1000;
+
+    type Client = Client<T>;
+
+    fn make(client: &Self::Client, model: impl Into<String>) -> Self {
+        Self::new(client.clone(), model)
+    }
+
+    async fn rerank(
+        &self,
+        query: &str,
+        documents: Vec<String>,
+    ) -> Result<rerank::RerankResponse, RerankError> {
+        let mut body = json!({
+            "query": query,
+            "documents": documents,
+            "model": self.model,
+        });
+
+        let body_obj = body.as_object_mut().ok_or_else(|| {
+            RerankError::ResponseError("rerank request body must be a JSON object".into())
+        })?;
+
+        if let Some(top_k) = self.top_k {
+            body_obj.insert("top_k".to_owned(), json!(top_k));
+        }
+
+        body_obj.insert("return_documents".to_owned(), json!(self.return_documents));
+
+        if let Some(truncation) = self.truncation {
+            body_obj.insert("truncation".to_owned(), json!(truncation));
+        }
+
+        let body = serde_json::to_vec(&body)?;
+
+        let req = self
+            .client
+            .post("/rerank")?
+            .body(body)
+            .map_err(|x| RerankError::HttpError(x.into()))?;
+
+        let response = self.client.send::<_, Bytes>(req).await?;
+        let status = response.status();
+        let response_body = response.into_body().into_future().await?.to_vec();
+
+        if status.is_success() {
+            match serde_json::from_slice::<ApiResponse<RerankApiResponse>>(&response_body)? {
+                ApiResponse::Ok(response) => {
+                    tracing::info!(target: "rig",
+                        "VoyageAI rerank token usage: {}",
+                        response.usage.total_tokens
+                    );
+
+                    let usage = crate::completion::Usage {
+                        input_tokens: response.usage.total_tokens as u64,
+                        output_tokens: 0,
+                        total_tokens: response.usage.total_tokens as u64,
+                        cached_input_tokens: 0,
+                        cache_creation_input_tokens: 0,
+                        reasoning_tokens: 0,
+                        tool_use_prompt_tokens: 0,
+                    };
+
+                    let results = response
+                        .data
+                        .into_iter()
+                        .map(|d| rerank::RerankResult {
+                            index: d.index,
+                            document: d.document,
+                            relevance_score: d.relevance_score,
+                        })
+                        .collect();
+
+                    Ok(rerank::RerankResponse {
+                        results,
+                        model: response.model,
+                        usage,
+                    })
+                }
+                ApiResponse::Err(err) => Err(RerankError::ProviderError(err.message)),
+            }
+        } else {
+            Err(RerankError::ProviderError(
+                String::from_utf8_lossy(&response_body).to_string(),
+            ))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/crates/rig-core/src/providers/xai/client.rs
+++ b/crates/rig-core/src/providers/xai/client.rs
@@ -35,6 +35,7 @@ impl<H> Capabilities<H> for XAiExt {
     type ImageGeneration = Capable<super::image_generation::ImageGenerationModel<H>>;
     #[cfg(feature = "audio")]
     type AudioGeneration = Capable<super::audio_generation::AudioGenerationModel<H>>;
+    type Rerank = Nothing;
 }
 
 impl DebugExt for XAiExt {}

--- a/crates/rig-core/src/providers/xiaomimimo.rs
+++ b/crates/rig-core/src/providers/xiaomimimo.rs
@@ -93,6 +93,7 @@ impl<H> Capabilities<H> for XiaomiMimoExt {
     type ImageGeneration = Nothing;
     #[cfg(feature = "audio")]
     type AudioGeneration = Nothing;
+    type Rerank = Nothing;
 }
 
 impl<H> Capabilities<H> for XiaomiMimoAnthropicExt {
@@ -105,6 +106,7 @@ impl<H> Capabilities<H> for XiaomiMimoAnthropicExt {
     type ImageGeneration = Nothing;
     #[cfg(feature = "audio")]
     type AudioGeneration = Nothing;
+    type Rerank = Nothing;
 }
 
 impl DebugExt for XiaomiMimoExt {}

--- a/crates/rig-core/src/providers/zai.rs
+++ b/crates/rig-core/src/providers/zai.rs
@@ -98,6 +98,7 @@ impl<H> Capabilities<H> for ZAiExt {
     type ImageGeneration = Nothing;
     #[cfg(feature = "audio")]
     type AudioGeneration = Nothing;
+    type Rerank = Nothing;
 }
 
 impl<H> Capabilities<H> for ZAiAnthropicExt {
@@ -110,6 +111,7 @@ impl<H> Capabilities<H> for ZAiAnthropicExt {
     type ImageGeneration = Nothing;
     #[cfg(feature = "audio")]
     type AudioGeneration = Nothing;
+    type Rerank = Nothing;
 }
 
 impl DebugExt for ZAiExt {}

--- a/crates/rig-core/src/rerank.rs
+++ b/crates/rig-core/src/rerank.rs
@@ -1,0 +1,71 @@
+//! Provider-agnostic reranking abstractions.
+//!
+//! Reranking models reorder a list of documents by relevance to a query.
+//! The [`RerankModel`] trait defines the interface, and [`RerankResponse`]
+//! carries both the scored results and token usage.
+
+use crate::{
+    completion::Usage,
+    http_client,
+    wasm_compat::{WasmCompatSend, WasmCompatSync},
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, thiserror::Error)]
+pub enum RerankError {
+    #[error("HttpError: {0}")]
+    HttpError(#[from] http_client::Error),
+
+    #[error("JsonError: {0}")]
+    JsonError(#[from] serde_json::Error),
+
+    #[error("UrlError: {0}")]
+    UrlError(#[from] url::ParseError),
+
+    #[error("ResponseError: {0}")]
+    ResponseError(String),
+
+    #[error("ProviderError: {0}")]
+    ProviderError(String),
+}
+
+/// Trait for reranking models that score documents by relevance to a query.
+pub trait RerankModel: WasmCompatSend + WasmCompatSync {
+    /// The maximum number of documents that can be reranked in a single request.
+    const MAX_DOCUMENTS: usize;
+
+    /// Provider client type used to construct this rerank model.
+    type Client;
+
+    /// Construct a model handle from a provider client and model identifier.
+    fn make(client: &Self::Client, model: impl Into<String>) -> Self;
+
+    /// Rerank a list of documents against a query.
+    fn rerank(
+        &self,
+        query: &str,
+        documents: Vec<String>,
+    ) -> impl std::future::Future<Output = Result<RerankResponse, RerankError>> + WasmCompatSend;
+}
+
+/// A single reranked document result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RerankResult {
+    /// Index of the document in the original input list.
+    pub index: usize,
+    /// The document text, if requested via `return_documents`.
+    pub document: Option<String>,
+    /// Relevance score between 0 and 1 (higher is more relevant).
+    pub relevance_score: f64,
+}
+
+/// Response from a reranking request.
+#[derive(Debug, Clone)]
+pub struct RerankResponse {
+    /// Reranked results sorted by relevance (highest first).
+    pub results: Vec<RerankResult>,
+    /// Model identifier used for this request.
+    pub model: String,
+    /// Token usage for this rerank request.
+    pub usage: Usage,
+}

--- a/tests/providers/voyageai/mod.rs
+++ b/tests/providers/voyageai/mod.rs
@@ -1,1 +1,2 @@
 mod embeddings;
+mod rerank;

--- a/tests/providers/voyageai/rerank.rs
+++ b/tests/providers/voyageai/rerank.rs
@@ -1,0 +1,38 @@
+//! VoyageAI reranking smoke test.
+
+use rig::providers::voyageai;
+use rig::rerank::RerankModel;
+
+#[tokio::test]
+#[ignore = "requires VOYAGE_API_KEY"]
+async fn rerank_smoke() {
+    let client =
+        voyageai::Client::from_env().expect("client should build from VOYAGE_API_KEY env var");
+    let model = client.rerank_model(voyageai::RERANK_2_5);
+
+    let response = model
+        .rerank(
+            "capital of France",
+            vec![
+                "Paris is the capital of France.".to_string(),
+                "Madrid is the capital of Spain.".to_string(),
+            ],
+        )
+        .await
+        .expect("rerank request should succeed");
+
+    assert!(
+        !response.results.is_empty(),
+        "should have at least one result"
+    );
+    assert!(
+        response.results[0].relevance_score > 0.0,
+        "top result should have positive relevance"
+    );
+    assert!(
+        response.results[0].index == 0,
+        "Paris should be the top result"
+    );
+    assert!(response.usage.total_tokens > 0, "usage should be positive");
+    assert!(!response.model.is_empty(), "model name should be present");
+}

--- a/tests/providers/voyageai/rerank.rs
+++ b/tests/providers/voyageai/rerank.rs
@@ -1,5 +1,6 @@
 //! VoyageAI reranking smoke test.
 
+use rig::client::{ProviderClient, RerankingClient};
 use rig::providers::voyageai;
 use rig::rerank::RerankModel;
 


### PR DESCRIPTION
Add RerankModel trait and VoyageAI reranker implementation.

- Add rerank module with RerankModel trait, RerankResponse, RerankError
- Add RerankingClient trait for provider client integration
- Add VoyageAI RerankModel with builder: top_k, return_documents, truncation
- Add model constants: RERANK_2_5, RERANK_2_5_LITE, RERANK_2, etc.
- Add type Rerank to Capabilities trait
- Add integration test for VoyageAI reranking