### PR TITLE
fix(gemini): tolerate omitted proto defaults

### DIFF
--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -581,8 +581,10 @@ pub mod gemini_api_types {
     #[derive(Debug, Deserialize, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct GenerateContentResponse {
+        #[serde(default)]
         pub response_id: String,
         /// Candidate responses from the model.
+        #[serde(default)]
         pub candidates: Vec<ContentCandidate>,
         /// Returns the prompt's feedback related to the content filters.
         pub prompt_feedback: Option<PromptFeedback>,
@@ -1363,6 +1365,7 @@ pub mod gemini_api_types {
     #[serde(rename_all = "camelCase")]
     pub struct ModalityTokenCount {
         pub modality: Modality,
+        #[serde(default)]
         pub token_count: i32,
     }
 
@@ -1484,6 +1487,7 @@ pub mod gemini_api_types {
     #[derive(Clone, Debug, Deserialize, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct CitationMetadata {
+        #[serde(default)]
         pub citation_sources: Vec<CitationSource>,
     }
 
@@ -1503,12 +1507,15 @@ pub mod gemini_api_types {
     #[derive(Clone, Debug, Deserialize, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct LogprobsResult {
+        #[serde(default)]
         pub top_candidate: Vec<TopCandidate>,
+        #[serde(default)]
         pub chosen_candidate: Vec<LogProbCandidate>,
     }
 
     #[derive(Clone, Debug, Deserialize, Serialize)]
     pub struct TopCandidate {
+        #[serde(default)]
         pub candidates: Vec<LogProbCandidate>,
     }
 
@@ -2167,8 +2174,9 @@ mod tests {
     use crate::{
         message,
         providers::gemini::completion::gemini_api_types::{
-            ContentCandidate, FinishReason, FunctionCall, Schema, UsageMetadata, flatten_schema,
-            tool_parameters_to_schema,
+            CitationMetadata, ContentCandidate, FinishReason, FunctionCall,
+            GenerateContentResponse, LogprobsResult, ModalityTokenCount, Schema, TopCandidate,
+            UsageMetadata, flatten_schema, tool_parameters_to_schema,
         },
     };
 
@@ -2183,6 +2191,51 @@ mod tests {
             serde_json::from_str(r#"{"promptTokenCount": 12}"#).expect("should deserialize");
         assert_eq!(usage.total_token_count, 0);
         assert_eq!(usage.prompt_token_count, 12);
+    }
+
+    #[test]
+    fn test_generate_content_response_deserializes_without_candidates_or_response_id() {
+        // Blocked prompt responses can omit default-valued proto fields, including
+        // empty repeated `candidates` and empty string `responseId`.
+        let response: GenerateContentResponse = serde_json::from_value(json!({
+            "promptFeedback": {
+                "blockReason": "SAFETY"
+            }
+        }))
+        .expect("blocked prompt response should deserialize");
+
+        assert!(response.response_id.is_empty());
+        assert!(response.candidates.is_empty());
+
+        let error = completion::CompletionResponse::try_from(response)
+            .expect_err("empty candidates should become a response error");
+        assert!(error.to_string().contains("No response candidates"));
+    }
+
+    #[test]
+    fn test_modality_token_count_deserializes_without_zero_token_count() {
+        let count: ModalityTokenCount = serde_json::from_value(json!({
+            "modality": "TEXT"
+        }))
+        .expect("zero tokenCount may be omitted");
+
+        assert_eq!(count.token_count, 0);
+    }
+
+    #[test]
+    fn test_response_metadata_repeated_fields_deserialize_when_omitted() {
+        let citation_metadata: CitationMetadata =
+            serde_json::from_value(json!({})).expect("empty citation metadata should deserialize");
+        assert!(citation_metadata.citation_sources.is_empty());
+
+        let logprobs: LogprobsResult =
+            serde_json::from_value(json!({})).expect("empty logprobs result should deserialize");
+        assert!(logprobs.top_candidate.is_empty());
+        assert!(logprobs.chosen_candidate.is_empty());
+
+        let top_candidate: TopCandidate =
+            serde_json::from_value(json!({})).expect("empty top candidate should deserialize");
+        assert!(top_candidate.candidates.is_empty());
     }
 
     #[test]

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -1508,9 +1508,11 @@ pub mod gemini_api_types {
     #[serde(rename_all = "camelCase")]
     pub struct LogprobsResult {
         #[serde(default)]
-        pub top_candidate: Vec<TopCandidate>,
+        pub top_candidates: Vec<TopCandidate>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub log_probability_sum: Option<f64>,
         #[serde(default)]
-        pub chosen_candidate: Vec<LogProbCandidate>,
+        pub chosen_candidates: Vec<LogProbCandidate>,
     }
 
     #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1522,9 +1524,12 @@ pub mod gemini_api_types {
     #[derive(Clone, Debug, Deserialize, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct LogProbCandidate {
-        pub token: String,
-        pub token_id: String,
-        pub log_probability: f64,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub token: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub token_id: Option<i32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub log_probability: Option<f64>,
     }
 
     /// Gemini API Configuration options for model generation and outputs. Not all parameters are
@@ -2230,12 +2235,64 @@ mod tests {
 
         let logprobs: LogprobsResult =
             serde_json::from_value(json!({})).expect("empty logprobs result should deserialize");
-        assert!(logprobs.top_candidate.is_empty());
-        assert!(logprobs.chosen_candidate.is_empty());
+        assert!(logprobs.top_candidates.is_empty());
+        assert_eq!(logprobs.log_probability_sum, None);
+        assert!(logprobs.chosen_candidates.is_empty());
 
         let top_candidate: TopCandidate =
             serde_json::from_value(json!({})).expect("empty top candidate should deserialize");
         assert!(top_candidate.candidates.is_empty());
+    }
+
+    #[test]
+    fn test_logprobs_result_deserializes_official_json_field_names() {
+        let logprobs: LogprobsResult = serde_json::from_value(json!({
+            "topCandidates": [
+                {
+                    "candidates": [
+                        {
+                            "token": "Hello",
+                            "tokenId": 123,
+                            "logProbability": -0.1
+                        },
+                        {
+                            "token": "Hi",
+                            "tokenId": 124,
+                            "logProbability": -1.25
+                        }
+                    ]
+                }
+            ],
+            "logProbabilitySum": -0.1,
+            "chosenCandidates": [
+                {
+                    "token": "Hello",
+                    "tokenId": 123,
+                    "logProbability": -0.1
+                }
+            ]
+        }))
+        .expect("official Gemini logprobs result should deserialize");
+
+        assert_eq!(logprobs.top_candidates.len(), 1);
+        assert_eq!(logprobs.top_candidates[0].candidates.len(), 2);
+        assert_eq!(
+            logprobs.top_candidates[0].candidates[0].token.as_deref(),
+            Some("Hello")
+        );
+        assert_eq!(logprobs.top_candidates[0].candidates[0].token_id, Some(123));
+        assert_eq!(
+            logprobs.top_candidates[0].candidates[0].log_probability,
+            Some(-0.1)
+        );
+        assert_eq!(logprobs.log_probability_sum, Some(-0.1));
+        assert_eq!(logprobs.chosen_candidates.len(), 1);
+        assert_eq!(
+            logprobs.chosen_candidates[0].token.as_deref(),
+            Some("Hello")
+        );
+        assert_eq!(logprobs.chosen_candidates[0].token_id, Some(123));
+        assert_eq!(logprobs.chosen_candidates[0].log_probability, Some(-0.1));
     }
 
     #[test]

--- a/crates/rig-core/src/providers/gemini/embedding.rs
+++ b/crates/rig-core/src/providers/gemini/embedding.rs
@@ -271,6 +271,7 @@ mod gemini_api_types {
 
     #[derive(Debug, Deserialize)]
     pub struct EmbeddingValues {
+        #[serde(default)]
         pub values: Vec<serde_json::Number>,
     }
 }
@@ -278,6 +279,13 @@ mod gemini_api_types {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_embedding_values_deserializes_without_empty_values_field() {
+        let values: gemini_api_types::EmbeddingValues =
+            serde_json::from_str("{}").expect("empty embedding values should deserialize");
+        assert!(values.values.is_empty());
+    }
 
     #[test]
     fn test_model_default_ndims_lookup() {

--- a/crates/rig-core/src/providers/gemini/model_listing.rs
+++ b/crates/rig-core/src/providers/gemini/model_listing.rs
@@ -13,6 +13,7 @@ const MAX_PAGE_SIZE: usize = 1000;
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ListModelsResponse {
+    #[serde(default)]
     models: Vec<ListModelEntry>,
     next_page_token: Option<String>,
 }
@@ -20,6 +21,7 @@ struct ListModelsResponse {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ListModelEntry {
+    #[serde(default)]
     name: String,
     base_model_id: Option<String>,
     display_name: Option<String>,
@@ -173,6 +175,15 @@ mod tests {
     use super::*;
 
     #[test]
+    fn parse_models_page_accepts_omitted_empty_models_list() {
+        let (models, next_page_token) =
+            parse_models_page(br#"{}"#, "/v1beta/models?pageSize=1000").expect("page should parse");
+
+        assert!(models.is_empty());
+        assert_eq!(next_page_token, None);
+    }
+
+    #[test]
     fn parse_models_page_falls_back_to_name_when_base_model_id_is_missing() {
         let body = br#"{
             "models": [
@@ -216,6 +227,23 @@ mod tests {
 
         assert_eq!(models.len(), 1);
         assert_eq!(models[0].id, "gemini-2.0-flash");
+    }
+
+    #[test]
+    fn parse_models_page_reports_missing_model_id_when_name_is_omitted() {
+        let error = parse_models_page(br#"{"models":[{}]}"#, "/v1beta/models?pageSize=1000")
+            .expect_err("entry without name/baseModelId should fail with contextual error");
+
+        match error {
+            ModelListingError::ParseError { message } => {
+                assert!(message.contains("provider=Gemini"));
+                assert!(message.contains("path=/v1beta/models?pageSize=1000"));
+                assert!(message.contains(
+                    "parse_error=model entry missing usable `baseModelId` and `name` values"
+                ));
+            }
+            _ => panic!("expected parse error"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- default Gemini generateContent responseId/candidates when proto3 JSON omits empty/default fields
- default nested repeated/token-count metadata fields used by Gemini responses
- keep Gemini embedding error-envelope detection intact while tolerating omitted embedding values
- allow omitted empty models list/name in Gemini model listing so contextual errors are preserved

## Testing
- cargo fmt --check
- git diff --check
- cargo test -p rig-core gemini --lib
- cargo clippy -p rig-core --lib --all-features -- -D warnings