### PR TITLE
feat(lancedb): implement InsertDocuments for LanceDbVectorIndex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ target/
 # nodejs stuff
 node_modules/
 dist/
+
+# local LanceDB stores created by integration tests
+/data/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9716,6 +9716,7 @@ version = "0.39.0"
 dependencies = [
  "anyhow",
  "arrow-array",
+ "arrow-json",
  "deranged",
  "futures",
  "httpmock",

--- a/crates/rig-lancedb/CHANGELOG.md
+++ b/crates/rig-lancedb/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+- *(lancedb)* implement `InsertDocuments` for `LanceDbVectorIndex` — append documents with precomputed embeddings directly into the backing table (one row per embedding). The document's JSON fields are decoded into the table's non-embedding columns via `arrow-json` and the vector is written to the `FixedSizeList<Float32|Float64>` column, auto-detected from the schema (or taken from `SearchParams::column`). Adds an `arrow-json` dependency. (closes [#1658](https://github.com/0xPlaygrounds/rig/issues/1658))
+
 ## [0.38.1](https://github.com/0xPlaygrounds/rig/compare/rig-lancedb-v0.4.7...rig-lancedb-v0.38.1) - 2026-06-02
 
 ### Other

--- a/crates/rig-lancedb/Cargo.toml
+++ b/crates/rig-lancedb/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 lancedb = { workspace = true }
 rig-core = { path = "../rig-core", version = "0.39.0", default-features = false }
 arrow-array = { workspace = true }
+arrow-json = "58"
 serde_json = { workspace = true }
 serde = { workspace = true }
 futures = { workspace = true }

--- a/crates/rig-lancedb/src/lib.rs
+++ b/crates/rig-lancedb/src/lib.rs
@@ -19,19 +19,27 @@
 //! `lancedb` feature is enabled.
 
 use std::ops::Range;
+use std::sync::Arc;
 
+use arrow_array::{
+    ArrayRef, FixedSizeListArray, RecordBatch,
+    types::{Float32Type, Float64Type},
+};
+use arrow_json::ReaderBuilder;
 use lancedb::{
     DistanceType,
+    arrow::arrow_schema::{DataType, Field, Fields, Schema},
     query::{QueryBase, VectorQuery},
 };
 use rig_core::{
-    embeddings::embedding::EmbeddingModel,
+    Embed, OneOrMany,
+    embeddings::{Embedding, embedding::EmbeddingModel},
     vector_store::{
-        VectorStoreError, VectorStoreIndex,
+        InsertDocuments, VectorStoreError, VectorStoreIndex,
         request::{FilterError, SearchFilter, VectorSearchRequest},
     },
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use utils::{FilterTableColumns, QueryToJson};
 
@@ -43,6 +51,10 @@ fn lancedb_to_rig_error(e: lancedb::Error) -> VectorStoreError {
 
 fn serde_to_rig_error(e: serde_json::Error) -> VectorStoreError {
     VectorStoreError::JsonError(e)
+}
+
+fn arrow_to_rig_error(e: lancedb::arrow::arrow_schema::ArrowError) -> VectorStoreError {
+    VectorStoreError::DatastoreError(Box::new(e))
 }
 
 /// Type on which vector searches can be performed for a lanceDb table.
@@ -128,6 +140,48 @@ where
         }
 
         query
+    }
+}
+
+/// Resolve the embedding column: an explicit `configured` column wins, otherwise
+/// auto-detect the single `FixedSizeList<Float32|Float64>` column in the schema
+/// (the same default LanceDB uses to pick a vector column). Errors if there is
+/// no such column or more than one and none was configured.
+fn resolve_embedding_column(
+    schema: &Schema,
+    configured: Option<&str>,
+) -> Result<String, VectorStoreError> {
+    if let Some(column) = configured {
+        return Ok(column.to_string());
+    }
+
+    let candidates: Vec<&str> = schema
+        .fields()
+        .iter()
+        .filter(|field| {
+            matches!(
+                field.data_type(),
+                DataType::FixedSizeList(inner, _)
+                    if matches!(inner.data_type(), DataType::Float32 | DataType::Float64)
+            )
+        })
+        .map(|field| field.name().as_str())
+        .collect();
+
+    match candidates.as_slice() {
+        [only] => Ok((*only).to_string()),
+        [] => Err(VectorStoreError::DatastoreError(
+            "no FixedSizeList<Float32|Float64> column found in table schema; \
+             set SearchParams::column to specify the embedding column"
+                .into(),
+        )),
+        _ => Err(VectorStoreError::DatastoreError(
+            format!(
+                "multiple FixedSizeList columns found ({candidates:?}); \
+                 set SearchParams::column to disambiguate"
+            )
+            .into(),
+        )),
     }
 }
 
@@ -499,5 +553,200 @@ where
                 ))
             })
             .collect()
+    }
+}
+
+/// Insert `(Doc, OneOrMany<Embedding>)` pairs directly into the backing LanceDB
+/// table without hand-building Arrow `RecordBatch`es.
+///
+/// Each embedding produces one row: the document's JSON fields are flattened
+/// onto that row (a non-object doc is stored under a `document` field), and the
+/// embedding vector is written to the table's `FixedSizeList<Float32|Float64>`
+/// column. The embedding column is taken from [`SearchParams::column`] when set,
+/// otherwise auto-detected. Doc fields absent from the table schema are dropped
+/// by the Arrow JSON decoder, so rows must be consistent with the schema the
+/// table was created with.
+impl<M> InsertDocuments for LanceDbVectorIndex<M>
+where
+    M: EmbeddingModel + Sync + Send,
+{
+    async fn insert_documents<Doc: Serialize + Embed + Send>(
+        &self,
+        documents: Vec<(Doc, OneOrMany<Embedding>)>,
+    ) -> Result<(), VectorStoreError> {
+        if documents.is_empty() {
+            return Ok(());
+        }
+
+        let table_schema: Arc<Schema> = self.table.schema().await.map_err(lancedb_to_rig_error)?;
+        let embedding_column =
+            resolve_embedding_column(&table_schema, self.search_params.column.as_deref())?;
+
+        let embedding_field = table_schema
+            .field_with_name(&embedding_column)
+            .map_err(arrow_to_rig_error)?
+            .clone();
+        let (embedding_inner_dtype, embedding_dims) = match embedding_field.data_type() {
+            DataType::FixedSizeList(inner, dims) => (inner.data_type().clone(), *dims),
+            _ => {
+                return Err(VectorStoreError::DatastoreError(
+                    format!("embedding column `{embedding_column}` is not a FixedSizeList").into(),
+                ));
+            }
+        };
+
+        // Decode the document rows against the non-embedding columns, then splice
+        // the embedding column back in at its schema position.
+        let non_embedding_fields: Vec<Arc<Field>> = table_schema
+            .fields()
+            .iter()
+            .filter(|field| field.name() != &embedding_column)
+            .cloned()
+            .collect();
+        let non_embedding_schema = Arc::new(Schema::new(Fields::from(non_embedding_fields)));
+
+        let mut json_rows: Vec<Value> = Vec::new();
+        let mut embedding_vecs: Vec<Vec<f64>> = Vec::new();
+        for (doc, embeddings) in documents {
+            let doc_value = serde_json::to_value(&doc).map_err(serde_to_rig_error)?;
+            for embedding in embeddings.into_iter() {
+                if embedding.vec.len() != embedding_dims as usize {
+                    return Err(VectorStoreError::DatastoreError(
+                        format!(
+                            "embedding dim mismatch: got {} expected {embedding_dims} for column `{embedding_column}`",
+                            embedding.vec.len(),
+                        )
+                        .into(),
+                    ));
+                }
+                let row = match &doc_value {
+                    Value::Object(_) => doc_value.clone(),
+                    other => {
+                        let mut map = serde_json::Map::new();
+                        map.insert("document".to_string(), other.clone());
+                        Value::Object(map)
+                    }
+                };
+                json_rows.push(row);
+                embedding_vecs.push(embedding.vec);
+            }
+        }
+
+        let mut decoder = ReaderBuilder::new(non_embedding_schema.clone())
+            .build_decoder()
+            .map_err(arrow_to_rig_error)?;
+        decoder.serialize(&json_rows).map_err(arrow_to_rig_error)?;
+        let partial_batch = decoder
+            .flush()
+            .map_err(arrow_to_rig_error)?
+            .ok_or_else(|| {
+                VectorStoreError::DatastoreError("arrow-json decoder produced no batch".into())
+            })?;
+
+        let embedding_array: ArrayRef = match embedding_inner_dtype {
+            DataType::Float64 => {
+                Arc::new(
+                    FixedSizeListArray::from_iter_primitive::<Float64Type, _, _>(
+                        embedding_vecs
+                            .iter()
+                            .map(|v| Some(v.iter().copied().map(Some).collect::<Vec<_>>()))
+                            .collect::<Vec<_>>(),
+                        embedding_dims,
+                    ),
+                )
+            }
+            DataType::Float32 => {
+                Arc::new(
+                    FixedSizeListArray::from_iter_primitive::<Float32Type, _, _>(
+                        embedding_vecs
+                            .iter()
+                            .map(|v| Some(v.iter().map(|x| Some(*x as f32)).collect::<Vec<_>>()))
+                            .collect::<Vec<_>>(),
+                        embedding_dims,
+                    ),
+                )
+            }
+            other => {
+                return Err(VectorStoreError::DatastoreError(
+                    format!(
+                        "unsupported embedding inner dtype `{other:?}`; expected Float32 or Float64"
+                    )
+                    .into(),
+                ));
+            }
+        };
+
+        let mut columns: Vec<ArrayRef> = Vec::with_capacity(table_schema.fields().len());
+        for field in table_schema.fields() {
+            if field.name() == &embedding_column {
+                columns.push(embedding_array.clone());
+            } else {
+                let idx = non_embedding_schema
+                    .index_of(field.name())
+                    .map_err(arrow_to_rig_error)?;
+                columns.push(partial_batch.column(idx).clone());
+            }
+        }
+
+        let batch = RecordBatch::try_new(table_schema, columns).map_err(arrow_to_rig_error)?;
+
+        self.table
+            .add(vec![batch])
+            .execute()
+            .await
+            .map_err(lancedb_to_rig_error)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixed_size_list(inner: DataType) -> DataType {
+        DataType::FixedSizeList(Arc::new(Field::new("item", inner, true)), 4)
+    }
+
+    fn schema_with(fields: Vec<(&str, DataType)>) -> Schema {
+        Schema::new(
+            fields
+                .into_iter()
+                .map(|(name, dt)| Field::new(name, dt, true))
+                .collect::<Fields>(),
+        )
+    }
+
+    #[test]
+    fn resolve_embedding_column_auto_detects_single_vector_column() {
+        let schema = schema_with(vec![
+            ("id", DataType::Utf8),
+            ("embedding", fixed_size_list(DataType::Float64)),
+        ]);
+        assert_eq!(
+            resolve_embedding_column(&schema, None).unwrap(),
+            "embedding"
+        );
+    }
+
+    #[test]
+    fn resolve_embedding_column_prefers_configured_override() {
+        let schema = schema_with(vec![
+            ("vec_a", fixed_size_list(DataType::Float32)),
+            ("vec_b", fixed_size_list(DataType::Float64)),
+        ]);
+        // Ambiguous without an override...
+        assert!(resolve_embedding_column(&schema, None).is_err());
+        // ...but the explicit column is honored.
+        assert_eq!(
+            resolve_embedding_column(&schema, Some("vec_b")).unwrap(),
+            "vec_b"
+        );
+    }
+
+    #[test]
+    fn resolve_embedding_column_errors_when_no_vector_column() {
+        let schema = schema_with(vec![("id", DataType::Utf8), ("n", DataType::Int64)]);
+        assert!(resolve_embedding_column(&schema, None).is_err());
     }
 }

--- a/tests/integrations/lancedb/fixtures/lib.rs
+++ b/tests/integrations/lancedb/fixtures/lib.rs
@@ -3,9 +3,9 @@ use std::sync::Arc;
 use arrow_array::{ArrayRef, FixedSizeListArray, RecordBatch, StringArray, types::Float64Type};
 use rig::embeddings::Embedding;
 use rig::{Embed, OneOrMany};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Embed, Clone, Deserialize, Debug)]
+#[derive(Embed, Clone, Deserialize, Serialize, Debug)]
 pub struct Word {
     pub id: String,
     #[embed]

--- a/tests/integrations/lancedb/mod.rs
+++ b/tests/integrations/lancedb/mod.rs
@@ -17,7 +17,7 @@ use rig::{
     embeddings::{EmbeddingModel, EmbeddingsBuilder},
     prelude::CompletionClient,
     providers::openai,
-    vector_store::{VectorStoreIndex, request::VectorSearchRequest},
+    vector_store::{InsertDocuments, VectorStoreIndex, request::VectorSearchRequest},
 };
 
 #[path = "./fixtures/lib.rs"]
@@ -407,6 +407,132 @@ async fn agent_with_dynamic_context_test() {
 
     assert!(response.contains("zindle") || response.contains("pretend to be working"));
     assert!(response.contains("important") || response.contains("unproductive"));
+
+    db.drop_table(table_name, &[]).await.unwrap();
+}
+
+#[tokio::test]
+async fn insert_documents_test() {
+    // Mock embeddings per distinct request: the response `data` length must
+    // match the request `input` length. We don't assert ranking, so the vector
+    // values are arbitrary.
+    let server = httpmock::MockServer::start();
+    let embedding = |index: usize| json!({ "object": "embedding", "embedding": vec![0.1; 1536], "index": index });
+    // Seed row (1 input).
+    server.mock(|when, then| {
+        when.method(httpmock::Method::POST)
+            .path("/embeddings")
+            .json_body(json!({ "input": ["seed row"], "model": "text-embedding-ada-002" }));
+        then.status(200).header("content-type", "application/json").json_body(json!({
+            "object": "list", "data": [embedding(0)],
+            "model": "text-embedding-ada-002", "usage": { "prompt_tokens": 8, "total_tokens": 8 }
+        }));
+    });
+    // The two inserted rows (2 inputs).
+    server.mock(|when, then| {
+        when.method(httpmock::Method::POST)
+            .path("/embeddings")
+            .json_body(json!({
+                "input": ["first inserted row", "second inserted row"],
+                "model": "text-embedding-ada-002"
+            }));
+        then.status(200).header("content-type", "application/json").json_body(json!({
+            "object": "list", "data": [embedding(0), embedding(1)],
+            "model": "text-embedding-ada-002", "usage": { "prompt_tokens": 8, "total_tokens": 8 }
+        }));
+    });
+    // The search query (1 input).
+    server.mock(|when, then| {
+        when.method(httpmock::Method::POST)
+            .path("/embeddings")
+            .json_body(json!({ "input": ["anything"], "model": "text-embedding-ada-002" }));
+        then.status(200).header("content-type", "application/json").json_body(json!({
+            "object": "list", "data": [embedding(0)],
+            "model": "text-embedding-ada-002", "usage": { "prompt_tokens": 8, "total_tokens": 8 }
+        }));
+    });
+
+    let openai_client = openai::Client::builder()
+        .api_key("TEST")
+        .base_url(server.base_url())
+        .build()
+        .unwrap();
+    let model = openai_client.embedding_model(openai::TEXT_EMBEDDING_ADA_002);
+
+    let db = lancedb::connect("data/lancedb-insert-documents")
+        .execute()
+        .await
+        .unwrap();
+
+    let table_name = "insert_docs";
+    if db
+        .table_names()
+        .execute()
+        .await
+        .unwrap()
+        .contains(&table_name.to_string())
+    {
+        db.drop_table(table_name, &[]).await.unwrap();
+    }
+
+    // Seed one row to establish the table's Arrow schema.
+    let seed = EmbeddingsBuilder::new(model.clone())
+        .documents(vec![Word {
+            id: "seed".to_string(),
+            definition: "seed row".to_string(),
+        }])
+        .unwrap()
+        .build()
+        .await
+        .unwrap();
+    let table = db
+        .create_table(
+            table_name,
+            vec![as_record_batch(seed, model.ndims()).unwrap()],
+        )
+        .execute()
+        .await
+        .unwrap();
+    assert_eq!(table.count_rows(None).await.unwrap(), 1);
+
+    let vector_store_index =
+        LanceDbVectorIndex::new(table, model.clone(), "id", SearchParams::default())
+            .await
+            .unwrap();
+
+    // Insert two more documents through the trait under test.
+    let new_docs = EmbeddingsBuilder::new(model.clone())
+        .documents(vec![
+            Word {
+                id: "inserted-1".to_string(),
+                definition: "first inserted row".to_string(),
+            },
+            Word {
+                id: "inserted-2".to_string(),
+                definition: "second inserted row".to_string(),
+            },
+        ])
+        .unwrap()
+        .build()
+        .await
+        .unwrap();
+    vector_store_index.insert_documents(new_docs).await.unwrap();
+
+    // Round-trip: the row count grew by two and the inserted ids are searchable.
+    let after = db.open_table(table_name).execute().await.unwrap();
+    assert_eq!(after.count_rows(None).await.unwrap(), 3);
+
+    let req = VectorSearchRequest::builder()
+        .query("anything")
+        .samples(5)
+        .build();
+    let results = vector_store_index
+        .top_n::<serde_json::Value>(req)
+        .await
+        .unwrap();
+    let ids: Vec<String> = results.iter().map(|(_, id, _)| id.clone()).collect();
+    assert!(ids.contains(&"inserted-1".to_string()), "ids = {ids:?}");
+    assert!(ids.contains(&"inserted-2".to_string()), "ids = {ids:?}");
 
     db.drop_table(table_name, &[]).await.unwrap();
 }


### PR DESCRIPTION
Closes #1658. Reimplements that PR on current main and **stacks on top of #1960**
(neo4j `InsertDocuments`) — together they fill the last two of the ten built-in
vector stores that were missing the trait. Review/merge #1960 first; this PR will
retarget to `main` automatically once it lands.

> Stacked PR: the diff below is LanceDB-only. Base = `feat/neo4j-insert-documents`.

## Why

LanceDB and Neo4j were the only two built-in vector stores not implementing
`InsertDocuments`. This adds the LanceDB half, so a `LanceDbVectorIndex` can
append documents with precomputed embeddings via the common trait instead of
callers hand-building Arrow `RecordBatch`es.

## What

- **`impl InsertDocuments for LanceDbVectorIndex`** — one row per embedding. The
  document's JSON fields are decoded into the table's non-embedding columns with
  `arrow-json`, and the vector is written to the `FixedSizeList<Float32|Float64>`
  embedding column, which is auto-detected from the schema (the same default
  LanceDB uses) or taken from `SearchParams::column`. Embedding dimensions are
  validated against the schema; non-object docs are stored under a `document` key.
- **`arrow-json` dependency** pinned to the workspace arrow major (`58`).

## Reconciliation with main (vs the original #1658)

- Crate moved `rig-integrations/rig-lancedb` → `crates/rig-lancedb`; imports
  `rig::` → `rig_core::`.
- LanceDB `0.30`'s `Table::add` now takes a `Scannable` (`Vec<RecordBatch>`)
  rather than a `RecordBatchIterator`.
- The integration tests moved to `tests/integrations/lancedb/`, so the round-trip
  test is added there (not the deleted crate-local `tests/`).

## Tests

- **Unit:** the embedding-column resolver — auto-detect single vector column,
  explicit override, ambiguous (multiple), and missing — all without a DB.
- **Integration (in-process, httpmock):** seed a table, insert two documents via
  the trait, then assert the row count grew to 3 and both inserted ids are
  retrievable via search.

Verified: `cargo test -p rig-lancedb` and `cargo test -p rig --features lancedb
--test integrations insert_documents_test` pass; `clippy --all-targets` and `fmt`
clean.