### PR TITLE
feat(rig-core)!: broaden provider error-response inspection coverage workspace-wide

### DIFF
--- a/crates/rig-bedrock/src/types/errors.rs
+++ b/crates/rig-bedrock/src/types/errors.rs
@@ -9,36 +9,103 @@ use rig_core::completion::CompletionError;
 use rig_core::embeddings::EmbeddingError;
 use rig_core::image_generation::ImageGenerationError;
 
-pub struct AwsSdkInvokeModelError(pub SdkError<InvokeModelError, HttpResponse>);
-
-impl AwsSdkInvokeModelError {
-    pub fn into_service_error(self) -> String {
-        let error: String = match self.0.into_service_error() {
-            InvokeModelError::ModelTimeoutException(e) => e.message.unwrap_or("The request took too long to process. Processing time exceeded the model timeout length.".into()),
-            InvokeModelError::AccessDeniedException(e) => e.message.unwrap_or("The request is denied because you do not have sufficient permissions to perform the requested action.".into()),
-            InvokeModelError::ResourceNotFoundException(e) => e.message.unwrap_or("The specified resource ARN was not found.".into()),
-            InvokeModelError::ThrottlingException(e) => e.message.unwrap_or("Your request was denied due to exceeding the account quotas for Amazon Bedrock.".into()),
-            InvokeModelError::ServiceUnavailableException(e) => e.message.unwrap_or("The service isn't currently available.".into()),
-            InvokeModelError::InternalServerException(e) => e.message.unwrap_or("An internal server error occurred.".into()),
-            InvokeModelError::ValidationException(e) => e.message.unwrap_or("The input fails to satisfy the constraints specified by Amazon Bedrock.".into()),
-            InvokeModelError::ModelNotReadyException(e) => e.message.unwrap_or("The model specified in the request is not ready to serve inference requests. The AWS SDK will automatically retry the operation up to 5 times.".into()),
-            InvokeModelError::ModelErrorException(e) => e.message.unwrap_or("The request failed due to an error while processing the model.".into()),
-            InvokeModelError::ServiceQuotaExceededException(e) => e.message.unwrap_or("Your request exceeds the service quota for your account.".into()),
-            _ => "An unexpected error occurred. Verify Internet connection or AWS keys".into(),
-        };
-        error
+/// Extracts the provider-supplied message from an [`InvokeModelError`] service
+/// error.
+///
+/// Returns `(Some(message), _)` when the service supplied a genuine error
+/// message (which should be surfaced as a provider response body), otherwise
+/// `(None, fallback)` where `fallback` is Rig-authored diagnostic prose. The
+/// caller decides which arm to surface so that Rig prose never leaks into
+/// `provider_response_body()`.
+fn invoke_model_message(err: InvokeModelError) -> (Option<String>, String) {
+    match err {
+        InvokeModelError::ModelTimeoutException(e) => (e.message, "The request took too long to process. Processing time exceeded the model timeout length.".into()),
+        InvokeModelError::AccessDeniedException(e) => (e.message, "The request is denied because you do not have sufficient permissions to perform the requested action.".into()),
+        InvokeModelError::ResourceNotFoundException(e) => (e.message, "The specified resource ARN was not found.".into()),
+        InvokeModelError::ThrottlingException(e) => (e.message, "Your request was denied due to exceeding the account quotas for Amazon Bedrock.".into()),
+        InvokeModelError::ServiceUnavailableException(e) => (e.message, "The service isn't currently available.".into()),
+        InvokeModelError::InternalServerException(e) => (e.message, "An internal server error occurred.".into()),
+        InvokeModelError::ValidationException(e) => (e.message, "The input fails to satisfy the constraints specified by Amazon Bedrock.".into()),
+        InvokeModelError::ModelNotReadyException(e) => (e.message, "The model specified in the request is not ready to serve inference requests. The AWS SDK will automatically retry the operation up to 5 times.".into()),
+        InvokeModelError::ModelErrorException(e) => (e.message, "The request failed due to an error while processing the model.".into()),
+        InvokeModelError::ServiceQuotaExceededException(e) => (e.message, "Your request exceeds the service quota for your account.".into()),
+        _ => (None, "An unexpected error occurred. Verify Internet connection or AWS keys".into()),
     }
 }
 
+/// Extracts the provider-supplied message from a [`ConverseError`] service
+/// error. See [`invoke_model_message`] for the gating contract.
+fn converse_message(err: ConverseError) -> (Option<String>, String) {
+    match err {
+        ConverseError::ModelTimeoutException(e) => (e.message, "The request took too long to process. Processing time exceeded the model timeout length.".into()),
+        ConverseError::AccessDeniedException(e) => (e.message, "The request is denied because you do not have sufficient permissions to perform the requested action.".into()),
+        ConverseError::ResourceNotFoundException(e) => (e.message, "The specified resource ARN was not found.".into()),
+        ConverseError::ThrottlingException(e) => (e.message, "Your request was denied due to exceeding the account quotas for AWS Bedrock.".into()),
+        ConverseError::ServiceUnavailableException(e) => (e.message, "The service isn't currently available.".into()),
+        ConverseError::InternalServerException(e) => (e.message, "An internal server error occurred.".into()),
+        ConverseError::ValidationException(e) => (e.message, "The input fails to satisfy the constraints specified by AWS Bedrock.".into()),
+        ConverseError::ModelNotReadyException(e) => (e.message, "The model specified in the request is not ready to serve inference requests. The AWS SDK will automatically retry the operation up to 5 times.".into()),
+        ConverseError::ModelErrorException(e) => (e.message, "The request failed due to an error while processing the model.".into()),
+        _ => (None, "An unexpected error occurred. Verify Internet connection or AWS keys".into()),
+    }
+}
+
+/// Extracts the provider-supplied message from a [`ConverseStreamError`]
+/// service error. See [`invoke_model_message`] for the gating contract.
+fn converse_stream_message(err: ConverseStreamError) -> (Option<String>, String) {
+    match err {
+        ConverseStreamError::ModelTimeoutException(e) => {
+            (e.message, "Bedrock model timed out".into())
+        }
+        ConverseStreamError::AccessDeniedException(e) => {
+            (e.message, "Bedrock access denied".into())
+        }
+        ConverseStreamError::ResourceNotFoundException(e) => {
+            (e.message, "Bedrock resource not found".into())
+        }
+        ConverseStreamError::ThrottlingException(e) => {
+            (e.message, "Bedrock request throttled".into())
+        }
+        ConverseStreamError::ServiceUnavailableException(e) => {
+            (e.message, "Bedrock service unavailable".into())
+        }
+        ConverseStreamError::InternalServerException(e) => {
+            (e.message, "Bedrock internal server error".into())
+        }
+        ConverseStreamError::ModelStreamErrorException(e) => {
+            (e.message, "Bedrock streaming model error".into())
+        }
+        ConverseStreamError::ValidationException(e) => {
+            (e.message, "Bedrock validation error".into())
+        }
+        ConverseStreamError::ModelNotReadyException(e) => {
+            (e.message, "Bedrock model not ready".into())
+        }
+        ConverseStreamError::ModelErrorException(e) => (e.message, "Bedrock model error".into()),
+        _ => (
+            None,
+            "An unexpected error occurred. Verify Internet connection or AWS keys".into(),
+        ),
+    }
+}
+
+pub struct AwsSdkInvokeModelError(pub SdkError<InvokeModelError, HttpResponse>);
+
 impl From<AwsSdkInvokeModelError> for ImageGenerationError {
     fn from(value: AwsSdkInvokeModelError) -> Self {
-        ImageGenerationError::ProviderError(value.into_service_error())
+        match invoke_model_message(value.0.into_service_error()) {
+            (Some(msg), _) => ImageGenerationError::from_provider_body(msg),
+            (None, fallback) => ImageGenerationError::ProviderError(fallback),
+        }
     }
 }
 
 impl From<AwsSdkInvokeModelError> for EmbeddingError {
     fn from(value: AwsSdkInvokeModelError) -> Self {
-        EmbeddingError::ProviderError(value.into_service_error())
+        match invoke_model_message(value.0.into_service_error()) {
+            (Some(msg), _) => EmbeddingError::from_provider_body(msg),
+            (None, fallback) => EmbeddingError::ProviderError(fallback),
+        }
     }
 }
 
@@ -46,59 +113,20 @@ pub struct AwsSdkConverseError(pub SdkError<ConverseError, HttpResponse>);
 
 impl From<AwsSdkConverseError> for CompletionError {
     fn from(value: AwsSdkConverseError) -> Self {
-        let error: String = match value.0.into_service_error() {
-            ConverseError::ModelTimeoutException(e) => e.message.unwrap_or("The request took too long to process. Processing time exceeded the model timeout length.".into()),
-            ConverseError::AccessDeniedException(e) => e.message.unwrap_or("The request is denied because you do not have sufficient permissions to perform the requested action.".into()),
-            ConverseError::ResourceNotFoundException(e) => e.message.unwrap_or("The specified resource ARN was not found.".into()),
-            ConverseError::ThrottlingException(e) => e.message.unwrap_or("Your request was denied due to exceeding the account quotas for AWS Bedrock.".into()),
-            ConverseError::ServiceUnavailableException(e) => e.message.unwrap_or("The service isn't currently available.".into()),
-            ConverseError::InternalServerException(e) => e.message.unwrap_or("An internal server error occurred.".into()),
-            ConverseError::ValidationException(e) => e.message.unwrap_or("The input fails to satisfy the constraints specified by AWS Bedrock.".into()),
-            ConverseError::ModelNotReadyException(e) => e.message.unwrap_or("The model specified in the request is not ready to serve inference requests. The AWS SDK will automatically retry the operation up to 5 times.".into()),
-            ConverseError::ModelErrorException(e) => e.message.unwrap_or("The request failed due to an error while processing the model.".into()),
-            _ => String::from("An unexpected error occurred. Verify Internet connection or AWS keys")
-        };
-        CompletionError::ProviderError(error)
+        match converse_message(value.0.into_service_error()) {
+            (Some(msg), _) => CompletionError::from_provider_body(msg),
+            (None, fallback) => CompletionError::ProviderError(fallback),
+        }
     }
 }
 
 pub struct AwsSdkConverseStreamError(pub SdkError<ConverseStreamError, HttpResponse>);
 impl From<AwsSdkConverseStreamError> for CompletionError {
     fn from(value: AwsSdkConverseStreamError) -> Self {
-        let error: String = match value.0.into_service_error() {
-            ConverseStreamError::ModelTimeoutException(e) => e
-                .message
-                .unwrap_or_else(|| "Bedrock model timed out".to_string()),
-            ConverseStreamError::AccessDeniedException(e) => e
-                .message
-                .unwrap_or_else(|| "Bedrock access denied".to_string()),
-            ConverseStreamError::ResourceNotFoundException(e) => e
-                .message
-                .unwrap_or_else(|| "Bedrock resource not found".to_string()),
-            ConverseStreamError::ThrottlingException(e) => e
-                .message
-                .unwrap_or_else(|| "Bedrock request throttled".to_string()),
-            ConverseStreamError::ServiceUnavailableException(e) => e
-                .message
-                .unwrap_or_else(|| "Bedrock service unavailable".to_string()),
-            ConverseStreamError::InternalServerException(e) => e
-                .message
-                .unwrap_or_else(|| "Bedrock internal server error".to_string()),
-            ConverseStreamError::ModelStreamErrorException(e) => e
-                .message
-                .unwrap_or_else(|| "Bedrock streaming model error".to_string()),
-            ConverseStreamError::ValidationException(e) => e
-                .message
-                .unwrap_or_else(|| "Bedrock validation error".to_string()),
-            ConverseStreamError::ModelNotReadyException(e) => e
-                .message
-                .unwrap_or_else(|| "Bedrock model not ready".to_string()),
-            ConverseStreamError::ModelErrorException(e) => e
-                .message
-                .unwrap_or_else(|| "Bedrock model error".to_string()),
-            _ => "An unexpected error occurred. Verify Internet connection or AWS keys".into(),
-        };
-        CompletionError::ProviderError(error)
+        match converse_stream_message(value.0.into_service_error()) {
+            (Some(msg), _) => CompletionError::from_provider_body(msg),
+            (None, fallback) => CompletionError::ProviderError(fallback),
+        }
     }
 }
 
@@ -119,3 +147,155 @@ impl fmt::Display for TypeConversionError {
 }
 
 impl std::error::Error for TypeConversionError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aws_sdk_bedrockruntime::types::error::{
+        InternalServerException, ModelTimeoutException, ValidationException,
+    };
+
+    // NOTE: These tests construct the *extracted* service-error enum variants
+    // directly via the AWS-provided builders and drive the gating helpers plus
+    // the `From` conversions. The `SdkError` wrapper (and thus the public
+    // `AwsSdk*Error` newtypes) cannot be constructed in a unit test, so the
+    // `From` contract is asserted on the helper + builder-routed error type
+    // rather than on the newtype. None of these paths are feature-gated in
+    // `rig-bedrock` (the crate exposes no `image`/`audio` features; the
+    // completion/embedding/image/streaming modules are always compiled), so the
+    // tests only need `#[cfg(test)]`.
+
+    #[test]
+    fn invoke_model_message_returns_provider_message_when_present() {
+        let err = InvokeModelError::ModelTimeoutException(
+            ModelTimeoutException::builder().message("boom").build(),
+        );
+        let (message, _fallback) = invoke_model_message(err);
+        assert_eq!(message, Some("boom".to_string()));
+    }
+
+    #[test]
+    fn invoke_model_message_returns_none_when_message_absent() {
+        let err =
+            InvokeModelError::InternalServerException(InternalServerException::builder().build());
+        let (message, fallback) = invoke_model_message(err);
+        assert_eq!(message, None);
+        assert_eq!(fallback, "An internal server error occurred.".to_string());
+    }
+
+    #[test]
+    fn image_generation_with_provider_message_yields_provider_response() {
+        let err = InvokeModelError::ValidationException(
+            ValidationException::builder().message("boom").build(),
+        );
+        let error: ImageGenerationError = match invoke_model_message(err) {
+            (Some(msg), _) => ImageGenerationError::from_provider_body(msg),
+            (None, fallback) => ImageGenerationError::ProviderError(fallback),
+        };
+        assert_eq!(error.provider_response_body(), Some("boom"));
+        assert_eq!(error.provider_response_status(), None);
+    }
+
+    #[test]
+    fn image_generation_without_provider_message_yields_provider_error() {
+        // A matched variant with no message -> `(None, fallback)` -> `ProviderError`,
+        // which must NOT surface Rig prose through `provider_response_body()`.
+        let err = InvokeModelError::ValidationException(ValidationException::builder().build());
+        let error: ImageGenerationError = match invoke_model_message(err) {
+            (Some(msg), _) => ImageGenerationError::from_provider_body(msg),
+            (None, fallback) => ImageGenerationError::ProviderError(fallback),
+        };
+        assert_eq!(error.provider_response_body(), None);
+        assert_eq!(error.provider_response_status(), None);
+    }
+
+    #[test]
+    fn embedding_with_provider_message_yields_provider_response() {
+        let err = InvokeModelError::ValidationException(
+            ValidationException::builder().message("boom").build(),
+        );
+        let error: EmbeddingError = match invoke_model_message(err) {
+            (Some(msg), _) => EmbeddingError::from_provider_body(msg),
+            (None, fallback) => EmbeddingError::ProviderError(fallback),
+        };
+        assert_eq!(error.provider_response_body(), Some("boom"));
+        assert_eq!(error.provider_response_status(), None);
+    }
+
+    #[test]
+    fn embedding_without_provider_message_yields_provider_error() {
+        let err =
+            InvokeModelError::InternalServerException(InternalServerException::builder().build());
+        let error: EmbeddingError = match invoke_model_message(err) {
+            (Some(msg), _) => EmbeddingError::from_provider_body(msg),
+            (None, fallback) => EmbeddingError::ProviderError(fallback),
+        };
+        assert_eq!(error.provider_response_body(), None);
+    }
+
+    #[test]
+    fn converse_message_returns_provider_message_when_present() {
+        let err = ConverseError::ModelTimeoutException(
+            ModelTimeoutException::builder().message("boom").build(),
+        );
+        let (message, _fallback) = converse_message(err);
+        assert_eq!(message, Some("boom".to_string()));
+    }
+
+    #[test]
+    fn converse_with_provider_message_yields_provider_response() {
+        let err = ConverseError::ModelTimeoutException(
+            ModelTimeoutException::builder().message("boom").build(),
+        );
+        let error: CompletionError = match converse_message(err) {
+            (Some(msg), _) => CompletionError::from_provider_body(msg),
+            (None, fallback) => CompletionError::ProviderError(fallback),
+        };
+        assert_eq!(error.provider_response_body(), Some("boom"));
+        assert_eq!(error.provider_response_status(), None);
+    }
+
+    #[test]
+    fn converse_without_provider_message_yields_provider_error() {
+        let err = ConverseError::ModelTimeoutException(ModelTimeoutException::builder().build());
+        let error: CompletionError = match converse_message(err) {
+            (Some(msg), _) => CompletionError::from_provider_body(msg),
+            (None, fallback) => CompletionError::ProviderError(fallback),
+        };
+        assert_eq!(error.provider_response_body(), None);
+        assert_eq!(error.provider_response_status(), None);
+    }
+
+    #[test]
+    fn converse_stream_message_returns_provider_message_when_present() {
+        let err = ConverseStreamError::ModelTimeoutException(
+            ModelTimeoutException::builder().message("boom").build(),
+        );
+        let (message, _fallback) = converse_stream_message(err);
+        assert_eq!(message, Some("boom".to_string()));
+    }
+
+    #[test]
+    fn converse_stream_with_provider_message_yields_provider_response() {
+        let err = ConverseStreamError::ValidationException(
+            ValidationException::builder().message("boom").build(),
+        );
+        let error: CompletionError = match converse_stream_message(err) {
+            (Some(msg), _) => CompletionError::from_provider_body(msg),
+            (None, fallback) => CompletionError::ProviderError(fallback),
+        };
+        assert_eq!(error.provider_response_body(), Some("boom"));
+        assert_eq!(error.provider_response_status(), None);
+    }
+
+    #[test]
+    fn converse_stream_without_provider_message_yields_provider_error() {
+        let err = ConverseStreamError::ValidationException(ValidationException::builder().build());
+        let error: CompletionError = match converse_stream_message(err) {
+            (Some(msg), _) => CompletionError::from_provider_body(msg),
+            (None, fallback) => CompletionError::ProviderError(fallback),
+        };
+        assert_eq!(error.provider_response_body(), None);
+        assert_eq!(error.provider_response_status(), None);
+    }
+}

--- a/crates/rig-core/CHANGELOG.md
+++ b/crates/rig-core/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+- *(providers)* broaden provider error-response inspection (`provider_response_body` / `provider_response_json` / `provider_response_status`) to all in-core providers (Anthropic, Gemini, Cohere, xAI, Hyperbolic, Ollama, Mira, VoyageAI, Mistral, Hugging Face, OpenRouter, OpenAI audio, …) and the gRPC/SDK companion crates (`rig-bedrock`, `rig-vertexai`, `rig-gemini-grpc`). Adds the shared `from_http_response(status, body)` and `from_provider_body(body)` constructors on every capability error so HTTP failures are no longer flattened into `ProviderError(String)` ([#1944](https://github.com/0xPlaygrounds/rig/pull/1944), closes [#1931](https://github.com/0xPlaygrounds/rig/issues/1931))
+
+### Changed
+
+- *(rerank)* [**breaking**] `RerankError` is now `#[non_exhaustive]` and gains a `ProviderResponse` variant, so rerank failures preserve the provider's raw status + body for inspection (parity with the other capability errors)
+- *(streaming)* the OpenAI-compatible SSE stream now treats a present, non-empty `error` field (object or string) as a terminal provider error and ignores `{"error":null}` / empty values.
+- *(streaming)* terminal streaming failures preserve the provider's error payload as `ProviderResponse` when present, otherwise surface `ProviderError` (so `provider_response_body()` may be `None`).
+- *(providers)* [**behavioral**] migrated provider HTTP-error paths now yield `ProviderResponse` / `HttpError` instead of `ProviderError(String)` / `ResponseError(String)`. The error variant — and the `Display` / `to_string()` output for those failures — changed accordingly (e.g. `"ProviderError: …"` → `"HttpError: …"`). Exhaustive matches keep compiling (`#[non_exhaustive]`), but downstream code that matches specific variants or string-greps error messages will observe different runtime behavior.
+
 ## [0.39.0](https://github.com/0xPlaygrounds/rig/compare/rig-core-v0.38.2...rig-core-v0.39.0) - 2026-06-19
 
 ### Added

--- a/crates/rig-core/src/audio_generation.rs
+++ b/crates/rig-core/src/audio_generation.rs
@@ -13,12 +13,10 @@ use thiserror::Error;
 /// Inspect provider failures with [`Self::provider_response_body`],
 /// [`Self::provider_response_json`], and [`Self::provider_response_status`].
 ///
-/// Note: no provider path currently constructs [`Self::ProviderResponse`] for
-/// audio generation; coverage is limited today — only Azure audio failures
-/// surface as [`Self::HttpError`], which the helpers read, while other audio
-/// providers still emit [`Self::ProviderError`]. The variant is kept for
-/// symmetry with the other capability errors and for future provider paths that
-/// preserve a 2xx error envelope.
+/// HTTP audio failures preserve the provider's status and body: a non-success
+/// response surfaces as [`Self::HttpError`], and a provider error envelope
+/// returned with a 2xx status surfaces as [`Self::ProviderResponse`] (for
+/// example the Hyperbolic audio path). Both are read by the helpers.
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum AudioGenerationError {

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -58,6 +58,32 @@ use thiserror::Error;
 ///
 /// Inspect provider failures with [`Self::provider_response_body`],
 /// [`Self::provider_response_json`], and [`Self::provider_response_status`].
+/// These recover the provider's raw HTTP status and response body so you can
+/// branch on a provider error code or surface a precise diagnostic. The same
+/// helpers are available on `EmbeddingError`, `ImageGenerationError`,
+/// `AudioGenerationError`, `TranscriptionError`, `RerankError`, and (forwarded)
+/// [`PromptError`].
+///
+/// ```
+/// use rig_core::completion::CompletionError;
+///
+/// /// Log the provider's raw error response when a completion fails.
+/// fn report(error: &CompletionError) {
+///     if let Some(status) = error.provider_response_status() {
+///         // Note: this can be a 2xx status for providers that return an error
+///         // envelope alongside a success status — the error itself means failure.
+///         eprintln!("provider returned HTTP {status}");
+///     }
+///     match error.provider_response_json() {
+///         Ok(Some(json)) => eprintln!("provider error payload: {json}"),
+///         Ok(None) => eprintln!("no provider response body (e.g. a transport error)"),
+///         Err(_) => eprintln!(
+///             "provider response body was not valid JSON: {:?}",
+///             error.provider_response_body(),
+///         ),
+///     }
+/// }
+/// ```
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum CompletionError {

--- a/crates/rig-core/src/provider_response.rs
+++ b/crates/rig-core/src/provider_response.rs
@@ -65,6 +65,48 @@ pub(crate) fn completion_error_from_body(
 macro_rules! impl_provider_response_helpers {
     ($error:ty) => {
         impl $error {
+            /// Builds an error from a captured HTTP status and raw response body,
+            /// routing it so the `provider_response_*` helpers stay useful.
+            ///
+            /// This is the single funnel every HTTP-error path should use instead
+            /// of flattening a status and body into a `ProviderError(String)`:
+            /// - A **success (2xx)** status carries a provider-authored error
+            ///   envelope, so it is preserved as [`Self::ProviderResponse`]
+            ///   together with the status.
+            /// - A **non-success** status is preserved as
+            ///   [`Self::HttpError`]`(`[`http_client::Error::InvalidStatusCodeWithMessage`](crate::http_client::Error::InvalidStatusCodeWithMessage)`)`.
+            ///
+            /// Either way the raw `body` is kept verbatim and the status stays
+            /// recoverable through [`Self::provider_response_status`]. Read the
+            /// response body exactly once and hand it here for both branches.
+            pub fn from_http_response(status: http::StatusCode, body: impl Into<String>) -> Self {
+                if status.is_success() {
+                    Self::ProviderResponse($crate::provider_response::ProviderResponseError {
+                        status: Some(status),
+                        body: body.into(),
+                    })
+                } else {
+                    Self::HttpError($crate::http_client::Error::InvalidStatusCodeWithMessage(
+                        status,
+                        body.into(),
+                    ))
+                }
+            }
+
+            /// Preserves a raw provider error body that has **no HTTP status**.
+            ///
+            /// Use this for non-HTTP transports (gRPC / SDK clients such as AWS
+            /// Bedrock, Vertex AI, or the gRPC Gemini client) where the provider
+            /// returns an error payload but no [`http::StatusCode`] is available.
+            /// The body is preserved as [`Self::ProviderResponse`] with
+            /// `status == None`, so [`Self::provider_response_body`] still surfaces
+            /// it while [`Self::provider_response_status`] returns `None`.
+            pub fn from_provider_body(body: impl Into<String>) -> Self {
+                Self::ProviderResponse(
+                    $crate::provider_response::ProviderResponseError::without_status(body),
+                )
+            }
+
             /// Returns the raw provider response body when available.
             ///
             /// This is available for:
@@ -72,9 +114,12 @@ macro_rules! impl_provider_response_helpers {
             /// - `Self::HttpError` when it wraps an HTTP non-success response that
             ///   carries a body.
             ///
-            /// Availability depends on the provider path preserving the response
-            /// body; not every provider is covered yet, so this can return `None`
-            /// for failures from providers that haven't been wired up.
+            /// Returns `None` for any other variant — for example a Rig-generated
+            /// `ProviderError` diagnostic, or a failure from a transport with no
+            /// provider response body to preserve. An empty preserved body is
+            /// reported as `Some("")` (the provider returned no payload), which is
+            /// distinct from `None`; note that [`Self::provider_response_json`]
+            /// maps that same empty body to `Ok(None)`.
             pub fn provider_response_body(&self) -> Option<&str> {
                 match self {
                     Self::ProviderResponse(response) => Some(response.body.as_str()),
@@ -98,6 +143,13 @@ macro_rules! impl_provider_response_helpers {
             /// Returns the HTTP status code when this error preserves one, either
             /// from a non-success HTTP response, from a preserved provider
             /// response, or from a 2xx error envelope.
+            ///
+            /// **Warning:** this can return a **2xx** status. Some providers send
+            /// an error envelope alongside a success status, which Rig preserves
+            /// via [`Self::ProviderResponse`]. Callers must not infer failure from
+            /// the status code alone — the existence of this error already means
+            /// the call failed. Returns `None` for non-HTTP transports (gRPC / SDK
+            /// clients) and for variants that carry no provider response.
             pub fn provider_response_status(&self) -> Option<http::StatusCode> {
                 match self {
                     Self::ProviderResponse(response) => response.status,
@@ -110,3 +162,101 @@ macro_rules! impl_provider_response_helpers {
 }
 
 pub(crate) use impl_provider_response_helpers;
+
+#[cfg(test)]
+mod tests {
+    use http::StatusCode;
+
+    /// Asserts the shared funnel preserves a provider's status + body across the
+    /// three routes every capability error exposes: a non-success HTTP response,
+    /// a 2xx provider error envelope, and a non-HTTP (gRPC/SDK) transport.
+    macro_rules! assert_funnel {
+        ($err:ty) => {{
+            let body = r#"{"error":{"message":"boom"}}"#;
+
+            // Non-success status -> HttpError, with status + body recoverable.
+            let err = <$err>::from_http_response(StatusCode::SERVICE_UNAVAILABLE, body);
+            assert_eq!(
+                err.provider_response_status(),
+                Some(StatusCode::SERVICE_UNAVAILABLE),
+                concat!(stringify!($err), ": non-success status not preserved"),
+            );
+            assert_eq!(
+                err.provider_response_body(),
+                Some(body),
+                concat!(stringify!($err), ": non-success body not preserved"),
+            );
+            assert_eq!(
+                err.provider_response_json()
+                    .expect("valid json")
+                    .expect("present json")["error"]["message"],
+                "boom",
+            );
+
+            // A provider error envelope returned with a 2xx status -> ProviderResponse,
+            // preserving the (success) status so callers can still see it.
+            let err = <$err>::from_http_response(StatusCode::OK, body);
+            assert_eq!(
+                err.provider_response_status(),
+                Some(StatusCode::OK),
+                concat!(stringify!($err), ": 2xx envelope status not preserved"),
+            );
+            assert_eq!(err.provider_response_body(), Some(body));
+
+            // No HTTP status available (gRPC/SDK) -> ProviderResponse with status None.
+            let err = <$err>::from_provider_body(body);
+            assert_eq!(
+                err.provider_response_status(),
+                None,
+                concat!(
+                    stringify!($err),
+                    ": status should be None for provider body"
+                ),
+            );
+            assert_eq!(err.provider_response_body(), Some(body));
+
+            // Empty-body asymmetry: the body is `Some("")` but JSON parses to `Ok(None)`.
+            let err = <$err>::from_provider_body("");
+            assert_eq!(err.provider_response_body(), Some(""));
+            assert!(err.provider_response_json().expect("ok").is_none());
+        }};
+    }
+
+    #[test]
+    fn funnel_preserves_status_and_body_for_every_capability_error() {
+        assert_funnel!(crate::completion::CompletionError);
+        assert_funnel!(crate::embeddings::embedding::EmbeddingError);
+        assert_funnel!(crate::transcription::TranscriptionError);
+        assert_funnel!(crate::client::verify::VerifyError);
+        assert_funnel!(crate::rerank::RerankError);
+        #[cfg(feature = "image")]
+        assert_funnel!(crate::image_generation::ImageGenerationError);
+        #[cfg(feature = "audio")]
+        assert_funnel!(crate::audio_generation::AudioGenerationError);
+    }
+
+    /// `PromptError` advertises that it forwards the `provider_response_*` helpers
+    /// to a wrapped `CompletionError`; this confirms the status, body, and JSON all
+    /// surface through the wrapper unchanged.
+    #[test]
+    fn prompt_error_forwards_provider_response_to_completion_error() {
+        let body = r#"{"error":{"message":"boom"}}"#;
+        let inner = crate::completion::CompletionError::from_http_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            body,
+        );
+        let err = crate::completion::PromptError::CompletionError(inner);
+
+        assert_eq!(
+            err.provider_response_status(),
+            Some(StatusCode::SERVICE_UNAVAILABLE),
+        );
+        assert_eq!(err.provider_response_body(), Some(body));
+        assert_eq!(
+            err.provider_response_json()
+                .expect("valid json")
+                .expect("present json")["error"]["message"],
+            "boom",
+        );
+    }
+}

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -2478,41 +2478,40 @@ where
                 .await
                 .map_err(CompletionError::HttpError)?;
 
-            if response.status().is_success() {
-                match serde_json::from_slice::<ApiResponse<CompletionResponse>>(
-                    response
-                        .into_body()
-                        .await
-                        .map_err(CompletionError::HttpError)?
-                        .to_vec()
-                        .as_slice(),
-                )? {
-                    ApiResponse::Message(completion) => {
-                        let span = tracing::Span::current();
-                        span.record_response_metadata(&completion);
-                        span.record_token_usage(&completion.usage);
-                        if enabled!(Level::TRACE) {
-                            tracing::trace!(
-                                target: "rig::completions",
-                                "Anthropic completion response: {}",
-                                serde_json::to_string_pretty(&completion)?
-                            );
-                        }
-                        completion.try_into()
+            let status = response.status();
+            let body = response
+                .into_body()
+                .await
+                .map_err(CompletionError::HttpError)?;
+
+            if !status.is_success() {
+                return Err(CompletionError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&body),
+                ));
+            }
+
+            match serde_json::from_slice::<ApiResponse<CompletionResponse>>(&body)? {
+                ApiResponse::Message(completion) => {
+                    let span = tracing::Span::current();
+                    span.record_response_metadata(&completion);
+                    span.record_token_usage(&completion.usage);
+                    if enabled!(Level::TRACE) {
+                        tracing::trace!(
+                            target: "rig::completions",
+                            "Anthropic completion response: {}",
+                            serde_json::to_string_pretty(&completion)?
+                        );
                     }
-                    ApiResponse::Error(ApiErrorResponse { message }) => {
-                        Err(CompletionError::ResponseError(message))
-                    }
+                    completion.try_into()
                 }
-            } else {
-                let text: String = String::from_utf8_lossy(
-                    &response
-                        .into_body()
-                        .await
-                        .map_err(CompletionError::HttpError)?,
-                )
-                .into();
-                Err(CompletionError::ProviderError(text))
+                ApiResponse::Error(ApiErrorResponse { message }) => {
+                    tracing::warn!(message = %message, "provider returned an error response");
+                    Err(CompletionError::from_http_response(
+                        status,
+                        String::from_utf8_lossy(&body),
+                    ))
+                }
             }
         }
         .instrument(span)
@@ -5715,5 +5714,111 @@ mod tests {
         };
 
         assert_eq!(document.additional_params, None);
+    }
+
+    #[tokio::test]
+    async fn completion_http_non_success_preserves_status_and_body() {
+        use crate::client::CompletionClient;
+        use crate::completion::CompletionModel as _;
+        use crate::providers::anthropic::Client;
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"type":"error","error":{"type":"overloaded_error","message":"slow down"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::TOO_MANY_REQUESTS, body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model(CLAUDE_SONNET_4_6);
+        let request = model.completion_request("hello").build();
+
+        let error = model
+            .completion(request)
+            .await
+            .expect_err("completion should fail with non-success status");
+
+        assert!(matches!(error, CompletionError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::TOO_MANY_REQUESTS)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+
+    #[tokio::test]
+    async fn completion_2xx_error_envelope_preserves_status_and_body() {
+        use crate::client::CompletionClient;
+        use crate::completion::CompletionModel as _;
+        use crate::providers::anthropic::Client;
+        use crate::test_utils::RecordingHttpClient;
+
+        // Anthropic's `ApiResponse` is internally tagged on `type`; the `Error`
+        // arm flattens `ApiErrorResponse { message }`, so a 200-OK error envelope
+        // deserializes from `{"type":"error","message":"..."}` and routes through
+        // `from_http_response(OK, ..)` into `ProviderResponse`.
+        let body = r#"{"type":"error","message":"model overloaded"}"#;
+        let http_client = RecordingHttpClient::new(body); // 200 OK
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model(CLAUDE_SONNET_4_6);
+        let request = model.completion_request("hello").build();
+
+        let error = model
+            .completion(request)
+            .await
+            .expect_err("completion should fail with provider error envelope");
+
+        match &error {
+            CompletionError::ProviderResponse(stored) => {
+                assert_eq!(stored.body, body);
+                assert_eq!(stored.status, Some(http::StatusCode::OK));
+                assert_eq!(error.provider_response_body(), Some(body));
+                assert_eq!(error.provider_response_status(), Some(http::StatusCode::OK));
+            }
+            other => panic!("expected ProviderResponse, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn completion_streaming_http_non_success_preserves_status_and_body() {
+        use crate::client::CompletionClient;
+        use crate::completion::CompletionModel as _;
+        use crate::providers::anthropic::Client;
+        use crate::test_utils::HttpErrorStreamingClient;
+        use futures::StreamExt;
+
+        let body = r#"{"type":"error","error":{"type":"overloaded_error","message":"slow down"}}"#;
+        let http_client =
+            HttpErrorStreamingClient::new(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model(CLAUDE_SONNET_4_6);
+        let request = model.completion_request("hello").build();
+
+        let mut stream = model.stream(request).await.expect("stream should start");
+
+        // The transport failure surfaces as the first error item yielded by the stream.
+        let error = loop {
+            match stream.next().await {
+                Some(Ok(_)) => continue,
+                Some(Err(error)) => break error,
+                None => panic!("stream ended without yielding the transport error"),
+            }
+        };
+
+        assert!(matches!(error, CompletionError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
     }
 }

--- a/crates/rig-core/src/providers/anthropic/streaming.rs
+++ b/crates/rig-core/src/providers/anthropic/streaming.rs
@@ -402,7 +402,7 @@ where
                         }
                     },
                     Err(e) => {
-                        yield Err(CompletionError::ProviderError(format!("SSE Error: {e}")));
+                        yield Err(CompletionError::from_stream_transport(e));
                         break;
                     }
                 }

--- a/crates/rig-core/src/providers/azure.rs
+++ b/crates/rig-core/src/providers/azure.rs
@@ -495,19 +495,15 @@ where
                 }
                 ApiResponse::Err(err) => {
                     tracing::warn!(message = %err.message, "provider returned an error response");
-                    Err(EmbeddingError::ProviderResponse(
-                        crate::provider_response::ProviderResponseError {
-                            status: Some(status),
-                            body: String::from_utf8_lossy(&response_body).into_owned(),
-                        },
+                    Err(EmbeddingError::from_http_response(
+                        status,
+                        String::from_utf8_lossy(&response_body).into_owned(),
                     ))
                 }
             }
         } else {
             let text = http_client::text(response).await?;
-            Err(EmbeddingError::HttpError(
-                http_client::Error::InvalidStatusCodeWithMessage(status, text),
-            ))
+            Err(EmbeddingError::from_http_response(status, text))
         }
     }
 }
@@ -748,20 +744,16 @@ where
                     }
                     ApiResponse::Err(err) => {
                         tracing::warn!(message = %err.message, "provider returned an error response");
-                        Err(CompletionError::ProviderResponse(
-                            crate::provider_response::ProviderResponseError {
-                                status: Some(status),
-                                body: String::from_utf8_lossy(&response_body).into_owned(),
-                            },
+                        Err(CompletionError::from_http_response(
+                            status,
+                            String::from_utf8_lossy(&response_body).into_owned(),
                         ))
                     }
                 }
             } else {
-                Err(CompletionError::HttpError(
-                    http_client::Error::InvalidStatusCodeWithMessage(
-                        status,
-                        String::from_utf8_lossy(&response_body).to_string(),
-                    ),
+                Err(CompletionError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&response_body).to_string(),
                 ))
             }
         }
@@ -904,20 +896,16 @@ where
                 ApiResponse::Ok(response) => response.try_into(),
                 ApiResponse::Err(api_error_response) => {
                     tracing::warn!(message = %api_error_response.message, "provider returned an error response");
-                    Err(TranscriptionError::ProviderResponse(
-                        crate::provider_response::ProviderResponseError {
-                            status: Some(status),
-                            body: String::from_utf8_lossy(&response_body).into_owned(),
-                        },
+                    Err(TranscriptionError::from_http_response(
+                        status,
+                        String::from_utf8_lossy(&response_body).into_owned(),
                     ))
                 }
             }
         } else {
-            Err(TranscriptionError::HttpError(
-                http_client::Error::InvalidStatusCodeWithMessage(
-                    status,
-                    String::from_utf8_lossy(&response_body).to_string(),
-                ),
+            Err(TranscriptionError::from_http_response(
+                status,
+                String::from_utf8_lossy(&response_body).to_string(),
             ))
         }
     }
@@ -986,11 +974,9 @@ mod image_generation {
             let response_body = response.into_body().into_future().await?.to_vec();
 
             if !status.is_success() {
-                return Err(ImageGenerationError::HttpError(
-                    crate::http_client::Error::InvalidStatusCodeWithMessage(
-                        status,
-                        String::from_utf8_lossy(&response_body).into_owned(),
-                    ),
+                return Err(ImageGenerationError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&response_body).into_owned(),
                 ));
             }
 
@@ -998,11 +984,9 @@ mod image_generation {
                 ApiResponse::Ok(response) => response.try_into(),
                 ApiResponse::Err(err) => {
                     tracing::warn!(message = %err.message, "provider returned an error response");
-                    Err(ImageGenerationError::ProviderResponse(
-                        crate::provider_response::ProviderResponseError {
-                            status: Some(status),
-                            body: String::from_utf8_lossy(&response_body).into_owned(),
-                        },
+                    Err(ImageGenerationError::from_http_response(
+                        status,
+                        String::from_utf8_lossy(&response_body).into_owned(),
                     ))
                 }
             }
@@ -1078,11 +1062,9 @@ mod audio_generation {
             let response_body = response.into_body().into_future().await?;
 
             if !status.is_success() {
-                return Err(AudioGenerationError::HttpError(
-                    crate::http_client::Error::InvalidStatusCodeWithMessage(
-                        status,
-                        String::from_utf8_lossy(&response_body).into_owned(),
-                    ),
+                return Err(AudioGenerationError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&response_body).into_owned(),
                 ));
             }
 
@@ -1212,6 +1194,78 @@ mod azure_tests {
         };
 
         assert!(matches!(error, TranscriptionError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::BAD_REQUEST)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+
+    #[tokio::test]
+    async fn embedding_http_non_success_preserves_status_and_body() {
+        use crate::embeddings::EmbeddingModel as _;
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"error":{"message":"bad embedding","type":"invalid_request_error"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::BAD_REQUEST, body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .azure_endpoint("https://example.openai.azure.com".to_string())
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = super::EmbeddingModel::new(client, TEXT_EMBEDDING_3_SMALL, None);
+
+        let error = match model.embed_texts(vec!["Hello, world!".to_string()]).await {
+            Err(error) => error,
+            Ok(_) => panic!("embedding should fail with non-success status"),
+        };
+
+        assert!(matches!(error, EmbeddingError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::BAD_REQUEST)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+
+    #[tokio::test]
+    async fn completion_http_non_success_preserves_status_and_body() {
+        use crate::completion::CompletionModel as _;
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"error":{"message":"bad completion","type":"invalid_request_error"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::BAD_REQUEST, body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .azure_endpoint("https://example.openai.azure.com".to_string())
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = super::CompletionModel::new(client, GPT_4O_MINI);
+
+        let error = match model
+            .completion(CompletionRequest {
+                model: None,
+                preamble: Some("You are a helpful assistant.".to_string()),
+                chat_history: OneOrMany::one("Hello!".into()),
+                documents: vec![],
+                max_tokens: Some(100),
+                temperature: Some(0.0),
+                tools: vec![],
+                tool_choice: None,
+                additional_params: None,
+                output_schema: None,
+            })
+            .await
+        {
+            Err(error) => error,
+            Ok(_) => panic!("completion should fail with non-success status"),
+        };
+
+        assert!(matches!(error, CompletionError::HttpError(_)));
         assert_eq!(
             error.provider_response_status(),
             Some(http::StatusCode::BAD_REQUEST)

--- a/crates/rig-core/src/providers/cohere/completion.rs
+++ b/crates/rig-core/src/providers/cohere/completion.rs
@@ -692,8 +692,9 @@ where
                     json_response.try_into()?;
                 Ok(completion)
             } else {
-                Err(CompletionError::ProviderError(
-                    String::from_utf8_lossy(&body).to_string(),
+                Err(CompletionError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&body),
                 ))
             }
         }
@@ -837,5 +838,35 @@ mod tests {
 
         assert_eq!(request.documents.len(), 1);
         assert_eq!(request.documents[0].id, "doc_1");
+    }
+
+    #[tokio::test]
+    async fn completion_non_success_preserves_status_and_body() {
+        use crate::client::CompletionClient;
+        use crate::completion::CompletionModel as _;
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"error":{"message":"boom"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = crate::providers::cohere::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model(crate::providers::cohere::COMMAND_R);
+        let request = model.completion_request("hello").build();
+
+        let error = model
+            .completion(request)
+            .await
+            .expect_err("should fail with non-success status");
+
+        assert!(matches!(error, CompletionError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
     }
 }

--- a/crates/rig-core/src/providers/cohere/embeddings.rs
+++ b/crates/rig-core/src/providers/cohere/embeddings.rs
@@ -111,9 +111,11 @@ where
             .await
             .map_err(EmbeddingError::HttpError)?;
 
-        if response.status().is_success() {
-            let body: ApiResponse<EmbeddingResponse> =
-                serde_json::from_slice(response.into_body().await?.as_slice())?;
+        let status = response.status();
+        let raw_body = response.into_body().await?;
+
+        if status.is_success() {
+            let body: ApiResponse<EmbeddingResponse> = serde_json::from_slice(raw_body.as_slice())?;
 
             match body {
                 ApiResponse::Ok(response) => {
@@ -148,11 +150,22 @@ where
                         })
                         .collect())
                 }
-                ApiResponse::Err(error) => Err(EmbeddingError::ProviderError(error.message)),
+                ApiResponse::Err(error) => {
+                    tracing::warn!(
+                        message = %error.message,
+                        "Cohere returned an error response"
+                    );
+                    Err(EmbeddingError::from_http_response(
+                        status,
+                        String::from_utf8_lossy(&raw_body),
+                    ))
+                }
             }
         } else {
-            let text = String::from_utf8_lossy(&response.into_body().await?).into();
-            Err(EmbeddingError::ProviderError(text))
+            Err(EmbeddingError::from_http_response(
+                status,
+                String::from_utf8_lossy(&raw_body),
+            ))
         }
     }
 }
@@ -178,6 +191,74 @@ impl<T> EmbeddingModel<T> {
             model: model.into(),
             input_type: input_type.into(),
             ndims,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn embeddings_non_success_preserves_status_and_body() {
+        use crate::embeddings::EmbeddingModel as _;
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"error":{"message":"boom"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = crate::providers::cohere::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.embedding_model(
+            crate::providers::cohere::EMBED_ENGLISH_V3,
+            "search_document",
+        );
+
+        let error = model
+            .embed_texts(["hello".to_string()])
+            .await
+            .expect_err("should fail with non-success status");
+
+        assert!(matches!(error, EmbeddingError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+
+    #[tokio::test]
+    async fn embeddings_2xx_error_envelope_preserves_status_and_body() {
+        use crate::embeddings::EmbeddingModel as _;
+        use crate::test_utils::RecordingHttpClient;
+
+        // Deserializes to `ApiResponse::Err(ApiErrorResponse { message })` on a 200 OK.
+        let body = r#"{"message":"boom"}"#;
+        let http_client = RecordingHttpClient::new(body);
+        let client = crate::providers::cohere::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.embedding_model(
+            crate::providers::cohere::EMBED_ENGLISH_V3,
+            "search_document",
+        );
+
+        let error = model
+            .embed_texts(["hello".to_string()])
+            .await
+            .expect_err("should fail with provider error envelope");
+
+        match &error {
+            EmbeddingError::ProviderResponse(stored) => {
+                assert_eq!(stored.body, body);
+                assert_eq!(stored.status, Some(http::StatusCode::OK));
+            }
+            other => panic!("expected ProviderResponse, got {other:?}"),
         }
     }
 }

--- a/crates/rig-core/src/providers/cohere/streaming.rs
+++ b/crates/rig-core/src/providers/cohere/streaming.rs
@@ -259,7 +259,7 @@ where
                     }
                     Err(err) => {
                         tracing::error!(?err, "SSE error");
-                        yield Err(CompletionError::ProviderError(err.to_string()));
+                        yield Err(CompletionError::from_stream_transport(err));
                         break;
                     }
                 }

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -860,19 +860,12 @@ where
                             message = %err.error_message(),
                             "provider returned an error response"
                         );
-                        Err(CompletionError::ProviderResponse(
-                            crate::provider_response::ProviderResponseError {
-                                status: Some(status),
-                                body,
-                            },
-                        ))
+                        Err(CompletionError::from_http_response(status, body))
                     }
                 }
             } else {
                 let body = http_client::text(response).await?;
-                Err(CompletionError::HttpError(
-                    http_client::Error::InvalidStatusCodeWithMessage(status, body),
-                ))
+                Err(CompletionError::from_http_response(status, body))
             }
         }
         .instrument(span)
@@ -945,9 +938,7 @@ where
                 })
             } else {
                 let body = http_client::text(response).await?;
-                Err(CompletionError::HttpError(
-                    http_client::Error::InvalidStatusCodeWithMessage(status, body),
-                ))
+                Err(CompletionError::from_http_response(status, body))
             }
         }
         .instrument(span)
@@ -1155,13 +1146,25 @@ where
                                     }
                                     responses_api::streaming::ResponseChunkKind::ResponseFailed
                                     | responses_api::streaming::ResponseChunkKind::ResponseIncomplete => {
-                                        let error = response
-                                            .error
-                                            .as_ref()
-                                            .map(|err| err.message.clone())
-                                            .unwrap_or_else(|| "Copilot response stream failed".into());
                                         terminated_with_error = true;
-                                        yield Err(CompletionError::ProviderError(error));
+                                        // Deliberate two-tier behaviour matching the OpenAI Responses
+                                        // SSE path: when the provider supplies an error object we
+                                        // preserve the raw event JSON via `completion_error_from_body`
+                                        // so the `provider_response_*` helpers surface the full payload
+                                        // (code + message). The error arrives over an established 2xx
+                                        // stream, so there is no HTTP status to attach (status: None).
+                                        // When the object is absent we emit a Rig-authored
+                                        // `ProviderError` diagnostic (provider_response_body() is None).
+                                        match response.error.as_ref() {
+                                            Some(_) => yield Err(
+                                                crate::provider_response::completion_error_from_body(
+                                                    evt.data.clone(),
+                                                ),
+                                            ),
+                                            None => yield Err(CompletionError::ProviderError(
+                                                "Copilot response stream failed".into(),
+                                            )),
+                                        }
                                         break;
                                     }
                                     _ => continue,
@@ -1363,11 +1366,9 @@ where
                 Err(parse_error) => {
                     if let Ok(err) = serde_json::from_slice::<NestedApiError>(&body) {
                         tracing::warn!(message = %err.error.message, "provider returned an error response");
-                        return Err(EmbeddingError::ProviderResponse(
-                            crate::provider_response::ProviderResponseError {
-                                status: Some(status),
-                                body: String::from_utf8_lossy(&body).into_owned(),
-                            },
+                        return Err(EmbeddingError::from_http_response(
+                            status,
+                            String::from_utf8_lossy(&body).into_owned(),
                         ));
                     }
 
@@ -1399,9 +1400,7 @@ where
                 .collect())
         } else {
             let text = http_client::text(response).await?;
-            Err(EmbeddingError::HttpError(
-                http_client::Error::InvalidStatusCodeWithMessage(status, text),
-            ))
+            Err(EmbeddingError::from_http_response(status, text))
         }
     }
 }
@@ -2112,9 +2111,32 @@ mod tests {
             Ok(_) => panic!("stream should surface a provider error"),
             Err(err) => err,
         };
+        // The terminal `response.failed` event carries the provider's error
+        // payload, so the full raw event JSON is preserved for inspection
+        // (status: None — the error arrived over an already-established stream),
+        // matching the OpenAI Responses SSE path.
+        assert!(matches!(
+            err,
+            crate::completion::CompletionError::ProviderResponse(_)
+        ));
+        assert_eq!(err.provider_response_status(), None);
+        let json = err
+            .provider_response_json()
+            .expect("preserved body should parse as JSON")
+            .expect("preserved body should not be empty");
+        let response_error = json
+            .get("response")
+            .and_then(|response| response.get("error"))
+            .expect("preserved body should retain the provider error object");
         assert_eq!(
-            err.to_string(),
-            "ProviderError: Copilot response stream failed"
+            response_error.get("code").and_then(|value| value.as_str()),
+            Some("server_error")
+        );
+        assert_eq!(
+            response_error
+                .get("message")
+                .and_then(|value| value.as_str()),
+            Some("Copilot response stream failed")
         );
         assert!(
             stream.next().await.is_none(),

--- a/crates/rig-core/src/providers/deepseek.rs
+++ b/crates/rig-core/src/providers/deepseek.rs
@@ -124,12 +124,6 @@ enum ApiResponse<T> {
     Err(ApiErrorResponse),
 }
 
-impl From<ApiErrorResponse> for CompletionError {
-    fn from(err: ApiErrorResponse) -> Self {
-        CompletionError::ProviderError(err.message)
-    }
-}
-
 /// The response shape from the DeepSeek API
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CompletionResponse {
@@ -619,20 +613,16 @@ where
                     }
                     ApiResponse::Err(err) => {
                         tracing::warn!(message = %err.message, "provider returned an error response");
-                        Err(CompletionError::ProviderResponse(
-                            crate::provider_response::ProviderResponseError {
-                                status: Some(status),
-                                body: String::from_utf8_lossy(&response_body).into_owned(),
-                            },
+                        Err(CompletionError::from_http_response(
+                            status,
+                            String::from_utf8_lossy(&response_body).into_owned(),
                         ))
                     }
                 }
             } else {
-                Err(CompletionError::HttpError(
-                    http_client::Error::InvalidStatusCodeWithMessage(
-                        status,
-                        String::from_utf8_lossy(&response_body).to_string(),
-                    ),
+                Err(CompletionError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&response_body).to_string(),
                 ))
             }
         }

--- a/crates/rig-core/src/providers/galadriel.rs
+++ b/crates/rig-core/src/providers/galadriel.rs
@@ -610,20 +610,13 @@ where
                     }
                     ApiResponse::Err(err) => {
                         tracing::warn!(message = %err.message, "provider returned an error response");
-                        Err(CompletionError::ProviderResponse(
-                            crate::provider_response::ProviderResponseError {
-                                status: Some(status),
-                                body: t,
-                            },
-                        ))
+                        Err(CompletionError::from_http_response(status, t))
                     }
                 }
             } else {
                 let text = http_client::text(response).await?;
 
-                Err(CompletionError::HttpError(
-                    http_client::Error::InvalidStatusCodeWithMessage(status, text),
-                ))
+                Err(CompletionError::from_http_response(status, text))
             }
         }
         .instrument(span)

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -170,15 +170,16 @@ where
 
                 response.try_into()
             } else {
-                let text = String::from_utf8_lossy(
-                    &response
-                        .into_body()
-                        .await
-                        .map_err(CompletionError::HttpError)?,
-                )
-                .into();
+                let status = response.status();
+                let body = response
+                    .into_body()
+                    .await
+                    .map_err(CompletionError::HttpError)?;
 
-                Err(CompletionError::ProviderError(text))
+                Err(CompletionError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&body),
+                ))
             }
         }
         .instrument(span)
@@ -3257,5 +3258,36 @@ mod tests {
         anyhow::ensure!(!response_text.is_empty(), "Response should not be empty");
 
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn completion_non_success_preserves_status_and_body() {
+        use crate::client::completion::CompletionClient;
+        use crate::completion::CompletionModel as _;
+        use crate::providers::gemini::Client;
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"error":{"code":503,"message":"boom","status":"UNAVAILABLE"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model(super::GEMINI_3_FLASH_PREVIEW);
+        let request = model.completion_request("hello").build();
+
+        let error = model
+            .completion(request)
+            .await
+            .expect_err("should fail with non-success status");
+
+        assert!(matches!(error, CompletionError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
     }
 }

--- a/crates/rig-core/src/providers/gemini/embedding.rs
+++ b/crates/rig-core/src/providers/gemini/embedding.rs
@@ -112,10 +112,22 @@ where
             .map_err(|e| EmbeddingError::HttpError(e.into()))?;
         let response = self.client.send::<_, Vec<u8>>(req).await?;
 
-        let response: ApiResponse<gemini_api_types::EmbeddingResponse> =
-            serde_json::from_slice(&response.into_body().await?)?;
+        let status = response.status();
+        let body = response.into_body().await?;
 
-        match response {
+        // A non-success status may carry an error body that does not match the
+        // `ApiResponse` shape (Gemini nests its error under `error`, with no
+        // top-level `message`), so preserve it verbatim before trying to
+        // deserialize the success envelope — otherwise it would surface as a
+        // `JsonError` and the provider_response_* helpers would lose it.
+        if !status.is_success() {
+            return Err(EmbeddingError::from_http_response(
+                status,
+                String::from_utf8_lossy(&body),
+            ));
+        }
+
+        match serde_json::from_slice::<ApiResponse<gemini_api_types::EmbeddingResponse>>(&body)? {
             ApiResponse::Ok(response) => {
                 let docs = documents
                     .into_iter()
@@ -132,7 +144,13 @@ where
 
                 Ok(docs)
             }
-            ApiResponse::Err(err) => Err(EmbeddingError::ProviderError(err.message)),
+            ApiResponse::Err(err) => {
+                tracing::warn!(message = %err.message, "provider returned an error response");
+                Err(EmbeddingError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&body),
+                ))
+            }
         }
     }
 }
@@ -306,5 +324,71 @@ mod tests {
 
         let model = EmbeddingModel::new(client, EMBEDDING_001, 512);
         assert_eq!(embeddings::EmbeddingModel::ndims(&model), 512);
+    }
+
+    #[tokio::test]
+    async fn embedding_non_success_preserves_status_and_body() {
+        use crate::client::embeddings::EmbeddingsClient;
+        use crate::embeddings::EmbeddingModel as _;
+        use crate::test_utils::RecordingHttpClient;
+
+        // A realistic Gemini error body: the error is nested under `error` with no
+        // top-level `message`, so it does NOT match the `ApiResponse` envelope. The
+        // non-success status guard must preserve it verbatim (otherwise it would
+        // surface as a `JsonError`).
+        let body =
+            r#"{"error":{"code":503,"message":"service unavailable","status":"UNAVAILABLE"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.embedding_model(EMBEDDING_001);
+
+        let error = model
+            .embed_texts(vec!["hello".to_string()])
+            .await
+            .expect_err("should fail with non-success status");
+
+        assert!(matches!(error, EmbeddingError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+
+    #[tokio::test]
+    async fn embedding_2xx_error_envelope_preserves_status_and_body() {
+        use crate::client::embeddings::EmbeddingsClient;
+        use crate::embeddings::EmbeddingModel as _;
+        use crate::test_utils::RecordingHttpClient;
+
+        // 200 OK whose body deserializes to `ApiResponse::Err` (requires a top-level
+        // `message`; absence of `embeddings` keeps it off the success variant).
+        let body =
+            r#"{"message":"boom","error":{"code":503,"message":"boom","status":"UNAVAILABLE"}}"#;
+        let http_client = RecordingHttpClient::new(body); // 200 OK
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.embedding_model(EMBEDDING_001);
+
+        let error = model
+            .embed_texts(vec!["hello".to_string()])
+            .await
+            .expect_err("should fail with provider error envelope");
+
+        match &error {
+            EmbeddingError::ProviderResponse(stored) => {
+                assert_eq!(stored.body, body);
+                assert_eq!(stored.status, Some(http::StatusCode::OK));
+            }
+            other => panic!("expected ProviderResponse, got {other:?}"),
+        }
     }
 }

--- a/crates/rig-core/src/providers/gemini/image_generation.rs
+++ b/crates/rig-core/src/providers/gemini/image_generation.rs
@@ -74,21 +74,19 @@ where
 
         let response = self.client.send(request).await?;
 
-        if !response.status().is_success() {
-            let status = response.status();
-            let text = http_client::text(response).await?;
-
-            return Err(ImageGenerationError::ProviderError(format!(
-                "{}: {}",
-                status, text,
-            )));
-        }
-
+        let status = response.status();
         let text = http_client::text(response).await?;
+
+        if !status.is_success() {
+            return Err(ImageGenerationError::from_http_response(status, text));
+        }
 
         match serde_json::from_str::<ApiResponse<GenerateContentResponse>>(&text)? {
             ApiResponse::Ok(response) => response.try_into(),
-            ApiResponse::Err(err) => Err(ImageGenerationError::ProviderError(err.message)),
+            ApiResponse::Err(err) => {
+                tracing::warn!(message = %err.message, "provider returned an error response");
+                Err(ImageGenerationError::from_http_response(status, text))
+            }
         }
     }
 }
@@ -358,5 +356,67 @@ mod tests {
         .expect_err("text-only responses should fail");
 
         assert!(err.to_string().contains("did not include image data"));
+    }
+
+    #[tokio::test]
+    async fn image_generation_non_success_preserves_status_and_body() {
+        use crate::client::image_generation::ImageGenerationClient;
+        use crate::image_generation::ImageGenerationModel as _;
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"error":{"code":503,"message":"boom","status":"UNAVAILABLE"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.image_generation_model(GEMINI_2_5_FLASH_IMAGE);
+
+        let error = model
+            .image_generation(image_generation_request("draw a cat"))
+            .await
+            .expect_err("should fail with non-success status");
+
+        assert!(matches!(error, ImageGenerationError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+
+    #[tokio::test]
+    async fn image_generation_2xx_error_envelope_preserves_status_and_body() {
+        use crate::client::image_generation::ImageGenerationClient;
+        use crate::image_generation::ImageGenerationModel as _;
+        use crate::test_utils::RecordingHttpClient;
+
+        // 200 OK whose body deserializes to `ApiResponse::Err` (Gemini `ApiErrorResponse`
+        // requires a top-level `message` field; the absence of `candidates`/`response_id`
+        // prevents it from matching the success `GenerateContentResponse` variant).
+        let body =
+            r#"{"message":"boom","error":{"code":503,"message":"boom","status":"UNAVAILABLE"}}"#;
+        let http_client = RecordingHttpClient::new(body); // 200 OK
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.image_generation_model(GEMINI_2_5_FLASH_IMAGE);
+
+        let error = model
+            .image_generation(image_generation_request("draw a cat"))
+            .await
+            .expect_err("should fail with provider error envelope");
+
+        match &error {
+            ImageGenerationError::ProviderResponse(stored) => {
+                assert_eq!(stored.body, body);
+                assert_eq!(stored.status, Some(http::StatusCode::OK));
+            }
+            other => panic!("expected ProviderResponse, got {other:?}"),
+        }
     }
 }

--- a/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
@@ -195,15 +195,16 @@ where
 
                 response.try_into()
             } else {
-                let text = String::from_utf8_lossy(
-                    &response
-                        .into_body()
-                        .await
-                        .map_err(CompletionError::HttpError)?,
-                )
-                .into();
+                let status = response.status();
+                let body = response
+                    .into_body()
+                    .await
+                    .map_err(CompletionError::HttpError)?;
 
-                Err(CompletionError::ProviderError(text))
+                Err(CompletionError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&body),
+                ))
             }
         }
         .instrument(span)
@@ -444,15 +445,16 @@ where
 
         Ok(response)
     } else {
-        let text = String::from_utf8_lossy(
-            &response
-                .into_body()
-                .await
-                .map_err(CompletionError::HttpError)?,
-        )
-        .into();
+        let status = response.status();
+        let body = response
+            .into_body()
+            .await
+            .map_err(CompletionError::HttpError)?;
 
-        Err(CompletionError::ProviderError(text))
+        Err(CompletionError::from_http_response(
+            status,
+            String::from_utf8_lossy(&body),
+        ))
     }
 }
 

--- a/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
@@ -149,8 +149,15 @@ where
                                 }
                                 final_interaction = Some(interaction);
                             }
-                            InteractionSseEvent::Error { error, .. } => {
-                                yield Err(CompletionError::ProviderError(error.message));
+                            InteractionSseEvent::Error { .. } => {
+                                // Preserve the full provider error payload (code +
+                                // message) by reusing the raw SSE event JSON, matching
+                                // the SSE path's `completion_error_from_body`. The error
+                                // arrives over an established stream, so there is no HTTP
+                                // status to attach (status: None).
+                                yield Err(crate::provider_response::completion_error_from_body(
+                                    message.data,
+                                ));
                                 break;
                             }
                             _ => continue,
@@ -161,7 +168,7 @@ where
                     }
                     Err(error) => {
                         tracing::error!(?error, "SSE error");
-                        yield Err(CompletionError::ProviderError(error.to_string()));
+                        yield Err(CompletionError::from_stream_transport(error));
                         break;
                     }
                 }
@@ -216,7 +223,7 @@ where
                 Err(crate::http_client::Error::StreamEnded) => break,
                 Err(error) => {
                     tracing::error!(?error, "SSE error");
-                    yield Err(CompletionError::ProviderError(error.to_string()));
+                    yield Err(CompletionError::from_stream_transport(error));
                     break;
                 }
             }

--- a/crates/rig-core/src/providers/gemini/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/streaming.rs
@@ -283,7 +283,7 @@ where
                     Err(error) => {
                         tracing::error!(?error, "SSE error");
                         stream_failed = true;
-                        yield Err(CompletionError::ProviderError(error.to_string()));
+                        yield Err(CompletionError::from_stream_transport(error));
                         break;
                     }
                 }

--- a/crates/rig-core/src/providers/gemini/transcription.rs
+++ b/crates/rig-core/src/providers/gemini/transcription.rs
@@ -129,8 +129,12 @@ where
 
             Ok(transcription::TranscriptionResponse::try_from(body)?)
         } else {
-            let text = String::from_utf8_lossy(&response.into_body().await?).into();
-            Err(TranscriptionError::ProviderError(text))
+            let status = response.status();
+            let body = response.into_body().await?;
+            Err(TranscriptionError::from_http_response(
+                status,
+                String::from_utf8_lossy(&body),
+            ))
         }
     }
 }
@@ -171,5 +175,52 @@ impl TryFrom<GenerateContentResponse>
             text: text.to_string(),
             response,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::transcription::TranscriptionClient;
+    use crate::providers::gemini::Client;
+    use crate::providers::gemini::completion::GEMINI_2_0_FLASH;
+    use crate::test_utils::RecordingHttpClient;
+    use crate::transcription::TranscriptionModel as _;
+
+    fn transcription_request() -> transcription::TranscriptionRequest {
+        transcription::TranscriptionRequest {
+            data: b"audio bytes".to_vec(),
+            filename: "audio.mp3".to_string(),
+            language: None,
+            prompt: None,
+            temperature: None,
+            additional_params: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn transcription_non_success_preserves_status_and_body() {
+        let body = r#"{"error":{"code":503,"message":"boom","status":"UNAVAILABLE"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.transcription_model(GEMINI_2_0_FLASH);
+
+        let error = model
+            .transcription(transcription_request())
+            .await
+            .err()
+            .expect("should fail with non-success status");
+
+        assert!(matches!(error, TranscriptionError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
     }
 }

--- a/crates/rig-core/src/providers/groq.rs
+++ b/crates/rig-core/src/providers/groq.rs
@@ -437,20 +437,16 @@ where
                     }
                     ApiResponse::Err(err) => {
                         tracing::warn!(message = %err.message, "provider returned an error response");
-                        Err(CompletionError::ProviderResponse(
-                            crate::provider_response::ProviderResponseError {
-                                status: Some(status),
-                                body: String::from_utf8_lossy(&response_body).into_owned(),
-                            },
+                        Err(CompletionError::from_http_response(
+                            status,
+                            String::from_utf8_lossy(&response_body).into_owned(),
                         ))
                     }
                 }
             } else {
-                Err(CompletionError::HttpError(
-                    http_client::Error::InvalidStatusCodeWithMessage(
-                        status,
-                        String::from_utf8_lossy(&response_body).to_string(),
-                    ),
+                Err(CompletionError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&response_body).to_string(),
                 ))
             }
         };
@@ -603,20 +599,16 @@ where
                 ApiResponse::Ok(response) => response.try_into(),
                 ApiResponse::Err(api_error_response) => {
                     tracing::warn!(message = %api_error_response.message, "provider returned an error response");
-                    Err(TranscriptionError::ProviderResponse(
-                        crate::provider_response::ProviderResponseError {
-                            status: Some(status),
-                            body: String::from_utf8_lossy(&response_body).into_owned(),
-                        },
+                    Err(TranscriptionError::from_http_response(
+                        status,
+                        String::from_utf8_lossy(&response_body).into_owned(),
                     ))
                 }
             }
         } else {
-            Err(TranscriptionError::HttpError(
-                http_client::Error::InvalidStatusCodeWithMessage(
-                    status,
-                    String::from_utf8_lossy(&response_body).to_string(),
-                ),
+            Err(TranscriptionError::from_http_response(
+                status,
+                String::from_utf8_lossy(&response_body).to_string(),
             ))
         }
     }

--- a/crates/rig-core/src/providers/huggingface/completion.rs
+++ b/crates/rig-core/src/providers/huggingface/completion.rs
@@ -802,11 +802,9 @@ where
                             message = %err,
                             "provider returned an error response"
                         );
-                        Err(CompletionError::ProviderResponse(
-                            crate::provider_response::ProviderResponseError {
-                                status: Some(status),
-                                body: String::from_utf8_lossy(&bytes).into_owned(),
-                            },
+                        Err(CompletionError::from_http_response(
+                            status,
+                            String::from_utf8_lossy(&bytes).into_owned(),
                         ))
                     }
                 }
@@ -814,9 +812,7 @@ where
                 let text: Vec<u8> = response.into_body().await?;
                 let text: String = String::from_utf8_lossy(&text).into();
 
-                Err(CompletionError::HttpError(
-                    crate::http_client::Error::InvalidStatusCodeWithMessage(status, text),
-                ))
+                Err(CompletionError::from_http_response(status, text))
             }
         }
         .instrument(span)

--- a/crates/rig-core/src/providers/huggingface/image_generation.rs
+++ b/crates/rig-core/src/providers/huggingface/image_generation.rs
@@ -89,16 +89,53 @@ where
         if !response.status().is_success() {
             let status = response.status();
             let text: Vec<u8> = response.into_body().await?;
-            let text: String = String::from_utf8_lossy(&text).into();
 
-            return Err(ImageGenerationError::ProviderError(format!(
-                "{}: {}",
-                status, text
-            )));
+            return Err(ImageGenerationError::from_http_response(
+                status,
+                String::from_utf8_lossy(&text),
+            ));
         }
 
         let data: Vec<u8> = response.into_body().await?;
 
         ImageGenerationResponse { data }.try_into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::image_generation::ImageGenerationClient;
+    use crate::image_generation::ImageGenerationModel as _;
+    use crate::test_utils::RecordingHttpClient;
+
+    #[tokio::test]
+    async fn image_generation_non_success_preserves_status_and_body() {
+        let body = r#"{"error":{"message":"boom"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.image_generation_model(Flux1);
+
+        let request = model
+            .image_generation_request()
+            .prompt("draw a cat")
+            .build();
+
+        let error = model
+            .image_generation(request)
+            .await
+            .expect_err("should fail with non-success status");
+
+        assert!(matches!(error, ImageGenerationError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
     }
 }

--- a/crates/rig-core/src/providers/huggingface/transcription.rs
+++ b/crates/rig-core/src/providers/huggingface/transcription.rs
@@ -85,19 +85,100 @@ where
             .map_err(|e| TranscriptionError::HttpError(e.into()))?;
 
         let response = self.client.send(req).await?;
+        let status = response.status();
+        let body: Vec<u8> = response.into_body().await?;
 
-        if response.status().is_success() {
-            let body: Vec<u8> = response.into_body().await?;
-            let body: ApiResponse<TranscriptionResponse> = serde_json::from_slice(&body)?;
-            match body {
-                ApiResponse::Ok(response) => response.try_into(),
-                ApiResponse::Err(err) => Err(TranscriptionError::ProviderError(err.to_string())),
+        if !status.is_success() {
+            return Err(TranscriptionError::from_http_response(
+                status,
+                String::from_utf8_lossy(&body),
+            ));
+        }
+
+        match serde_json::from_slice::<ApiResponse<TranscriptionResponse>>(&body)? {
+            ApiResponse::Ok(response) => response.try_into(),
+            ApiResponse::Err(err) => {
+                let message = err
+                    .get("error")
+                    .and_then(|e| {
+                        e.as_str()
+                            .or_else(|| e.get("message").and_then(|m| m.as_str()))
+                    })
+                    .or_else(|| err.get("message").and_then(|m| m.as_str()))
+                    .unwrap_or_default();
+                tracing::warn!(message = %message, "provider returned an error response");
+                Err(TranscriptionError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&body),
+                ))
             }
-        } else {
-            let text: Vec<u8> = response.into_body().await?;
-            let text = String::from_utf8_lossy(&text).into();
+        }
+    }
+}
 
-            Err(TranscriptionError::ProviderError(text))
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::transcription::TranscriptionClient;
+    use crate::test_utils::RecordingHttpClient;
+    use crate::transcription::TranscriptionModel as _;
+
+    #[tokio::test]
+    async fn transcription_non_success_preserves_status_and_body() {
+        let body = r#"{"error":{"message":"boom"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.transcription_model(WHISPER_LARGE_V3);
+
+        let request = model.transcription_request().data(vec![0u8; 16]).build();
+
+        let error = model
+            .transcription(request)
+            .await
+            .err()
+            .expect("should fail with non-success status");
+
+        assert!(matches!(error, TranscriptionError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+
+    #[tokio::test]
+    async fn transcription_2xx_error_envelope_preserves_status_and_body() {
+        // A 200 OK body that is not a valid `TranscriptionResponse` (no `text`
+        // field) falls through the untagged `ApiResponse` to its `Err(Value)`
+        // variant, which the provider routes through `from_http_response`.
+        let body = r#"{"error":"Model openai/whisper-large-v3 is currently loading"}"#;
+        let http_client = RecordingHttpClient::new(body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.transcription_model(WHISPER_LARGE_V3);
+
+        let request = model.transcription_request().data(vec![0u8; 16]).build();
+
+        let error = model
+            .transcription(request)
+            .await
+            .err()
+            .expect("should fail with provider error envelope");
+
+        match &error {
+            TranscriptionError::ProviderResponse(stored) => {
+                assert_eq!(stored.body, body);
+                assert_eq!(stored.status, Some(http::StatusCode::OK));
+            }
+            other => panic!("expected ProviderResponse, got {other:?}"),
         }
     }
 }

--- a/crates/rig-core/src/providers/hyperbolic.rs
+++ b/crates/rig-core/src/providers/hyperbolic.rs
@@ -174,12 +174,6 @@ pub struct CompletionResponse {
     pub usage: Option<Usage>,
 }
 
-impl From<ApiErrorResponse> for CompletionError {
-    fn from(err: ApiErrorResponse) -> Self {
-        CompletionError::ProviderError(err.message)
-    }
-}
-
 impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionResponse> {
     type Error = CompletionError;
 
@@ -406,11 +400,18 @@ where
 
                         response.try_into()
                     }
-                    ApiResponse::Err(err) => Err(CompletionError::ProviderError(err.message)),
+                    ApiResponse::Err(err) => {
+                        tracing::warn!(message = %err.message, "provider returned an error response");
+                        Err(CompletionError::from_http_response(
+                            status,
+                            String::from_utf8_lossy(&response_body),
+                        ))
+                    }
                 }
             } else {
-                Err(CompletionError::ProviderError(
-                    String::from_utf8_lossy(&response_body).to_string(),
+                Err(CompletionError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&response_body),
                 ))
             }
         };
@@ -596,15 +597,21 @@ mod image_generation {
             let response_body = response.into_body().into_future().await?.to_vec();
 
             if !status.is_success() {
-                return Err(ImageGenerationError::ProviderError(format!(
-                    "{status}: {}",
-                    String::from_utf8_lossy(&response_body)
-                )));
+                return Err(ImageGenerationError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&response_body),
+                ));
             }
 
             match serde_json::from_slice::<ApiResponse<ImageGenerationResponse>>(&response_body)? {
                 ApiResponse::Ok(response) => response.try_into(),
-                ApiResponse::Err(err) => Err(ImageGenerationError::ResponseError(err.message)),
+                ApiResponse::Err(err) => {
+                    tracing::warn!(message = %err.message, "provider returned an error response");
+                    Err(ImageGenerationError::from_http_response(
+                        status,
+                        String::from_utf8_lossy(&response_body),
+                    ))
+                }
             }
         }
     }
@@ -697,15 +704,21 @@ mod audio_generation {
             let response_body = response.into_body().into_future().await?.to_vec();
 
             if !status.is_success() {
-                return Err(AudioGenerationError::ProviderError(format!(
-                    "{status}: {}",
-                    String::from_utf8_lossy(&response_body)
-                )));
+                return Err(AudioGenerationError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&response_body),
+                ));
             }
 
             match serde_json::from_slice::<ApiResponse<AudioGenerationResponse>>(&response_body)? {
                 ApiResponse::Ok(response) => response.try_into(),
-                ApiResponse::Err(err) => Err(AudioGenerationError::ProviderError(err.message)),
+                ApiResponse::Err(err) => {
+                    tracing::warn!(message = %err.message, "provider returned an error response");
+                    Err(AudioGenerationError::from_http_response(
+                        status,
+                        String::from_utf8_lossy(&response_body),
+                    ))
+                }
             }
         }
     }
@@ -721,5 +734,225 @@ mod tests {
             .api_key("dummy-key")
             .build()
             .expect("Client::builder() failed");
+    }
+
+    #[tokio::test]
+    async fn completion_non_success_preserves_status_and_body() {
+        use crate::client::CompletionClient;
+        use crate::completion::{CompletionError, CompletionModel};
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"error":{"message":"boom"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = super::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model(super::LLAMA_3_1_8B);
+        let request = model.completion_request("hello").build();
+
+        let error = model
+            .completion(request)
+            .await
+            .expect_err("completion should fail with non-success status");
+
+        assert!(matches!(error, CompletionError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+
+    #[tokio::test]
+    async fn completion_2xx_error_envelope_preserves_status_and_body() {
+        use crate::client::CompletionClient;
+        use crate::completion::{CompletionError, CompletionModel};
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"message":"boom"}"#;
+        let http_client = RecordingHttpClient::new(body); // 200 OK
+        let client = super::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model(super::LLAMA_3_1_8B);
+        let request = model.completion_request("hello").build();
+
+        let error = model
+            .completion(request)
+            .await
+            .expect_err("completion should fail with provider error envelope");
+
+        match &error {
+            CompletionError::ProviderResponse(stored) => {
+                assert_eq!(stored.body, body);
+                assert_eq!(stored.status, Some(http::StatusCode::OK));
+            }
+            other => panic!("expected ProviderResponse, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "image")]
+    #[tokio::test]
+    async fn image_generation_non_success_preserves_status_and_body() {
+        use crate::client::image_generation::ImageGenerationClient;
+        use crate::image_generation::{
+            ImageGenerationError, ImageGenerationModel as _, ImageGenerationRequest,
+        };
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"error":{"message":"boom"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = super::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.image_generation_model(super::SDXL1_0_BASE);
+
+        let request = ImageGenerationRequest {
+            prompt: "draw a cat".to_string(),
+            width: 256,
+            height: 256,
+            additional_params: None,
+        };
+
+        let error = model
+            .image_generation(request)
+            .await
+            .err()
+            .expect("image generation should fail with non-success status");
+
+        assert!(matches!(error, ImageGenerationError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+
+    #[cfg(feature = "image")]
+    #[tokio::test]
+    async fn image_generation_2xx_error_envelope_preserves_status_and_body() {
+        use crate::client::image_generation::ImageGenerationClient;
+        use crate::image_generation::{
+            ImageGenerationError, ImageGenerationModel as _, ImageGenerationRequest,
+        };
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"message":"boom"}"#;
+        let http_client = RecordingHttpClient::new(body); // 200 OK
+        let client = super::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.image_generation_model(super::SDXL1_0_BASE);
+
+        let request = ImageGenerationRequest {
+            prompt: "draw a cat".to_string(),
+            width: 256,
+            height: 256,
+            additional_params: None,
+        };
+
+        let error = model
+            .image_generation(request)
+            .await
+            .err()
+            .expect("image generation should fail with provider error envelope");
+
+        match &error {
+            ImageGenerationError::ProviderResponse(stored) => {
+                assert_eq!(stored.body, body);
+                assert_eq!(stored.status, Some(http::StatusCode::OK));
+            }
+            other => panic!("expected ProviderResponse, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "audio")]
+    #[tokio::test]
+    async fn audio_generation_non_success_preserves_status_and_body() {
+        use crate::audio_generation::{
+            AudioGenerationError, AudioGenerationModel as _, AudioGenerationRequest,
+        };
+        use crate::client::audio_generation::AudioGenerationClient;
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"error":{"message":"boom"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = super::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.audio_generation_model("EN");
+
+        let request = AudioGenerationRequest {
+            text: "hello".to_string(),
+            voice: "default".to_string(),
+            speed: 1.0,
+            additional_params: None,
+        };
+
+        let error = model
+            .audio_generation(request)
+            .await
+            .err()
+            .expect("audio generation should fail with non-success status");
+
+        assert!(matches!(error, AudioGenerationError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+
+    #[cfg(feature = "audio")]
+    #[tokio::test]
+    async fn audio_generation_2xx_error_envelope_preserves_status_and_body() {
+        use crate::audio_generation::{
+            AudioGenerationError, AudioGenerationModel as _, AudioGenerationRequest,
+        };
+        use crate::client::audio_generation::AudioGenerationClient;
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"message":"boom"}"#;
+        let http_client = RecordingHttpClient::new(body); // 200 OK
+        let client = super::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.audio_generation_model("EN");
+
+        let request = AudioGenerationRequest {
+            text: "hello".to_string(),
+            voice: "default".to_string(),
+            speed: 1.0,
+            additional_params: None,
+        };
+
+        let error = model
+            .audio_generation(request)
+            .await
+            .err()
+            .expect("audio generation should fail with provider error envelope");
+
+        match &error {
+            AudioGenerationError::ProviderResponse(stored) => {
+                assert_eq!(stored.body, body);
+                assert_eq!(stored.status, Some(http::StatusCode::OK));
+            }
+            other => panic!("expected ProviderResponse, got {other:?}"),
+        }
     }
 }

--- a/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
+++ b/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
@@ -22,15 +22,19 @@ use crate::wasm_compat::WasmCompatSend;
 
 fn provider_response_from_compatible_sse_data(data: &str) -> Option<CompletionError> {
     let value = serde_json::from_str::<serde_json::Value>(data).ok()?;
-    if value.get("error").is_none() || value.get("choices").is_some() {
+    // Treat the chunk as an error only when `error` is present AND carries a
+    // payload: either an object (`{"error":{...}}`, the canonical OpenAI-compatible
+    // error event) or a non-empty string (`{"error":"oops"}`, used by some
+    // gateways). A `{"error":null}` or `{"error":""}` chunk — which some providers
+    // send alongside the terminal usage event — must not terminate the stream.
+    let error = value
+        .get("error")
+        .filter(|error| error.is_object() || error.as_str().is_some_and(|s| !s.is_empty()))?;
+    if value.get("choices").is_some() {
         return None;
     }
 
-    if let Some(message) = value
-        .get("error")
-        .and_then(|error| error.get("message"))
-        .and_then(serde_json::Value::as_str)
-    {
+    if let Some(message) = error.get("message").and_then(serde_json::Value::as_str) {
         tracing::warn!(message, "provider returned a streaming error event");
     }
 
@@ -634,6 +638,39 @@ mod tests {
         FinishReasonCleanupProfile,
     };
     use futures::StreamExt;
+
+    #[test]
+    fn sse_error_detector_handles_null_empty_and_object_or_string_errors() {
+        use super::provider_response_from_compatible_sse_data as detect;
+
+        // An empty `error` (`null` or `""`) with no choices must NOT terminate the
+        // stream — some providers send one with the terminal usage event. Each of
+        // these should be treated as "not an error chunk".
+        assert!(detect(r#"{"error":null}"#).is_none());
+        assert!(detect(r#"{"error":null,"usage":{"total_tokens":3}}"#).is_none());
+        assert!(detect(r#"{"error":""}"#).is_none());
+        // A normal content chunk (no `error` key) is also not an error.
+        assert!(detect(r#"{"choices":[{"delta":{"content":"hi"}}]}"#).is_none());
+        // A live content chunk that ALSO carries an `error` field must NOT terminate
+        // the stream — the `choices` guard wins regardless of the error value.
+        assert!(detect(r#"{"error":"metadata","choices":[{"delta":{"content":"hi"}}]}"#).is_none());
+        assert!(
+            detect(r#"{"error":{"message":"x"},"choices":[{"delta":{"content":"hi"}}]}"#).is_none()
+        );
+
+        // A non-empty string `error` IS detected, preserving the raw body.
+        let string_body = r#"{"error":"oops"}"#;
+        let string_error = detect(string_body).expect("string error should be detected");
+        assert_eq!(string_error.provider_response_body(), Some(string_body));
+        assert_eq!(string_error.provider_response_status(), None);
+
+        // A real provider error envelope IS detected, preserving the raw body.
+        let body = r#"{"error":{"message":"rate limited","type":"rate_limit_error"}}"#;
+        let error = detect(body).expect("object error envelope should be detected");
+        assert_eq!(error.provider_response_body(), Some(body));
+        // It arrives mid-stream with no HTTP status attached.
+        assert_eq!(error.provider_response_status(), None);
+    }
 
     #[test]
     fn eof_cleanup_preserves_parameterless_tool_calls() {

--- a/crates/rig-core/src/providers/llamafile.rs
+++ b/crates/rig-core/src/providers/llamafile.rs
@@ -438,20 +438,16 @@ where
                     }
                     ApiResponse::Err(err) => {
                         tracing::warn!(message = %err.message, "provider returned an error response");
-                        Err(CompletionError::ProviderResponse(
-                            crate::provider_response::ProviderResponseError {
-                                status: Some(status),
-                                body: String::from_utf8_lossy(&response_body).into_owned(),
-                            },
+                        Err(CompletionError::from_http_response(
+                            status,
+                            String::from_utf8_lossy(&response_body).into_owned(),
                         ))
                     }
                 }
             } else {
-                Err(CompletionError::HttpError(
-                    http_client::Error::InvalidStatusCodeWithMessage(
-                        status,
-                        String::from_utf8_lossy(&response_body).to_string(),
-                    ),
+                Err(CompletionError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&response_body).to_string(),
                 ))
             }
         }
@@ -731,19 +727,15 @@ where
                 }
                 ApiResponse::Err(err) => {
                     tracing::warn!(message = %err.message, "provider returned an error response");
-                    Err(EmbeddingError::ProviderResponse(
-                        crate::provider_response::ProviderResponseError {
-                            status: Some(status),
-                            body: String::from_utf8_lossy(&response_body).into_owned(),
-                        },
+                    Err(EmbeddingError::from_http_response(
+                        status,
+                        String::from_utf8_lossy(&response_body).into_owned(),
                     ))
                 }
             }
         } else {
             let text = http_client::text(response).await?;
-            Err(EmbeddingError::HttpError(
-                http_client::Error::InvalidStatusCodeWithMessage(status, text),
-            ))
+            Err(EmbeddingError::from_http_response(status, text))
         }
     }
 }

--- a/crates/rig-core/src/providers/mira.rs
+++ b/crates/rig-core/src/providers/mira.rs
@@ -92,11 +92,6 @@ pub enum MiraError {
     JsonError(#[from] serde_json::Error),
 }
 
-#[derive(Debug, Deserialize)]
-struct ApiErrorResponse {
-    message: String,
-}
-
 #[derive(Debug, Deserialize, Clone, Serialize)]
 pub struct RawMessage {
     pub role: String,
@@ -384,11 +379,10 @@ where
             let response_body = response.into_body().into_future().await?.to_vec();
 
             if !status.is_success() {
-                let status = status.as_u16();
-                let error_text = String::from_utf8_lossy(&response_body).to_string();
-                return Err(CompletionError::ProviderError(format!(
-                    "API error: {status} - {error_text}"
-                )));
+                return Err(CompletionError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&response_body),
+                ));
             }
 
             let response: CompletionResponse = serde_json::from_slice(&response_body)?;
@@ -482,12 +476,6 @@ where
         send_compatible_streaming_request(self.client.clone(), req)
             .instrument(span)
             .await
-    }
-}
-
-impl From<ApiErrorResponse> for CompletionError {
-    fn from(err: ApiErrorResponse) -> Self {
-        CompletionError::ProviderError(err.message)
     }
 }
 
@@ -810,5 +798,38 @@ mod tests {
             .api_key("dummy-key")
             .build()
             .expect("Client::builder() failed");
+    }
+
+    // Proves a non-success HTTP response from `/v1/chat/completions` preserves
+    // the provider's status + body through the `provider_response_*` helpers
+    // (issue #1931).
+    #[tokio::test]
+    async fn completion_non_success_preserves_status_and_body() {
+        use crate::client::CompletionClient;
+        use crate::completion::CompletionModel;
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"error":{"message":"boom"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model("deepseek-r1");
+        let request = model.completion_request("hello").build();
+
+        let error = model
+            .completion(request)
+            .await
+            .expect_err("should fail with non-success status");
+
+        assert!(matches!(error, CompletionError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
     }
 }

--- a/crates/rig-core/src/providers/mistral/completion.rs
+++ b/crates/rig-core/src/providers/mistral/completion.rs
@@ -636,19 +636,12 @@ where
                     }
                     ApiResponse::Err(err) => {
                         tracing::warn!(message = %err.message, "provider returned an error response");
-                        Err(CompletionError::ProviderResponse(
-                            crate::provider_response::ProviderResponseError {
-                                status: Some(status),
-                                body: text,
-                            },
-                        ))
+                        Err(CompletionError::from_http_response(status, text))
                     }
                 }
             } else {
                 let text = http_client::text(response).await?;
-                Err(CompletionError::HttpError(
-                    http_client::Error::InvalidStatusCodeWithMessage(status, text),
-                ))
+                Err(CompletionError::from_http_response(status, text))
             }
         }
         .instrument(span)

--- a/crates/rig-core/src/providers/mistral/embedding.rs
+++ b/crates/rig-core/src/providers/mistral/embedding.rs
@@ -110,19 +110,15 @@ where
                 }
                 ApiResponse::Err(err) => {
                     tracing::warn!(message = %err.message, "provider returned an error response");
-                    Err(EmbeddingError::ProviderResponse(
-                        crate::provider_response::ProviderResponseError {
-                            status: Some(status),
-                            body: String::from_utf8_lossy(&response_body).into_owned(),
-                        },
+                    Err(EmbeddingError::from_http_response(
+                        status,
+                        String::from_utf8_lossy(&response_body),
                     ))
                 }
             }
         } else {
             let text = http_client::text(response).await?;
-            Err(EmbeddingError::HttpError(
-                http_client::Error::InvalidStatusCodeWithMessage(status, text),
-            ))
+            Err(EmbeddingError::from_http_response(status, text))
         }
     }
 }

--- a/crates/rig-core/src/providers/mistral/transcription.rs
+++ b/crates/rig-core/src/providers/mistral/transcription.rs
@@ -147,8 +147,10 @@ where
             .await
             .map_err(TranscriptionError::HttpError)?;
 
-        if response.status().is_success() {
-            let response_bytes = response.into_body().await?;
+        let status = response.status();
+        let response_bytes = response.into_body().await?;
+
+        if status.is_success() {
             let response_body: MistralTranscriptionResponse =
                 serde_json::from_slice(&response_bytes)?;
 
@@ -158,8 +160,10 @@ where
                 response_body,
             )?)
         } else {
-            let text = String::from_utf8_lossy(&response.into_body().await?).into();
-            Err(TranscriptionError::ProviderError(text))
+            Err(TranscriptionError::from_http_response(
+                status,
+                String::from_utf8_lossy(&response_bytes),
+            ))
         }
     }
 }
@@ -263,5 +267,39 @@ mod test {
         );
         assert_eq!(response.response.model, VOXTRAL_MINI);
         assert_eq!(response.response.language, Some("en".to_string()));
+    }
+
+    #[tokio::test]
+    async fn transcription_non_success_preserves_status_and_body() {
+        use crate::client::transcription::TranscriptionClient;
+        use crate::test_utils::RecordingHttpClient;
+        use crate::transcription::{TranscriptionError, TranscriptionModel as _};
+
+        let body = r#"{"error":{"message":"boom"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.transcription_model(VOXTRAL_MINI);
+
+        let error = match model
+            .transcription_request()
+            .data(vec![0u8; 16])
+            .send()
+            .await
+        {
+            Err(error) => error,
+            Ok(_) => panic!("transcription should fail with non-success status"),
+        };
+
+        assert!(matches!(error, TranscriptionError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
     }
 }

--- a/crates/rig-core/src/providers/moonshot.rs
+++ b/crates/rig-core/src/providers/moonshot.rs
@@ -567,20 +567,16 @@ where
                     }
                     ApiResponse::Err(err) => {
                         tracing::warn!(message = %err.error.message, "provider returned an error response");
-                        Err(CompletionError::ProviderResponse(
-                            crate::provider_response::ProviderResponseError {
-                                status: Some(status),
-                                body: String::from_utf8_lossy(&response_body).into_owned(),
-                            },
+                        Err(CompletionError::from_http_response(
+                            status,
+                            String::from_utf8_lossy(&response_body).into_owned(),
                         ))
                     }
                 }
             } else {
-                Err(CompletionError::HttpError(
-                    http_client::Error::InvalidStatusCodeWithMessage(
-                        status,
-                        String::from_utf8_lossy(&response_body).to_string(),
-                    ),
+                Err(CompletionError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&response_body).to_string(),
                 ))
             }
         };

--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -179,20 +179,6 @@ impl ProviderClient for Client {
     }
 }
 
-// ---------- API Error and Response Structures ----------
-
-#[derive(Debug, Deserialize)]
-struct ApiErrorResponse {
-    message: String,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(untagged)]
-enum ApiResponse<T> {
-    Ok(T),
-    Err(ApiErrorResponse),
-}
-
 // ---------- Embedding API ----------
 
 pub const ALL_MINILM: &str = "all-minilm";
@@ -216,21 +202,6 @@ pub struct EmbeddingResponse {
     pub load_duration: Option<u64>,
     #[serde(default)]
     pub prompt_eval_count: Option<u64>,
-}
-
-impl From<ApiErrorResponse> for EmbeddingError {
-    fn from(err: ApiErrorResponse) -> Self {
-        EmbeddingError::ProviderError(err.message)
-    }
-}
-
-impl From<ApiResponse<EmbeddingResponse>> for Result<EmbeddingResponse, EmbeddingError> {
-    fn from(value: ApiResponse<EmbeddingResponse>) -> Self {
-        match value {
-            ApiResponse::Ok(response) => Ok(response),
-            ApiResponse::Err(err) => Err(EmbeddingError::ProviderError(err.message)),
-        }
-    }
 }
 
 // ---------- Embedding Model ----------
@@ -298,9 +269,10 @@ where
 
         let response = self.client.send::<_, Vec<u8>>(req).await?;
 
-        if !response.status().is_success() {
+        let status = response.status();
+        if !status.is_success() {
             let text = http_client::text(response).await?;
-            return Err(EmbeddingError::ProviderError(text));
+            return Err(EmbeddingError::from_http_response(status, text));
         }
 
         let bytes: Vec<u8> = response.into_body().await?;
@@ -693,8 +665,9 @@ where
             let response_body = response.into_body().into_future().await?.to_vec();
 
             if !status.is_success() {
-                return Err(CompletionError::ProviderError(
-                    String::from_utf8_lossy(&response_body).to_string(),
+                return Err(CompletionError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&response_body),
                 ));
             }
 
@@ -774,9 +747,20 @@ where
         let mut byte_stream = response.into_body();
 
         if !status.is_success() {
-            return Err(CompletionError::ProviderError(format!(
-                "Got error status code trying to send a request to Ollama: {status}"
-            )));
+            let mut body = Vec::new();
+            while let Some(chunk) = byte_stream.next().await {
+                match chunk {
+                    Ok(bytes) => body.extend_from_slice(&bytes),
+                    Err(e) => {
+                        tracing::warn!(error = %e, "failed reading Ollama error-response body; preserving partial body");
+                        break;
+                    }
+                }
+            }
+            return Err(CompletionError::from_http_response(
+                status,
+                String::from_utf8_lossy(&body),
+            ));
         }
 
         let stream = try_stream! {
@@ -2221,5 +2205,70 @@ mod tests {
         assert_eq!(received.len(), 2);
         assert_eq!(received[0]["message"]["content"], "hi");
         assert_eq!(received[1]["done"], true);
+    }
+
+    // Proves a non-success HTTP response from `/api/chat` preserves the
+    // provider's status + body through the `provider_response_*` helpers
+    // (issue #1931).
+    #[tokio::test]
+    async fn completion_non_success_preserves_status_and_body() {
+        use crate::client::CompletionClient;
+        use crate::completion::CompletionModel;
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"error":"model not found"}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model(LLAMA3_2);
+        let request = model.completion_request("hello").build();
+
+        let error = model
+            .completion(request)
+            .await
+            .expect_err("should fail with non-success status");
+
+        assert!(matches!(error, CompletionError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+
+    // Proves a non-success HTTP response from `/api/embed` preserves the
+    // provider's status + body through the `provider_response_*` helpers
+    // (issue #1931).
+    #[tokio::test]
+    async fn embeddings_non_success_preserves_status_and_body() {
+        use crate::client::EmbeddingsClient;
+        use crate::embeddings::EmbeddingModel;
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"error":"model not found"}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.embedding_model(ALL_MINILM);
+
+        let error = model
+            .embed_texts(vec!["hello".to_string()])
+            .await
+            .expect_err("should fail with non-success status");
+
+        assert!(matches!(error, EmbeddingError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
     }
 }

--- a/crates/rig-core/src/providers/openai/audio_generation.rs
+++ b/crates/rig-core/src/providers/openai/audio_generation.rs
@@ -3,7 +3,7 @@ use crate::audio_generation::{
 };
 use crate::http_client::{self, HttpClientExt};
 use crate::providers::openai::Client;
-use bytes::{Buf, Bytes};
+use bytes::Bytes;
 use serde_json::json;
 
 pub const TTS_1: &str = "tts-1";
@@ -57,16 +57,12 @@ where
 
         if !response.status().is_success() {
             let status = response.status();
-            let mut bytes: Bytes = response.into_body().await?;
-            let mut as_slice = Vec::new();
-            bytes.copy_to_slice(&mut as_slice);
+            let bytes: Bytes = response.into_body().await?;
 
-            let text: String = String::from_utf8_lossy(&as_slice).into();
-
-            return Err(AudioGenerationError::ProviderError(format!(
-                "{}: {}",
-                status, text
-            )));
+            return Err(AudioGenerationError::from_http_response(
+                status,
+                String::from_utf8_lossy(&bytes),
+            ));
         }
 
         let bytes: Bytes = response.into_body().await?;
@@ -75,5 +71,45 @@ where
             audio: bytes.to_vec(),
             response: bytes,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audio_generation::AudioGenerationModel as _;
+    use crate::client::audio_generation::AudioGenerationClient;
+    use crate::test_utils::RecordingHttpClient;
+
+    #[tokio::test]
+    async fn audio_generation_non_success_preserves_status_and_body() {
+        let body = r#"{"error":{"message":"boom"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.audio_generation_model(TTS_1);
+
+        let request = model
+            .audio_generation_request()
+            .text("hello")
+            .voice("alloy")
+            .build();
+
+        let error = model
+            .audio_generation(request)
+            .await
+            .err()
+            .expect("should fail with non-success status");
+
+        assert!(matches!(error, AudioGenerationError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
     }
 }

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -1476,19 +1476,12 @@ where
                     }
                     ApiResponse::Err(err) => {
                         tracing::warn!(message = %err.message, "provider returned an error response");
-                        Err(CompletionError::ProviderResponse(
-                            crate::provider_response::ProviderResponseError {
-                                status: Some(status),
-                                body: text,
-                            },
-                        ))
+                        Err(CompletionError::from_http_response(status, text))
                     }
                 }
             } else {
                 let text = http_client::text(response).await?;
-                Err(CompletionError::HttpError(
-                    http_client::Error::InvalidStatusCodeWithMessage(status, text),
-                ))
+                Err(CompletionError::from_http_response(status, text))
             }
         }
         .instrument(span)

--- a/crates/rig-core/src/providers/openai/embedding.rs
+++ b/crates/rig-core/src/providers/openai/embedding.rs
@@ -180,19 +180,15 @@ where
                 }
                 ApiResponse::Err(err) => {
                     tracing::warn!(message = %err.message, "provider returned an error response");
-                    Err(EmbeddingError::ProviderResponse(
-                        crate::provider_response::ProviderResponseError {
-                            status: Some(status),
-                            body: String::from_utf8_lossy(&response_body).into_owned(),
-                        },
+                    Err(EmbeddingError::from_http_response(
+                        status,
+                        String::from_utf8_lossy(&response_body).into_owned(),
                     ))
                 }
             }
         } else {
             let text = http_client::text(response).await?;
-            Err(EmbeddingError::HttpError(
-                http_client::Error::InvalidStatusCodeWithMessage(status, text),
-            ))
+            Err(EmbeddingError::from_http_response(status, text))
         }
     }
 }

--- a/crates/rig-core/src/providers/openai/image_generation.rs
+++ b/crates/rig-core/src/providers/openai/image_generation.rs
@@ -117,9 +117,7 @@ where
         if !status.is_success() {
             let text = http_client::text(response).await?;
 
-            return Err(ImageGenerationError::HttpError(
-                http_client::Error::InvalidStatusCodeWithMessage(status, text),
-            ));
+            return Err(ImageGenerationError::from_http_response(status, text));
         }
 
         let text = http_client::text(response).await?;
@@ -128,12 +126,7 @@ where
             ApiResponse::Ok(response) => response.try_into(),
             ApiResponse::Err(err) => {
                 tracing::warn!(message = %err.message, "provider returned an error response");
-                Err(ImageGenerationError::ProviderResponse(
-                    crate::provider_response::ProviderResponseError {
-                        status: Some(status),
-                        body: text,
-                    },
-                ))
+                Err(ImageGenerationError::from_http_response(status, text))
             }
         }
     }

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -1538,9 +1538,7 @@ where
             } else {
                 let status = response.status();
                 let text = http_client::text(response).await?;
-                Err(CompletionError::HttpError(
-                    http_client::Error::InvalidStatusCodeWithMessage(status, text),
-                ))
+                Err(CompletionError::from_http_response(status, text))
             }
         }
         .instrument(span)

--- a/crates/rig-core/src/providers/openai/responses_api/websocket.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/websocket.rs
@@ -22,7 +22,7 @@ use tokio_tungstenite::{
 use tracing::Level;
 use url::Url;
 
-use super::{CompletionResponse, ResponseError, ResponseStatus, ResponsesCompletionModel};
+use super::{CompletionResponse, ResponseStatus, ResponsesCompletionModel};
 
 type OpenAIWebSocket = WebSocketStream<MaybeTlsStream<TcpStream>>;
 const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
@@ -507,7 +507,11 @@ where
                     return Err(CompletionError::ProviderError(message));
                 }
                 ResponsesWebSocketEvent::Error(error) => {
-                    return Err(CompletionError::ProviderError(error.to_string()));
+                    // Genuine provider error event: preserve the serialized payload
+                    // (code + message + any extra fields) so provider_response_json()
+                    // parses it, matching the response.failed path. No HTTP status on
+                    // the websocket stream, so status: None.
+                    return Err(provider_error_from_event(error));
                 }
                 ResponsesWebSocketEvent::Item(_) => {}
             }
@@ -619,10 +623,24 @@ fn terminal_response_result(
 ) -> Result<CompletionResponse, CompletionError> {
     match response.status {
         ResponseStatus::Completed => Ok(response),
-        ResponseStatus::Failed => Err(CompletionError::ProviderError(response_error_message(
-            response.error.as_ref(),
-            "failed response",
-        ))),
+        // Deliberate two-tier behaviour: when the provider supplies its own error
+        // object we preserve the full failed-response envelope through
+        // `from_provider_body` (status: None, no HTTP status on the websocket
+        // stream) so `provider_response_json()` parses it — consistent with the
+        // `error` event and the streaming paths. The body is re-serialized from
+        // the parsed response (not byte-identical to the wire bytes, which aren't
+        // retained past parsing) — semantically the provider's payload. When the
+        // object is absent we have nothing provider-authored to surface, so we
+        // emit a Rig-authored `ProviderError` diagnostic (provider_response_body()
+        // is None).
+        ResponseStatus::Failed => match response.error.as_ref() {
+            Some(error) => Err(CompletionError::from_provider_body(
+                serde_json::to_string(&response).unwrap_or_else(|_| error.message.clone()),
+            )),
+            None => Err(CompletionError::ProviderError(response_error_message(
+                "failed response",
+            ))),
+        },
         ResponseStatus::Incomplete => {
             let reason = response
                 .incomplete_details
@@ -633,23 +651,26 @@ fn terminal_response_result(
                 "OpenAI websocket response was incomplete: {reason}"
             )))
         }
-        status => Err(CompletionError::ProviderError(format!(
-            "OpenAI websocket response ended with status {:?}",
-            status
+        other => Err(CompletionError::ProviderError(format!(
+            "OpenAI websocket response ended in state {other:?}"
         ))),
     }
 }
 
-fn response_error_message(error: Option<&ResponseError>, fallback: &str) -> String {
-    if let Some(error) = error {
-        if error.code.is_empty() {
-            error.message.clone()
-        } else {
-            format!("{}: {}", error.code, error.message)
-        }
-    } else {
-        format!("OpenAI websocket returned a {fallback}")
-    }
+fn response_error_message(fallback: &str) -> String {
+    format!("OpenAI websocket returned a {fallback}")
+}
+
+/// Maps a provider `error` event into a [`CompletionError`] that preserves the
+/// raw error payload as JSON (code + message + any extra provider fields) so the
+/// `provider_response_*` helpers can inspect it. The websocket stream carries no
+/// HTTP status, so `status` is `None`. The body is the event re-serialized from
+/// the parsed representation (not byte-identical to the original wire bytes,
+/// which are not retained past parsing) — semantically the provider's payload.
+fn provider_error_from_event(error: ResponsesWebSocketErrorEvent) -> CompletionError {
+    CompletionError::from_provider_body(
+        serde_json::to_string(&error).unwrap_or_else(|_| error.to_string()),
+    )
 }
 
 fn is_known_streaming_event(kind: &str) -> bool {
@@ -812,7 +833,7 @@ mod tests {
     use crate::client::CompletionClient;
     use crate::completion::CompletionModel;
     use crate::providers::openai::responses_api::{
-        CompletionResponse, ResponseObject, ResponseStatus, ResponsesUsage,
+        CompletionResponse, ResponseError, ResponseObject, ResponseStatus, ResponsesUsage,
     };
     use futures::{SinkExt, StreamExt};
     use serde_json::json;
@@ -820,6 +841,36 @@ mod tests {
     use tokio::net::TcpListener;
     use tokio::time::sleep;
     use tokio_tungstenite::{accept_async, tungstenite::Message};
+
+    #[test]
+    fn websocket_error_event_preserves_provider_payload_as_json() {
+        let mut extra = serde_json::Map::new();
+        extra.insert(
+            "type".to_string(),
+            serde_json::Value::String("invalid_request_error".to_string()),
+        );
+        let event = super::ResponsesWebSocketErrorEvent {
+            kind: super::ResponsesWebSocketErrorEventKind::Error,
+            error: super::ResponsesWebSocketErrorPayload {
+                code: Some("rate_limit_exceeded".to_string()),
+                message: Some("slow down".to_string()),
+                extra,
+            },
+        };
+
+        let err = super::provider_error_from_event(event);
+
+        // No HTTP status on the websocket stream, and the raw payload round-trips
+        // through provider_response_json() (code + message + extra all preserved).
+        assert_eq!(err.provider_response_status(), None);
+        let json = err
+            .provider_response_json()
+            .expect("preserved body should be valid JSON")
+            .expect("provider response body should be present");
+        assert_eq!(json["error"]["code"], "rate_limit_exceeded");
+        assert_eq!(json["error"]["message"], "slow down");
+        assert_eq!(json["error"]["type"], "invalid_request_error");
+    }
 
     fn sample_response(status: ResponseStatus) -> CompletionResponse {
         CompletionResponse {
@@ -990,6 +1041,49 @@ mod tests {
         let failed = terminal_response_result(sample_response(ResponseStatus::Failed))
             .expect_err("failed response should error");
         assert!(failed.to_string().contains("failed response"));
+    }
+
+    #[test]
+    fn terminal_failed_response_with_error_preserves_raw_payload() {
+        let mut response = sample_response(ResponseStatus::Failed);
+        response.error = Some(ResponseError {
+            code: "server_error".to_string(),
+            message: "the model failed to generate a response".to_string(),
+        });
+
+        let err = match terminal_response_result(response) {
+            Ok(_) => panic!("failed response with an error object should fail"),
+            Err(e) => e,
+        };
+
+        // The full failed-response envelope is preserved as a ProviderResponse with
+        // no HTTP status (the websocket stream carries none), so the raw JSON parses
+        // back with the provider error nested under `error` — proving the whole
+        // envelope is kept, not just the error object.
+        assert_eq!(err.provider_response_status(), None);
+
+        let json = err
+            .provider_response_json()
+            .expect("preserved body should parse as JSON")
+            .expect("preserved body should not be empty");
+        assert_eq!(
+            json["error"]["message"],
+            "the model failed to generate a response"
+        );
+        assert_eq!(json["error"]["code"], "server_error");
+    }
+
+    #[test]
+    fn terminal_failed_response_without_error_is_rig_diagnostic() {
+        let err = match terminal_response_result(sample_response(ResponseStatus::Failed)) {
+            Ok(_) => panic!("failed response should fail"),
+            Err(e) => e,
+        };
+
+        // No provider error object, so this is a Rig-authored diagnostic and exposes
+        // no preserved provider response body.
+        assert_eq!(err.provider_response_body(), None);
+        assert!(err.to_string().contains("failed response"));
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/providers/openai/transcription.rs
+++ b/crates/rig-core/src/providers/openai/transcription.rs
@@ -111,19 +111,15 @@ where
                 ApiResponse::Ok(response) => response.try_into(),
                 ApiResponse::Err(api_error_response) => {
                     tracing::warn!(message = %api_error_response.message, "provider returned an error response");
-                    Err(TranscriptionError::ProviderResponse(
-                        crate::provider_response::ProviderResponseError {
-                            status: Some(status),
-                            body: String::from_utf8_lossy(&response_body).into_owned(),
-                        },
+                    Err(TranscriptionError::from_http_response(
+                        status,
+                        String::from_utf8_lossy(&response_body).into_owned(),
                     ))
                 }
             }
         } else {
             let str = String::from_utf8_lossy(&response_body).to_string();
-            Err(TranscriptionError::HttpError(
-                crate::http_client::Error::InvalidStatusCodeWithMessage(status, str),
-            ))
+            Err(TranscriptionError::from_http_response(status, str))
         }
     }
 }

--- a/crates/rig-core/src/providers/openrouter/audio_generation.rs
+++ b/crates/rig-core/src/providers/openrouter/audio_generation.rs
@@ -94,10 +94,7 @@ where
         if !response.status().is_success() {
             let status = response.status();
             let text = http_client::text(response).await?;
-            return Err(AudioGenerationError::ProviderError(format!(
-                "{}: {}",
-                status, text
-            )));
+            return Err(AudioGenerationError::from_http_response(status, text));
         }
 
         let audio: Vec<u8> = response.into_body().await?;
@@ -106,5 +103,45 @@ where
             audio: audio.clone(),
             response: Bytes::from(audio),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audio_generation::AudioGenerationModel as _;
+    use crate::client::audio_generation::AudioGenerationClient;
+    use crate::test_utils::RecordingHttpClient;
+
+    #[tokio::test]
+    async fn audio_generation_non_success_preserves_status_and_body() {
+        let body = r#"{"error":{"message":"boom"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.audio_generation_model(GPT_4O_MINI_TTS);
+
+        let request = model
+            .audio_generation_request()
+            .text("hello")
+            .voice("alloy")
+            .build();
+
+        let error = model
+            .audio_generation(request)
+            .await
+            .err()
+            .expect("should fail with non-success status");
+
+        assert!(matches!(error, AudioGenerationError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
     }
 }

--- a/crates/rig-core/src/providers/openrouter/completion.rs
+++ b/crates/rig-core/src/providers/openrouter/completion.rs
@@ -1,5 +1,5 @@
 use super::{
-    client::{ApiErrorResponse, ApiResponse, Client, Usage},
+    client::{ApiResponse, Client, Usage},
     streaming::StreamingCompletionResponse,
 };
 use crate::message::{
@@ -583,12 +583,6 @@ pub struct CompletionResponse {
     pub choices: Vec<Choice>,
     pub system_fingerprint: Option<String>,
     pub usage: Option<Usage>,
-}
-
-impl From<ApiErrorResponse> for CompletionError {
-    fn from(err: ApiErrorResponse) -> Self {
-        CompletionError::ProviderError(err.message)
-    }
 }
 
 impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionResponse> {
@@ -2021,20 +2015,16 @@ where
                     }
                     ApiResponse::Err(err) => {
                         tracing::warn!(message = %err.message, "provider returned an error response");
-                        Err(CompletionError::ProviderResponse(
-                            crate::provider_response::ProviderResponseError {
-                                status: Some(status),
-                                body: String::from_utf8_lossy(&response_body).into_owned(),
-                            },
+                        Err(CompletionError::from_http_response(
+                            status,
+                            String::from_utf8_lossy(&response_body).into_owned(),
                         ))
                     }
                 }
             } else {
-                Err(CompletionError::HttpError(
-                    crate::http_client::Error::InvalidStatusCodeWithMessage(
-                        status,
-                        String::from_utf8_lossy(&response_body).to_string(),
-                    ),
+                Err(CompletionError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&response_body).to_string(),
                 ))
             }
         }

--- a/crates/rig-core/src/providers/openrouter/embedding.rs
+++ b/crates/rig-core/src/providers/openrouter/embedding.rs
@@ -1,7 +1,4 @@
-use super::{
-    Client, Usage,
-    client::{ApiErrorResponse, ApiResponse},
-};
+use super::{Client, Usage, client::ApiResponse};
 use crate::embeddings::EmbeddingError;
 use crate::http_client::HttpClientExt;
 use crate::wasm_compat::WasmCompatSend;
@@ -16,21 +13,6 @@ pub struct EmbeddingResponse {
     pub model: String,
     pub usage: Option<Usage>,
     pub id: Option<String>,
-}
-
-impl From<ApiErrorResponse> for EmbeddingError {
-    fn from(err: ApiErrorResponse) -> Self {
-        EmbeddingError::ProviderError(err.message)
-    }
-}
-
-impl From<ApiResponse<EmbeddingResponse>> for Result<EmbeddingResponse, EmbeddingError> {
-    fn from(value: ApiResponse<EmbeddingResponse>) -> Self {
-        match value {
-            ApiResponse::Ok(response) => Ok(response),
-            ApiResponse::Err(err) => Err(EmbeddingError::ProviderError(err.message)),
-        }
-    }
 }
 
 #[derive(Debug, Deserialize, Clone, Serialize)]
@@ -146,19 +128,15 @@ where
                 }
                 ApiResponse::Err(err) => {
                     tracing::warn!(message = %err.message, "provider returned an error response");
-                    Err(EmbeddingError::ProviderResponse(
-                        crate::provider_response::ProviderResponseError {
-                            status: Some(status),
-                            body: String::from_utf8_lossy(&response_body).into_owned(),
-                        },
+                    Err(EmbeddingError::from_http_response(
+                        status,
+                        String::from_utf8_lossy(&response_body).into_owned(),
                     ))
                 }
             }
         } else {
             let text = http_client::text(response).await?;
-            Err(EmbeddingError::HttpError(
-                http_client::Error::InvalidStatusCodeWithMessage(status, text),
-            ))
+            Err(EmbeddingError::from_http_response(status, text))
         }
     }
 }

--- a/crates/rig-core/src/providers/openrouter/transcription.rs
+++ b/crates/rig-core/src/providers/openrouter/transcription.rs
@@ -196,8 +196,10 @@ where
             let resp: TranscriptionResponse = serde_json::from_slice(&body_bytes)?;
             resp.try_into()
         } else {
-            let text = String::from_utf8_lossy(&body_bytes).to_string();
-            Err(TranscriptionError::ProviderError(text))
+            Err(TranscriptionError::from_http_response(
+                status,
+                String::from_utf8_lossy(&body_bytes),
+            ))
         }
     }
 }
@@ -256,5 +258,37 @@ mod tests {
         let resp: TranscriptionResponse = serde_json::from_str(json).unwrap();
         assert_eq!(resp.text, "Hello world");
         assert!(resp.usage.is_none());
+    }
+
+    #[tokio::test]
+    async fn transcription_non_success_preserves_status_and_body() {
+        use crate::client::transcription::TranscriptionClient;
+        use crate::test_utils::RecordingHttpClient;
+        use crate::transcription::TranscriptionModel as _;
+
+        let body = r#"{"error":{"message":"boom"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.transcription_model(WHISPER_1);
+
+        let request = model.transcription_request().data(vec![0u8; 16]).build();
+
+        let error = model
+            .transcription(request)
+            .await
+            .err()
+            .expect("should fail with non-success status");
+
+        assert!(matches!(error, TranscriptionError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
     }
 }

--- a/crates/rig-core/src/providers/perplexity.rs
+++ b/crates/rig-core/src/providers/perplexity.rs
@@ -429,20 +429,16 @@ where
                     }
                     ApiResponse::Err(error) => {
                         tracing::warn!(message = %error.message, "provider returned an error response");
-                        Err(CompletionError::ProviderResponse(
-                            crate::provider_response::ProviderResponseError {
-                                status: Some(status),
-                                body: String::from_utf8_lossy(&response_body).into_owned(),
-                            },
+                        Err(CompletionError::from_http_response(
+                            status,
+                            String::from_utf8_lossy(&response_body).into_owned(),
                         ))
                     }
                 }
             } else {
-                Err(CompletionError::HttpError(
-                    http_client::Error::InvalidStatusCodeWithMessage(
-                        status,
-                        String::from_utf8_lossy(&response_body).to_string(),
-                    ),
+                Err(CompletionError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&response_body).to_string(),
                 ))
             }
         };

--- a/crates/rig-core/src/providers/together/completion.rs
+++ b/crates/rig-core/src/providers/together/completion.rs
@@ -305,20 +305,16 @@ where
                             message = %err.error,
                             "provider returned an error response"
                         );
-                        Err(CompletionError::ProviderResponse(
-                            crate::provider_response::ProviderResponseError {
-                                status: Some(status),
-                                body: String::from_utf8_lossy(&response_body).into_owned(),
-                            },
+                        Err(CompletionError::from_http_response(
+                            status,
+                            String::from_utf8_lossy(&response_body),
                         ))
                     }
                 }
             } else {
-                Err(CompletionError::HttpError(
-                    crate::http_client::Error::InvalidStatusCodeWithMessage(
-                        status,
-                        String::from_utf8_lossy(&response_body).to_string(),
-                    ),
+                Err(CompletionError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&response_body),
                 ))
             }
         }

--- a/crates/rig-core/src/providers/together/embedding.rs
+++ b/crates/rig-core/src/providers/together/embedding.rs
@@ -120,19 +120,15 @@ where
                         message = %err.error,
                         "provider returned an error response"
                     );
-                    Err(EmbeddingError::ProviderResponse(
-                        crate::provider_response::ProviderResponseError {
-                            status: Some(status),
-                            body: String::from_utf8_lossy(&response_body).into_owned(),
-                        },
+                    Err(EmbeddingError::from_http_response(
+                        status,
+                        String::from_utf8_lossy(&response_body),
                     ))
                 }
             }
         } else {
             let text = http_client::text(response).await?;
-            Err(EmbeddingError::HttpError(
-                http_client::Error::InvalidStatusCodeWithMessage(status, text),
-            ))
+            Err(EmbeddingError::from_http_response(status, text))
         }
     }
 }

--- a/crates/rig-core/src/providers/voyageai.rs
+++ b/crates/rig-core/src/providers/voyageai.rs
@@ -148,26 +148,11 @@ pub struct ApiErrorResponse {
     pub(crate) message: String,
 }
 
-impl From<ApiErrorResponse> for EmbeddingError {
-    fn from(err: ApiErrorResponse) -> Self {
-        EmbeddingError::ProviderError(err.message)
-    }
-}
-
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 pub(crate) enum ApiResponse<T> {
     Ok(T),
     Err(ApiErrorResponse),
-}
-
-impl From<ApiResponse<EmbeddingResponse>> for Result<EmbeddingResponse, EmbeddingError> {
-    fn from(value: ApiResponse<EmbeddingResponse>) -> Self {
-        match value {
-            ApiResponse::Ok(response) => Ok(response),
-            ApiResponse::Err(err) => Err(EmbeddingError::ProviderError(err.message)),
-        }
-    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -274,20 +259,16 @@ where
                 }
                 ApiResponse::Err(err) => {
                     tracing::warn!(message = %err.message, "provider returned an error response");
-                    Err(EmbeddingError::ProviderResponse(
-                        crate::provider_response::ProviderResponseError {
-                            status: Some(status),
-                            body: String::from_utf8_lossy(&response_body).into_owned(),
-                        },
+                    Err(EmbeddingError::from_http_response(
+                        status,
+                        String::from_utf8_lossy(&response_body),
                     ))
                 }
             }
         } else {
-            Err(EmbeddingError::HttpError(
-                crate::http_client::Error::InvalidStatusCodeWithMessage(
-                    status,
-                    String::from_utf8_lossy(&response_body).to_string(),
-                ),
+            Err(EmbeddingError::from_http_response(
+                status,
+                String::from_utf8_lossy(&response_body),
             ))
         }
     }
@@ -328,12 +309,6 @@ pub struct RerankApiData {
     pub relevance_score: f64,
     #[serde(default)]
     pub document: Option<String>,
-}
-
-impl From<ApiErrorResponse> for RerankError {
-    fn from(err: ApiErrorResponse) -> Self {
-        RerankError::ProviderError(err.message)
-    }
 }
 
 #[derive(Clone)]
@@ -455,11 +430,18 @@ where
                         usage,
                     })
                 }
-                ApiResponse::Err(err) => Err(RerankError::ProviderError(err.message)),
+                ApiResponse::Err(err) => {
+                    tracing::warn!(message = %err.message, "provider returned an error response");
+                    Err(RerankError::from_http_response(
+                        status,
+                        String::from_utf8_lossy(&response_body),
+                    ))
+                }
             }
         } else {
-            Err(RerankError::ProviderError(
-                String::from_utf8_lossy(&response_body).to_string(),
+            Err(RerankError::from_http_response(
+                status,
+                String::from_utf8_lossy(&response_body),
             ))
         }
     }
@@ -475,5 +457,63 @@ mod tests {
             .api_key("dummy-key")
             .build()
             .expect("Client::builder() failed");
+    }
+
+    #[tokio::test]
+    async fn rerank_non_success_preserves_status_and_body() {
+        use crate::client::RerankingClient;
+        use crate::rerank::{RerankError, RerankModel as _};
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"error":{"message":"boom"}}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = super::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.rerank_model(super::RERANK_2_5);
+
+        let error = model
+            .rerank("query", vec!["doc one".to_string(), "doc two".to_string()])
+            .await
+            .expect_err("rerank should fail with non-success status");
+
+        assert!(matches!(error, RerankError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+
+    #[tokio::test]
+    async fn rerank_2xx_error_envelope_preserves_status_and_body() {
+        use crate::client::RerankingClient;
+        use crate::rerank::{RerankError, RerankModel as _};
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"message":"boom"}"#;
+        let http_client = RecordingHttpClient::new(body); // 200 OK
+        let client = super::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.rerank_model(super::RERANK_2_5);
+
+        let error = model
+            .rerank("query", vec!["doc one".to_string(), "doc two".to_string()])
+            .await
+            .expect_err("rerank should fail with provider error envelope");
+
+        match &error {
+            RerankError::ProviderResponse(stored) => {
+                assert_eq!(stored.body, body);
+                assert_eq!(stored.status, Some(http::StatusCode::OK));
+            }
+            other => panic!("expected ProviderResponse, got {other:?}"),
+        }
     }
 }

--- a/crates/rig-core/src/providers/xai/audio_generation.rs
+++ b/crates/rig-core/src/providers/xai/audio_generation.rs
@@ -73,10 +73,7 @@ where
             let status = response.status();
             let text = http_client::text(response).await?;
 
-            return Err(AudioGenerationError::ProviderError(format!(
-                "{}: {}",
-                status, text,
-            )));
+            return Err(AudioGenerationError::from_http_response(status, text));
         }
 
         let bytes: Bytes = response.into_body().await?.into();
@@ -85,5 +82,46 @@ where
             audio: bytes.to_vec(),
             response: bytes,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audio_generation::AudioGenerationModel as _;
+    use crate::client::audio_generation::AudioGenerationClient;
+
+    #[tokio::test]
+    async fn audio_generation_non_success_preserves_status_and_body() {
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"error":"boom","code":"503"}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = crate::providers::xai::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.audio_generation_model(TTS_1);
+
+        let request = model
+            .audio_generation_request()
+            .text("hello")
+            .voice("eve")
+            .build();
+
+        let error = model
+            .audio_generation(request)
+            .await
+            .err()
+            .expect("should fail with non-success status");
+
+        assert!(matches!(error, AudioGenerationError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
     }
 }

--- a/crates/rig-core/src/providers/xai/completion.rs
+++ b/crates/rig-core/src/providers/xai/completion.rs
@@ -263,12 +263,17 @@ where
                         response.try_into()
                     }
                     ApiResponse::Error(error) => {
-                        Err(CompletionError::ProviderError(error.message()))
+                        tracing::warn!(message = %error.message(), "provider returned an error response");
+                        Err(CompletionError::from_http_response(
+                            status,
+                            String::from_utf8_lossy(&response_body),
+                        ))
                     }
                 }
             } else {
-                Err(CompletionError::ProviderError(
-                    String::from_utf8_lossy(&response_body).to_string(),
+                Err(CompletionError::from_http_response(
+                    status,
+                    String::from_utf8_lossy(&response_body),
                 ))
             }
         }
@@ -369,5 +374,66 @@ mod tests {
             1,
             "document input should appear exactly once: {input:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn completion_non_success_preserves_status_and_body() {
+        use crate::client::CompletionClient;
+        use crate::completion::{CompletionError, CompletionModel as _};
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"error":"boom","code":"503"}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = crate::providers::xai::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model(crate::providers::xai::completion::GROK_4);
+        let request = model.completion_request("hello").build();
+
+        let error = model
+            .completion(request)
+            .await
+            .expect_err("should fail with non-success status");
+
+        assert!(matches!(error, CompletionError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+
+    #[tokio::test]
+    async fn completion_2xx_error_envelope_preserves_status_and_body() {
+        use crate::client::CompletionClient;
+        use crate::completion::{CompletionError, CompletionModel as _};
+        use crate::test_utils::RecordingHttpClient;
+
+        // Deserializes to `ApiResponse::Error(ApiError { error, code })` on a 200 OK.
+        let body = r#"{"error":"boom","code":"503"}"#;
+        let http_client = RecordingHttpClient::new(body);
+        let client = crate::providers::xai::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model(crate::providers::xai::completion::GROK_4);
+        let request = model.completion_request("hello").build();
+
+        let error = model
+            .completion(request)
+            .await
+            .expect_err("should fail with provider error envelope");
+
+        match &error {
+            CompletionError::ProviderResponse(stored) => {
+                assert_eq!(stored.body, body);
+                assert_eq!(stored.status, Some(http::StatusCode::OK));
+            }
+            other => panic!("expected ProviderResponse, got {other:?}"),
+        }
     }
 }

--- a/crates/rig-core/src/providers/xai/image_generation.rs
+++ b/crates/rig-core/src/providers/xai/image_generation.rs
@@ -101,21 +101,90 @@ where
 
         let response = self.client.send(request).await?;
 
-        if !response.status().is_success() {
-            let status = response.status();
-            let text = http_client::text(response).await?;
-
-            return Err(ImageGenerationError::ProviderError(format!(
-                "{}: {}",
-                status, text,
-            )));
-        }
-
+        let status = response.status();
         let text = http_client::text(response).await?;
+
+        if !status.is_success() {
+            return Err(ImageGenerationError::from_http_response(status, text));
+        }
 
         match serde_json::from_str::<ApiResponse<ImageGenerationResponse>>(&text)? {
             ApiResponse::Ok(response) => response.try_into(),
-            ApiResponse::Error(err) => Err(ImageGenerationError::ProviderError(err.message())),
+            ApiResponse::Error(err) => {
+                tracing::warn!(message = %err.message(), "provider returned an error response");
+                Err(ImageGenerationError::from_http_response(status, text))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::image_generation::ImageGenerationClient;
+    use crate::image_generation::ImageGenerationModel as _;
+
+    fn request() -> ImageGenerationRequest {
+        ImageGenerationRequest {
+            prompt: "draw a cat".to_string(),
+            width: 256,
+            height: 256,
+            additional_params: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn image_generation_non_success_preserves_status_and_body() {
+        use crate::test_utils::RecordingHttpClient;
+
+        let body = r#"{"error":"boom","code":"503"}"#;
+        let http_client =
+            RecordingHttpClient::with_error_response(http::StatusCode::SERVICE_UNAVAILABLE, body);
+        let client = crate::providers::xai::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.image_generation_model(GROK_IMAGINE_IMAGE);
+
+        let error = model
+            .image_generation(request())
+            .await
+            .expect_err("should fail with non-success status");
+
+        assert!(matches!(error, ImageGenerationError::HttpError(_)));
+        assert_eq!(
+            error.provider_response_status(),
+            Some(http::StatusCode::SERVICE_UNAVAILABLE)
+        );
+        assert_eq!(error.provider_response_body(), Some(body));
+    }
+
+    #[tokio::test]
+    async fn image_generation_2xx_error_envelope_preserves_status_and_body() {
+        use crate::test_utils::RecordingHttpClient;
+
+        // Deserializes to `ApiResponse::Error(ApiError { error, code })` on a 200 OK.
+        let body = r#"{"error":"boom","code":"503"}"#;
+        let http_client = RecordingHttpClient::new(body);
+        let client = crate::providers::xai::Client::builder()
+            .api_key("test-key")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.image_generation_model(GROK_IMAGINE_IMAGE);
+
+        let error = model
+            .image_generation(request())
+            .await
+            .expect_err("should fail with provider error envelope");
+
+        match &error {
+            ImageGenerationError::ProviderResponse(stored) => {
+                assert_eq!(stored.body, body);
+                assert_eq!(stored.status, Some(http::StatusCode::OK));
+            }
+            other => panic!("expected ProviderResponse, got {other:?}"),
         }
     }
 }

--- a/crates/rig-core/src/rerank.rs
+++ b/crates/rig-core/src/rerank.rs
@@ -6,12 +6,17 @@
 
 use crate::{
     completion::Usage,
-    http_client,
+    http_client, provider_response,
     wasm_compat::{WasmCompatSend, WasmCompatSync},
 };
 use serde::{Deserialize, Serialize};
 
+/// Errors returned by reranking models.
+///
+/// Inspect provider failures with [`Self::provider_response_body`],
+/// [`Self::provider_response_json`], and [`Self::provider_response_status`].
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum RerankError {
     #[error("HttpError: {0}")]
     HttpError(#[from] http_client::Error),
@@ -27,7 +32,13 @@ pub enum RerankError {
 
     #[error("ProviderError: {0}")]
     ProviderError(String),
+
+    /// Raw error response preserved from the reranking model provider
+    #[error("ProviderResponseError: {0}")]
+    ProviderResponse(provider_response::ProviderResponseError),
 }
+
+crate::provider_response::impl_provider_response_helpers!(RerankError);
 
 /// Trait for reranking models that score documents by relevance to a query.
 pub trait RerankModel: WasmCompatSend + WasmCompatSync {

--- a/crates/rig-core/src/test_utils/http.rs
+++ b/crates/rig-core/src/test_utils/http.rs
@@ -262,6 +262,14 @@ impl HttpErrorStreamingClient {
     }
 }
 
+impl Default for HttpErrorStreamingClient {
+    /// The completion-model client bound requires `H: Default`; this lets the
+    /// streaming error client back a real model in tests.
+    fn default() -> Self {
+        Self::new(http::StatusCode::INTERNAL_SERVER_ERROR, String::new())
+    }
+}
+
 impl HttpClientExt for HttpErrorStreamingClient {
     fn send<T, U>(
         &self,

--- a/crates/rig-gemini-grpc/src/completion.rs
+++ b/crates/rig-gemini-grpc/src/completion.rs
@@ -64,7 +64,7 @@ impl completion::CompletionModel for CompletionModel {
         let response = grpc_client
             .generate_content(request)
             .await
-            .map_err(|e| CompletionError::ProviderError(e.to_string()))?
+            .map_err(rpc_error)?
             .into_inner();
 
         response.try_into()
@@ -79,6 +79,17 @@ impl completion::CompletionModel for CompletionModel {
     > {
         super::streaming::stream(self.client.clone(), self.model.clone(), request).await
     }
+}
+
+// Map a failed gRPC call into a `CompletionError` that preserves the provider's
+// error payload verbatim. gRPC is a non-HTTP transport, so there is no
+// `http::StatusCode`; the body is preserved via `from_provider_body` (status:
+// None) rather than a Rig-prefixed `ProviderError` diagnostic. Note: tonic does
+// not distinguish a server-returned gRPC error from a transport/connection
+// failure, so a pure connection error is also preserved here rather than gated
+// out as a Rig diagnostic the way Bedrock's typed service errors are.
+pub(crate) fn rpc_error(status: tonic::Status) -> CompletionError {
+    CompletionError::from_provider_body(status.to_string())
 }
 
 // Helper function to create gRPC request from Rig's CompletionRequest
@@ -709,6 +720,23 @@ fn json_type_to_proto_type(t: &str) -> proto::Type {
 #[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 mod tests {
     use super::*;
+
+    // ============================================================
+    // rpc_error — pins the from_provider_body usage on the RPC error path
+    // ============================================================
+
+    #[test]
+    fn rpc_error_preserves_status_text_without_http_status() {
+        let status = tonic::Status::unavailable("boom");
+        let expected = status.to_string();
+
+        let err = rpc_error(status);
+
+        // The raw provider error text is preserved verbatim, and there is no
+        // HTTP status because gRPC is a non-HTTP transport.
+        assert_eq!(err.provider_response_body(), Some(expected.as_str()));
+        assert_eq!(err.provider_response_status(), None);
+    }
 
     #[test]
     fn test_decode_base64_bytes_accepts_url_safe_with_padding() {

--- a/crates/rig-gemini-grpc/src/embedding.rs
+++ b/crates/rig-gemini-grpc/src/embedding.rs
@@ -72,7 +72,7 @@ impl embeddings::EmbeddingModel for EmbeddingModel {
             let response = grpc_client
                 .embed_content(request)
                 .await
-                .map_err(|e| EmbeddingError::ProviderError(e.to_string()))?
+                .map_err(rpc_error)?
                 .into_inner();
 
             if let Some(embedding) = response.embedding {
@@ -88,5 +88,35 @@ impl embeddings::EmbeddingModel for EmbeddingModel {
         }
 
         Ok(embeddings)
+    }
+}
+
+// Map a failed gRPC call into an `EmbeddingError` that preserves the provider's
+// error payload verbatim. gRPC is a non-HTTP transport, so there is no
+// `http::StatusCode`; the body is preserved via `from_provider_body` (status:
+// None) rather than a Rig-prefixed `ProviderError` diagnostic. Note: tonic does
+// not distinguish a server-returned gRPC error from a transport/connection
+// failure, so a pure connection error is also preserved here rather than gated
+// out as a Rig diagnostic the way Bedrock's typed service errors are.
+fn rpc_error(status: tonic::Status) -> EmbeddingError {
+    EmbeddingError::from_provider_body(status.to_string())
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rpc_error_preserves_status_text_without_http_status() {
+        let status = tonic::Status::unavailable("boom");
+        let expected = status.to_string();
+
+        let err = rpc_error(status);
+
+        // The raw provider error text is preserved verbatim, and there is no
+        // HTTP status because gRPC is a non-HTTP transport.
+        assert_eq!(err.provider_response_body(), Some(expected.as_str()));
+        assert_eq!(err.provider_response_status(), None);
     }
 }

--- a/crates/rig-gemini-grpc/src/streaming.rs
+++ b/crates/rig-gemini-grpc/src/streaming.rs
@@ -30,7 +30,7 @@ pub(crate) async fn stream(
     let mut response_stream = grpc_client
         .stream_generate_content(request)
         .await
-        .map_err(|e| CompletionError::ProviderError(e.to_string()))?
+        .map_err(super::completion::rpc_error)?
         .into_inner();
 
     let stream = stream! {
@@ -101,7 +101,7 @@ pub(crate) async fn stream(
                     }
                 }
                 Err(status) => {
-                    yield Err(CompletionError::ProviderError(status.to_string()));
+                    yield Err(super::completion::rpc_error(status));
                     return;
                 }
             }
@@ -144,5 +144,23 @@ fn prost_value_to_json(v: &proto::Value) -> Value {
         Some(proto::value::Kind::ListValue(list)) => {
             Value::Array(list.values.iter().map(prost_value_to_json).collect())
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    // The streaming path maps both the initial `stream_generate_content` RPC
+    // failure and any per-item iteration error through `rpc_error`. Pin that the
+    // mapping preserves the provider's status text and exposes no HTTP status.
+    #[test]
+    fn stream_rpc_error_preserves_status_text_without_http_status() {
+        let status = tonic::Status::unavailable("boom");
+        let expected = status.to_string();
+
+        let err = super::super::completion::rpc_error(status);
+
+        assert_eq!(err.provider_response_body(), Some(expected.as_str()));
+        assert_eq!(err.provider_response_status(), None);
     }
 }

--- a/crates/rig-vertexai/src/completion.rs
+++ b/crates/rig-vertexai/src/completion.rs
@@ -121,10 +121,7 @@ impl CompletionModelTrait for CompletionModel {
             request_builder = request_builder.set_tool_config(tool_config);
         }
 
-        let response = request_builder
-            .send()
-            .await
-            .map_err(|e| CompletionError::ProviderError(format!("Vertex AI API error: {e}")))?;
+        let response = request_builder.send().await.map_err(rpc_error)?;
 
         tracing::debug!(
             target: "rig_core::vertexai",
@@ -144,5 +141,44 @@ impl CompletionModelTrait for CompletionModel {
         Err(CompletionError::ProviderError(
             "Streaming is not supported for Vertex AI in this integration".to_string(),
         ))
+    }
+}
+
+/// Map a failed `send()` RPC into a [`CompletionError`] that preserves the
+/// provider's gRPC error text verbatim.
+///
+/// Vertex AI uses a non-HTTP (gRPC/SDK) transport, so there is no
+/// [`http::StatusCode`] to attach; the error body is preserved via
+/// [`CompletionError::from_provider_body`] (`status: None`) rather than a
+/// Rig-prefixed [`CompletionError::ProviderError`] diagnostic. (The
+/// `get_inner()` client-init failure stays a `ProviderError` because it is a
+/// Rig-side setup failure, not a provider response.)
+///
+/// Note: the SDK does not distinguish a server-returned gRPC error from a
+/// transport/connection failure, so a pure connection error is also preserved
+/// here (`status: None`) rather than gated out as a Rig diagnostic the way
+/// Bedrock's typed service errors are.
+fn rpc_error(error: impl std::fmt::Display) -> CompletionError {
+    CompletionError::from_provider_body(error.to_string())
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    // The `send()` RPC error type comes from the `google-cloud-aiplatform-v1`
+    // SDK and is not trivially constructible, so `rpc_error` is generic over
+    // `impl Display` and we pin it here with a representative error string of
+    // its parameter type. This guards against a revert to `ProviderError`,
+    // which would surface the body as `None`.
+    #[test]
+    fn rpc_error_preserves_raw_text_without_http_status() {
+        let raw = "status: Unavailable, message: \"the service is currently unavailable\"";
+
+        let err = rpc_error(raw);
+
+        assert_eq!(err.provider_response_body(), Some(raw));
+        assert_eq!(err.provider_response_status(), None);
     }
 }


### PR DESCRIPTION
Closes #1931. Follow-up to #1859 (#1820).

## What

#1859 exposed `provider_response_body()` / `provider_response_json()` / `provider_response_status()` on the capability errors, but only the OpenAI family populated them — every other provider flattened HTTP failures into `ProviderError(String)`, so the helpers returned `None`. This PR closes that gap **workspace-wide** in a single pass, rather than the staged sequence the issue sketched.

## 1. Shared funnel constructors (the regression anchor)

`crates/rig-core/src/provider_response.rs` adds two **public** constructors to every capability error via the `impl_provider_response_helpers!` macro:

- `from_http_response(status, body)` — the single funnel for HTTP-error paths: a **2xx** status carrying a provider error envelope → `ProviderResponse { status, body }`; a **non-success** status → `HttpError(InvalidStatusCodeWithMessage(status, body))`. Read the body once, hand it here for both branches.
- `from_provider_body(body)` — for non-HTTP transports (gRPC/SDK) with no `StatusCode` → `ProviderResponse { status: None, body }`.

SSE transport errors continue to route through `CompletionError::from_stream_transport`. Making the constructors `pub` lets the companion crates funnel through the same path.

## 2. Coverage — every in-core provider

Routed through the funnel (full raw body preserved verbatim, not just `err.message`): **Anthropic** (completion envelope + non-success + SSE), **Gemini** (completion, image, transcription, embedding, streaming, interactions API + its streaming), **Cohere** (completion, embeddings, streaming), **xAI** (completion, image, audio), **Hyperbolic** (completion, image, audio — incl. 2xx envelopes), **Ollama** (completion, embeddings, NDJSON streaming), **Mira**, **VoyageAI rerank**, **Mistral** transcription, **Hugging Face** (transcription, image), **OpenRouter** (transcription, audio), **OpenAI** audio. The OpenAI Responses-API websocket and Copilot streaming "response failed" arms preserve the provider's error via `from_provider_body`. Dead `From<ApiErrorResponse>` / `From<ApiResponse<T>>` flatten-impls (deepseek, openrouter, ollama, mira, voyageai, hyperbolic) were deleted. Gemini embedding gained a non-success status guard so an error body that doesn't match its envelope shape is preserved instead of surfacing as a `JsonError`. `minimax` / `xiaomimimo` / `zai` are thin wrappers over the already-wired OpenAI-compatible code.

## 3. Companion crates (gRPC/SDK — `status: None` deliberately)

`rig-bedrock`, `rig-vertexai`, `rig-gemini-grpc` preserve the provider/SDK error text through `from_provider_body`. `rig-fastembed` is local inference (no remote provider) — intentionally untouched.

## 4. Tests

- A **shared/parametrized funnel test** asserts every capability error (incl. the new `RerankError`) preserves status + body across all three routes, plus per-provider tests asserting the wiring end-to-end (non-success `HttpError` and 2xx-envelope `ProviderResponse`). The structural funnel (`from_http_response` / `from_provider_body` is the single construction path) plus review keep the gap closed.

## 5. Polish (from the #1859 review)

- `provider_response_status` rustdoc warns it can return a **2xx** status.
- Hardened the chat-completions SSE detector so a `{"error":null}` chunk can't terminate a stream.
- Documented the empty-body asymmetry (`body() == Some("")` vs `json() == Ok(None)`).
- An audio path (Hyperbolic 2xx envelope) now constructs `AudioGenerationError::ProviderResponse`; the "forward-looking dead variant" note is gone.
- Added a user-facing rustdoc example of the inspection pattern.

## Breaking changes

Non-breaking **except**: **`RerankError` becomes `#[non_exhaustive]` and gains a `ProviderResponse` variant** (it wasn't prepared in #1859) so rerank reaches parity with the other capability errors. CHANGELOG updated.

## Verification

`cargo fmt --check`, `cargo clippy --all-features --all-targets -D warnings`, `cargo test -p rig-core --all-features` (1024 unit + 104 doc, all pass), the companion crates (`rig-bedrock`/`rig-vertexai`/`rig-gemini-grpc`), and `cargo doc --no-deps --all-features -D warnings` all pass locally.

