### PR TITLE
feat(neo4j): implement InsertDocuments for Neo4jVectorIndex

### DIFF
--- a/crates/rig-neo4j/CHANGELOG.md
+++ b/crates/rig-neo4j/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+- *(neo4j)* implement `InsertDocuments` for `Neo4jVectorIndex` — bulk-insert documents with precomputed embeddings via a single `UNWIND` Cypher write (one node per embedding, document fields flattened onto the node alongside `embedded_text` and the configured embedding property). Nodes are written under the index's label, which `get_index` now resolves from the index's `labelsOrTypes` (default `Document`); `IndexConfig` gains a `node_label` field + builder. (closes [#1636](https://github.com/0xPlaygrounds/rig/issues/1636))
+
 ## [0.38.1](https://github.com/0xPlaygrounds/rig/compare/rig-neo4j-v0.5.7...rig-neo4j-v0.38.1) - 2026-06-02
 
 ### Other

--- a/crates/rig-neo4j/src/lib.rs
+++ b/crates/rig-neo4j/src/lib.rs
@@ -279,9 +279,9 @@ where
 impl Neo4jClient {
     const GET_INDEX_QUERY: &'static str = "
     SHOW VECTOR INDEXES
-    YIELD name, properties, options
+    YIELD name, labelsOrTypes, properties, options
     WHERE name=$index_name
-    RETURN name, properties, options
+    RETURN name, labelsOrTypes, properties, options
     ";
 
     const SHOW_INDEXES_QUERY: &'static str = "SHOW VECTOR INDEXES YIELD name RETURN name";
@@ -332,8 +332,10 @@ impl Neo4jClient {
         index_name: &str,
     ) -> Result<Neo4jVectorIndex<M>, VectorStoreError> {
         #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
         struct IndexInfo {
             name: String,
+            labels_or_types: Vec<String>,
             properties: Vec<String>,
             options: IndexOptions,
         }
@@ -373,11 +375,17 @@ impl Neo4jClient {
                     "Neo4j index is missing an embedding property",
                 )))
             })?;
-            IndexConfig::new(index.name.clone())
+            let mut config = IndexConfig::new(index.name.clone())
                 .embedding_property(embedding_property)
                 .similarity_function(VectorSimilarityFunction::from_str(
                     &index.options.index_config.vector_similarity_function,
-                )?)
+                )?);
+            // Preserve the node label the index is attached to so `insert_documents`
+            // writes to the same label.
+            if let Some(label) = index.labels_or_types.first() {
+                config = config.node_label(label);
+            }
+            config
         } else {
             let indexes = Self::execute_and_collect::<String>(
                 &self.graph,

--- a/crates/rig-neo4j/src/vector_index.rs
+++ b/crates/rig-neo4j/src/vector_index.rs
@@ -6,15 +6,16 @@
 
 use neo4rs::{Graph, Query};
 use rig_core::{
+    Embed, OneOrMany,
     embeddings::{Embedding, EmbeddingModel},
     vector_store::{
-        VectorStoreError, VectorStoreIndex,
+        InsertDocuments, VectorStoreError, VectorStoreIndex,
         request::{SearchFilter, VectorSearchRequest},
     },
 };
 use serde::{Deserialize, Serialize, de::Error};
 
-use crate::{Neo4jClient, Neo4jSearchFilter};
+use crate::{Neo4jClient, Neo4jSearchFilter, ToBoltType};
 
 pub struct Neo4jVectorIndex<M>
 where
@@ -32,11 +33,16 @@ where
 /// - `index_name`: "vector_index"
 /// - `embedding_property`: "embedding"
 /// - `similarity_function`: VectorSimilarityFunction::Cosine
+/// - `node_label`: None (inserts default to the `Document` label)
 #[derive(Serialize, Deserialize, Clone)]
 pub struct IndexConfig {
     pub index_name: String,
     pub embedding_property: String,
     pub similarity_function: VectorSimilarityFunction,
+    /// The node label that [`InsertDocuments`] writes to (and that the index
+    /// applies to). Populated from the index's `labelsOrTypes` when loaded via
+    /// [`Neo4jClient::get_index`](crate::Neo4jClient::get_index).
+    pub node_label: Option<String>,
 }
 
 impl Default for IndexConfig {
@@ -45,6 +51,7 @@ impl Default for IndexConfig {
             index_name: "vector_index".to_string(),
             embedding_property: "embedding".to_string(),
             similarity_function: VectorSimilarityFunction::Cosine,
+            node_label: None,
         }
     }
 }
@@ -55,6 +62,7 @@ impl IndexConfig {
             index_name: index_name.into(),
             embedding_property: "embedding".to_string(),
             similarity_function: VectorSimilarityFunction::Cosine,
+            node_label: None,
         }
     }
 
@@ -70,6 +78,12 @@ impl IndexConfig {
 
     pub fn embedding_property(mut self, embedding_property: &str) -> Self {
         self.embedding_property = embedding_property.to_string();
+        self
+    }
+
+    /// Sets the node label that [`InsertDocuments`] writes to.
+    pub fn node_label(mut self, node_label: &str) -> Self {
+        self.node_label = Some(node_label.to_string());
         self
     }
 }
@@ -266,5 +280,97 @@ where
             .collect::<Vec<_>>();
 
         Ok(results)
+    }
+}
+
+/// The node label [`InsertDocuments`] writes to when the index config does not
+/// specify one (i.e. `node_label` is `None`).
+const DEFAULT_NODE_LABEL: &str = "Document";
+
+/// The Cypher used to bulk-insert nodes from an `$items` parameter list.
+fn insert_documents_query(node_label: &str) -> String {
+    format!("UNWIND $items AS item CREATE (n:{node_label}) SET n = item")
+}
+
+impl<M> InsertDocuments for Neo4jVectorIndex<M>
+where
+    M: EmbeddingModel + Send + Sync,
+{
+    /// Inserts one node per embedding, flattening the document's JSON fields
+    /// onto the node alongside the embedding (`embedding_property`) and its
+    /// source text (`embedded_text`). Nodes are written under the index's
+    /// `node_label`, defaulting to [`DEFAULT_NODE_LABEL`].
+    async fn insert_documents<Doc: Serialize + Embed + Send>(
+        &self,
+        documents: Vec<(Doc, OneOrMany<Embedding>)>,
+    ) -> Result<(), VectorStoreError> {
+        let node_label = self
+            .index_config
+            .node_label
+            .as_deref()
+            .unwrap_or(DEFAULT_NODE_LABEL);
+        let embedding_property = &self.index_config.embedding_property;
+
+        // Build one parameter map per embedding for a single UNWIND insert.
+        let mut items: Vec<neo4rs::BoltType> = Vec::new();
+        for (document, embeddings) in documents {
+            let json_doc = serde_json::to_value(&document)?;
+
+            for embedding in embeddings {
+                let mut props = neo4rs::BoltMap::new();
+                if let serde_json::Value::Object(map) = &json_doc {
+                    for (key, value) in map {
+                        props.put(neo4rs::BoltString::new(key), value.to_bolt_type());
+                    }
+                } else {
+                    props.put(neo4rs::BoltString::new("document"), json_doc.to_bolt_type());
+                }
+                props.put(
+                    neo4rs::BoltString::new("embedded_text"),
+                    neo4rs::BoltType::String(neo4rs::BoltString::new(&embedding.document)),
+                );
+                props.put(
+                    neo4rs::BoltString::new(embedding_property),
+                    embedding.vec.to_bolt_type(),
+                );
+                items.push(neo4rs::BoltType::Map(props));
+            }
+        }
+
+        self.graph
+            .run(neo4rs::query(&insert_documents_query(node_label)).param("items", items))
+            .await
+            .map_err(|e| VectorStoreError::DatastoreError(Box::new(e)))?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn node_label_defaults_to_none_and_builder_sets_it() {
+        assert_eq!(IndexConfig::new("idx").node_label, None);
+        assert_eq!(
+            IndexConfig::new("idx")
+                .node_label("Movie")
+                .node_label
+                .as_deref(),
+            Some("Movie"),
+        );
+    }
+
+    #[test]
+    fn insert_documents_query_uses_label_else_default() {
+        assert_eq!(
+            insert_documents_query("Movie"),
+            "UNWIND $items AS item CREATE (n:Movie) SET n = item",
+        );
+        assert_eq!(
+            insert_documents_query(DEFAULT_NODE_LABEL),
+            "UNWIND $items AS item CREATE (n:Document) SET n = item",
+        );
     }
 }


### PR DESCRIPTION
Closes #1636. Reimplements that PR on current main (the crate moved from
`rig-integrations/` to `crates/rig-neo4j/` and `get_index` was refactored since,
so the original no longer rebases).

## Why

Neo4j and LanceDB are the only two of the ten built-in vector stores that don't
implement `InsertDocuments` (the other eight do). This fills the neo4j half, so a
`Neo4jVectorIndex` can ingest documents with precomputed embeddings directly via
the common trait instead of dropping to raw Cypher. (LanceDB follows in a stacked
PR.)

## What

- **`impl InsertDocuments for Neo4jVectorIndex`** — a single
  `UNWIND $items AS item CREATE (n:<label>) SET n = item` write: one node per
  embedding, with the document's JSON object fields flattened onto the node
  (non-object docs are stored under a `document` key), plus `embedded_text` (the
  source text) and the configured `embedding_property` (the vector). Reuses the
  crate's existing `ToBoltType` for value conversion.
- **Node label resolution** — `IndexConfig` gains a `node_label: Option<String>`
  field + builder, and `Neo4jClient::get_index` now yields `labelsOrTypes` and
  populates it, so inserts write to the same label the loaded index covers
  (defaulting to `Document` when unset).

## Tests

DB-touching coverage for vector stores in this repo lives in examples (a live
Neo4j isn't available in unit tests, and no sibling has a direct `insert_documents`
unit test). The added unit tests cover the deterministic logic: the `node_label`
default/builder, and the generated Cypher for a custom vs default label.

Verified: `cargo test -p rig-neo4j` (2 new tests pass), `clippy --all-targets`,
and `fmt` all clean.