### PR TITLE
feat(examples): human-in-the-loop tool-call approval — examples + tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "agent_with_approval_policy"
+version = "0.39.0"
+dependencies = [
+ "anyhow",
+ "rig",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "agent_with_context"
 version = "0.39.0"
 dependencies = [
@@ -163,6 +175,18 @@ dependencies = [
 
 [[package]]
 name = "agent_with_default_max_turns"
+version = "0.39.0"
+dependencies = [
+ "anyhow",
+ "rig",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "agent_with_durable_approval"
 version = "0.39.0"
 dependencies = [
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "agent_with_human_in_the_loop"
+version = "0.39.0"
+dependencies = [
+ "anyhow",
+ "rig",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "agent_with_loaders"
 version = "0.39.0"
 dependencies = [

--- a/crates/rig-core/src/agent/run/mod.rs
+++ b/crates/rig-core/src/agent/run/mod.rs
@@ -2188,4 +2188,73 @@ mod tests {
             self
         }
     }
+
+    /// Durable human-in-the-loop: the run is serialized while tool calls are
+    /// pending, reconstructed from JSON (as a separate process / request would),
+    /// and only then does the human decision land — approve one call, deny the
+    /// other. The resumed-from-bytes run accepts those results and continues to
+    /// completion, proving approval can happen out-of-process / arbitrarily later.
+    /// This is the state-machine foundation for `examples/agent_with_durable_approval`.
+    #[test]
+    fn durable_human_in_the_loop_approval_survives_serialize_resume() {
+        let mut run = AgentRun::new("pay two invoices").max_turns(3);
+        let (_, _, turn) = expect_call_model(&mut run);
+        assert_eq!(turn, 1);
+
+        // Turn 1: the model emits two tool calls.
+        let two_calls =
+            OneOrMany::many([tool_call("c1", "add"), tool_call("c2", "add")]).expect("two calls");
+        let outcome = run
+            .model_response(ModelTurn::new(
+                None,
+                two_calls,
+                Usage::new(),
+                tool_names(&["add"]),
+                tool_names(&["add"]),
+            ))
+            .expect("model_response");
+        expect_continue(outcome);
+
+        // CallTools is now pending. Serialize the run (a durable checkpoint) and
+        // reconstruct it from the bytes — nothing live crosses this boundary.
+        let checkpoint = serde_json::to_string(&run).expect("serialize suspended run");
+        let mut resumed: AgentRun = serde_json::from_str(&checkpoint).expect("deserialize run");
+
+        // The resumed run re-emits the pending calls purely from its own state.
+        let calls = expect_call_tools(&mut resumed);
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].tool_call.id, "c1");
+        assert_eq!(calls[1].tool_call.id, "c2");
+
+        // The human decision lands only after the resume: approve c1 (real
+        // result), deny c2 (the reason becomes the tool result the model sees).
+        resumed
+            .tool_results(vec![
+                tool_result("c1", "approved-result"),
+                tool_result("c2", "denied by reviewer: second payment not authorized"),
+            ])
+            .expect("tool_results on the resumed run");
+
+        // Both decisions are recorded in the resumed run's persisted state.
+        let after = serde_json::to_string(&resumed).expect("serialize resumed run");
+        assert!(
+            after.contains("approved-result"),
+            "the approved call's result must be in the resumed run state"
+        );
+        assert!(
+            after.contains("denied by reviewer: second payment not authorized"),
+            "the denied call's reason must be in the resumed run state"
+        );
+
+        // Turn 2: the model wraps up; the run completes from the resumed state.
+        let (_, _, turn2) = expect_call_model(&mut resumed);
+        assert_eq!(turn2, 2);
+        expect_continue(
+            resumed
+                .model_response(text_turn("done"))
+                .expect("model_response 2"),
+        );
+        let response = expect_done(&mut resumed);
+        assert_eq!(response.output, "done");
+    }
 }

--- a/crates/rig-core/src/agent/runner.rs
+++ b/crates/rig-core/src/agent/runner.rs
@@ -3057,7 +3057,6 @@ mod tests {
     // -----------------------------------------------------------------------
 
     /// A human reviewer's decision for a pending tool call.
-    #[derive(Clone)]
     enum Decision {
         /// Run the tool as the model requested.
         Approve,
@@ -3119,7 +3118,7 @@ mod tests {
     /// edits the third's arguments behaves identically under `run()` and
     /// `stream()`: approved/edited tools execute (and the edit takes effect),
     /// the denied tool runs nothing while its reason reaches the model, and the
-    /// model-visible history is byte-identical across drivers.
+    /// model-visible history is identical across drivers (compared structurally).
     #[tokio::test]
     async fn human_in_the_loop_approve_deny_edit_parity_across_run_and_stream() {
         // One turn issues three tool calls; the reviewer decides each differently.
@@ -3192,9 +3191,28 @@ mod tests {
             streaming_recorder.tool_results()
         );
 
-        // The reviewer was consulted for all three calls, identically per driver.
-        assert_eq!(blocking_approver.reviewed().len(), 3);
-        assert_eq!(blocking_approver.reviewed(), streaming_approver.reviewed());
+        // The denied call (10 + 20) never executed, so its result 30 is absent —
+        // this, with tool_results == [5, 101], rules out the test passing if deny
+        // were silently treated as approve.
+        assert!(
+            !blocking_recorder.tool_results().contains(&"30".to_string()),
+            "the denied call must not have executed"
+        );
+
+        // The reviewer was consulted for all three calls, in order, identically per
+        // driver — pinning each decision to its call (approve=2+3, deny=10+20,
+        // edit=the third).
+        let reviewed = blocking_approver.reviewed();
+        assert_eq!(reviewed.len(), 3);
+        assert_eq!(reviewed, streaming_approver.reviewed());
+        assert!(
+            reviewed[0].contains('2') && reviewed[0].contains('3'),
+            "first reviewed call should be add(2, 3): {reviewed:?}"
+        );
+        assert!(
+            reviewed[1].contains("10") && reviewed[1].contains("20"),
+            "the denied (second) call should be add(10, 20): {reviewed:?}"
+        );
 
         assert_eq!(blocking.output, "done");
         assert_eq!(final_response.response(), blocking.output);
@@ -3203,8 +3221,9 @@ mod tests {
             streaming_recorder.shared_events()
         );
 
-        // Model-visible history is byte-identical across drivers and carries the
-        // denial reason and the edited result 101 (not the model's 1 + 1 = 2).
+        // Model-visible history is identical across drivers (compared structurally
+        // as serde_json::Value) and carries the denial reason and the edited result
+        // 101 (not the model's 1 + 1 = 2).
         let blocking_messages = blocking.messages.expect("blocking messages");
         let streaming_messages = final_response
             .history()
@@ -3225,13 +3244,17 @@ mod tests {
     }
 
     /// A HITL hook that aborts a tool call (`Decision::Abort` -> `Flow::terminate`)
-    /// stops the run and surfaces the reason as a `PromptCancelled` error.
+    /// stops the run and surfaces the reason as a `PromptCancelled` error — on both
+    /// the blocking and streaming drivers.
     #[tokio::test]
     async fn human_in_the_loop_abort_terminates_the_run() {
         let turns = [
             ScriptedTurn::ToolCalls(vec![add_call("tc1", 2, 3)]),
             ScriptedTurn::Text("unreachable"),
         ];
+        const ABORT_REASON: &str = "aborted by the human reviewer";
+
+        // Blocking driver: the run resolves to a PromptCancelled error.
         let blocking_model =
             MockCompletionModel::from_turns(turns.iter().map(ScriptedTurn::as_blocking_turn));
         let err = AgentBuilder::new(blocking_model)
@@ -3239,15 +3262,44 @@ mod tests {
             .build()
             .runner("do the sensitive thing")
             .max_turns(3)
-            .add_hook(HumanApprovalHook::new([Decision::Abort(
-                "aborted by the human reviewer",
-            )]))
+            .add_hook(HumanApprovalHook::new([Decision::Abort(ABORT_REASON)]))
             .run()
             .await
-            .expect_err("an aborted tool call should terminate the run");
+            .expect_err("an aborted tool call should terminate the blocking run");
         assert!(
-            format!("{err}").contains("aborted by the human reviewer"),
-            "the abort reason should surface in the error, got: {err}"
+            format!("{err}").contains(ABORT_REASON),
+            "the abort reason should surface in the blocking error, got: {err}"
+        );
+
+        // Streaming driver: the stream yields an error carrying the same reason and
+        // never reaches the "unreachable" final text.
+        let streaming_model = MockCompletionModel::from_stream_turns(
+            turns
+                .iter()
+                .map(|turn| turn.as_stream_events(StreamShape::Complete)),
+        );
+        let mut stream = AgentBuilder::new(streaming_model)
+            .tool(MockAddTool)
+            .build()
+            .runner("do the sensitive thing")
+            .max_turns(3)
+            .add_hook(HumanApprovalHook::new([Decision::Abort(ABORT_REASON)]))
+            .stream()
+            .await;
+        let mut stream_error = None;
+        while let Some(item) = stream.next().await {
+            match item {
+                Err(err) => stream_error = Some(format!("{err}")),
+                Ok(MultiTurnStreamItem::FinalResponse(resp)) => {
+                    panic!("aborted stream must not finalize, got: {}", resp.response())
+                }
+                Ok(_) => {}
+            }
+        }
+        let stream_error = stream_error.expect("an aborted tool call should error the stream");
+        assert!(
+            stream_error.contains(ABORT_REASON),
+            "the abort reason should surface in the streaming error, got: {stream_error}"
         );
     }
 }

--- a/crates/rig-core/src/agent/runner.rs
+++ b/crates/rig-core/src/agent/runner.rs
@@ -3105,11 +3105,13 @@ mod tests {
                 .push(format!("{tool_name}({args})"));
             let decision = self.decisions.lock().unwrap().pop_front();
             match decision {
-                // Default to approval when the script runs out, like the example.
-                Some(Decision::Approve) | None => Flow::cont(),
+                Some(Decision::Approve) => Flow::cont(),
                 Some(Decision::Deny(reason)) => Flow::skip(reason),
                 Some(Decision::Edit(args)) => Flow::rewrite_args(args),
                 Some(Decision::Abort(reason)) => Flow::terminate(reason),
+                // Fail closed if the script is exhausted (it shouldn't be) — deny
+                // rather than silently approve, matching the example's contract.
+                None => Flow::skip("denied: no scripted decision (fail-closed)"),
             }
         }
     }
@@ -3300,6 +3302,114 @@ mod tests {
         assert!(
             stream_error.contains(ABORT_REASON),
             "the abort reason should surface in the streaming error, got: {stream_error}"
+        );
+    }
+
+    /// A non-interactive *policy* HITL hook: auto-approve an allow-list, deny
+    /// everything else (fail-closed), and cache each decision so a repeated tool
+    /// is not re-evaluated ("sticky", like the OpenAI Agents SDK's
+    /// `always_approve`). Backs `examples/agent_with_approval_policy`.
+    #[derive(Clone)]
+    struct PolicyHook {
+        auto_approve: std::collections::HashSet<&'static str>,
+        /// Tool names the policy actually evaluated (cache misses), in order.
+        evaluated: Arc<Mutex<Vec<String>>>,
+        /// Sticky cache of prior decisions, keyed by tool name.
+        cache: Arc<Mutex<std::collections::HashMap<String, bool>>>,
+    }
+
+    impl PolicyHook {
+        fn new(auto_approve: impl IntoIterator<Item = &'static str>) -> Self {
+            Self {
+                auto_approve: auto_approve.into_iter().collect(),
+                evaluated: Arc::new(Mutex::new(Vec::new())),
+                cache: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            }
+        }
+
+        fn evaluated(&self) -> Vec<String> {
+            self.evaluated.lock().unwrap().clone()
+        }
+    }
+
+    impl<M: CompletionModel> AgentHook<M> for PolicyHook {
+        async fn on_event(&self, event: StepEvent<'_, M>) -> Flow {
+            let StepEvent::ToolCall { tool_name, .. } = event else {
+                return Flow::cont();
+            };
+            let cached = self.cache.lock().unwrap().get(tool_name).copied();
+            let approved = match cached {
+                Some(decision) => decision, // sticky: reuse without re-evaluating
+                None => {
+                    self.evaluated.lock().unwrap().push(tool_name.to_string());
+                    let decision = self.auto_approve.contains(tool_name);
+                    self.cache
+                        .lock()
+                        .unwrap()
+                        .insert(tool_name.to_string(), decision);
+                    decision
+                }
+            };
+            if approved {
+                Flow::cont()
+            } else {
+                Flow::skip(format!("denied by policy: `{tool_name}` not allowed"))
+            }
+        }
+    }
+
+    /// The policy hook auto-approves `add` and denies `subtract`, and its decision
+    /// is sticky: a second `add` call reuses the cached approval instead of being
+    /// re-evaluated. The denied call never runs and its reason reaches the model.
+    #[tokio::test]
+    async fn approval_policy_allow_list_with_sticky_decisions() {
+        // One turn issues three calls: add, subtract (denied), add again (sticky).
+        let turns = [
+            ScriptedTurn::ToolCalls(vec![
+                add_call("c1", 2, 3),
+                ScriptedToolCall {
+                    id: "c2",
+                    name: "subtract",
+                    args: json!({ "x": 10, "y": 4 }),
+                },
+                add_call("c3", 2, 3),
+            ]),
+            ScriptedTurn::Text("done"),
+        ];
+
+        let model =
+            MockCompletionModel::from_turns(turns.iter().map(ScriptedTurn::as_blocking_turn));
+        let recorder = RecordingHook::default();
+        let policy = PolicyHook::new(["add"]);
+        let out = AgentBuilder::new(model)
+            .tool(MockAddTool)
+            .tool(MockSubtractTool)
+            .build()
+            .runner("go")
+            .max_turns(3)
+            .add_hook(recorder.clone())
+            .add_hook(policy.clone())
+            .run()
+            .await
+            .expect("policy run should succeed");
+
+        assert_eq!(out.output, "done");
+        // `add` ran twice (auto-approved, then sticky-reused); `subtract` was denied
+        // and executed nothing.
+        assert_eq!(
+            recorder.tool_results(),
+            vec!["5".to_string(), "5".to_string()]
+        );
+        // The policy evaluated each distinct tool once; the second `add` reused the
+        // cached decision rather than being re-evaluated.
+        assert_eq!(
+            policy.evaluated(),
+            vec!["add".to_string(), "subtract".to_string()]
+        );
+        let messages = out.messages.expect("messages");
+        assert!(
+            tool_result_text_in_history(&messages, "denied by policy: `subtract` not allowed"),
+            "the policy denial reason must reach the model as the subtract tool result"
         );
     }
 }

--- a/crates/rig-core/src/agent/runner.rs
+++ b/crates/rig-core/src/agent/runner.rs
@@ -3048,4 +3048,206 @@ mod tests {
              its name, saw {tool_names:?}"
         );
     }
+
+    // -----------------------------------------------------------------------
+    // Human-in-the-loop (HITL): one hook gates each tool call behind a human
+    // decision, mapping approve/deny/edit/abort onto the existing Flow actions
+    // (cont / skip / rewrite_args / terminate). The runnable interactive
+    // version lives in `examples/agent_with_human_in_the_loop`.
+    // -----------------------------------------------------------------------
+
+    /// A human reviewer's decision for a pending tool call.
+    #[derive(Clone)]
+    enum Decision {
+        /// Run the tool as the model requested.
+        Approve,
+        /// Don't run the tool; feed `reason` back to the model as the result.
+        Deny(&'static str),
+        /// Run the tool with these arguments instead of the model's.
+        Edit(serde_json::Value),
+        /// Abort the whole run with this reason.
+        Abort(&'static str),
+    }
+
+    /// Simulates a human reviewer by popping a scripted decision per `ToolCall`
+    /// and mapping it to the matching `Flow`. A real reviewer would `.await`
+    /// interactive input here (the hook is async) rather than read a queue.
+    #[derive(Clone)]
+    struct HumanApprovalHook {
+        decisions: Arc<Mutex<std::collections::VecDeque<Decision>>>,
+        reviewed: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl HumanApprovalHook {
+        fn new(decisions: impl IntoIterator<Item = Decision>) -> Self {
+            Self {
+                decisions: Arc::new(Mutex::new(decisions.into_iter().collect())),
+                reviewed: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        /// `"name(args)"` for each call presented for review, in order.
+        fn reviewed(&self) -> Vec<String> {
+            self.reviewed.lock().unwrap().clone()
+        }
+    }
+
+    impl<M: CompletionModel> AgentHook<M> for HumanApprovalHook {
+        async fn on_event(&self, event: StepEvent<'_, M>) -> Flow {
+            let StepEvent::ToolCall {
+                tool_name, args, ..
+            } = event
+            else {
+                return Flow::cont();
+            };
+            self.reviewed
+                .lock()
+                .unwrap()
+                .push(format!("{tool_name}({args})"));
+            let decision = self.decisions.lock().unwrap().pop_front();
+            match decision {
+                // Default to approval when the script runs out, like the example.
+                Some(Decision::Approve) | None => Flow::cont(),
+                Some(Decision::Deny(reason)) => Flow::skip(reason),
+                Some(Decision::Edit(args)) => Flow::rewrite_args(args),
+                Some(Decision::Abort(reason)) => Flow::terminate(reason),
+            }
+        }
+    }
+
+    /// A HITL hook that approves the first tool call, denies the second, and
+    /// edits the third's arguments behaves identically under `run()` and
+    /// `stream()`: approved/edited tools execute (and the edit takes effect),
+    /// the denied tool runs nothing while its reason reaches the model, and the
+    /// model-visible history is byte-identical across drivers.
+    #[tokio::test]
+    async fn human_in_the_loop_approve_deny_edit_parity_across_run_and_stream() {
+        // One turn issues three tool calls; the reviewer decides each differently.
+        let turns = [
+            ScriptedTurn::ToolCalls(vec![
+                add_call("tc1", 2, 3),   // approve -> runs, 2 + 3 = 5
+                add_call("tc2", 10, 20), // deny    -> skipped; model sees the reason
+                add_call("tc3", 1, 1),   // edit    -> runs 1 + 100 = 101, not 1 + 1 = 2
+            ]),
+            ScriptedTurn::Text("done"),
+        ];
+        let denial = "denied by reviewer: amount too large";
+        let decisions = || {
+            vec![
+                Decision::Approve,
+                Decision::Deny(denial),
+                Decision::Edit(json!({"x": 1, "y": 100})),
+            ]
+        };
+
+        let blocking_model =
+            MockCompletionModel::from_turns(turns.iter().map(ScriptedTurn::as_blocking_turn));
+        let blocking_recorder = RecordingHook::default();
+        let blocking_approver = HumanApprovalHook::new(decisions());
+        let blocking = AgentBuilder::new(blocking_model)
+            .tool(MockAddTool)
+            .build()
+            .runner("carry out the plan")
+            .max_turns(3)
+            .add_hook(blocking_recorder.clone())
+            .add_hook(blocking_approver.clone())
+            .run()
+            .await
+            .expect("blocking HITL run should succeed");
+
+        let streaming_model = MockCompletionModel::from_stream_turns(
+            turns
+                .iter()
+                .map(|turn| turn.as_stream_events(StreamShape::Complete)),
+        );
+        let streaming_recorder = RecordingHook::default();
+        let streaming_approver = HumanApprovalHook::new(decisions());
+        let mut stream = AgentBuilder::new(streaming_model)
+            .tool(MockAddTool)
+            .build()
+            .runner("carry out the plan")
+            .max_turns(3)
+            .add_hook(streaming_recorder.clone())
+            .add_hook(streaming_approver.clone())
+            .stream()
+            .await;
+        let mut final_response = None;
+        while let Some(item) = stream.next().await {
+            if let Ok(MultiTurnStreamItem::FinalResponse(resp)) =
+                item.map_err(|err| panic!("stream item errored: {err}"))
+            {
+                final_response = Some(resp);
+            }
+        }
+        let final_response = final_response.expect("stream should yield a final response");
+
+        // Approved (5) and edited (101) tools executed, in call order; the denied
+        // call executed nothing, so it fired no ToolResult — on both drivers.
+        assert_eq!(
+            blocking_recorder.tool_results(),
+            vec!["5".to_string(), "101".to_string()]
+        );
+        assert_eq!(
+            blocking_recorder.tool_results(),
+            streaming_recorder.tool_results()
+        );
+
+        // The reviewer was consulted for all three calls, identically per driver.
+        assert_eq!(blocking_approver.reviewed().len(), 3);
+        assert_eq!(blocking_approver.reviewed(), streaming_approver.reviewed());
+
+        assert_eq!(blocking.output, "done");
+        assert_eq!(final_response.response(), blocking.output);
+        assert_eq!(
+            blocking_recorder.shared_events(),
+            streaming_recorder.shared_events()
+        );
+
+        // Model-visible history is byte-identical across drivers and carries the
+        // denial reason and the edited result 101 (not the model's 1 + 1 = 2).
+        let blocking_messages = blocking.messages.expect("blocking messages");
+        let streaming_messages = final_response
+            .history()
+            .expect("streaming history")
+            .to_vec();
+        assert_eq!(
+            serde_json::to_value(&blocking_messages).expect("serialize blocking"),
+            serde_json::to_value(&streaming_messages).expect("serialize streaming"),
+        );
+        assert!(
+            tool_result_text_in_history(&blocking_messages, denial),
+            "the denial reason must be the denied call's tool result in the history"
+        );
+        assert!(
+            tool_result_text_in_history(&blocking_messages, "101"),
+            "the edited call must have executed with the rewritten arguments"
+        );
+    }
+
+    /// A HITL hook that aborts a tool call (`Decision::Abort` -> `Flow::terminate`)
+    /// stops the run and surfaces the reason as a `PromptCancelled` error.
+    #[tokio::test]
+    async fn human_in_the_loop_abort_terminates_the_run() {
+        let turns = [
+            ScriptedTurn::ToolCalls(vec![add_call("tc1", 2, 3)]),
+            ScriptedTurn::Text("unreachable"),
+        ];
+        let blocking_model =
+            MockCompletionModel::from_turns(turns.iter().map(ScriptedTurn::as_blocking_turn));
+        let err = AgentBuilder::new(blocking_model)
+            .tool(MockAddTool)
+            .build()
+            .runner("do the sensitive thing")
+            .max_turns(3)
+            .add_hook(HumanApprovalHook::new([Decision::Abort(
+                "aborted by the human reviewer",
+            )]))
+            .run()
+            .await
+            .expect_err("an aborted tool call should terminate the run");
+        assert!(
+            format!("{err}").contains("aborted by the human reviewer"),
+            "the abort reason should surface in the error, got: {err}"
+        );
+    }
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,6 +23,7 @@ Most examples expect provider API keys in the environment (e.g. `OPENAI_API_KEY`
 | `agent_with_context` | Demonstrates adding small context documents directly to an agent. |
 | `agent_with_default_max_turns` | Demonstrates extending the default agent loop budget for tool-heavy prompts. |
 | `agent_with_echochambers` | See source. |
+| `agent_with_human_in_the_loop` | Demonstrates human-in-the-loop tool-call approval: an `AgentHook` pauses on each tool call so a human can approve/deny/edit/abort, mapped onto `Flow` (`cont`/`skip`/`rewrite_args`/`terminate`). |
 | `agent_with_loaders` | Demonstrates loading real example files into agent context. |
 | `agent_with_memory_streaming` | Demonstrates Rig-managed conversation memory with streaming. |
 | `agent_with_memory` | Demonstrates Rig-managed conversation memory with an in-memory backend. |

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,8 +20,10 @@ Most examples expect provider API keys in the environment (e.g. `OPENAI_API_KEY`
 | `agent_run_stepping` | Drives the agent loop by hand with the sans-IO [`AgentRun`] state machine. |
 | `agent_stream_chat` | Demonstrates `stream_chat` with prior conversation history. |
 | `agent_with_agent_tool` | See source. |
+| `agent_with_approval_policy` | Demonstrates a non-interactive, policy-based HITL gate: an `AgentHook` auto-approves an allow-list, denies the rest (fail-closed), and applies an arg-based rule (mirrors `needs_approval`/`interrupt_on` predicates). |
 | `agent_with_context` | Demonstrates adding small context documents directly to an agent. |
 | `agent_with_default_max_turns` | Demonstrates extending the default agent loop budget for tool-heavy prompts. |
+| `agent_with_durable_approval` | Demonstrates **durable** HITL: the hand-driven `AgentRun` is serialized while tool calls are pending and resumed from JSON (as another process would), so approval can happen out-of-process / later. |
 | `agent_with_echochambers` | See source. |
 | `agent_with_human_in_the_loop` | Demonstrates human-in-the-loop tool-call approval: an `AgentHook` pauses on each tool call so a human can approve/deny/edit/abort, mapped onto `Flow` (`cont`/`skip`/`rewrite_args`/`terminate`). |
 | `agent_with_loaders` | Demonstrates loading real example files into agent context. |

--- a/examples/agent_with_approval_policy/Cargo.toml
+++ b/examples/agent_with_approval_policy/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "agent_with_approval_policy"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+rig.workspace = true
+anyhow = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }

--- a/examples/agent_with_approval_policy/src/main.rs
+++ b/examples/agent_with_approval_policy/src/main.rs
@@ -1,0 +1,189 @@
+//! Policy-based (non-interactive) human-in-the-loop: approval *rules* decided up
+//! front, evaluated per tool call by an `AgentHook` — no human prompt in the
+//! loop. This mirrors the OpenAI Agents SDK's `needs_approval(fn)`, Vercel AI
+//! SDK's `needsApproval(({input}) => ...)`, and LangGraph's `interrupt_on`
+//! predicates: a person encodes the policy once, and the agent runs within it.
+//!
+//! The [`ApprovalPolicy`] hook fires on [`StepEvent::ToolCall`] and returns:
+//! - [`Flow::cont`] to allow a tool that is on the safe allow-list, or a guarded
+//!   tool whose arguments satisfy the rule;
+//! - [`Flow::skip`] to **deny** otherwise — the denial reason is fed back to the
+//!   model as the tool result, so it can adjust (e.g. transfer a smaller amount
+//!   or ask the user) rather than the run simply failing.
+//!
+//! The policy is **fail-closed**: any tool not explicitly allowed is denied. As
+//! always, this is guardrail/UX logic, not a security boundary — enforce real
+//! authorization inside the tool.
+//!
+//! Requires `OPENAI_API_KEY`. Run with: `cargo run -p agent_with_approval_policy`
+
+use std::collections::HashSet;
+
+use anyhow::Result;
+use rig::agent::{AgentHook, Flow, StepEvent};
+use rig::client::{CompletionClient, ProviderClient};
+use rig::completion::{CompletionModel, Prompt, ToolDefinition};
+use rig::providers::openai;
+use rig::tool::Tool;
+use serde::Deserialize;
+use serde_json::json;
+
+#[derive(Debug, thiserror::Error)]
+#[error("tool failed: {0}")]
+struct ToolError(String);
+
+#[derive(Deserialize)]
+struct SearchArgs {
+    query: String,
+}
+
+struct SearchWeb;
+
+impl Tool for SearchWeb {
+    const NAME: &'static str = "search_web";
+    type Error = ToolError;
+    type Args = SearchArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "Search the web for a query (read-only).".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": { "query": { "type": "string", "description": "Search query" } },
+                "required": ["query"]
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        println!("   🔎 [search_web] -> {}", args.query);
+        Ok(format!("top result for '{}': $1000 is plenty.", args.query))
+    }
+}
+
+#[derive(Deserialize)]
+struct TransferArgs {
+    to: String,
+    amount: u64,
+}
+
+struct TransferFunds;
+
+impl Tool for TransferFunds {
+    const NAME: &'static str = "transfer_funds";
+    type Error = ToolError;
+    type Args = TransferArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "Transfer funds to an account.".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "to": { "type": "string", "description": "Destination account id" },
+                    "amount": { "type": "integer", "description": "Amount in whole dollars" }
+                },
+                "required": ["to", "amount"]
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        println!("   🏦 [transfer_funds] -> ${} to {}", args.amount, args.to);
+        Ok(format!("transferred ${} to {}", args.amount, args.to))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The approval policy, evaluated on every tool call.
+// ---------------------------------------------------------------------------
+
+struct ApprovalPolicy {
+    /// Tools allowed to run unconditionally (read-only / low risk).
+    auto_approve: HashSet<&'static str>,
+    /// Transfers at or below this amount are auto-approved; above it they are
+    /// denied (a real app would route those to a human instead).
+    max_auto_transfer: u64,
+}
+
+impl<M: CompletionModel> AgentHook<M> for ApprovalPolicy {
+    async fn on_event(&self, event: StepEvent<'_, M>) -> Flow {
+        let StepEvent::ToolCall {
+            tool_name, args, ..
+        } = event
+        else {
+            return Flow::cont();
+        };
+
+        if self.auto_approve.contains(tool_name) {
+            println!("[policy] auto-approve `{tool_name}` (safe)");
+            return Flow::cont();
+        }
+
+        if tool_name == TransferFunds::NAME {
+            let amount = serde_json::from_str::<serde_json::Value>(args)
+                .ok()
+                .and_then(|v| v.get("amount").and_then(|a| a.as_u64()));
+            return match amount {
+                Some(a) if a <= self.max_auto_transfer => {
+                    println!(
+                        "[policy] approve transfer ${a} (<= ${})",
+                        self.max_auto_transfer
+                    );
+                    Flow::cont()
+                }
+                Some(a) => {
+                    println!(
+                        "[policy] DENY transfer ${a} (over ${})",
+                        self.max_auto_transfer
+                    );
+                    Flow::skip(format!(
+                        "denied by policy: transfers over ${} require human approval; \
+                         ${a} exceeds the limit",
+                        self.max_auto_transfer
+                    ))
+                }
+                None => Flow::skip("denied by policy: could not read the transfer amount"),
+            };
+        }
+
+        // Fail closed: anything not explicitly allowed is denied.
+        println!("[policy] DENY `{tool_name}` (not on the approved list)");
+        Flow::skip(format!(
+            "denied by policy: `{tool_name}` is not on the approved tool list"
+        ))
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let agent = openai::Client::from_env()?
+        .agent(openai::GPT_4O)
+        .preamble(
+            "You are a banking assistant. Use the tools to carry out the user's request. \
+             If a tool is denied by policy, explain the limit to the user instead of retrying.",
+        )
+        .tool(SearchWeb)
+        .tool(TransferFunds)
+        .build();
+
+    let policy = ApprovalPolicy {
+        auto_approve: HashSet::from([SearchWeb::NAME]),
+        max_auto_transfer: 1000,
+    };
+
+    let prompt = "Look up how much I should send, then transfer $5000 to account B-2.";
+    println!("User: {prompt}\n");
+
+    // The transfer of $5000 exceeds the $1000 policy limit, so it is denied and
+    // the reason is handed to the model, which should explain rather than retry.
+    let response = agent.prompt(prompt).max_turns(10).add_hook(policy).await?;
+
+    println!("\nFinal response:\n{response}");
+
+    Ok(())
+}

--- a/examples/agent_with_durable_approval/Cargo.toml
+++ b/examples/agent_with_durable_approval/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "agent_with_durable_approval"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+rig.workspace = true
+anyhow = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }

--- a/examples/agent_with_durable_approval/src/main.rs
+++ b/examples/agent_with_durable_approval/src/main.rs
@@ -1,0 +1,294 @@
+//! **Durable** human-in-the-loop tool-call approval.
+//!
+//! Unlike `agent_with_human_in_the_loop` (which `.await`s the human *inline*
+//! inside an `AgentHook`, so the approval only lives as long as the running
+//! task), this example pauses the run **across a serialization boundary**: when
+//! the model wants to run tools, the entire [`AgentRun`] state machine is written
+//! to a JSON file and then reconstructed from that file before the decision is
+//! taken. Everything between the write and the reload could be a *different
+//! process*, an HTTP request handler, or hours/days later — the run carries no
+//! live futures, only serializable state.
+//!
+//! This is rig's analogue of LangGraph's `interrupt()` + checkpointer, the OpenAI
+//! Agents SDK's serializable `RunState`, and pydantic-ai's `DeferredToolRequests`
+//! — built on the fact that `AgentRun` is `Serialize + Deserialize` and the run
+//! loop is driven by hand (see also `agent_run_stepping`). Each per-call decision
+//! maps to ordinary tool-result content:
+//!
+//! - **approve** → execute the tool, return its real output
+//! - **deny**    → don't execute; return the reason as the tool result so the model adapts
+//! - **edit**    → execute with human-supplied JSON arguments instead
+//! - **abort**   → stop the run
+//!
+//! The gate is **fail-closed**: empty/unknown input denies, and closed stdin
+//! (e.g. piped `< /dev/null`) aborts — a destructive tool never runs on ambiguous
+//! input. The prompt is a UX affordance, not a security boundary; enforce real
+//! authorization inside the tool.
+//!
+//! Requires `OPENAI_API_KEY`. Run with: `cargo run -p agent_with_durable_approval`
+
+use anyhow::Result;
+use rig::agent::InvalidToolCallHookAction;
+use rig::agent::run::{AgentRun, AgentRunStep, ModelTurn, ModelTurnOutcome};
+use rig::client::{CompletionClient, ProviderClient};
+use rig::completion::{Completion, ToolDefinition};
+use rig::message::{ToolResultContent, UserContent};
+use rig::providers::openai;
+use rig::tool::Tool;
+use serde::Deserialize;
+use serde_json::json;
+use std::collections::BTreeSet;
+
+// ---------------------------------------------------------------------------
+// One read-only tool and one side-effecting tool worth gating.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, thiserror::Error)]
+#[error("tool failed: {0}")]
+struct ToolError(String);
+
+#[derive(Deserialize)]
+struct BalanceArgs {
+    account: String,
+}
+
+struct GetBalance;
+
+impl Tool for GetBalance {
+    const NAME: &'static str = "get_balance";
+    type Error = ToolError;
+    type Args = BalanceArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "Get the balance of an account.".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": { "account": { "type": "string", "description": "Account id" } },
+                "required": ["account"]
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        println!("   💰 [get_balance] -> {}", args.account);
+        Ok(format!("account {} balance: $1000", args.account))
+    }
+}
+
+#[derive(Deserialize)]
+struct TransferArgs {
+    to: String,
+    amount: u64,
+}
+
+struct TransferFunds;
+
+impl Tool for TransferFunds {
+    const NAME: &'static str = "transfer_funds";
+    type Error = ToolError;
+    type Args = TransferArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "Transfer funds to an account.".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "to": { "type": "string", "description": "Destination account id" },
+                    "amount": { "type": "integer", "description": "Amount in whole dollars" }
+                },
+                "required": ["to", "amount"]
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        // A real implementation would move money here.
+        println!("   🏦 [transfer_funds] -> ${} to {}", args.amount, args.to);
+        Ok(format!("transferred ${} to {}", args.amount, args.to))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fail-closed stdin reader (None on EOF / closed stdin / read error).
+// ---------------------------------------------------------------------------
+
+async fn ask(prompt: &str) -> Option<String> {
+    use std::io::Write;
+    print!("{prompt}");
+    let _ = std::io::stdout().flush();
+    let line = tokio::task::spawn_blocking(|| {
+        let mut line = String::new();
+        match std::io::stdin().read_line(&mut line) {
+            Ok(0) | Err(_) => None,
+            Ok(_) => Some(line),
+        }
+    })
+    .await
+    .ok()
+    .flatten()?;
+    Some(line.trim().to_ascii_lowercase())
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let agent = openai::Client::from_env()?
+        .agent(openai::GPT_4O)
+        .preamble(
+            "You are a banking assistant. Use the tools to carry out the user's request. \
+             Call one tool at a time.",
+        )
+        .tool(GetBalance)
+        .tool(TransferFunds)
+        .build();
+
+    let prompt = "Check the balance of account A-1, then transfer $500 to account B-2.";
+    println!("User: {prompt}");
+
+    // Where the suspended run is checkpointed between approval rounds.
+    let state_path = std::env::temp_dir().join("rig_durable_approval.json");
+    let _ = std::fs::remove_file(&state_path);
+
+    let mut run = AgentRun::new(prompt).max_turns(10);
+
+    loop {
+        match run.next_step()? {
+            AgentRunStep::CallModel {
+                prompt,
+                history,
+                turn,
+            } => {
+                println!("\n→ model call #{turn}");
+                let response = agent.completion(prompt, history).await?.send().await?;
+                let tool_names: BTreeSet<String> = agent
+                    .tool_server_handle
+                    .get_tool_defs(None)
+                    .await?
+                    .into_iter()
+                    .map(|def| def.name)
+                    .collect();
+                let mut outcome = run.model_response(ModelTurn::new(
+                    response.message_id.clone(),
+                    response.choice.clone(),
+                    response.usage,
+                    tool_names.clone(),
+                    tool_names,
+                ))?;
+                while let ModelTurnOutcome::NeedsResolution(context) = outcome {
+                    eprintln!("model called unknown tool `{}`", context.tool_name);
+                    outcome = run.resolve_invalid_tool_call(InvalidToolCallHookAction::fail())?;
+                }
+            }
+
+            AgentRunStep::CallTools { .. } => {
+                // DURABLE PAUSE. Persist the whole run, then reconstruct it from
+                // the file before deciding. The write→reload boundary below could
+                // be a separate process / request / much later — the resumed run
+                // re-emits the pending tool calls purely from serialized state.
+                std::fs::write(&state_path, serde_json::to_vec_pretty(&run)?)?;
+                println!("\n💾 run suspended to {}", state_path.display());
+
+                // ----- imagine the process exits here and resumes later -----
+
+                let mut resumed: AgentRun = serde_json::from_slice(&std::fs::read(&state_path)?)?;
+                let AgentRunStep::CallTools { calls } = resumed.next_step()? else {
+                    anyhow::bail!("resumed run must re-emit the pending tool calls");
+                };
+
+                let mut results = Vec::new();
+                let mut aborted = false;
+                for call in calls {
+                    // Calls suppressed by invalid-tool-call recovery come pre-resolved.
+                    if let Some(result) = call.preresolved_result {
+                        results.push(result);
+                        continue;
+                    }
+                    let id = call.tool_call.id.clone();
+                    let name = call.tool_call.function.name.clone();
+                    let args = call.tool_call.function.arguments.to_string();
+
+                    println!("\n⏸  approval required: {name}({args})");
+                    match ask("     [a]pprove / [d]eny / [e]dit args / a[b]ort? ")
+                        .await
+                        .as_deref()
+                    {
+                        Some("a") | Some("approve") => {
+                            let output = agent.tool_server_handle.call_tool(&name, &args).await?;
+                            results.push(UserContent::tool_result(
+                                id,
+                                ToolResultContent::from_tool_output(output),
+                            ));
+                        }
+                        Some("e") | Some("edit") => {
+                            let edited = ask("     replacement JSON args (single line): ").await;
+                            match edited
+                                .as_deref()
+                                .map(serde_json::from_str::<serde_json::Value>)
+                            {
+                                Some(Ok(value)) => {
+                                    let output = agent
+                                        .tool_server_handle
+                                        .call_tool(&name, &value.to_string())
+                                        .await?;
+                                    results.push(UserContent::tool_result(
+                                        id,
+                                        ToolResultContent::from_tool_output(output),
+                                    ));
+                                }
+                                _ => {
+                                    println!("     ! no valid JSON; denying instead");
+                                    results.push(UserContent::tool_result(
+                                        id,
+                                        ToolResultContent::from_tool_output(
+                                            "denied: the reviewer supplied no valid JSON to edit with",
+                                        ),
+                                    ));
+                                }
+                            }
+                        }
+                        // Abort on explicit request or closed stdin (None): fail-closed.
+                        Some("b") | Some("abort") | None => {
+                            aborted = true;
+                            break;
+                        }
+                        // Deny / empty / unknown: fail-closed; the reason reaches the model.
+                        other => {
+                            let reason = if matches!(other, Some("d") | Some("deny")) {
+                                ask("     reason (shown to the model): ")
+                                    .await
+                                    .filter(|r| !r.is_empty())
+                                    .unwrap_or_else(|| "denied by the human reviewer".to_string())
+                            } else {
+                                "denied: no clear approval given".to_string()
+                            };
+                            results.push(UserContent::tool_result(
+                                id,
+                                ToolResultContent::from_tool_output(reason),
+                            ));
+                        }
+                    }
+                }
+
+                if aborted {
+                    let _ = std::fs::remove_file(&state_path);
+                    println!("\nrun aborted by the reviewer");
+                    return Ok(());
+                }
+
+                resumed.tool_results(results)?;
+                let _ = std::fs::remove_file(&state_path);
+                run = resumed;
+            }
+
+            AgentRunStep::Done(response) => {
+                println!("\n✓ {}", response.output);
+                return Ok(());
+            }
+        }
+    }
+}

--- a/examples/agent_with_human_in_the_loop/Cargo.toml
+++ b/examples/agent_with_human_in_the_loop/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "agent_with_human_in_the_loop"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+rig.workspace = true
+anyhow = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }

--- a/examples/agent_with_human_in_the_loop/src/main.rs
+++ b/examples/agent_with_human_in_the_loop/src/main.rs
@@ -1,0 +1,238 @@
+//! Human-in-the-loop (HITL) tool-call approval with `AgentHook`.
+//!
+//! An agent is given two side-effecting tools (`send_email`, `delete_file`).
+//! Before *any* tool runs, an [`ApprovalHook`] pauses the run on the
+//! [`StepEvent::ToolCall`] event, shows the human the tool name and arguments,
+//! and waits for a decision on stdin. Each decision maps to an existing [`Flow`]
+//! action — no special HITL machinery is required:
+//!
+//! | Human decision | `Flow` returned        | Effect                                                              |
+//! |----------------|------------------------|--------------------------------------------------------------------|
+//! | **approve**    | [`Flow::cont`]         | the tool executes as the model requested                           |
+//! | **deny**       | [`Flow::skip`]         | the tool does *not* run; the reason becomes the tool result the model sees, so it can adapt |
+//! | **edit**       | [`Flow::rewrite_args`] | the tool executes with human-supplied arguments instead            |
+//! | **abort**      | [`Flow::terminate`]    | the whole run stops and surfaces the reason as an error            |
+//!
+//! Because `AgentHook::on_event` is `async`, the hook can simply `.await` the
+//! human's input inline (here from stdin; in a real app this might be an HTTP
+//! request to an approval UI, a Slack round-trip, or a database poll). The same
+//! hook works unchanged on the streaming driver (`stream_prompt`).
+//!
+//! Requires `OPENAI_API_KEY`. Run with: `cargo run -p agent_with_human_in_the_loop`
+
+use anyhow::Result;
+use rig::agent::{AgentHook, Flow, StepEvent};
+use rig::client::{CompletionClient, ProviderClient};
+use rig::completion::{CompletionModel, Prompt, ToolDefinition};
+use rig::providers::openai;
+use rig::tool::Tool;
+use serde::Deserialize;
+use serde_json::json;
+
+// ---------------------------------------------------------------------------
+// Two side-effecting tools worth gating behind human approval.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, thiserror::Error)]
+#[error("tool failed: {0}")]
+struct ToolError(String);
+
+#[derive(Deserialize)]
+struct SendEmailArgs {
+    to: String,
+    subject: String,
+    body: String,
+}
+
+struct SendEmail;
+
+impl Tool for SendEmail {
+    const NAME: &'static str = "send_email";
+    type Error = ToolError;
+    type Args = SendEmailArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "Send an email to a recipient.".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "to": { "type": "string", "description": "Recipient email address" },
+                    "subject": { "type": "string", "description": "Email subject line" },
+                    "body": { "type": "string", "description": "Email body" }
+                },
+                "required": ["to", "subject", "body"]
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        // A real implementation would hit an email API here.
+        println!(
+            "   📧 [send_email] -> {} (subject: {:?}, {} chars)",
+            args.to,
+            args.subject,
+            args.body.len()
+        );
+        Ok(format!("email sent to {}", args.to))
+    }
+}
+
+#[derive(Deserialize)]
+struct DeleteFileArgs {
+    path: String,
+}
+
+struct DeleteFile;
+
+impl Tool for DeleteFile {
+    const NAME: &'static str = "delete_file";
+    type Error = ToolError;
+    type Args = DeleteFileArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "Permanently delete a file at the given path.".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "path": { "type": "string", "description": "Absolute path of the file to delete" }
+                },
+                "required": ["path"]
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        // A real implementation would delete the file here.
+        println!("   🗑️  [delete_file] -> {}", args.path);
+        Ok(format!("deleted {}", args.path))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The HITL hook: pause on each tool call and ask a human.
+// ---------------------------------------------------------------------------
+
+/// Print `prompt`, then read one trimmed line from stdin without blocking the
+/// async runtime (the blocking read runs on a dedicated thread).
+async fn ask(prompt: &str) -> String {
+    use std::io::Write;
+    print!("{prompt}");
+    let _ = std::io::stdout().flush();
+    tokio::task::spawn_blocking(|| {
+        let mut line = String::new();
+        let _ = std::io::stdin().read_line(&mut line);
+        line
+    })
+    .await
+    .unwrap_or_default()
+    .trim()
+    .to_string()
+}
+
+/// Gates every tool call behind interactive human approval.
+struct ApprovalHook;
+
+impl<M: CompletionModel> AgentHook<M> for ApprovalHook {
+    async fn on_event(&self, event: StepEvent<'_, M>) -> Flow {
+        // Only the pre-execution tool-call event is a decision point; everything
+        // else falls through untouched.
+        let StepEvent::ToolCall {
+            tool_name, args, ..
+        } = event
+        else {
+            return Flow::cont();
+        };
+
+        println!("\n⏸  The agent wants to run a tool — your approval is required:");
+        println!("     tool: {tool_name}");
+        println!("     args: {args}");
+
+        match ask("     [a]pprove / [d]eny / [e]dit args / a[b]ort run? ")
+            .await
+            .chars()
+            .next()
+        {
+            // Approve (also the default on an empty line): run as requested.
+            Some('a') | None => {
+                println!("     → approved");
+                Flow::cont()
+            }
+            // Deny: the tool does not run; the reason is fed back to the model as
+            // the tool result so it can choose another course of action.
+            Some('d') => {
+                let reason = ask("     reason (shown to the model): ").await;
+                let reason = if reason.is_empty() {
+                    "denied by the human reviewer".to_string()
+                } else {
+                    reason
+                };
+                println!("     → denied");
+                Flow::skip(reason)
+            }
+            // Edit: run the tool with human-supplied JSON arguments instead.
+            Some('e') => {
+                let raw = ask("     replacement JSON args: ").await;
+                match serde_json::from_str::<serde_json::Value>(&raw) {
+                    Ok(value) => {
+                        println!("     → running with edited arguments");
+                        Flow::rewrite_args(value)
+                    }
+                    Err(err) => {
+                        println!("     ! invalid JSON ({err}); denying instead");
+                        Flow::skip(format!(
+                            "the reviewer tried to edit the arguments but supplied invalid JSON: {err}"
+                        ))
+                    }
+                }
+            }
+            // Abort: stop the whole run.
+            Some('b') => {
+                println!("     → aborting the run");
+                Flow::terminate("run aborted by the human reviewer")
+            }
+            Some(other) => {
+                println!("     ! unrecognized choice '{other}', approving by default");
+                Flow::cont()
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let agent = openai::Client::from_env()?
+        .agent(openai::GPT_4O)
+        .preamble(
+            "You are an operations assistant. Use the available tools to carry out the user's \
+             request. Call one tool at a time and wait for its result before the next step.",
+        )
+        .tool(SendEmail)
+        .tool(DeleteFile)
+        .build();
+
+    let prompt = "Email alice@example.com a reminder that the budget review is at 3pm, \
+                  then delete the stale file /tmp/old_report.csv.";
+    println!("User: {prompt}");
+
+    // Attach the approval hook for this run. It fires before every tool call;
+    // the run pauses for your decision each time.
+    let response = agent
+        .prompt(prompt)
+        .max_turns(10)
+        .add_hook(ApprovalHook)
+        .await?;
+
+    println!("\nFinal response:\n{response}");
+
+    Ok(())
+}

--- a/examples/agent_with_human_in_the_loop/src/main.rs
+++ b/examples/agent_with_human_in_the_loop/src/main.rs
@@ -119,23 +119,34 @@ impl Tool for DeleteFile {
 // ---------------------------------------------------------------------------
 
 /// Print `prompt`, then read one trimmed line from stdin without blocking the
-/// async runtime (the blocking read runs on a dedicated thread).
-async fn ask(prompt: &str) -> String {
+/// async runtime (the blocking read runs on a dedicated thread). Returns `None`
+/// on EOF / closed stdin (e.g. piped `< /dev/null`, Ctrl-D) or a read error —
+/// the caller treats "no input" as fail-closed, never as approval.
+async fn ask(prompt: &str) -> Option<String> {
     use std::io::Write;
     print!("{prompt}");
     let _ = std::io::stdout().flush();
-    tokio::task::spawn_blocking(|| {
+    let line = tokio::task::spawn_blocking(|| {
         let mut line = String::new();
-        let _ = std::io::stdin().read_line(&mut line);
-        line
+        match std::io::stdin().read_line(&mut line) {
+            Ok(0) | Err(_) => None, // EOF / closed stdin / read error
+            Ok(_) => Some(line),
+        }
     })
     .await
-    .unwrap_or_default()
-    .trim()
-    .to_string()
+    .ok()
+    .flatten()?;
+    Some(line.trim().to_string())
 }
 
 /// Gates every tool call behind interactive human approval.
+///
+/// The gate is **fail-closed**: anything other than an explicit approval (an
+/// empty line, an unrecognized choice, or closed stdin) denies or aborts rather
+/// than running the tool. An approval prompt that guards side-effecting tools
+/// must never run them on ambiguous input — and note that the prompt is a UX
+/// affordance, not a security boundary; real authorization belongs inside the
+/// tool itself.
 struct ApprovalHook;
 
 impl<M: CompletionModel> AgentHook<M> for ApprovalHook {
@@ -153,52 +164,62 @@ impl<M: CompletionModel> AgentHook<M> for ApprovalHook {
         println!("     tool: {tool_name}");
         println!("     args: {args}");
 
-        match ask("     [a]pprove / [d]eny / [e]dit args / a[b]ort run? ")
-            .await
-            .chars()
-            .next()
-        {
-            // Approve (also the default on an empty line): run as requested.
-            Some('a') | None => {
+        // No input at all (closed stdin) → abort the run; there is no reviewer.
+        let Some(choice) = ask("     [a]pprove / [d]eny / [e]dit args / a[b]ort run? ").await
+        else {
+            println!("     → no input (stdin closed); aborting (fail-closed)");
+            return Flow::terminate("no reviewer input available (stdin closed)");
+        };
+
+        // Match the whole (lowercased) answer, accepting either the hotkey or the
+        // full word, so typing "abort" can never be mistaken for "approve".
+        match choice.to_ascii_lowercase().as_str() {
+            "a" | "approve" => {
                 println!("     → approved");
                 Flow::cont()
             }
             // Deny: the tool does not run; the reason is fed back to the model as
             // the tool result so it can choose another course of action.
-            Some('d') => {
-                let reason = ask("     reason (shown to the model): ").await;
-                let reason = if reason.is_empty() {
-                    "denied by the human reviewer".to_string()
-                } else {
-                    reason
-                };
+            "d" | "deny" | "n" | "no" => {
+                let reason = ask("     reason (shown to the model): ")
+                    .await
+                    .filter(|r| !r.is_empty())
+                    .unwrap_or_else(|| "denied by the human reviewer".to_string());
                 println!("     → denied");
                 Flow::skip(reason)
             }
             // Edit: run the tool with human-supplied JSON arguments instead.
-            Some('e') => {
-                let raw = ask("     replacement JSON args: ").await;
-                match serde_json::from_str::<serde_json::Value>(&raw) {
-                    Ok(value) => {
+            "e" | "edit" => {
+                match ask("     replacement JSON args (single line): ")
+                    .await
+                    .as_deref()
+                    .map(serde_json::from_str::<serde_json::Value>)
+                {
+                    Some(Ok(value)) => {
                         println!("     → running with edited arguments");
                         Flow::rewrite_args(value)
                     }
-                    Err(err) => {
-                        println!("     ! invalid JSON ({err}); denying instead");
-                        Flow::skip(format!(
-                            "the reviewer tried to edit the arguments but supplied invalid JSON: {err}"
-                        ))
+                    other => {
+                        println!("     ! no valid JSON ({other:?}); denying instead");
+                        Flow::skip(
+                            "the reviewer tried to edit the arguments but supplied no valid JSON",
+                        )
                     }
                 }
             }
             // Abort: stop the whole run.
-            Some('b') => {
+            "b" | "abort" | "q" | "quit" => {
                 println!("     → aborting the run");
                 Flow::terminate("run aborted by the human reviewer")
             }
-            Some(other) => {
-                println!("     ! unrecognized choice '{other}', approving by default");
-                Flow::cont()
+            // Fail closed: empty or unrecognized input denies rather than runs.
+            "" => {
+                println!("     → empty input; denying (fail-closed)");
+                Flow::skip("denied: the reviewer gave no decision")
+            }
+            other => {
+                println!("     ! unrecognized choice '{other}'; denying (fail-closed)");
+                Flow::skip(format!("denied: unrecognized reviewer input '{other}'"))
             }
         }
     }


### PR DESCRIPTION
## What

A set of **human-in-the-loop (HITL)** examples and rig-core tests, showing rig's `AgentHook`/`Flow` and serializable `AgentRun` cover the HITL patterns found across pydantic-ai, LangGraph, the OpenAI Agents SDK, Vercel AI SDK, and Semantic Kernel — **no new library API**.

HITL decisions map onto existing primitives:

| Decision | Mechanism |
|---|---|
| approve | `Flow::cont` |
| deny | `Flow::skip(reason)` (reason becomes the tool result the model sees) |
| edit args | `Flow::rewrite_args` |
| abort | `Flow::terminate` |

## Examples

- **`agent_with_human_in_the_loop`** — interactive CLI approval gate (approve/deny/edit/abort from stdin). **Fail-closed**: empty/unknown input denies, closed stdin aborts; "abort" can't be misread as "approve".
- **`agent_with_durable_approval`** — **durable** HITL. Hand-drives the serializable `AgentRun`; at the pending-tool-call seam it serializes the run to JSON and reconstructs it before the decision is taken, so approval can happen **out-of-process / later** (rig's analogue of LangGraph `interrupt()`+checkpointer, OpenAI `RunState`, pydantic `DeferredToolRequests`).
- **`agent_with_approval_policy`** — non-interactive **policy** gate: auto-approve an allow-list, apply an arg-based rule to a guarded tool, deny the rest fail-closed (mirrors `needs_approval`/`needsApproval`/`interrupt_on` predicates).

## Tests (rig-core)

- `human_in_the_loop_approve_deny_edit_parity_across_run_and_stream` — one scripted reviewer making three decisions, `run()`/`stream()` parity, pinned so it can't pass if deny were treated as approve.
- `human_in_the_loop_abort_terminates_the_run` — abort→`terminate` on both drivers.
- `durable_human_in_the_loop_approval_survives_serialize_resume` (run module) — serialize a run with pending tool calls, deserialize into a fresh `AgentRun`, apply approve/deny, resume to completion; both decisions persist across the boundary.
- `approval_policy_allow_list_with_sticky_decisions` — allow-list policy with sticky (consult-once) decisions, mirroring `always_approve`.

## Notes

- **No library API changes** — examples + tests only.
- Every example carries the caveat: an approval gate is a UX affordance, not a security boundary — enforce authz inside the tool.
- Verified: `cargo test -p rig-core --lib` (1045 pass), all examples build, `cargo fmt --all -- --check` clean, clippy clean on the changed crates.

Follow-up (separate RFC, out of scope): a high-level `AgentRunner` "approval-required" suspension so durable HITL doesn't require hand-stepping `AgentRun`.