### PR TITLE
fix(rig-core): fix epub loader tests + prevent CWD-relative fixture-path regressions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,21 @@ jobs:
       - name: Run cargo fmt
         run: cargo fmt -- --check
 
+      # Guard against CWD-relative test fixture paths. `cargo test` runs from the
+      # crate root while `cargo nextest` (CI's runner) runs from the workspace
+      # root, so a bare `tests/data/...` path passes under one and fails under the
+      # other — letting a broken fixture path stay green in CI. Real test code
+      # must anchor fixtures to CARGO_MANIFEST_DIR (see
+      # crates/rig-core/src/loaders/test_fixtures.rs). Doc-comment example
+      # snippets (`///`, `//!`) are exempt.
+      - name: Check test fixture paths are CWD-independent
+        run: |
+          if grep -rnE '"(\./)?tests/data' crates/*/src crates/*/tests --include='*.rs' \
+            | grep -vE ':[[:space:]]*//[/!]'; then
+            echo "::error::Found a CWD-relative 'tests/data' path in test code. Anchor it to CARGO_MANIFEST_DIR via crate::loaders::test_fixtures (see crates/rig-core/src/loaders/test_fixtures.rs)."
+            exit 1
+          fi
+
   # Special check to make sure rig-core is compatible with the wasm target
   check-wasm:
     name: stable / check rig-core wasm target

--- a/crates/rig-core/src/loaders/epub/loader.rs
+++ b/crates/rig-core/src/loaders/epub/loader.rs
@@ -523,15 +523,15 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
-
     use crate::loaders::epub::RawTextProcessor;
+    use crate::loaders::test_fixtures::{fixture_glob, fixture_path};
 
     use super::EpubFileLoader;
 
     #[test]
     fn test_epub_loader_with_errors() {
-        let loader = EpubFileLoader::<_, RawTextProcessor>::with_glob("tests/data/*.epub").unwrap();
+        let glob = fixture_glob("*.epub");
+        let loader = EpubFileLoader::<_, RawTextProcessor>::with_glob(&glob).unwrap();
         let actual = loader
             .load_with_path()
             .ignore_errors()
@@ -551,7 +551,8 @@ mod tests {
 
     #[test]
     fn test_epub_loader_with_ignoring_errors() {
-        let loader = EpubFileLoader::<_, RawTextProcessor>::with_glob("tests/data/*.epub").unwrap();
+        let glob = fixture_glob("*.epub");
+        let loader = EpubFileLoader::<_, RawTextProcessor>::with_glob(&glob).unwrap();
         let actual = loader
             .load_with_path()
             .ignore_errors()
@@ -568,7 +569,8 @@ mod tests {
 
     #[test]
     fn test_single_file() {
-        let loader = EpubFileLoader::<_, RawTextProcessor>::with_glob("tests/data/*.epub").unwrap();
+        let glob = fixture_glob("*.epub");
+        let loader = EpubFileLoader::<_, RawTextProcessor>::with_glob(&glob).unwrap();
 
         let actual = loader
             .read()
@@ -581,7 +583,8 @@ mod tests {
 
     #[test]
     fn test_single_file_with_path() {
-        let loader = EpubFileLoader::<_, RawTextProcessor>::with_glob("tests/data/*.epub").unwrap();
+        let glob = fixture_glob("*.epub");
+        let loader = EpubFileLoader::<_, RawTextProcessor>::with_glob(&glob).unwrap();
 
         let actual = loader
             .read_with_path()
@@ -592,6 +595,6 @@ mod tests {
         assert_eq!(actual.len(), 1);
 
         let (path, _) = &actual[0];
-        assert_eq!(path, &PathBuf::from("tests/data/dummy.epub"));
+        assert_eq!(path, &fixture_path("dummy.epub"));
     }
 }

--- a/crates/rig-core/src/loaders/mod.rs
+++ b/crates/rig-core/src/loaders/mod.rs
@@ -14,6 +14,11 @@ pub mod file;
 
 pub use file::FileLoader;
 
+// Test-only helpers for resolving on-disk fixtures in a CWD-independent way.
+// Gated to the features whose tests use them so it never warns as dead code.
+#[cfg(all(test, any(feature = "pdf", feature = "epub")))]
+mod test_fixtures;
+
 #[cfg(feature = "pdf")]
 #[cfg_attr(docsrs, doc(cfg(feature = "pdf")))]
 pub mod pdf;

--- a/crates/rig-core/src/loaders/pdf.rs
+++ b/crates/rig-core/src/loaders/pdf.rs
@@ -502,26 +502,13 @@ impl<T> Iterator for IntoIter<'_, T> {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use crate::loaders::test_fixtures::{fixture_glob, fixture_path};
 
     use super::PdfFileLoader;
 
-    fn fixture_path(filename: &str) -> PathBuf {
-        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("../../tests/data")
-            .join(filename)
-    }
-
-    fn fixture_glob() -> String {
-        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("../../tests/data/*.pdf")
-            .to_string_lossy()
-            .into_owned()
-    }
-
     #[test]
     fn test_pdf_loader() {
-        let glob = fixture_glob();
+        let glob = fixture_glob("*.pdf");
         let loader = PdfFileLoader::with_glob(&glob).unwrap();
         let actual = loader
             .load_with_path()

--- a/crates/rig-core/src/loaders/test_fixtures.rs
+++ b/crates/rig-core/src/loaders/test_fixtures.rs
@@ -1,0 +1,25 @@
+//! Shared helpers for locating on-disk test fixtures.
+//!
+//! Fixtures live at the workspace-root `tests/data/`. The working directory a
+//! test runs in differs by runner — `cargo test` uses the crate root while
+//! `cargo nextest` uses the workspace root — so a path written relative to the
+//! CWD (e.g. `"tests/data/*.epub"`) resolves under one runner but not the other,
+//! letting a broken fixture path stay green in CI yet fail locally.
+//!
+//! Always resolve fixtures through these helpers, which anchor to the crate via
+//! `CARGO_MANIFEST_DIR` and are therefore CWD-independent. A CI guard rejects
+//! bare `tests/data` paths in test code to keep it that way.
+
+use std::path::PathBuf;
+
+/// Absolute path to `<workspace>/tests/data/<filename>`, anchored to this crate.
+pub(crate) fn fixture_path(filename: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../tests/data")
+        .join(filename)
+}
+
+/// Absolute glob into `<workspace>/tests/data/` for `pattern` (e.g. `"*.epub"`).
+pub(crate) fn fixture_glob(pattern: &str) -> String {
+    fixture_path(pattern).to_string_lossy().into_owned()
+}


### PR DESCRIPTION
## Problem

`cargo test -p rig-core --all-features` fails 4 epub-loader tests:

```
loaders::epub::loader::tests::test_epub_loader_with_errors          ... FAILED
loaders::epub::loader::tests::test_epub_loader_with_ignoring_errors ... FAILED
loaders::epub::loader::tests::test_single_file                      ... FAILED
loaders::epub::loader::tests::test_single_file_with_path            ... FAILED
assertion `left == right` failed
  left: 0
 right: 1
```

## Root cause

These tests globbed `tests/data/*.epub` **relative to the working directory**. The crate reorg (#1699) moved the fixture from `rig-core/tests/data/dummy.epub` to the workspace-root `tests/data/` (`git show f4ad17cd` → `{rig/rig-core/tests => tests}/data/dummy.epub`), but the epub tests kept the bare relative path.

`cargo test -p rig-core` runs each test with the working directory set to the **crate root**, so the glob resolves to `crates/rig-core/tests/data/` — which doesn't exist — and matches zero files (`actual.len() == 0`).

The sibling **pdf** loader tests had already been fixed (anchored to `CARGO_MANIFEST_DIR`); the epub tests were simply missed in that migration.

**Why CI stayed green:** the `test` job runs `cargo nextest`, which — [unlike `cargo test`](https://nexte.st/) — runs tests from the **workspace root**, not the crate root. So the bare `tests/data/...` path happened to resolve there and the failure never surfaced in CI. nextest exposes no setting to align its working directory with `cargo test`'s, so the fix is to make the tests CWD-independent and guard against the pattern returning.

## Changes

1. **Shared helper** — extract the `CARGO_MANIFEST_DIR`-anchored fixture lookup into `crates/rig-core/src/loaders/test_fixtures.rs` (`fixture_path` / `fixture_glob`) and route **both** the pdf and epub loader tests through it. Single source of truth; no duplication; CWD-independent.
2. **CI guard** — a `fmt`-job step fails the build if any test code references a CWD-relative `tests/data` path, with a message pointing at the helper. Doc-comment example snippets (`///`, `//!`) are exempt. (Verified it both passes on the current tree and fails on an injected bare path.)

No production code is touched — only test code, a test-only helper, and CI.

## Verification

- `cargo test -p rig-core --all-features` → **1012 passed, 0 failed** (was 1008 passed, 4 failed).
- `cargo nextest run -p rig-core --all-features` → **1012 passed** (local nextest uses the strict crate-root CWD, confirming the fix holds under the harder case).
- CI guard: passes on this tree; fails when a bare `tests/data` path is injected into real test code.