### PR TITLE
test(openai-compat): genuinely exercise the #1958 tool-call eviction string-leak (+ live cassette)

### DIFF
--- a/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
+++ b/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
@@ -789,15 +789,27 @@ mod tests {
 
     #[tokio::test]
     async fn evicted_tool_call_emits_object_input_end_to_end() {
-        // End-to-end through the streaming aggregator + eviction path: a distinct
-        // second tool call evicts the first via `finalize_completed_streaming_tool_call`.
-        // Every emitted tool call's arguments must be a JSON object so a downstream
-        // object-typed serializer (e.g. Anthropic's `tool_use.input`) never sends a
-        // bare string.
+        // Regression guard for #1958, end-to-end through the streaming aggregator.
+        //
+        // The first tool call is evicted (a distinct second call starts at the
+        // same index) **while its arguments are still a partial, non-object
+        // string** (`first_args_partial` streams `{"query":` — a fragment the
+        // accumulator holds as a bare `Value::String`). Before the fix,
+        // `finalize_completed_streaming_tool_call` forwarded that string verbatim,
+        // so the evicted call emerged with a string `function.arguments`; a
+        // downstream object-typed serializer (e.g. Anthropic's `tool_use.input`)
+        // then sent a bare string and strict providers rejected it.
+        //
+        // This sequence is what makes the test load-bearing: with the fix
+        // reverted the evicted call's arguments are `String("{\"query\":")` and
+        // the `is_object()` assertion below fails; the sibling
+        // `distinct_same_name_tool_calls_evict_by_id_when_a_new_call_starts` test
+        // (which lets the first call's args *complete* before eviction) does not
+        // exercise this path.
         let client = MockStreamingClient {
             sse_bytes: sse_bytes_from_data_lines([
                 "first_start",
-                "first_args",
+                "first_args_partial",
                 "second_start",
                 "second_args",
                 "finish",
@@ -833,6 +845,11 @@ mod tests {
                 tc.function.name
             );
         }
+        // Pin the evicted call specifically: its unparseable partial string is
+        // normalized to `{}` (not forwarded as a string, not dropped).
+        let evicted = &collected_tool_calls[0];
+        assert_eq!(evicted.id, "call_aaa");
+        assert_eq!(evicted.function.arguments, serde_json::json!({}));
     }
 
     #[test]

--- a/crates/rig-core/src/test_utils/internal_streaming_profiles.rs
+++ b/crates/rig-core/src/test_utils/internal_streaming_profiles.rs
@@ -103,6 +103,14 @@ impl CompatibleStreamProfile for DistinctToolCallEvictionProfile {
                 CompatibleFinishReason::Other,
                 vec![tool_call_chunk(0, None, None, Some("{\"query\":\"one\"}"))],
             )),
+            // A partial (still-streaming) argument fragment: the accumulator
+            // holds it as a bare `Value::String` because it is not yet a complete
+            // `{...}` object. If the first call is evicted at this point, its
+            // arguments are a non-object string — the exact #1958 leak condition.
+            "first_args_partial" => Some(tool_call_choice(
+                CompatibleFinishReason::Other,
+                vec![tool_call_chunk(0, None, None, Some("{\"query\":"))],
+            )),
             "second_start" => Some(tool_call_choice(
                 CompatibleFinishReason::Other,
                 vec![tool_call_chunk(

--- a/tests/cassettes/deepseek/streaming_tools/raw_stream_tool_call_arguments_are_objects.yaml
+++ b/tests/cassettes/deepseek/streaming_tools/raw_stream_tool_call_arguments_are_objects.yaml
@@ -1,0 +1,30 @@
+when:
+  path: /chat/completions
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"messages":[{"content":"You are a precise assistant. When tools are available, you must use them instead of guessing. Call both `lookup_harbor_label` and `lookup_orchard_label` before writing any normal text. Never call the same tool twice once you already have its result.","role":"system"},{"content":"Call `lookup_harbor_label` and `lookup_orchard_label` exactly once each before answering. After both tool results are available, stop calling tools and respond in one short sentence that includes both exact tool outputs.","role":"user"}],"model":"deepseek-v4-flash","stream":true,"stream_options":{"include_usage":true},"thinking":{"type":"disabled"},"tools":[{"function":{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"properties":{},"required":[],"type":"object"}},"type":"function"},{"function":{"description":"Return the beta signal marker.","name":"lookup_orchard_label","parameters":{"properties":{},"required":[],"type":"object"}},"type":"function"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream; charset=utf-8
+  body: |+
+    data: {"choices":[{"delta":{"content":"","role":"assistant"},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"deepseek-v4-flash","object":"chat.completion.chunk","system_fingerprint":"fp_REDACTED_1","usage":null}
+
+    data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"","name":"lookup_harbor_label"},"id":"call_REDACTED_1","index":0,"type":"function"}]},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"deepseek-v4-flash","object":"chat.completion.chunk","system_fingerprint":"fp_REDACTED_1","usage":null}
+
+    data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"{}"},"index":0}]},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"deepseek-v4-flash","object":"chat.completion.chunk","system_fingerprint":"fp_REDACTED_1","usage":null}
+
+    data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"","name":"lookup_orchard_label"},"id":"call_REDACTED_2","index":1,"type":"function"}]},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"deepseek-v4-flash","object":"chat.completion.chunk","system_fingerprint":"fp_REDACTED_1","usage":null}
+
+    data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"{}"},"index":1}]},"finish_reason":null,"index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"deepseek-v4-flash","object":"chat.completion.chunk","system_fingerprint":"fp_REDACTED_1","usage":null}
+
+    data: {"choices":[{"delta":{"content":""},"finish_reason":"tool_calls","index":0,"logprobs":null}],"created":0,"id":"chatcmpl-REDACTED_1","model":"deepseek-v4-flash","object":"chat.completion.chunk","system_fingerprint":"fp_REDACTED_1","usage":{"completion_tokens":48,"prompt_cache_hit_tokens":384,"prompt_cache_miss_tokens":20,"prompt_tokens":404,"prompt_tokens_details":{"cached_tokens":384},"total_tokens":452}}
+
+    data: [DONE]
+

--- a/tests/common/support.rs
+++ b/tests/common/support.rs
@@ -867,6 +867,45 @@ pub(crate) fn assert_raw_stream_contains_distinct_tool_calls_before_text(
     }
 }
 
+/// Every tool call surfaced on the raw stream must carry a JSON **object** as
+/// its `function.arguments` (never a bare string), the invariant fixed in #1958:
+/// a downstream object-typed serializer (e.g. Anthropic's `tool_use.input`)
+/// rejects a string input. This guards the streaming aggregator end-to-end on
+/// real provider traffic, complementing the in-crate eviction unit tests.
+pub(crate) fn assert_raw_stream_tool_call_arguments_are_objects(
+    observation: &RawStreamObservation,
+    expected_tools: &[&str],
+) {
+    assert!(
+        observation.errors.is_empty(),
+        "raw stream should not emit errors: {:?}",
+        observation.errors
+    );
+    assert!(
+        observation.got_final,
+        "raw stream should emit a final response"
+    );
+    assert!(
+        observation.tool_calls.len() >= expected_tools.len(),
+        "expected at least {} raw stream tool calls, saw {:?}",
+        expected_tools.len(),
+        observation
+            .tool_calls
+            .iter()
+            .map(|tool_call| tool_call.function.name.clone())
+            .collect::<Vec<_>>(),
+    );
+
+    for tool_call in &observation.tool_calls {
+        assert!(
+            tool_call.function.arguments.is_object(),
+            "tool call `{}` must surface object arguments, got {:?}",
+            tool_call.function.name,
+            tool_call.function.arguments,
+        );
+    }
+}
+
 pub(crate) fn assert_raw_stream_text_contains(
     observation: &RawStreamObservation,
     expected: &[&str],

--- a/tests/providers/deepseek/streaming_tools.rs
+++ b/tests/providers/deepseek/streaming_tools.rs
@@ -14,7 +14,8 @@ use crate::support::{
     ORDERED_TOOL_STREAM_PREAMBLE, ORDERED_TOOL_STREAM_PROMPT, REQUIRED_ZERO_ARG_TOOL_PROMPT,
     Subtract, TWO_TOOL_STREAM_PREAMBLE, TWO_TOOL_STREAM_PROMPT, assert_mentions_expected_number,
     assert_raw_stream_contains_distinct_tool_calls_before_text, assert_raw_stream_text_contains,
-    assert_raw_stream_tool_call_precedes_text, assert_stream_contains_zero_arg_tool_call_named,
+    assert_raw_stream_tool_call_arguments_are_objects, assert_raw_stream_tool_call_precedes_text,
+    assert_stream_contains_zero_arg_tool_call_named,
     assert_tool_call_precedes_later_text, assert_two_tool_roundtrip_contract,
     collect_raw_stream_observation, collect_stream_final_response, collect_stream_observation,
     zero_arg_tool_definition,
@@ -97,6 +98,44 @@ async fn raw_stream_surfaces_two_distinct_tool_calls_before_text() {
             .await;
 
             assert_raw_stream_contains_distinct_tool_calls_before_text(
+                &observation,
+                &["lookup_harbor_label", "lookup_orchard_label"],
+            );
+        },
+    )
+    .await;
+}
+
+/// Live end-to-end guard for the #1958 invariant: every tool call surfaced by
+/// the streaming aggregator carries a JSON **object** as its arguments, never a
+/// bare string. Recorded against real DeepSeek traffic with two tool calls in a
+/// single streamed turn (which exercises the same-turn multi-tool accumulation
+/// path). DeepSeek assigns distinct indices, so this complements — rather than
+/// replaces — the in-crate unit tests that drive the same-index eviction path
+/// directly (a quirk only some API gateways emit and not reproducible live).
+#[tokio::test]
+async fn raw_stream_tool_call_arguments_are_objects() {
+    with_deepseek_cassette(
+        "streaming_tools/raw_stream_tool_call_arguments_are_objects",
+        |client| async move {
+            let model = client.completion_model(DEEPSEEK_V4_FLASH);
+            let request = model
+                .completion_request(TWO_TOOL_STREAM_PROMPT)
+                .preamble(TWO_TOOL_STREAM_PREAMBLE.to_string())
+                .tool(AlphaSignal.definition(String::new()).await)
+                .tool(BetaSignal.definition(String::new()).await)
+                .additional_params(non_thinking_params())
+                .build();
+
+            let observation = collect_raw_stream_observation(
+                model
+                    .stream(request)
+                    .await
+                    .expect("raw stream should start"),
+            )
+            .await;
+
+            assert_raw_stream_tool_call_arguments_are_objects(
                 &observation,
                 &["lookup_harbor_label", "lookup_orchard_label"],
             );

--- a/tests/providers/deepseek/streaming_tools.rs
+++ b/tests/providers/deepseek/streaming_tools.rs
@@ -15,10 +15,9 @@ use crate::support::{
     Subtract, TWO_TOOL_STREAM_PREAMBLE, TWO_TOOL_STREAM_PROMPT, assert_mentions_expected_number,
     assert_raw_stream_contains_distinct_tool_calls_before_text, assert_raw_stream_text_contains,
     assert_raw_stream_tool_call_arguments_are_objects, assert_raw_stream_tool_call_precedes_text,
-    assert_stream_contains_zero_arg_tool_call_named,
-    assert_tool_call_precedes_later_text, assert_two_tool_roundtrip_contract,
-    collect_raw_stream_observation, collect_stream_final_response, collect_stream_observation,
-    zero_arg_tool_definition,
+    assert_stream_contains_zero_arg_tool_call_named, assert_tool_call_precedes_later_text,
+    assert_two_tool_roundtrip_contract, collect_raw_stream_observation,
+    collect_stream_final_response, collect_stream_observation, zero_arg_tool_definition,
 };
 
 fn non_thinking_params() -> serde_json::Value {


### PR DESCRIPTION
Follow-up test hardening for #1958 (*normalize evicted tool-call string arguments to an object*). **Test-only — no library behavior change.**

## Context: why a "live cassette that triggers #1958" isn't achievable

#1958's bug lives in the streaming **eviction finalizer** (`finalize_completed_streaming_tool_call`), which only runs when a provider streams *distinct tool calls at the same `index`* **and** the evicted call's args are still a non-object string at eviction time. Per rig's own history (#1443/#1510), the same-index behavior is a quirk of **API gateways (LiteLLM/OneAPI) and some models (GLM-4)** — not normal provider streaming.

I verified empirically that this isn't reproducible against available live endpoints:

| Endpoint | Tool-call indices | Triggers eviction? |
|---|---|---|
| DeepSeek (direct, live) | 0, 1 | No |
| DeepSeek via LiteLLM 1.89.4 | 0, 1 | No |
| Anthropic via LiteLLM 1.89.4 | 0, 1 | No |
| Anthropic via LiteLLM **1.81.16** (contemporaneous with #1443) | 0, 1 | No |

Every direct provider, and LiteLLM (current and the Feb-2026 version) fronting both OpenAI-native and Anthropic upstreams, follows the OpenAI convention and assigns **distinct indices** — LiteLLM has since fixed the index-0 behavior. So a live cassette can't drive the eviction path; that path's natural test level is an in-crate test that constructs the exact streaming state.

## What this PR does

**1. Makes #1958's merged end-to-end test load-bearing.** `evicted_tool_call_emits_object_input_end_to_end` previously used a data-line sequence where the first tool call's args *completed to an object before eviction* — so it passed even with the fix reverted (it didn't exercise the bug). This adds a `first_args_partial` line to `DistinctToolCallEvictionProfile` and evicts the first call while its args are still a partial, non-object string (`{"query":`). 
   - **Verified:** with the #1958 finalizer fix reverted, the test now fails with the exact symptom — `tool_use input must be an object, got String("{\"query\":")` — and passes once restored. It also pins the evicted call's normalized `{}`.
   - The sibling `distinct_same_name_tool_calls_evict_by_id_when_a_new_call_starts` (which lets the first call's args complete) is unchanged.

**2. Adds a live-recorded DeepSeek cassette** (`raw_stream_tool_call_arguments_are_objects`) asserting that **every tool call surfaced by the streaming aggregator carries object-typed `function.arguments`** — the #1958 invariant — on real two-tool streaming traffic. Recorded via `RIG_PROVIDER_TEST_MODE=record` against live DeepSeek, scrubbed, and replays with no API key. DeepSeek uses distinct indices (doesn't hit the eviction path), so this **complements** the in-crate eviction test as a general end-to-end guard rather than replacing it. New shared helper `assert_raw_stream_tool_call_arguments_are_objects`.

## Verification
- Revert the #1958 finalizer fix → `evicted_tool_call_emits_object_input_end_to_end` fails; restore → green.
- `cargo test -p rig-core --lib` affected module: 17/17.
- `cargo test -p rig --all-features --test deepseek deepseek::streaming_tools` (replay): 7/7; cassette-safety: 31/31.
- `cargo clippy -p rig-core --all-features --all-targets` and `cargo clippy -p rig --test deepseek`: clean.

## Note
The cassette was **recorded live, not hand-written**. The eviction-string path itself is covered by the in-crate unit tests (which is the appropriate level, since no live endpoint reproduces the same-index gateway quirk) — and those are now genuinely load-bearing.