### PR TITLE
fix(rmcp): bound MCP tool calls with a default, configurable, wasm-friendly timeout (#1914)

### DIFF
--- a/crates/rig-core/Cargo.toml
+++ b/crates/rig-core/Cargo.toml
@@ -66,6 +66,16 @@ reqwest-middleware = { workspace = true, optional = true, features = [
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 tokio-tungstenite = { workspace = true, optional = true }
 
+# futures-timer's default backend uses a background timer thread, which cannot
+# drive timers on wasm. Pull in its wasm-bindgen (setTimeout) backend whenever
+# the target is browser wasm — regardless of feature flags — so
+# `wasm_compat::timeout` and the SSE retry backoff actually fire instead of
+# hanging. Scoped to `target_os = "unknown"` (browser) rather than the whole
+# `wasm` family because the gloo-timers/setTimeout backend needs a JS host and
+# would be wrong-by-construction on WASI.
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+futures-timer = { workspace = true, features = ["wasm-bindgen"] }
+
 [dev-dependencies]
 anyhow = { workspace = true }
 assert_fs = { workspace = true }
@@ -119,7 +129,6 @@ rayon = ["dep:rayon"]
 wasm = [
   "dep:getrandom",
   "dep:wasm-bindgen-futures",
-  "futures-timer/wasm-bindgen",
   "getrandom/js",
 ]
 rmcp = ["dep:rmcp"]

--- a/crates/rig-core/src/agent/builder.rs
+++ b/crates/rig-core/src/agent/builder.rs
@@ -727,4 +727,89 @@ mod tests {
             .hook(BuilderHook)
             .build();
     }
+
+    /// The builder's shared MCP helper threads the configured timeout (default,
+    /// explicit, or `None`/disabled) onto every built tool, and the threaded
+    /// timeout actually bounds a hanging call. This covers the plumbing behind
+    /// `rmcp_tool[s]` / `rmcp_tool[s]_with_timeout` (see issue #1914).
+    #[cfg(feature = "rmcp")]
+    #[tokio::test]
+    async fn build_rmcp_tools_threads_timeout_into_built_tools() {
+        use crate::tool::ToolDyn;
+        use crate::tool::rmcp::DEFAULT_MCP_TOOL_TIMEOUT;
+        use rmcp::model::{
+            CallToolRequestParams, CallToolResult, ClientInfo, ErrorData, Implementation,
+            ProtocolVersion, ServerCapabilities, ServerInfo, Tool,
+        };
+        use rmcp::service::RequestContext;
+        use rmcp::{RoleServer, ServerHandler, ServiceExt};
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        #[derive(Clone)]
+        struct HangingServer;
+        impl ServerHandler for HangingServer {
+            fn get_info(&self) -> ServerInfo {
+                ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+                    .with_protocol_version(ProtocolVersion::LATEST)
+                    .with_server_info(Implementation::new("builder-timeout-test", "0.1.0"))
+            }
+            async fn call_tool(
+                &self,
+                _request: CallToolRequestParams,
+                _context: RequestContext<RoleServer>,
+            ) -> Result<CallToolResult, ErrorData> {
+                std::future::pending::<Result<CallToolResult, ErrorData>>().await
+            }
+        }
+
+        fn tool(name: &str) -> Tool {
+            Tool::new(
+                name.to_string(),
+                String::new(),
+                Arc::new(serde_json::Map::new()),
+            )
+        }
+
+        let (c2s, sfc) = tokio::io::duplex(8192);
+        let (s2c, cfs) = tokio::io::duplex(8192);
+        let server_task = tokio::spawn(async move {
+            let running = HangingServer.serve((sfc, s2c)).await.expect("server start");
+            running.waiting().await.expect("server error");
+        });
+        let client = ClientInfo::default()
+            .serve((cfs, c2s))
+            .await
+            .expect("client connect");
+        let peer = client.peer().clone();
+
+        // The configured timeout (default, explicit, or disabled) is threaded
+        // onto each built tool.
+        let built_default = build_rmcp_tools(
+            vec![tool("a")],
+            peer.clone(),
+            Some(DEFAULT_MCP_TOOL_TIMEOUT),
+        );
+        assert_eq!(built_default[0].1.timeout(), Some(DEFAULT_MCP_TOOL_TIMEOUT));
+        let built_none = build_rmcp_tools(vec![tool("b")], peer.clone(), None);
+        assert_eq!(built_none[0].1.timeout(), None);
+
+        // ...and the threaded timeout actually bounds a hanging call.
+        let built = build_rmcp_tools(
+            vec![tool("hang_forever")],
+            peer,
+            Some(Duration::from_millis(200)),
+        );
+        assert_eq!(built.len(), 1);
+        assert_eq!(built[0].0, "hang_forever");
+        let timed =
+            tokio::time::timeout(Duration::from_secs(5), built[0].1.call("{}".to_string())).await;
+        let err = timed
+            .expect("built tool hung past the safety timeout")
+            .expect_err("call should time out");
+        assert!(err.to_string().contains("timed out"), "got: {err}");
+
+        drop(client);
+        server_task.abort();
+    }
 }

--- a/crates/rig-core/src/agent/builder.rs
+++ b/crates/rig-core/src/agent/builder.rs
@@ -18,8 +18,11 @@ use crate::{
 #[cfg_attr(docsrs, doc(cfg(feature = "rmcp")))]
 use crate::tool::rmcp::McpTool as RmcpTool;
 
-/// Build [`RmcpTool`]s from MCP tool definitions, applying an optional per-call
-/// timeout to each (see issue #1914). Returns `(tool_name, tool)` pairs.
+use super::Agent;
+
+/// Build [`RmcpTool`]s from MCP tool definitions, applying the given per-call
+/// timeout to each (`None` disables it; see issue #1914). Returns
+/// `(tool_name, tool)` pairs.
 #[cfg(feature = "rmcp")]
 fn build_rmcp_tools(
     tools: Vec<rmcp::model::Tool>,
@@ -30,16 +33,11 @@ fn build_rmcp_tools(
         .into_iter()
         .map(|tool| {
             let name = tool.name.to_string();
-            let mut rmcp_tool = RmcpTool::from_mcp_server(tool, client.clone());
-            if let Some(timeout) = timeout {
-                rmcp_tool = rmcp_tool.with_timeout(timeout);
-            }
+            let rmcp_tool = RmcpTool::from_mcp_server(tool, client.clone()).with_timeout(timeout);
             (name, rmcp_tool)
         })
         .collect()
 }
-
-use super::Agent;
 
 /// Marker type indicating no tool configuration has been set yet.
 ///
@@ -413,7 +411,10 @@ where
         }
     }
 
-    /// Add an MCP tool (from `rmcp`) to the agent.
+    /// Add an MCP tool (from `rmcp`) to the agent, bounded by
+    /// [`DEFAULT_MCP_TOOL_TIMEOUT`](crate::tool::rmcp::DEFAULT_MCP_TOOL_TIMEOUT)
+    /// (see issue #1914). Use [`rmcp_tool_with_timeout`](Self::rmcp_tool_with_timeout)
+    /// to change or disable it.
     ///
     /// Transitions the builder to the `WithBuilderTools` state.
     #[cfg(feature = "rmcp")]
@@ -423,13 +424,14 @@ where
         tool: rmcp::model::Tool,
         client: rmcp::service::ServerSink,
     ) -> AgentBuilder<M, P, WithBuilderTools> {
-        self.with_rmcp_toolset(build_rmcp_tools(vec![tool], client, None))
+        self.rmcp_tool_with_timeout(tool, client, crate::tool::rmcp::DEFAULT_MCP_TOOL_TIMEOUT)
     }
 
     /// Add an MCP tool (from `rmcp`) with a per-call timeout (see issue #1914).
     ///
-    /// If the tool call does not complete within `timeout`, it resolves to a
-    /// tool error the agent can recover from instead of blocking forever.
+    /// Pass a [`Duration`](std::time::Duration) to bound the call, or `None` to
+    /// disable the timeout (unbounded). On timeout the call resolves to a tool
+    /// error the agent can recover from instead of blocking forever.
     /// Transitions the builder to the `WithBuilderTools` state.
     #[cfg(feature = "rmcp")]
     #[cfg_attr(docsrs, doc(cfg(feature = "rmcp")))]
@@ -437,12 +439,15 @@ where
         self,
         tool: rmcp::model::Tool,
         client: rmcp::service::ServerSink,
-        timeout: std::time::Duration,
+        timeout: impl Into<Option<std::time::Duration>>,
     ) -> AgentBuilder<M, P, WithBuilderTools> {
-        self.with_rmcp_toolset(build_rmcp_tools(vec![tool], client, Some(timeout)))
+        self.with_rmcp_toolset(build_rmcp_tools(vec![tool], client, timeout.into()))
     }
 
-    /// Add an array of MCP tools (from `rmcp`) to the agent.
+    /// Add an array of MCP tools (from `rmcp`) to the agent, each bounded by
+    /// [`DEFAULT_MCP_TOOL_TIMEOUT`](crate::tool::rmcp::DEFAULT_MCP_TOOL_TIMEOUT)
+    /// (see issue #1914). Use [`rmcp_tools_with_timeout`](Self::rmcp_tools_with_timeout)
+    /// to change or disable it.
     ///
     /// Transitions the builder to the `WithBuilderTools` state.
     #[cfg(feature = "rmcp")]
@@ -452,13 +457,14 @@ where
         tools: Vec<rmcp::model::Tool>,
         client: rmcp::service::ServerSink,
     ) -> AgentBuilder<M, P, WithBuilderTools> {
-        self.with_rmcp_toolset(build_rmcp_tools(tools, client, None))
+        self.rmcp_tools_with_timeout(tools, client, crate::tool::rmcp::DEFAULT_MCP_TOOL_TIMEOUT)
     }
 
     /// Add an array of MCP tools (from `rmcp`) with a per-call timeout (see
     /// issue #1914).
     ///
-    /// If a tool call does not complete within `timeout`, it resolves to a tool
+    /// Pass a [`Duration`](std::time::Duration) to bound calls, or `None` to
+    /// disable the timeout (unbounded). On timeout a call resolves to a tool
     /// error the agent can recover from instead of blocking forever.
     /// Transitions the builder to the `WithBuilderTools` state.
     #[cfg(feature = "rmcp")]
@@ -467,9 +473,9 @@ where
         self,
         tools: Vec<rmcp::model::Tool>,
         client: rmcp::service::ServerSink,
-        timeout: std::time::Duration,
+        timeout: impl Into<Option<std::time::Duration>>,
     ) -> AgentBuilder<M, P, WithBuilderTools> {
-        self.with_rmcp_toolset(build_rmcp_tools(tools, client, Some(timeout)))
+        self.with_rmcp_toolset(build_rmcp_tools(tools, client, timeout.into()))
     }
 
     /// Transition into the `WithBuilderTools` state carrying the given built
@@ -479,12 +485,7 @@ where
         self,
         built: Vec<(String, RmcpTool)>,
     ) -> AgentBuilder<M, P, WithBuilderTools> {
-        let mut static_tools = Vec::with_capacity(built.len());
-        let mut toolset = Vec::with_capacity(built.len());
-        for (name, tool) in built {
-            static_tools.push(name);
-            toolset.push(tool);
-        }
+        let (static_tools, toolset): (Vec<String>, Vec<RmcpTool>) = built.into_iter().unzip();
 
         AgentBuilder {
             name: self.name,
@@ -621,7 +622,10 @@ where
         self
     }
 
-    /// Add an array of MCP tools (from `rmcp`) to the agent.
+    /// Add an array of MCP tools (from `rmcp`) to the agent, each bounded by
+    /// [`DEFAULT_MCP_TOOL_TIMEOUT`](crate::tool::rmcp::DEFAULT_MCP_TOOL_TIMEOUT)
+    /// (see issue #1914). Use [`rmcp_tools_with_timeout`](Self::rmcp_tools_with_timeout)
+    /// to change or disable it.
     #[cfg(feature = "rmcp")]
     #[cfg_attr(docsrs, doc(cfg(feature = "rmcp")))]
     pub fn rmcp_tools(
@@ -629,13 +633,14 @@ where
         tools: Vec<rmcp::model::Tool>,
         client: rmcp::service::ServerSink,
     ) -> Self {
-        self.add_rmcp_tools(build_rmcp_tools(tools, client, None))
+        self.rmcp_tools_with_timeout(tools, client, crate::tool::rmcp::DEFAULT_MCP_TOOL_TIMEOUT)
     }
 
     /// Add an array of MCP tools (from `rmcp`) with a per-call timeout (see
     /// issue #1914).
     ///
-    /// If a tool call does not complete within `timeout`, it resolves to a tool
+    /// Pass a [`Duration`](std::time::Duration) to bound calls, or `None` to
+    /// disable the timeout (unbounded). On timeout a call resolves to a tool
     /// error the agent can recover from instead of blocking forever.
     #[cfg(feature = "rmcp")]
     #[cfg_attr(docsrs, doc(cfg(feature = "rmcp")))]
@@ -643,9 +648,9 @@ where
         self,
         tools: Vec<rmcp::model::Tool>,
         client: rmcp::service::ServerSink,
-        timeout: std::time::Duration,
+        timeout: impl Into<Option<std::time::Duration>>,
     ) -> Self {
-        self.add_rmcp_tools(build_rmcp_tools(tools, client, Some(timeout)))
+        self.add_rmcp_tools(build_rmcp_tools(tools, client, timeout.into()))
     }
 
     #[cfg(feature = "rmcp")]

--- a/crates/rig-core/src/agent/builder.rs
+++ b/crates/rig-core/src/agent/builder.rs
@@ -18,6 +18,27 @@ use crate::{
 #[cfg_attr(docsrs, doc(cfg(feature = "rmcp")))]
 use crate::tool::rmcp::McpTool as RmcpTool;
 
+/// Build [`RmcpTool`]s from MCP tool definitions, applying an optional per-call
+/// timeout to each (see issue #1914). Returns `(tool_name, tool)` pairs.
+#[cfg(feature = "rmcp")]
+fn build_rmcp_tools(
+    tools: Vec<rmcp::model::Tool>,
+    client: rmcp::service::ServerSink,
+    timeout: Option<std::time::Duration>,
+) -> Vec<(String, RmcpTool)> {
+    tools
+        .into_iter()
+        .map(|tool| {
+            let name = tool.name.to_string();
+            let mut rmcp_tool = RmcpTool::from_mcp_server(tool, client.clone());
+            if let Some(timeout) = timeout {
+                rmcp_tool = rmcp_tool.with_timeout(timeout);
+            }
+            (name, rmcp_tool)
+        })
+        .collect()
+}
+
 use super::Agent;
 
 /// Marker type indicating no tool configuration has been set yet.
@@ -402,31 +423,23 @@ where
         tool: rmcp::model::Tool,
         client: rmcp::service::ServerSink,
     ) -> AgentBuilder<M, P, WithBuilderTools> {
-        let toolname = tool.name.clone().to_string();
-        let tools = ToolSet::from_tools(vec![RmcpTool::from_mcp_server(tool, client)]);
+        self.with_rmcp_toolset(build_rmcp_tools(vec![tool], client, None))
+    }
 
-        AgentBuilder {
-            name: self.name,
-            description: self.description,
-            model: self.model,
-            preamble: self.preamble,
-            static_context: self.static_context,
-            additional_params: self.additional_params,
-            max_tokens: self.max_tokens,
-            dynamic_context: self.dynamic_context,
-            temperature: self.temperature,
-            tool_choice: self.tool_choice,
-            default_max_turns: self.default_max_turns,
-            hook: self.hook,
-            output_schema: self.output_schema,
-            memory: self.memory,
-            default_conversation_id: self.default_conversation_id,
-            tool_state: WithBuilderTools {
-                static_tools: vec![toolname],
-                tools,
-                dynamic_tools: vec![],
-            },
-        }
+    /// Add an MCP tool (from `rmcp`) with a per-call timeout (see issue #1914).
+    ///
+    /// If the tool call does not complete within `timeout`, it resolves to a
+    /// tool error the agent can recover from instead of blocking forever.
+    /// Transitions the builder to the `WithBuilderTools` state.
+    #[cfg(feature = "rmcp")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rmcp")))]
+    pub fn rmcp_tool_with_timeout(
+        self,
+        tool: rmcp::model::Tool,
+        client: rmcp::service::ServerSink,
+        timeout: std::time::Duration,
+    ) -> AgentBuilder<M, P, WithBuilderTools> {
+        self.with_rmcp_toolset(build_rmcp_tools(vec![tool], client, Some(timeout)))
     }
 
     /// Add an array of MCP tools (from `rmcp`) to the agent.
@@ -439,18 +452,39 @@ where
         tools: Vec<rmcp::model::Tool>,
         client: rmcp::service::ServerSink,
     ) -> AgentBuilder<M, P, WithBuilderTools> {
-        let (static_tools, tools) = tools.into_iter().fold(
-            (Vec::new(), Vec::new()),
-            |(mut toolnames, mut toolset), tool| {
-                let tool_name = tool.name.to_string();
-                let tool = RmcpTool::from_mcp_server(tool, client.clone());
-                toolnames.push(tool_name);
-                toolset.push(tool);
-                (toolnames, toolset)
-            },
-        );
+        self.with_rmcp_toolset(build_rmcp_tools(tools, client, None))
+    }
 
-        let tools = ToolSet::from_tools(tools);
+    /// Add an array of MCP tools (from `rmcp`) with a per-call timeout (see
+    /// issue #1914).
+    ///
+    /// If a tool call does not complete within `timeout`, it resolves to a tool
+    /// error the agent can recover from instead of blocking forever.
+    /// Transitions the builder to the `WithBuilderTools` state.
+    #[cfg(feature = "rmcp")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rmcp")))]
+    pub fn rmcp_tools_with_timeout(
+        self,
+        tools: Vec<rmcp::model::Tool>,
+        client: rmcp::service::ServerSink,
+        timeout: std::time::Duration,
+    ) -> AgentBuilder<M, P, WithBuilderTools> {
+        self.with_rmcp_toolset(build_rmcp_tools(tools, client, Some(timeout)))
+    }
+
+    /// Transition into the `WithBuilderTools` state carrying the given built
+    /// MCP tools.
+    #[cfg(feature = "rmcp")]
+    fn with_rmcp_toolset(
+        self,
+        built: Vec<(String, RmcpTool)>,
+    ) -> AgentBuilder<M, P, WithBuilderTools> {
+        let mut static_tools = Vec::with_capacity(built.len());
+        let mut toolset = Vec::with_capacity(built.len());
+        for (name, tool) in built {
+            static_tools.push(name);
+            toolset.push(tool);
+        }
 
         AgentBuilder {
             name: self.name,
@@ -470,7 +504,7 @@ where
             default_conversation_id: self.default_conversation_id,
             tool_state: WithBuilderTools {
                 static_tools,
-                tools,
+                tools: ToolSet::from_tools(toolset),
                 dynamic_tools: vec![],
             },
         }
@@ -591,14 +625,33 @@ where
     #[cfg(feature = "rmcp")]
     #[cfg_attr(docsrs, doc(cfg(feature = "rmcp")))]
     pub fn rmcp_tools(
-        mut self,
+        self,
         tools: Vec<rmcp::model::Tool>,
         client: rmcp::service::ServerSink,
     ) -> Self {
-        for tool in tools {
-            let tool_name = tool.name.to_string();
-            let tool = RmcpTool::from_mcp_server(tool, client.clone());
-            self.tool_state.static_tools.push(tool_name);
+        self.add_rmcp_tools(build_rmcp_tools(tools, client, None))
+    }
+
+    /// Add an array of MCP tools (from `rmcp`) with a per-call timeout (see
+    /// issue #1914).
+    ///
+    /// If a tool call does not complete within `timeout`, it resolves to a tool
+    /// error the agent can recover from instead of blocking forever.
+    #[cfg(feature = "rmcp")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rmcp")))]
+    pub fn rmcp_tools_with_timeout(
+        self,
+        tools: Vec<rmcp::model::Tool>,
+        client: rmcp::service::ServerSink,
+        timeout: std::time::Duration,
+    ) -> Self {
+        self.add_rmcp_tools(build_rmcp_tools(tools, client, Some(timeout)))
+    }
+
+    #[cfg(feature = "rmcp")]
+    fn add_rmcp_tools(mut self, built: Vec<(String, RmcpTool)>) -> Self {
+        for (name, tool) in built {
+            self.tool_state.static_tools.push(name);
             self.tool_state.tools.add_tool(tool);
         }
 

--- a/crates/rig-core/src/tool/rmcp.rs
+++ b/crates/rig-core/src/tool/rmcp.rs
@@ -31,6 +31,7 @@
 
 use std::borrow::Cow;
 use std::sync::Arc;
+use std::time::Duration;
 
 use rmcp::ServiceExt;
 use rmcp::model::RawContent;
@@ -42,6 +43,16 @@ use crate::tool::ToolError;
 use crate::tool::server::{ToolServerError, ToolServerHandle};
 use crate::wasm_compat::WasmBoxedFuture;
 
+/// Default per-call timeout applied to MCP tools (see issue #1914).
+///
+/// MCP tool calls await a response that can be silently lost by the transport
+/// (e.g. an rmcp StreamableHttp session re-init dropping an in-flight request),
+/// which would otherwise hang the agent forever. A generous default bounds that
+/// without disrupting normal, long-running tools. Override per tool with
+/// [`McpTool::with_timeout`] (pass `None` to disable, e.g. for tools that may
+/// legitimately run longer than this).
+pub const DEFAULT_MCP_TOOL_TIMEOUT: Duration = Duration::from_secs(300);
+
 /// A Rig tool adapter wrapping an `rmcp` MCP tool.
 ///
 /// Bridges between the MCP tool protocol and Rig's [`ToolDyn`] trait,
@@ -50,18 +61,23 @@ use crate::wasm_compat::WasmBoxedFuture;
 pub struct McpTool {
     definition: rmcp::model::Tool,
     client: rmcp::service::ServerSink,
-    /// Optional per-call timeout. When set, an MCP `call_tool` that does not
-    /// complete within this duration resolves to a [`ToolError`] instead of
-    /// blocking forever (see issue #1914).
-    timeout: Option<std::time::Duration>,
+    /// Per-call timeout. When `Some`, an MCP `call_tool` that does not complete
+    /// within this duration resolves to a [`ToolError`] instead of blocking
+    /// forever (see issue #1914). When `None`, the call is unbounded.
+    ///
+    /// On elapse the call is abandoned **locally** (the future is dropped); the
+    /// server is not sent a cancellation, so a still-running tool keeps running
+    /// server-side, and rmcp reclaims the request slot when the session closes.
+    timeout: Option<Duration>,
 }
 
 impl McpTool {
     /// Create a new `McpTool` from an MCP tool definition and server sink.
     ///
-    /// No per-call timeout is applied: a tool call that never receives a
-    /// response will await indefinitely. Use [`McpTool::with_timeout`] or
-    /// [`McpTool::from_mcp_server_with_timeout`] to bound it (see issue #1914).
+    /// Applies [`DEFAULT_MCP_TOOL_TIMEOUT`] so a lost/never-answered response
+    /// cannot hang the agent forever (issue #1914). Use [`McpTool::with_timeout`]
+    /// to change it, or `with_timeout(None)` to disable it for tools that may
+    /// legitimately run longer.
     pub fn from_mcp_server(
         definition: rmcp::model::Tool,
         client: rmcp::service::ServerSink,
@@ -69,34 +85,26 @@ impl McpTool {
         Self {
             definition,
             client,
-            timeout: None,
+            timeout: Some(DEFAULT_MCP_TOOL_TIMEOUT),
         }
     }
 
-    /// Create a new `McpTool` with a per-call timeout.
+    /// Set (or clear) the per-call timeout, consuming and returning the tool.
     ///
-    /// If the underlying MCP `call_tool` does not complete within `timeout`, the
-    /// call resolves to a [`ToolError`] instead of blocking forever. The agent
-    /// loop surfaces that error to the model as a tool result, so the agent can
-    /// recover rather than hang.
-    pub fn from_mcp_server_with_timeout(
-        definition: rmcp::model::Tool,
-        client: rmcp::service::ServerSink,
-        timeout: std::time::Duration,
-    ) -> Self {
-        Self {
-            definition,
-            client,
-            timeout: Some(timeout),
-        }
-    }
-
-    /// Set a per-call timeout, consuming and returning the tool.
-    ///
-    /// See [`McpTool::from_mcp_server_with_timeout`].
-    pub fn with_timeout(mut self, timeout: std::time::Duration) -> Self {
-        self.timeout = Some(timeout);
+    /// Pass a [`Duration`] to bound calls, or `None` to make them unbounded.
+    /// On timeout the call resolves to a [`ToolError`] (which the agent loop
+    /// surfaces to the model as a tool result, so the agent can recover rather
+    /// than hang). Note the timeout abandons the call locally and does **not**
+    /// send a cancellation to the MCP server — see the [`McpTool::timeout`]
+    /// field docs.
+    pub fn with_timeout(mut self, timeout: impl Into<Option<Duration>>) -> Self {
+        self.timeout = timeout.into();
         self
+    }
+
+    /// The per-call timeout, if any.
+    pub fn timeout(&self) -> Option<Duration> {
+        self.timeout
     }
 }
 
@@ -162,11 +170,12 @@ impl ToolDyn for McpTool {
                 })
                 .unwrap_or_else(|| rmcp::model::CallToolRequestParams::new(name));
 
-            let result = match self.timeout {
-                // Bound the call so a never-answered request (see issue #1914)
-                // becomes a recoverable error instead of an unbounded await.
+            let call = self.client.call_tool(request);
+            // Bound the call so a never-answered request (see issue #1914)
+            // becomes a recoverable error instead of an unbounded await.
+            let call_result = match self.timeout {
                 Some(timeout) => {
-                    crate::wasm_compat::timeout(timeout, self.client.call_tool(request))
+                    crate::wasm_compat::timeout(timeout, call)
                         .await
                         .map_err(|_| {
                             McpToolError(format!(
@@ -174,14 +183,11 @@ impl ToolDyn for McpTool {
                                 self.definition.name
                             ))
                         })?
-                        .map_err(|e| McpToolError(format!("Tool returned an error: {e}")))?
                 }
-                None => self
-                    .client
-                    .call_tool(request)
-                    .await
-                    .map_err(|e| McpToolError(format!("Tool returned an error: {e}")))?,
+                None => call.await,
             };
+            let result =
+                call_result.map_err(|e| McpToolError(format!("Tool returned an error: {e}")))?;
 
             if let Some(true) = result.is_error {
                 let error_msg = result
@@ -295,9 +301,9 @@ pub enum McpClientError {
 pub struct McpClientHandler {
     client_info: rmcp::model::ClientInfo,
     tool_server_handle: ToolServerHandle,
-    /// Optional per-call timeout applied to every MCP tool this handler
-    /// registers (see issue #1914).
-    timeout: Option<std::time::Duration>,
+    /// Per-call timeout applied to every MCP tool this handler registers
+    /// (see issue #1914). Defaults to [`DEFAULT_MCP_TOOL_TIMEOUT`].
+    timeout: Option<Duration>,
     /// Tracks which tool names were registered by this handler so they
     /// can be removed and replaced on list-change notifications.
     managed_tool_names: Arc<RwLock<Vec<String>>>,
@@ -307,30 +313,29 @@ impl McpClientHandler {
     /// Create a new handler with the given client info and tool server handle.
     ///
     /// The `tool_server_handle` should be a clone of the handle used by the agent,
-    /// so that tool updates are reflected in agent requests.
+    /// so that tool updates are reflected in agent requests. Registered tools get
+    /// [`DEFAULT_MCP_TOOL_TIMEOUT`]; change it with [`McpClientHandler::with_timeout`].
     pub fn new(client_info: rmcp::model::ClientInfo, tool_server_handle: ToolServerHandle) -> Self {
         Self {
             client_info,
             tool_server_handle,
-            timeout: None,
+            timeout: Some(DEFAULT_MCP_TOOL_TIMEOUT),
             managed_tool_names: Arc::new(RwLock::new(Vec::new())),
         }
     }
 
-    /// Apply a per-call timeout to every MCP tool registered by this handler.
+    /// Set (or clear) the per-call timeout applied to every MCP tool this handler
+    /// registers. Pass a [`Duration`] to bound calls, or `None` to disable.
     ///
-    /// See [`McpTool::from_mcp_server_with_timeout`].
-    pub fn with_timeout(mut self, timeout: std::time::Duration) -> Self {
-        self.timeout = Some(timeout);
+    /// See [`McpTool::with_timeout`].
+    pub fn with_timeout(mut self, timeout: impl Into<Option<Duration>>) -> Self {
+        self.timeout = timeout.into();
         self
     }
 
-    /// Build an [`McpTool`], applying this handler's configured timeout (if any).
+    /// Build an [`McpTool`], applying this handler's configured timeout.
     fn build_tool(&self, tool: rmcp::model::Tool, client: rmcp::service::ServerSink) -> McpTool {
-        match self.timeout {
-            Some(timeout) => McpTool::from_mcp_server_with_timeout(tool, client, timeout),
-            None => McpTool::from_mcp_server(tool, client),
-        }
+        McpTool::from_mcp_server(tool, client).with_timeout(self.timeout)
     }
 
     /// Connect to an MCP server, fetch the initial tool list, and register
@@ -649,24 +654,22 @@ mod tests {
         assert_eq!(returned.client_info.version, "1.0.0");
     }
 
-    /// Reproduction for <https://github.com/0xPlaygrounds/rig/issues/1914>.
+    /// Documents the unbounded escape hatch and the underlying issue #1914 hazard.
     ///
-    /// `McpTool::call` (this file) awaits `self.client.call_tool(request)` with
-    /// no timeout, cancellation, or retry. When the underlying MCP request is
-    /// orphaned (no response, no error), this `.await` never completes, and the
-    /// agent loop — which awaits the tool call the same way at
-    /// `agent/prompt_request/mod.rs` and `streaming.rs` — wedges forever. The
-    /// agent loop already turns a tool *error* into a tool-result string, so a
-    /// call that never returns is the one failure mode it cannot recover from.
+    /// `McpTool::call` awaits `self.client.call_tool(request)`; if the MCP request
+    /// is orphaned (no response, no error — e.g. an rmcp StreamableHttp session
+    /// re-init dropping an in-flight request), that `.await` never completes and
+    /// the agent loop wedges (the loop turns a tool *error* into a tool result,
+    /// but cannot recover from a call that never returns). That is exactly why
+    /// the default now applies [`DEFAULT_MCP_TOOL_TIMEOUT`].
     ///
-    /// We wire rig's `McpTool` to a server whose tool never responds and show
-    /// the call does not resolve within a generous window. The outer
-    /// `timeout` exists only so this test itself terminates; the timeout
-    /// *elapsing* is the bug. Once a fix adds an internal timeout/cancellation
-    /// to `McpTool::call` (returning `Err` instead of hanging), this call will
-    /// resolve quickly and the assertion below should flip to `timed.is_ok()`.
+    /// Here we opt **out** with `with_timeout(None)` and show the call stays
+    /// unbounded (does not resolve within the window). The outer `timeout` exists
+    /// only so this test terminates; it elapsing is the *intended* unbounded
+    /// behavior of the disabled-timeout path, not a bug. The bounded paths are
+    /// covered by `mcp_tool_call_with_timeout_errors_instead_of_hanging`.
     #[tokio::test]
-    async fn repro_issue_1914_mcp_tool_call_hangs_when_response_never_arrives() {
+    async fn mcp_tool_call_without_timeout_is_unbounded() {
         use super::McpTool;
         use crate::tool::ToolDyn;
 
@@ -695,18 +698,19 @@ mod tests {
             .expect("list_tools failed");
         assert_eq!(tools.len(), 1, "expected exactly one advertised tool");
 
-        // Build the rig tool exactly as `AgentBuilder::rmcp_tools(tools, peer)` does.
+        // `from_mcp_server` applies the generous default out of the box...
         let mcp_tool = McpTool::from_mcp_server(tools[0].clone(), client.peer().clone());
+        assert_eq!(mcp_tool.timeout(), Some(super::DEFAULT_MCP_TOOL_TIMEOUT));
+        // ...and callers can explicitly disable it to opt into unbounded behavior.
+        let mcp_tool = mcp_tool.with_timeout(None);
+        assert_eq!(mcp_tool.timeout(), None);
 
         let timed =
-            tokio::time::timeout(Duration::from_millis(500), mcp_tool.call("{}".to_string())).await;
+            tokio::time::timeout(Duration::from_millis(150), mcp_tool.call("{}".to_string())).await;
 
         assert!(
             timed.is_err(),
-            "issue #1914 NOT reproduced: McpTool::call returned {:?} within 500ms; \
-             it was expected to hang because the server never sends a CallToolResult \
-             and McpTool::call has no internal timeout. If you just added a timeout \
-             fix, flip this assertion to `timed.is_ok()`.",
+            "with the timeout disabled, McpTool::call must stay unbounded; got {:?}",
             timed.ok(),
         );
 
@@ -748,11 +752,8 @@ mod tests {
             .expect("list_tools failed");
 
         // The fix: a per-call timeout bounds the otherwise-unbounded await.
-        let mcp_tool = McpTool::from_mcp_server_with_timeout(
-            tools[0].clone(),
-            client.peer().clone(),
-            Duration::from_millis(200),
-        );
+        let mcp_tool = McpTool::from_mcp_server(tools[0].clone(), client.peer().clone())
+            .with_timeout(Duration::from_millis(200));
 
         let timed =
             tokio::time::timeout(Duration::from_secs(5), mcp_tool.call("{}".to_string())).await;
@@ -763,6 +764,7 @@ mod tests {
         );
         let err =
             result.expect_err("call should resolve to an error when the server never responds");
+        // "timed out" mirrors the McpToolError format string in McpTool::call.
         assert!(
             err.to_string().contains("timed out"),
             "expected a timeout error, got: {err}"
@@ -771,10 +773,11 @@ mod tests {
         server_task.abort();
     }
 
-    /// Guard for the reproduction above: with a server that *does* respond, the
-    /// same in-process duplex harness resolves well within the timeout window.
-    /// This proves the 500ms bound in the repro is meaningful — the hang is
-    /// caused by the missing response, not by the transport being slow.
+    /// Success path with a timeout *configured*: a responsive tool resolves with
+    /// its result (exercising the `Some(timeout)` arm of `McpTool::call` and the
+    /// `wasm_compat::timeout` "completed" branch, with a real `CallToolResult`
+    /// flowing through content parsing). Also guards that the bound in the
+    /// hanging-server tests is meaningful — a healthy call returns well inside it.
     #[tokio::test]
     async fn mcp_tool_call_returns_promptly_for_responsive_server() {
         use super::McpTool;
@@ -804,15 +807,58 @@ mod tests {
             .list_all_tools()
             .await
             .expect("list_tools failed");
-        let mcp_tool = McpTool::from_mcp_server(tools[0].clone(), client.peer().clone());
+        let mcp_tool = McpTool::from_mcp_server(tools[0].clone(), client.peer().clone())
+            .with_timeout(Duration::from_secs(2));
 
         let timed =
-            tokio::time::timeout(Duration::from_secs(2), mcp_tool.call("{}".to_string())).await;
+            tokio::time::timeout(Duration::from_secs(5), mcp_tool.call("{}".to_string())).await;
 
         let result = timed
-            .expect("responsive tool should resolve within 2s")
+            .expect("responsive tool should resolve within the safety window")
             .expect("tool call should succeed");
         assert!(result.contains("ping"), "unexpected tool output: {result}");
+
+        server_task.abort();
+    }
+
+    /// `McpClientHandler::with_timeout` is applied to every tool it registers:
+    /// calling a registered tool from the shared `ToolServerHandle` (the path the
+    /// agent loop uses) surfaces a timeout error instead of hanging.
+    #[tokio::test]
+    async fn mcp_client_handler_with_timeout_bounds_registered_tools() {
+        let tool_server_handle = ToolServer::new().run();
+
+        let (client_to_server, server_from_client) = tokio::io::duplex(8192);
+        let (server_to_client, client_from_server) = tokio::io::duplex(8192);
+
+        let server_task = tokio::spawn(async move {
+            let running = HangingToolServer
+                .serve((server_from_client, server_to_client))
+                .await
+                .expect("server failed to start");
+            running.waiting().await.expect("server error");
+        });
+
+        let handler = McpClientHandler::new(ClientInfo::default(), tool_server_handle.clone())
+            .with_timeout(Duration::from_millis(200));
+        let _mcp_service = handler
+            .connect((client_from_server, client_to_server))
+            .await
+            .expect("connect failed");
+
+        // Call through the shared handle exactly as the agent loop does.
+        let timed = tokio::time::timeout(
+            Duration::from_secs(5),
+            tool_server_handle.call_tool("hang_forever", "{}"),
+        )
+        .await;
+
+        let result = timed.expect("handler-registered tool hung past the safety timeout");
+        let err = result.expect_err("call should time out when the server never responds");
+        assert!(
+            err.to_string().contains("timed out"),
+            "expected a timeout error, got: {err}"
+        );
 
         server_task.abort();
     }

--- a/crates/rig-core/src/tool/rmcp.rs
+++ b/crates/rig-core/src/tool/rmcp.rs
@@ -50,15 +50,53 @@ use crate::wasm_compat::WasmBoxedFuture;
 pub struct McpTool {
     definition: rmcp::model::Tool,
     client: rmcp::service::ServerSink,
+    /// Optional per-call timeout. When set, an MCP `call_tool` that does not
+    /// complete within this duration resolves to a [`ToolError`] instead of
+    /// blocking forever (see issue #1914).
+    timeout: Option<std::time::Duration>,
 }
 
 impl McpTool {
     /// Create a new `McpTool` from an MCP tool definition and server sink.
+    ///
+    /// No per-call timeout is applied: a tool call that never receives a
+    /// response will await indefinitely. Use [`McpTool::with_timeout`] or
+    /// [`McpTool::from_mcp_server_with_timeout`] to bound it (see issue #1914).
     pub fn from_mcp_server(
         definition: rmcp::model::Tool,
         client: rmcp::service::ServerSink,
     ) -> Self {
-        Self { definition, client }
+        Self {
+            definition,
+            client,
+            timeout: None,
+        }
+    }
+
+    /// Create a new `McpTool` with a per-call timeout.
+    ///
+    /// If the underlying MCP `call_tool` does not complete within `timeout`, the
+    /// call resolves to a [`ToolError`] instead of blocking forever. The agent
+    /// loop surfaces that error to the model as a tool result, so the agent can
+    /// recover rather than hang.
+    pub fn from_mcp_server_with_timeout(
+        definition: rmcp::model::Tool,
+        client: rmcp::service::ServerSink,
+        timeout: std::time::Duration,
+    ) -> Self {
+        Self {
+            definition,
+            client,
+            timeout: Some(timeout),
+        }
+    }
+
+    /// Set a per-call timeout, consuming and returning the tool.
+    ///
+    /// See [`McpTool::from_mcp_server_with_timeout`].
+    pub fn with_timeout(mut self, timeout: std::time::Duration) -> Self {
+        self.timeout = Some(timeout);
+        self
     }
 }
 
@@ -124,11 +162,26 @@ impl ToolDyn for McpTool {
                 })
                 .unwrap_or_else(|| rmcp::model::CallToolRequestParams::new(name));
 
-            let result = self
-                .client
-                .call_tool(request)
-                .await
-                .map_err(|e| McpToolError(format!("Tool returned an error: {e}")))?;
+            let result = match self.timeout {
+                // Bound the call so a never-answered request (see issue #1914)
+                // becomes a recoverable error instead of an unbounded await.
+                Some(timeout) => {
+                    crate::wasm_compat::timeout(timeout, self.client.call_tool(request))
+                        .await
+                        .map_err(|_| {
+                            McpToolError(format!(
+                                "MCP tool '{}' timed out after {timeout:?}",
+                                self.definition.name
+                            ))
+                        })?
+                        .map_err(|e| McpToolError(format!("Tool returned an error: {e}")))?
+                }
+                None => self
+                    .client
+                    .call_tool(request)
+                    .await
+                    .map_err(|e| McpToolError(format!("Tool returned an error: {e}")))?,
+            };
 
             if let Some(true) = result.is_error {
                 let error_msg = result
@@ -242,6 +295,9 @@ pub enum McpClientError {
 pub struct McpClientHandler {
     client_info: rmcp::model::ClientInfo,
     tool_server_handle: ToolServerHandle,
+    /// Optional per-call timeout applied to every MCP tool this handler
+    /// registers (see issue #1914).
+    timeout: Option<std::time::Duration>,
     /// Tracks which tool names were registered by this handler so they
     /// can be removed and replaced on list-change notifications.
     managed_tool_names: Arc<RwLock<Vec<String>>>,
@@ -256,7 +312,24 @@ impl McpClientHandler {
         Self {
             client_info,
             tool_server_handle,
+            timeout: None,
             managed_tool_names: Arc::new(RwLock::new(Vec::new())),
+        }
+    }
+
+    /// Apply a per-call timeout to every MCP tool registered by this handler.
+    ///
+    /// See [`McpTool::from_mcp_server_with_timeout`].
+    pub fn with_timeout(mut self, timeout: std::time::Duration) -> Self {
+        self.timeout = Some(timeout);
+        self
+    }
+
+    /// Build an [`McpTool`], applying this handler's configured timeout (if any).
+    fn build_tool(&self, tool: rmcp::model::Tool, client: rmcp::service::ServerSink) -> McpTool {
+        match self.timeout {
+            Some(timeout) => McpTool::from_mcp_server_with_timeout(tool, client, timeout),
+            None => McpTool::from_mcp_server(tool, client),
         }
     }
 
@@ -292,7 +365,7 @@ impl McpClientHandler {
 
             for tool in tools {
                 let tool_name = tool.name.to_string();
-                let mcp_tool = McpTool::from_mcp_server(tool, service.peer().clone());
+                let mcp_tool = handler.build_tool(tool, service.peer().clone());
                 handler.tool_server_handle.add_tool(mcp_tool).await?;
                 managed.push(tool_name);
             }
@@ -329,7 +402,7 @@ impl rmcp::handler::client::ClientHandler for McpClientHandler {
 
         for tool in tools {
             let tool_name = tool.name.to_string();
-            let mcp_tool = McpTool::from_mcp_server(tool, context.peer.clone());
+            let mcp_tool = self.build_tool(tool, context.peer.clone());
             match self.tool_server_handle.add_tool(mcp_tool).await {
                 Ok(()) => {
                     managed.push(tool_name);
@@ -635,6 +708,64 @@ mod tests {
              and McpTool::call has no internal timeout. If you just added a timeout \
              fix, flip this assertion to `timed.is_ok()`.",
             timed.ok(),
+        );
+
+        server_task.abort();
+    }
+
+    /// Regression test for the fix to <https://github.com/0xPlaygrounds/rig/issues/1914>.
+    ///
+    /// With a per-call timeout configured, `McpTool::call` against a server that
+    /// never responds resolves to a `ToolError` (which the agent loop surfaces
+    /// to the model) instead of hanging forever. The outer `timeout` is only a
+    /// safety net so a regression cannot wedge the test runner; the inner 200ms
+    /// timeout fires first.
+    #[tokio::test]
+    async fn mcp_tool_call_with_timeout_errors_instead_of_hanging() {
+        use super::McpTool;
+        use crate::tool::ToolDyn;
+
+        let (client_to_server, server_from_client) = tokio::io::duplex(8192);
+        let (server_to_client, client_from_server) = tokio::io::duplex(8192);
+
+        let server_task = tokio::spawn(async move {
+            let running = HangingToolServer
+                .serve((server_from_client, server_to_client))
+                .await
+                .expect("server failed to start");
+            running.waiting().await.expect("server error");
+        });
+
+        let client = ClientInfo::default()
+            .serve((client_from_server, client_to_server))
+            .await
+            .expect("client connect failed");
+
+        let tools = client
+            .peer()
+            .list_all_tools()
+            .await
+            .expect("list_tools failed");
+
+        // The fix: a per-call timeout bounds the otherwise-unbounded await.
+        let mcp_tool = McpTool::from_mcp_server_with_timeout(
+            tools[0].clone(),
+            client.peer().clone(),
+            Duration::from_millis(200),
+        );
+
+        let timed =
+            tokio::time::timeout(Duration::from_secs(5), mcp_tool.call("{}".to_string())).await;
+
+        let result = timed.expect(
+            "regression: McpTool::call hung past the safety timeout; the per-call \
+             timeout did not fire (issue #1914 fix is broken)",
+        );
+        let err =
+            result.expect_err("call should resolve to an error when the server never responds");
+        assert!(
+            err.to_string().contains("timed out"),
+            "expected a timeout error, got: {err}"
         );
 
         server_task.abort();

--- a/crates/rig-core/src/tool/rmcp.rs
+++ b/crates/rig-core/src/tool/rmcp.rs
@@ -862,4 +862,50 @@ mod tests {
 
         server_task.abort();
     }
+
+    /// `ToolServer::rmcp_tool_with_timeout` bounds the registered tool: calling it
+    /// through the `ToolServerHandle` surfaces a timeout error instead of hanging.
+    #[tokio::test]
+    async fn tool_server_rmcp_tool_with_timeout_bounds_calls() {
+        let (client_to_server, server_from_client) = tokio::io::duplex(8192);
+        let (server_to_client, client_from_server) = tokio::io::duplex(8192);
+
+        let server_task = tokio::spawn(async move {
+            let running = HangingToolServer
+                .serve((server_from_client, server_to_client))
+                .await
+                .expect("server failed to start");
+            running.waiting().await.expect("server error");
+        });
+
+        let client = ClientInfo::default()
+            .serve((client_from_server, client_to_server))
+            .await
+            .expect("client connect failed");
+
+        // The tool definition is constructed directly; the peer routes the call
+        // to the hanging server, which never responds.
+        let handle = ToolServer::new()
+            .rmcp_tool_with_timeout(
+                make_tool("hang_forever", "never returns"),
+                client.peer().clone(),
+                Duration::from_millis(200),
+            )
+            .run();
+
+        let timed = tokio::time::timeout(
+            Duration::from_secs(5),
+            handle.call_tool("hang_forever", "{}"),
+        )
+        .await;
+
+        let result = timed.expect("ToolServer-registered tool hung past the safety timeout");
+        let err = result.expect_err("call should time out when the server never responds");
+        assert!(
+            err.to_string().contains("timed out"),
+            "expected a timeout error, got: {err}"
+        );
+
+        server_task.abort();
+    }
 }

--- a/crates/rig-core/src/tool/rmcp.rs
+++ b/crates/rig-core/src/tool/rmcp.rs
@@ -415,6 +415,50 @@ mod tests {
         )
     }
 
+    /// An MCP server that advertises one tool whose `call_tool` handler never
+    /// returns, so no `CallToolResult` is ever sent back to the client.
+    ///
+    /// This models the failure in <https://github.com/0xPlaygrounds/rig/issues/1914>:
+    /// in the wild, rmcp 1.7.0's StreamableHttp transport can drop an in-flight
+    /// tool response during transparent session re-initialization (server
+    /// returns HTTP 404 -> the worker calls `streams.abort_all()`, cancelling
+    /// the SSE task carrying the outstanding response -> `JoinError::Cancelled`).
+    /// The request is then permanently orphaned: it never receives a response
+    /// and never errors. A handler that simply never returns produces the same
+    /// observable client-side behavior, deterministically and without a network.
+    #[derive(Clone)]
+    struct HangingToolServer;
+
+    impl ServerHandler for HangingToolServer {
+        fn get_info(&self) -> ServerInfo {
+            ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+                .with_protocol_version(ProtocolVersion::LATEST)
+                .with_server_info(Implementation::new("hanging-server", "0.1.0"))
+        }
+
+        async fn list_tools(
+            &self,
+            _request: Option<PaginatedRequestParams>,
+            _context: RequestContext<RoleServer>,
+        ) -> Result<ListToolsResult, ErrorData> {
+            Ok(ListToolsResult::with_all_items(vec![make_tool(
+                "hang_forever",
+                "A tool whose handler never returns",
+            )]))
+        }
+
+        async fn call_tool(
+            &self,
+            _request: CallToolRequestParams,
+            _context: RequestContext<RoleServer>,
+        ) -> Result<CallToolResult, ErrorData> {
+            // Never resolves: the crux of the reproduction. No response is ever
+            // sent, so the client's `call_tool` future (and therefore rig's
+            // `McpTool::call`) never completes.
+            std::future::pending::<Result<CallToolResult, ErrorData>>().await
+        }
+    }
+
     #[tokio::test]
     async fn test_mcp_client_handler_initial_tool_registration() {
         let initial_tools = vec![
@@ -530,5 +574,115 @@ mod tests {
         let returned = handler.get_info();
         assert_eq!(returned.client_info.name, "test-client");
         assert_eq!(returned.client_info.version, "1.0.0");
+    }
+
+    /// Reproduction for <https://github.com/0xPlaygrounds/rig/issues/1914>.
+    ///
+    /// `McpTool::call` (this file) awaits `self.client.call_tool(request)` with
+    /// no timeout, cancellation, or retry. When the underlying MCP request is
+    /// orphaned (no response, no error), this `.await` never completes, and the
+    /// agent loop — which awaits the tool call the same way at
+    /// `agent/prompt_request/mod.rs` and `streaming.rs` — wedges forever. The
+    /// agent loop already turns a tool *error* into a tool-result string, so a
+    /// call that never returns is the one failure mode it cannot recover from.
+    ///
+    /// We wire rig's `McpTool` to a server whose tool never responds and show
+    /// the call does not resolve within a generous window. The outer
+    /// `timeout` exists only so this test itself terminates; the timeout
+    /// *elapsing* is the bug. Once a fix adds an internal timeout/cancellation
+    /// to `McpTool::call` (returning `Err` instead of hanging), this call will
+    /// resolve quickly and the assertion below should flip to `timed.is_ok()`.
+    #[tokio::test]
+    async fn repro_issue_1914_mcp_tool_call_hangs_when_response_never_arrives() {
+        use super::McpTool;
+        use crate::tool::ToolDyn;
+
+        let (client_to_server, server_from_client) = tokio::io::duplex(8192);
+        let (server_to_client, client_from_server) = tokio::io::duplex(8192);
+
+        let server_task = tokio::spawn(async move {
+            let running = HangingToolServer
+                .serve((server_from_client, server_to_client))
+                .await
+                .expect("server failed to start");
+            running.waiting().await.expect("server error");
+        });
+
+        // A bare client (`ClientInfo` implements `ClientHandler`); `.peer()` is
+        // the `ServerSink` that rig stores inside every `McpTool`.
+        let client = ClientInfo::default()
+            .serve((client_from_server, client_to_server))
+            .await
+            .expect("client connect failed");
+
+        let tools = client
+            .peer()
+            .list_all_tools()
+            .await
+            .expect("list_tools failed");
+        assert_eq!(tools.len(), 1, "expected exactly one advertised tool");
+
+        // Build the rig tool exactly as `AgentBuilder::rmcp_tools(tools, peer)` does.
+        let mcp_tool = McpTool::from_mcp_server(tools[0].clone(), client.peer().clone());
+
+        let timed =
+            tokio::time::timeout(Duration::from_millis(500), mcp_tool.call("{}".to_string())).await;
+
+        assert!(
+            timed.is_err(),
+            "issue #1914 NOT reproduced: McpTool::call returned {:?} within 500ms; \
+             it was expected to hang because the server never sends a CallToolResult \
+             and McpTool::call has no internal timeout. If you just added a timeout \
+             fix, flip this assertion to `timed.is_ok()`.",
+            timed.ok(),
+        );
+
+        server_task.abort();
+    }
+
+    /// Guard for the reproduction above: with a server that *does* respond, the
+    /// same in-process duplex harness resolves well within the timeout window.
+    /// This proves the 500ms bound in the repro is meaningful — the hang is
+    /// caused by the missing response, not by the transport being slow.
+    #[tokio::test]
+    async fn mcp_tool_call_returns_promptly_for_responsive_server() {
+        use super::McpTool;
+        use crate::tool::ToolDyn;
+
+        let server = DynamicToolServer::new(vec![make_tool("ping", "responds immediately")]);
+
+        let (client_to_server, server_from_client) = tokio::io::duplex(8192);
+        let (server_to_client, client_from_server) = tokio::io::duplex(8192);
+
+        let server_clone = server.clone();
+        let server_task = tokio::spawn(async move {
+            let running = server_clone
+                .serve((server_from_client, server_to_client))
+                .await
+                .expect("server failed to start");
+            running.waiting().await.expect("server error");
+        });
+
+        let client = ClientInfo::default()
+            .serve((client_from_server, client_to_server))
+            .await
+            .expect("client connect failed");
+
+        let tools = client
+            .peer()
+            .list_all_tools()
+            .await
+            .expect("list_tools failed");
+        let mcp_tool = McpTool::from_mcp_server(tools[0].clone(), client.peer().clone());
+
+        let timed =
+            tokio::time::timeout(Duration::from_secs(2), mcp_tool.call("{}".to_string())).await;
+
+        let result = timed
+            .expect("responsive tool should resolve within 2s")
+            .expect("tool call should succeed");
+        assert!(result.contains("ping"), "unexpected tool output: {result}");
+
+        server_task.abort();
     }
 }

--- a/crates/rig-core/src/tool/server.rs
+++ b/crates/rig-core/src/tool/server.rs
@@ -87,14 +87,32 @@ impl ToolServer {
         self
     }
 
-    /// Add an MCP tool (from `rmcp`) to the agent
+    /// Add an MCP tool (from `rmcp`) to the agent, bounded by
+    /// [`DEFAULT_MCP_TOOL_TIMEOUT`](crate::tool::rmcp::DEFAULT_MCP_TOOL_TIMEOUT)
+    /// (see issue #1914). Use [`rmcp_tool_with_timeout`](Self::rmcp_tool_with_timeout)
+    /// to change or disable it.
     #[cfg_attr(docsrs, doc(cfg(feature = "rmcp")))]
     #[cfg(feature = "rmcp")]
-    pub fn rmcp_tool(mut self, tool: rmcp::model::Tool, client: rmcp::service::ServerSink) -> Self {
+    pub fn rmcp_tool(self, tool: rmcp::model::Tool, client: rmcp::service::ServerSink) -> Self {
+        self.rmcp_tool_with_timeout(tool, client, crate::tool::rmcp::DEFAULT_MCP_TOOL_TIMEOUT)
+    }
+
+    /// Add an MCP tool (from `rmcp`) with a per-call timeout (see issue #1914).
+    ///
+    /// Pass a [`Duration`](std::time::Duration) to bound the call, or `None` to
+    /// disable the timeout (unbounded).
+    #[cfg_attr(docsrs, doc(cfg(feature = "rmcp")))]
+    #[cfg(feature = "rmcp")]
+    pub fn rmcp_tool_with_timeout(
+        mut self,
+        tool: rmcp::model::Tool,
+        client: rmcp::service::ServerSink,
+        timeout: impl Into<Option<std::time::Duration>>,
+    ) -> Self {
         use crate::tool::rmcp::McpTool;
         let toolname = tool.name.to_string();
         self.toolset
-            .add_tool(McpTool::from_mcp_server(tool, client));
+            .add_tool(McpTool::from_mcp_server(tool, client).with_timeout(timeout));
         push_unique_name(&mut self.static_tool_names, toolname);
         self
     }

--- a/crates/rig-core/src/wasm_compat.rs
+++ b/crates/rig-core/src/wasm_compat.rs
@@ -83,8 +83,20 @@ impl std::error::Error for Elapsed {}
 /// A cross-platform (native + wasm) replacement for `tokio::time::timeout`: rig's
 /// `tokio` dependency is built without the `time` feature, and `tokio::time` does
 /// not function on wasm. This is built on [`futures_timer::Delay`], which rig
-/// already uses for SSE retry backoff and which supports wasm via its
-/// `wasm-bindgen` feature (enabled by rig's `wasm` feature).
+/// already uses for SSE retry backoff.
+///
+/// On elapse the pending `future` is **dropped** (cancelled by drop); it gets no
+/// chance to run cleanup beyond its own `Drop`. A zero or already-elapsed
+/// `duration` still polls `future` once before electing `Elapsed`, and an absurdly
+/// large `duration` may panic when added to `Instant::now()` inside the timer.
+///
+/// # Wasm
+/// On `wasm32` the underlying timer only fires when the `futures-timer/wasm-bindgen`
+/// backend is active, which rig enables through its `wasm` feature. Building for
+/// `wasm32` **without** rig's `wasm` feature leaves the native (thread/park) timer
+/// backend in place — it cannot drive timers on wasm, so the timeout would never
+/// fire. Enable rig's `wasm` feature when targeting wasm. (This is the same
+/// `futures_timer::Delay` contract the existing SSE retry backoff relies on.)
 pub async fn timeout<F>(duration: std::time::Duration, future: F) -> Result<F::Output, Elapsed>
 where
     F: Future,
@@ -116,4 +128,22 @@ macro_rules! if_not_wasm {
         $($tokens)*
 
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Elapsed, timeout};
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn timeout_returns_ok_for_a_future_that_completes_in_time() {
+        let result = timeout(Duration::from_secs(5), async { 42 }).await;
+        assert_eq!(result, Ok(42));
+    }
+
+    #[tokio::test]
+    async fn timeout_returns_elapsed_for_a_future_that_never_completes() {
+        let result = timeout(Duration::from_millis(20), std::future::pending::<()>()).await;
+        assert_eq!(result, Err(Elapsed));
+    }
 }

--- a/crates/rig-core/src/wasm_compat.rs
+++ b/crates/rig-core/src/wasm_compat.rs
@@ -146,4 +146,12 @@ mod tests {
         let result = timeout(Duration::from_millis(20), std::future::pending::<()>()).await;
         assert_eq!(result, Err(Elapsed));
     }
+
+    #[tokio::test]
+    async fn timeout_zero_duration_still_polls_a_ready_future_once() {
+        // Documented contract: a zero/already-elapsed duration still polls the
+        // future once before electing `Elapsed`, so a ready future wins.
+        let result = timeout(Duration::ZERO, async { 7 }).await;
+        assert_eq!(result, Ok(7));
+    }
 }

--- a/crates/rig-core/src/wasm_compat.rs
+++ b/crates/rig-core/src/wasm_compat.rs
@@ -91,12 +91,10 @@ impl std::error::Error for Elapsed {}
 /// large `duration` may panic when added to `Instant::now()` inside the timer.
 ///
 /// # Wasm
-/// On `wasm32` the underlying timer only fires when the `futures-timer/wasm-bindgen`
-/// backend is active, which rig enables through its `wasm` feature. Building for
-/// `wasm32` **without** rig's `wasm` feature leaves the native (thread/park) timer
-/// backend in place — it cannot drive timers on wasm, so the timeout would never
-/// fire. Enable rig's `wasm` feature when targeting wasm. (This is the same
-/// `futures_timer::Delay` contract the existing SSE retry backoff relies on.)
+/// On browser wasm (`wasm32-unknown-unknown`) the `futures-timer` `wasm-bindgen`
+/// (`setTimeout`) backend is selected automatically via a target-scoped
+/// dependency, so the timer fires without depending on any cargo feature. (The
+/// `futures_timer::Delay` SSE retry backoff relies on the same backend.)
 pub async fn timeout<F>(duration: std::time::Duration, future: F) -> Result<F::Output, Elapsed>
 where
     F: Future,

--- a/crates/rig-core/src/wasm_compat.rs
+++ b/crates/rig-core/src/wasm_compat.rs
@@ -65,6 +65,41 @@ pub type WasmBoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 /// Boxed future type without `Send` on wasm targets.
 pub type WasmBoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
 
+/// Error returned by [`timeout`] when the future does not complete in time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Elapsed;
+
+impl std::fmt::Display for Elapsed {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("future timed out")
+    }
+}
+
+impl std::error::Error for Elapsed {}
+
+/// Await `future`, returning `Err(`[`Elapsed`]`)` if it does not complete within
+/// `duration`.
+///
+/// A cross-platform (native + wasm) replacement for `tokio::time::timeout`: rig's
+/// `tokio` dependency is built without the `time` feature, and `tokio::time` does
+/// not function on wasm. This is built on [`futures_timer::Delay`], which rig
+/// already uses for SSE retry backoff and which supports wasm via its
+/// `wasm-bindgen` feature (enabled by rig's `wasm` feature).
+pub async fn timeout<F>(duration: std::time::Duration, future: F) -> Result<F::Output, Elapsed>
+where
+    F: Future,
+{
+    use futures::future::{Either, select};
+
+    let delay = futures_timer::Delay::new(duration);
+    futures::pin_mut!(future);
+    futures::pin_mut!(delay);
+    match select(future, delay).await {
+        Either::Left((output, _)) => Ok(output),
+        Either::Right(((), _)) => Err(Elapsed),
+    }
+}
+
 #[macro_export]
 macro_rules! if_wasm {
     ($($tokens:tt)*) => {

--- a/crates/rig-core/src/wasm_compat.rs
+++ b/crates/rig-core/src/wasm_compat.rs
@@ -57,12 +57,17 @@ impl<T> WasmCompatSync for T where T: Sync {}
 #[cfg(all(feature = "wasm", target_arch = "wasm32"))]
 impl<T> WasmCompatSync for T {}
 
-#[cfg(not(target_family = "wasm"))]
-/// Boxed future type that includes `Send` on non-wasm targets.
+#[cfg(not(all(feature = "wasm", target_arch = "wasm32")))]
+/// Boxed future type that includes `Send`, except on wasm32 with the `wasm` feature.
+///
+/// Gated to match [`WasmCompatSend`]/[`WasmCompatSync`] (and the streaming `Box`
+/// selection) — a `WasmBoxedFuture` returned by a `WasmCompatSend` bound (e.g.
+/// [`ToolDyn::call`](crate::tool::ToolDyn)) must drop `Send` under the same
+/// condition the marker relaxes it, or the two disagree on wasm.
 pub type WasmBoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
-#[cfg(target_family = "wasm")]
-/// Boxed future type without `Send` on wasm targets.
+#[cfg(all(feature = "wasm", target_arch = "wasm32"))]
+/// Boxed future type without `Send`, on wasm32 with the `wasm` feature.
 pub type WasmBoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
 
 /// Error returned by [`timeout`] when the future does not complete in time.


### PR DESCRIPTION
## Summary

Fixes #1914, where an agent using an `rmcp` `StreamableHttpClientTransport` **occasionally gets permanently stuck**. `McpTool::call` awaited the rmcp peer's `call_tool` with **no timeout**:

```rust
let result = self.client.call_tool(request).await?; // never returns if the response is lost
```

When the StreamableHttp transport orphans an in-flight request during transparent session re-initialization (server returns HTTP 404 → the worker's `streams.abort_all()` cancels the SSE task carrying the outstanding response — the `JoinError::Cancelled` WARN in the issue), the request **never gets a response and never errors**, so `call_tool` hangs forever and wedges the agent loop. The loop already turns a tool *error* into a tool result the model can react to, but it cannot escape a call that never returns. The upstream root cause is tracked at **modelcontextprotocol/rust-sdk#912**.

## What changed

- **Default timeout (`DEFAULT_MCP_TOOL_TIMEOUT`, 5 min):** `McpTool::from_mcp_server` now applies a generous default, so the hang is bounded **out of the box**. The default lives in the constructor, so every entry point inherits it: `AgentBuilder::rmcp_tool[s]`, `McpClientHandler::new`, and `ToolServer::rmcp_tool`.
- **Override or disable** via `*_with_timeout` / `with_timeout`, which take `impl Into<Option<Duration>>` — pass a `Duration` to change it, or `None` for unbounded (e.g. legitimately long-running tools):
  ```rust
  let agent = client.agent("model")
      .rmcp_tools_with_timeout(tools, peer, Duration::from_secs(60)) // or `None` to disable
      .build();
  ```
- **wasm-friendly, automatically:** the timeout uses a new `wasm_compat::timeout` built on `futures_timer::Delay` (already used for SSE backoff), **not `tokio::time`** (rig's `tokio` dep has no `time` feature and `tokio::time` doesn't work on wasm). The wasm `setTimeout` backend is now selected by a **target-scoped dependency** (`cfg(all(target_arch = "wasm32", target_os = "unknown"))`) rather than the `wasm` feature — a timer backend is a property of the target, not a user preference. This matches the existing `cfg(not(target_family = "wasm"))` convention, fixes the same latent issue in the **SSE retry backoff**, and as a bonus stops dragging `gloo-timers`/`send_wrapper`/`js-sys` into native and docs.rs builds.
- **wasm `cfg` consistency:** aligned `WasmBoxedFuture`'s `Send` gating with the `WasmCompatSend/Sync` markers it's coupled to (a `WasmBoxedFuture` returned under a `WasmCompatSend` bound, e.g. `ToolDyn::call`, must drop `Send` under the same condition). Both now use `cfg(all(feature = "wasm", target_arch = "wasm32"))`; behavior-identical for all building configs.
- **Coverage:** added `ToolServer::rmcp_tool_with_timeout` (this path previously couldn't configure the timeout).

> **Behavior change / upgrade note:** previously these paths were unbounded; MCP tool calls now error with `MCP tool '<name>' timed out after 300s` by default. Tools that legitimately run longer should opt out with `with_timeout(None)` (or a larger `Duration`).

## Known trade-off (documented)

On elapse the call is abandoned **locally** (the future is dropped); rig does **not** send an MCP `CancelledNotification`, so a still-running server-side tool keeps running and rmcp reclaims the request slot when the session closes. This is documented on `McpTool` and `wasm_compat::timeout`. A follow-up could switch to rmcp's `send_cancellable_request` + `RequestHandle::cancel` (verified `tokio::time`-free / wasm-safe) to notify the server and free the slot eagerly. Also out of scope: a timeout at the shared tool choke point (`ToolSet::call`) that would protect non-MCP tools too.

## Testing

Deterministic, in-process (no network, no LLM key):
- **`McpTool`:** `mcp_tool_call_with_timeout_errors_instead_of_hanging` (configured timeout → recoverable error); `mcp_tool_call_returns_promptly_for_responsive_server` (timeout configured + responsive → `Ok`); `mcp_tool_call_without_timeout_is_unbounded` (`with_timeout(None)` opt-out); asserts `from_mcp_server` applies `Some(DEFAULT)`.
- **`McpClientHandler`:** `mcp_client_handler_with_timeout_bounds_registered_tools` — end-to-end through the shared `ToolServerHandle` (the path the agent loop uses).
- **`AgentBuilder`:** `build_rmcp_tools_threads_timeout_into_built_tools` — the shared builder helper threads the default / explicit / `None` timeout onto each built tool, and the threaded timeout actually bounds a hanging call.
- **`ToolServer`:** `tool_server_rmcp_tool_with_timeout_bounds_calls` — `ToolServer::rmcp_tool_with_timeout` end-to-end.
- **`wasm_compat::timeout`:** `Ok`, `Elapsed`, and the zero-duration "polls once" contract.

Verified: `cargo test -p rig-core --features rmcp --lib` (**893 pass**), `cargo clippy --features rmcp --all-targets` (clean), `cargo fmt --check`, native build, and `cargo check --target wasm32-unknown-unknown --features wasm` — plus `cargo tree` confirming `gloo-timers` is pulled on wasm32 and **not** on native.
