### PR TITLE
docs: add Archestra to "Who is using Rig?" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Below is a non-exhaustive list of companies and people who are using Rig:
 - [Cortex Memory](https://github.com/sopaco/cortex-mem) - The production-ready memory system for intelligent agents. A complete solution for memory management, from extraction and vector search to automated optimization, with a REST API, MCP, CLI, and insights dashboard out-of-the-box.
 - [Ironclaw](https://github.com/nearai/ironclaw) - A secure personal AI assistant
 - [ilert](https://www.ilert.com/) - Incident management & alerting platform. Uses Rig as the multi-provider abstraction in its agentic LLM proxy powering ilert AI.
+- [Archestra](https://github.com/archestra-ai/archestra) - MCP-native secure AI platform. Uses Rig in its agentic benchmark.
 
 For a full list, check out our [ECOSYSTEM.md file.](https://www.github.com/0xPlaygrounds/rig/tree/main/ECOSYSTEM.md)
 


### PR DESCRIPTION
Adds Archestra to the "Who is using Rig?" section of the README, as requested in #1919.

[Archestra](https://github.com/archestra-ai/archestra) is an MCP-native secure AI platform that uses Rig in its agentic benchmark.

Closes #1919

🤖 Generated with [Claude Code](https://claude.com/claude-code)