### PR TITLE
ci: run doctests (and stop rig-sqlite opting out of them)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,6 +109,31 @@ jobs:
           COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
           PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
 
+  # `cargo nextest` (used by the `test` job) does NOT run doctests, and the
+  # `doc` job only builds documentation — so without this job nothing executes
+  # the `///` code examples and a broken doctest can sail through CI.
+  doctest:
+    name: stable / doctest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      # Required to compile rig-lancedb
+      - name: Install Protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      # No API keys needed: the doctests that actually execute are pure (the
+      # provider examples are all `no_run`/compile-only), so this job stays
+      # hermetic and non-flaky.
+      - name: Run doctests
+        run: cargo test --doc --workspace --all-features
+
   doc:
     name: stable / doc
     runs-on: ubuntu-latest

--- a/crates/rig-sqlite/Cargo.toml
+++ b/crates/rig-sqlite/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 workspace = true
 
 [lib]
-doctest = false
+doctest = true
 
 [dependencies]
 rig-core = { path = "../rig-core", version = "0.39.0", default-features = false, features = [


### PR DESCRIPTION
## Problem

**No CI job runs doctests.** The `test` job uses `cargo nextest`, which [does not run doctests by design](https://nexte.st/docs/running/#running-doctests), and the `doc` job only *builds* documentation (`cargo doc --no-deps`) — it never executes the `///` code examples. So a doctest that fails to compile, or panics when run, sails straight through with CI green. This is exactly why a broken example can survive unnoticed.

This is compounded in **rig-sqlite**, which set `[lib] doctest = false` — excluding its examples from `cargo test --doc` *entirely*, even though #1716 set doctests to `true` project-wide specifically to "ensure that we do not have stale uncompileable examples inside our docs."

## Fix

- **Add a `doctest` CI job** that runs `cargo test --doc --workspace --all-features` (with `protoc` installed, matching the other jobs). No API keys: the doctests that actually execute are pure — the provider examples are all `no_run`/compile-only — so the job is hermetic and non-flaky.
- **Flip rig-sqlite's `doctest = false` → `true`** so its examples are tested alongside every other crate's.

## Verification

- Audited every crate's doctests **in isolation** with its own default features (19/19 pass) and across the **full workspace with `--all-features`** (all pass). No existing doctest is currently broken — so this change is *preventive*: it closes the hole before a broken example lands.
- Confirmed the new coverage is actually effective: temporarily introducing a typo into a rig-sqlite doctest now makes `cargo test --doc` fail with `E0599` — whereas with `doctest = false` it passed silently.

```
test crates/rig-sqlite/src/lib.rs - SqliteVectorStoreTable (line 82) ... FAILED
error[E0599]: no function or associated item named `neww` found for struct `Column`
test result: FAILED. 1 passed; 1 failed; ...
```