### PR TITLE
test(anthropic): add null citation streaming cassette

### DIFF
--- a/tests/cassettes/anthropic/plaintext_document/streaming_document_citations_accepts_null_citation_start.yaml
+++ b/tests/cassettes/anthropic/plaintext_document/streaming_document_citations_accepts_null_citation_start.yaml
@@ -1,0 +1,42 @@
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":64000,"messages":[{"content":[{"citations":{"enabled":true},"source":{"data":"The Rust Programming Language\n\nRust is a systems programming language focused on three goals: safety, speed,\nand concurrency. It accomplishes these goals without a garbage collector.\n\nKey Features:\n- Zero-cost abstractions\n- Move semantics\n- Guaranteed memory safety\n- Threads without data races","media_type":"text/plain","type":"text"},"title":"Rust Goals","type":"document"},{"text":"Using citations, answer in one sentence: what three goals does Rust focus on?","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","stream":true,"system":[{"text":"Answer using the supplied document and citation metadata.","type":"text"}],"temperature":0.0}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream; charset=utf-8
+  body: |+
+    event: message_start
+    data: {"message":{"content":[],"id":"msg_REDACTED_1","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":683,"output_tokens":5,"service_tier":"standard"}},"type":"message_start"}
+
+    event: content_block_start
+    data: {"content_block":{"citations":null,"text":"","type":"text"},"index":0,"type":"content_block_start"}
+
+    event: ping
+    data: {"type":"ping"}
+
+    event: content_block_delta
+    data: {"delta":{"citation":{"cited_text":"The Rust Programming Language\n\nRust is a systems programming language focused on three goals: safety, speed,\nand concurrency. ","document_index":0,"document_title":"Rust Goals","end_char_index":126,"start_char_index":0,"type":"char_location"},"type":"citations_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"text":"Rust focuses on three goals: **safety**, **speed**, and **concurrency**.","type":"text_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_stop
+    data: {"index":0,"type":"content_block_stop"}
+
+    event: message_delta
+    data: {"delta":{"stop_details":null,"stop_reason":"end_turn","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":683,"output_tokens":38}}
+
+    event: message_stop
+    data: {"type":"message_stop"}
+

--- a/tests/providers/anthropic/cassette/plaintext_document.rs
+++ b/tests/providers/anthropic/cassette/plaintext_document.rs
@@ -6,11 +6,14 @@ use rig::completion::{CompletionModel, Prompt};
 use rig::message::{Document, DocumentMediaType, DocumentSourceKind, Message, UserContent};
 use rig::providers::anthropic::completion::Citation;
 use rig::providers::anthropic::completion::{self as anthropic_completion, CLAUDE_SONNET_4_6};
+use rig::streaming::StreamingPrompt;
 use rig::telemetry::ProviderResponseExt;
 
 use serde_json::json;
 
-use crate::support::{assert_contains_any_case_insensitive, assert_nonempty_response};
+use crate::support::{
+    assert_contains_any_case_insensitive, assert_nonempty_response, collect_stream_final_response,
+};
 
 fn rust_document() -> String {
     r#"
@@ -129,6 +132,28 @@ async fn plaintext_document_with_instruction() {
                 })
                 .await
                 .expect("instruction prompt should succeed");
+
+            assert_contains_any_case_insensitive(&response, &["safety", "speed", "concurrency"]);
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn streaming_document_citations_accepts_null_citation_start() {
+    super::super::support::with_anthropic_cassette(
+        "plaintext_document/streaming_document_citations_accepts_null_citation_start",
+        |client| async move {
+            let agent = client
+                .agent(CLAUDE_SONNET_4_6)
+                .preamble("Answer using the supplied document and citation metadata.")
+                .temperature(0.0)
+                .build();
+
+            let mut stream = agent.stream_prompt(citation_prompt()).await;
+            let response = collect_stream_final_response(&mut stream)
+                .await
+                .expect("streaming document citations should accept null citations on text start");
 
             assert_contains_any_case_insensitive(&response, &["safety", "speed", "concurrency"]);
         },


### PR DESCRIPTION
## Summary
- Add an Anthropic streaming document-citation cassette that exercises the null citations content_block_start shape from #1971/#1972
- Verify the end-to-end streaming flow still returns citation-backed text instead of failing during SSE deserialization

Follows up #1972.

## Tests
- cargo test -p rig --all-features --test anthropic anthropic::cassette::plaintext_document -- --nocapture --test-threads=1
- cargo test -p rig --all-features --test anthropic cassette_safety -- --nocapture