### PR TITLE
feat(rig-core): add AgentBuilder provider-hosted tools

### DIFF
--- a/crates/rig-core/src/agent/builder.rs
+++ b/crates/rig-core/src/agent/builder.rs
@@ -4,7 +4,7 @@ use schemars::{JsonSchema, Schema, schema_for};
 
 use crate::{
     agent::hook::{AgentHook, HookStack},
-    completion::{CompletionModel, Document},
+    completion::{CompletionModel, Document, ProviderToolDefinition},
     memory::ConversationMemory,
     message::ToolChoice,
     tool::{
@@ -109,6 +109,8 @@ where
     static_context: Vec<Document>,
     /// Additional parameters to be passed to the model
     additional_params: Option<serde_json::Value>,
+    /// Provider-hosted tools executed by the model provider rather than Rig.
+    provider_tools: Vec<ProviderToolDefinition>,
     /// Maximum number of tokens for the completion
     max_tokens: Option<u64>,
     /// List of vector store, with the sample number
@@ -219,6 +221,27 @@ where
         self
     }
 
+    /// Add a provider-hosted tool to the agent.
+    ///
+    /// Provider-hosted tools are sent to the underlying provider and executed by
+    /// that provider; they are not registered in Rig's local [`ToolServer`].
+    pub fn provider_tool(mut self, tool: ProviderToolDefinition) -> Self {
+        self.provider_tools.push(tool);
+        self
+    }
+
+    /// Add provider-hosted tools to the agent.
+    ///
+    /// Provider-hosted tools are sent to the underlying provider and executed by
+    /// that provider; they are not registered in Rig's local [`ToolServer`].
+    pub fn provider_tools(
+        mut self,
+        tools: impl IntoIterator<Item = ProviderToolDefinition>,
+    ) -> Self {
+        self.provider_tools.extend(tools);
+        self
+    }
+
     /// Set the output schema for structured output. When set, providers that support
     /// native structured outputs will constrain the model's response to match this schema.
     pub fn output_schema<T>(mut self) -> Self
@@ -296,6 +319,7 @@ where
             temperature: None,
             max_tokens: None,
             additional_params: None,
+            provider_tools: vec![],
             dynamic_context: vec![],
             tool_choice: None,
             default_max_turns: None,
@@ -329,6 +353,7 @@ where
             preamble: self.preamble,
             static_context: self.static_context,
             additional_params: self.additional_params,
+            provider_tools: self.provider_tools,
             max_tokens: self.max_tokens,
             dynamic_context: self.dynamic_context,
             temperature: self.temperature,
@@ -356,6 +381,7 @@ where
             preamble: self.preamble,
             static_context: self.static_context,
             additional_params: self.additional_params,
+            provider_tools: self.provider_tools,
             max_tokens: self.max_tokens,
             dynamic_context: self.dynamic_context,
             temperature: self.temperature,
@@ -389,6 +415,7 @@ where
             preamble: self.preamble,
             static_context: self.static_context,
             additional_params: self.additional_params,
+            provider_tools: self.provider_tools,
             max_tokens: self.max_tokens,
             dynamic_context: self.dynamic_context,
             temperature: self.temperature,
@@ -490,6 +517,7 @@ where
             preamble: self.preamble,
             static_context: self.static_context,
             additional_params: self.additional_params,
+            provider_tools: self.provider_tools,
             max_tokens: self.max_tokens,
             dynamic_context: self.dynamic_context,
             temperature: self.temperature,
@@ -525,6 +553,7 @@ where
             preamble: self.preamble,
             static_context: self.static_context,
             additional_params: self.additional_params,
+            provider_tools: self.provider_tools,
             max_tokens: self.max_tokens,
             dynamic_context: self.dynamic_context,
             temperature: self.temperature,
@@ -558,6 +587,7 @@ where
             temperature: self.temperature,
             max_tokens: self.max_tokens,
             additional_params: self.additional_params,
+            provider_tools: self.provider_tools,
             tool_choice: self.tool_choice,
             dynamic_context: Arc::new(self.dynamic_context),
             tool_server_handle,
@@ -586,6 +616,7 @@ where
             temperature: self.temperature,
             max_tokens: self.max_tokens,
             additional_params: self.additional_params,
+            provider_tools: self.provider_tools,
             tool_choice: self.tool_choice,
             dynamic_context: Arc::new(self.dynamic_context),
             tool_server_handle: self.tool_state.handle,
@@ -696,6 +727,7 @@ where
             temperature: self.temperature,
             max_tokens: self.max_tokens,
             additional_params: self.additional_params,
+            provider_tools: self.provider_tools,
             tool_choice: self.tool_choice,
             dynamic_context: Arc::new(self.dynamic_context),
             tool_server_handle,
@@ -712,7 +744,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{MockAddTool, MockCompletionModel};
+    use crate::{
+        completion::{Completion, Message, ProviderToolDefinition},
+        test_utils::{MockAddTool, MockCompletionModel},
+    };
 
     #[derive(Clone)]
     struct BuilderHook;
@@ -725,6 +760,65 @@ mod tests {
             .tool(MockAddTool)
             .add_hook(BuilderHook)
             .build();
+    }
+
+    #[tokio::test]
+    async fn provider_tool_is_agent_config_not_local_tool() {
+        let agent = AgentBuilder::new(MockCompletionModel::text("ok"))
+            .provider_tool(
+                ProviderToolDefinition::new("web_search")
+                    .with_config("search_context_size", serde_json::json!("medium")),
+            )
+            .build();
+
+        assert_eq!(agent.provider_tools.len(), 1);
+        assert_eq!(agent.provider_tools[0].kind, "web_search");
+        assert_eq!(
+            agent.provider_tools[0].config["search_context_size"],
+            serde_json::json!("medium")
+        );
+        assert!(
+            agent
+                .tool_server_handle
+                .get_tool_defs(None)
+                .await
+                .expect("tool defs")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_tools_survive_tool_typestate_transitions_and_reach_requests() {
+        let agent = AgentBuilder::new(MockCompletionModel::text("ok"))
+            .provider_tools([
+                ProviderToolDefinition::new("web_search"),
+                ProviderToolDefinition::new("file_search")
+                    .with_config("vector_store_ids", serde_json::json!(["vs_123"])),
+            ])
+            .tool(MockAddTool)
+            .build();
+
+        assert_eq!(
+            agent
+                .provider_tools
+                .iter()
+                .map(|tool| tool.kind.as_str())
+                .collect::<Vec<_>>(),
+            vec!["web_search", "file_search"]
+        );
+
+        let request = agent
+            .completion("search", std::iter::empty::<Message>())
+            .await
+            .expect("completion request builder")
+            .build();
+        assert_eq!(
+            request.additional_params.expect("additional params")["tools"],
+            serde_json::json!([
+                { "type": "web_search" },
+                { "type": "file_search", "vector_store_ids": ["vs_123"] }
+            ])
+        );
     }
 
     /// The builder's shared MCP helper threads the configured timeout (default,

--- a/crates/rig-core/src/agent/completion.rs
+++ b/crates/rig-core/src/agent/completion.rs
@@ -6,7 +6,7 @@ use crate::{
     agent::prompt_request::streaming::StreamingPromptRequest,
     completion::{
         Chat, Completion, CompletionError, CompletionModel, CompletionRequestBuilder, Document,
-        GetTokenUsage, Message, Prompt, PromptError, TypedPrompt,
+        GetTokenUsage, Message, Prompt, PromptError, ProviderToolDefinition, TypedPrompt,
     },
     message::ToolChoice,
     streaming::{StreamingChat, StreamingCompletion, StreamingPrompt},
@@ -152,6 +152,7 @@ pub(crate) async fn build_completion_request<M: CompletionModel>(
     temperature: Option<f64>,
     max_tokens: Option<u64>,
     additional_params: Option<&serde_json::Value>,
+    provider_tools: &[ProviderToolDefinition],
     tool_choice: Option<&ToolChoice>,
     tool_server_handle: &ToolServerHandle,
     dynamic_context: &DynamicContextStore,
@@ -166,6 +167,7 @@ pub(crate) async fn build_completion_request<M: CompletionModel>(
         temperature,
         max_tokens,
         additional_params,
+        provider_tools,
         tool_choice,
         tool_server_handle,
         dynamic_context,
@@ -191,6 +193,7 @@ pub(crate) async fn build_prepared_completion_request<M: CompletionModel>(
     temperature: Option<f64>,
     max_tokens: Option<u64>,
     additional_params: Option<&serde_json::Value>,
+    provider_tools: &[ProviderToolDefinition],
     tool_choice: Option<&ToolChoice>,
     tool_server_handle: &ToolServerHandle,
     dynamic_context: &DynamicContextStore,
@@ -377,6 +380,7 @@ pub(crate) async fn build_prepared_completion_request<M: CompletionModel>(
         .temperature_opt(temperature)
         .max_tokens_opt(max_tokens)
         .additional_params_opt(additional_params.cloned())
+        .provider_tools(provider_tools.to_vec())
         .documents(static_context.to_vec())
         .tools(tooldefs);
 
@@ -461,6 +465,8 @@ where
     pub max_tokens: Option<u64>,
     /// Additional parameters to be passed to the model
     pub additional_params: Option<serde_json::Value>,
+    /// Provider-hosted tools executed by the model provider rather than Rig.
+    pub provider_tools: Vec<ProviderToolDefinition>,
     pub tool_server_handle: ToolServerHandle,
     /// List of vector store, with the sample number
     pub dynamic_context: DynamicContextStore,
@@ -523,6 +529,7 @@ where
             self.temperature,
             self.max_tokens,
             self.additional_params.as_ref(),
+            &self.provider_tools,
             self.tool_choice.as_ref(),
             &self.tool_server_handle,
             &self.dynamic_context,

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -428,6 +428,7 @@ where
         let temperature = self.temperature;
         let max_tokens = self.max_tokens;
         let additional_params = self.additional_params.clone();
+        let provider_tools = self.provider_tools.clone();
         let tool_server_handle = self.tool_server_handle.clone();
         let tool_extensions = self.tool_extensions.clone();
         let dynamic_context = self.dynamic_context.clone();
@@ -561,6 +562,7 @@ where
                             temperature,
                             max_tokens,
                             additional_params.as_ref(),
+                            &provider_tools,
                             tool_choice.as_ref(),
                             &tool_server_handle,
                             &dynamic_context,

--- a/crates/rig-core/src/agent/runner.rs
+++ b/crates/rig-core/src/agent/runner.rs
@@ -43,7 +43,7 @@ use super::{
     },
 };
 use crate::{
-    completion::{CompletionModel, Document, Message, PromptError},
+    completion::{CompletionModel, Document, Message, PromptError, ProviderToolDefinition},
     json_utils,
     memory::ConversationMemory,
     message::{ToolCall, ToolChoice, UserContent},
@@ -162,6 +162,7 @@ where
     pub(crate) temperature: Option<f64>,
     pub(crate) max_tokens: Option<u64>,
     pub(crate) additional_params: Option<serde_json::Value>,
+    pub(crate) provider_tools: Vec<ProviderToolDefinition>,
     pub(crate) tool_server_handle: ToolServerHandle,
     /// Per-call runtime extensions made available to every tool executed during
     /// this run via [`Tool::call_with_extensions`](crate::tool::Tool::call_with_extensions).
@@ -197,6 +198,7 @@ where
             temperature: agent.temperature,
             max_tokens: agent.max_tokens,
             additional_params: agent.additional_params.clone(),
+            provider_tools: agent.provider_tools.clone(),
             tool_server_handle: agent.tool_server_handle.clone(),
             tool_extensions: ToolCallExtensions::new(),
             dynamic_context: agent.dynamic_context.clone(),
@@ -554,6 +556,7 @@ where
                         self.temperature,
                         self.max_tokens,
                         self.additional_params.as_ref(),
+                        &self.provider_tools,
                         self.tool_choice.as_ref(),
                         &self.tool_server_handle,
                         &self.dynamic_context,


### PR DESCRIPTION
## Summary
- add `AgentBuilder::provider_tool` / `provider_tools` for provider-hosted tools
- carry provider-hosted tools through Agent and AgentRunner into completion requests
- keep hosted tools out of Rig local ToolServer execution and add regression coverage

Closes #1890

## Tests
- cargo test -p rig-core agent::builder::tests
- cargo check -p rig-core