### PR TITLE
feat(rig-core)!: complete provider error-response inspection coverage (closes #1931)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,6 +50,30 @@ jobs:
             exit 1
           fi
 
+      # Guard migrated providers against re-flattening an HTTP failure into a
+      # capability error's `ProviderError(String)`. The `provider_response_*`
+      # inspection helpers (#1859) can only recover a status + body from the
+      # `ProviderResponse` / `HttpError(InvalidStatusCodeWithMessage)` variants,
+      # so an HTTP status must never be `format!`'d into a `ProviderError`. Route
+      # the raw status + body through `<Capability>Error::from_http_response(status, body)`
+      # instead (see crates/rig-core/src/provider_response.rs).
+      #
+      # `perl -0777` slurps each whole file so the check is MULTI-LINE aware (the
+      # canonical flatten spans several lines: `ProviderError(format!(\n "..",\n
+      # status, body))`). It is scoped to providers already migrated through the
+      # funnel; add a directory here as each remaining provider migrates (#1931).
+      # New, not-yet-migrated providers rely on the structural funnel + review.
+      - name: Check migrated providers don't flatten HTTP errors into ProviderError
+        run: |
+          hits=$(perl -0777 -ne '
+            print "$ARGV\n" if /(Completion|Embedding|ImageGeneration|AudioGeneration|Transcription|Verify|Rerank)Error::ProviderError\(\s*format!\([^;]*?\bstatus\b/s;
+          ' $(find crates/rig-core/src/providers/anthropic \
+                   crates/rig-core/src/providers/gemini -name '*.rs'))
+          if [ -n "$hits" ]; then
+            echo "::error::A migrated provider flattened an HTTP status into ProviderError(format!(...)): ${hits}. Route the raw status + body through <Capability>Error::from_http_response(status, body) so the provider_response_* helpers can recover them (see crates/rig-core/src/provider_response.rs)."
+            exit 1
+          fi
+
   # Special check to make sure rig-core is compatible with the wasm target
   check-wasm:
     name: stable / check rig-core wasm target

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
             exit 1
           fi
 
-      # Guard migrated providers against re-flattening an HTTP failure into a
+      # Guard every in-core provider against re-flattening an HTTP failure into a
       # capability error's `ProviderError(String)`. The `provider_response_*`
       # inspection helpers (#1859) can only recover a status + body from the
       # `ProviderResponse` / `HttpError(InvalidStatusCodeWithMessage)` variants,
@@ -60,17 +60,17 @@ jobs:
       #
       # `perl -0777` slurps each whole file so the check is MULTI-LINE aware (the
       # canonical flatten spans several lines: `ProviderError(format!(\n "..",\n
-      # status, body))`). It is scoped to providers already migrated through the
-      # funnel; add a directory here as each remaining provider migrates (#1931).
-      # New, not-yet-migrated providers rely on the structural funnel + review.
-      - name: Check migrated providers don't flatten HTTP errors into ProviderError
+      # status, body))`). Companion crates (rig-bedrock/rig-vertexai/rig-gemini-grpc/
+      # rig-fastembed) are intentionally excluded: they use AWS SDK / gRPC / local
+      # inference, have no HTTP status to preserve, and the helpers correctly
+      # return None for them.
+      - name: Check providers don't flatten HTTP errors into ProviderError
         run: |
           hits=$(perl -0777 -ne '
             print "$ARGV\n" if /(Completion|Embedding|ImageGeneration|AudioGeneration|Transcription|Verify|Rerank)Error::ProviderError\(\s*format!\([^;]*?\bstatus\b/s;
-          ' $(find crates/rig-core/src/providers/anthropic \
-                   crates/rig-core/src/providers/gemini -name '*.rs'))
+          ' $(find crates/rig-core/src/providers -name '*.rs'))
           if [ -n "$hits" ]; then
-            echo "::error::A migrated provider flattened an HTTP status into ProviderError(format!(...)): ${hits}. Route the raw status + body through <Capability>Error::from_http_response(status, body) so the provider_response_* helpers can recover them (see crates/rig-core/src/provider_response.rs)."
+            echo "::error::A provider flattened an HTTP status into ProviderError(format!(...)): ${hits}. Route the raw status + body through <Capability>Error::from_http_response(status, body) so the provider_response_* helpers can recover them (see crates/rig-core/src/provider_response.rs)."
             exit 1
           fi
 

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -56,8 +56,30 @@ use thiserror::Error;
 // Errors
 /// Errors returned by completion models.
 ///
-/// Inspect provider failures with [`Self::provider_response_body`],
-/// [`Self::provider_response_json`], and [`Self::provider_response_status`].
+/// When a request fails because the provider returned an error response, the
+/// raw status and body are preserved so you can inspect them with
+/// [`Self::provider_response_body`], [`Self::provider_response_json`], and
+/// [`Self::provider_response_status`]:
+///
+/// ```
+/// use rig_core::completion::CompletionError;
+///
+/// fn inspect(err: &CompletionError) {
+///     if let Some(status) = err.provider_response_status() {
+///         eprintln!("provider responded with HTTP {status}");
+///     }
+///     match err.provider_response_json() {
+///         // The provider returned a structured (JSON) error envelope.
+///         Ok(Some(json)) => eprintln!("error details: {json}"),
+///         // No body was preserved (e.g. a transport error, or a provider
+///         // that has no response to inspect).
+///         Ok(None) => {}
+///         // A body was preserved but is not JSON; read it verbatim.
+///         Err(_) => eprintln!("raw body: {:?}", err.provider_response_body()),
+///     }
+/// }
+/// # let _ = inspect;
+/// ```
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum CompletionError {

--- a/crates/rig-core/src/provider_response.rs
+++ b/crates/rig-core/src/provider_response.rs
@@ -65,6 +65,39 @@ pub(crate) fn completion_error_from_body(
 macro_rules! impl_provider_response_helpers {
     ($error:ty) => {
         impl $error {
+            /// Builds an error from a captured HTTP status and raw response body,
+            /// routing it so the `provider_response_*` helpers stay useful.
+            ///
+            /// This is the single funnel every HTTP-error path should use instead of
+            /// flattening a status and body into a `ProviderError(String)`:
+            /// - A success (2xx) status carries a provider-authored error envelope, so
+            ///   it is preserved as [`Self::ProviderResponse`] together with the status.
+            /// - A non-success status is preserved as
+            ///   [`Self::HttpError`]`(`[`http_client::Error::InvalidStatusCodeWithMessage`](crate::http_client::Error::InvalidStatusCodeWithMessage)`)`.
+            ///
+            /// Either way the raw `body` is kept verbatim and the status stays
+            /// recoverable through [`Self::provider_response_status`].
+            // Generated uniformly for every capability error as the regression
+            // anchor; not all of them have a wired HTTP path yet (mirrors the
+            // `ProviderResponse` variant being kept for symmetry / future paths).
+            #[allow(dead_code)]
+            pub(crate) fn from_http_response(
+                status: http::StatusCode,
+                body: impl Into<String>,
+            ) -> Self {
+                if status.is_success() {
+                    Self::ProviderResponse($crate::provider_response::ProviderResponseError {
+                        status: Some(status),
+                        body: body.into(),
+                    })
+                } else {
+                    Self::HttpError($crate::http_client::Error::InvalidStatusCodeWithMessage(
+                        status,
+                        body.into(),
+                    ))
+                }
+            }
+
             /// Returns the raw provider response body when available.
             ///
             /// This is available for:

--- a/crates/rig-core/src/provider_response.rs
+++ b/crates/rig-core/src/provider_response.rs
@@ -16,7 +16,12 @@ pub struct ProviderResponseError {
 }
 
 impl ProviderResponseError {
-    pub(crate) fn without_status(body: impl Into<String>) -> Self {
+    /// Preserves a raw provider error body that has no associated HTTP status.
+    ///
+    /// Use this for non-HTTP transports (gRPC, native SDKs) where there is no
+    /// [`http::StatusCode`] to record but the provider still returned an error
+    /// payload worth surfacing through the `provider_response_*` helpers.
+    pub fn without_status(body: impl Into<String>) -> Self {
         Self {
             status: None,
             body: body.into(),
@@ -41,6 +46,11 @@ impl std::error::Error for ProviderResponseError {}
 /// - `Ok(Some(value))` when a body is present and valid JSON.
 /// - `Ok(None)` when no body is present.
 /// - `Err(error)` when a body is present but isn't valid JSON.
+///
+/// Note the empty-body asymmetry: an empty preserved body is reported as
+/// `Some("")` by `provider_response_body()` but treated as absent here (returns
+/// `Ok(None)`), since an empty string is not valid JSON. To distinguish "no
+/// body" from "empty body", check `provider_response_body()` directly.
 pub(crate) fn json(body: Option<&str>) -> Result<Option<serde_json::Value>, serde_json::Error> {
     body.filter(|body| !body.is_empty())
         .map(serde_json::from_str)
@@ -77,14 +87,14 @@ macro_rules! impl_provider_response_helpers {
             ///
             /// Either way the raw `body` is kept verbatim and the status stays
             /// recoverable through [`Self::provider_response_status`].
-            // Generated uniformly for every capability error as the regression
-            // anchor; not all of them have a wired HTTP path yet (mirrors the
-            // `ProviderResponse` variant being kept for symmetry / future paths).
+            ///
+            /// Provider integrations (including out-of-tree ones) should route
+            /// HTTP error responses through this constructor rather than
+            /// re-implementing the read-body-then-route logic.
+            // Generated uniformly for every capability error; `VerifyError` has
+            // no wired HTTP path yet, so allow the unused constructor there.
             #[allow(dead_code)]
-            pub(crate) fn from_http_response(
-                status: http::StatusCode,
-                body: impl Into<String>,
-            ) -> Self {
+            pub fn from_http_response(status: http::StatusCode, body: impl Into<String>) -> Self {
                 if status.is_success() {
                     Self::ProviderResponse($crate::provider_response::ProviderResponseError {
                         status: Some(status),
@@ -131,6 +141,13 @@ macro_rules! impl_provider_response_helpers {
             /// Returns the HTTP status code when this error preserves one, either
             /// from a non-success HTTP response, from a preserved provider
             /// response, or from a 2xx error envelope.
+            ///
+            /// **A returned 2xx status does not mean success**: some providers
+            /// return a structured error envelope with a success status (e.g.
+            /// OpenAI Chat Completions streaming errors). Never infer failure
+            /// from the status alone — this method only ever returns a status on
+            /// an error value; inspect [`Self::provider_response_body`] /
+            /// [`Self::provider_response_json`] for the error details.
             pub fn provider_response_status(&self) -> Option<http::StatusCode> {
                 match self {
                     Self::ProviderResponse(response) => response.status,

--- a/crates/rig-core/src/provider_response.rs
+++ b/crates/rig-core/src/provider_response.rs
@@ -1,4 +1,12 @@
 //! Shared logic for inspecting provider error response bodies across capability errors.
+//!
+//! HTTP providers route their error responses through `from_http_response` (see
+//! [`CompletionError::from_http_response`](crate::completion::CompletionError::from_http_response))
+//! so callers can recover the raw status and body. Non-HTTP transports — AWS SDK (`rig-bedrock`), gRPC
+//! (`rig-vertexai`, `rig-gemini-grpc`), and local inference (`rig-fastembed`) —
+//! have no HTTP response to preserve, so the `provider_response_*` helpers
+//! deliberately return `None` for their failures (status `None` is correct
+//! there rather than a synthetic status).
 use http::StatusCode;
 
 /// A raw error response preserved from a provider.

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -2478,41 +2478,44 @@ where
                 .await
                 .map_err(CompletionError::HttpError)?;
 
-            if response.status().is_success() {
-                match serde_json::from_slice::<ApiResponse<CompletionResponse>>(
-                    response
-                        .into_body()
-                        .await
-                        .map_err(CompletionError::HttpError)?
-                        .to_vec()
-                        .as_slice(),
-                )? {
-                    ApiResponse::Message(completion) => {
-                        let span = tracing::Span::current();
-                        span.record_response_metadata(&completion);
-                        span.record_token_usage(&completion.usage);
-                        if enabled!(Level::TRACE) {
-                            tracing::trace!(
-                                target: "rig::completions",
-                                "Anthropic completion response: {}",
-                                serde_json::to_string_pretty(&completion)?
-                            );
-                        }
-                        completion.try_into()
+            // Read the raw body exactly once so we can both deserialize it and, on
+            // failure, preserve it verbatim for `provider_response_*` inspection.
+            let status = response.status();
+            let body = response
+                .into_body()
+                .await
+                .map_err(CompletionError::HttpError)?;
+
+            if !status.is_success() {
+                return Err(CompletionError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&body),
+                ));
+            }
+
+            match serde_json::from_slice::<ApiResponse<CompletionResponse>>(&body)? {
+                ApiResponse::Message(completion) => {
+                    let span = tracing::Span::current();
+                    span.record_response_metadata(&completion);
+                    span.record_token_usage(&completion.usage);
+                    if enabled!(Level::TRACE) {
+                        tracing::trace!(
+                            target: "rig::completions",
+                            "Anthropic completion response: {}",
+                            serde_json::to_string_pretty(&completion)?
+                        );
                     }
-                    ApiResponse::Error(ApiErrorResponse { message }) => {
-                        Err(CompletionError::ResponseError(message))
-                    }
+                    completion.try_into()
                 }
-            } else {
-                let text: String = String::from_utf8_lossy(
-                    &response
-                        .into_body()
-                        .await
-                        .map_err(CompletionError::HttpError)?,
-                )
-                .into();
-                Err(CompletionError::ProviderError(text))
+                // Anthropic occasionally returns its `{"type":"error",...}` envelope
+                // with a 2xx status; preserve the raw body alongside that status.
+                ApiResponse::Error(ApiErrorResponse { message }) => {
+                    tracing::warn!(message = %message, "provider returned an error response");
+                    Err(CompletionError::from_http_response(
+                        status,
+                        String::from_utf8_lossy(&body),
+                    ))
+                }
             }
         }
         .instrument(span)
@@ -2547,6 +2550,109 @@ mod tests {
     use super::*;
     use serde_json::json;
     use serde_path_to_error::deserialize;
+
+    #[tokio::test]
+    async fn completion_http_non_success_preserves_status_and_body() {
+        use crate::client::CompletionClient;
+        use crate::completion::CompletionModel;
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"type":"error","error":{"type":"rate_limit_error","message":"slow down"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::TOO_MANY_REQUESTS, body);
+        let client = crate::providers::anthropic::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model(CLAUDE_SONNET_4_6);
+        let request = model.completion_request("hello").build();
+
+        let error = model
+            .completion(request)
+            .await
+            .expect_err("completion should fail with non-success status");
+
+        assert!(matches!(error, CompletionError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::TOO_MANY_REQUESTS)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+        let json = error
+            .provider_response_json()
+            .expect("raw body should be valid JSON")
+            .expect("parsed JSON should be present");
+        assert_eq!(json["error"]["type"], "rate_limit_error");
+    }
+
+    #[tokio::test]
+    async fn completion_preserves_provider_error_envelope_on_2xx() {
+        use crate::client::CompletionClient;
+        use crate::completion::CompletionModel;
+        use crate::test_utils::RecordingHttpClient;
+
+        // Anthropic can return its error envelope with a 2xx status; the raw body
+        // and status should be preserved as a `ProviderResponse`.
+        let body = r#"{"type":"error","message":"overloaded"}"#;
+        let http_client = RecordingHttpClient::with_error_response(http::StatusCode::OK, body);
+        let client = crate::providers::anthropic::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model(CLAUDE_SONNET_4_6);
+        let request = model.completion_request("hello").build();
+
+        let error = model
+            .completion(request)
+            .await
+            .expect_err("completion should fail with provider error envelope");
+
+        match &error {
+            CompletionError::ProviderResponse(stored) => {
+                assert_eq!(stored.body, body);
+                assert_eq!(stored.status, Some(http::StatusCode::OK));
+                assert_eq!(error.provider_response_body(), Some(body));
+                assert_eq!(error.provider_response_status(), Some(http::StatusCode::OK));
+            }
+            other => panic!("expected ProviderResponse, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn streaming_http_non_success_preserves_status_and_body() {
+        use crate::client::CompletionClient;
+        use crate::completion::CompletionModel;
+        use crate::test_utils::HttpErrorStreamingClient;
+        use futures::StreamExt;
+
+        let body = r#"{"type":"error","error":{"type":"overloaded_error","message":"overloaded"}}"#;
+        let http_client = HttpErrorStreamingClient::new(http::StatusCode::TOO_MANY_REQUESTS, body);
+        let client = crate::providers::anthropic::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model(CLAUDE_SONNET_4_6);
+        let request = model.completion_request("hello").build();
+
+        let mut stream = model.stream(request).await.expect("stream should start");
+        let error = loop {
+            match stream.next().await {
+                Some(Ok(_)) => continue,
+                Some(Err(error)) => break error,
+                None => panic!("stream ended without surfacing the transport error"),
+            }
+        };
+
+        assert!(matches!(error, CompletionError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::TOO_MANY_REQUESTS)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
 
     #[test]
     fn current_model_default_max_tokens_match_anthropic_limits() {

--- a/crates/rig-core/src/providers/anthropic/streaming.rs
+++ b/crates/rig-core/src/providers/anthropic/streaming.rs
@@ -402,7 +402,10 @@ where
                         }
                     },
                     Err(e) => {
-                        yield Err(CompletionError::ProviderError(format!("SSE Error: {e}")));
+                        // Keep non-success HTTP status recoverable through the
+                        // `provider_response_*` helpers instead of flattening it
+                        // into a display string.
+                        yield Err(CompletionError::from_stream_transport(e));
                         break;
                     }
                 }

--- a/crates/rig-core/src/providers/cohere/completion.rs
+++ b/crates/rig-core/src/providers/cohere/completion.rs
@@ -839,4 +839,34 @@ mod tests {
         assert_eq!(request.documents.len(), 1);
         assert_eq!(request.documents[0].id, "doc_1");
     }
+
+    #[tokio::test]
+    async fn completion_http_non_success_preserves_status_and_body() {
+        use crate::client::CompletionClient;
+        use crate::completion::{CompletionError, CompletionModel};
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"message":"service unavailable"}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = super::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model("command-r");
+        let request = model.completion_request("hello").build();
+
+        let error = model
+            .completion(request)
+            .await
+            .expect_err("completion should fail with non-success status");
+
+        assert!(matches!(error, CompletionError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
 }

--- a/crates/rig-core/src/providers/cohere/completion.rs
+++ b/crates/rig-core/src/providers/cohere/completion.rs
@@ -692,8 +692,9 @@ where
                     json_response.try_into()?;
                 Ok(completion)
             } else {
-                Err(CompletionError::ProviderError(
-                    String::from_utf8_lossy(&body).to_string(),
+                Err(CompletionError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&body),
                 ))
             }
         }

--- a/crates/rig-core/src/providers/cohere/embeddings.rs
+++ b/crates/rig-core/src/providers/cohere/embeddings.rs
@@ -190,3 +190,64 @@ impl<T> EmbeddingModel<T> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::embeddings::EmbeddingModel as _;
+    use crate::test_utils::RecordingHttpClient;
+
+    #[tokio::test]
+    async fn embedding_http_non_success_preserves_status_and_body() {
+        let body = r#"{"message":"too many requests"}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::TOO_MANY_REQUESTS, body);
+        let client = super::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.embedding_model("embed-english-v3.0", "search_document");
+
+        let error = model
+            .embed_texts(["hello".to_string()])
+            .await
+            .expect_err("embedding should fail with non-success status");
+
+        assert!(matches!(error, EmbeddingError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::TOO_MANY_REQUESTS)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+
+    #[tokio::test]
+    async fn embedding_preserves_provider_error_envelope_on_2xx() {
+        // Cohere returns its error envelope with a 2xx status; the raw body and
+        // status should be preserved as a `ProviderResponse`.
+        let body = r#"{"message":"invalid request"}"#;
+        let http_client = RecordingHttpClient::with_error_response(http::StatusCode::OK, body);
+        let client = super::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.embedding_model("embed-english-v3.0", "search_document");
+
+        let error = model
+            .embed_texts(["hello".to_string()])
+            .await
+            .expect_err("embedding should fail with provider error envelope");
+
+        match &error {
+            EmbeddingError::ProviderResponse(stored) => {
+                assert_eq!(stored.body, body);
+                assert_eq!(stored.status, Some(http::StatusCode::OK));
+                assert_eq!(error.provider_response_body(), Some(body));
+                assert_eq!(error.provider_response_status(), Some(http::StatusCode::OK));
+            }
+            other => panic!("expected ProviderResponse, got {other:?}"),
+        }
+    }
+}

--- a/crates/rig-core/src/providers/cohere/embeddings.rs
+++ b/crates/rig-core/src/providers/cohere/embeddings.rs
@@ -111,9 +111,14 @@ where
             .await
             .map_err(EmbeddingError::HttpError)?;
 
-        if response.status().is_success() {
-            let body: ApiResponse<EmbeddingResponse> =
-                serde_json::from_slice(response.into_body().await?.as_slice())?;
+        // Read the raw body exactly once so we can both deserialize it and, on a
+        // provider-authored error envelope, preserve it verbatim alongside the status.
+        let status = response.status();
+        let bytes = response.into_body().await?;
+        let text = String::from_utf8_lossy(&bytes);
+
+        if status.is_success() {
+            let body: ApiResponse<EmbeddingResponse> = serde_json::from_str(&text)?;
 
             match body {
                 ApiResponse::Ok(response) => {
@@ -148,11 +153,15 @@ where
                         })
                         .collect())
                 }
-                ApiResponse::Err(error) => Err(EmbeddingError::ProviderError(error.message)),
+                // Cohere returns its error envelope with a 2xx status; preserve the
+                // raw body alongside that status instead of flattening the message.
+                ApiResponse::Err(error) => {
+                    tracing::warn!(message = %error.message, "provider returned an error response");
+                    Err(EmbeddingError::from_http_response(status, text))
+                }
             }
         } else {
-            let text = String::from_utf8_lossy(&response.into_body().await?).into();
-            Err(EmbeddingError::ProviderError(text))
+            Err(EmbeddingError::from_http_response(status, text))
         }
     }
 }

--- a/crates/rig-core/src/providers/cohere/streaming.rs
+++ b/crates/rig-core/src/providers/cohere/streaming.rs
@@ -259,7 +259,7 @@ where
                     }
                     Err(err) => {
                         tracing::error!(?err, "SSE error");
-                        yield Err(CompletionError::ProviderError(err.to_string()));
+                        yield Err(CompletionError::from_stream_transport(err));
                         break;
                     }
                 }

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -170,15 +170,16 @@ where
 
                 response.try_into()
             } else {
-                let text = String::from_utf8_lossy(
-                    &response
-                        .into_body()
-                        .await
-                        .map_err(CompletionError::HttpError)?,
-                )
-                .into();
+                let status = response.status();
+                let body = response
+                    .into_body()
+                    .await
+                    .map_err(CompletionError::HttpError)?;
 
-                Err(CompletionError::ProviderError(text))
+                Err(CompletionError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&body),
+                ))
             }
         }
         .instrument(span)
@@ -2173,6 +2174,42 @@ mod tests {
 
     use super::*;
     use serde_json::json;
+
+    #[tokio::test]
+    async fn completion_http_non_success_preserves_status_and_body() {
+        use crate::client::CompletionClient;
+        use crate::completion::CompletionModel;
+        use crate::test_utils::RecordingHttpClient;
+
+        let body =
+            r#"{"error":{"code":503,"message":"service unavailable","status":"UNAVAILABLE"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = crate::providers::gemini::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model(GEMINI_3_FLASH_PREVIEW);
+        let request = model.completion_request("hello").build();
+
+        let error = model
+            .completion(request)
+            .await
+            .expect_err("completion should fail with non-success status");
+
+        assert!(matches!(error, CompletionError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+        let json = error
+            .provider_response_json()
+            .expect("raw body should be valid JSON")
+            .expect("parsed JSON should be present");
+        assert_eq!(json["error"]["status"], "UNAVAILABLE");
+    }
 
     #[test]
     fn test_usage_metadata_deserializes_without_total_token_count() {

--- a/crates/rig-core/src/providers/gemini/embedding.rs
+++ b/crates/rig-core/src/providers/gemini/embedding.rs
@@ -112,10 +112,17 @@ where
             .map_err(|e| EmbeddingError::HttpError(e.into()))?;
         let response = self.client.send::<_, Vec<u8>>(req).await?;
 
-        let response: ApiResponse<gemini_api_types::EmbeddingResponse> =
-            serde_json::from_slice(&response.into_body().await?)?;
+        // Read the raw body exactly once so we can both deserialize it and, on
+        // failure, preserve it verbatim alongside the status for inspection.
+        let status = response.status();
+        let body = response.into_body().await?;
+        let text = String::from_utf8_lossy(&body);
 
-        match response {
+        if !status.is_success() {
+            return Err(EmbeddingError::from_http_response(status, text));
+        }
+
+        match serde_json::from_str::<ApiResponse<gemini_api_types::EmbeddingResponse>>(&text)? {
             ApiResponse::Ok(response) => {
                 let docs = documents
                     .into_iter()
@@ -132,7 +139,12 @@ where
 
                 Ok(docs)
             }
-            ApiResponse::Err(err) => Err(EmbeddingError::ProviderError(err.message)),
+            // Gemini returns its error envelope with a 2xx status; preserve the
+            // raw body alongside that status instead of flattening the message.
+            ApiResponse::Err(err) => {
+                tracing::warn!(message = %err.message, "provider returned an error response");
+                Err(EmbeddingError::from_http_response(status, text))
+            }
         }
     }
 }

--- a/crates/rig-core/src/providers/gemini/embedding.rs
+++ b/crates/rig-core/src/providers/gemini/embedding.rs
@@ -319,4 +319,67 @@ mod tests {
         let model = EmbeddingModel::new(client, EMBEDDING_001, 512);
         assert_eq!(embeddings::EmbeddingModel::ndims(&model), 512);
     }
+
+    #[tokio::test]
+    async fn embedding_http_non_success_preserves_status_and_body() {
+        use crate::client::EmbeddingsClient;
+        use crate::embeddings::EmbeddingModel as _;
+        use crate::test_utils::RecordingHttpClient;
+
+        let body =
+            r#"{"error":{"code":503,"message":"service unavailable","status":"UNAVAILABLE"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.embedding_model(EMBEDDING_001);
+
+        let error = model
+            .embed_texts(["hello".to_string()])
+            .await
+            .expect_err("embedding should fail with non-success status");
+
+        assert!(matches!(error, EmbeddingError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+
+    #[tokio::test]
+    async fn embedding_preserves_provider_error_envelope_on_2xx() {
+        use crate::client::EmbeddingsClient;
+        use crate::embeddings::EmbeddingModel as _;
+        use crate::test_utils::RecordingHttpClient;
+
+        // Gemini returns its error envelope with a 2xx status; the raw body and
+        // status should be preserved as a `ProviderResponse`.
+        let body = r#"{"message":"embedding request blocked"}"#;
+        let http_client = RecordingHttpClient::new(body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.embedding_model(EMBEDDING_001);
+
+        let error = model
+            .embed_texts(["hello".to_string()])
+            .await
+            .expect_err("embedding should fail with provider error envelope");
+
+        match &error {
+            EmbeddingError::ProviderResponse(stored) => {
+                assert_eq!(stored.body, body);
+                assert_eq!(stored.status, Some(http::StatusCode::OK));
+                assert_eq!(error.provider_response_body(), Some(body));
+                assert_eq!(error.provider_response_status(), Some(http::StatusCode::OK));
+            }
+            other => panic!("expected ProviderResponse, got {other:?}"),
+        }
+    }
 }

--- a/crates/rig-core/src/providers/gemini/image_generation.rs
+++ b/crates/rig-core/src/providers/gemini/image_generation.rs
@@ -74,21 +74,21 @@ where
 
         let response = self.client.send(request).await?;
 
-        if !response.status().is_success() {
-            let status = response.status();
-            let text = http_client::text(response).await?;
-
-            return Err(ImageGenerationError::ProviderError(format!(
-                "{}: {}",
-                status, text,
-            )));
-        }
-
+        let status = response.status();
         let text = http_client::text(response).await?;
+
+        if !status.is_success() {
+            return Err(ImageGenerationError::from_http_response(status, text));
+        }
 
         match serde_json::from_str::<ApiResponse<GenerateContentResponse>>(&text)? {
             ApiResponse::Ok(response) => response.try_into(),
-            ApiResponse::Err(err) => Err(ImageGenerationError::ProviderError(err.message)),
+            // Gemini returns its error envelope with a 2xx status; preserve the
+            // raw body alongside that status instead of flattening the message.
+            ApiResponse::Err(err) => {
+                tracing::warn!(message = %err.message, "provider returned an error response");
+                Err(ImageGenerationError::from_http_response(status, text))
+            }
         }
     }
 }
@@ -358,5 +358,66 @@ mod tests {
         .expect_err("text-only responses should fail");
 
         assert!(err.to_string().contains("did not include image data"));
+    }
+
+    #[tokio::test]
+    async fn image_generation_non_success_response_preserves_status_and_body() {
+        use crate::image_generation::ImageGenerationModel as _;
+        use crate::test_utils::RecordingHttpClient;
+
+        let body =
+            r#"{"error":{"code":400,"message":"invalid request","status":"INVALID_ARGUMENT"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::BAD_REQUEST, body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = ImageGenerationModel::new(client, GEMINI_2_5_FLASH_IMAGE);
+
+        let error = model
+            .image_generation(image_generation_request("draw a cat"))
+            .await
+            .expect_err("image generation should fail with non-success status");
+
+        assert!(matches!(error, ImageGenerationError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::BAD_REQUEST)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+
+    #[tokio::test]
+    async fn image_generation_preserves_provider_error_envelope_on_2xx() {
+        use crate::image_generation::ImageGenerationModel as _;
+        use crate::test_utils::RecordingHttpClient;
+
+        // Gemini returns its error envelope with a 2xx status; the raw body and
+        // status should be preserved as a `ProviderResponse`.
+        let body = r#"{"message":"image generation blocked by safety filters"}"#;
+        let http_client = RecordingHttpClient::new(body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = ImageGenerationModel::new(client, GEMINI_2_5_FLASH_IMAGE);
+
+        let error = model
+            .image_generation(image_generation_request("draw a cat"))
+            .await
+            .expect_err("image generation should fail with provider error envelope");
+
+        match &error {
+            ImageGenerationError::ProviderResponse(stored) => {
+                assert_eq!(stored.body, body);
+                assert_eq!(stored.status, Some(http::StatusCode::OK));
+                assert_eq!(error.provider_response_body(), Some(body));
+                assert_eq!(error.provider_response_status(), Some(http::StatusCode::OK));
+            }
+            other => panic!("expected ProviderResponse, got {other:?}"),
+        }
     }
 }

--- a/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
@@ -195,15 +195,16 @@ where
 
                 response.try_into()
             } else {
-                let text = String::from_utf8_lossy(
-                    &response
-                        .into_body()
-                        .await
-                        .map_err(CompletionError::HttpError)?,
-                )
-                .into();
+                let status = response.status();
+                let body = response
+                    .into_body()
+                    .await
+                    .map_err(CompletionError::HttpError)?;
 
-                Err(CompletionError::ProviderError(text))
+                Err(CompletionError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&body),
+                ))
             }
         }
         .instrument(span)
@@ -444,15 +445,16 @@ where
 
         Ok(response)
     } else {
-        let text = String::from_utf8_lossy(
-            &response
-                .into_body()
-                .await
-                .map_err(CompletionError::HttpError)?,
-        )
-        .into();
+        let status = response.status();
+        let body = response
+            .into_body()
+            .await
+            .map_err(CompletionError::HttpError)?;
 
-        Err(CompletionError::ProviderError(text))
+        Err(CompletionError::from_http_response(
+            status,
+            String::from_utf8_lossy(&body),
+        ))
     }
 }
 

--- a/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
@@ -161,7 +161,7 @@ where
                     }
                     Err(error) => {
                         tracing::error!(?error, "SSE error");
-                        yield Err(CompletionError::ProviderError(error.to_string()));
+                        yield Err(CompletionError::from_stream_transport(error));
                         break;
                     }
                 }
@@ -216,7 +216,7 @@ where
                 Err(crate::http_client::Error::StreamEnded) => break,
                 Err(error) => {
                     tracing::error!(?error, "SSE error");
-                    yield Err(CompletionError::ProviderError(error.to_string()));
+                    yield Err(CompletionError::from_stream_transport(error));
                     break;
                 }
             }

--- a/crates/rig-core/src/providers/gemini/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/streaming.rs
@@ -283,7 +283,7 @@ where
                     Err(error) => {
                         tracing::error!(?error, "SSE error");
                         stream_failed = true;
-                        yield Err(CompletionError::ProviderError(error.to_string()));
+                        yield Err(CompletionError::from_stream_transport(error));
                         break;
                     }
                 }

--- a/crates/rig-core/src/providers/gemini/transcription.rs
+++ b/crates/rig-core/src/providers/gemini/transcription.rs
@@ -177,3 +177,41 @@ impl TryFrom<GenerateContentResponse>
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::transcription::TranscriptionClient;
+    use crate::test_utils::RecordingHttpClient;
+    use crate::transcription::TranscriptionModel as _;
+
+    #[tokio::test]
+    async fn transcription_http_non_success_preserves_status_and_body() {
+        let body = r#"{"error":{"code":429,"message":"resource exhausted","status":"RESOURCE_EXHAUSTED"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::TOO_MANY_REQUESTS, body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.transcription_model("gemini-2.5-flash");
+
+        let error = match model
+            .transcription_request()
+            .data(vec![0u8; 16])
+            .send()
+            .await
+        {
+            Err(error) => error,
+            Ok(_) => panic!("transcription should fail with non-success status"),
+        };
+
+        assert!(matches!(error, TranscriptionError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::TOO_MANY_REQUESTS)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+}

--- a/crates/rig-core/src/providers/gemini/transcription.rs
+++ b/crates/rig-core/src/providers/gemini/transcription.rs
@@ -129,8 +129,12 @@ where
 
             Ok(transcription::TranscriptionResponse::try_from(body)?)
         } else {
-            let text = String::from_utf8_lossy(&response.into_body().await?).into();
-            Err(TranscriptionError::ProviderError(text))
+            let status = response.status();
+            let body = response.into_body().await?;
+            Err(TranscriptionError::from_http_response(
+                status,
+                String::from_utf8_lossy(&body),
+            ))
         }
     }
 }

--- a/crates/rig-core/src/providers/huggingface/completion.rs
+++ b/crates/rig-core/src/providers/huggingface/completion.rs
@@ -797,17 +797,14 @@ where
 
                         response.try_into()
                     }
+                    // Huggingface returns its error envelope with a 2xx status;
+                    // preserve the raw body alongside that status.
                     ApiResponse::Err(err) => {
                         tracing::warn!(
                             message = %err,
                             "provider returned an error response"
                         );
-                        Err(CompletionError::ProviderResponse(
-                            crate::provider_response::ProviderResponseError {
-                                status: Some(status),
-                                body: String::from_utf8_lossy(&bytes).into_owned(),
-                            },
-                        ))
+                        Err(CompletionError::from_http_response(status, text))
                     }
                 }
             } else {

--- a/crates/rig-core/src/providers/huggingface/completion.rs
+++ b/crates/rig-core/src/providers/huggingface/completion.rs
@@ -1336,4 +1336,39 @@ mod tests {
         let result = HuggingfaceCompletionRequest::try_from(("meta/test-model", request));
         assert!(matches!(result, Err(CompletionError::RequestError(_))));
     }
+
+    #[tokio::test]
+    async fn completion_preserves_provider_error_envelope_on_2xx() {
+        use crate::client::CompletionClient;
+        use crate::completion::CompletionModel as _;
+        use crate::test_utils::RecordingHttpClient;
+
+        // Huggingface can return its error envelope with a 2xx status; the raw
+        // body and status should be preserved as a `ProviderResponse`.
+        let body =
+            r#"{"error":"Model google/gemma-2-2b-it is currently loading","estimated_time":20.0}"#;
+        let http_client = RecordingHttpClient::new(body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model(GEMMA_2);
+        let request = model.completion_request("hello").build();
+
+        let error = model
+            .completion(request)
+            .await
+            .expect_err("completion should fail with provider error envelope");
+
+        match &error {
+            CompletionError::ProviderResponse(stored) => {
+                assert_eq!(stored.body, body);
+                assert_eq!(stored.status, Some(http::StatusCode::OK));
+                assert_eq!(error.provider_response_body(), Some(body));
+                assert_eq!(error.provider_response_status(), Some(http::StatusCode::OK));
+            }
+            other => panic!("expected ProviderResponse, got {other:?}"),
+        }
+    }
 }

--- a/crates/rig-core/src/providers/huggingface/image_generation.rs
+++ b/crates/rig-core/src/providers/huggingface/image_generation.rs
@@ -99,3 +99,46 @@ where
         ImageGenerationResponse { data }.try_into()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::image_generation::ImageGenerationClient;
+    use crate::image_generation::ImageGenerationModel as _;
+    use crate::test_utils::RecordingHttpClient;
+
+    fn request() -> ImageGenerationRequest {
+        ImageGenerationRequest {
+            prompt: "draw a cat".to_string(),
+            width: 1024,
+            height: 1024,
+            additional_params: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn image_generation_non_success_response_preserves_status_and_body() {
+        let body = r#"{"error":"Model is currently loading","estimated_time":20.0}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.image_generation_model(Flux1);
+
+        let error = model
+            .image_generation(request())
+            .await
+            .err()
+            .expect("image generation should fail with non-success status");
+
+        assert!(matches!(error, ImageGenerationError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+}

--- a/crates/rig-core/src/providers/huggingface/image_generation.rs
+++ b/crates/rig-core/src/providers/huggingface/image_generation.rs
@@ -88,13 +88,10 @@ where
 
         if !response.status().is_success() {
             let status = response.status();
-            let text: Vec<u8> = response.into_body().await?;
-            let text: String = String::from_utf8_lossy(&text).into();
+            let bytes: Vec<u8> = response.into_body().await?;
+            let text = String::from_utf8_lossy(&bytes);
 
-            return Err(ImageGenerationError::ProviderError(format!(
-                "{}: {}",
-                status, text
-            )));
+            return Err(ImageGenerationError::from_http_response(status, text));
         }
 
         let data: Vec<u8> = response.into_body().await?;

--- a/crates/rig-core/src/providers/huggingface/transcription.rs
+++ b/crates/rig-core/src/providers/huggingface/transcription.rs
@@ -86,18 +86,22 @@ where
 
         let response = self.client.send(req).await?;
 
-        if response.status().is_success() {
-            let body: Vec<u8> = response.into_body().await?;
-            let body: ApiResponse<TranscriptionResponse> = serde_json::from_slice(&body)?;
-            match body {
+        let status = response.status();
+        let bytes: Vec<u8> = response.into_body().await?;
+        let text = String::from_utf8_lossy(&bytes).into_owned();
+
+        if status.is_success() {
+            match serde_json::from_str::<ApiResponse<TranscriptionResponse>>(&text)? {
                 ApiResponse::Ok(response) => response.try_into(),
-                ApiResponse::Err(err) => Err(TranscriptionError::ProviderError(err.to_string())),
+                // Huggingface returns its error envelope with a 2xx status;
+                // preserve the raw body alongside that status.
+                ApiResponse::Err(err) => {
+                    tracing::warn!(message = %err, "provider returned an error response");
+                    Err(TranscriptionError::from_http_response(status, text))
+                }
             }
         } else {
-            let text: Vec<u8> = response.into_body().await?;
-            let text = String::from_utf8_lossy(&text).into();
-
-            Err(TranscriptionError::ProviderError(text))
+            Err(TranscriptionError::from_http_response(status, text))
         }
     }
 }

--- a/crates/rig-core/src/providers/huggingface/transcription.rs
+++ b/crates/rig-core/src/providers/huggingface/transcription.rs
@@ -105,3 +105,39 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::transcription::TranscriptionClient;
+    use crate::test_utils::RecordingHttpClient;
+    use crate::transcription::TranscriptionModel as _;
+
+    #[tokio::test]
+    async fn transcription_http_non_success_preserves_status_and_body() {
+        let body = r#"{"error":"Service Unavailable","estimated_time":30.0}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.transcription_model(WHISPER_LARGE_V3);
+
+        let error = model
+            .transcription_request()
+            .data(vec![0u8; 16])
+            .send()
+            .await
+            .err()
+            .expect("transcription should fail with non-success status");
+
+        assert!(matches!(error, TranscriptionError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+}

--- a/crates/rig-core/src/providers/hyperbolic.rs
+++ b/crates/rig-core/src/providers/hyperbolic.rs
@@ -744,4 +744,146 @@ mod tests {
             .build()
             .expect("Client::builder() failed");
     }
+
+    #[tokio::test]
+    async fn completion_http_non_success_preserves_status_and_body() {
+        use crate::client::CompletionClient;
+        use crate::completion::{CompletionError, CompletionModel as _};
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"message":"service unavailable"}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = super::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model(super::LLAMA_3_1_8B);
+        let request = model.completion_request("hello").build();
+
+        let error = model
+            .completion(request)
+            .await
+            .expect_err("completion should fail with non-success status");
+
+        assert!(matches!(error, CompletionError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+
+    #[tokio::test]
+    async fn completion_preserves_provider_error_envelope_on_2xx() {
+        use crate::client::CompletionClient;
+        use crate::completion::{CompletionError, CompletionModel as _};
+        use crate::test_utils::RecordingHttpClient;
+
+        // Hyperbolic can return its error envelope with a 2xx status; the raw body
+        // and status should be preserved as a `ProviderResponse`.
+        let body = r#"{"message":"model is overloaded"}"#;
+        let http_client = RecordingHttpClient::with_error_response(http::StatusCode::OK, body);
+        let client = super::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model(super::LLAMA_3_1_8B);
+        let request = model.completion_request("hello").build();
+
+        let error = model
+            .completion(request)
+            .await
+            .expect_err("completion should fail with provider error envelope");
+
+        match &error {
+            CompletionError::ProviderResponse(stored) => {
+                assert_eq!(stored.body, body);
+                assert_eq!(stored.status, Some(http::StatusCode::OK));
+                assert_eq!(error.provider_response_body(), Some(body));
+                assert_eq!(error.provider_response_status(), Some(http::StatusCode::OK));
+            }
+            other => panic!("expected ProviderResponse, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "image")]
+    #[tokio::test]
+    async fn image_generation_non_success_response_preserves_status_and_body() {
+        use crate::client::image_generation::ImageGenerationClient;
+        use crate::image_generation::{
+            ImageGenerationError, ImageGenerationModel as _, ImageGenerationRequest,
+        };
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"message":"invalid image request"}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::BAD_REQUEST, body);
+        let client = super::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.image_generation_model(super::SDXL1_0_BASE);
+
+        let error = model
+            .image_generation(ImageGenerationRequest {
+                prompt: "draw a cat".to_string(),
+                width: 256,
+                height: 256,
+                additional_params: None,
+            })
+            .await
+            .err()
+            .expect("image generation should fail with non-success status");
+
+        assert!(matches!(error, ImageGenerationError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::BAD_REQUEST)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+
+    #[cfg(feature = "audio")]
+    #[tokio::test]
+    async fn audio_generation_non_success_response_preserves_status_and_body() {
+        use crate::audio_generation::{
+            AudioGenerationError, AudioGenerationModel as _, AudioGenerationRequest,
+        };
+        use crate::client::audio_generation::AudioGenerationClient;
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"message":"invalid voice"}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::UNPROCESSABLE_ENTITY, body);
+        let client = super::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.audio_generation_model("English");
+
+        let error = match model
+            .audio_generation(AudioGenerationRequest {
+                text: "hello".to_string(),
+                voice: "alloy".to_string(),
+                speed: 1.0,
+                additional_params: None,
+            })
+            .await
+        {
+            Err(error) => error,
+            Ok(_) => panic!("audio generation should fail with non-success status"),
+        };
+
+        assert!(matches!(error, AudioGenerationError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::UNPROCESSABLE_ENTITY)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
 }

--- a/crates/rig-core/src/providers/hyperbolic.rs
+++ b/crates/rig-core/src/providers/hyperbolic.rs
@@ -406,11 +406,21 @@ where
 
                         response.try_into()
                     }
-                    ApiResponse::Err(err) => Err(CompletionError::ProviderError(err.message)),
+                    // Hyperbolic can return its error envelope with a 2xx status;
+                    // preserve the raw body alongside that status instead of
+                    // flattening to just the message.
+                    ApiResponse::Err(err) => {
+                        tracing::warn!(message = %err.message, "provider returned an error response");
+                        Err(CompletionError::from_http_response(
+                            status,
+                            String::from_utf8_lossy(&response_body),
+                        ))
+                    }
                 }
             } else {
-                Err(CompletionError::ProviderError(
-                    String::from_utf8_lossy(&response_body).to_string(),
+                Err(CompletionError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&response_body),
                 ))
             }
         };
@@ -596,15 +606,21 @@ mod image_generation {
             let response_body = response.into_body().into_future().await?.to_vec();
 
             if !status.is_success() {
-                return Err(ImageGenerationError::ProviderError(format!(
-                    "{status}: {}",
-                    String::from_utf8_lossy(&response_body)
-                )));
+                return Err(ImageGenerationError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&response_body),
+                ));
             }
 
             match serde_json::from_slice::<ApiResponse<ImageGenerationResponse>>(&response_body)? {
                 ApiResponse::Ok(response) => response.try_into(),
-                ApiResponse::Err(err) => Err(ImageGenerationError::ResponseError(err.message)),
+                ApiResponse::Err(err) => {
+                    tracing::warn!(message = %err.message, "provider returned an error response");
+                    Err(ImageGenerationError::from_http_response(
+                        status,
+                        String::from_utf8_lossy(&response_body),
+                    ))
+                }
             }
         }
     }
@@ -697,15 +713,21 @@ mod audio_generation {
             let response_body = response.into_body().into_future().await?.to_vec();
 
             if !status.is_success() {
-                return Err(AudioGenerationError::ProviderError(format!(
-                    "{status}: {}",
-                    String::from_utf8_lossy(&response_body)
-                )));
+                return Err(AudioGenerationError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&response_body),
+                ));
             }
 
             match serde_json::from_slice::<ApiResponse<AudioGenerationResponse>>(&response_body)? {
                 ApiResponse::Ok(response) => response.try_into(),
-                ApiResponse::Err(err) => Err(AudioGenerationError::ProviderError(err.message)),
+                ApiResponse::Err(err) => {
+                    tracing::warn!(message = %err.message, "provider returned an error response");
+                    Err(AudioGenerationError::from_http_response(
+                        status,
+                        String::from_utf8_lossy(&response_body),
+                    ))
+                }
             }
         }
     }

--- a/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
+++ b/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
@@ -22,7 +22,15 @@ use crate::wasm_compat::WasmCompatSend;
 
 fn provider_response_from_compatible_sse_data(data: &str) -> Option<CompletionError> {
     let value = serde_json::from_str::<serde_json::Value>(data).ok()?;
-    if value.get("error").is_none() || value.get("choices").is_some() {
+    // Require `error` to be a non-null object so a `{"error":null}` (or
+    // `{"error":"..."}`) chunk that happens to omit `choices` can't be mistaken
+    // for an error envelope and prematurely terminate the stream.
+    if value
+        .get("error")
+        .and_then(serde_json::Value::as_object)
+        .is_none()
+        || value.get("choices").is_some()
+    {
         return None;
     }
 
@@ -623,7 +631,10 @@ pub(crate) mod test_support {
 #[cfg(test)]
 mod tests {
     use super::test_support::sse_bytes_from_data_lines;
-    use super::{finalize_pending_tool_call, send_compatible_streaming_request};
+    use super::{
+        finalize_pending_tool_call, provider_response_from_compatible_sse_data,
+        send_compatible_streaming_request,
+    };
     use crate::completion::CompletionError;
     use crate::http_client;
     use crate::streaming::RawStreamingToolCall;
@@ -663,6 +674,25 @@ mod tests {
             finalize_pending_tool_call(tool_call).expect("tool call should be preserved");
 
         assert_eq!(finalized.arguments, serde_json::json!({}));
+    }
+
+    #[test]
+    fn sse_error_detector_ignores_null_or_non_object_error_field() {
+        // A chunk with `error: null` (or a non-object error) and no `choices`
+        // must not be mistaken for an error envelope that terminates the stream.
+        assert!(provider_response_from_compatible_sse_data(r#"{"error":null}"#).is_none());
+        assert!(provider_response_from_compatible_sse_data(r#"{"error":"oops"}"#).is_none());
+        assert!(provider_response_from_compatible_sse_data(r#"{"choices":[]}"#).is_none());
+
+        // A genuine error envelope (object `error`, no `choices`) is still detected.
+        let detected = provider_response_from_compatible_sse_data(
+            r#"{"error":{"message":"slow down","type":"rate_limit"}}"#,
+        )
+        .expect("object error envelope should be detected");
+        assert_eq!(
+            detected.provider_response_body(),
+            Some(r#"{"error":{"message":"slow down","type":"rate_limit"}}"#)
+        );
     }
 
     #[test]

--- a/crates/rig-core/src/providers/mira.rs
+++ b/crates/rig-core/src/providers/mira.rs
@@ -384,11 +384,10 @@ where
             let response_body = response.into_body().into_future().await?.to_vec();
 
             if !status.is_success() {
-                let status = status.as_u16();
-                let error_text = String::from_utf8_lossy(&response_body).to_string();
-                return Err(CompletionError::ProviderError(format!(
-                    "API error: {status} - {error_text}"
-                )));
+                return Err(CompletionError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&response_body),
+                ));
             }
 
             let response: CompletionResponse = serde_json::from_slice(&response_body)?;

--- a/crates/rig-core/src/providers/mira.rs
+++ b/crates/rig-core/src/providers/mira.rs
@@ -693,6 +693,36 @@ mod tests {
     use crate::message::UserContent;
     use serde_json::json;
 
+    #[tokio::test]
+    async fn completion_http_non_success_preserves_status_and_body() {
+        use crate::client::CompletionClient;
+        use crate::completion::{CompletionError, CompletionModel as _};
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"error":{"message":"service unavailable"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = super::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model("deepseek-r1");
+        let request = model.completion_request("hello").build();
+
+        let error = model
+            .completion(request)
+            .await
+            .expect_err("completion should fail with non-success status");
+
+        assert!(matches!(error, CompletionError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+
     #[test]
     fn test_deserialize_message() {
         // Test string content format

--- a/crates/rig-core/src/providers/mistral/embedding.rs
+++ b/crates/rig-core/src/providers/mistral/embedding.rs
@@ -138,3 +138,66 @@ pub struct EmbeddingData {
     pub embedding: Vec<serde_json::Number>,
     pub index: usize,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::EmbeddingsClient;
+    use crate::embeddings::EmbeddingModel as _;
+    use crate::test_utils::RecordingHttpClient;
+
+    #[tokio::test]
+    async fn embedding_http_non_success_preserves_status_and_body() {
+        let body = r#"{"message":"service unavailable","type":"service_unavailable"}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = super::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.embedding_model(MISTRAL_EMBED);
+
+        let error = model
+            .embed_texts(["hello".to_string()])
+            .await
+            .expect_err("embedding should fail with non-success status");
+
+        assert!(matches!(error, EmbeddingError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+
+    #[tokio::test]
+    async fn embedding_preserves_provider_error_envelope_on_2xx() {
+        // Mistral can return an error envelope (`{"message": ...}`) with a 2xx
+        // status; the raw body and status should be preserved as a
+        // `ProviderResponse`.
+        let body = r#"{"message":"embedding quota exceeded"}"#;
+        let http_client = RecordingHttpClient::with_error_response(http::StatusCode::OK, body);
+        let client = super::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.embedding_model(MISTRAL_EMBED);
+
+        let error = model
+            .embed_texts(["hello".to_string()])
+            .await
+            .expect_err("embedding should fail with provider error envelope");
+
+        match &error {
+            EmbeddingError::ProviderResponse(stored) => {
+                assert_eq!(stored.body, body);
+                assert_eq!(stored.status, Some(http::StatusCode::OK));
+                assert_eq!(error.provider_response_body(), Some(body));
+                assert_eq!(error.provider_response_status(), Some(http::StatusCode::OK));
+            }
+            other => panic!("expected ProviderResponse, got {other:?}"),
+        }
+    }
+}

--- a/crates/rig-core/src/providers/mistral/embedding.rs
+++ b/crates/rig-core/src/providers/mistral/embedding.rs
@@ -110,19 +110,15 @@ where
                 }
                 ApiResponse::Err(err) => {
                     tracing::warn!(message = %err.message, "provider returned an error response");
-                    Err(EmbeddingError::ProviderResponse(
-                        crate::provider_response::ProviderResponseError {
-                            status: Some(status),
-                            body: String::from_utf8_lossy(&response_body).into_owned(),
-                        },
+                    Err(EmbeddingError::from_http_response(
+                        status,
+                        String::from_utf8_lossy(&response_body),
                     ))
                 }
             }
         } else {
             let text = http_client::text(response).await?;
-            Err(EmbeddingError::HttpError(
-                http_client::Error::InvalidStatusCodeWithMessage(status, text),
-            ))
+            Err(EmbeddingError::from_http_response(status, text))
         }
     }
 }

--- a/crates/rig-core/src/providers/mistral/transcription.rs
+++ b/crates/rig-core/src/providers/mistral/transcription.rs
@@ -268,4 +268,38 @@ mod test {
         assert_eq!(response.response.model, VOXTRAL_MINI);
         assert_eq!(response.response.language, Some("en".to_string()));
     }
+
+    #[tokio::test]
+    async fn transcription_http_non_success_preserves_status_and_body() {
+        use crate::client::transcription::TranscriptionClient;
+        use crate::test_utils::RecordingHttpClient;
+        use crate::transcription::TranscriptionModel as _;
+
+        let body = r#"{"message":"bad audio","type":"invalid_request_error"}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::BAD_REQUEST, body);
+        let client = crate::providers::mistral::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.transcription_model(VOXTRAL_MINI);
+
+        let error = match model
+            .transcription_request()
+            .data(vec![0u8; 16])
+            .send()
+            .await
+        {
+            Err(error) => error,
+            Ok(_) => panic!("transcription should fail with non-success status"),
+        };
+
+        assert!(matches!(error, TranscriptionError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::BAD_REQUEST)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
 }

--- a/crates/rig-core/src/providers/mistral/transcription.rs
+++ b/crates/rig-core/src/providers/mistral/transcription.rs
@@ -147,7 +147,8 @@ where
             .await
             .map_err(TranscriptionError::HttpError)?;
 
-        if response.status().is_success() {
+        let status = response.status();
+        if status.is_success() {
             let response_bytes = response.into_body().await?;
             let response_body: MistralTranscriptionResponse =
                 serde_json::from_slice(&response_bytes)?;
@@ -158,8 +159,11 @@ where
                 response_body,
             )?)
         } else {
-            let text = String::from_utf8_lossy(&response.into_body().await?).into();
-            Err(TranscriptionError::ProviderError(text))
+            let body = response.into_body().await?;
+            Err(TranscriptionError::from_http_response(
+                status,
+                String::from_utf8_lossy(&body),
+            ))
         }
     }
 }

--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -1304,6 +1304,65 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    #[tokio::test]
+    async fn completion_http_non_success_preserves_status_and_body() {
+        use crate::client::CompletionClient;
+        use crate::completion::{CompletionError, CompletionModel as _};
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"error":"model not found"}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = super::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model("llama3.2");
+        let request = model.completion_request("hello").build();
+
+        let error = model
+            .completion(request)
+            .await
+            .expect_err("completion should fail with non-success status");
+
+        assert!(matches!(error, CompletionError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+
+    #[tokio::test]
+    async fn embedding_http_non_success_preserves_status_and_body() {
+        use crate::client::EmbeddingsClient;
+        use crate::embeddings::{EmbeddingError, EmbeddingModel as _};
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"error":"model not found"}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = super::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.embedding_model("all-minilm");
+
+        let error = model
+            .embed_texts(["hello".to_string()])
+            .await
+            .expect_err("embedding should fail with non-success status");
+
+        assert!(matches!(error, EmbeddingError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+
     // Test deserialization and conversion for the /api/chat endpoint.
     #[tokio::test]
     async fn test_chat_completion() {

--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -298,9 +298,10 @@ where
 
         let response = self.client.send::<_, Vec<u8>>(req).await?;
 
-        if !response.status().is_success() {
+        let status = response.status();
+        if !status.is_success() {
             let text = http_client::text(response).await?;
-            return Err(EmbeddingError::ProviderError(text));
+            return Err(EmbeddingError::from_http_response(status, text));
         }
 
         let bytes: Vec<u8> = response.into_body().await?;
@@ -693,8 +694,9 @@ where
             let response_body = response.into_body().into_future().await?.to_vec();
 
             if !status.is_success() {
-                return Err(CompletionError::ProviderError(
-                    String::from_utf8_lossy(&response_body).to_string(),
+                return Err(CompletionError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&response_body),
                 ));
             }
 
@@ -774,9 +776,20 @@ where
         let mut byte_stream = response.into_body();
 
         if !status.is_success() {
-            return Err(CompletionError::ProviderError(format!(
-                "Got error status code trying to send a request to Ollama: {status}"
-            )));
+            // Drain the streaming body so the raw error payload is preserved
+            // verbatim alongside the status, instead of discarding it.
+            let mut error_body = Vec::new();
+            while let Some(chunk) = byte_stream.next().await {
+                match chunk {
+                    Ok(bytes) => error_body.extend_from_slice(&bytes),
+                    Err(_) => break,
+                }
+            }
+
+            return Err(CompletionError::from_http_response(
+                status,
+                String::from_utf8_lossy(&error_body),
+            ));
         }
 
         let stream = try_stream! {

--- a/crates/rig-core/src/providers/openai/audio_generation.rs
+++ b/crates/rig-core/src/providers/openai/audio_generation.rs
@@ -3,7 +3,7 @@ use crate::audio_generation::{
 };
 use crate::http_client::{self, HttpClientExt};
 use crate::providers::openai::Client;
-use bytes::{Buf, Bytes};
+use bytes::Bytes;
 use serde_json::json;
 
 pub const TTS_1: &str = "tts-1";
@@ -57,13 +57,12 @@ where
 
         if !response.status().is_success() {
             let status = response.status();
-            let mut bytes: Bytes = response.into_body().await?;
-            let mut as_slice = Vec::new();
-            bytes.copy_to_slice(&mut as_slice);
+            let bytes: Bytes = response.into_body().await?;
 
-            let text: String = String::from_utf8_lossy(&as_slice).into();
-
-            return Err(AudioGenerationError::from_http_response(status, text));
+            return Err(AudioGenerationError::from_http_response(
+                status,
+                String::from_utf8_lossy(&bytes),
+            ));
         }
 
         let bytes: Bytes = response.into_body().await?;
@@ -72,5 +71,45 @@ where
             audio: bytes.to_vec(),
             response: bytes,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audio_generation::AudioGenerationModel as _;
+    use crate::test_utils::RecordingHttpClient;
+
+    #[tokio::test]
+    async fn audio_generation_http_non_success_preserves_status_and_body() {
+        let body = r#"{"error":{"message":"invalid voice","type":"invalid_request_error"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = AudioGenerationModel::new(client, TTS_1);
+
+        let error = match model
+            .audio_generation(AudioGenerationRequest {
+                text: "hello".to_string(),
+                voice: "alloy".to_string(),
+                speed: 1.0,
+                additional_params: None,
+            })
+            .await
+        {
+            Err(error) => error,
+            Ok(_) => panic!("audio generation should fail with non-success status"),
+        };
+
+        assert!(matches!(error, AudioGenerationError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
     }
 }

--- a/crates/rig-core/src/providers/openai/audio_generation.rs
+++ b/crates/rig-core/src/providers/openai/audio_generation.rs
@@ -63,10 +63,7 @@ where
 
             let text: String = String::from_utf8_lossy(&as_slice).into();
 
-            return Err(AudioGenerationError::ProviderError(format!(
-                "{}: {}",
-                status, text
-            )));
+            return Err(AudioGenerationError::from_http_response(status, text));
         }
 
         let bytes: Bytes = response.into_body().await?;

--- a/crates/rig-core/src/providers/openai/responses_api/websocket.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/websocket.rs
@@ -633,9 +633,8 @@ fn terminal_response_result(
                 "OpenAI websocket response was incomplete: {reason}"
             )))
         }
-        status => Err(CompletionError::ProviderError(format!(
-            "OpenAI websocket response ended with status {:?}",
-            status
+        state => Err(CompletionError::ProviderError(format!(
+            "OpenAI websocket response ended in state {state:?}"
         ))),
     }
 }

--- a/crates/rig-core/src/providers/openrouter/audio_generation.rs
+++ b/crates/rig-core/src/providers/openrouter/audio_generation.rs
@@ -94,10 +94,7 @@ where
         if !response.status().is_success() {
             let status = response.status();
             let text = http_client::text(response).await?;
-            return Err(AudioGenerationError::ProviderError(format!(
-                "{}: {}",
-                status, text
-            )));
+            return Err(AudioGenerationError::from_http_response(status, text));
         }
 
         let audio: Vec<u8> = response.into_body().await?;

--- a/crates/rig-core/src/providers/openrouter/audio_generation.rs
+++ b/crates/rig-core/src/providers/openrouter/audio_generation.rs
@@ -105,3 +105,43 @@ where
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audio_generation::AudioGenerationModel as _;
+    use crate::test_utils::RecordingHttpClient;
+
+    #[tokio::test]
+    async fn audio_generation_http_non_success_preserves_status_and_body() {
+        let body = r#"{"error":{"message":"invalid voice","code":422}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::UNPROCESSABLE_ENTITY, body);
+        let client = crate::providers::openrouter::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = AudioGenerationModel::new(client, GPT_4O_MINI_TTS);
+
+        let error = match model
+            .audio_generation(AudioGenerationRequest {
+                text: "hello".to_string(),
+                voice: "alloy".to_string(),
+                speed: 1.0,
+                additional_params: None,
+            })
+            .await
+        {
+            Err(error) => error,
+            Ok(_) => panic!("audio generation should fail with non-success status"),
+        };
+
+        assert!(matches!(error, AudioGenerationError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::UNPROCESSABLE_ENTITY)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+}

--- a/crates/rig-core/src/providers/openrouter/completion.rs
+++ b/crates/rig-core/src/providers/openrouter/completion.rs
@@ -2021,20 +2021,16 @@ where
                     }
                     ApiResponse::Err(err) => {
                         tracing::warn!(message = %err.message, "provider returned an error response");
-                        Err(CompletionError::ProviderResponse(
-                            crate::provider_response::ProviderResponseError {
-                                status: Some(status),
-                                body: String::from_utf8_lossy(&response_body).into_owned(),
-                            },
+                        Err(CompletionError::from_http_response(
+                            status,
+                            String::from_utf8_lossy(&response_body),
                         ))
                     }
                 }
             } else {
-                Err(CompletionError::HttpError(
-                    crate::http_client::Error::InvalidStatusCodeWithMessage(
-                        status,
-                        String::from_utf8_lossy(&response_body).to_string(),
-                    ),
+                Err(CompletionError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&response_body),
                 ))
             }
         }

--- a/crates/rig-core/src/providers/openrouter/completion.rs
+++ b/crates/rig-core/src/providers/openrouter/completion.rs
@@ -2054,6 +2054,70 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    #[tokio::test]
+    async fn completion_http_non_success_preserves_status_and_body() {
+        use crate::client::CompletionClient;
+        use crate::completion::{CompletionError, CompletionModel};
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"error":{"message":"service unavailable","code":503}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = crate::providers::openrouter::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model(GEMINI_FLASH_2_0);
+        let request = model.completion_request("hello").build();
+
+        let error = model
+            .completion(request)
+            .await
+            .expect_err("completion should fail with non-success status");
+
+        assert!(matches!(error, CompletionError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+
+    #[tokio::test]
+    async fn completion_preserves_provider_error_envelope_on_2xx() {
+        use crate::client::CompletionClient;
+        use crate::completion::CompletionModel;
+        use crate::test_utils::RecordingHttpClient;
+
+        // OpenRouter can return its error envelope with a 2xx status; the raw body
+        // and status should be preserved as a `ProviderResponse`.
+        let body = r#"{"message":"rate limited"}"#;
+        let http_client = RecordingHttpClient::with_error_response(http::StatusCode::OK, body);
+        let client = crate::providers::openrouter::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model(GEMINI_FLASH_2_0);
+        let request = model.completion_request("hello").build();
+
+        let error = model
+            .completion(request)
+            .await
+            .expect_err("completion should fail with provider error envelope");
+
+        match &error {
+            CompletionError::ProviderResponse(stored) => {
+                assert_eq!(stored.body, body);
+                assert_eq!(stored.status, Some(http::StatusCode::OK));
+                assert_eq!(error.provider_response_body(), Some(body));
+                assert_eq!(error.provider_response_status(), Some(http::StatusCode::OK));
+            }
+            other => panic!("expected ProviderResponse, got {other:?}"),
+        }
+    }
+
     #[test]
     fn test_openrouter_request_uses_request_model_override() {
         let request = CompletionRequest {

--- a/crates/rig-core/src/providers/openrouter/embedding.rs
+++ b/crates/rig-core/src/providers/openrouter/embedding.rs
@@ -205,3 +205,36 @@ impl<T> EmbeddingModel<T> {
         self
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::EmbeddingsClient;
+    use crate::embeddings::EmbeddingModel as _;
+    use crate::test_utils::RecordingHttpClient;
+
+    #[tokio::test]
+    async fn embedding_http_non_success_preserves_status_and_body() {
+        let body = r#"{"error":{"message":"invalid api key","code":401}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::UNAUTHORIZED, body);
+        let client = crate::providers::openrouter::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.embedding_model("openai/text-embedding-3-small");
+
+        let error = model
+            .embed_texts(["hello".to_string()])
+            .await
+            .expect_err("embedding should fail with non-success status");
+
+        assert!(matches!(error, EmbeddingError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::UNAUTHORIZED)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+}

--- a/crates/rig-core/src/providers/openrouter/embedding.rs
+++ b/crates/rig-core/src/providers/openrouter/embedding.rs
@@ -146,19 +146,15 @@ where
                 }
                 ApiResponse::Err(err) => {
                     tracing::warn!(message = %err.message, "provider returned an error response");
-                    Err(EmbeddingError::ProviderResponse(
-                        crate::provider_response::ProviderResponseError {
-                            status: Some(status),
-                            body: String::from_utf8_lossy(&response_body).into_owned(),
-                        },
+                    Err(EmbeddingError::from_http_response(
+                        status,
+                        String::from_utf8_lossy(&response_body),
                     ))
                 }
             }
         } else {
             let text = http_client::text(response).await?;
-            Err(EmbeddingError::HttpError(
-                http_client::Error::InvalidStatusCodeWithMessage(status, text),
-            ))
+            Err(EmbeddingError::from_http_response(status, text))
         }
     }
 }

--- a/crates/rig-core/src/providers/openrouter/transcription.rs
+++ b/crates/rig-core/src/providers/openrouter/transcription.rs
@@ -197,7 +197,7 @@ where
             resp.try_into()
         } else {
             let text = String::from_utf8_lossy(&body_bytes).to_string();
-            Err(TranscriptionError::ProviderError(text))
+            Err(TranscriptionError::from_http_response(status, text))
         }
     }
 }

--- a/crates/rig-core/src/providers/openrouter/transcription.rs
+++ b/crates/rig-core/src/providers/openrouter/transcription.rs
@@ -257,4 +257,38 @@ mod tests {
         assert_eq!(resp.text, "Hello world");
         assert!(resp.usage.is_none());
     }
+
+    #[tokio::test]
+    async fn transcription_http_non_success_preserves_status_and_body() {
+        use crate::client::transcription::TranscriptionClient;
+        use crate::test_utils::RecordingHttpClient;
+        use crate::transcription::TranscriptionModel as _;
+
+        let body = r#"{"error":{"message":"bad audio","code":400}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::BAD_REQUEST, body);
+        let client = crate::providers::openrouter::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.transcription_model(WHISPER_1);
+
+        let error = match model
+            .transcription_request()
+            .data(vec![0u8; 16])
+            .send()
+            .await
+        {
+            Err(error) => error,
+            Ok(_) => panic!("transcription should fail with non-success status"),
+        };
+
+        assert!(matches!(error, TranscriptionError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::BAD_REQUEST)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
 }

--- a/crates/rig-core/src/providers/voyageai.rs
+++ b/crates/rig-core/src/providers/voyageai.rs
@@ -455,11 +455,20 @@ where
                         usage,
                     })
                 }
-                ApiResponse::Err(err) => Err(RerankError::ProviderError(err.message)),
+                // VoyageAI returns its error envelope with a 2xx status; preserve
+                // the raw body alongside that status instead of flattening it.
+                ApiResponse::Err(err) => {
+                    tracing::warn!(message = %err.message, "provider returned an error response");
+                    Err(RerankError::from_http_response(
+                        status,
+                        String::from_utf8_lossy(&response_body),
+                    ))
+                }
             }
         } else {
-            Err(RerankError::ProviderError(
-                String::from_utf8_lossy(&response_body).to_string(),
+            Err(RerankError::from_http_response(
+                status,
+                String::from_utf8_lossy(&response_body),
             ))
         }
     }
@@ -475,5 +484,66 @@ mod tests {
             .api_key("dummy-key")
             .build()
             .expect("Client::builder() failed");
+    }
+
+    #[tokio::test]
+    async fn rerank_http_non_success_preserves_status_and_body() {
+        use crate::client::RerankingClient;
+        use crate::rerank::{RerankError, RerankModel as _};
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"detail":"rate limited"}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::TOO_MANY_REQUESTS, body);
+        let client = crate::providers::voyageai::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.rerank_model("rerank-2");
+
+        let error = model
+            .rerank("query", vec!["doc a".to_string(), "doc b".to_string()])
+            .await
+            .expect_err("rerank should fail with non-success status");
+
+        assert!(matches!(error, RerankError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::TOO_MANY_REQUESTS)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+
+    #[tokio::test]
+    async fn rerank_preserves_provider_error_envelope_on_2xx() {
+        use crate::client::RerankingClient;
+        use crate::rerank::{RerankError, RerankModel as _};
+        use crate::test_utils::RecordingHttpClient;
+
+        // VoyageAI returns its error envelope with a 2xx status.
+        let body = r#"{"message":"model overloaded"}"#;
+        let http_client = RecordingHttpClient::with_error_response(http::StatusCode::OK, body);
+        let client = crate::providers::voyageai::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.rerank_model("rerank-2");
+
+        let error = model
+            .rerank("query", vec!["doc a".to_string()])
+            .await
+            .expect_err("rerank should fail with provider error envelope");
+
+        match &error {
+            RerankError::ProviderResponse(stored) => {
+                assert_eq!(stored.body, body);
+                assert_eq!(stored.status, Some(http::StatusCode::OK));
+                assert_eq!(error.provider_response_body(), Some(body));
+                assert_eq!(error.provider_response_status(), Some(http::StatusCode::OK));
+            }
+            other => panic!("expected ProviderResponse, got {other:?}"),
+        }
     }
 }

--- a/crates/rig-core/src/providers/xai/audio_generation.rs
+++ b/crates/rig-core/src/providers/xai/audio_generation.rs
@@ -84,3 +84,45 @@ where
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::audio_generation::{
+        AudioGenerationError, AudioGenerationModel as _, AudioGenerationRequest,
+    };
+    use crate::client::audio_generation::AudioGenerationClient;
+    use crate::test_utils::RecordingHttpClient;
+
+    #[tokio::test]
+    async fn audio_generation_non_success_response_preserves_status_and_body() {
+        let body = r#"{"error":"invalid voice","code":"422"}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::UNPROCESSABLE_ENTITY, body);
+        let client = crate::providers::xai::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.audio_generation_model(super::TTS_1);
+
+        let error = match model
+            .audio_generation(AudioGenerationRequest {
+                text: "hello".to_string(),
+                voice: "eve".to_string(),
+                speed: 1.0,
+                additional_params: None,
+            })
+            .await
+        {
+            Err(error) => error,
+            Ok(_) => panic!("audio generation should fail with non-success status"),
+        };
+
+        assert!(matches!(error, AudioGenerationError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::UNPROCESSABLE_ENTITY)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+}

--- a/crates/rig-core/src/providers/xai/audio_generation.rs
+++ b/crates/rig-core/src/providers/xai/audio_generation.rs
@@ -73,10 +73,7 @@ where
             let status = response.status();
             let text = http_client::text(response).await?;
 
-            return Err(AudioGenerationError::ProviderError(format!(
-                "{}: {}",
-                status, text,
-            )));
+            return Err(AudioGenerationError::from_http_response(status, text));
         }
 
         let bytes: Bytes = response.into_body().await?.into();

--- a/crates/rig-core/src/providers/xai/completion.rs
+++ b/crates/rig-core/src/providers/xai/completion.rs
@@ -378,4 +378,68 @@ mod tests {
             "document input should appear exactly once: {input:?}"
         );
     }
+
+    #[tokio::test]
+    async fn completion_http_non_success_preserves_status_and_body() {
+        use crate::client::CompletionClient;
+        use crate::completion::{CompletionError, CompletionModel};
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"error":"service unavailable","code":"503"}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = crate::providers::xai::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model(super::GROK_4);
+        let request = model.completion_request("hello").build();
+
+        let error = model
+            .completion(request)
+            .await
+            .expect_err("completion should fail with non-success status");
+
+        assert!(matches!(error, CompletionError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+
+    #[tokio::test]
+    async fn completion_preserves_provider_error_envelope_on_2xx() {
+        use crate::client::CompletionClient;
+        use crate::completion::{CompletionError, CompletionModel};
+        use crate::test_utils::RecordingHttpClient;
+
+        // xAI can return its error envelope with a 2xx status; the raw body and
+        // status should be preserved as a `ProviderResponse`.
+        let body = r#"{"error":"rate limited","code":"429"}"#;
+        let http_client = RecordingHttpClient::with_error_response(http::StatusCode::OK, body);
+        let client = crate::providers::xai::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model(super::GROK_4);
+        let request = model.completion_request("hello").build();
+
+        let error = model
+            .completion(request)
+            .await
+            .expect_err("completion should fail with provider error envelope");
+
+        match &error {
+            CompletionError::ProviderResponse(stored) => {
+                assert_eq!(stored.body, body);
+                assert_eq!(stored.status, Some(http::StatusCode::OK));
+                assert_eq!(error.provider_response_body(), Some(body));
+                assert_eq!(error.provider_response_status(), Some(http::StatusCode::OK));
+            }
+            other => panic!("expected ProviderResponse, got {other:?}"),
+        }
+    }
 }

--- a/crates/rig-core/src/providers/xai/completion.rs
+++ b/crates/rig-core/src/providers/xai/completion.rs
@@ -262,13 +262,21 @@ where
 
                         response.try_into()
                     }
+                    // xAI returns its error envelope with a 2xx status; preserve
+                    // the raw body alongside that status instead of flattening the
+                    // message.
                     ApiResponse::Error(error) => {
-                        Err(CompletionError::ProviderError(error.message()))
+                        tracing::warn!(message = %error.message(), "provider returned an error response");
+                        Err(CompletionError::from_http_response(
+                            status,
+                            String::from_utf8_lossy(&response_body),
+                        ))
                     }
                 }
             } else {
-                Err(CompletionError::ProviderError(
-                    String::from_utf8_lossy(&response_body).to_string(),
+                Err(CompletionError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&response_body),
                 ))
             }
         }

--- a/crates/rig-core/src/providers/xai/image_generation.rs
+++ b/crates/rig-core/src/providers/xai/image_generation.rs
@@ -119,3 +119,40 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::client::image_generation::ImageGenerationClient;
+    use crate::image_generation::{ImageGenerationError, ImageGenerationModel as _};
+    use crate::test_utils::RecordingHttpClient;
+
+    #[tokio::test]
+    async fn image_generation_non_success_response_preserves_status_and_body() {
+        let body = r#"{"error":"invalid prompt","code":"400"}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::BAD_REQUEST, body);
+        let client = crate::providers::xai::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.image_generation_model(super::GROK_IMAGINE_IMAGE);
+
+        let error = model
+            .image_generation_request()
+            .prompt("draw a cat")
+            .width(256)
+            .height(256)
+            .send()
+            .await
+            .err()
+            .expect("image generation should fail with non-success status");
+
+        assert!(matches!(error, ImageGenerationError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::BAD_REQUEST)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+}

--- a/crates/rig-core/src/providers/xai/image_generation.rs
+++ b/crates/rig-core/src/providers/xai/image_generation.rs
@@ -101,21 +101,21 @@ where
 
         let response = self.client.send(request).await?;
 
-        if !response.status().is_success() {
-            let status = response.status();
-            let text = http_client::text(response).await?;
-
-            return Err(ImageGenerationError::ProviderError(format!(
-                "{}: {}",
-                status, text,
-            )));
-        }
-
+        let status = response.status();
         let text = http_client::text(response).await?;
+
+        if !status.is_success() {
+            return Err(ImageGenerationError::from_http_response(status, text));
+        }
 
         match serde_json::from_str::<ApiResponse<ImageGenerationResponse>>(&text)? {
             ApiResponse::Ok(response) => response.try_into(),
-            ApiResponse::Error(err) => Err(ImageGenerationError::ProviderError(err.message())),
+            // xAI returns its error envelope with a 2xx status; preserve the raw
+            // body alongside that status instead of flattening the message.
+            ApiResponse::Error(err) => {
+                tracing::warn!(message = %err.message(), "provider returned an error response");
+                Err(ImageGenerationError::from_http_response(status, text))
+            }
         }
     }
 }

--- a/crates/rig-core/src/rerank.rs
+++ b/crates/rig-core/src/rerank.rs
@@ -11,7 +11,12 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 
+/// Errors returned by rerank models.
+///
+/// Inspect provider failures with [`Self::provider_response_body`],
+/// [`Self::provider_response_json`], and [`Self::provider_response_status`].
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum RerankError {
     #[error("HttpError: {0}")]
     HttpError(#[from] http_client::Error),
@@ -27,7 +32,13 @@ pub enum RerankError {
 
     #[error("ProviderError: {0}")]
     ProviderError(String),
+
+    /// Raw error response preserved from the rerank model provider
+    #[error("ProviderResponseError: {0}")]
+    ProviderResponse(crate::provider_response::ProviderResponseError),
 }
+
+crate::provider_response::impl_provider_response_helpers!(RerankError);
 
 /// Trait for reranking models that score documents by relevance to a query.
 pub trait RerankModel: WasmCompatSend + WasmCompatSync {

--- a/crates/rig-core/src/test_utils/http.rs
+++ b/crates/rig-core/src/test_utils/http.rs
@@ -262,6 +262,18 @@ impl HttpErrorStreamingClient {
     }
 }
 
+// `http::StatusCode` has no `Default`, so derive cannot apply. A `Default` impl
+// is required to use this client as a provider `Client`'s HTTP backend (the
+// completion model bounds require `H: Default`), e.g. for streaming error tests.
+impl Default for HttpErrorStreamingClient {
+    fn default() -> Self {
+        Self {
+            status: http::StatusCode::INTERNAL_SERVER_ERROR,
+            body: String::new(),
+        }
+    }
+}
+
 impl HttpClientExt for HttpErrorStreamingClient {
     fn send<T, U>(
         &self,


### PR DESCRIPTION
Closes #1931. Follow-up to #1859 — completes provider error-response inspection across the **entire** workspace in one PR (the issue's PRs 2–4 + the "un-reopenable" guard + the #1859-review polish).

## Background

#1859 added `provider_response_body()` / `provider_response_json()` / `provider_response_status()` on the capability errors but only wired the OpenAI family. Every other provider flattened HTTP failures into `ProviderError(String)`, so the helpers returned `None`.

## What this PR does

### 1. Shared funnel (the regression anchor)
`<Capability>Error::from_http_response(status, body)` — now **`pub`** — is the single constructor every HTTP error path routes through. It routes a **2xx** provider-authored error envelope to `ProviderResponse { status, body }` and a **non-success** status to `HttpError(InvalidStatusCodeWithMessage)`. `ProviderResponseError::without_status` is also `pub` for non-HTTP transports. The raw body is read **once** and preserved verbatim.

### 2. Every in-core HTTP provider wired
Non-success **and** 2xx-error-envelope paths (and SSE transport errors via `from_stream_transport`) migrated for: **Anthropic** (completion + streaming), **Gemini** (completion, image, embedding, transcription, interactions API + its streaming), **cohere**, **xAI** (completion/image/audio), **ollama** (unary + streaming + embeddings), **mira**, **hyperbolic** (completion/image/audio), **huggingface** (completion/image/transcription), **openrouter** (completion/embedding/transcription/audio), **mistral** (embedding/transcription), and **openai audio generation**. This also makes `AudioGenerationError::ProviderResponse` a live variant and fixes the image/audio asymmetries the issue called out.

### 3. Rerank wired (breaking) — see caveat
`RerankError` was the one capability error #1859 missed (rerank landed separately in #1917). It now gets `#[non_exhaustive]` + a `ProviderResponse` variant + the inspection helpers, and VoyageAI rerank routes through the funnel — bringing it in line with the other six errors.

### 4. Companion crates: deliberate `None`
`rig-bedrock` (AWS SDK), `rig-vertexai` / `rig-gemini-grpc` (gRPC), and `rig-fastembed` (local inference) have **no HTTP response** to preserve, so the helpers correctly return `None` (status `None` is the deliberate decision, not a synthetic status). Documented in the `provider_response` module; no behavioral change.

### 5. Make the gap un-reopenable
- **CI guard** (`perl -0777`, multi-line aware) over `crates/rig-core/src/providers` fails the build if any provider re-flattens an HTTP status into `ProviderError(format!(…status…))`. Companion crates are excluded by design.
- **~50 tests** asserting status + body are preserved across providers and capabilities (non-success `HttpError` and 2xx `ProviderResponse`), for unary and streaming failures.

### 6. #1859-review polish
- Harden the OpenAI-compatible SSE error detector to require a non-null **object** `error` field (so `{"error":null}` can't terminate the stream) + test.
- Expand `provider_response_status()` rustdoc to warn a 2xx status is **not** success; document the empty-body (`Some("")` vs `Ok(None)`) asymmetry.
- Add a `CompletionError` rustdoc example showing the inspection pattern.

## Caveats / breaking

- **Breaking:** `RerankError` gains a variant and becomes `#[non_exhaustive]` (mirrors the #1859 change to the other capability errors; breaks downstream exhaustive matches on `RerankError`). Everything else is non-breaking — it only changes *which* variant some errors use (the `ProviderResponse` variant + `#[non_exhaustive]` already shipped in #1859).
- A bug found by the new tests during development — OpenAI audio's error path discarded the body (`copy_to_slice` into an empty `Vec`) — is fixed here.

## Verification

Local: `cargo fmt --check`, `cargo clippy --all-features --all-targets`, `cargo test -p rig-core --all-features` (1026 lib tests), `cargo test --doc --workspace --all-features`, `cargo doc --no-deps --all-features` (`-D warnings`), `cargo check -p rig-core --features wasm --target wasm32-unknown-unknown`, and the CI flatten-guard all pass. The full workspace (companion crates + integration tests) compiles with the `RerankError` change.