### PR TITLE
fix(anthropic): deserialize explicit null citations as empty vec

### DIFF
--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -284,7 +284,11 @@ pub enum Content {
         text: String,
         /// Citations returned by Claude pointing back into the source documents.
         /// Empty (and skipped during serialization) on request-side blocks.
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        #[serde(
+            default,
+            deserialize_with = "null_as_empty_vec",
+            skip_serializing_if = "Vec::is_empty"
+        )]
         citations: Vec<Citation>,
         #[serde(skip_serializing_if = "Option::is_none")]
         cache_control: Option<CacheControl>,
@@ -697,6 +701,20 @@ impl<'de> Deserialize<'de> for Citation {
             _ => Ok(Citation::Unknown(value)),
         }
     }
+}
+
+/// Deserialize a `Vec<T>`, treating an explicit JSON `null` as an empty vec.
+///
+/// `#[serde(default)]` only fills in a *missing* field, but the Anthropic
+/// Messages API emits an explicit `"citations": null` on text
+/// `content_block_start` events. Without this, `Vec` deserialization rejects the
+/// null and the whole stream fails before any text arrives.
+fn null_as_empty_vec<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de>,
+{
+    Ok(Option::<Vec<T>>::deserialize(deserializer)?.unwrap_or_default())
 }
 
 /// Decoded Anthropic document fields lifted out of [`message::Document::additional_params`]:

--- a/crates/rig-core/src/providers/anthropic/streaming.rs
+++ b/crates/rig-core/src/providers/anthropic/streaming.rs
@@ -1293,6 +1293,36 @@ mod tests {
     }
 
     #[test]
+    fn test_text_content_block_start_allows_null_citations() {
+        // The Anthropic Messages API emits an explicit `"citations": null` on the
+        // first text `content_block_start` event. `#[serde(default)]` alone covers
+        // a missing field but not an explicit null, so this must deserialize to an
+        // empty citation list rather than failing the whole stream (see #1971).
+        let json = r#"{
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {
+                "type": "text",
+                "text": "",
+                "citations": null
+            }
+        }"#;
+
+        let event: StreamingEvent = serde_json::from_str(json).unwrap();
+        let StreamingEvent::ContentBlockStart { content_block, .. } = event else {
+            panic!("expected ContentBlockStart");
+        };
+        let Content::Text {
+            text, citations, ..
+        } = content_block
+        else {
+            panic!("expected text content block");
+        };
+        assert_eq!(text, "");
+        assert!(citations.is_empty());
+    }
+
+    #[test]
     fn test_web_search_content_block_start_events_deserialize() {
         let server_tool_use = r#"{
             "type": "content_block_start",


### PR DESCRIPTION
Fixes #1971

## Problem

Anthropic streaming fails on the very first text content block. The Messages API emits an explicit `"citations": null` on the text `content_block_start` SSE event, regardless of request parameters:

```
event: content_block_start
data: {"content_block":{"citations":null,"text":"","type":"text"},"index":0,"type":"content_block_start"}
```

This event deserializes into `StreamingEvent::ContentBlockStart { content_block: Content }` (`streaming.rs`), where `Content::Text.citations` (`completion.rs`) is declared as:

```rust
#[serde(default, skip_serializing_if = "Vec::is_empty")]
citations: Vec<Citation>,
```

`#[serde(default)]` supplies the field only when it is **missing** — it does not accept an explicit `null`. Serde therefore fails with `invalid type: null, expected a sequence`, and because this is the first SSE event, the error is the first and only item the stream yields: no text ever arrives. It is not opt-in — the API sends `"citations": null` for plain text blocks on every streaming call.

## Root cause

`#[serde(default)]` and an explicit `null` are distinct cases in serde: `default` covers an absent key, but a present `null` is still dispatched to `Vec`'s deserializer, which rejects it. The field needs a deserializer that maps `null` to the empty vec, while keeping `default` (for the absent case) and `skip_serializing_if` (so request-side serialization is unchanged).

## Fix

- Add a small `null_as_empty_vec` deserializer (`completion.rs`) that reads `Option<Vec<T>>` and maps `None` (i.e. `null`) to an empty vec.
- Apply it to `Content::Text.citations` via `deserialize_with`, leaving the existing `default` and `skip_serializing_if = "Vec::is_empty"` in place.

Because streaming and non-streaming share the same `Content` enum, this fixes both paths from one change. Request-side output is unchanged: `deserialize_with` only affects deserialization, and an empty `citations` is still skipped on serialization.

## Test

Added `test_text_content_block_start_allows_null_citations` (`streaming.rs`), built from the exact `content_block_start` payload in the report. I verified it reproduces the reported `invalid type: null, expected a sequence` error when the `deserialize_with` is reverted, and passes with the fix in place.

## Verification

- `cargo fmt -- --check`
- `cargo clippy -p rig-core --all-features --all-targets` — no warnings
- `cargo test -p rig-core --lib` — 1047 passed
- `cargo check -p rig-core --features wasm --target wasm32-unknown-unknown` — clean

## AI assistance

This PR was written with the assistance of AI tools (Claude Code). I reviewed every line, confirmed the root cause against serde's `default`-vs-`null` behavior, and verified the regression test fails without the fix.