### PR TITLE
feat(agent): support provider-hosted tools

### DIFF
--- a/crates/rig-core/src/agent/builder.rs
+++ b/crates/rig-core/src/agent/builder.rs
@@ -4,7 +4,7 @@ use schemars::{JsonSchema, Schema, schema_for};
 
 use crate::{
     agent::hook::{AgentHook, HookStack},
-    completion::{CompletionModel, Document},
+    completion::{CompletionModel, Document, ProviderToolDefinition},
     memory::ConversationMemory,
     message::ToolChoice,
     tool::{
@@ -109,6 +109,8 @@ where
     static_context: Vec<Document>,
     /// Additional parameters to be passed to the model
     additional_params: Option<serde_json::Value>,
+    /// Provider-hosted tools executed by the model provider rather than Rig's tool server.
+    provider_tools: Vec<ProviderToolDefinition>,
     /// Maximum number of tokens for the completion
     max_tokens: Option<u64>,
     /// List of vector store, with the sample number
@@ -219,6 +221,26 @@ where
         self
     }
 
+    /// Add a provider-hosted tool to the agent.
+    ///
+    /// Provider-hosted tools are serialized into the provider request but are
+    /// executed by the model provider, not by Rig's [`ToolServer`]. They may be
+    /// mixed with normal Rig tools; providers that support hosted tools merge
+    /// both kinds into the same wire `tools` array.
+    pub fn provider_tool(mut self, tool: ProviderToolDefinition) -> Self {
+        self.provider_tools.push(tool);
+        self
+    }
+
+    /// Add provider-hosted tools to the agent.
+    pub fn provider_tools(
+        mut self,
+        tools: impl IntoIterator<Item = ProviderToolDefinition>,
+    ) -> Self {
+        self.provider_tools.extend(tools);
+        self
+    }
+
     /// Set the output schema for structured output. When set, providers that support
     /// native structured outputs will constrain the model's response to match this schema.
     pub fn output_schema<T>(mut self) -> Self
@@ -296,6 +318,7 @@ where
             temperature: None,
             max_tokens: None,
             additional_params: None,
+            provider_tools: Vec::new(),
             dynamic_context: vec![],
             tool_choice: None,
             default_max_turns: None,
@@ -329,6 +352,7 @@ where
             preamble: self.preamble,
             static_context: self.static_context,
             additional_params: self.additional_params,
+            provider_tools: self.provider_tools,
             max_tokens: self.max_tokens,
             dynamic_context: self.dynamic_context,
             temperature: self.temperature,
@@ -356,6 +380,7 @@ where
             preamble: self.preamble,
             static_context: self.static_context,
             additional_params: self.additional_params,
+            provider_tools: self.provider_tools,
             max_tokens: self.max_tokens,
             dynamic_context: self.dynamic_context,
             temperature: self.temperature,
@@ -389,6 +414,7 @@ where
             preamble: self.preamble,
             static_context: self.static_context,
             additional_params: self.additional_params,
+            provider_tools: self.provider_tools,
             max_tokens: self.max_tokens,
             dynamic_context: self.dynamic_context,
             temperature: self.temperature,
@@ -490,6 +516,7 @@ where
             preamble: self.preamble,
             static_context: self.static_context,
             additional_params: self.additional_params,
+            provider_tools: self.provider_tools,
             max_tokens: self.max_tokens,
             dynamic_context: self.dynamic_context,
             temperature: self.temperature,
@@ -525,6 +552,7 @@ where
             preamble: self.preamble,
             static_context: self.static_context,
             additional_params: self.additional_params,
+            provider_tools: self.provider_tools,
             max_tokens: self.max_tokens,
             dynamic_context: self.dynamic_context,
             temperature: self.temperature,
@@ -558,6 +586,7 @@ where
             temperature: self.temperature,
             max_tokens: self.max_tokens,
             additional_params: self.additional_params,
+            provider_tools: self.provider_tools,
             tool_choice: self.tool_choice,
             dynamic_context: Arc::new(self.dynamic_context),
             tool_server_handle,
@@ -586,6 +615,7 @@ where
             temperature: self.temperature,
             max_tokens: self.max_tokens,
             additional_params: self.additional_params,
+            provider_tools: self.provider_tools,
             tool_choice: self.tool_choice,
             dynamic_context: Arc::new(self.dynamic_context),
             tool_server_handle: self.tool_state.handle,
@@ -696,6 +726,7 @@ where
             temperature: self.temperature,
             max_tokens: self.max_tokens,
             additional_params: self.additional_params,
+            provider_tools: self.provider_tools,
             tool_choice: self.tool_choice,
             dynamic_context: Arc::new(self.dynamic_context),
             tool_server_handle,
@@ -712,6 +743,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::completion::Completion;
     use crate::test_utils::{MockAddTool, MockCompletionModel};
 
     #[derive(Clone)]
@@ -725,6 +757,61 @@ mod tests {
             .tool(MockAddTool)
             .add_hook(BuilderHook)
             .build();
+    }
+
+    #[tokio::test]
+    async fn provider_tool_is_forwarded_to_completion_request() {
+        let agent = AgentBuilder::new(MockCompletionModel::text("ok"))
+            .provider_tool(
+                ProviderToolDefinition::new("web_search")
+                    .with_config("search_context_size", serde_json::json!("low")),
+            )
+            .build();
+
+        let request = agent
+            .completion("search", Vec::<crate::completion::Message>::new())
+            .await
+            .expect("completion request should build")
+            .build();
+
+        assert!(request.tools.is_empty());
+        assert_eq!(
+            request.additional_params.as_ref().and_then(|params| {
+                params
+                    .get("tools")
+                    .and_then(|tools| tools.get(0))
+                    .and_then(|tool| tool.get("type"))
+                    .and_then(serde_json::Value::as_str)
+            }),
+            Some("web_search")
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_tools_do_not_enter_executable_tool_set() {
+        let agent = AgentBuilder::new(MockCompletionModel::text("ok"))
+            .provider_tool(ProviderToolDefinition::new("web_search"))
+            .tool(MockAddTool)
+            .build();
+
+        let request = agent
+            .completion("search", Vec::<crate::completion::Message>::new())
+            .await
+            .expect("completion request should build")
+            .build();
+
+        assert_eq!(request.tools.len(), 1);
+        assert_eq!(request.tools[0].name, "add");
+        assert_eq!(
+            request.additional_params.as_ref().and_then(|params| {
+                params
+                    .get("tools")
+                    .and_then(|tools| tools.get(0))
+                    .and_then(|tool| tool.get("type"))
+                    .and_then(serde_json::Value::as_str)
+            }),
+            Some("web_search")
+        );
     }
 
     /// The builder's shared MCP helper threads the configured timeout (default,

--- a/crates/rig-core/src/agent/completion.rs
+++ b/crates/rig-core/src/agent/completion.rs
@@ -58,19 +58,19 @@ fn tool_choice_permits_output_tool(tool_choice: Option<&ToolChoice>) -> bool {
 ///
 /// With no schema there is nothing to enforce, so the result is always `Native`
 /// (the synthetic tool and prompt injection only make sense with a schema).
-/// `Auto` becomes `Tool` only when a real executable tool is present, the tool
-/// choice permits the output-tool call, AND the provider does *not* compose
-/// native structured output with tools — i.e. only where the native constraint
-/// would actually suppress tool calls (#1928). On providers that compose them
-/// (OpenAI, Anthropic), `Auto` keeps guaranteed native structured output.
-/// `Tool` (explicit or via `Auto`) requires that the active [`ToolChoice`]
-/// permit the output-tool call; when it does not, it degrades to `Native` so
-/// structured output is still enforced rather than silently dropped. Explicit
-/// `Prompted`/`Native` are honored when a schema is present. The returned mode is
-/// never `Auto`.
+/// `Auto` becomes `Tool` only when any tool (Rig-executable or provider-hosted)
+/// is present, the tool choice permits the output-tool call, AND the provider
+/// does *not* compose native structured output with tools — i.e. only where the
+/// native constraint would actually suppress tool calls (#1928). On providers
+/// that compose them (OpenAI, Anthropic), `Auto` keeps guaranteed native
+/// structured output. `Tool` (explicit or via `Auto`) requires that the active
+/// [`ToolChoice`] permit the output-tool call; when it does not, it degrades to
+/// `Native` so structured output is still enforced rather than silently dropped.
+/// Explicit `Prompted`/`Native` are honored when a schema is present. The
+/// returned mode is never `Auto`.
 fn resolve_output_mode(
     has_schema: bool,
-    has_executable_tools: bool,
+    has_tools: bool,
     output_tool_callable: bool,
     provider_composes_native: bool,
     requested: &OutputMode,
@@ -83,9 +83,7 @@ fn resolve_output_mode(
         OutputMode::Prompted => OutputMode::Prompted,
         OutputMode::Tool if output_tool_callable => OutputMode::Tool,
         OutputMode::Tool => OutputMode::Native,
-        OutputMode::Auto
-            if has_executable_tools && output_tool_callable && !provider_composes_native =>
-        {
+        OutputMode::Auto if has_tools && output_tool_callable && !provider_composes_native => {
             OutputMode::Tool
         }
         OutputMode::Auto => OutputMode::Native,
@@ -102,6 +100,13 @@ fn pick_output_tool_name(executable_tool_names: &BTreeSet<String>) -> String {
         suffix += 1;
     }
     name
+}
+
+fn additional_params_has_provider_tools(additional_params: Option<&serde_json::Value>) -> bool {
+    additional_params
+        .and_then(|params| params.get("tools"))
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|tools| !tools.is_empty())
 }
 
 pub(crate) fn allowed_tool_names_for_choice(
@@ -342,6 +347,9 @@ pub(crate) async fn build_prepared_completion_request<M: CompletionModel>(
     // synthetic output tool is appended.
     let executable_tool_names: BTreeSet<String> =
         tooldefs.iter().map(|tool| tool.name.clone()).collect();
+    let has_provider_hosted_tools = !provider_tools.is_empty()
+        || additional_params_has_provider_tools(additional_params.as_ref());
+    let has_tools_for_output_mode = !executable_tool_names.is_empty() || has_provider_hosted_tools;
 
     // Resolve the effective output mode (#1928). Once the run has committed to a
     // Tool-mode output tool on an earlier turn (signaled by `committed_output_
@@ -351,14 +359,15 @@ pub(crate) async fn build_prepared_completion_request<M: CompletionModel>(
     // constraint that suppressed tools in the first place. Only Tool mode is
     // pinned; Native/Prompted re-resolve, so a tool-less first turn can still
     // become Tool once tools appear. Otherwise resolve from the request, the
-    // schema, the tool set, whether the tool choice permits the output-tool call,
-    // and whether the provider composes native structured output with tools.
+    // schema, the Rig/provider-hosted tool set, whether the tool choice permits
+    // the output-tool call, and whether the provider composes native structured
+    // output with tools.
     let resolved_mode = if committed_output_tool.is_some() && output_schema.is_some() {
         OutputMode::Tool
     } else {
         resolve_output_mode(
             output_schema.is_some(),
-            !executable_tool_names.is_empty(),
+            has_tools_for_output_mode,
             tool_choice_permits_output_tool(tool_choice),
             model.composes_native_output_with_tools(),
             output_mode,
@@ -1007,6 +1016,72 @@ mod tests {
     fn pick_output_tool_name_defaults_when_unused() {
         let executable = tool_names(&["add", "subtract"]);
         assert_eq!(pick_output_tool_name(&executable), DEFAULT_OUTPUT_TOOL_NAME);
+    }
+
+    #[tokio::test]
+    async fn auto_output_mode_counts_provider_hosted_tools_without_making_them_executable() {
+        let model = std::sync::Arc::new(crate::test_utils::MockCompletionModel::default());
+        let tool_server = crate::tool::server::ToolServer::new().run();
+        let dynamic_context: DynamicContextStore = std::sync::Arc::new(Vec::new());
+        let schema: schemars::Schema = serde_json::from_value(serde_json::json!({
+            "title": "SearchAnswer",
+            "type": "object",
+            "properties": {
+                "answer": { "type": "string" }
+            },
+            "required": ["answer"]
+        }))
+        .expect("schema should deserialize");
+
+        let prepared = build_prepared_completion_request(
+            &model,
+            Message::user("search then answer"),
+            &[],
+            None,
+            &[],
+            None,
+            None,
+            None,
+            &[ProviderToolDefinition::new("web_search")],
+            None,
+            &tool_server,
+            &dynamic_context,
+            Some(&schema),
+            &OutputMode::Auto,
+            None,
+            None,
+        )
+        .await
+        .expect("request should build");
+
+        assert!(prepared.executable_tool_names.is_empty());
+        assert_eq!(
+            prepared.output_tool_name.as_deref(),
+            Some(DEFAULT_OUTPUT_TOOL_NAME)
+        );
+        assert_eq!(
+            prepared.allowed_tool_names,
+            tool_names(&[DEFAULT_OUTPUT_TOOL_NAME])
+        );
+
+        let request = prepared.builder.build();
+        assert!(
+            request.output_schema.is_none(),
+            "Tool mode should not set native output_schema"
+        );
+        assert_eq!(request.tools.len(), 1);
+        assert_eq!(request.tools[0].name, DEFAULT_OUTPUT_TOOL_NAME);
+        assert_eq!(
+            request.additional_params.as_ref().and_then(|params| {
+                params
+                    .get("tools")
+                    .and_then(serde_json::Value::as_array)
+                    .and_then(|tools| tools.first())
+                    .and_then(|tool| tool.get("type"))
+                    .and_then(serde_json::Value::as_str)
+            }),
+            Some("web_search")
+        );
     }
 
     #[test]

--- a/crates/rig-core/src/agent/completion.rs
+++ b/crates/rig-core/src/agent/completion.rs
@@ -6,7 +6,7 @@ use crate::{
     agent::prompt_request::streaming::StreamingPromptRequest,
     completion::{
         Chat, Completion, CompletionError, CompletionModel, CompletionRequestBuilder, Document,
-        GetTokenUsage, Message, Prompt, PromptError, TypedPrompt,
+        GetTokenUsage, Message, Prompt, PromptError, ProviderToolDefinition, TypedPrompt,
     },
     json_utils,
     message::ToolChoice,
@@ -153,6 +153,7 @@ pub(crate) async fn build_completion_request<M: CompletionModel>(
     temperature: Option<f64>,
     max_tokens: Option<u64>,
     additional_params: Option<&serde_json::Value>,
+    provider_tools: &[ProviderToolDefinition],
     tool_choice: Option<&ToolChoice>,
     tool_server_handle: &ToolServerHandle,
     dynamic_context: &DynamicContextStore,
@@ -167,6 +168,7 @@ pub(crate) async fn build_completion_request<M: CompletionModel>(
         temperature,
         max_tokens,
         additional_params,
+        provider_tools,
         tool_choice,
         tool_server_handle,
         dynamic_context,
@@ -194,6 +196,7 @@ pub(crate) async fn build_prepared_completion_request<M: CompletionModel>(
     temperature: Option<f64>,
     max_tokens: Option<u64>,
     additional_params: Option<&serde_json::Value>,
+    provider_tools: &[ProviderToolDefinition],
     tool_choice: Option<&ToolChoice>,
     tool_server_handle: &ToolServerHandle,
     dynamic_context: &DynamicContextStore,
@@ -465,6 +468,7 @@ pub(crate) async fn build_prepared_completion_request<M: CompletionModel>(
         .temperature_opt(temperature)
         .max_tokens_opt(max_tokens)
         .additional_params_opt(additional_params)
+        .provider_tools(provider_tools.to_vec())
         .documents(static_context.to_vec())
         .tools(tooldefs);
 
@@ -549,6 +553,8 @@ where
     pub max_tokens: Option<u64>,
     /// Additional parameters to be passed to the model
     pub additional_params: Option<serde_json::Value>,
+    /// Provider-hosted tools executed by the model provider rather than Rig.
+    pub provider_tools: Vec<ProviderToolDefinition>,
     pub tool_server_handle: ToolServerHandle,
     /// List of vector store, with the sample number
     pub dynamic_context: DynamicContextStore,
@@ -611,6 +617,7 @@ where
             self.temperature,
             self.max_tokens,
             self.additional_params.as_ref(),
+            &self.provider_tools,
             self.tool_choice.as_ref(),
             &self.tool_server_handle,
             &self.dynamic_context,

--- a/crates/rig-core/src/agent/completion.rs
+++ b/crates/rig-core/src/agent/completion.rs
@@ -109,6 +109,22 @@ fn additional_params_has_provider_tools(additional_params: Option<&serde_json::V
         .is_some_and(|tools| !tools.is_empty())
 }
 
+fn suppress_provider_tools_from_additional_params(
+    additional_params: Option<serde_json::Value>,
+) -> Option<serde_json::Value> {
+    match additional_params {
+        Some(serde_json::Value::Object(mut params)) if params.contains_key("tools") => {
+            params.remove("tools");
+            if params.is_empty() {
+                None
+            } else {
+                Some(serde_json::Value::Object(params))
+            }
+        }
+        other => other,
+    }
+}
+
 pub(crate) fn allowed_tool_names_for_choice(
     executable_tool_names: &BTreeSet<String>,
     tool_choice: Option<&ToolChoice>,
@@ -238,6 +254,21 @@ pub(crate) async fn build_prepared_completion_request<M: CompletionModel>(
         (base, patch) => patch.or(base).cloned(),
     };
     let active_tools = request_override.and_then(|o| o.active_tools.as_deref());
+    // `active_tools` is an allow-list for all tools advertised this turn. Since
+    // provider-hosted tools are not Rig-executable and cannot be named in the
+    // allow-list, suppress them (both builder-provided tools and passthrough
+    // `additional_params.tools`) whenever the allow-list is present. With no
+    // allow-list, preserve baseline/override provider-tool injection.
+    let provider_tools = if active_tools.is_some() {
+        &[]
+    } else {
+        provider_tools
+    };
+    let additional_params = if active_tools.is_some() {
+        suppress_provider_tools_from_additional_params(additional_params)
+    } else {
+        additional_params
+    };
 
     // Find the latest message in the chat history that contains RAG text
     let rag_text = prompt.rag_text();
@@ -1016,6 +1047,81 @@ mod tests {
     fn pick_output_tool_name_defaults_when_unused() {
         let executable = tool_names(&["add", "subtract"]);
         assert_eq!(pick_output_tool_name(&executable), DEFAULT_OUTPUT_TOOL_NAME);
+    }
+
+    #[tokio::test]
+    async fn active_tools_empty_suppresses_provider_hosted_tools_and_keeps_auto_native() {
+        let model = std::sync::Arc::new(crate::test_utils::MockCompletionModel::default());
+        let tool_server = crate::tool::server::ToolServer::new().run();
+        let dynamic_context: DynamicContextStore = std::sync::Arc::new(Vec::new());
+        let schema: schemars::Schema = serde_json::from_value(serde_json::json!({
+            "title": "SearchAnswer",
+            "type": "object",
+            "properties": {
+                "answer": { "type": "string" }
+            },
+            "required": ["answer"]
+        }))
+        .expect("schema should deserialize");
+        let provider_tools = vec![ProviderToolDefinition::new("web_search")];
+        let base_additional_params = serde_json::json!({
+            "metadata": { "source": "baseline" },
+            "tools": [ProviderToolDefinition::new("file_search")]
+        });
+        let request_override = RequestOverride::new()
+            .active_tools(Vec::<String>::new())
+            .additional_params(serde_json::json!({
+                "reasoning_effort": "low",
+                "tools": [ProviderToolDefinition::new("custom")]
+            }));
+
+        let prepared = build_prepared_completion_request(
+            &model,
+            Message::user("answer without tools"),
+            &[],
+            None,
+            &[],
+            None,
+            None,
+            Some(&base_additional_params),
+            &provider_tools,
+            None,
+            &tool_server,
+            &dynamic_context,
+            Some(&schema),
+            &OutputMode::Auto,
+            None,
+            Some(&request_override),
+        )
+        .await
+        .expect("request should build");
+
+        assert!(prepared.executable_tool_names.is_empty());
+        assert!(prepared.output_tool_name.is_none());
+        assert!(prepared.allowed_tool_names.is_empty());
+
+        let request = prepared.builder.build();
+        assert!(
+            request.output_schema.is_some(),
+            "Auto mode should stay Native when active_tools suppresses provider tools"
+        );
+        assert!(request.tools.is_empty());
+        let additional_params = request
+            .additional_params
+            .as_ref()
+            .expect("non-tool passthrough params should be preserved");
+        assert!(
+            additional_params.get("tools").is_none(),
+            "provider-hosted tools from builder, baseline params, and override params should be suppressed"
+        );
+        assert_eq!(
+            additional_params.get("metadata"),
+            Some(&serde_json::json!({ "source": "baseline" }))
+        );
+        assert_eq!(
+            additional_params.get("reasoning_effort"),
+            Some(&serde_json::json!("low"))
+        );
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/agent/hook.rs
+++ b/crates/rig-core/src/agent/hook.rs
@@ -320,7 +320,8 @@ pub struct RequestOverride {
     /// Override the tool choice for this turn.
     pub tool_choice: Option<ToolChoice>,
     /// Restrict the advertised tools to this allow-list (by name) for this turn.
-    /// `Some(vec![])` advertises no executable tools; `None` keeps the full set.
+    /// `Some(vec![])` advertises no tools; `None` keeps the full set, including
+    /// any provider-hosted tools supplied through the builder or passthrough params.
     pub active_tools: Option<Vec<String>>,
     /// Provider-passthrough params shallow-merged onto the agent's for this turn.
     pub additional_params: Option<serde_json::Value>,
@@ -365,12 +366,13 @@ impl RequestOverride {
 
     /// Restrict the advertised tools to this allow-list (by name) for this turn.
     ///
-    /// This narrows the executable tool set, so it composes with `tool_choice`:
-    /// if the effective tool choice is a [`ToolChoice::Specific`] naming a tool
-    /// that `active_tools` filters out (e.g. the agent's baseline choice is
-    /// inherited because this override didn't set its own), the request fails
-    /// closed with a request error rather than silently forcing a dropped tool.
-    /// When narrowing the set, set a compatible `tool_choice` in the same patch.
+    /// This narrows the executable tool set and suppresses provider-hosted tools
+    /// for the turn, so it composes with `tool_choice`: if the effective tool
+    /// choice is a [`ToolChoice::Specific`] naming a tool that `active_tools`
+    /// filters out (e.g. the agent's baseline choice is inherited because this
+    /// override didn't set its own), the request fails closed with a request
+    /// error rather than silently forcing a dropped tool. When narrowing the set,
+    /// set a compatible `tool_choice` in the same patch.
     pub fn active_tools<I, S>(mut self, names: I) -> Self
     where
         I: IntoIterator<Item = S>,

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -439,6 +439,7 @@ where
         let temperature = self.temperature;
         let max_tokens = self.max_tokens;
         let additional_params = self.additional_params.clone();
+        let provider_tools = self.provider_tools.clone();
         let tool_server_handle = self.tool_server_handle.clone();
         let tool_extensions = self.tool_extensions.clone();
         let dynamic_context = self.dynamic_context.clone();
@@ -589,6 +590,7 @@ where
                             temperature,
                             max_tokens,
                             additional_params.as_ref(),
+                            &provider_tools,
                             tool_choice.as_ref(),
                             &tool_server_handle,
                             &dynamic_context,

--- a/crates/rig-core/src/agent/run/output_mode.rs
+++ b/crates/rig-core/src/agent/run/output_mode.rs
@@ -28,11 +28,14 @@ use serde::{Deserialize, Serialize};
 #[non_exhaustive]
 pub enum OutputMode {
     /// Resolve at request time: [`OutputMode::Tool`] when the agent has an
-    /// `output_schema` **and** at least one function tool (and the tool choice
-    /// permits the output-tool call), otherwise [`OutputMode::Native`]. This is
-    /// the default and only changes behavior for the tool + schema case (which is
-    /// broken under `Native` on providers whose native constraint suppresses
-    /// tool calls).
+    /// `output_schema`, at least one Rig-executable or provider-hosted tool, the
+    /// tool choice permits the output-tool call, and the provider's native
+    /// structured output does **not** compose with tool calls. Otherwise resolves
+    /// to [`OutputMode::Native`], so provider-composing models (e.g. OpenAI,
+    /// Anthropic) keep guaranteed native structured output. This is the default
+    /// and only changes behavior for the tool + schema case (which is broken
+    /// under `Native` on providers whose native constraint suppresses tool
+    /// calls).
     #[default]
     Auto,
     /// Register the schema as a synthetic "output tool" the model calls to

--- a/crates/rig-core/src/agent/runner.rs
+++ b/crates/rig-core/src/agent/runner.rs
@@ -43,7 +43,7 @@ use super::{
     },
 };
 use crate::{
-    completion::{CompletionModel, Document, Message, PromptError},
+    completion::{CompletionModel, Document, Message, PromptError, ProviderToolDefinition},
     json_utils,
     memory::ConversationMemory,
     message::{ToolCall, ToolChoice, UserContent},
@@ -233,6 +233,7 @@ where
     pub(crate) temperature: Option<f64>,
     pub(crate) max_tokens: Option<u64>,
     pub(crate) additional_params: Option<serde_json::Value>,
+    pub(crate) provider_tools: Vec<ProviderToolDefinition>,
     pub(crate) tool_server_handle: ToolServerHandle,
     /// Per-call runtime extensions made available to every tool executed during
     /// this run via [`Tool::call_with_extensions`](crate::tool::Tool::call_with_extensions).
@@ -268,6 +269,7 @@ where
             temperature: agent.temperature,
             max_tokens: agent.max_tokens,
             additional_params: agent.additional_params.clone(),
+            provider_tools: agent.provider_tools.clone(),
             tool_server_handle: agent.tool_server_handle.clone(),
             tool_extensions: ToolCallExtensions::new(),
             dynamic_context: agent.dynamic_context.clone(),
@@ -759,6 +761,7 @@ where
                         self.temperature,
                         self.max_tokens,
                         self.additional_params.as_ref(),
+                        &self.provider_tools,
                         self.tool_choice.as_ref(),
                         &self.tool_server_handle,
                         &self.dynamic_context,

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -763,7 +763,7 @@ impl CompletionRequest {
     }
 }
 
-pub(crate) fn take_provider_tools_from_additional_params(
+pub(crate) fn take_function_provider_tools_from_additional_params(
     additional_params: &mut Option<serde_json::Value>,
     provider_name: &str,
 ) -> Result<Vec<serde_json::Value>, CompletionError> {
@@ -771,11 +771,37 @@ pub(crate) fn take_provider_tools_from_additional_params(
         && let Some(map) = params.as_object_mut()
         && let Some(raw_tools) = map.remove("tools")
     {
-        return serde_json::from_value::<Vec<serde_json::Value>>(raw_tools).map_err(|err| {
+        let tools = serde_json::from_value::<Vec<serde_json::Value>>(raw_tools).map_err(|err| {
             CompletionError::RequestError(
                 format!("Invalid {provider_name} `additional_params.tools` payload: {err}").into(),
             )
-        });
+        })?;
+
+        for (idx, tool) in tools.iter().enumerate() {
+            let Some(tool_object) = tool.as_object() else {
+                return Err(CompletionError::RequestError(
+                    format!(
+                        "Unsupported {provider_name} provider tool at additional_params.tools[{idx}]: only function tools are supported because this provider does not handle native provider-tool outputs"
+                    )
+                    .into(),
+                ));
+            };
+
+            if tool_object.get("type").and_then(|kind| kind.as_str()) != Some("function")
+                || !tool_object
+                    .get("function")
+                    .is_some_and(serde_json::Value::is_object)
+            {
+                return Err(CompletionError::RequestError(
+                    format!(
+                        "Unsupported {provider_name} provider tool at additional_params.tools[{idx}]: only function tools are supported because this provider does not handle native provider-tool outputs"
+                    )
+                    .into(),
+                ));
+            }
+        }
+
+        return Ok(tools);
     }
 
     Ok(Vec::new())
@@ -1124,6 +1150,73 @@ mod tests {
 
     use super::*;
     use crate::test_utils::MockCompletionModel;
+
+    #[test]
+    fn function_provider_tools_from_additional_params_rejects_non_array_payload() {
+        let mut additional_params = Some(serde_json::json!({
+            "tools": { "type": "function" }
+        }));
+
+        let result = take_function_provider_tools_from_additional_params(
+            &mut additional_params,
+            "TestProvider",
+        );
+
+        assert!(matches!(result, Err(CompletionError::RequestError(_))));
+    }
+
+    #[test]
+    fn function_provider_tools_from_additional_params_rejects_native_tool() {
+        let mut additional_params = Some(serde_json::json!({
+            "tools": [{ "type": "web_search_preview" }]
+        }));
+
+        let result = take_function_provider_tools_from_additional_params(
+            &mut additional_params,
+            "TestProvider",
+        );
+
+        let error = result.expect_err("native provider tool should be rejected");
+        assert!(matches!(error, CompletionError::RequestError(_)));
+        assert!(
+            error
+                .to_string()
+                .contains("only function tools are supported")
+        );
+    }
+
+    #[test]
+    fn function_provider_tools_from_additional_params_accepts_function_tool_and_keeps_other_params()
+    {
+        let mut additional_params = Some(serde_json::json!({
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "description": "Lookup a value",
+                    "parameters": {"type": "object", "properties": {}}
+                },
+                "strict": true
+            }],
+            "metadata": {"source": "test"}
+        }));
+
+        let tools = take_function_provider_tools_from_additional_params(
+            &mut additional_params,
+            "TestProvider",
+        )
+        .expect("function provider tool should be accepted");
+
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0]["type"], "function");
+        assert_eq!(tools[0]["function"]["name"], "lookup");
+        assert_eq!(tools[0]["strict"], true);
+        assert_eq!(
+            additional_params.as_ref().unwrap()["metadata"]["source"],
+            "test"
+        );
+        assert!(additional_params.as_ref().unwrap().get("tools").is_none());
+    }
 
     fn test_document(id: &str, text: &str) -> Document {
         Document {

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -763,6 +763,24 @@ impl CompletionRequest {
     }
 }
 
+pub(crate) fn take_provider_tools_from_additional_params(
+    additional_params: &mut Option<serde_json::Value>,
+    provider_name: &str,
+) -> Result<Vec<serde_json::Value>, CompletionError> {
+    if let Some(params) = additional_params.as_mut()
+        && let Some(map) = params.as_object_mut()
+        && let Some(raw_tools) = map.remove("tools")
+    {
+        return serde_json::from_value::<Vec<serde_json::Value>>(raw_tools).map_err(|err| {
+            CompletionError::RequestError(
+                format!("Invalid {provider_name} `additional_params.tools` payload: {err}").into(),
+            )
+        });
+    }
+
+    Ok(Vec::new())
+}
+
 fn merge_provider_tools_into_additional_params(
     additional_params: Option<serde_json::Value>,
     provider_tools: Vec<ProviderToolDefinition>,

--- a/crates/rig-core/src/providers/azure.rs
+++ b/crates/rig-core/src/providers/azure.rs
@@ -36,7 +36,8 @@ use crate::streaming::StreamingCompletionResponse;
 use crate::transcription::TranscriptionError;
 use crate::{
     completion::{
-        self, CompletionError, CompletionRequest, take_provider_tools_from_additional_params,
+        self, CompletionError, CompletionRequest,
+        take_function_provider_tools_from_additional_params,
     },
     embeddings::{self, EmbeddingError},
     json_utils,
@@ -639,8 +640,10 @@ impl TryFrom<(&str, CompletionRequest)> for AzureOpenAICompletionRequest {
         };
 
         let mut additional_params = additional_params;
-        let mut provider_tools =
-            take_provider_tools_from_additional_params(&mut additional_params, "Azure OpenAI")?;
+        let mut provider_tools = take_function_provider_tools_from_additional_params(
+            &mut additional_params,
+            "Azure OpenAI",
+        )?;
         let mut tools = req
             .tools
             .clone()
@@ -1117,7 +1120,14 @@ mod azure_tests {
             max_tokens: None,
             tool_choice: None,
             additional_params: Some(serde_json::json!({
-                "tools": [{"type": "web_search_preview"}],
+                "tools": [{
+                    "type": "function",
+                    "function": {
+                        "name": "provider_lookup",
+                        "description": "Lookup a provider value",
+                        "parameters": {"type": "object", "properties": {}}
+                    }
+                }],
                 "metadata": {"source": "test"}
             })),
             output_schema: None,
@@ -1132,8 +1142,40 @@ mod azure_tests {
             2
         );
         assert_eq!(serialized["tools"][0]["type"], "function");
-        assert_eq!(serialized["tools"][1]["type"], "web_search_preview");
+        assert_eq!(serialized["tools"][1]["type"], "function");
+        assert_eq!(
+            serialized["tools"][1]["function"]["name"],
+            "provider_lookup"
+        );
         assert_eq!(serialized["metadata"]["source"], "test");
+    }
+
+    #[test]
+    fn azure_request_rejects_native_provider_tool() {
+        let request = CompletionRequest {
+            model: None,
+            preamble: None,
+            chat_history: OneOrMany::one("Hello".into()),
+            documents: vec![],
+            tools: vec![],
+            temperature: None,
+            max_tokens: None,
+            tool_choice: None,
+            additional_params: Some(serde_json::json!({
+                "tools": [{"type": "web_search_preview"}]
+            })),
+            output_schema: None,
+        };
+
+        let result = AzureOpenAICompletionRequest::try_from((GPT_4O_MINI, request));
+
+        let error = result.expect_err("native provider tool should be rejected");
+        assert!(matches!(error, CompletionError::RequestError(_)));
+        assert!(
+            error
+                .to_string()
+                .contains("only function tools are supported")
+        );
     }
 
     #[cfg(any(feature = "image", feature = "audio"))]

--- a/crates/rig-core/src/providers/azure.rs
+++ b/crates/rig-core/src/providers/azure.rs
@@ -35,7 +35,9 @@ use crate::http_client::{self, HttpClientExt, MultipartForm, bearer_auth_header}
 use crate::streaming::StreamingCompletionResponse;
 use crate::transcription::TranscriptionError;
 use crate::{
-    completion::{self, CompletionError, CompletionRequest},
+    completion::{
+        self, CompletionError, CompletionRequest, take_provider_tools_from_additional_params,
+    },
     embeddings::{self, EmbeddingError},
     json_utils,
     providers::openai,
@@ -44,7 +46,7 @@ use crate::{
 };
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
-use serde_json::json;
+use serde_json::{Value, json};
 // ================================================================
 // Main Azure OpenAI Client
 // ================================================================
@@ -571,7 +573,7 @@ pub(super) struct AzureOpenAICompletionRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     temperature: Option<f64>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    tools: Vec<openai::ToolDefinition>,
+    tools: Vec<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tool_choice: Option<crate::providers::openai::ToolChoice>,
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
@@ -636,16 +638,23 @@ impl TryFrom<(&str, CompletionRequest)> for AzureOpenAICompletionRequest {
             req.additional_params
         };
 
+        let mut additional_params = additional_params;
+        let mut provider_tools =
+            take_provider_tools_from_additional_params(&mut additional_params, "Azure OpenAI")?;
+        let mut tools = req
+            .tools
+            .clone()
+            .into_iter()
+            .map(openai::ToolDefinition::from)
+            .map(serde_json::to_value)
+            .collect::<Result<Vec<_>, _>>()?;
+        tools.append(&mut provider_tools);
+
         Ok(Self {
             model: model.to_string(),
             messages: full_history,
             temperature: req.temperature,
-            tools: req
-                .tools
-                .clone()
-                .into_iter()
-                .map(openai::ToolDefinition::from)
-                .collect::<Vec<_>>(),
+            tools,
             tool_choice,
             additional_params,
         })
@@ -1088,6 +1097,44 @@ mod azure_tests {
     use crate::embeddings::EmbeddingModel;
     use crate::prelude::TypedPrompt;
     use crate::providers::openai::GPT_5_MINI;
+
+    #[test]
+    fn azure_request_merges_provider_tools_into_single_tools_array() {
+        let request = CompletionRequest {
+            model: None,
+            preamble: None,
+            chat_history: OneOrMany::one("Hello".into()),
+            documents: vec![],
+            tools: vec![completion::ToolDefinition {
+                name: "lookup".to_string(),
+                description: "Lookup a value".to_string(),
+                parameters: serde_json::json!({
+                    "type": "object",
+                    "properties": {},
+                }),
+            }],
+            temperature: None,
+            max_tokens: None,
+            tool_choice: None,
+            additional_params: Some(serde_json::json!({
+                "tools": [{"type": "web_search_preview"}],
+                "metadata": {"source": "test"}
+            })),
+            output_schema: None,
+        };
+
+        let azure_request = AzureOpenAICompletionRequest::try_from((GPT_4O_MINI, request))
+            .expect("request conversion should succeed");
+        let serialized = serde_json::to_value(azure_request).expect("serialization should succeed");
+
+        assert_eq!(
+            serialized["tools"].as_array().expect("tools array").len(),
+            2
+        );
+        assert_eq!(serialized["tools"][0]["type"], "function");
+        assert_eq!(serialized["tools"][1]["type"], "web_search_preview");
+        assert_eq!(serialized["metadata"]["source"], "test");
+    }
 
     #[cfg(any(feature = "image", feature = "audio"))]
     fn test_client(

--- a/crates/rig-core/src/providers/cohere/completion.rs
+++ b/crates/rig-core/src/providers/cohere/completion.rs
@@ -1,7 +1,7 @@
 use crate::{
     OneOrMany,
     completion::{
-        self, CompletionError, GetTokenUsage, take_provider_tools_from_additional_params,
+        self, CompletionError, GetTokenUsage, take_function_provider_tools_from_additional_params,
     },
     http_client::{self, HttpClientExt},
     json_utils,
@@ -594,7 +594,7 @@ impl TryFrom<(&str, CompletionRequest)> for CohereCompletionRequest {
 
         let mut additional_params = req.additional_params;
         let mut provider_tools =
-            take_provider_tools_from_additional_params(&mut additional_params, "Cohere")?;
+            take_function_provider_tools_from_additional_params(&mut additional_params, "Cohere")?;
         let mut tools = req
             .tools
             .into_iter()
@@ -831,6 +831,34 @@ mod tests {
 
         let completion_message: completion::Message = message.clone().try_into().unwrap();
         let _converted_back: Vec<Message> = completion_message.try_into().unwrap();
+    }
+
+    #[test]
+    fn cohere_request_rejects_native_provider_tool() {
+        let request = CompletionRequest {
+            model: None,
+            preamble: None,
+            chat_history: OneOrMany::one("Hello".into()),
+            documents: vec![],
+            tools: vec![],
+            temperature: None,
+            max_tokens: None,
+            tool_choice: None,
+            additional_params: Some(serde_json::json!({
+                "tools": [{"type": "web_search_preview"}]
+            })),
+            output_schema: None,
+        };
+
+        let result = CohereCompletionRequest::try_from(("command-r", request));
+
+        let error = result.expect_err("native provider tool should be rejected");
+        assert!(matches!(error, CompletionError::RequestError(_)));
+        assert!(
+            error
+                .to_string()
+                .contains("only function tools are supported")
+        );
     }
 
     #[test]

--- a/crates/rig-core/src/providers/cohere/completion.rs
+++ b/crates/rig-core/src/providers/cohere/completion.rs
@@ -1,6 +1,8 @@
 use crate::{
     OneOrMany,
-    completion::{self, CompletionError, GetTokenUsage},
+    completion::{
+        self, CompletionError, GetTokenUsage, take_provider_tools_from_additional_params,
+    },
     http_client::{self, HttpClientExt},
     json_utils,
     message::{self, Reasoning, ToolChoice},
@@ -544,7 +546,7 @@ pub(super) struct CohereCompletionRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     temperature: Option<f64>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    tools: Vec<Tool>,
+    tools: Vec<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tool_choice: Option<ToolChoice>,
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
@@ -590,14 +592,25 @@ impl TryFrom<(&str, CompletionRequest)> for CohereCompletionRequest {
             None
         };
 
+        let mut additional_params = req.additional_params;
+        let mut provider_tools =
+            take_provider_tools_from_additional_params(&mut additional_params, "Cohere")?;
+        let mut tools = req
+            .tools
+            .into_iter()
+            .map(Tool::from)
+            .map(serde_json::to_value)
+            .collect::<Result<Vec<_>, _>>()?;
+        tools.append(&mut provider_tools);
+
         Ok(Self {
             model: model.to_string(),
             messages: full_history,
             documents,
             temperature: req.temperature,
-            tools: req.tools.into_iter().map(Tool::from).collect::<Vec<_>>(),
+            tools,
             tool_choice,
-            additional_params: req.additional_params,
+            additional_params,
         })
     }
 }

--- a/crates/rig-core/src/providers/deepseek.rs
+++ b/crates/rig-core/src/providers/deepseek.rs
@@ -29,7 +29,9 @@ use crate::providers::internal::openai_chat_completions_compatible::{
 };
 use crate::{
     OneOrMany,
-    completion::{self, CompletionError, CompletionRequest},
+    completion::{
+        self, CompletionError, CompletionRequest, take_provider_tools_from_additional_params,
+    },
     json_utils, message,
     wasm_compat::{WasmCompatSend, WasmCompatSync},
 };
@@ -460,7 +462,7 @@ pub(super) struct DeepseekCompletionRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     temperature: Option<f64>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    tools: Vec<ToolDefinition>,
+    tools: Vec<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tool_choice: Option<crate::providers::openrouter::ToolChoice>,
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
@@ -497,18 +499,25 @@ impl TryFrom<(&str, CompletionRequest)> for DeepseekCompletionRequest {
             .map(crate::providers::openrouter::ToolChoice::try_from)
             .transpose()?;
 
+        let mut additional_params = req.additional_params;
+        let mut provider_tools =
+            take_provider_tools_from_additional_params(&mut additional_params, "DeepSeek")?;
+        let mut tools = req
+            .tools
+            .clone()
+            .into_iter()
+            .map(ToolDefinition::from)
+            .map(serde_json::to_value)
+            .collect::<Result<Vec<_>, _>>()?;
+        tools.append(&mut provider_tools);
+
         Ok(Self {
             model: model.to_string(),
             messages: full_history,
             temperature: req.temperature,
-            tools: req
-                .tools
-                .clone()
-                .into_iter()
-                .map(ToolDefinition::from)
-                .collect::<Vec<_>>(),
+            tools,
             tool_choice,
-            additional_params: req.additional_params,
+            additional_params,
         })
     }
 }

--- a/crates/rig-core/src/providers/deepseek.rs
+++ b/crates/rig-core/src/providers/deepseek.rs
@@ -30,7 +30,8 @@ use crate::providers::internal::openai_chat_completions_compatible::{
 use crate::{
     OneOrMany,
     completion::{
-        self, CompletionError, CompletionRequest, take_provider_tools_from_additional_params,
+        self, CompletionError, CompletionRequest,
+        take_function_provider_tools_from_additional_params,
     },
     json_utils, message,
     wasm_compat::{WasmCompatSend, WasmCompatSync},
@@ -500,8 +501,10 @@ impl TryFrom<(&str, CompletionRequest)> for DeepseekCompletionRequest {
             .transpose()?;
 
         let mut additional_params = req.additional_params;
-        let mut provider_tools =
-            take_provider_tools_from_additional_params(&mut additional_params, "DeepSeek")?;
+        let mut provider_tools = take_function_provider_tools_from_additional_params(
+            &mut additional_params,
+            "DeepSeek",
+        )?;
         let mut tools = req
             .tools
             .clone()

--- a/crates/rig-core/src/providers/galadriel.rs
+++ b/crates/rig-core/src/providers/galadriel.rs
@@ -28,7 +28,8 @@ use crate::streaming::StreamingCompletionResponse;
 use crate::{
     OneOrMany,
     completion::{
-        self, CompletionError, CompletionRequest, take_provider_tools_from_additional_params,
+        self, CompletionError, CompletionRequest,
+        take_function_provider_tools_from_additional_params,
     },
     json_utils, message,
 };
@@ -486,8 +487,10 @@ impl TryFrom<(&str, CompletionRequest)> for GaladrielCompletionRequest {
             .transpose()?;
 
         let mut additional_params = req.additional_params;
-        let mut provider_tools =
-            take_provider_tools_from_additional_params(&mut additional_params, "Galadriel")?;
+        let mut provider_tools = take_function_provider_tools_from_additional_params(
+            &mut additional_params,
+            "Galadriel",
+        )?;
         let mut tools = req
             .tools
             .clone()

--- a/crates/rig-core/src/providers/galadriel.rs
+++ b/crates/rig-core/src/providers/galadriel.rs
@@ -27,7 +27,9 @@ use crate::providers::openai::send_compatible_streaming_request;
 use crate::streaming::StreamingCompletionResponse;
 use crate::{
     OneOrMany,
-    completion::{self, CompletionError, CompletionRequest},
+    completion::{
+        self, CompletionError, CompletionRequest, take_provider_tools_from_additional_params,
+    },
     json_utils, message,
 };
 use serde::{Deserialize, Serialize};
@@ -443,7 +445,7 @@ pub(super) struct GaladrielCompletionRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     temperature: Option<f64>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    tools: Vec<ToolDefinition>,
+    tools: Vec<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tool_choice: Option<crate::providers::openai::completion::ToolChoice>,
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
@@ -483,18 +485,25 @@ impl TryFrom<(&str, CompletionRequest)> for GaladrielCompletionRequest {
             .map(crate::providers::openai::completion::ToolChoice::try_from)
             .transpose()?;
 
+        let mut additional_params = req.additional_params;
+        let mut provider_tools =
+            take_provider_tools_from_additional_params(&mut additional_params, "Galadriel")?;
+        let mut tools = req
+            .tools
+            .clone()
+            .into_iter()
+            .map(ToolDefinition::from)
+            .map(serde_json::to_value)
+            .collect::<Result<Vec<_>, _>>()?;
+        tools.append(&mut provider_tools);
+
         Ok(Self {
             model: model.to_string(),
             messages: full_history,
             temperature: req.temperature,
-            tools: req
-                .tools
-                .clone()
-                .into_iter()
-                .map(ToolDefinition::from)
-                .collect::<Vec<_>>(),
+            tools,
             tool_choice,
-            additional_params: req.additional_params,
+            additional_params,
         })
     }
 }

--- a/crates/rig-core/src/providers/huggingface/completion.rs
+++ b/crates/rig-core/src/providers/huggingface/completion.rs
@@ -5,7 +5,9 @@ use crate::providers::openai::StreamingCompletionResponse;
 use crate::telemetry::SpanCombinator;
 use crate::{
     OneOrMany,
-    completion::{self, CompletionError, CompletionRequest},
+    completion::{
+        self, CompletionError, CompletionRequest, take_provider_tools_from_additional_params,
+    },
     json_utils,
     message::{self},
     one_or_many::string_or_one_or_many,
@@ -630,7 +632,7 @@ pub(super) struct HuggingfaceCompletionRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     temperature: Option<f64>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    tools: Vec<ToolDefinition>,
+    tools: Vec<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tool_choice: Option<crate::providers::openai::completion::ToolChoice>,
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
@@ -676,18 +678,25 @@ impl TryFrom<(&str, CompletionRequest)> for HuggingfaceCompletionRequest {
             .map(crate::providers::openai::completion::ToolChoice::try_from)
             .transpose()?;
 
+        let mut additional_params = req.additional_params;
+        let mut provider_tools =
+            take_provider_tools_from_additional_params(&mut additional_params, "HuggingFace")?;
+        let mut tools = req
+            .tools
+            .clone()
+            .into_iter()
+            .map(ToolDefinition::from)
+            .map(serde_json::to_value)
+            .collect::<Result<Vec<_>, _>>()?;
+        tools.append(&mut provider_tools);
+
         Ok(Self {
             model: model.to_string(),
             messages: full_history,
             temperature: req.temperature,
-            tools: req
-                .tools
-                .clone()
-                .into_iter()
-                .map(ToolDefinition::from)
-                .collect::<Vec<_>>(),
+            tools,
             tool_choice,
-            additional_params: req.additional_params,
+            additional_params,
         })
     }
 }

--- a/crates/rig-core/src/providers/huggingface/completion.rs
+++ b/crates/rig-core/src/providers/huggingface/completion.rs
@@ -6,7 +6,8 @@ use crate::telemetry::SpanCombinator;
 use crate::{
     OneOrMany,
     completion::{
-        self, CompletionError, CompletionRequest, take_provider_tools_from_additional_params,
+        self, CompletionError, CompletionRequest,
+        take_function_provider_tools_from_additional_params,
     },
     json_utils,
     message::{self},
@@ -679,8 +680,10 @@ impl TryFrom<(&str, CompletionRequest)> for HuggingfaceCompletionRequest {
             .transpose()?;
 
         let mut additional_params = req.additional_params;
-        let mut provider_tools =
-            take_provider_tools_from_additional_params(&mut additional_params, "HuggingFace")?;
+        let mut provider_tools = take_function_provider_tools_from_additional_params(
+            &mut additional_params,
+            "HuggingFace",
+        )?;
         let mut tools = req
             .tools
             .clone()

--- a/crates/rig-core/src/providers/llamafile.rs
+++ b/crates/rig-core/src/providers/llamafile.rs
@@ -34,7 +34,8 @@ use crate::providers::internal::openai_chat_completions_compatible::{
 use crate::providers::openai::{self, StreamingToolCall};
 use crate::{
     completion::{
-        self, CompletionError, CompletionRequest, take_provider_tools_from_additional_params,
+        self, CompletionError, CompletionRequest,
+        take_function_provider_tools_from_additional_params,
     },
     embeddings::{self, EmbeddingError},
     json_utils,
@@ -318,8 +319,10 @@ impl TryFrom<(&str, CompletionRequest)> for LlamafileCompletionRequest {
         full_history.extend(chat_history);
 
         let mut additional_params = req.additional_params;
-        let mut provider_tools =
-            take_provider_tools_from_additional_params(&mut additional_params, "llamafile")?;
+        let mut provider_tools = take_function_provider_tools_from_additional_params(
+            &mut additional_params,
+            "llamafile",
+        )?;
         let mut tools = req
             .tools
             .into_iter()

--- a/crates/rig-core/src/providers/llamafile.rs
+++ b/crates/rig-core/src/providers/llamafile.rs
@@ -33,7 +33,9 @@ use crate::providers::internal::openai_chat_completions_compatible::{
 };
 use crate::providers::openai::{self, StreamingToolCall};
 use crate::{
-    completion::{self, CompletionError, CompletionRequest},
+    completion::{
+        self, CompletionError, CompletionRequest, take_provider_tools_from_additional_params,
+    },
     embeddings::{self, EmbeddingError},
     json_utils,
 };
@@ -156,7 +158,7 @@ struct LlamafileCompletionRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     max_tokens: Option<u64>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    tools: Vec<openai::ToolDefinition>,
+    tools: Vec<Value>,
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
     additional_params: Option<serde_json::Value>,
 }
@@ -315,6 +317,17 @@ impl TryFrom<(&str, CompletionRequest)> for LlamafileCompletionRequest {
 
         full_history.extend(chat_history);
 
+        let mut additional_params = req.additional_params;
+        let mut provider_tools =
+            take_provider_tools_from_additional_params(&mut additional_params, "llamafile")?;
+        let mut tools = req
+            .tools
+            .into_iter()
+            .map(openai::ToolDefinition::from)
+            .map(serde_json::to_value)
+            .collect::<Result<Vec<_>, _>>()?;
+        tools.append(&mut provider_tools);
+
         Ok(Self {
             model,
             messages: full_history
@@ -323,12 +336,8 @@ impl TryFrom<(&str, CompletionRequest)> for LlamafileCompletionRequest {
                 .collect::<Result<Vec<_>, _>>()?,
             temperature: req.temperature,
             max_tokens: req.max_tokens,
-            tools: req
-                .tools
-                .into_iter()
-                .map(openai::ToolDefinition::from)
-                .collect(),
-            additional_params: req.additional_params,
+            tools,
+            additional_params,
         })
     }
 }

--- a/crates/rig-core/src/providers/mistral/completion.rs
+++ b/crates/rig-core/src/providers/mistral/completion.rs
@@ -10,7 +10,8 @@ use crate::streaming::{RawStreamingChoice, RawStreamingToolCall, StreamingComple
 use crate::{
     OneOrMany,
     completion::{
-        self, CompletionError, CompletionRequest, take_provider_tools_from_additional_params,
+        self, CompletionError, CompletionRequest,
+        take_function_provider_tools_from_additional_params,
     },
     json_utils, message,
     providers::mistral::client::ApiResponse,
@@ -388,7 +389,7 @@ impl TryFrom<(&str, CompletionRequest)> for MistralCompletionRequest {
 
         let mut additional_params = req.additional_params;
         let mut provider_tools =
-            take_provider_tools_from_additional_params(&mut additional_params, "Mistral")?;
+            take_function_provider_tools_from_additional_params(&mut additional_params, "Mistral")?;
         let mut tools = req
             .tools
             .clone()

--- a/crates/rig-core/src/providers/mistral/completion.rs
+++ b/crates/rig-core/src/providers/mistral/completion.rs
@@ -9,7 +9,9 @@ use crate::providers::internal::buffered;
 use crate::streaming::{RawStreamingChoice, RawStreamingToolCall, StreamingCompletionResponse};
 use crate::{
     OneOrMany,
-    completion::{self, CompletionError, CompletionRequest},
+    completion::{
+        self, CompletionError, CompletionRequest, take_provider_tools_from_additional_params,
+    },
     json_utils, message,
     providers::mistral::client::ApiResponse,
     telemetry::SpanCombinator,
@@ -338,7 +340,7 @@ pub(super) struct MistralCompletionRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     temperature: Option<f64>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    tools: Vec<ToolDefinition>,
+    tools: Vec<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tool_choice: Option<crate::providers::openai::completion::ToolChoice>,
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
@@ -384,18 +386,25 @@ impl TryFrom<(&str, CompletionRequest)> for MistralCompletionRequest {
             .map(crate::providers::openai::completion::ToolChoice::try_from)
             .transpose()?;
 
+        let mut additional_params = req.additional_params;
+        let mut provider_tools =
+            take_provider_tools_from_additional_params(&mut additional_params, "Mistral")?;
+        let mut tools = req
+            .tools
+            .clone()
+            .into_iter()
+            .map(ToolDefinition::from)
+            .map(serde_json::to_value)
+            .collect::<Result<Vec<_>, _>>()?;
+        tools.append(&mut provider_tools);
+
         Ok(Self {
             model: model.to_string(),
             messages: full_history,
             temperature: req.temperature,
-            tools: req
-                .tools
-                .clone()
-                .into_iter()
-                .map(ToolDefinition::from)
-                .collect::<Vec<_>>(),
+            tools,
             tool_choice,
-            additional_params: req.additional_params,
+            additional_params,
         })
     }
 }

--- a/crates/rig-core/src/providers/moonshot.rs
+++ b/crates/rig-core/src/providers/moonshot.rs
@@ -34,7 +34,8 @@ use crate::providers::openai::send_compatible_streaming_request;
 use crate::streaming::StreamingCompletionResponse;
 use crate::{
     completion::{
-        self, CompletionError, CompletionRequest, take_provider_tools_from_additional_params,
+        self, CompletionError, CompletionRequest,
+        take_function_provider_tools_from_additional_params,
     },
     json_utils,
     providers::openai,
@@ -371,8 +372,10 @@ impl TryFrom<(&str, CompletionRequest)> for MoonshotCompletionRequest {
         }
 
         let mut additional_params = req.additional_params;
-        let mut provider_tools =
-            take_provider_tools_from_additional_params(&mut additional_params, "Moonshot")?;
+        let mut provider_tools = take_function_provider_tools_from_additional_params(
+            &mut additional_params,
+            "Moonshot",
+        )?;
         let mut tools = req
             .tools
             .clone()

--- a/crates/rig-core/src/providers/moonshot.rs
+++ b/crates/rig-core/src/providers/moonshot.rs
@@ -33,7 +33,9 @@ use crate::providers::anthropic::client::{
 use crate::providers::openai::send_compatible_streaming_request;
 use crate::streaming::StreamingCompletionResponse;
 use crate::{
-    completion::{self, CompletionError, CompletionRequest},
+    completion::{
+        self, CompletionError, CompletionRequest, take_provider_tools_from_additional_params,
+    },
     json_utils,
     providers::openai,
 };
@@ -315,7 +317,7 @@ pub(super) struct MoonshotCompletionRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     temperature: Option<f64>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    tools: Vec<openai::ToolDefinition>,
+    tools: Vec<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     max_tokens: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -368,19 +370,26 @@ impl TryFrom<(&str, CompletionRequest)> for MoonshotCompletionRequest {
             }));
         }
 
+        let mut additional_params = req.additional_params;
+        let mut provider_tools =
+            take_provider_tools_from_additional_params(&mut additional_params, "Moonshot")?;
+        let mut tools = req
+            .tools
+            .clone()
+            .into_iter()
+            .map(openai::ToolDefinition::from)
+            .map(serde_json::to_value)
+            .collect::<Result<Vec<_>, _>>()?;
+        tools.append(&mut provider_tools);
+
         Ok(Self {
             model: model.to_string(),
             messages: full_history,
             temperature: req.temperature,
             max_tokens: req.max_tokens,
-            tools: req
-                .tools
-                .clone()
-                .into_iter()
-                .map(openai::ToolDefinition::from)
-                .collect::<Vec<_>>(),
+            tools,
             tool_choice,
-            additional_params: req.additional_params,
+            additional_params,
         })
     }
 }

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -1203,14 +1203,44 @@ fn extract_tools_from_additional_params(
         && let Some(map) = params.as_object_mut()
         && let Some(raw_tools) = map.remove("tools")
     {
-        return serde_json::from_value::<Vec<serde_json::Value>>(raw_tools).map_err(|err| {
+        let tools = serde_json::from_value::<Vec<serde_json::Value>>(raw_tools).map_err(|err| {
             CompletionError::RequestError(
                 format!("Invalid OpenAI `additional_params.tools` payload: {err}").into(),
             )
-        });
+        })?;
+        validate_openai_chat_provider_tools(&tools)?;
+        return Ok(tools);
     }
 
     Ok(Vec::new())
+}
+
+fn validate_openai_chat_provider_tools(tools: &[serde_json::Value]) -> Result<(), CompletionError> {
+    for (idx, tool) in tools.iter().enumerate() {
+        let tool_type = tool
+            .as_object()
+            .and_then(|tool| tool.get("type"))
+            .and_then(|tool_type| tool_type.as_str())
+            .ok_or_else(|| {
+                CompletionError::RequestError(
+                    format!(
+                        "OpenAI Chat Completions additional_params.tools[{idx}] must be an object with a string `type`"
+                    )
+                    .into(),
+                )
+            })?;
+
+        if matches!(tool_type, "custom" | "function") {
+            return Err(CompletionError::RequestError(
+                format!(
+                    "OpenAI Chat Completions additional_params.tools[{idx}] has unsupported app-dispatched tool type `{tool_type}`; use Rig executable tools or OpenAI Responses API support instead"
+                )
+                .into(),
+            ));
+        }
+    }
+
+    Ok(())
 }
 
 impl TryFrom<OpenAIRequestParams> for CompletionRequest {
@@ -1659,6 +1689,108 @@ mod tests {
         assert_eq!(serialized["tools"][0]["type"], "function");
         assert_eq!(serialized["tools"][1]["type"], "web_search_preview");
         assert_eq!(serialized["metadata"]["source"], "test");
+    }
+
+    #[test]
+    fn openai_chat_request_rejects_custom_provider_tool() {
+        let request = crate::completion::CompletionRequest {
+            model: None,
+            preamble: None,
+            chat_history: crate::OneOrMany::one("Hello".into()),
+            documents: vec![],
+            tools: vec![],
+            temperature: None,
+            max_tokens: None,
+            tool_choice: None,
+            additional_params: Some(serde_json::json!({
+                "tools": [{
+                    "type": "custom",
+                    "custom": {
+                        "name": "hosted_lookup",
+                        "description": "Lookup a value"
+                    }
+                }]
+            })),
+            output_schema: None,
+        };
+
+        let error = CompletionRequest::try_from(OpenAIRequestParams {
+            model: "gpt-4o-mini".to_string(),
+            request,
+            strict_tools: false,
+            tool_result_array_content: false,
+        })
+        .expect_err("custom provider tool should be rejected");
+
+        assert!(matches!(error, CompletionError::RequestError(_)));
+        assert!(error.to_string().contains("custom"));
+        assert!(error.to_string().contains("app-dispatched"));
+    }
+
+    #[test]
+    fn openai_chat_request_rejects_raw_function_provider_tool() {
+        let request = crate::completion::CompletionRequest {
+            model: None,
+            preamble: None,
+            chat_history: crate::OneOrMany::one("Hello".into()),
+            documents: vec![],
+            tools: vec![],
+            temperature: None,
+            max_tokens: None,
+            tool_choice: None,
+            additional_params: Some(serde_json::json!({
+                "tools": [{
+                    "type": "function",
+                    "function": {
+                        "name": "lookup",
+                        "description": "Lookup a value",
+                        "parameters": {"type": "object", "properties": {}}
+                    }
+                }]
+            })),
+            output_schema: None,
+        };
+
+        let error = CompletionRequest::try_from(OpenAIRequestParams {
+            model: "gpt-4o-mini".to_string(),
+            request,
+            strict_tools: false,
+            tool_result_array_content: false,
+        })
+        .expect_err("raw function provider tool should be rejected");
+
+        assert!(matches!(error, CompletionError::RequestError(_)));
+        assert!(error.to_string().contains("function"));
+        assert!(error.to_string().contains("Rig executable tools"));
+    }
+
+    #[test]
+    fn openai_chat_request_rejects_provider_tool_without_string_type() {
+        let request = crate::completion::CompletionRequest {
+            model: None,
+            preamble: None,
+            chat_history: crate::OneOrMany::one("Hello".into()),
+            documents: vec![],
+            tools: vec![],
+            temperature: None,
+            max_tokens: None,
+            tool_choice: None,
+            additional_params: Some(serde_json::json!({
+                "tools": [{"custom": {"name": "hosted_lookup"}}]
+            })),
+            output_schema: None,
+        };
+
+        let error = CompletionRequest::try_from(OpenAIRequestParams {
+            model: "gpt-4o-mini".to_string(),
+            request,
+            strict_tools: false,
+            tool_result_array_content: false,
+        })
+        .expect_err("provider tool without string type should be rejected");
+
+        assert!(matches!(error, CompletionError::RequestError(_)));
+        assert!(error.to_string().contains("string `type`"));
     }
 
     #[test]

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -1284,16 +1284,18 @@ impl TryFrom<OpenAIRequestParams> for CompletionRequest {
             })
             .collect();
 
+        let has_executable_tools = !tools.is_empty();
         let mut additional_params = additional_params;
         let mut provider_tools = extract_tools_from_additional_params(&mut additional_params)?;
-        let has_tools = !tools.is_empty() || !provider_tools.is_empty();
 
-        // Some OpenAI-compatible backends such as llama.cpp will skip tool execution
-        // if `response_format` is sent on the first turn alongside tools. Delay the
-        // schema until after the conversation contains a tool result. Provider-hosted
-        // tools count here too because they are merged into the same wire `tools` array.
+        // Some OpenAI-compatible backends such as llama.cpp will skip Rig-executed
+        // function tool calls if `response_format` is sent on the first turn. Delay
+        // the schema only for executable Rig tools until after the conversation
+        // contains a Rig tool result. Provider-hosted tools are executed by the
+        // provider, so there may never be a Rig `ToolResult`; keep their schema
+        // enforcement active on hosted-only requests.
         let should_apply_response_format =
-            output_schema.is_some() && (!has_tools || history_has_tool_result);
+            output_schema.is_some() && (!has_executable_tools || history_has_tool_result);
 
         // Map output_schema to OpenAI's response_format and merge into additional_params
         let additional_params = if let Some(schema) = output_schema
@@ -1423,13 +1425,15 @@ where
         Self::new(client.clone(), model)
     }
 
-    // OpenAI Chat Completions *defers* `response_format` while tools are present
-    // and no tool result exists yet (see `should_apply_response_format`), then
-    // applies it once a tool result is in the history. So the native constraint
-    // does not suppress tool calls — they compose — which is what this flag
-    // governs. (Caveat: a turn-1 answer with no tool call is therefore not
-    // schema-constrained; `Native` is "guaranteed" only once tools have run.)
-    // See issue #1928.
+    // OpenAI Chat Completions *defers* `response_format` while executable Rig
+    // function tools are present and no tool result exists yet (see
+    // `should_apply_response_format`), then applies it once a tool result is in
+    // the history. So the native constraint does not suppress Rig tool calls —
+    // they compose — which is what this flag governs. Provider-hosted tools keep
+    // their native schema constraint because Rig does not execute them and may
+    // never observe a tool result. (Caveat: a turn-1 answer with no Rig tool call
+    // is therefore not schema-constrained; `Native` is "guaranteed" only once
+    // Rig tools have run.) See issue #1928.
     fn composes_native_output_with_tools(&self) -> bool {
         true
     }
@@ -1658,7 +1662,7 @@ mod tests {
     }
 
     #[test]
-    fn provider_tools_delay_response_format_on_initial_tool_turn() {
+    fn provider_tools_keep_response_format_on_hosted_only_tool_turn() {
         let request = crate::completion::CompletionRequest {
             model: None,
             preamble: None,
@@ -1695,9 +1699,25 @@ mod tests {
             serde_json::to_value(openai_request).expect("serialization should succeed");
 
         assert_eq!(serialized["tools"][0]["type"], "web_search_preview");
-        assert!(
-            serialized.get("response_format").is_none(),
-            "initial provider-tool turn should omit response_format: {serialized:?}"
+        assert_eq!(
+            serialized["response_format"],
+            serde_json::json!({
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "SearchAnswer",
+                    "strict": true,
+                    "schema": {
+                        "title": "SearchAnswer",
+                        "type": "object",
+                        "properties": {
+                            "answer": { "type": "string" }
+                        },
+                        "required": ["answer"],
+                        "additionalProperties": false
+                    }
+                }
+            }),
+            "hosted-only provider-tool turn should keep response_format: {serialized:?}"
         );
     }
 

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -1178,7 +1178,7 @@ pub struct CompletionRequest {
     model: String,
     messages: Vec<Message>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    tools: Vec<ToolDefinition>,
+    tools: Vec<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tool_choice: Option<ToolChoice>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1194,6 +1194,23 @@ pub struct OpenAIRequestParams {
     pub request: CoreCompletionRequest,
     pub strict_tools: bool,
     pub tool_result_array_content: bool,
+}
+
+fn extract_tools_from_additional_params(
+    additional_params: &mut Option<serde_json::Value>,
+) -> Result<Vec<serde_json::Value>, CompletionError> {
+    if let Some(params) = additional_params.as_mut()
+        && let Some(map) = params.as_object_mut()
+        && let Some(raw_tools) = map.remove("tools")
+    {
+        return serde_json::from_value::<Vec<serde_json::Value>>(raw_tools).map_err(|err| {
+            CompletionError::RequestError(
+                format!("Invalid OpenAI `additional_params.tools` payload: {err}").into(),
+            )
+        });
+    }
+
+    Ok(Vec::new())
 }
 
 impl TryFrom<OpenAIRequestParams> for CompletionRequest {
@@ -1274,7 +1291,7 @@ impl TryFrom<OpenAIRequestParams> for CompletionRequest {
             output_schema.is_some() && (tools.is_empty() || history_has_tool_result);
 
         // Map output_schema to OpenAI's response_format and merge into additional_params
-        let additional_params = if let Some(schema) = output_schema
+        let mut additional_params = if let Some(schema) = output_schema
             && should_apply_response_format
         {
             let name = schema
@@ -1302,6 +1319,14 @@ impl TryFrom<OpenAIRequestParams> for CompletionRequest {
         } else {
             additional_params
         };
+
+        let mut tools = tools
+            .into_iter()
+            .map(serde_json::to_value)
+            .collect::<Result<Vec<_>, _>>()?;
+        tools.append(&mut extract_tools_from_additional_params(
+            &mut additional_params,
+        )?);
 
         let res = Self {
             model: request_model.unwrap_or(model),
@@ -1583,6 +1608,50 @@ mod tests {
             serde_json::to_value(openai_request).expect("serialization should succeed");
 
         assert_eq!(serialized["model"], "gpt-4o-mini");
+    }
+
+    #[test]
+    fn openai_chat_request_merges_provider_tools_into_single_tools_array() {
+        let request = crate::completion::CompletionRequest {
+            model: None,
+            preamble: None,
+            chat_history: crate::OneOrMany::one("Hello".into()),
+            documents: vec![],
+            tools: vec![crate::completion::ToolDefinition {
+                name: "lookup".to_string(),
+                description: "Lookup a value".to_string(),
+                parameters: serde_json::json!({
+                    "type": "object",
+                    "properties": {},
+                }),
+            }],
+            temperature: None,
+            max_tokens: None,
+            tool_choice: None,
+            additional_params: Some(serde_json::json!({
+                "tools": [{"type": "web_search_preview"}],
+                "metadata": {"source": "test"}
+            })),
+            output_schema: None,
+        };
+
+        let openai_request = CompletionRequest::try_from(OpenAIRequestParams {
+            model: "gpt-4o-mini".to_string(),
+            request,
+            strict_tools: false,
+            tool_result_array_content: false,
+        })
+        .expect("request conversion should succeed");
+        let serialized =
+            serde_json::to_value(openai_request).expect("serialization should succeed");
+
+        assert_eq!(
+            serialized["tools"].as_array().expect("tools array").len(),
+            2
+        );
+        assert_eq!(serialized["tools"][0]["type"], "function");
+        assert_eq!(serialized["tools"][1]["type"], "web_search_preview");
+        assert_eq!(serialized["metadata"]["source"], "test");
     }
 
     #[test]

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -1284,14 +1284,19 @@ impl TryFrom<OpenAIRequestParams> for CompletionRequest {
             })
             .collect();
 
+        let mut additional_params = additional_params;
+        let mut provider_tools = extract_tools_from_additional_params(&mut additional_params)?;
+        let has_tools = !tools.is_empty() || !provider_tools.is_empty();
+
         // Some OpenAI-compatible backends such as llama.cpp will skip tool execution
         // if `response_format` is sent on the first turn alongside tools. Delay the
-        // schema until after the conversation contains a tool result.
+        // schema until after the conversation contains a tool result. Provider-hosted
+        // tools count here too because they are merged into the same wire `tools` array.
         let should_apply_response_format =
-            output_schema.is_some() && (tools.is_empty() || history_has_tool_result);
+            output_schema.is_some() && (!has_tools || history_has_tool_result);
 
         // Map output_schema to OpenAI's response_format and merge into additional_params
-        let mut additional_params = if let Some(schema) = output_schema
+        let additional_params = if let Some(schema) = output_schema
             && should_apply_response_format
         {
             let name = schema
@@ -1324,9 +1329,7 @@ impl TryFrom<OpenAIRequestParams> for CompletionRequest {
             .into_iter()
             .map(serde_json::to_value)
             .collect::<Result<Vec<_>, _>>()?;
-        tools.append(&mut extract_tools_from_additional_params(
-            &mut additional_params,
-        )?);
+        tools.append(&mut provider_tools);
 
         let res = Self {
             model: request_model.unwrap_or(model),
@@ -1652,6 +1655,50 @@ mod tests {
         assert_eq!(serialized["tools"][0]["type"], "function");
         assert_eq!(serialized["tools"][1]["type"], "web_search_preview");
         assert_eq!(serialized["metadata"]["source"], "test");
+    }
+
+    #[test]
+    fn provider_tools_delay_response_format_on_initial_tool_turn() {
+        let request = crate::completion::CompletionRequest {
+            model: None,
+            preamble: None,
+            chat_history: crate::OneOrMany::one("Hello".into()),
+            documents: vec![],
+            tools: vec![],
+            temperature: None,
+            max_tokens: None,
+            tool_choice: None,
+            additional_params: Some(serde_json::json!({
+                "tools": [{"type": "web_search_preview"}]
+            })),
+            output_schema: Some(
+                serde_json::from_value(serde_json::json!({
+                    "title": "SearchAnswer",
+                    "type": "object",
+                    "properties": {
+                        "answer": { "type": "string" }
+                    },
+                    "required": ["answer"]
+                }))
+                .expect("schema should deserialize"),
+            ),
+        };
+
+        let openai_request = CompletionRequest::try_from(OpenAIRequestParams {
+            model: "gpt-4o-mini".to_string(),
+            request,
+            strict_tools: false,
+            tool_result_array_content: false,
+        })
+        .expect("request conversion should succeed");
+        let serialized =
+            serde_json::to_value(openai_request).expect("serialization should succeed");
+
+        assert_eq!(serialized["tools"][0]["type"], "web_search_preview");
+        assert!(
+            serialized.get("response_format").is_none(),
+            "initial provider-tool turn should omit response_format: {serialized:?}"
+        );
     }
 
     #[test]

--- a/crates/rig-core/src/providers/openrouter/completion.rs
+++ b/crates/rig-core/src/providers/openrouter/completion.rs
@@ -10,7 +10,8 @@ use crate::telemetry::SpanCombinator;
 use crate::{
     OneOrMany,
     completion::{
-        self, CompletionError, CompletionRequest, take_provider_tools_from_additional_params,
+        self, CompletionError, CompletionRequest,
+        take_function_provider_tools_from_additional_params,
     },
     http_client::HttpClientExt,
     json_utils,
@@ -1852,8 +1853,10 @@ impl TryFrom<OpenRouterRequestParams<'_>> for OpenrouterCompletionRequest {
         };
 
         let mut additional_params = additional_params;
-        let mut provider_tools =
-            take_provider_tools_from_additional_params(&mut additional_params, "OpenRouter")?;
+        let mut provider_tools = take_function_provider_tools_from_additional_params(
+            &mut additional_params,
+            "OpenRouter",
+        )?;
         let mut tools = tools
             .into_iter()
             .map(serde_json::to_value)

--- a/crates/rig-core/src/providers/openrouter/completion.rs
+++ b/crates/rig-core/src/providers/openrouter/completion.rs
@@ -9,7 +9,9 @@ use crate::message::{
 use crate::telemetry::SpanCombinator;
 use crate::{
     OneOrMany,
-    completion::{self, CompletionError, CompletionRequest},
+    completion::{
+        self, CompletionError, CompletionRequest, take_provider_tools_from_additional_params,
+    },
     http_client::HttpClientExt,
     json_utils,
     one_or_many::string_or_one_or_many,
@@ -1765,7 +1767,7 @@ pub(super) struct OpenrouterCompletionRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     temperature: Option<f64>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    tools: Vec<crate::providers::openai::completion::ToolDefinition>,
+    tools: Vec<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tool_choice: Option<crate::providers::openai::completion::ToolChoice>,
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
@@ -1848,6 +1850,15 @@ impl TryFrom<OpenRouterRequestParams<'_>> for OpenrouterCompletionRequest {
         } else {
             req.additional_params
         };
+
+        let mut additional_params = additional_params;
+        let mut provider_tools =
+            take_provider_tools_from_additional_params(&mut additional_params, "OpenRouter")?;
+        let mut tools = tools
+            .into_iter()
+            .map(serde_json::to_value)
+            .collect::<Result<Vec<_>, _>>()?;
+        tools.append(&mut provider_tools);
 
         Ok(Self {
             model,

--- a/crates/rig-core/src/providers/together/completion.rs
+++ b/crates/rig-core/src/providers/together/completion.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 use super::client::{Client, together_ai_api_types::ApiResponse};
-use crate::completion::{CompletionRequest, take_provider_tools_from_additional_params};
+use crate::completion::{CompletionRequest, take_function_provider_tools_from_additional_params};
 use crate::streaming::StreamingCompletionResponse;
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
@@ -184,8 +184,10 @@ impl TryFrom<(&str, CompletionRequest)> for TogetherAICompletionRequest {
             .transpose()?;
 
         let mut additional_params = req.additional_params;
-        let mut provider_tools =
-            take_provider_tools_from_additional_params(&mut additional_params, "TogetherAI")?;
+        let mut provider_tools = take_function_provider_tools_from_additional_params(
+            &mut additional_params,
+            "TogetherAI",
+        )?;
         let mut tools = req
             .tools
             .clone()
@@ -421,6 +423,34 @@ mod tests {
             }
             other => panic!("expected ProviderResponse, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn together_request_rejects_native_provider_tool() {
+        let request = CompletionRequest {
+            preamble: None,
+            chat_history: OneOrMany::one(message::Message::user("Hello")),
+            documents: vec![],
+            tools: vec![],
+            temperature: None,
+            max_tokens: None,
+            tool_choice: None,
+            additional_params: Some(serde_json::json!({
+                "tools": [{"type": "web_search_preview"}]
+            })),
+            model: None,
+            output_schema: None,
+        };
+
+        let result = TogetherAICompletionRequest::try_from(("meta-llama/test-model", request));
+
+        let error = result.expect_err("native provider tool should be rejected");
+        assert!(matches!(error, CompletionError::RequestError(_)));
+        assert!(
+            error
+                .to_string()
+                .contains("only function tools are supported")
+        );
     }
 
     #[test]

--- a/crates/rig-core/src/providers/together/completion.rs
+++ b/crates/rig-core/src/providers/together/completion.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 use super::client::{Client, together_ai_api_types::ApiResponse};
-use crate::completion::CompletionRequest;
+use crate::completion::{CompletionRequest, take_provider_tools_from_additional_params};
 use crate::streaming::StreamingCompletionResponse;
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
@@ -136,7 +136,7 @@ pub(super) struct TogetherAICompletionRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     temperature: Option<f64>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    tools: Vec<crate::providers::openai::completion::ToolDefinition>,
+    tools: Vec<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tool_choice: Option<ToolChoice>,
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
@@ -183,18 +183,25 @@ impl TryFrom<(&str, CompletionRequest)> for TogetherAICompletionRequest {
             .map(ToolChoice::try_from)
             .transpose()?;
 
+        let mut additional_params = req.additional_params;
+        let mut provider_tools =
+            take_provider_tools_from_additional_params(&mut additional_params, "TogetherAI")?;
+        let mut tools = req
+            .tools
+            .clone()
+            .into_iter()
+            .map(crate::providers::openai::completion::ToolDefinition::from)
+            .map(serde_json::to_value)
+            .collect::<Result<Vec<_>, _>>()?;
+        tools.append(&mut provider_tools);
+
         Ok(Self {
             model: model.to_string(),
             messages: full_history,
             temperature: req.temperature,
-            tools: req
-                .tools
-                .clone()
-                .into_iter()
-                .map(crate::providers::openai::completion::ToolDefinition::from)
-                .collect::<Vec<_>>(),
+            tools,
             tool_choice,
-            additional_params: req.additional_params,
+            additional_params,
         })
     }
 }

--- a/tests/cassettes/openai/provider_tools/mixed_rig_and_provider_tools_with_schema_defers_response_format.yaml
+++ b/tests/cassettes/openai/provider_tools/mixed_rig_and_provider_tools_with_schema_defers_response_format.yaml
@@ -7,7 +7,7 @@ when:
     value: '*/*'
   - name: content-type
     value: application/json
-  body: '{"messages":[{"content":[{"text":"Reply concisely. Do not call tools unless the user explicitly asks.","type":"text"}],"role":"system"},{"content":"Say a friendly one-sentence greeting without using tools.","role":"user"}],"model":"gpt-5-nano","tools":[{"function":{"description":"Get the current weather for a city.","name":"weather","parameters":{"properties":{"city":{"type":"string"}},"required":["city"],"type":"object"}},"type":"function"},{"custom":{"description":"A provider-hosted lookup tool. Do not use it unless explicitly asked.","name":"hosted_lookup"},"type":"custom"}]}'
+  body: '{"messages":[{"content":[{"text":"Reply concisely. Do not call tools unless the user explicitly asks.","type":"text"}],"role":"system"},{"content":"Say a friendly one-sentence greeting without using tools.","role":"user"}],"model":"gpt-5-nano","tools":[{"function":{"description":"Get the current weather for a city.","name":"weather","parameters":{"properties":{"city":{"type":"string"}},"required":["city"],"type":"object"}},"type":"function"},{"type":"web_search_preview"}]}'
 then:
   status: 200
   header:

--- a/tests/cassettes/openai/provider_tools/mixed_rig_and_provider_tools_with_schema_defers_response_format.yaml
+++ b/tests/cassettes/openai/provider_tools/mixed_rig_and_provider_tools_with_schema_defers_response_format.yaml
@@ -1,0 +1,16 @@
+when:
+  path: /v1/chat/completions
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"messages":[{"content":[{"text":"Reply concisely. Do not call tools unless the user explicitly asks.","type":"text"}],"role":"system"},{"content":"Say a friendly one-sentence greeting without using tools.","role":"user"}],"model":"gpt-5-nano","tools":[{"function":{"description":"Get the current weather for a city.","name":"weather","parameters":{"properties":{"city":{"type":"string"}},"required":["city"],"type":"object"}},"type":"function"},{"custom":{"description":"A provider-hosted lookup tool. Do not use it unless explicitly asked.","name":"hosted_lookup"},"type":"custom"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"choices":[{"finish_reason":"stop","index":0,"message":{"annotations":[],"content":"Hi there, I hope you''re having a wonderful day.","refusal":null,"role":"assistant"}}],"created":0,"id":"chatcmpl-REDACTED_1","model":"gpt-5-nano-2025-08-07","object":"chat.completion","service_tier":"default","system_fingerprint":null,"usage":{"completion_tokens":276,"completion_tokens_details":{"accepted_prediction_tokens":0,"audio_tokens":0,"reasoning_tokens":256,"rejected_prediction_tokens":0},"prompt_tokens":180,"prompt_tokens_details":{"audio_tokens":0,"cached_tokens":0},"total_tokens":456}}'

--- a/tests/cassettes/openai/provider_tools/request_override_additional_params_can_inject_provider_tools.yaml
+++ b/tests/cassettes/openai/provider_tools/request_override_additional_params_can_inject_provider_tools.yaml
@@ -1,0 +1,16 @@
+when:
+  path: /v1/chat/completions
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"messages":[{"content":[{"text":"Reply concisely. Do not use tools unless explicitly asked.","type":"text"}],"role":"system"},{"content":"Reply exactly: ok","role":"user"}],"model":"gpt-5-nano","tools":[{"custom":{"description":"A provider-hosted lookup tool. Do not use it unless explicitly asked.","name":"hosted_lookup"},"type":"custom"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"choices":[{"finish_reason":"stop","index":0,"message":{"annotations":[],"content":"ok","refusal":null,"role":"assistant"}}],"created":0,"id":"chatcmpl-REDACTED_1","model":"gpt-5-nano-2025-08-07","object":"chat.completion","service_tier":"default","system_fingerprint":null,"usage":{"completion_tokens":74,"completion_tokens_details":{"accepted_prediction_tokens":0,"audio_tokens":0,"reasoning_tokens":64,"rejected_prediction_tokens":0},"prompt_tokens":150,"prompt_tokens_details":{"audio_tokens":0,"cached_tokens":0},"total_tokens":224}}'

--- a/tests/cassettes/openai/provider_tools/request_override_additional_params_can_inject_provider_tools.yaml
+++ b/tests/cassettes/openai/provider_tools/request_override_additional_params_can_inject_provider_tools.yaml
@@ -7,7 +7,7 @@ when:
     value: '*/*'
   - name: content-type
     value: application/json
-  body: '{"messages":[{"content":[{"text":"Reply concisely. Do not use tools unless explicitly asked.","type":"text"}],"role":"system"},{"content":"Reply exactly: ok","role":"user"}],"model":"gpt-5-nano","tools":[{"custom":{"description":"A provider-hosted lookup tool. Do not use it unless explicitly asked.","name":"hosted_lookup"},"type":"custom"}]}'
+  body: '{"messages":[{"content":[{"text":"Reply concisely. Do not use tools unless explicitly asked.","type":"text"}],"role":"system"},{"content":"Reply exactly: ok","role":"user"}],"model":"gpt-5-nano","tools":[{"type":"web_search_preview"}]}'
 then:
   status: 200
   header:

--- a/tests/cassettes/openai/provider_tools/streaming_agent_forwards_provider_tools.yaml
+++ b/tests/cassettes/openai/provider_tools/streaming_agent_forwards_provider_tools.yaml
@@ -13,7 +13,7 @@ then:
   header:
   - name: content-type
     value: text/event-stream; charset=utf-8
-  body: |+
+  body: |
     data: {"choices":[{"delta":{"content":"","refusal":null,"role":"assistant"},"finish_reason":null,"index":0}],"created":0,"id":"chatcmpl-REDACTED_1","model":"gpt-5-nano-2025-08-07","obfuscation":"obfuscation_REDACTED_1","object":"chat.completion.chunk","service_tier":"default","system_fingerprint":null,"usage":null}
 
     data: {"choices":[{"delta":{"content":"ok"},"finish_reason":null,"index":0}],"created":0,"id":"chatcmpl-REDACTED_1","model":"gpt-5-nano-2025-08-07","obfuscation":"obfuscation_REDACTED_2","object":"chat.completion.chunk","service_tier":"default","system_fingerprint":null,"usage":null}

--- a/tests/cassettes/openai/provider_tools/streaming_agent_forwards_provider_tools.yaml
+++ b/tests/cassettes/openai/provider_tools/streaming_agent_forwards_provider_tools.yaml
@@ -1,0 +1,26 @@
+when:
+  path: /v1/chat/completions
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"messages":[{"content":[{"text":"Reply concisely. Do not use tools unless explicitly asked.","type":"text"}],"role":"system"},{"content":"Reply exactly: ok","role":"user"}],"model":"gpt-5-nano","stream":true,"stream_options":{"include_usage":true},"tools":[{"custom":{"description":"A provider-hosted lookup tool. Do not use it unless explicitly asked.","name":"hosted_lookup"},"type":"custom"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream; charset=utf-8
+  body: |+
+    data: {"choices":[{"delta":{"content":"","refusal":null,"role":"assistant"},"finish_reason":null,"index":0}],"created":0,"id":"chatcmpl-REDACTED_1","model":"gpt-5-nano-2025-08-07","obfuscation":"obfuscation_REDACTED_1","object":"chat.completion.chunk","service_tier":"default","system_fingerprint":null,"usage":null}
+
+    data: {"choices":[{"delta":{"content":"ok"},"finish_reason":null,"index":0}],"created":0,"id":"chatcmpl-REDACTED_1","model":"gpt-5-nano-2025-08-07","obfuscation":"obfuscation_REDACTED_2","object":"chat.completion.chunk","service_tier":"default","system_fingerprint":null,"usage":null}
+
+    data: {"choices":[{"delta":{},"finish_reason":"stop","index":0}],"created":0,"id":"chatcmpl-REDACTED_1","model":"gpt-5-nano-2025-08-07","obfuscation":"obfuscation_REDACTED_3","object":"chat.completion.chunk","service_tier":"default","system_fingerprint":null,"usage":null}
+
+    data: {"choices":[],"created":0,"id":"chatcmpl-REDACTED_1","model":"gpt-5-nano-2025-08-07","obfuscation":"obfuscation_REDACTED_4","object":"chat.completion.chunk","service_tier":"default","system_fingerprint":null,"usage":{"completion_tokens":138,"completion_tokens_details":{"accepted_prediction_tokens":0,"audio_tokens":0,"reasoning_tokens":128,"rejected_prediction_tokens":0},"prompt_tokens":150,"prompt_tokens_details":{"audio_tokens":0,"cached_tokens":0},"total_tokens":288}}
+
+    data: [DONE]
+

--- a/tests/cassettes/openai/provider_tools/streaming_agent_forwards_provider_tools.yaml
+++ b/tests/cassettes/openai/provider_tools/streaming_agent_forwards_provider_tools.yaml
@@ -23,4 +23,3 @@ then:
     data: {"choices":[],"created":0,"id":"chatcmpl-REDACTED_1","model":"gpt-5-nano-2025-08-07","obfuscation":"obfuscation_REDACTED_4","object":"chat.completion.chunk","service_tier":"default","system_fingerprint":null,"usage":{"completion_tokens":138,"completion_tokens_details":{"accepted_prediction_tokens":0,"audio_tokens":0,"reasoning_tokens":128,"rejected_prediction_tokens":0},"prompt_tokens":150,"prompt_tokens_details":{"audio_tokens":0,"cached_tokens":0},"total_tokens":288}}
 
     data: [DONE]
-

--- a/tests/cassettes/openai/provider_tools/streaming_agent_forwards_provider_tools.yaml
+++ b/tests/cassettes/openai/provider_tools/streaming_agent_forwards_provider_tools.yaml
@@ -7,7 +7,7 @@ when:
     value: text/event-stream
   - name: content-type
     value: application/json
-  body: '{"messages":[{"content":[{"text":"Reply concisely. Do not use tools unless explicitly asked.","type":"text"}],"role":"system"},{"content":"Reply exactly: ok","role":"user"}],"model":"gpt-5-nano","stream":true,"stream_options":{"include_usage":true},"tools":[{"custom":{"description":"A provider-hosted lookup tool. Do not use it unless explicitly asked.","name":"hosted_lookup"},"type":"custom"}]}'
+  body: '{"messages":[{"content":[{"text":"Reply concisely. Do not use tools unless explicitly asked.","type":"text"}],"role":"system"},{"content":"Reply exactly: ok","role":"user"}],"model":"gpt-5-nano","stream":true,"stream_options":{"include_usage":true},"tools":[{"type":"web_search_preview"}]}'
 then:
   status: 200
   header:

--- a/tests/providers/openai/cassette/provider_tools.rs
+++ b/tests/providers/openai/cassette/provider_tools.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result, bail, ensure};
 use rig::OneOrMany;
 use rig::agent::{AgentHook, Flow, RequestOverride, StepEvent};
 use rig::client::CompletionClient;
@@ -58,7 +58,7 @@ async fn streaming_agent_forwards_provider_tools() -> Result<()> {
             let mut stream = agent.stream_prompt("Reply exactly: ok").await;
             let response = collect_stream_final_response(&mut stream)
                 .await
-                .expect("streaming provider-tool prompt should succeed");
+                .context("streaming provider-tool prompt should succeed")?;
             assert_nonempty_response(&response);
 
             Ok::<(), anyhow::Error>(())
@@ -66,9 +66,12 @@ async fn streaming_agent_forwards_provider_tools() -> Result<()> {
     )
     .await?;
 
-    let body = recorded_request_body("provider_tools/streaming_agent_forwards_provider_tools");
-    assert_eq!(body["stream"], true, "expected streaming request: {body:#}");
-    assert_hosted_custom_tool_present(&body);
+    let body = recorded_request_body("provider_tools/streaming_agent_forwards_provider_tools")?;
+    ensure!(
+        body["stream"] == true,
+        "expected streaming request: {body:#}"
+    );
+    assert_hosted_custom_tool_present(&body)?;
 
     Ok(())
 }
@@ -87,7 +90,7 @@ async fn request_override_additional_params_can_inject_provider_tools() -> Resul
                 .prompt("Reply exactly: ok")
                 .add_hook(ProviderToolOverrideHook)
                 .await
-                .expect("hook-injected provider-tool prompt should succeed");
+                .context("hook-injected provider-tool prompt should succeed")?;
             assert_nonempty_response(&response);
 
             Ok::<(), anyhow::Error>(())
@@ -97,8 +100,8 @@ async fn request_override_additional_params_can_inject_provider_tools() -> Resul
 
     let body = recorded_request_body(
         "provider_tools/request_override_additional_params_can_inject_provider_tools",
-    );
-    assert_hosted_custom_tool_present(&body);
+    )?;
+    assert_hosted_custom_tool_present(&body)?;
 
     Ok(())
 }
@@ -145,14 +148,14 @@ async fn mixed_rig_and_provider_tools_with_schema_defers_response_format() -> Re
                         },
                         "required": ["answer"]
                     }))
-                    .expect("schema should deserialize"),
+                    .context("schema should deserialize")?,
                 ),
             };
 
             model
                 .completion(request)
                 .await
-                .expect("mixed provider/Rig tool completion request should succeed");
+                .context("mixed provider/Rig tool completion request should succeed")?;
 
             Ok::<(), anyhow::Error>(())
         },
@@ -161,19 +164,22 @@ async fn mixed_rig_and_provider_tools_with_schema_defers_response_format() -> Re
 
     let body = recorded_request_body(
         "provider_tools/mixed_rig_and_provider_tools_with_schema_defers_response_format",
-    );
+    )?;
     let tools = body["tools"]
         .as_array()
-        .unwrap_or_else(|| panic!("expected tools array in request: {body:#}"));
-    assert_eq!(tools.len(), 2, "expected Rig and provider tools: {body:#}");
-    assert!(
+        .with_context(|| format!("expected tools array in request: {body:#}"))?;
+    ensure!(
+        tools.len() == 2,
+        "expected Rig and provider tools: {body:#}"
+    );
+    ensure!(
         tools
             .iter()
             .any(|tool| tool["type"] == "function" && tool["function"]["name"] == "weather"),
         "expected Rig function tool in request: {body:#}"
     );
-    assert_hosted_custom_tool_present(&body);
-    assert!(
+    assert_hosted_custom_tool_present(&body)?;
+    ensure!(
         body.get("response_format").is_none(),
         "initial mixed executable-tool turn should defer response_format: {body:#}"
     );
@@ -222,35 +228,37 @@ struct RecordedRequest {
     body: Option<String>,
 }
 
-fn recorded_request_body(scenario: &str) -> Value {
+fn recorded_request_body(scenario: &str) -> Result<Value> {
     let cassette_path = crate::cassettes::cassette_path("openai", scenario);
-    let contents = std::fs::read_to_string(&cassette_path).unwrap_or_else(|error| {
-        panic!(
-            "provider cassette {} should be readable after recording/replay: {error}",
+    let contents = std::fs::read_to_string(&cassette_path).with_context(|| {
+        format!(
+            "provider cassette {} should be readable after recording/replay",
             cassette_path.display()
         )
-    });
+    })?;
 
-    serde_yaml::Deserializer::from_str(&contents)
-        .find_map(|document| {
-            let interaction = RecordedInteraction::deserialize(document)
-                .expect("cassette interaction should deserialize");
-            interaction
-                .when
-                .body
-                .and_then(|body| serde_json::from_str::<Value>(&body).ok())
-        })
-        .unwrap_or_else(|| panic!("expected cassette {scenario} to contain a JSON request body"))
+    for document in serde_yaml::Deserializer::from_str(&contents) {
+        let interaction = RecordedInteraction::deserialize(document)
+            .context("cassette interaction should deserialize")?;
+        if let Some(body) = interaction.when.body
+            && let Ok(body) = serde_json::from_str::<Value>(&body)
+        {
+            return Ok(body);
+        }
+    }
+
+    bail!("expected cassette {scenario} to contain a JSON request body")
 }
 
-fn assert_hosted_custom_tool_present(body: &Value) {
+fn assert_hosted_custom_tool_present(body: &Value) -> Result<()> {
     let tools = body["tools"]
         .as_array()
-        .unwrap_or_else(|| panic!("expected tools array in request: {body:#}"));
-    assert!(
+        .with_context(|| format!("expected tools array in request: {body:#}"))?;
+    ensure!(
         tools
             .iter()
             .any(|tool| tool["type"] == "custom" && tool["custom"]["name"] == HOSTED_TOOL_NAME),
         "expected provider-hosted custom tool in request: {body:#}"
     );
+    Ok(())
 }

--- a/tests/providers/openai/cassette/provider_tools.rs
+++ b/tests/providers/openai/cassette/provider_tools.rs
@@ -13,8 +13,6 @@ use serde_json::{Value, json};
 use super::super::support::with_openai_completions_cassette_result;
 use crate::support::{assert_nonempty_response, collect_stream_final_response};
 
-const HOSTED_TOOL_NAME: &str = "hosted_lookup";
-
 #[derive(Clone)]
 struct ProviderToolOverrideHook;
 
@@ -26,7 +24,7 @@ where
         match event {
             StepEvent::CompletionCall { .. } => {
                 Flow::override_request(RequestOverride::new().additional_params(json!({
-                    "tools": [hosted_custom_tool()]
+                    "tools": [hosted_search_preview_tool()]
                 })))
             }
             _ => Flow::cont(),
@@ -34,14 +32,8 @@ where
     }
 }
 
-fn hosted_custom_tool() -> ProviderToolDefinition {
-    ProviderToolDefinition::new("custom").with_config(
-        "custom",
-        json!({
-            "name": HOSTED_TOOL_NAME,
-            "description": "A provider-hosted lookup tool. Do not use it unless explicitly asked."
-        }),
-    )
+fn hosted_search_preview_tool() -> ProviderToolDefinition {
+    ProviderToolDefinition::new("web_search_preview")
 }
 
 #[tokio::test]
@@ -52,7 +44,7 @@ async fn streaming_agent_forwards_provider_tools() -> Result<()> {
             let agent = client
                 .agent(openai::GPT_5_NANO)
                 .preamble("Reply concisely. Do not use tools unless explicitly asked.")
-                .provider_tool(hosted_custom_tool())
+                .provider_tool(hosted_search_preview_tool())
                 .build();
 
             let mut stream = agent.stream_prompt("Reply exactly: ok").await;
@@ -71,7 +63,7 @@ async fn streaming_agent_forwards_provider_tools() -> Result<()> {
         body["stream"] == true,
         "expected streaming request: {body:#}"
     );
-    assert_hosted_custom_tool_present(&body)?;
+    assert_hosted_search_preview_tool_present(&body)?;
 
     Ok(())
 }
@@ -101,7 +93,7 @@ async fn request_override_additional_params_can_inject_provider_tools() -> Resul
     let body = recorded_request_body(
         "provider_tools/request_override_additional_params_can_inject_provider_tools",
     )?;
-    assert_hosted_custom_tool_present(&body)?;
+    assert_hosted_search_preview_tool_present(&body)?;
 
     Ok(())
 }
@@ -137,7 +129,7 @@ async fn mixed_rig_and_provider_tools_with_schema_defers_response_format() -> Re
                 max_tokens: None,
                 tool_choice: None,
                 additional_params: Some(json!({
-                    "tools": [hosted_custom_tool()]
+                    "tools": [hosted_search_preview_tool()]
                 })),
                 output_schema: Some(
                     serde_json::from_value(json!({
@@ -178,7 +170,7 @@ async fn mixed_rig_and_provider_tools_with_schema_defers_response_format() -> Re
             .any(|tool| tool["type"] == "function" && tool["function"]["name"] == "weather"),
         "expected Rig function tool in request: {body:#}"
     );
-    assert_hosted_custom_tool_present(&body)?;
+    assert_hosted_search_preview_tool_present(&body)?;
     ensure!(
         body.get("response_format").is_none(),
         "initial mixed executable-tool turn should defer response_format: {body:#}"
@@ -250,15 +242,15 @@ fn recorded_request_body(scenario: &str) -> Result<Value> {
     bail!("expected cassette {scenario} to contain a JSON request body")
 }
 
-fn assert_hosted_custom_tool_present(body: &Value) -> Result<()> {
+fn assert_hosted_search_preview_tool_present(body: &Value) -> Result<()> {
     let tools = body["tools"]
         .as_array()
         .with_context(|| format!("expected tools array in request: {body:#}"))?;
     ensure!(
         tools
             .iter()
-            .any(|tool| tool["type"] == "custom" && tool["custom"]["name"] == HOSTED_TOOL_NAME),
-        "expected provider-hosted custom tool in request: {body:#}"
+            .any(|tool| tool["type"] == "web_search_preview"),
+        "expected provider-hosted web search preview tool in request: {body:#}"
     );
     Ok(())
 }

--- a/tests/providers/openai/cassette/provider_tools.rs
+++ b/tests/providers/openai/cassette/provider_tools.rs
@@ -1,0 +1,256 @@
+use anyhow::Result;
+use rig::OneOrMany;
+use rig::agent::{AgentHook, Flow, RequestOverride, StepEvent};
+use rig::client::CompletionClient;
+use rig::completion::{
+    CompletionModel, CompletionRequest, Message, Prompt, ProviderToolDefinition,
+};
+use rig::providers::openai;
+use rig::streaming::StreamingPrompt;
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use super::super::support::with_openai_completions_cassette_result;
+use crate::support::{assert_nonempty_response, collect_stream_final_response};
+
+const HOSTED_TOOL_NAME: &str = "hosted_lookup";
+
+#[derive(Clone)]
+struct ProviderToolOverrideHook;
+
+impl<M> AgentHook<M> for ProviderToolOverrideHook
+where
+    M: CompletionModel,
+{
+    async fn on_event(&self, event: StepEvent<'_, M>) -> Flow {
+        match event {
+            StepEvent::CompletionCall { .. } => {
+                Flow::override_request(RequestOverride::new().additional_params(json!({
+                    "tools": [hosted_custom_tool()]
+                })))
+            }
+            _ => Flow::cont(),
+        }
+    }
+}
+
+fn hosted_custom_tool() -> ProviderToolDefinition {
+    ProviderToolDefinition::new("custom").with_config(
+        "custom",
+        json!({
+            "name": HOSTED_TOOL_NAME,
+            "description": "A provider-hosted lookup tool. Do not use it unless explicitly asked."
+        }),
+    )
+}
+
+#[tokio::test]
+async fn streaming_agent_forwards_provider_tools() -> Result<()> {
+    with_openai_completions_cassette_result(
+        "provider_tools/streaming_agent_forwards_provider_tools",
+        |client| async move {
+            let agent = client
+                .agent(openai::GPT_5_NANO)
+                .preamble("Reply concisely. Do not use tools unless explicitly asked.")
+                .provider_tool(hosted_custom_tool())
+                .build();
+
+            let mut stream = agent.stream_prompt("Reply exactly: ok").await;
+            let response = collect_stream_final_response(&mut stream)
+                .await
+                .expect("streaming provider-tool prompt should succeed");
+            assert_nonempty_response(&response);
+
+            Ok::<(), anyhow::Error>(())
+        },
+    )
+    .await?;
+
+    let body = recorded_request_body("provider_tools/streaming_agent_forwards_provider_tools");
+    assert_eq!(body["stream"], true, "expected streaming request: {body:#}");
+    assert_hosted_custom_tool_present(&body);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn request_override_additional_params_can_inject_provider_tools() -> Result<()> {
+    with_openai_completions_cassette_result(
+        "provider_tools/request_override_additional_params_can_inject_provider_tools",
+        |client| async move {
+            let agent = client
+                .agent(openai::GPT_5_NANO)
+                .preamble("Reply concisely. Do not use tools unless explicitly asked.")
+                .build();
+
+            let response = agent
+                .prompt("Reply exactly: ok")
+                .add_hook(ProviderToolOverrideHook)
+                .await
+                .expect("hook-injected provider-tool prompt should succeed");
+            assert_nonempty_response(&response);
+
+            Ok::<(), anyhow::Error>(())
+        },
+    )
+    .await?;
+
+    let body = recorded_request_body(
+        "provider_tools/request_override_additional_params_can_inject_provider_tools",
+    );
+    assert_hosted_custom_tool_present(&body);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn mixed_rig_and_provider_tools_with_schema_defers_response_format() -> Result<()> {
+    with_openai_completions_cassette_result(
+        "provider_tools/mixed_rig_and_provider_tools_with_schema_defers_response_format",
+        |client| async move {
+            let model = client.completion_model(openai::GPT_5_NANO);
+            let request = CompletionRequest {
+                model: None,
+                preamble: Some(
+                    "Reply concisely. Do not call tools unless the user explicitly asks."
+                        .to_string(),
+                ),
+                chat_history: OneOrMany::one(Message::user(
+                    "Say a friendly one-sentence greeting without using tools.",
+                )),
+                documents: vec![],
+                tools: vec![rig::completion::ToolDefinition {
+                    name: "weather".to_string(),
+                    description: "Get the current weather for a city.".to_string(),
+                    parameters: json!({
+                        "type": "object",
+                        "properties": {
+                            "city": { "type": "string" }
+                        },
+                        "required": ["city"]
+                    }),
+                }],
+                temperature: None,
+                max_tokens: None,
+                tool_choice: None,
+                additional_params: Some(json!({
+                    "tools": [hosted_custom_tool()]
+                })),
+                output_schema: Some(
+                    serde_json::from_value(json!({
+                        "title": "GreetingAnswer",
+                        "type": "object",
+                        "properties": {
+                            "answer": { "type": "string" }
+                        },
+                        "required": ["answer"]
+                    }))
+                    .expect("schema should deserialize"),
+                ),
+            };
+
+            model
+                .completion(request)
+                .await
+                .expect("mixed provider/Rig tool completion request should succeed");
+
+            Ok::<(), anyhow::Error>(())
+        },
+    )
+    .await?;
+
+    let body = recorded_request_body(
+        "provider_tools/mixed_rig_and_provider_tools_with_schema_defers_response_format",
+    );
+    let tools = body["tools"]
+        .as_array()
+        .unwrap_or_else(|| panic!("expected tools array in request: {body:#}"));
+    assert_eq!(tools.len(), 2, "expected Rig and provider tools: {body:#}");
+    assert!(
+        tools
+            .iter()
+            .any(|tool| tool["type"] == "function" && tool["function"]["name"] == "weather"),
+        "expected Rig function tool in request: {body:#}"
+    );
+    assert_hosted_custom_tool_present(&body);
+    assert!(
+        body.get("response_format").is_none(),
+        "initial mixed executable-tool turn should defer response_format: {body:#}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn invalid_provider_tools_payload_fails_before_http() {
+    let request = CompletionRequest {
+        model: None,
+        preamble: None,
+        chat_history: OneOrMany::one(Message::user("Hello")),
+        documents: vec![],
+        tools: vec![],
+        temperature: None,
+        max_tokens: None,
+        tool_choice: None,
+        additional_params: Some(json!({
+            "tools": { "type": "custom" }
+        })),
+        output_schema: None,
+    };
+
+    let result = rig::providers::openai::completion::CompletionRequest::try_from((
+        openai::GPT_5_NANO.to_string(),
+        request,
+    ));
+
+    assert!(
+        matches!(
+            result,
+            Err(rig::completion::CompletionError::RequestError(_))
+        ),
+        "invalid provider tools payload should be rejected before sending"
+    );
+}
+
+#[derive(Deserialize)]
+struct RecordedInteraction {
+    when: RecordedRequest,
+}
+
+#[derive(Deserialize)]
+struct RecordedRequest {
+    body: Option<String>,
+}
+
+fn recorded_request_body(scenario: &str) -> Value {
+    let cassette_path = crate::cassettes::cassette_path("openai", scenario);
+    let contents = std::fs::read_to_string(&cassette_path).unwrap_or_else(|error| {
+        panic!(
+            "provider cassette {} should be readable after recording/replay: {error}",
+            cassette_path.display()
+        )
+    });
+
+    serde_yaml::Deserializer::from_str(&contents)
+        .find_map(|document| {
+            let interaction = RecordedInteraction::deserialize(document)
+                .expect("cassette interaction should deserialize");
+            interaction
+                .when
+                .body
+                .and_then(|body| serde_json::from_str::<Value>(&body).ok())
+        })
+        .unwrap_or_else(|| panic!("expected cassette {scenario} to contain a JSON request body"))
+}
+
+fn assert_hosted_custom_tool_present(body: &Value) {
+    let tools = body["tools"]
+        .as_array()
+        .unwrap_or_else(|| panic!("expected tools array in request: {body:#}"));
+    assert!(
+        tools
+            .iter()
+            .any(|tool| tool["type"] == "custom" && tool["custom"]["name"] == HOSTED_TOOL_NAME),
+        "expected provider-hosted custom tool in request: {body:#}"
+    );
+}

--- a/tests/providers/openai/mod.rs
+++ b/tests/providers/openai/mod.rs
@@ -10,6 +10,7 @@ mod cassette {
     mod models;
     mod multi_extract;
     mod permission_control;
+    mod provider_tools;
     mod reasoning_roundtrip;
     mod reasoning_tool_roundtrip;
     mod request_hook;


### PR DESCRIPTION
## Summary
- Add `AgentBuilder::provider_tool` / `provider_tools` so hosted provider tools flow through agent request construction
- Keep provider-hosted tools separate from Rig executable tools; they are serialized via provider `additional_params.tools` and are not registered with the `ToolServer`
- Merge OpenAI Chat Completions provider tools into the single wire `tools` array to avoid duplicate `tools` keys when mixed with function tools

Closes #1890.

## Tests
- cargo test -p rig-core --lib --no-default-features
- cargo test -p rig-core --lib agent::builder::tests --all-features
- cargo test -p rig-core --lib providers::openai::completion::tests::openai_chat_request_merges_provider_tools_into_single_tools_array --all-features
- cargo clippy -p rig-core --lib --no-default-features -- -D warnings
