### PR TITLE
fix(gemini): default totalTokenCount to fix deserialization crash on empty generations

### DIFF
--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -1340,6 +1340,7 @@ pub mod gemini_api_types {
         pub cached_content_token_count: Option<i32>,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub candidates_token_count: Option<i32>,
+        #[serde(default)]
         pub total_token_count: i32,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub thoughts_token_count: Option<i32>,
@@ -2172,6 +2173,16 @@ mod tests {
 
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn test_usage_metadata_deserializes_without_total_token_count() {
+        // Gemini's proto3-JSON encoding omits fields whose value is the default (0),
+        // so `totalTokenCount` is absent on short/empty/blocked generations.
+        let usage: UsageMetadata =
+            serde_json::from_str(r#"{"promptTokenCount": 12}"#).expect("should deserialize");
+        assert_eq!(usage.total_token_count, 0);
+        assert_eq!(usage.prompt_token_count, 12);
+    }
 
     #[test]
     fn test_resolve_request_model_uses_override() {

--- a/crates/rig-core/src/providers/gemini/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/streaming.rs
@@ -21,6 +21,7 @@ use crate::telemetry::SpanCombinator;
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct PartialUsage {
+    #[serde(default)]
     pub total_token_count: i32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cached_content_token_count: Option<i32>,
@@ -710,6 +711,16 @@ mod tests {
         assert_eq!(token_usage.output_tokens, 30);
         assert_eq!(token_usage.reasoning_tokens, 0);
         assert_eq!(token_usage.total_tokens, 50);
+    }
+
+    #[test]
+    fn test_partial_usage_deserializes_without_total_token_count() {
+        // Gemini's proto3-JSON encoding omits fields whose value is the default (0),
+        // so `totalTokenCount` is absent on short/empty/blocked generations.
+        let usage: PartialUsage =
+            serde_json::from_str(r#"{"promptTokenCount": 12}"#).expect("should deserialize");
+        assert_eq!(usage.total_token_count, 0);
+        assert_eq!(usage.prompt_token_count, 12);
     }
 
     #[test]


### PR DESCRIPTION
## Symptom

Calls to the Gemini provider intermittently fail with:

    JsonError: missing field `totalTokenCount` at line 1 column 479

This happens on short/empty/blocked generations (e.g. safety-filtered responses or malformed/hallucinated tool-call outputs).

## Root cause

Gemini's REST API is proto3-JSON-encoded, which omits fields whose value is the default (`0`). So when `totalTokenCount == 0`, Gemini leaves the key out of the response entirely. rig's usage structs declare `total_token_count: i32` as a required field (no default, not `Option`), so serde fails to deserialize.

This is the same class of bug already fixed for `promptTokenCount`, which carries `#[serde(default)]` — `totalTokenCount` was simply missed.

## Fix

Add `#[serde(default)]` to the `total_token_count` field in both structs:

1. `crates/rig-core/src/providers/gemini/completion.rs` — `UsageMetadata`
2. `crates/rig-core/src/providers/gemini/streaming.rs` — `PartialUsage`

The type stays `i32` (defaulting to `0`) rather than becoming `Option<i32>`, so the existing `Display` impl and `GetTokenUsage::token_usage()` keep compiling unchanged, matching the existing `prompt_token_count` pattern.

`rig-vertexai` and `rig-gemini-grpc` are unaffected — they use generated proto types, not serde JSON.

## Tests

Added a regression test for each struct that deserializes a `usageMetadata` payload without a `totalTokenCount` key (`{"promptTokenCount": 12}`) and asserts it succeeds with `total_token_count == 0`.