### PR TITLE
docs(examples): refresh Gemini Deep Research example

### DIFF
--- a/examples/gemini_deep_research/src/main.rs
+++ b/examples/gemini_deep_research/src/main.rs
@@ -1,31 +1,60 @@
 use anyhow::Result;
 use futures::StreamExt;
-use rig::completion::CompletionModel;
 use rig::prelude::*;
 use rig::providers::gemini::{
     self,
     interactions_api::{
-        AdditionalParameters, AgentConfig, Content, ContentDelta, InteractionSseEvent,
-        InteractionStatus, Step, TextDelta, ThinkingSummaries, ThoughtSummaryContent,
-        ThoughtSummaryDelta,
+        AgentConfig, Content, ContentDelta, CreateInteractionRequest, Interaction,
+        InteractionInput, InteractionSseEvent, InteractionStatus, Step, TextDelta,
+        ThinkingSummaries, ThoughtSummaryContent, ThoughtSummaryDelta,
     },
 };
 use std::time::Duration;
 use tokio::time::sleep;
 use tracing_subscriber::EnvFilter;
 
-const DEEP_RESEARCH_AGENT: &str = "deep-research-pro-preview-12-2025";
+/// Known-working Deep Research agent for this example.
+///
+/// Override with `GEMINI_DEEP_RESEARCH_AGENT` to try another documented variant,
+/// such as `deep-research-preview-04-2026` or
+/// `deep-research-max-preview-04-2026`.
+const DEFAULT_DEEP_RESEARCH_AGENT: &str = "deep-research-pro-preview-12-2025";
+const DEFAULT_PROMPT: &str = "Research the history of Google TPUs.";
 const STREAM_RETRY_DELAY_SECS: u64 = 2;
+const POLL_INTERVAL_SECS: u64 = 10;
 
-fn deep_research_params() -> AdditionalParameters {
-    AdditionalParameters {
-        agent: Some(DEEP_RESEARCH_AGENT.to_string()),
+fn deep_research_agent() -> String {
+    std::env::var("GEMINI_DEEP_RESEARCH_AGENT")
+        .ok()
+        .filter(|agent| !agent.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_DEEP_RESEARCH_AGENT.to_string())
+}
+
+fn deep_research_request(
+    agent: impl Into<String>,
+    prompt: impl Into<String>,
+    stream: bool,
+) -> CreateInteractionRequest {
+    CreateInteractionRequest {
+        model: None,
+        agent: Some(agent.into()),
+        input: InteractionInput::Text(prompt.into()),
+        system_instruction: None,
+        tools: None,
+        response_format: None,
+        response_mime_type: None,
+        stream: stream.then_some(true),
+        store: None,
         background: Some(true),
-        store: Some(true),
-        agent_config: Some(AgentConfig::DeepResearch {
+        generation_config: None,
+        agent_config: stream.then_some(AgentConfig::DeepResearch {
+            // The Gemini docs recommend enabling thinking summaries for Deep
+            // Research streams; otherwise a stream may only include final text.
             thinking_summaries: Some(ThinkingSummaries::Auto),
         }),
-        ..Default::default()
+        response_modalities: None,
+        previous_interaction_id: None,
+        additional_params: None,
     }
 }
 
@@ -40,16 +69,43 @@ fn extract_text(contents: &[Content]) -> String {
         .join("\n")
 }
 
-fn extract_text_from_steps(steps: &[Step]) -> String {
-    steps
-        .iter()
-        .filter_map(|step| match step {
-            Step::ModelOutput { content } => Some(extract_text(content)),
-            _ => None,
-        })
-        .filter(|text| !text.is_empty())
-        .collect::<Vec<_>>()
-        .join("\n")
+fn last_model_output_text(steps: &[Step]) -> Option<String> {
+    steps.iter().rev().find_map(|step| match step {
+        Step::ModelOutput { content } => {
+            let text = extract_text(content);
+            (!text.is_empty()).then_some(text)
+        }
+        _ => None,
+    })
+}
+
+fn print_interaction_result(interaction: &Interaction) {
+    match interaction.status.as_ref() {
+        Some(InteractionStatus::Completed) => match last_model_output_text(&interaction.steps) {
+            Some(text) => println!("{text}"),
+            None => println!("No text output returned."),
+        },
+        Some(status) => println!("Research ended with status: {status:?}"),
+        None => println!("Research ended without a status."),
+    }
+}
+
+async fn poll_until_terminal(
+    client: &gemini::InteractionsClient,
+    interaction_id: &str,
+) -> Result<Interaction> {
+    loop {
+        let interaction = client.get_interaction(interaction_id).await?;
+        if interaction.is_terminal() {
+            return Ok(interaction);
+        }
+
+        println!(
+            "Status: {:?}. Polling again in {POLL_INTERVAL_SECS}s...",
+            interaction.status.unwrap_or(InteractionStatus::InProgress)
+        );
+        sleep(Duration::from_secs(POLL_INTERVAL_SECS)).await;
+    }
 }
 
 fn track_event_id(last_event_id: &mut Option<String>, event_id: Option<String>) {
@@ -112,11 +168,9 @@ fn handle_stream_event(state: &mut StreamState, event: InteractionSseEvent) {
             track_event_id(&mut state.last_event_id, event_id);
             println!("\nResearch complete.");
             if !state.saw_text {
-                let text = extract_text_from_steps(&interaction.steps);
-                if text.is_empty() {
-                    println!("No text output returned.");
-                } else {
-                    println!("{text}");
+                match last_model_output_text(&interaction.steps) {
+                    Some(text) => println!("{text}"),
+                    None => println!("No text output returned."),
                 }
             }
             state.is_complete = true;
@@ -145,26 +199,24 @@ async fn main() -> Result<()> {
         .init();
 
     let use_streaming = std::env::args().any(|arg| arg == "--stream");
+    let agent = deep_research_agent();
     let client = gemini::Client::from_env()?.interactions_api();
-    let model = client.completion_model("gemini-3-pro-preview");
-    let prompt = "Research the history of Google TPUs.";
 
-    let params = deep_research_params();
-    let request = model
-        .completion_request(prompt)
-        .additional_params(serde_json::to_value(&params)?)
-        .build();
+    // Deep Research is selected by `request.agent`; the request intentionally
+    // omits `model`, matching the official Gemini Deep Research examples.
+    let request = deep_research_request(agent.clone(), DEFAULT_PROMPT, use_streaming);
 
     if use_streaming {
         println!("== Deep Research (streaming) ==");
+        println!("Agent: {agent}");
         let mut state = StreamState::default();
         let mut attempt = 0usize;
 
         loop {
             let stream = if attempt == 0 {
-                model.stream_interaction_events(request.clone()).await
+                client.stream_interaction_events(request.clone()).await
             } else if let Some(interaction_id) = state.interaction_id.as_deref() {
-                model
+                client
                     .stream_interaction_events_by_id(interaction_id, state.last_event_id.as_deref())
                     .await
             } else {
@@ -198,12 +250,24 @@ async fn main() -> Result<()> {
                 break;
             }
 
-            if state.interaction_id.is_none() {
+            let Some(interaction_id) = state.interaction_id.as_deref() else {
+                break;
+            };
+
+            // Official Deep Research guidance recommends checking the background
+            // interaction status before reconnecting a dropped/expired stream.
+            let interaction = client.get_interaction(interaction_id).await?;
+            if interaction.is_terminal() {
+                println!("Stream ended after interaction reached a terminal state.");
+                print_interaction_result(&interaction);
                 break;
             }
 
             attempt += 1;
-            println!("\nStream interrupted. Reconnecting in {STREAM_RETRY_DELAY_SECS}s...");
+            println!(
+                "\nStream interrupted while status was {:?}. Reconnecting in {STREAM_RETRY_DELAY_SECS}s...",
+                interaction.status.unwrap_or(InteractionStatus::InProgress)
+            );
             sleep(Duration::from_secs(STREAM_RETRY_DELAY_SECS)).await;
         }
 
@@ -211,33 +275,8 @@ async fn main() -> Result<()> {
             && let Some(interaction_id) = state.interaction_id.as_deref()
         {
             println!("Switching to polling for interaction {interaction_id}...");
-            loop {
-                let interaction = model.get_interaction(interaction_id).await?;
-                if interaction.is_terminal() {
-                    match interaction.status {
-                        Some(InteractionStatus::Completed) => {
-                            let text = extract_text_from_steps(&interaction.steps);
-                            if text.is_empty() {
-                                println!("No text output returned.");
-                            } else {
-                                println!("{text}");
-                            }
-                        }
-                        Some(status) => {
-                            println!("Research ended with status: {status:?}");
-                        }
-                        None => {
-                            println!("Research ended without a status.");
-                        }
-                    }
-                    break;
-                }
-                println!(
-                    "Status: {:?}. Polling again in 10s...",
-                    interaction.status.unwrap_or(InteractionStatus::InProgress)
-                );
-                sleep(Duration::from_secs(10)).await;
-            }
+            let interaction = poll_until_terminal(&client, interaction_id).await?;
+            print_interaction_result(&interaction);
         }
 
         if let Some(interaction_id) = state.interaction_id {
@@ -251,41 +290,16 @@ async fn main() -> Result<()> {
     }
 
     println!("== Deep Research (background polling) ==");
-    let interaction = model.create_interaction(request).await?;
+    println!("Agent: {agent}");
+    let interaction = client.create_interaction(request).await?;
     if interaction.id.is_empty() {
         println!("No interaction id returned; aborting.");
         return Ok(());
     }
     println!("Research started: {}", interaction.id);
 
-    loop {
-        let interaction = model.get_interaction(&interaction.id).await?;
-        if interaction.is_terminal() {
-            match interaction.status {
-                Some(InteractionStatus::Completed) => {
-                    let text = extract_text_from_steps(&interaction.steps);
-                    if text.is_empty() {
-                        println!("No text output returned.");
-                    } else {
-                        println!("{text}");
-                    }
-                }
-                Some(status) => {
-                    println!("Research ended with status: {status:?}");
-                }
-                None => {
-                    println!("Research ended without a status.");
-                }
-            }
-            break;
-        }
-
-        println!(
-            "Status: {:?}. Polling again in 10s...",
-            interaction.status.unwrap_or(InteractionStatus::InProgress)
-        );
-        sleep(Duration::from_secs(10)).await;
-    }
+    let interaction = poll_until_terminal(&client, &interaction.id).await?;
+    print_interaction_result(&interaction);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Build the Deep Research request directly as an Interactions API request, matching the official Gemini examples (`agent` + text `input`, no model)
- Add an overridable Deep Research agent via `GEMINI_DEEP_RESEARCH_AGENT`
- Share polling/final-result handling and prefer the last non-empty model output
- Improve streaming reconnection by checking interaction status before resuming with `last_event_id`

## Testing
- `cargo check -p gemini_deep_research`
- `GEMINI_DEEP_RESEARCH_AGENT=deep-research-pro-preview-12-2025 cargo run -p gemini_deep_research`

Note: I also tried the currently documented `deep-research-preview-04-2026` agent with this API key, but those interactions remained `in_progress` past local timeouts, so the example keeps the previously verified agent as the default while allowing documented variants through the env override.
