### PR TITLE
feat(rig-core): ToolCallExtensions — per-call runtime context for tools, wired through the agent loop

### DIFF
--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -82,6 +82,45 @@ where
         self
     }
 
+    /// Attach per-call runtime [extensions](crate::tool::ToolCallExtensions) for
+    /// this request.
+    ///
+    /// The extensions are threaded through the agent loop to every tool executed
+    /// during this run, where they can be read by overriding
+    /// [`Tool::call_with_extensions`](crate::tool::Tool::call_with_extensions).
+    /// Use this to pass auth tokens, session IDs, A2A `context_id`/`task_id`, or
+    /// any other per-call value to tools without exposing it to the model.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use rig_core::{
+    ///     client::{CompletionClient, ProviderClient},
+    ///     completion::Prompt,
+    ///     providers::openai,
+    ///     tool::ToolCallExtensions,
+    /// };
+    ///
+    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// #[derive(Clone)]
+    /// struct SessionId(String);
+    ///
+    /// let agent = openai::Client::from_env()?.agent(openai::GPT_5_2).build();
+    ///
+    /// let mut extensions = ToolCallExtensions::new();
+    /// extensions.insert(SessionId("session-123".to_string()));
+    ///
+    /// let answer = agent
+    ///     .prompt("do the thing")
+    ///     .with_tool_extensions(extensions)
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn with_tool_extensions(mut self, extensions: crate::tool::ToolCallExtensions) -> Self {
+        self.runner = self.runner.tool_extensions(extensions);
+        self
+    }
+
     /// Add chat history to the prompt request.
     pub fn history<H, T>(mut self, history: H) -> Self
     where
@@ -2210,5 +2249,107 @@ mod tests {
             .expect("append failure must not block successful completion");
 
         assert!(!response.is_empty());
+    }
+
+    // --- tool call extensions end-to-end ---
+
+    #[derive(Clone)]
+    struct CallSessionId(String);
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("read session error")]
+    struct ReadSessionError;
+
+    /// Tool that reports the `CallSessionId` it received via the call
+    /// extensions, also recording it into a shared slot for assertions.
+    #[derive(Clone)]
+    struct RecordingExtensionsTool {
+        seen: Arc<Mutex<Option<String>>>,
+    }
+
+    impl Tool for RecordingExtensionsTool {
+        const NAME: &'static str = "read_session";
+        type Error = ReadSessionError;
+        type Args = serde_json::Value;
+        type Output = String;
+
+        async fn definition(&self, _prompt: String) -> ToolDefinition {
+            ToolDefinition {
+                name: Self::NAME.to_string(),
+                description: "reads the session id from the call extensions".to_string(),
+                parameters: json!({"type": "object", "properties": {}}),
+            }
+        }
+
+        async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
+            // The agent always dispatches through `call_with_extensions`; this
+            // bare path should not be hit during an agent run.
+            *self.seen.lock().unwrap() = None;
+            Ok("no-extensions".to_string())
+        }
+
+        async fn call_with_extensions(
+            &self,
+            _args: Self::Args,
+            extensions: &crate::tool::ToolCallExtensions,
+        ) -> Result<Self::Output, Self::Error> {
+            let session = extensions.get::<CallSessionId>().map(|s| s.0.clone());
+            *self.seen.lock().unwrap() = session.clone();
+            Ok(session.unwrap_or_else(|| "no-session".to_string()))
+        }
+    }
+
+    #[tokio::test]
+    async fn tool_extensions_reach_tool_through_agent_prompt() {
+        let seen = Arc::new(Mutex::new(None));
+        let tool = RecordingExtensionsTool { seen: seen.clone() };
+        let model = MockCompletionModel::new([
+            MockTurn::tool_call("tool_call_1", "read_session", json!({})),
+            MockTurn::text("done"),
+        ]);
+        let agent = AgentBuilder::new(model).tool(tool).build();
+
+        let mut extensions = crate::tool::ToolCallExtensions::new();
+        extensions.insert(CallSessionId("session-xyz".to_string()));
+
+        let answer: String = agent
+            .prompt("use the tool")
+            .with_tool_extensions(extensions)
+            .max_turns(3)
+            .await
+            .expect("prompt should succeed");
+
+        assert_eq!(answer, "done");
+        assert_eq!(
+            seen.lock().unwrap().as_deref(),
+            Some("session-xyz"),
+            "the injected CallSessionId must reach the tool through the agent loop"
+        );
+    }
+
+    #[tokio::test]
+    async fn agent_without_tool_extensions_dispatches_empty_extensions() {
+        // Pre-seed a stale value so we can prove `call_with_extensions` ran with
+        // an empty map (not that the slot was simply never written).
+        let seen = Arc::new(Mutex::new(Some("stale".to_string())));
+        let tool = RecordingExtensionsTool { seen: seen.clone() };
+        let model = MockCompletionModel::new([
+            MockTurn::tool_call("tool_call_1", "read_session", json!({})),
+            MockTurn::text("done"),
+        ]);
+        let agent = AgentBuilder::new(model).tool(tool).build();
+
+        let answer: String = agent
+            .prompt("use the tool")
+            .max_turns(3)
+            .await
+            .expect("prompt should succeed");
+
+        assert_eq!(answer, "done");
+        assert_eq!(
+            seen.lock().unwrap().as_deref(),
+            None,
+            "with no extensions set, the tool should observe an empty extensions map"
+        );
     }
 }

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -363,6 +363,19 @@ where
         self
     }
 
+    /// Attach per-call runtime [extensions](crate::tool::ToolCallExtensions) for
+    /// this request.
+    ///
+    /// The extensions are threaded through the agent loop to every tool executed
+    /// during this run, where they can be read by overriding
+    /// [`Tool::call_with_extensions`](crate::tool::Tool::call_with_extensions).
+    /// Use this to pass auth tokens, session IDs, A2A `context_id`/`task_id`, or
+    /// any other per-call value to tools without exposing it to the model.
+    pub fn with_tool_extensions(mut self, extensions: crate::tool::ToolCallExtensions) -> Self {
+        self.runner = self.runner.tool_extensions(extensions);
+        self
+    }
+
     async fn send(self) -> StreamingResult<M::StreamingResponse> {
         self.runner.stream().await
     }
@@ -907,6 +920,7 @@ where
                             let result = run_single_tool(
                                 &self.hooks,
                                 &tool_server_handle,
+                                &self.tool_extensions,
                                 &tool_call,
                                 &internal_call_id,
                                 &full_history_for_errors,
@@ -5291,6 +5305,86 @@ mod tests {
         assert!(
             saw_final,
             "FinalResponse must be yielded even when memory.append fails"
+        );
+    }
+
+    // --- tool call extensions end-to-end (streaming) ---
+
+    #[derive(Clone)]
+    struct StreamSessionId(String);
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("read session error")]
+    struct StreamReadSessionError;
+
+    #[derive(Clone)]
+    struct StreamingExtensionsTool {
+        seen: Arc<Mutex<Option<String>>>,
+    }
+
+    impl Tool for StreamingExtensionsTool {
+        const NAME: &'static str = "read_session";
+        type Error = StreamReadSessionError;
+        type Args = serde_json::Value;
+        type Output = String;
+
+        async fn definition(&self, _prompt: String) -> ToolDefinition {
+            ToolDefinition {
+                name: Self::NAME.to_string(),
+                description: "reads the session id from the call extensions".to_string(),
+                parameters: serde_json::json!({"type": "object", "properties": {}}),
+            }
+        }
+
+        async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
+            *self.seen.lock().unwrap() = None;
+            Ok("no-extensions".to_string())
+        }
+
+        async fn call_with_extensions(
+            &self,
+            _args: Self::Args,
+            extensions: &crate::tool::ToolCallExtensions,
+        ) -> Result<Self::Output, Self::Error> {
+            let session = extensions.get::<StreamSessionId>().map(|s| s.0.clone());
+            *self.seen.lock().unwrap() = session.clone();
+            Ok(session.unwrap_or_else(|| "no-session".to_string()))
+        }
+    }
+
+    #[tokio::test]
+    async fn streaming_tool_extensions_reach_tool() {
+        let seen = Arc::new(Mutex::new(None));
+        let tool = StreamingExtensionsTool { seen: seen.clone() };
+        let model = MockCompletionModel::from_stream_turns([
+            vec![
+                MockStreamEvent::tool_call("tool_call_1", "read_session", serde_json::json!({})),
+                MockStreamEvent::final_response_with_total_tokens(4),
+            ],
+            vec![
+                MockStreamEvent::text("done"),
+                MockStreamEvent::final_response_with_total_tokens(6),
+            ],
+        ]);
+        let agent = AgentBuilder::new(model).tool(tool).build();
+
+        let mut extensions = crate::tool::ToolCallExtensions::new();
+        extensions.insert(StreamSessionId("stream-session".to_string()));
+
+        let mut stream = agent
+            .stream_prompt("use the tool")
+            .with_tool_extensions(extensions)
+            .multi_turn(3)
+            .await;
+
+        while let Some(item) = stream.next().await {
+            item.expect("stream item should not error");
+        }
+
+        assert_eq!(
+            seen.lock().unwrap().as_deref(),
+            Some("stream-session"),
+            "the injected StreamSessionId must reach the tool through the streaming agent loop"
         );
     }
 }

--- a/crates/rig-core/src/agent/runner.rs
+++ b/crates/rig-core/src/agent/runner.rs
@@ -47,7 +47,7 @@ use crate::{
     json_utils,
     memory::ConversationMemory,
     message::{ToolCall, ToolChoice, UserContent},
-    tool::server::ToolServerHandle,
+    tool::{ToolCallExtensions, server::ToolServerHandle},
 };
 
 const UNKNOWN_AGENT_NAME: &str = "Unnamed Agent";
@@ -163,6 +163,8 @@ where
     pub(crate) max_tokens: Option<u64>,
     pub(crate) additional_params: Option<serde_json::Value>,
     pub(crate) tool_server_handle: ToolServerHandle,
+    /// Per-call runtime extensions threaded to every tool executed in this run.
+    pub(crate) tool_extensions: ToolCallExtensions,
     pub(crate) dynamic_context: DynamicContextStore,
     pub(crate) tool_choice: Option<ToolChoice>,
     pub(crate) output_schema: Option<schemars::Schema>,
@@ -193,6 +195,7 @@ where
             max_tokens: agent.max_tokens,
             additional_params: agent.additional_params.clone(),
             tool_server_handle: agent.tool_server_handle.clone(),
+            tool_extensions: ToolCallExtensions::new(),
             dynamic_context: agent.dynamic_context.clone(),
             tool_choice: agent.tool_choice.clone(),
             output_schema: agent.output_schema.clone(),
@@ -254,6 +257,16 @@ where
     /// so it would otherwise hang the run the first time the model calls a tool.
     pub fn tool_concurrency(mut self, concurrency: usize) -> Self {
         self.concurrency = concurrency.max(1);
+        self
+    }
+
+    /// Attach per-call runtime [extensions](ToolCallExtensions) for this run.
+    ///
+    /// The extensions are threaded to every tool executed during the run, where
+    /// they can be read by overriding
+    /// [`Tool::call_with_extensions`](crate::tool::Tool::call_with_extensions).
+    pub fn tool_extensions(mut self, extensions: ToolCallExtensions) -> Self {
+        self.tool_extensions = extensions;
         self
     }
 
@@ -334,6 +347,7 @@ pub(crate) fn build_agent_run(
 pub(crate) async fn run_single_tool<M>(
     hooks: &HookStack<M>,
     tool_server: &ToolServerHandle,
+    tool_extensions: &ToolCallExtensions,
     tool_call: &ToolCall,
     internal_call_id: &str,
     error_history: &[Message],
@@ -377,7 +391,10 @@ where
         ToolCallDecision::Proceed => {}
     }
 
-    let output = match tool_server.call_tool(tool_name, &args).await {
+    let output = match tool_server
+        .call_tool_with_extensions(tool_name, &args, tool_extensions)
+        .await
+    {
         Ok(res) => res,
         Err(e) => {
             tracing::warn!("Error while executing tool: {e}");
@@ -598,6 +615,7 @@ where
                 AgentRunStep::CallTools { calls } => {
                     let hooks = &self.hooks;
                     let tool_server = &self.tool_server_handle;
+                    let tool_extensions = &self.tool_extensions;
                     // Materialize the diagnostic history once; tools only read it
                     // (verbatim, on a hook-terminate error path), so every tool
                     // future shares a single borrow instead of deep-cloning the
@@ -643,6 +661,7 @@ where
                                 run_single_tool(
                                     hooks,
                                     tool_server,
+                                    tool_extensions,
                                     &tool_call,
                                     &internal_call_id,
                                     error_history,

--- a/crates/rig-core/src/lib.rs
+++ b/crates/rig-core/src/lib.rs
@@ -177,6 +177,7 @@ pub mod streaming;
 #[cfg_attr(docsrs, doc(cfg(feature = "test-utils")))]
 pub mod test_utils;
 pub mod tool;
+pub use tool::ToolCallExtensions;
 pub mod tools;
 pub mod transcription;
 pub mod vector_store;

--- a/crates/rig-core/src/tool/extensions.rs
+++ b/crates/rig-core/src/tool/extensions.rs
@@ -1,0 +1,391 @@
+//! Per-call runtime context for tool execution.
+//!
+//! This module provides [`ToolCallExtensions`], a type-map that lets callers
+//! attach arbitrary typed values to a tool call and lets tools extract them at
+//! call time. Tools that don't need any extensions simply ignore them.
+//!
+//! The implementation follows the `AnyClone` pattern from the
+//! [`http::Extensions`](https://docs.rs/http/latest/http/struct.Extensions.html)
+//! type in the `http` crate, including the no-op [`IdHasher`] over `TypeId`
+//! keys.
+
+use std::any::{Any, TypeId, type_name};
+use std::collections::HashMap;
+use std::hash::{BuildHasherDefault, Hasher};
+
+#[cfg(not(target_family = "wasm"))]
+type AnyMap = HashMap<TypeId, Box<dyn AnyClone + Send + Sync>, BuildHasherDefault<IdHasher>>;
+
+#[cfg(target_family = "wasm")]
+type AnyMap = HashMap<TypeId, Box<dyn AnyClone>, BuildHasherDefault<IdHasher>>;
+
+// --- IdHasher (modeled after http::Extensions) ---
+
+/// Hasher for the `TypeId` keys of the type-map.
+///
+/// A `TypeId` is already a high-quality hash, so the keys do not need to be
+/// re-hashed with the default `SipHash`. The fast path stores the `u64` that
+/// `TypeId`'s `Hash` impl writes directly. The byte-oriented [`write`] fallback
+/// keeps this correct (never panicking) if a future `TypeId` representation
+/// hashes via a different `Hasher` method — a poor hash only costs extra probe
+/// work, never correctness, because the map still compares full `TypeId` keys.
+///
+/// [`write`]: Hasher::write
+#[derive(Default)]
+struct IdHasher(u64);
+
+impl Hasher for IdHasher {
+    #[inline]
+    fn write_u64(&mut self, id: u64) {
+        self.0 = id;
+    }
+
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        // Fallback path: fold the bytes so we never panic regardless of how
+        // `TypeId` chooses to hash itself.
+        for &byte in bytes {
+            self.0 = self.0.rotate_left(8) ^ u64::from(byte);
+        }
+    }
+
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+}
+
+// --- AnyClone helper trait (modeled after http::Extensions) ---
+
+#[cfg(not(target_family = "wasm"))]
+trait AnyClone: Any + Send + Sync {
+    fn clone_box(&self) -> Box<dyn AnyClone + Send + Sync>;
+    fn as_any(&self) -> &dyn Any;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+    fn into_any(self: Box<Self>) -> Box<dyn Any>;
+    fn type_name(&self) -> &'static str;
+}
+
+#[cfg(target_family = "wasm")]
+trait AnyClone: Any {
+    fn clone_box(&self) -> Box<dyn AnyClone>;
+    fn as_any(&self) -> &dyn Any;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+    fn into_any(self: Box<Self>) -> Box<dyn Any>;
+    fn type_name(&self) -> &'static str;
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl<T: Clone + Send + Sync + 'static> AnyClone for T {
+    fn clone_box(&self) -> Box<dyn AnyClone + Send + Sync> {
+        Box::new(self.clone())
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+        self
+    }
+    fn type_name(&self) -> &'static str {
+        type_name::<T>()
+    }
+}
+
+#[cfg(target_family = "wasm")]
+impl<T: Clone + 'static> AnyClone for T {
+    fn clone_box(&self) -> Box<dyn AnyClone> {
+        Box::new(self.clone())
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+        self
+    }
+    fn type_name(&self) -> &'static str {
+        type_name::<T>()
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl Clone for Box<dyn AnyClone + Send + Sync> {
+    fn clone(&self) -> Self {
+        // Explicit deref to dispatch via the trait object's vtable, not the
+        // blanket AnyClone impl on Box itself (which would recurse).
+        (**self).clone_box()
+    }
+}
+
+#[cfg(target_family = "wasm")]
+impl Clone for Box<dyn AnyClone> {
+    fn clone(&self) -> Self {
+        (**self).clone_box()
+    }
+}
+
+// --- ToolCallExtensions ---
+
+/// Per-call runtime extensions for tools.
+///
+/// A type-map that lets callers attach arbitrary typed values to a tool call
+/// (auth tokens, session IDs, conversation state, A2A `context_id`/`task_id`,
+/// …) and lets tools extract them by type. Tools that don't need any extension
+/// ignore it.
+///
+/// Inject extensions into an agent run with
+/// [`PromptRequest::with_tool_extensions`](crate::agent::prompt_request::PromptRequest::with_tool_extensions)
+/// (or the streaming equivalent); read them inside a tool by overriding
+/// [`Tool::call_with_extensions`](crate::tool::Tool::call_with_extensions).
+///
+/// Inspired by [`http::Extensions`](https://docs.rs/http/latest/http/struct.Extensions.html).
+/// Uses `Option<Box<HashMap>>` internally so that empty extensions (the common
+/// case when no caller-provided values are needed) require zero allocation, and
+/// a no-op [`IdHasher`] over the `TypeId` keys to avoid re-hashing them.
+///
+/// # Example
+/// ```
+/// use rig_core::tool::ToolCallExtensions;
+///
+/// let mut extensions = ToolCallExtensions::new();
+/// assert_eq!(extensions.insert(42u32), None);
+/// assert_eq!(extensions.get::<u32>(), Some(&42));
+/// ```
+#[derive(Default, Clone)]
+pub struct ToolCallExtensions {
+    map: Option<Box<AnyMap>>,
+}
+
+impl ToolCallExtensions {
+    /// Shared empty instance. Lets dispatch layers that need a default
+    /// value hand out a `'static` reference instead of constructing (and
+    /// having to own) a fresh value just to borrow it.
+    pub(crate) const EMPTY: ToolCallExtensions = ToolCallExtensions { map: None };
+
+    /// Create an empty set of extensions.
+    pub const fn new() -> Self {
+        Self::EMPTY
+    }
+
+    /// Insert a typed value, returning the previous value of the same type if
+    /// one was present (matching [`http::Extensions::insert`]).
+    #[cfg(not(target_family = "wasm"))]
+    pub fn insert<T: Clone + Send + Sync + 'static>(&mut self, val: T) -> Option<T> {
+        self.map
+            .get_or_insert_with(Default::default)
+            .insert(TypeId::of::<T>(), Box::new(val))
+            // The displaced value was stored under the same `TypeId`, so the
+            // downcast is guaranteed to succeed.
+            .and_then(|boxed| boxed.into_any().downcast::<T>().ok())
+            .map(|boxed| *boxed)
+    }
+
+    /// Insert a typed value, returning the previous value of the same type if
+    /// one was present (matching [`http::Extensions::insert`]).
+    #[cfg(target_family = "wasm")]
+    pub fn insert<T: Clone + 'static>(&mut self, val: T) -> Option<T> {
+        self.map
+            .get_or_insert_with(Default::default)
+            .insert(TypeId::of::<T>(), Box::new(val))
+            .and_then(|boxed| boxed.into_any().downcast::<T>().ok())
+            .map(|boxed| *boxed)
+    }
+
+    /// Get a reference to a value by type. Returns `None` if not present.
+    pub fn get<T: 'static>(&self) -> Option<&T> {
+        self.map
+            .as_ref()
+            .and_then(|map| map.get(&TypeId::of::<T>()))
+            // Explicit deref to dispatch via the trait object's vtable, not
+            // the blanket AnyClone impl that Box itself satisfies.
+            .and_then(|boxed| (**boxed).as_any().downcast_ref::<T>())
+    }
+
+    /// Get a mutable reference to a value by type. Returns `None` if not present.
+    pub fn get_mut<T: 'static>(&mut self) -> Option<&mut T> {
+        self.map
+            .as_mut()
+            .and_then(|map| map.get_mut(&TypeId::of::<T>()))
+            .and_then(|boxed| (**boxed).as_any_mut().downcast_mut::<T>())
+    }
+
+    /// Remove a value by type, returning it if present.
+    pub fn remove<T: 'static>(&mut self) -> Option<T> {
+        self.map
+            .as_mut()
+            .and_then(|map| map.remove(&TypeId::of::<T>()))
+            .and_then(|boxed| boxed.into_any().downcast::<T>().ok())
+            .map(|boxed| *boxed)
+    }
+
+    /// Check if a value of the given type is present.
+    pub fn contains<T: 'static>(&self) -> bool {
+        self.map
+            .as_ref()
+            .is_some_and(|map| map.contains_key(&TypeId::of::<T>()))
+    }
+
+    /// The number of values currently stored.
+    pub fn len(&self) -> usize {
+        self.map.as_ref().map_or(0, |map| map.len())
+    }
+
+    /// Whether no values are stored.
+    pub fn is_empty(&self) -> bool {
+        self.map.as_ref().is_none_or(|map| map.is_empty())
+    }
+}
+
+impl std::fmt::Debug for ToolCallExtensions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut dbg = f.debug_struct("ToolCallExtensions");
+        if let Some(map) = &self.map {
+            dbg.field("entries", &map.len());
+            let type_names: Vec<&'static str> = map.values().map(|v| (**v).type_name()).collect();
+            dbg.field("types", &type_names);
+        } else {
+            dbg.field("entries", &0);
+        }
+        dbg.finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insert_and_get_returns_value() {
+        let mut extensions = ToolCallExtensions::new();
+        extensions.insert(42u32);
+        assert_eq!(extensions.get::<u32>(), Some(&42));
+    }
+
+    #[test]
+    fn get_missing_type_returns_none() {
+        let extensions = ToolCallExtensions::new();
+        assert_eq!(extensions.get::<u32>(), None);
+    }
+
+    #[test]
+    fn insert_overwrites_same_type_and_returns_previous() {
+        let mut extensions = ToolCallExtensions::new();
+        assert_eq!(extensions.insert(1u32), None);
+        assert_eq!(extensions.insert(2u32), Some(1));
+        assert_eq!(extensions.get::<u32>(), Some(&2));
+    }
+
+    #[test]
+    fn different_types_are_independent() {
+        let mut extensions = ToolCallExtensions::new();
+        extensions.insert(42u32);
+        extensions.insert("hello".to_string());
+        assert_eq!(extensions.get::<u32>(), Some(&42));
+        assert_eq!(extensions.get::<String>(), Some(&"hello".to_string()));
+    }
+
+    #[test]
+    fn contains_returns_true_when_present() {
+        let mut extensions = ToolCallExtensions::new();
+        extensions.insert(42u32);
+        assert!(extensions.contains::<u32>());
+        assert!(!extensions.contains::<String>());
+    }
+
+    #[test]
+    fn len_and_is_empty_track_entries() {
+        let mut extensions = ToolCallExtensions::new();
+        assert!(extensions.is_empty());
+        assert_eq!(extensions.len(), 0);
+        extensions.insert(42u32);
+        extensions.insert("hello".to_string());
+        assert!(!extensions.is_empty());
+        assert_eq!(extensions.len(), 2);
+    }
+
+    #[test]
+    fn clone_produces_independent_copy() {
+        let mut extensions = ToolCallExtensions::new();
+        extensions.insert(42u32);
+        let mut cloned = extensions.clone();
+        cloned.insert(99u32);
+        assert_eq!(extensions.get::<u32>(), Some(&42));
+        assert_eq!(cloned.get::<u32>(), Some(&99));
+    }
+
+    #[test]
+    fn debug_shows_entry_count_and_types() {
+        let mut extensions = ToolCallExtensions::new();
+        extensions.insert(42u32);
+        extensions.insert("hi".to_string());
+        let debug = format!("{:?}", extensions);
+        assert!(debug.contains("entries: 2"));
+        assert!(debug.contains("u32"));
+        assert!(debug.contains("String"));
+    }
+
+    #[test]
+    fn empty_extensions_is_default() {
+        let extensions = ToolCallExtensions::default();
+        assert!(!extensions.contains::<u32>());
+    }
+
+    #[test]
+    fn empty_extensions_has_no_allocation() {
+        let extensions = ToolCallExtensions::new();
+        assert!(extensions.map.is_none());
+    }
+
+    #[test]
+    fn get_mut_modifies_in_place() {
+        let mut extensions = ToolCallExtensions::new();
+        extensions.insert(42u32);
+        if let Some(val) = extensions.get_mut::<u32>() {
+            *val = 99;
+        }
+        assert_eq!(extensions.get::<u32>(), Some(&99));
+    }
+
+    #[test]
+    fn remove_returns_value_and_clears_entry() {
+        let mut extensions = ToolCallExtensions::new();
+        extensions.insert(42u32);
+        assert_eq!(extensions.remove::<u32>(), Some(42));
+        assert!(!extensions.contains::<u32>());
+    }
+
+    #[test]
+    fn remove_missing_type_returns_none() {
+        let mut extensions = ToolCallExtensions::new();
+        assert_eq!(extensions.remove::<u32>(), None);
+    }
+
+    #[test]
+    fn many_distinct_types_round_trip_through_id_hasher() {
+        // Exercises the IdHasher across many TypeId keys to guard against
+        // collisions corrupting lookups.
+        let mut extensions = ToolCallExtensions::new();
+        extensions.insert(1u8);
+        extensions.insert(2u16);
+        extensions.insert(3u32);
+        extensions.insert(4u64);
+        extensions.insert(5i8);
+        extensions.insert(6i16);
+        extensions.insert(7i32);
+        extensions.insert("eight".to_string());
+        assert_eq!(extensions.get::<u8>(), Some(&1));
+        assert_eq!(extensions.get::<u16>(), Some(&2));
+        assert_eq!(extensions.get::<u32>(), Some(&3));
+        assert_eq!(extensions.get::<u64>(), Some(&4));
+        assert_eq!(extensions.get::<i8>(), Some(&5));
+        assert_eq!(extensions.get::<i16>(), Some(&6));
+        assert_eq!(extensions.get::<i32>(), Some(&7));
+        assert_eq!(extensions.get::<String>(), Some(&"eight".to_string()));
+        assert_eq!(extensions.len(), 8);
+    }
+}

--- a/crates/rig-core/src/tool/mod.rs
+++ b/crates/rig-core/src/tool/mod.rs
@@ -9,7 +9,10 @@
 //! The [ToolSet] struct is a collection of tools that can be used by an [Agent](crate::agent::Agent)
 //! and optionally RAGged.
 
+pub mod extensions;
 pub mod server;
+
+pub use extensions::ToolCallExtensions;
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
@@ -141,6 +144,24 @@ pub trait Tool: Sized + WasmCompatSend + WasmCompatSync {
         &self,
         args: Self::Args,
     ) -> impl Future<Output = Result<Self::Output, Self::Error>> + WasmCompatSend;
+
+    /// Tool execution with per-call runtime [extensions](ToolCallExtensions).
+    ///
+    /// Override this to read runtime values (auth tokens, session IDs, A2A
+    /// `context_id`/`task_id`, …) that the caller injected for this call. The
+    /// default ignores the extensions and delegates to [`Tool::call`].
+    ///
+    /// The agent loop always dispatches through this method, so overriding it is
+    /// sufficient to receive extensions. [`Tool::call`] is the extension-free
+    /// entry point and remains the right method to override for tools that don't
+    /// need any; if you override both, keep their behaviour consistent.
+    fn call_with_extensions(
+        &self,
+        args: Self::Args,
+        _extensions: &ToolCallExtensions,
+    ) -> impl Future<Output = Result<Self::Output, Self::Error>> + WasmCompatSend {
+        self.call(args)
+    }
 }
 
 /// Trait that represents an LLM tool that can be stored in a vector store and RAGged
@@ -181,6 +202,20 @@ pub trait ToolDyn: WasmCompatSend + WasmCompatSync {
 
     /// Calls the tool with JSON-encoded arguments and returns model-facing text.
     fn call<'a>(&'a self, args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>>;
+
+    /// Dynamic dispatch variant of tool execution with per-call runtime
+    /// [extensions](ToolCallExtensions).
+    ///
+    /// The default ignores the extensions and delegates to [`ToolDyn::call`].
+    /// The blanket impl for [`Tool`] types overrides this to thread the
+    /// extensions through to [`Tool::call_with_extensions`].
+    fn call_with_extensions<'a>(
+        &'a self,
+        args: String,
+        _extensions: &'a ToolCallExtensions,
+    ) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
+        self.call(args)
+    }
 }
 
 fn serialize_tool_output(output: impl Serialize) -> serde_json::Result<String> {
@@ -200,6 +235,14 @@ impl<T: Tool> ToolDyn for T {
     }
 
     fn call<'a>(&'a self, args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
+        ToolDyn::call_with_extensions(self, args, &ToolCallExtensions::EMPTY)
+    }
+
+    fn call_with_extensions<'a>(
+        &'a self,
+        args: String,
+        extensions: &'a ToolCallExtensions,
+    ) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
         Box::pin(async move {
             // LLMs frequently send `null` for tools whose arguments are all optional.
             // `serde_json::from_str::<T>("null")` fails for struct types even when
@@ -213,7 +256,7 @@ impl<T: Tool> ToolDyn for T {
                 Err(err) => Err(err),
             };
             match args {
-                Ok(args) => <Self as Tool>::call(self, args)
+                Ok(args) => <Self as Tool>::call_with_extensions(self, args, extensions)
                     .await
                     .map_err(|e| ToolError::ToolCallError(Box::new(e)))
                     .and_then(|output| serialize_tool_output(output).map_err(ToolError::JsonError)),
@@ -270,10 +313,14 @@ impl ToolType {
         }
     }
 
-    pub async fn call(&self, args: String) -> Result<String, ToolError> {
+    pub async fn call_with_extensions(
+        &self,
+        args: String,
+        extensions: &ToolCallExtensions,
+    ) -> Result<String, ToolError> {
         match self {
-            ToolType::Simple(tool) => tool.call(args).await,
-            ToolType::Embedding(tool) => tool.call(args).await,
+            ToolType::Simple(tool) => tool.call_with_extensions(args, extensions).await,
+            ToolType::Embedding(tool) => tool.call_with_extensions(args, extensions).await,
         }
     }
 }
@@ -402,12 +449,28 @@ impl ToolSet {
 
     /// Call a tool with the given name and arguments
     pub async fn call(&self, toolname: &str, args: String) -> Result<String, ToolSetError> {
+        self.call_with_extensions(toolname, args, &ToolCallExtensions::EMPTY)
+            .await
+    }
+
+    /// Call a tool with the given name, arguments, and per-call runtime
+    /// [extensions](ToolCallExtensions).
+    ///
+    /// The extensions are threaded through to [`Tool::call_with_extensions`],
+    /// allowing tools to access caller-provided values (auth tokens, session
+    /// IDs, etc.).
+    pub async fn call_with_extensions(
+        &self,
+        toolname: &str,
+        args: String,
+        extensions: &ToolCallExtensions,
+    ) -> Result<String, ToolSetError> {
         if let Some(tool) = self.tools.get(toolname) {
             tracing::debug!(target: "rig",
                 "Calling tool {toolname} with args:\n{}",
                 args
             );
-            Ok(tool.call(args).await?)
+            Ok(tool.call_with_extensions(args, extensions).await?)
         } else {
             Err(ToolSetError::ToolNotFoundError(toolname.to_string()))
         }

--- a/crates/rig-core/src/tool/server.rs
+++ b/crates/rig-core/src/tool/server.rs
@@ -4,7 +4,7 @@ use tokio::sync::RwLock;
 
 use crate::{
     completion::{CompletionError, ToolDefinition},
-    tool::{Tool, ToolDyn, ToolSet, ToolSetError},
+    tool::{Tool, ToolCallExtensions, ToolDyn, ToolSet, ToolSetError},
     vector_store::{VectorSearchRequest, VectorStoreError, VectorStoreIndexDyn, request::Filter},
 };
 
@@ -186,6 +186,23 @@ impl ToolServerHandle {
     /// The tool handle is cloned under a brief read lock so that
     /// long-running tool executions never block writers.
     pub async fn call_tool(&self, tool_name: &str, args: &str) -> Result<String, ToolServerError> {
+        self.call_tool_with_extensions(tool_name, args, &ToolCallExtensions::EMPTY)
+            .await
+    }
+
+    /// Look up and execute a tool by name with per-call runtime
+    /// [extensions](ToolCallExtensions).
+    ///
+    /// The extensions are threaded through to [`Tool::call_with_extensions`],
+    /// allowing tools to access caller-provided values (auth tokens, session
+    /// IDs, etc.). The tool handle is cloned under a brief read lock so that
+    /// long-running tool executions never block writers.
+    pub async fn call_tool_with_extensions(
+        &self,
+        tool_name: &str,
+        args: &str,
+        extensions: &ToolCallExtensions,
+    ) -> Result<String, ToolServerError> {
         let tool = {
             let state = self.0.read().await;
             state.toolset.get(tool_name).cloned()
@@ -197,7 +214,7 @@ impl ToolServerHandle {
                     "Calling tool {tool_name} with args:\n{}",
                     serde_json::to_string_pretty(&args).unwrap_or_default()
                 );
-                tool.call(args.to_string())
+                tool.call_with_extensions(args.to_string(), extensions)
                     .await
                     .map_err(|e| ToolSetError::ToolCallError(e).into())
             }
@@ -590,5 +607,89 @@ mod tests {
         let tool_names: Vec<&str> = defs.iter().map(|t| t.name.as_str()).collect();
         assert!(tool_names.contains(&"add"));
         assert!(tool_names.contains(&"subtract"));
+    }
+
+    // --- call_with_extensions tests ---
+
+    #[derive(Clone)]
+    struct SessionId(String);
+
+    #[derive(serde::Deserialize, serde::Serialize)]
+    struct ExtensionsReader;
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("extensions reader error")]
+    struct ExtensionsReaderError;
+
+    impl crate::tool::Tool for ExtensionsReader {
+        const NAME: &'static str = "extensions_reader";
+        type Error = ExtensionsReaderError;
+        type Args = serde_json::Value;
+        type Output = String;
+
+        async fn definition(&self, _prompt: String) -> crate::completion::ToolDefinition {
+            crate::completion::ToolDefinition {
+                name: "extensions_reader".to_string(),
+                description: "Reads SessionId from the call extensions".to_string(),
+                parameters: serde_json::json!({"type": "object", "properties": {}}),
+            }
+        }
+
+        async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
+            Ok("no extensions".to_string())
+        }
+
+        async fn call_with_extensions(
+            &self,
+            _args: Self::Args,
+            extensions: &crate::tool::ToolCallExtensions,
+        ) -> Result<Self::Output, Self::Error> {
+            match extensions.get::<SessionId>() {
+                Some(session) => Ok(format!("session:{}", session.0)),
+                None => Ok("no session".to_string()),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_call_tool_with_extensions_reaches_tool() {
+        let server = ToolServer::new().tool(ExtensionsReader);
+        let handle = server.run();
+
+        let mut extensions = crate::tool::ToolCallExtensions::new();
+        extensions.insert(SessionId("abc-123".to_string()));
+
+        let result = handle
+            .call_tool_with_extensions("extensions_reader", "{}", &extensions)
+            .await
+            .unwrap();
+
+        assert_eq!(result, "session:abc-123");
+    }
+
+    #[tokio::test]
+    async fn test_call_tool_without_extensions_uses_default() {
+        let server = ToolServer::new().tool(ExtensionsReader);
+        let handle = server.run();
+
+        let result = handle.call_tool("extensions_reader", "{}").await.unwrap();
+        assert_eq!(result, "no session");
+    }
+
+    #[tokio::test]
+    async fn test_tool_ignoring_extensions_still_works() {
+        let server = ToolServer::new().tool(MockAddTool);
+        let handle = server.run();
+
+        let mut extensions = crate::tool::ToolCallExtensions::new();
+        extensions.insert(SessionId("ignored".to_string()));
+
+        let args = serde_json::to_string(&serde_json::json!({"x": 3, "y": 7})).unwrap();
+        let result = handle
+            .call_tool_with_extensions("add", &args, &extensions)
+            .await
+            .unwrap();
+
+        assert_eq!(result, "10");
     }
 }


### PR DESCRIPTION
Closes #1536. Supersedes #1537 (and the stacked #1952) by reimplementing the feature on current `main`, where the #1945 refactor unified tool dispatch into a single `run_single_tool` site.

## What

`ToolCallExtensions` is a per-call, type-erased type-map that lets callers attach arbitrary typed values to a tool call — auth tokens, session IDs, A2A `context_id`/`task_id`, conversation state — and lets tools read them by type, without exposing anything to the model.

```rust
use rig_core::tool::ToolCallExtensions;

#[derive(Clone)]
struct SessionId(String);

let mut extensions = ToolCallExtensions::new();
extensions.insert(SessionId("session-123".to_string()));

let answer = agent
    .prompt("do the thing")
    .with_tool_extensions(extensions) // also on `.stream_prompt(..)`
    .await?;
```

A tool reads them by overriding `call_with_extensions`:

```rust
impl Tool for MyTool {
    // ...
    async fn call_with_extensions(
        &self,
        args: Self::Args,
        extensions: &ToolCallExtensions,
    ) -> Result<Self::Output, Self::Error> {
        let session = extensions.get::<SessionId>();
        // ...
    }
}
```

## How

**The type** (`tool/extensions.rs`) is a faithful port of `http::Extensions`' `AnyClone` pattern: type-erased, cloneable, zero-allocation when empty (`Option<Box<HashMap>>`), `TypeId` keys hashed with a no-op `IdHasher` (no SipHash). `insert` returns the displaced value like `http::Extensions`; `len`/`is_empty` provided; WASM-gated via `cfg(target_family = "wasm")`.

**The dispatch chain** gains a parallel `call_with_extensions` on `Tool` → `ToolDyn` → `ToolType` → `ToolSet` → `ToolServerHandle`, each defaulting to the existing extension-free `call`. Fully backward compatible — every existing `Tool`/`ToolDyn` impl keeps working unchanged.

**The agent loop** is the part #1537 was missing: a `tool_extensions` field on `AgentRunner` (the shared blocking + streaming driver) is threaded into the single `run_single_tool` dispatch site (borrowed, not cloned, so no per-call deep copy), and surfaced via `.with_tool_extensions(..)` on `PromptRequest` and `StreamingPromptRequest`. Per-call injection, mirroring pydantic-ai's per-run `deps=`.

## Design notes (vs #1537)

- **Named `ToolCallExtensions`** rather than `ToolCallContext`, to avoid colliding with the `rmcp` dependency's own `ToolCallContext` (a different concept) and rig's `InvalidToolCallContext` / `Tool::Context`, and to match the `Extensions` vocabulary the maintainers want to converge on.
- **No dead code:** `call_with_extensions` fully replaces the internal dispatch, and the now-redundant `ToolType::call` is removed (not `#[allow(dead_code)]`'d).
- **`http::Extensions` parity:** `insert -> Option<T>`, `IdHasher`, `len`/`is_empty`.

## Test plan
- [x] `cargo test -p rig-core --lib` — 1013 passed, 0 failed (incl. blocking + streaming end-to-end tests that an injected value reaches a tool, and that the default path dispatches an empty map)
- [x] `cargo test -p rig-core --doc` — 82 passed, 0 failed
- [x] `cargo clippy -p rig-core --lib --tests -- -D warnings` — clean
- [x] `cargo fmt -p rig-core -- --check` — clean
- [x] `cargo check -p rig-core --features rmcp` — clean
- [x] `cargo check -p rig-core --target wasm32-unknown-unknown --no-default-features --features wasm` — clean (exercises the `cfg(target_family = "wasm")` branch)

## Notes
- Per-call injection only (matches pydantic-ai). An agent-level default on the builder could be layered on later.
- Co-authored with @redroy44, whose #1537 established the approach and the A2A motivation.