### PR TITLE
refactor(agent): unify the streaming and non-streaming drivers over one engine

### DIFF
--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -633,6 +633,204 @@ where
     }
 }
 
+/// Execute a turn's tool calls, shared by both surfaces.
+///
+/// Emits a `ToolCall` item before each tool runs and a `ToolResult` item as each
+/// finishes, feeding the (call-ordered) results back into the machine. The tool
+/// items carry no raw provider response, so this is generic over the surface's
+/// `R`. `chain_tool_span` lets the blocking surface chain spans into its linear
+/// `follows_from` sequence (the streaming surface returns the span unchanged).
+pub(crate) fn drive_tool_calls<'a, M, R, F>(
+    runner: &'a AgentRunner<M>,
+    run: &'a mut AgentRun,
+    calls: Vec<PendingToolCall>,
+    chain_tool_span: F,
+) -> DriveStream<'a, R>
+where
+    M: CompletionModel,
+    R: WasmCompatSend + 'a,
+    F: Fn(tracing::Span) -> tracing::Span + WasmCompatSend + 'a,
+{
+    Box::pin(async_stream::stream! {
+        let full_history_for_errors = run.full_history();
+
+        if runner.concurrency <= 1 {
+            // Sequential default: one ToolCall/ToolResult pair per tool, strictly
+            // interleaved. Byte-identical to the pre-concurrency behavior.
+            let mut results: Vec<UserContent> = Vec::with_capacity(calls.len());
+
+            for pending in calls {
+                let tool_call = pending.tool_call;
+                if let Some(result) = pending.preresolved_result {
+                    results.push(result);
+                    continue;
+                }
+                let internal_call_id =
+                    pending.internal_call_id.unwrap_or_else(crate::id::generate);
+
+                let tool_span = chain_tool_span(new_execute_tool_span());
+
+                yield Ok(MultiTurnStreamItem::stream_item(
+                    StreamedAssistantContent::ToolCall {
+                        tool_call: tool_call.clone(),
+                        internal_call_id: internal_call_id.clone(),
+                    },
+                ));
+
+                let result = run_single_tool(
+                    &runner.hooks,
+                    &runner.tool_server_handle,
+                    &runner.tool_extensions,
+                    &tool_call,
+                    &internal_call_id,
+                    &full_history_for_errors,
+                )
+                .instrument(tool_span)
+                .await;
+
+                match result {
+                    Ok(content) => {
+                        results.push(content.clone());
+                        if let UserContent::ToolResult(tool_result) = content {
+                            yield Ok(MultiTurnStreamItem::StreamUserItem(
+                                StreamedUserContent::ToolResult {
+                                    tool_result,
+                                    internal_call_id,
+                                },
+                            ));
+                        }
+                    }
+                    Err(err) => {
+                        yield Err(StreamingError::Prompt(Box::new(err)));
+                        return;
+                    }
+                }
+            }
+
+            if let Err(err) = run.tool_results(results) {
+                yield Err(Box::new(err).into());
+                return;
+            }
+        } else {
+            // Concurrent path: emit every ToolCall stream item eagerly in call
+            // order, then run tools concurrently and surface each ToolResult as
+            // soon as its tool finishes. Results are still stored by original
+            // call index, so persisted history remains deterministic.
+            let call_count = calls.len();
+            let mut indexed_calls: Vec<(usize, PendingToolCall, tracing::Span, Option<String>)> =
+                Vec::with_capacity(call_count);
+
+            for (index, mut pending) in calls.into_iter().enumerate() {
+                let tool_span = chain_tool_span(new_execute_tool_span());
+
+                if pending.preresolved_result.is_some() {
+                    indexed_calls.push((index, pending, tool_span, None));
+                    continue;
+                }
+
+                let internal_call_id = pending
+                    .internal_call_id
+                    .clone()
+                    .unwrap_or_else(crate::id::generate);
+                pending.internal_call_id = Some(internal_call_id.clone());
+
+                yield Ok(MultiTurnStreamItem::stream_item(
+                    StreamedAssistantContent::ToolCall {
+                        tool_call: pending.tool_call.clone(),
+                        internal_call_id: internal_call_id.clone(),
+                    },
+                ));
+
+                indexed_calls.push((index, pending, tool_span, Some(internal_call_id)));
+            }
+
+            let unordered = stream::iter(indexed_calls)
+                .map(|(index, pending, tool_span, yield_id)| {
+                    let hooks = &runner.hooks;
+                    let tool_server_handle = &runner.tool_server_handle;
+                    let tool_extensions = &runner.tool_extensions;
+                    let full_history_for_errors = &full_history_for_errors;
+                    async move {
+                        if let Some(result) = pending.preresolved_result {
+                            return (index, yield_id, Ok(result));
+                        }
+
+                        let internal_call_id =
+                            pending.internal_call_id.unwrap_or_else(crate::id::generate);
+                        let result = run_single_tool(
+                            hooks,
+                            tool_server_handle,
+                            tool_extensions,
+                            &pending.tool_call,
+                            &internal_call_id,
+                            full_history_for_errors,
+                        )
+                        .await;
+                        (index, yield_id, result)
+                    }
+                    .instrument(tool_span)
+                })
+                .buffer_unordered(runner.concurrency);
+            futures::pin_mut!(unordered);
+
+            let mut results: Vec<Option<UserContent>> = Vec::with_capacity(call_count);
+            results.resize_with(call_count, || None);
+            let mut first_error: Option<PromptError> = None;
+            while let Some((index, yield_id, result)) = unordered.next().await {
+                if first_error.is_some() {
+                    continue;
+                }
+                match result {
+                    Ok(content) => {
+                        let Some(slot) = results.get_mut(index) else {
+                            first_error = Some(PromptError::CompletionError(
+                                CompletionError::ResponseError(
+                                    "tool execution returned an invalid result index".to_string(),
+                                ),
+                            ));
+                            continue;
+                        };
+                        *slot = Some(content.clone());
+                        if let Some(internal_call_id) = yield_id
+                            && let UserContent::ToolResult(tool_result) = content
+                        {
+                            yield Ok(MultiTurnStreamItem::StreamUserItem(
+                                StreamedUserContent::ToolResult {
+                                    tool_result,
+                                    internal_call_id,
+                                },
+                            ));
+                        }
+                    }
+                    Err(err) => first_error = Some(err),
+                }
+            }
+
+            if let Some(err) = first_error {
+                yield Err(StreamingError::Prompt(Box::new(err)));
+                return;
+            }
+
+            let results: Vec<UserContent> = match results.into_iter().collect::<Option<Vec<_>>>() {
+                Some(results) => results,
+                None => {
+                    yield Err(StreamingError::Prompt(Box::new(PromptError::CompletionError(
+                        CompletionError::ResponseError(
+                            "tool execution finished without producing every result".to_string(),
+                        ),
+                    ))));
+                    return;
+                }
+            };
+
+            if let Err(err) = run.tool_results(results) {
+                yield Err(Box::new(err).into());
+                return;
+            }
+        }
+    })
+}
+
 /// [`TurnSource`] for the streaming surface: each turn opens a provider stream,
 /// drives a [`StreamedTurnAssembler`], and yields assistant/tool deltas.
 pub(crate) struct StreamingTurnSource {
@@ -987,192 +1185,8 @@ where
         run: &'a mut AgentRun,
         calls: Vec<PendingToolCall>,
     ) -> DriveStream<'a, M::StreamingResponse> {
-        Box::pin(async_stream::stream! {
-            let full_history_for_errors = run.full_history();
-
-            if runner.concurrency <= 1 {
-                // Sequential default: one ToolCall/ToolResult pair per tool,
-                // strictly interleaved. Byte-identical to the pre-concurrency
-                // behavior.
-                let mut results: Vec<UserContent> = Vec::with_capacity(calls.len());
-
-                for pending in calls {
-                    let tool_call = pending.tool_call;
-                    if let Some(result) = pending.preresolved_result {
-                        results.push(result);
-                        continue;
-                    }
-                    let internal_call_id =
-                        pending.internal_call_id.unwrap_or_else(crate::id::generate);
-
-                    let tool_span = new_execute_tool_span();
-
-                    yield Ok(MultiTurnStreamItem::stream_item(
-                        StreamedAssistantContent::ToolCall {
-                            tool_call: tool_call.clone(),
-                            internal_call_id: internal_call_id.clone(),
-                        },
-                    ));
-
-                    let result = run_single_tool(
-                        &runner.hooks,
-                        &runner.tool_server_handle,
-                        &runner.tool_extensions,
-                        &tool_call,
-                        &internal_call_id,
-                        &full_history_for_errors,
-                    )
-                    .instrument(tool_span)
-                    .await;
-
-                    match result {
-                        Ok(content) => {
-                            results.push(content.clone());
-                            if let UserContent::ToolResult(tool_result) = content {
-                                yield Ok(MultiTurnStreamItem::StreamUserItem(
-                                    StreamedUserContent::ToolResult {
-                                        tool_result,
-                                        internal_call_id,
-                                    },
-                                ));
-                            }
-                        }
-                        Err(err) => {
-                            yield Err(StreamingError::Prompt(Box::new(err)));
-                            return;
-                        }
-                    }
-                }
-
-                if let Err(err) = run.tool_results(results) {
-                    yield Err(Box::new(err).into());
-                    return;
-                }
-            } else {
-                // Concurrent path: emit every ToolCall stream item eagerly in
-                // call order, then run tools concurrently and surface each
-                // ToolResult as soon as its tool finishes. Results are still
-                // stored by original call index, so persisted history remains
-                // deterministic.
-                let call_count = calls.len();
-                let mut indexed_calls: Vec<(
-                    usize,
-                    PendingToolCall,
-                    tracing::Span,
-                    Option<String>,
-                )> = Vec::with_capacity(call_count);
-
-                for (index, mut pending) in calls.into_iter().enumerate() {
-                    let tool_span = new_execute_tool_span();
-
-                    if pending.preresolved_result.is_some() {
-                        indexed_calls.push((index, pending, tool_span, None));
-                        continue;
-                    }
-
-                    let internal_call_id = pending
-                        .internal_call_id
-                        .clone()
-                        .unwrap_or_else(crate::id::generate);
-                    pending.internal_call_id = Some(internal_call_id.clone());
-
-                    yield Ok(MultiTurnStreamItem::stream_item(
-                        StreamedAssistantContent::ToolCall {
-                            tool_call: pending.tool_call.clone(),
-                            internal_call_id: internal_call_id.clone(),
-                        },
-                    ));
-
-                    indexed_calls.push((index, pending, tool_span, Some(internal_call_id)));
-                }
-
-                let unordered = stream::iter(indexed_calls)
-                    .map(|(index, pending, tool_span, yield_id)| {
-                        let hooks = &runner.hooks;
-                        let tool_server_handle = &runner.tool_server_handle;
-                        let tool_extensions = &runner.tool_extensions;
-                        let full_history_for_errors = &full_history_for_errors;
-                        async move {
-                            if let Some(result) = pending.preresolved_result {
-                                return (index, yield_id, Ok(result));
-                            }
-
-                            let internal_call_id =
-                                pending.internal_call_id.unwrap_or_else(crate::id::generate);
-                            let result = run_single_tool(
-                                hooks,
-                                tool_server_handle,
-                                tool_extensions,
-                                &pending.tool_call,
-                                &internal_call_id,
-                                full_history_for_errors,
-                            )
-                            .await;
-                            (index, yield_id, result)
-                        }
-                        .instrument(tool_span)
-                    })
-                    .buffer_unordered(runner.concurrency);
-                futures::pin_mut!(unordered);
-
-                let mut results: Vec<Option<UserContent>> = Vec::with_capacity(call_count);
-                results.resize_with(call_count, || None);
-                let mut first_error: Option<PromptError> = None;
-                while let Some((index, yield_id, result)) = unordered.next().await {
-                    if first_error.is_some() {
-                        continue;
-                    }
-                    match result {
-                        Ok(content) => {
-                            let Some(slot) = results.get_mut(index) else {
-                                first_error = Some(PromptError::CompletionError(
-                                    CompletionError::ResponseError(
-                                        "tool execution returned an invalid result index"
-                                            .to_string(),
-                                    ),
-                                ));
-                                continue;
-                            };
-                            *slot = Some(content.clone());
-                            if let Some(internal_call_id) = yield_id
-                                && let UserContent::ToolResult(tool_result) = content
-                            {
-                                yield Ok(MultiTurnStreamItem::StreamUserItem(
-                                    StreamedUserContent::ToolResult {
-                                        tool_result,
-                                        internal_call_id,
-                                    },
-                                ));
-                            }
-                        }
-                        Err(err) => first_error = Some(err),
-                    }
-                }
-
-                if let Some(err) = first_error {
-                    yield Err(StreamingError::Prompt(Box::new(err)));
-                    return;
-                }
-
-                let results: Vec<UserContent> = match results.into_iter().collect::<Option<Vec<_>>>()
-                {
-                    Some(results) => results,
-                    None => {
-                        yield Err(StreamingError::Prompt(Box::new(PromptError::CompletionError(
-                            CompletionError::ResponseError(
-                                "tool execution finished without producing every result".to_string(),
-                            ),
-                        ))));
-                        return;
-                    }
-                };
-
-                if let Err(err) = run.tool_results(results) {
-                    yield Err(Box::new(err).into());
-                    return;
-                }
-            }
-        })
+        // The streaming surface chains nothing onto its tool spans.
+        drive_tool_calls(runner, run, calls, |span| span)
     }
 
     fn record_run_level_telemetry(
@@ -1204,7 +1218,8 @@ where
             });
         // Always surface the accumulated messages (parity with the blocking
         // `run()`), regardless of whether the caller supplied input history.
-        let final_messages: Option<Vec<Message>> = Some(response.messages.clone().unwrap_or_default());
+        let final_messages: Option<Vec<Message>> =
+            Some(response.messages.clone().unwrap_or_default());
         MultiTurnStreamItem::final_response_with_completion_calls(
             final_choice,
             response.usage,

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -426,8 +426,10 @@ pub(crate) enum DriveItem<R> {
 /// The per-medium half of the agent loop: how a turn is fetched from the model,
 /// how its tools are executed, and how the run's spans/usage/final item are
 /// shaped. The medium-independent outer loop (turn counting, the `CompletionCall`
-/// hook, request preparation, invalid-tool resolution wiring, memory) lives once
-/// in [`drive_agent`]; only the genuinely divergent pieces are behind this trait.
+/// hook, request preparation, memory) lives once in [`drive_agent`]; only the
+/// genuinely divergent pieces are behind this trait. Invalid-tool-call recovery
+/// is one of them — it lives inside each source's `run_model_turn` (end-of-turn
+/// for blocking, mid-stream for streaming), not in `drive_agent`.
 pub(crate) trait TurnSource<M>: WasmCompatSend
 where
     M: CompletionModel,
@@ -629,7 +631,7 @@ where
                     source.record_run_level_telemetry(&agent_span, &response, created_agent_span);
                     append_run_messages(
                         memory_handle.as_ref(),
-                        response.messages.clone().unwrap_or_default(),
+                        response.messages.as_deref().unwrap_or_default(),
                     )
                     .await;
                     // Build the final item only when the surface forwards it
@@ -648,16 +650,22 @@ where
 
 /// Execute a turn's tool calls, shared by both surfaces.
 ///
-/// Emits a `ToolCall` item before each tool runs and a `ToolResult` item as each
-/// finishes, feeding the (call-ordered) results back into the machine. The tool
-/// items carry no raw provider response, so this is generic over the surface's
-/// `R`. `chain_tool_span` lets the blocking surface chain spans into its linear
-/// `follows_from` sequence (the streaming surface returns the span unchanged).
+/// Feeds the (call-ordered) results back into the machine. When `forward_items`
+/// is set (streaming), a `ToolCall` item is emitted before each tool runs and a
+/// `ToolResult` item as each finishes; the blocking fold passes `false` to skip
+/// building those items — and the per-tool `tool_call`/result clones they need —
+/// since it discards them (the same "blocking opts out" gating as
+/// `TurnSource::final_item`). Tool execution and hook firing are identical either
+/// way. The tool items carry no raw provider response, so this is generic over
+/// the surface's `R`. `chain_tool_span` lets the blocking surface chain spans into
+/// its linear `follows_from` sequence (the streaming surface returns the span
+/// unchanged).
 pub(crate) fn drive_tool_calls<'a, M, R, F>(
     runner: &'a AgentRunner<M>,
     run: &'a mut AgentRun,
     calls: Vec<PendingToolCall>,
     chain_tool_span: F,
+    forward_items: bool,
 ) -> DriveStream<'a, R>
 where
     M: CompletionModel,
@@ -689,7 +697,7 @@ where
 
                 let tool_span = chain_tool_span(new_execute_tool_span());
 
-                if first_error.is_none() {
+                if forward_items && first_error.is_none() {
                     yield Ok(MultiTurnStreamItem::stream_item(
                         StreamedAssistantContent::ToolCall {
                             tool_call: tool_call.clone(),
@@ -711,17 +719,18 @@ where
 
                 match result {
                     Ok(content) => {
-                        results.push(content.clone());
-                        if first_error.is_none()
-                            && let UserContent::ToolResult(tool_result) = content
+                        if forward_items
+                            && first_error.is_none()
+                            && let UserContent::ToolResult(tool_result) = &content
                         {
                             yield Ok(MultiTurnStreamItem::StreamUserItem(
                                 StreamedUserContent::ToolResult {
-                                    tool_result,
+                                    tool_result: tool_result.clone(),
                                     internal_call_id,
                                 },
                             ));
                         }
+                        results.push(content);
                     }
                     Err(err) => {
                         if first_error.as_ref().is_none_or(|(i, _)| index < *i) {
@@ -766,14 +775,19 @@ where
                     .unwrap_or_else(crate::id::generate);
                 pending.internal_call_id = Some(internal_call_id.clone());
 
-                yield Ok(MultiTurnStreamItem::stream_item(
-                    StreamedAssistantContent::ToolCall {
-                        tool_call: pending.tool_call.clone(),
-                        internal_call_id: internal_call_id.clone(),
-                    },
-                ));
+                let yield_id = if forward_items {
+                    yield Ok(MultiTurnStreamItem::stream_item(
+                        StreamedAssistantContent::ToolCall {
+                            tool_call: pending.tool_call.clone(),
+                            internal_call_id: internal_call_id.clone(),
+                        },
+                    ));
+                    Some(internal_call_id)
+                } else {
+                    None
+                };
 
-                indexed_calls.push((index, pending, tool_span, Some(internal_call_id)));
+                indexed_calls.push((index, pending, tool_span, yield_id));
             }
 
             let unordered = stream::iter(indexed_calls)
@@ -816,20 +830,22 @@ where
                 match result {
                     Ok(content) => match results.get_mut(index) {
                         Some(slot) => {
-                            *slot = Some(content.clone());
                             // Once any tool has errored the run will terminate, so
                             // stop surfacing successful results (but keep draining).
+                            // `yield_id` is `None` when items aren't forwarded (the
+                            // blocking fold), so no clone happens there.
                             if first_error.is_none()
                                 && let Some(internal_call_id) = yield_id
-                                && let UserContent::ToolResult(tool_result) = content
+                                && let UserContent::ToolResult(tool_result) = &content
                             {
                                 yield Ok(MultiTurnStreamItem::StreamUserItem(
                                     StreamedUserContent::ToolResult {
-                                        tool_result,
+                                        tool_result: tool_result.clone(),
                                         internal_call_id,
                                     },
                                 ));
                             }
+                            *slot = Some(content);
                         }
                         None => {
                             if first_error.as_ref().is_none_or(|(i, _)| index < *i) {
@@ -885,6 +901,10 @@ pub(crate) struct StreamingTurnSource {
     last_message_id: Option<String>,
     /// Resolved agent name, kept only for the empty-turn diagnostic warning.
     agent_name: String,
+    /// Whether we created the agent span (vs. adopting a caller's ambient span);
+    /// gates recording `gen_ai.completion` onto it, matching the blocking source
+    /// so neither surface pollutes a caller-supplied span.
+    created_agent_span: bool,
     /// Hot-path interest gates, computed once: skip building/dispatching the
     /// high-frequency delta events when no hook observes them.
     observes_text_delta: bool,
@@ -895,11 +915,16 @@ pub(crate) struct StreamingTurnSource {
 }
 
 impl StreamingTurnSource {
-    pub(crate) fn new<M: CompletionModel>(hooks: &HookStack<M>, agent_name: String) -> Self {
+    pub(crate) fn new<M: CompletionModel>(
+        hooks: &HookStack<M>,
+        agent_name: String,
+        created_agent_span: bool,
+    ) -> Self {
         Self {
             last_final_choice: OneOrMany::one(AssistantContent::text("")),
             last_message_id: None,
             agent_name,
+            created_agent_span,
             observes_text_delta: hooks.observes(StepEventKind::TextDelta),
             observes_tool_call_delta: hooks.observes(StepEventKind::ToolCallDelta),
             has_hooks: !hooks.is_empty(),
@@ -1212,10 +1237,14 @@ where
             }
 
             let final_turn_content = stream.choice.clone();
-            agent_span.record(
-                "gen_ai.completion",
-                assistant_text_from_choice(&final_turn_content),
-            );
+            // Only record onto the agent span when we own it — never pollute a
+            // caller-supplied span (parity with the blocking source).
+            if self.created_agent_span {
+                agent_span.record(
+                    "gen_ai.completion",
+                    assistant_text_from_choice(&final_turn_content),
+                );
+            }
 
             self.last_message_id = stream.message_id.clone();
             let streamed_turn = assembler.finish(stream.message_id.clone(), &final_turn_content);
@@ -1233,8 +1262,9 @@ where
         run: &'a mut AgentRun,
         calls: Vec<PendingToolCall>,
     ) -> DriveStream<'a, M::StreamingResponse> {
-        // The streaming surface chains nothing onto its tool spans.
-        drive_tool_calls(runner, run, calls, |span| span)
+        // The streaming surface chains nothing onto its tool spans, and forwards
+        // the ToolCall/ToolResult items to the consumer.
+        drive_tool_calls(runner, run, calls, |span| span, true)
     }
 
     fn record_run_level_telemetry(
@@ -1322,8 +1352,11 @@ where
         };
 
         let run = self.build_run(history_override);
-        let source =
-            StreamingTurnSource::new(&self.hooks, self.agent_name_or_default().to_string());
+        let source = StreamingTurnSource::new(
+            &self.hooks,
+            self.agent_name_or_default().to_string(),
+            created_agent_span,
+        );
 
         // The blocking surface folds this same engine; the streaming surface
         // forwards intermediate items (the final response item is the last one)
@@ -1994,7 +2027,15 @@ mod tests {
             self.fields.push((field.name().to_string(), value));
         }
 
-        fn record_debug(&mut self, _field: &Field, _value: &dyn std::fmt::Debug) {}
+        // Capture the *presence* of non-numeric fields (e.g. `gen_ai.completion`)
+        // with a placeholder value so tests can assert whether they were recorded.
+        fn record_str(&mut self, field: &Field, _value: &str) {
+            self.fields.push((field.name().to_string(), 0));
+        }
+
+        fn record_debug(&mut self, field: &Field, _value: &dyn std::fmt::Debug) {
+            self.fields.push((field.name().to_string(), 0));
+        }
     }
 
     async fn assert_stream_usage_recorded_on_chat_spans(
@@ -2041,7 +2082,9 @@ mod tests {
         spans.clear();
 
         let empty_history: &[Message] = &[];
-        let outer_span = tracing::info_span!("outer");
+        // Declare the fields the guard protects so a regression (recording onto
+        // a caller span) is actually observable, not silently a no-op.
+        let outer_span = tracing::info_span!("outer", gen_ai.completion = tracing::field::Empty);
 
         async {
             let mut stream = agent
@@ -2116,6 +2159,11 @@ mod tests {
                 .keys()
                 .all(|field| !field.starts_with("gen_ai.usage.")),
             "usage should not be recorded onto the caller's outer span"
+        );
+        assert!(
+            !outer_span.fields.contains_key("gen_ai.completion"),
+            "gen_ai.completion should not be recorded onto the caller's outer span \
+             (parity with the blocking driver)"
         );
     }
 

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -8,9 +8,9 @@ use crate::{
         streamed::{StreamedResolution, StreamedTurnAssembler, StreamedTurnEvent},
     },
     agent::runner::{
-        AgentRunner, CompletionCallDecision, InvalidDecision, build_agent_run,
-        flow_into_completion_call, flow_into_invalid, new_execute_tool_span, observe_flow,
-        run_single_tool,
+        AgentRunner, CompletionCallOutcome, InvalidDecision, acquire_agent_span,
+        append_run_messages, build_agent_run, flow_into_invalid, new_execute_tool_span,
+        observe_flow, resolve_completion_call, run_single_tool,
     },
     completion::GetTokenUsage,
     message::{AssistantContent, UserContent},
@@ -406,27 +406,8 @@ where
     /// fail-closed hook handling with the blocking [`run`](AgentRunner::run), so
     /// the two behave identically apart from the streamed delta events.
     pub async fn stream(self) -> StreamingResult<M::StreamingResponse> {
-        let (agent_span, created_agent_span) = if tracing::Span::current().is_disabled() {
-            (
-                info_span!(
-                    "invoke_agent",
-                    gen_ai.operation.name = "invoke_agent",
-                    gen_ai.agent.name = self.agent_name_or_default(),
-                    gen_ai.system_instructions = self.preamble,
-                    gen_ai.prompt = tracing::field::Empty,
-                    gen_ai.completion = tracing::field::Empty,
-                    gen_ai.usage.input_tokens = tracing::field::Empty,
-                    gen_ai.usage.output_tokens = tracing::field::Empty,
-                    gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
-                    gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
-                    gen_ai.usage.tool_use_prompt_tokens = tracing::field::Empty,
-                    gen_ai.usage.reasoning_tokens = tracing::field::Empty,
-                ),
-                true,
-            )
-        } else {
-            (tracing::Span::current(), false)
-        };
+        let (agent_span, created_agent_span) =
+            acquire_agent_span(self.agent_name_or_default(), self.preamble.as_deref());
 
         let prompt = self.prompt;
         if let Some(text) = prompt.rag_text() {
@@ -525,23 +506,21 @@ where
                             );
                         }
 
-                        let request_override = match flow_into_completion_call(
-                            self.hooks
-                                .on_event(StepEvent::CompletionCall {
-                                    prompt: &current_prompt,
-                                    history: &history,
-                                    turn,
-                                })
-                                .await,
-                        ) {
-                            CompletionCallDecision::Terminate(reason) => {
+                        let request_override = match resolve_completion_call(
+                            &self.hooks,
+                            &current_prompt,
+                            &history,
+                            turn,
+                        )
+                        .await
+                        {
+                            CompletionCallOutcome::Terminate(reason) => {
                                 yield Err(StreamingError::Prompt(Box::new(
                                     run.cancel_error(reason),
                                 )));
                                 break 'outer;
                             }
-                            CompletionCallDecision::Override(request) => Some(request),
-                            CompletionCallDecision::Proceed => None,
+                            CompletionCallOutcome::Proceed(request_override) => request_override,
                         };
 
                         // Record this turn's base system prompt — the override-or-baseline
@@ -1139,17 +1118,11 @@ where
                             record_usage_on_span(&current_span, response.usage);
                         }
                         tracing::info!("Agent multi-turn stream finished");
-                        if let Some((memory, id)) = memory_handle.as_ref()
-                            && let Err(err) = memory
-                                .append(id, response.messages.clone().unwrap_or_default())
-                                .await
-                        {
-                            tracing::warn!(
-                                error = %err,
-                                conversation_id = %id,
-                                "conversation memory append failed; yielding final response anyway"
-                            );
-                        }
+                        append_run_messages(
+                            memory_handle.as_ref(),
+                            response.messages.clone().unwrap_or_default(),
+                        )
+                        .await;
                         // Always surface the accumulated messages (parity with
                         // the blocking `run()`, whose `PromptResponse.messages`
                         // is always populated), regardless of whether the caller

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -413,9 +413,8 @@ pub(crate) enum DriveItem<R> {
     Item(MultiTurnStreamItem<R>),
     /// The run finished.
     Done {
-        // Read by the blocking fold (`AgentRunner::run`); the streaming surface
-        // uses only `final_item`.
-        #[allow(dead_code)]
+        /// Read by the blocking fold (`AgentRunner::run`); the streaming surface
+        /// uses only `final_item`.
         response: Box<PromptResponse>,
         final_item: MultiTurnStreamItem<R>,
     },
@@ -478,10 +477,8 @@ where
 }
 
 /// Convert a [`StreamingError`] back into a [`PromptError`] for the blocking
-/// surface, which folds the shared engine. Lossless: every streaming error
-/// originates as one of these.
-// Used by `AgentRunner::run`'s fold over `drive_agent`.
-#[allow(dead_code)]
+/// surface ([`AgentRunner::run`]), which folds the shared engine. Lossless:
+/// every streaming error originates as one of these.
 pub(crate) fn streaming_error_into_prompt(err: StreamingError) -> PromptError {
     match err {
         StreamingError::Completion(err) => PromptError::CompletionError(err),

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -1,16 +1,16 @@
 use crate::{
     OneOrMany,
-    agent::completion::build_prepared_completion_request,
+    agent::completion::{PreparedCompletionRequest, build_prepared_completion_request},
     agent::hook::{AgentHook, HookStack, InvalidToolCallHookAction, StepEvent, StepEventKind},
     agent::prompt_request::{assistant_text_from_choice, is_empty_assistant_turn},
     agent::run::{
-        AgentRunStep, PendingToolCall,
+        AgentRun, AgentRunStep, PendingToolCall,
         streamed::{StreamedResolution, StreamedTurnAssembler, StreamedTurnEvent},
     },
     agent::runner::{
         AgentRunner, CompletionCallOutcome, InvalidDecision, acquire_agent_span,
-        append_run_messages, build_agent_run, flow_into_invalid, new_execute_tool_span,
-        observe_flow, resolve_completion_call, run_single_tool,
+        append_run_messages, flow_into_invalid, new_execute_tool_span, observe_flow,
+        resolve_completion_call, run_single_tool,
     },
     completion::GetTokenUsage,
     message::{AssistantContent, UserContent},
@@ -24,7 +24,7 @@ use std::{collections::VecDeque, pin::Pin, sync::Arc};
 use tracing::info_span;
 use tracing_futures::Instrument;
 
-use super::CompletionCall;
+use super::{CompletionCall, PromptResponse};
 use crate::{
     agent::Agent,
     completion::{CompletionError, CompletionModel, PromptError},
@@ -278,8 +278,6 @@ impl From<crate::memory::MemoryError> for StreamingError {
     }
 }
 
-const UNKNOWN_AGENT_NAME: &str = "Unnamed Agent";
-
 /// A builder for creating prompt requests with customizable options.
 /// Uses generics to track which options have been set during the build process.
 ///
@@ -392,6 +390,833 @@ where
     }
 }
 
+/// A boxed, medium-specific item stream for one engine step (model turn or tool
+/// batch). Boxed so a generic [`drive_agent`] can forward it without the
+/// per-step future leaking into the engine's own (`Send`) inference.
+#[cfg(not(all(feature = "wasm", target_arch = "wasm32")))]
+pub(crate) type DriveStream<'a, R> =
+    Pin<Box<dyn Stream<Item = Result<MultiTurnStreamItem<R>, StreamingError>> + Send + 'a>>;
+
+#[cfg(all(feature = "wasm", target_arch = "wasm32"))]
+pub(crate) type DriveStream<'a, R> =
+    Pin<Box<dyn Stream<Item = Result<MultiTurnStreamItem<R>, StreamingError>> + 'a>>;
+
+/// One item emitted by the shared engine [`drive_agent`].
+///
+/// `Item`s are forwarded to a streaming consumer (and ignored by the blocking
+/// fold); `Done` carries both the canonical [`PromptResponse`] the blocking
+/// surface returns and the medium-specific final stream item the streaming
+/// surface yields.
+pub(crate) enum DriveItem<R> {
+    /// An intermediate stream item (assistant delta, tool call/result, or a
+    /// per-call `CompletionCall`).
+    Item(MultiTurnStreamItem<R>),
+    /// The run finished.
+    Done {
+        // Read by the blocking fold (`AgentRunner::run`); the streaming surface
+        // uses only `final_item`.
+        #[allow(dead_code)]
+        response: Box<PromptResponse>,
+        final_item: MultiTurnStreamItem<R>,
+    },
+}
+
+/// The per-medium half of the agent loop: how a turn is fetched from the model,
+/// how its tools are executed, and how the run's spans/usage/final item are
+/// shaped. The medium-independent outer loop (turn counting, the `CompletionCall`
+/// hook, request preparation, invalid-tool resolution wiring, memory) lives once
+/// in [`drive_agent`]; only the genuinely divergent pieces are behind this trait.
+pub(crate) trait TurnSource<M>: WasmCompatSend
+where
+    M: CompletionModel,
+{
+    /// The raw provider response carried on per-delta stream items.
+    type Raw: WasmCompatSend;
+
+    /// Build this medium's per-turn `chat` span (name + parenting + any
+    /// `follows_from` chaining differ between blocking and streaming).
+    fn open_chat_span(
+        &self,
+        runner: &AgentRunner<M>,
+        effective_preamble: Option<&str>,
+    ) -> tracing::Span;
+
+    /// Run one model turn: issue the provider call, feed the result into the
+    /// sans-IO machine, and yield any intermediate items. Returning normally
+    /// advances the loop; yielding an `Err` terminates the run.
+    fn run_model_turn<'a>(
+        &'a mut self,
+        runner: &'a AgentRunner<M>,
+        run: &'a mut AgentRun,
+        prepared: PreparedCompletionRequest<M>,
+        chat_span: tracing::Span,
+        agent_span: &'a tracing::Span,
+        prompt: Message,
+    ) -> DriveStream<'a, Self::Raw>;
+
+    /// Execute a turn's tool calls, feeding the results into the machine and
+    /// yielding any intermediate items.
+    fn run_tool_calls<'a>(
+        &'a self,
+        runner: &'a AgentRunner<M>,
+        run: &'a mut AgentRun,
+        calls: Vec<PendingToolCall>,
+    ) -> DriveStream<'a, Self::Raw>;
+
+    /// Record run-level telemetry onto the agent span at `Done`. Gated on
+    /// `created_agent_span` so a caller-supplied outer span is never polluted.
+    fn record_run_level_telemetry(
+        &self,
+        agent_span: &tracing::Span,
+        response: &PromptResponse,
+        created_agent_span: bool,
+    );
+
+    /// Build the final stream item surfaced at `Done` (medium-specific final
+    /// content shaping).
+    fn build_final_item(&self, response: &PromptResponse) -> MultiTurnStreamItem<Self::Raw>;
+}
+
+/// Convert a [`StreamingError`] back into a [`PromptError`] for the blocking
+/// surface, which folds the shared engine. Lossless: every streaming error
+/// originates as one of these.
+// Used by `AgentRunner::run`'s fold over `drive_agent`.
+#[allow(dead_code)]
+pub(crate) fn streaming_error_into_prompt(err: StreamingError) -> PromptError {
+    match err {
+        StreamingError::Completion(err) => PromptError::CompletionError(err),
+        StreamingError::Prompt(err) => *err,
+        StreamingError::Tool(err) => PromptError::ToolError(err),
+    }
+}
+
+/// The single agent drive loop, shared by the blocking and streaming surfaces.
+///
+/// Owns the medium-independent loop — `next_step` dispatch, the `CompletionCall`
+/// hook + request preparation, the `Done` memory append — and delegates the
+/// medium-specific model call, tool execution, span shaping and finalization to
+/// a [`TurnSource`]. The streaming surface forwards the yielded [`DriveItem`]s;
+/// the blocking surface folds them to `Done`.
+pub(crate) fn drive_agent<M, S>(
+    runner: AgentRunner<M>,
+    mut source: S,
+    mut run: AgentRun,
+    agent_span: tracing::Span,
+    created_agent_span: bool,
+    memory_handle: Option<(Arc<dyn crate::memory::ConversationMemory>, String)>,
+) -> impl Stream<Item = Result<DriveItem<S::Raw>, StreamingError>>
+where
+    M: CompletionModel,
+    S: TurnSource<M>,
+{
+    async_stream::stream! {
+        'outer: loop {
+            let step = match run.next_step() {
+                Ok(step) => step,
+                Err(err) => {
+                    yield Err(Box::new(err).into());
+                    break 'outer;
+                }
+            };
+
+            match step {
+                AgentRunStep::CallModel { prompt, history, turn } => {
+                    if runner.max_turns > 1 {
+                        tracing::info!("Current conversation Turns: {}/{}", turn, runner.max_turns);
+                    }
+
+                    let request_override =
+                        match resolve_completion_call(&runner.hooks, &prompt, &history, turn).await {
+                            CompletionCallOutcome::Terminate(reason) => {
+                                yield Err(StreamingError::Prompt(Box::new(run.cancel_error(reason))));
+                                break 'outer;
+                            }
+                            CompletionCallOutcome::Proceed(request_override) => request_override,
+                        };
+
+                    // Record this turn's base system prompt — the override-or-baseline
+                    // preamble, before any output-mode augmentation the request builder
+                    // appends. Borrow rather than clone since it only needs to outlive
+                    // span creation.
+                    let effective_preamble = request_override
+                        .as_ref()
+                        .and_then(|o| o.preamble.as_deref())
+                        .or(runner.preamble.as_deref());
+
+                    let chat_span = source.open_chat_span(&runner, effective_preamble);
+
+                    // Pin Tool output mode once committed so later turns stay
+                    // consistent even if the per-turn tool set changes (#1928).
+                    let committed_output_tool = run.output_tool_name().map(str::to_owned);
+                    let prepared = match build_prepared_completion_request(
+                        &runner.model,
+                        prompt.clone(),
+                        &history,
+                        runner.preamble.as_deref(),
+                        &runner.static_context,
+                        runner.temperature,
+                        runner.max_tokens,
+                        runner.additional_params.as_ref(),
+                        runner.tool_choice.as_ref(),
+                        &runner.tool_server_handle,
+                        &runner.dynamic_context,
+                        runner.output_schema.as_ref(),
+                        &runner.output_mode,
+                        committed_output_tool.as_deref(),
+                        request_override.as_ref(),
+                    )
+                    .await
+                    {
+                        Ok(prepared) => prepared,
+                        Err(err) => {
+                            yield Err(err.into());
+                            break 'outer;
+                        }
+                    };
+                    run.set_output_tool_name(prepared.output_tool_name.clone());
+
+                    let mut turn_stream = source.run_model_turn(
+                        &runner,
+                        &mut run,
+                        prepared,
+                        chat_span,
+                        &agent_span,
+                        prompt,
+                    );
+                    let mut errored = false;
+                    while let Some(item) = turn_stream.next().await {
+                        match item {
+                            Ok(item) => yield Ok(DriveItem::Item(item)),
+                            Err(err) => {
+                                errored = true;
+                                yield Err(err);
+                                break;
+                            }
+                        }
+                    }
+                    drop(turn_stream);
+                    if errored {
+                        break 'outer;
+                    }
+                }
+                AgentRunStep::CallTools { calls } => {
+                    let mut tool_stream = source.run_tool_calls(&runner, &mut run, calls);
+                    let mut errored = false;
+                    while let Some(item) = tool_stream.next().await {
+                        match item {
+                            Ok(item) => yield Ok(DriveItem::Item(item)),
+                            Err(err) => {
+                                errored = true;
+                                yield Err(err);
+                                break;
+                            }
+                        }
+                    }
+                    drop(tool_stream);
+                    if errored {
+                        break 'outer;
+                    }
+                }
+                AgentRunStep::Done(response) => {
+                    source.record_run_level_telemetry(&agent_span, &response, created_agent_span);
+                    append_run_messages(
+                        memory_handle.as_ref(),
+                        response.messages.clone().unwrap_or_default(),
+                    )
+                    .await;
+                    let final_item = source.build_final_item(&response);
+                    yield Ok(DriveItem::Done {
+                        response: Box::new(response),
+                        final_item,
+                    });
+                    break 'outer;
+                }
+            }
+        }
+    }
+}
+
+/// [`TurnSource`] for the streaming surface: each turn opens a provider stream,
+/// drives a [`StreamedTurnAssembler`], and yields assistant/tool deltas.
+pub(crate) struct StreamingTurnSource {
+    /// The raw provider choice of the most recent turn; the final response
+    /// surfaces it as-is, even when canonical reordering was recorded in history.
+    last_final_choice: OneOrMany<AssistantContent>,
+    last_message_id: Option<String>,
+    /// Hot-path interest gates, computed once: skip building/dispatching the
+    /// high-frequency delta events when no hook observes them.
+    observes_text_delta: bool,
+    observes_tool_call_delta: bool,
+    /// Whether any hook is present — gates building the (history-cloning)
+    /// invalid-tool diagnostic context.
+    has_hooks: bool,
+}
+
+impl StreamingTurnSource {
+    pub(crate) fn new<M: CompletionModel>(hooks: &HookStack<M>) -> Self {
+        Self {
+            last_final_choice: OneOrMany::one(AssistantContent::text("")),
+            last_message_id: None,
+            observes_text_delta: hooks.observes(StepEventKind::TextDelta),
+            observes_tool_call_delta: hooks.observes(StepEventKind::ToolCallDelta),
+            has_hooks: !hooks.is_empty(),
+        }
+    }
+}
+
+impl<M> TurnSource<M> for StreamingTurnSource
+where
+    M: CompletionModel,
+    <M as CompletionModel>::StreamingResponse: WasmCompatSend + GetTokenUsage,
+{
+    type Raw = M::StreamingResponse;
+
+    fn open_chat_span(
+        &self,
+        runner: &AgentRunner<M>,
+        effective_preamble: Option<&str>,
+    ) -> tracing::Span {
+        info_span!(
+            target: "rig::agent_chat",
+            parent: tracing::Span::current(),
+            "chat_streaming",
+            gen_ai.operation.name = "chat",
+            gen_ai.agent.name = runner.agent_name_or_default(),
+            gen_ai.system_instructions = effective_preamble,
+            gen_ai.provider.name = tracing::field::Empty,
+            gen_ai.request.model = tracing::field::Empty,
+            gen_ai.response.id = tracing::field::Empty,
+            gen_ai.response.model = tracing::field::Empty,
+            gen_ai.usage.output_tokens = tracing::field::Empty,
+            gen_ai.usage.input_tokens = tracing::field::Empty,
+            gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
+            gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
+            gen_ai.usage.tool_use_prompt_tokens = tracing::field::Empty,
+            gen_ai.usage.reasoning_tokens = tracing::field::Empty,
+            gen_ai.input.messages = tracing::field::Empty,
+            gen_ai.output.messages = tracing::field::Empty,
+        )
+    }
+
+    fn run_model_turn<'a>(
+        &'a mut self,
+        runner: &'a AgentRunner<M>,
+        run: &'a mut AgentRun,
+        prepared: PreparedCompletionRequest<M>,
+        chat_span: tracing::Span,
+        agent_span: &'a tracing::Span,
+        current_prompt: Message,
+    ) -> DriveStream<'a, M::StreamingResponse> {
+        Box::pin(async_stream::stream! {
+            let mut stream = match prepared
+                .builder
+                .stream()
+                .instrument(chat_span.clone())
+                .await
+            {
+                Ok(stream) => stream,
+                Err(err) => {
+                    yield Err(err.into());
+                    return;
+                }
+            };
+
+            let mut assembler = StreamedTurnAssembler::new(
+                prepared.executable_tool_names.clone(),
+                prepared.allowed_tool_names.clone(),
+            );
+            let mut completion_call_emitted = false;
+            let mut turn_abandoned = false;
+            // Mirrors the blocking driver's `response_hook_suppressed`: a turn
+            // whose invalid tool call was repaired is a recovered turn, so its
+            // response-finish hook is suppressed.
+            let mut turn_recovered = false;
+
+            'turn: while let Some(item) = stream.next().await {
+                let item = match item {
+                    Ok(item) => item,
+                    Err(err) => {
+                        yield Err(err.into());
+                        return;
+                    }
+                };
+                let mut events: VecDeque<StreamedTurnEvent> = match assembler.ingest(&item) {
+                    Ok(events) => events.into(),
+                    Err(err) => {
+                        yield Err(err.into());
+                        return;
+                    }
+                };
+                // At most one event per ingested item forwards the item itself;
+                // moving it out of the slot avoids a clone per streamed delta.
+                let mut item_slot = Some(item);
+                while let Some(event) = events.pop_front() {
+                    match event {
+                        StreamedTurnEvent::EmitIngested => {
+                            if self.observes_text_delta
+                                && let Some(StreamedAssistantContent::Text(text)) =
+                                    item_slot.as_ref()
+                                && let Some(reason) = observe_flow(
+                                    runner
+                                        .hooks
+                                        .on_event(StepEvent::TextDelta {
+                                            delta: &text.text,
+                                            aggregated: assembler.aggregated_text(),
+                                        })
+                                        .await,
+                                )
+                            {
+                                yield Err(StreamingError::Prompt(Box::new(
+                                    run.cancel_error(reason),
+                                )));
+                                return;
+                            }
+                            if let Some(item) = item_slot.take() {
+                                yield Ok(MultiTurnStreamItem::stream_item(item));
+                            }
+                        }
+                        StreamedTurnEvent::EmitToolCallDelta {
+                            id,
+                            internal_call_id,
+                            content,
+                        } => {
+                            if self.observes_tool_call_delta {
+                                let (delta_name, delta_text) = match &content {
+                                    ToolCallDeltaContent::Name(name) => (Some(name.as_str()), ""),
+                                    ToolCallDeltaContent::Delta(delta) => (None, delta.as_str()),
+                                };
+                                if let Some(reason) = observe_flow(
+                                    runner
+                                        .hooks
+                                        .on_event(StepEvent::ToolCallDelta {
+                                            tool_call_id: &id,
+                                            internal_call_id: &internal_call_id,
+                                            tool_name: delta_name,
+                                            delta: delta_text,
+                                        })
+                                        .await,
+                                ) {
+                                    yield Err(StreamingError::Prompt(Box::new(
+                                        run.cancel_error(reason),
+                                    )));
+                                    return;
+                                }
+                            }
+
+                            yield Ok(MultiTurnStreamItem::StreamAssistantItem(
+                                StreamedAssistantContent::ToolCallDelta {
+                                    id,
+                                    internal_call_id,
+                                    content,
+                                },
+                            ));
+                        }
+                        StreamedTurnEvent::Completed { usage, emit_final } => {
+                            if !completion_call_emitted {
+                                if usage.has_values() {
+                                    record_usage_on_span(&chat_span, usage);
+                                }
+                                let completion_call =
+                                    match run.record_streamed_completion_call(usage) {
+                                        Ok(call) => call,
+                                        Err(err) => {
+                                            yield Err(Box::new(err).into());
+                                            return;
+                                        }
+                                    };
+                                completion_call_emitted = true;
+                                yield Ok(MultiTurnStreamItem::CompletionCall(completion_call));
+                            }
+
+                            if emit_final
+                                && let Some(StreamedAssistantContent::Final(final_resp)) =
+                                    item_slot.as_ref()
+                            {
+                                if !turn_recovered
+                                    && let Some(reason) = observe_flow(
+                                        runner
+                                            .hooks
+                                            .on_event(StepEvent::StreamResponseFinish {
+                                                prompt: &current_prompt,
+                                                response: final_resp,
+                                            })
+                                            .await,
+                                    )
+                                {
+                                    yield Err(StreamingError::Prompt(Box::new(
+                                        run.cancel_error(reason),
+                                    )));
+                                    return;
+                                }
+                                if let Some(item) = item_slot.take() {
+                                    yield Ok(MultiTurnStreamItem::stream_item(item));
+                                }
+                            }
+                        }
+                        StreamedTurnEvent::InvalidToolCall(invalid) => {
+                            let partial = assembler.partial_turn(stream.message_id.clone());
+                            // Gated on `has_hooks`: building the diagnostic context
+                            // clones the chat history, so an empty stack skips it and
+                            // fails fast — identical to the blocking path.
+                            let action = if self.has_hooks {
+                                let context =
+                                    run.streamed_invalid_tool_call_context(&partial, &invalid);
+                                match flow_into_invalid(
+                                    runner
+                                        .hooks
+                                        .on_event(StepEvent::InvalidToolCall(&context))
+                                        .await,
+                                ) {
+                                    InvalidDecision::Action(action) => action,
+                                    InvalidDecision::Terminate(reason) => {
+                                        yield Err(StreamingError::Prompt(Box::new(
+                                            run.cancel_error(reason),
+                                        )));
+                                        return;
+                                    }
+                                }
+                            } else {
+                                InvalidToolCallHookAction::fail()
+                            };
+
+                            let resolution =
+                                match run.resolve_streamed_invalid_tool_call(&partial, &invalid, action) {
+                                    Ok(resolution) => resolution,
+                                    Err(err) => {
+                                        yield Err(Box::new(err).into());
+                                        return;
+                                    }
+                                };
+
+                            match resolution {
+                                StreamedResolution::Repaired { .. } => {
+                                    // Replayed deltas flow through the same event
+                                    // handling above; the turn is now recovered, so
+                                    // its response-finish hook is suppressed.
+                                    turn_recovered = true;
+                                    events.extend(assembler.resolve_pending_invalid(&resolution));
+                                }
+                                StreamedResolution::TurnAbandoned {
+                                    ref skipped_tool_result,
+                                } => {
+                                    let skipped_tool_result = skipped_tool_result.clone();
+                                    assembler.resolve_pending_invalid(&resolution);
+
+                                    if let Some(err) = assembler.pending_delta_error() {
+                                        yield Err(err.into());
+                                        return;
+                                    }
+                                    let drained_usage = match drain_stream_usage(&mut stream).await {
+                                        Ok(usage) => usage,
+                                        Err(err) => {
+                                            yield Err(err);
+                                            return;
+                                        }
+                                    };
+                                    if !completion_call_emitted {
+                                        if drained_usage.has_values() {
+                                            record_usage_on_span(&chat_span, drained_usage);
+                                        }
+                                        let completion_call =
+                                            match run.record_streamed_completion_call(drained_usage) {
+                                                Ok(call) => call,
+                                                Err(err) => {
+                                                    yield Err(Box::new(err).into());
+                                                    return;
+                                                }
+                                            };
+                                        completion_call_emitted = true;
+                                        yield Ok(MultiTurnStreamItem::CompletionCall(
+                                            completion_call,
+                                        ));
+                                    }
+                                    if let Some(tool_result) = skipped_tool_result {
+                                        yield Ok(MultiTurnStreamItem::StreamUserItem(
+                                            StreamedUserContent::ToolResult {
+                                                tool_result,
+                                                internal_call_id: invalid.internal_call_id.clone(),
+                                            },
+                                        ));
+                                    }
+                                    turn_abandoned = true;
+                                    break 'turn;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if turn_abandoned {
+                return;
+            }
+
+            if let Some(err) = assembler.pending_delta_error() {
+                yield Err(err.into());
+                return;
+            }
+
+            if !completion_call_emitted {
+                let completion_call =
+                    match run.record_streamed_completion_call(crate::completion::Usage::new()) {
+                        Ok(call) => call,
+                        Err(err) => {
+                            yield Err(Box::new(err).into());
+                            return;
+                        }
+                    };
+                yield Ok(MultiTurnStreamItem::CompletionCall(completion_call));
+            }
+
+            let final_turn_content = stream.choice.clone();
+            agent_span.record(
+                "gen_ai.completion",
+                assistant_text_from_choice(&final_turn_content),
+            );
+
+            self.last_message_id = stream.message_id.clone();
+            let streamed_turn = assembler.finish(stream.message_id.clone(), &final_turn_content);
+            if let Err(err) = run.streamed_turn(streamed_turn) {
+                yield Err(Box::new(err).into());
+                return;
+            }
+            self.last_final_choice = final_turn_content;
+        })
+    }
+
+    fn run_tool_calls<'a>(
+        &'a self,
+        runner: &'a AgentRunner<M>,
+        run: &'a mut AgentRun,
+        calls: Vec<PendingToolCall>,
+    ) -> DriveStream<'a, M::StreamingResponse> {
+        Box::pin(async_stream::stream! {
+            let full_history_for_errors = run.full_history();
+
+            if runner.concurrency <= 1 {
+                // Sequential default: one ToolCall/ToolResult pair per tool,
+                // strictly interleaved. Byte-identical to the pre-concurrency
+                // behavior.
+                let mut results: Vec<UserContent> = Vec::with_capacity(calls.len());
+
+                for pending in calls {
+                    let tool_call = pending.tool_call;
+                    if let Some(result) = pending.preresolved_result {
+                        results.push(result);
+                        continue;
+                    }
+                    let internal_call_id =
+                        pending.internal_call_id.unwrap_or_else(crate::id::generate);
+
+                    let tool_span = new_execute_tool_span();
+
+                    yield Ok(MultiTurnStreamItem::stream_item(
+                        StreamedAssistantContent::ToolCall {
+                            tool_call: tool_call.clone(),
+                            internal_call_id: internal_call_id.clone(),
+                        },
+                    ));
+
+                    let result = run_single_tool(
+                        &runner.hooks,
+                        &runner.tool_server_handle,
+                        &runner.tool_extensions,
+                        &tool_call,
+                        &internal_call_id,
+                        &full_history_for_errors,
+                    )
+                    .instrument(tool_span)
+                    .await;
+
+                    match result {
+                        Ok(content) => {
+                            results.push(content.clone());
+                            if let UserContent::ToolResult(tool_result) = content {
+                                yield Ok(MultiTurnStreamItem::StreamUserItem(
+                                    StreamedUserContent::ToolResult {
+                                        tool_result,
+                                        internal_call_id,
+                                    },
+                                ));
+                            }
+                        }
+                        Err(err) => {
+                            yield Err(StreamingError::Prompt(Box::new(err)));
+                            return;
+                        }
+                    }
+                }
+
+                if let Err(err) = run.tool_results(results) {
+                    yield Err(Box::new(err).into());
+                    return;
+                }
+            } else {
+                // Concurrent path: emit every ToolCall stream item eagerly in
+                // call order, then run tools concurrently and surface each
+                // ToolResult as soon as its tool finishes. Results are still
+                // stored by original call index, so persisted history remains
+                // deterministic.
+                let call_count = calls.len();
+                let mut indexed_calls: Vec<(
+                    usize,
+                    PendingToolCall,
+                    tracing::Span,
+                    Option<String>,
+                )> = Vec::with_capacity(call_count);
+
+                for (index, mut pending) in calls.into_iter().enumerate() {
+                    let tool_span = new_execute_tool_span();
+
+                    if pending.preresolved_result.is_some() {
+                        indexed_calls.push((index, pending, tool_span, None));
+                        continue;
+                    }
+
+                    let internal_call_id = pending
+                        .internal_call_id
+                        .clone()
+                        .unwrap_or_else(crate::id::generate);
+                    pending.internal_call_id = Some(internal_call_id.clone());
+
+                    yield Ok(MultiTurnStreamItem::stream_item(
+                        StreamedAssistantContent::ToolCall {
+                            tool_call: pending.tool_call.clone(),
+                            internal_call_id: internal_call_id.clone(),
+                        },
+                    ));
+
+                    indexed_calls.push((index, pending, tool_span, Some(internal_call_id)));
+                }
+
+                let unordered = stream::iter(indexed_calls)
+                    .map(|(index, pending, tool_span, yield_id)| {
+                        let hooks = &runner.hooks;
+                        let tool_server_handle = &runner.tool_server_handle;
+                        let tool_extensions = &runner.tool_extensions;
+                        let full_history_for_errors = &full_history_for_errors;
+                        async move {
+                            if let Some(result) = pending.preresolved_result {
+                                return (index, yield_id, Ok(result));
+                            }
+
+                            let internal_call_id =
+                                pending.internal_call_id.unwrap_or_else(crate::id::generate);
+                            let result = run_single_tool(
+                                hooks,
+                                tool_server_handle,
+                                tool_extensions,
+                                &pending.tool_call,
+                                &internal_call_id,
+                                full_history_for_errors,
+                            )
+                            .await;
+                            (index, yield_id, result)
+                        }
+                        .instrument(tool_span)
+                    })
+                    .buffer_unordered(runner.concurrency);
+                futures::pin_mut!(unordered);
+
+                let mut results: Vec<Option<UserContent>> = Vec::with_capacity(call_count);
+                results.resize_with(call_count, || None);
+                let mut first_error: Option<PromptError> = None;
+                while let Some((index, yield_id, result)) = unordered.next().await {
+                    if first_error.is_some() {
+                        continue;
+                    }
+                    match result {
+                        Ok(content) => {
+                            let Some(slot) = results.get_mut(index) else {
+                                first_error = Some(PromptError::CompletionError(
+                                    CompletionError::ResponseError(
+                                        "tool execution returned an invalid result index"
+                                            .to_string(),
+                                    ),
+                                ));
+                                continue;
+                            };
+                            *slot = Some(content.clone());
+                            if let Some(internal_call_id) = yield_id
+                                && let UserContent::ToolResult(tool_result) = content
+                            {
+                                yield Ok(MultiTurnStreamItem::StreamUserItem(
+                                    StreamedUserContent::ToolResult {
+                                        tool_result,
+                                        internal_call_id,
+                                    },
+                                ));
+                            }
+                        }
+                        Err(err) => first_error = Some(err),
+                    }
+                }
+
+                if let Some(err) = first_error {
+                    yield Err(StreamingError::Prompt(Box::new(err)));
+                    return;
+                }
+
+                let results: Vec<UserContent> = match results.into_iter().collect::<Option<Vec<_>>>()
+                {
+                    Some(results) => results,
+                    None => {
+                        yield Err(StreamingError::Prompt(Box::new(PromptError::CompletionError(
+                            CompletionError::ResponseError(
+                                "tool execution finished without producing every result".to_string(),
+                            ),
+                        ))));
+                        return;
+                    }
+                };
+
+                if let Err(err) = run.tool_results(results) {
+                    yield Err(Box::new(err).into());
+                    return;
+                }
+            }
+        })
+    }
+
+    fn record_run_level_telemetry(
+        &self,
+        agent_span: &tracing::Span,
+        response: &PromptResponse,
+        created_agent_span: bool,
+    ) {
+        if created_agent_span {
+            record_usage_on_span(agent_span, response.usage);
+        }
+    }
+
+    fn build_final_item(
+        &self,
+        response: &PromptResponse,
+    ) -> MultiTurnStreamItem<M::StreamingResponse> {
+        // Tool output mode (#1928): when the finishing turn made the output-tool
+        // call, surface the run's structured output as the final content.
+        let final_choice = finalize_streamed_choice(&self.last_final_choice, &response.output)
+            .unwrap_or_else(|| {
+                if is_empty_assistant_turn(&self.last_final_choice) {
+                    tracing::warn!(
+                        message_id = ?self.last_message_id,
+                        "Streaming turn completed without assistant text; final response will be empty"
+                    );
+                }
+                self.last_final_choice.clone()
+            });
+        // Always surface the accumulated messages (parity with the blocking
+        // `run()`), regardless of whether the caller supplied input history.
+        let final_messages: Option<Vec<Message>> = Some(response.messages.clone().unwrap_or_default());
+        MultiTurnStreamItem::final_response_with_completion_calls(
+            final_choice,
+            response.usage,
+            response.completion_calls.clone(),
+            final_messages,
+        )
+    }
+}
+
 impl<M> AgentRunner<M>
 where
     M: CompletionModel + 'static,
@@ -402,47 +1227,32 @@ where
     /// text and tool-call deltas. Returns the stream after loading any
     /// configured conversation memory.
     ///
-    /// This shares the drive loop, run construction, tool execution and
-    /// fail-closed hook handling with the blocking [`run`](AgentRunner::run), so
-    /// the two behave identically apart from the streamed delta events.
+    /// Shares the drive loop, run construction, tool execution and fail-closed
+    /// hook handling with the blocking [`run`](AgentRunner::run) via
+    /// [`drive_agent`], so the two behave identically apart from the streamed
+    /// delta events.
     pub async fn stream(self) -> StreamingResult<M::StreamingResponse> {
         let (agent_span, created_agent_span) =
             acquire_agent_span(self.agent_name_or_default(), self.preamble.as_deref());
 
-        let prompt = self.prompt;
-        if let Some(text) = prompt.rag_text() {
+        if let Some(text) = self.prompt.rag_text() {
             agent_span.record("gen_ai.prompt", text);
         }
 
-        // Clone fields needed inside the stream
-        let model = self.model.clone();
-        let preamble = self.preamble.clone();
-        let static_context = self.static_context.clone();
-        let temperature = self.temperature;
-        let max_tokens = self.max_tokens;
-        let additional_params = self.additional_params.clone();
-        let tool_server_handle = self.tool_server_handle.clone();
-        let tool_extensions = self.tool_extensions.clone();
-        let dynamic_context = self.dynamic_context.clone();
-        let tool_choice = self.tool_choice.clone();
-        let agent_name = self.agent_name.clone();
-        let output_schema = self.output_schema;
-        let output_mode = self.output_mode.clone();
         // When the caller passes explicit history, memory is fully bypassed for
         // this request (no load AND no save). Otherwise, if a memory backend and
-        // conversation id are both configured, load prior history; if either is
-        // missing, behave as if no memory is configured.
-        let (chat_history, memory_handle) = match self.chat_history {
-            Some(history) => (Some(history), None),
-            None => match (self.memory, self.conversation_id) {
-                (Some(memory), Some(id)) => match memory.load(&id).await {
-                    Ok(loaded) => (Some(loaded), Some((memory, id))),
+        // conversation id are both configured, load prior history.
+        let (history_override, memory_handle) = match &self.chat_history {
+            Some(_) => (None, None),
+            None => match (&self.memory, &self.conversation_id) {
+                (Some(memory), Some(id)) => match memory.load(id).await {
+                    Ok(loaded) => (Some(loaded), Some((memory.clone(), id.clone()))),
                     Err(err) => {
                         let stream = async_stream::stream! {
                             yield Err(StreamingError::from(err));
                         };
-                        // Instrument under the agent span like the success path
-                        // (line ~995) so a load failure stays tied to invoke_agent.
+                        // Instrument under the agent span like the success path so
+                        // a load failure stays tied to invoke_agent.
                         return Box::pin(stream.instrument(agent_span));
                     }
                 },
@@ -450,698 +1260,26 @@ where
             },
         };
 
-        // Shared construction with the blocking path so the two configure runs
-        // identically.
-        let mut run = build_agent_run(
-            prompt.clone(),
-            self.max_turns,
-            self.max_invalid_tool_call_retries,
-            output_schema.as_ref(),
-            chat_history,
-            tool_choice.clone(),
-        );
+        let run = self.build_run(history_override);
+        let source = StreamingTurnSource::new(&self.hooks);
 
-        // Compute interest in the high-frequency streaming delta events once so
-        // the hot path can skip building and dispatching them when no hook
-        // observes them. (Only the streaming-only delta events are gated this
-        // way; the shared, steering events fire identically to the blocking
-        // path — see the `InvalidToolCall` handling below.)
-        let observes_text_delta = self.hooks.observes(StepEventKind::TextDelta);
-        let observes_tool_call_delta = self.hooks.observes(StepEventKind::ToolCallDelta);
-        // The invalid-tool diagnostic context is only built when a hook is
-        // present to consult — an empty stack always fails fast, matching the
-        // blocking path, without depending on `observes` for this steering event.
-        let has_hooks = !self.hooks.is_empty();
+        // The blocking surface folds this same engine; the streaming surface
+        // forwards intermediate items and maps `Done` to the final item.
+        let driver = drive_agent(
+            self,
+            source,
+            run,
+            agent_span.clone(),
+            created_agent_span,
+            memory_handle,
+        )
+        .map(|item| match item {
+            Ok(DriveItem::Item(item)) => Ok(item),
+            Ok(DriveItem::Done { final_item, .. }) => Ok(final_item),
+            Err(err) => Err(err),
+        });
 
-        // NOTE: We use .instrument(agent_span) instead of span.enter() to avoid
-        // span context leaking to other concurrent tasks. Using span.enter() inside
-        // async_stream::stream! holds the guard across yield points, which causes
-        // thread-local span context to leak when other tasks run on the same thread.
-        // See: https://docs.rs/tracing/latest/tracing/span/struct.Span.html#in-asynchronous-code
-        // See also: https://github.com/rust-lang/rust-clippy/issues/8722
-        let stream = async_stream::stream! {
-            // The raw provider choice of the most recent turn; the final
-            // response surfaces it as-is, even when canonical reordering was
-            // recorded in history.
-            let mut last_final_choice: OneOrMany<AssistantContent> =
-                OneOrMany::one(AssistantContent::text(""));
-            let mut last_message_id: Option<String> = None;
-
-            'outer: loop {
-                let step = match run.next_step() {
-                    Ok(step) => step,
-                    Err(err) => {
-                        yield Err(Box::new(err).into());
-                        break 'outer;
-                    }
-                };
-
-                match step {
-                    AgentRunStep::CallModel { prompt: current_prompt, history, turn } => {
-                        if self.max_turns > 1 {
-                            tracing::info!(
-                                "Current conversation Turns: {}/{}",
-                                turn,
-                                self.max_turns
-                            );
-                        }
-
-                        let request_override = match resolve_completion_call(
-                            &self.hooks,
-                            &current_prompt,
-                            &history,
-                            turn,
-                        )
-                        .await
-                        {
-                            CompletionCallOutcome::Terminate(reason) => {
-                                yield Err(StreamingError::Prompt(Box::new(
-                                    run.cancel_error(reason),
-                                )));
-                                break 'outer;
-                            }
-                            CompletionCallOutcome::Proceed(request_override) => request_override,
-                        };
-
-                        // Record this turn's base system prompt — the override-or-baseline
-                        // preamble, before any output-mode augmentation the request
-                        // builder appends (the provider-level span records the final
-                        // value). A per-turn `RequestOverride` can replace it, and the
-                        // builder below resolves the same precedence; borrow rather than
-                        // clone since the value only needs to outlive span creation.
-                        let effective_preamble = request_override
-                            .as_ref()
-                            .and_then(|o| o.preamble.as_deref())
-                            .or(preamble.as_deref());
-
-                        let chat_stream_span = info_span!(
-                            target: "rig::agent_chat",
-                            parent: tracing::Span::current(),
-                            "chat_streaming",
-                            gen_ai.operation.name = "chat",
-                            gen_ai.agent.name = agent_name.as_deref().unwrap_or(UNKNOWN_AGENT_NAME),
-                            gen_ai.system_instructions = effective_preamble,
-                            gen_ai.provider.name = tracing::field::Empty,
-                            gen_ai.request.model = tracing::field::Empty,
-                            gen_ai.response.id = tracing::field::Empty,
-                            gen_ai.response.model = tracing::field::Empty,
-                            gen_ai.usage.output_tokens = tracing::field::Empty,
-                            gen_ai.usage.input_tokens = tracing::field::Empty,
-                            gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
-                            gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
-                            gen_ai.usage.tool_use_prompt_tokens = tracing::field::Empty,
-                            gen_ai.usage.reasoning_tokens = tracing::field::Empty,
-                            gen_ai.input.messages = tracing::field::Empty,
-                            gen_ai.output.messages = tracing::field::Empty,
-                        );
-
-                        // Pin Tool output mode once committed so later turns stay
-                        // consistent even if the per-turn tool set changes (#1928).
-                        // The pin rides on `output_tool_name`, which is persisted
-                        // on the run, so it also survives a serialize/resume.
-                        let committed_output_tool = run.output_tool_name().map(str::to_owned);
-                        let prepared_request = build_prepared_completion_request(
-                            &model,
-                            current_prompt.clone(),
-                            &history,
-                            preamble.as_deref(),
-                            &static_context,
-                            temperature,
-                            max_tokens,
-                            additional_params.as_ref(),
-                            tool_choice.as_ref(),
-                            &tool_server_handle,
-                            &dynamic_context,
-                            output_schema.as_ref(),
-                            &output_mode,
-                            committed_output_tool.as_deref(),
-                            request_override.as_ref(),
-                        )
-                        .await?;
-
-                        run.set_output_tool_name(prepared_request.output_tool_name.clone());
-
-                        let mut stream = prepared_request
-                            .builder
-                            .stream()
-                            .instrument(chat_stream_span.clone())
-                            .await?;
-
-                        let mut assembler = StreamedTurnAssembler::new(
-                            prepared_request.executable_tool_names.clone(),
-                            prepared_request.allowed_tool_names.clone(),
-                        );
-                        let mut completion_call_emitted = false;
-                        let mut turn_abandoned = false;
-                        // Mirrors the blocking driver's `response_hook_suppressed`:
-                        // a turn whose invalid tool call was repaired is a
-                        // recovered turn, so its response-finish hook is
-                        // suppressed (the blocking path suppresses
-                        // `CompletionResponse` the same way).
-                        let mut turn_recovered = false;
-
-                        'turn: while let Some(item) = stream.next().await {
-                            let item = match item {
-                                Ok(item) => item,
-                                Err(err) => {
-                                    yield Err(err.into());
-                                    break 'outer;
-                                }
-                            };
-                            let mut events: VecDeque<StreamedTurnEvent> =
-                                match assembler.ingest(&item) {
-                                    Ok(events) => events.into(),
-                                    Err(err) => {
-                                        yield Err(err.into());
-                                        break 'outer;
-                                    }
-                                };
-                            // At most one event per ingested item forwards the
-                            // item itself; moving it out of the slot avoids a
-                            // clone per streamed delta.
-                            let mut item_slot = Some(item);
-                            while let Some(event) = events.pop_front() {
-                                match event {
-                                    StreamedTurnEvent::EmitIngested => {
-                                        // Gated on `observes_text_delta`: skip the
-                                        // per-delta hook dispatch entirely when no
-                                        // hook subscribes (the item is still yielded).
-                                        if observes_text_delta
-                                            && let Some(StreamedAssistantContent::Text(text)) =
-                                                item_slot.as_ref()
-                                            && let Some(reason) = observe_flow(
-                                                self.hooks
-                                                    .on_event(StepEvent::TextDelta {
-                                                        delta: &text.text,
-                                                        aggregated: assembler.aggregated_text(),
-                                                    })
-                                                    .await,
-                                            )
-                                        {
-                                            yield Err(StreamingError::Prompt(Box::new(
-                                                run.cancel_error(reason),
-                                            )));
-                                            break 'outer;
-                                        }
-                                        if let Some(item) = item_slot.take() {
-                                            yield Ok(MultiTurnStreamItem::stream_item(item));
-                                        }
-                                    }
-                                    StreamedTurnEvent::EmitToolCallDelta {
-                                        id,
-                                        internal_call_id,
-                                        content,
-                                    } => {
-                                        // Gated on `observes_tool_call_delta` (hot path).
-                                        if observes_tool_call_delta {
-                                            let (delta_name, delta_text) = match &content {
-                                                ToolCallDeltaContent::Name(name) => {
-                                                    (Some(name.as_str()), "")
-                                                }
-                                                ToolCallDeltaContent::Delta(delta) => {
-                                                    (None, delta.as_str())
-                                                }
-                                            };
-                                            if let Some(reason) = observe_flow(
-                                                self.hooks
-                                                    .on_event(StepEvent::ToolCallDelta {
-                                                        tool_call_id: &id,
-                                                        internal_call_id: &internal_call_id,
-                                                        tool_name: delta_name,
-                                                        delta: delta_text,
-                                                    })
-                                                    .await,
-                                            ) {
-                                                yield Err(StreamingError::Prompt(Box::new(
-                                                    run.cancel_error(reason),
-                                                )));
-                                                break 'outer;
-                                            }
-                                        }
-
-                                        yield Ok(MultiTurnStreamItem::StreamAssistantItem(
-                                            StreamedAssistantContent::ToolCallDelta {
-                                                id,
-                                                internal_call_id,
-                                                content,
-                                            },
-                                        ));
-                                    }
-                                    StreamedTurnEvent::Completed { usage, emit_final } => {
-                                        if !completion_call_emitted {
-                                            if usage.has_values() {
-                                                record_usage_on_span(&chat_stream_span, usage);
-                                            }
-                                            let completion_call =
-                                                match run.record_streamed_completion_call(usage) {
-                                                    Ok(call) => call,
-                                                    Err(err) => {
-                                                        yield Err(Box::new(err).into());
-                                                        break 'outer;
-                                                    }
-                                                };
-                                            completion_call_emitted = true;
-                                            yield Ok(MultiTurnStreamItem::CompletionCall(
-                                                completion_call,
-                                            ));
-                                        }
-
-                                        if emit_final
-                                            && let Some(StreamedAssistantContent::Final(
-                                                final_resp,
-                                            )) = item_slot.as_ref()
-                                        {
-                                            // The response-finish hook is suppressed for a
-                                            // recovered turn (parity with the blocking
-                                            // `CompletionResponse`), but the streamed final
-                                            // item is still yielded so the text output and
-                                            // message history are unchanged.
-                                            if !turn_recovered
-                                                && let Some(reason) = observe_flow(
-                                                    self.hooks
-                                                        .on_event(StepEvent::StreamResponseFinish {
-                                                            prompt: &current_prompt,
-                                                            response: final_resp,
-                                                        })
-                                                        .await,
-                                                )
-                                            {
-                                                yield Err(StreamingError::Prompt(Box::new(
-                                                    run.cancel_error(reason),
-                                                )));
-                                                break 'outer;
-                                            }
-                                            if let Some(item) = item_slot.take() {
-                                                yield Ok(MultiTurnStreamItem::stream_item(item));
-                                            }
-                                        }
-                                    }
-                                    StreamedTurnEvent::InvalidToolCall(invalid) => {
-                                        let partial =
-                                            assembler.partial_turn(stream.message_id.clone());
-                                        // Gated on `has_hooks`: building the
-                                        // diagnostic context clones the chat
-                                        // history, so an empty stack skips it and
-                                        // fails fast — identical to the blocking
-                                        // path's empty-stack outcome.
-                                        let action = if has_hooks {
-                                            let context = run.streamed_invalid_tool_call_context(
-                                                &partial, &invalid,
-                                            );
-                                            match flow_into_invalid(
-                                                self.hooks
-                                                    .on_event(StepEvent::InvalidToolCall(&context))
-                                                    .await,
-                                            ) {
-                                                InvalidDecision::Action(action) => action,
-                                                InvalidDecision::Terminate(reason) => {
-                                                    yield Err(StreamingError::Prompt(Box::new(
-                                                        run.cancel_error(reason),
-                                                    )));
-                                                    break 'outer;
-                                                }
-                                            }
-                                        } else {
-                                            InvalidToolCallHookAction::fail()
-                                        };
-
-                                        let resolution = match run
-                                            .resolve_streamed_invalid_tool_call(
-                                                &partial, &invalid, action,
-                                            ) {
-                                            Ok(resolution) => resolution,
-                                            Err(err) => {
-                                                yield Err(Box::new(err).into());
-                                                break 'outer;
-                                            }
-                                        };
-
-                                        match resolution {
-                                            StreamedResolution::Repaired { .. } => {
-                                                // Replayed name/argument deltas flow through
-                                                // the same event handling above. The turn is
-                                                // now a recovered turn, so its response-finish
-                                                // hook must be suppressed (parity with the
-                                                // blocking path's recovered `CompletionResponse`).
-                                                turn_recovered = true;
-                                                events.extend(
-                                                    assembler.resolve_pending_invalid(&resolution),
-                                                );
-                                            }
-                                            StreamedResolution::TurnAbandoned {
-                                                ref skipped_tool_result,
-                                            } => {
-                                                let skipped_tool_result =
-                                                    skipped_tool_result.clone();
-                                                assembler.resolve_pending_invalid(&resolution);
-
-                                                if let Some(err) = assembler.pending_delta_error() {
-                                                    yield Err(err.into());
-                                                    break 'outer;
-                                                }
-                                                let drained_usage =
-                                                    match drain_stream_usage(&mut stream).await {
-                                                        Ok(usage) => usage,
-                                                        Err(err) => {
-                                                            yield Err(err);
-                                                            break 'outer;
-                                                        }
-                                                    };
-                                                if !completion_call_emitted {
-                                                    if drained_usage.has_values() {
-                                                        record_usage_on_span(
-                                                            &chat_stream_span,
-                                                            drained_usage,
-                                                        );
-                                                    }
-                                                    let completion_call = match run
-                                                        .record_streamed_completion_call(
-                                                            drained_usage,
-                                                        ) {
-                                                        Ok(call) => call,
-                                                        Err(err) => {
-                                                            yield Err(Box::new(err).into());
-                                                            break 'outer;
-                                                        }
-                                                    };
-                                                    completion_call_emitted = true;
-                                                    yield Ok(MultiTurnStreamItem::CompletionCall(
-                                                        completion_call,
-                                                    ));
-                                                }
-                                                if let Some(tool_result) = skipped_tool_result {
-                                                    yield Ok(MultiTurnStreamItem::StreamUserItem(
-                                                        StreamedUserContent::ToolResult {
-                                                            tool_result,
-                                                            internal_call_id: invalid
-                                                                .internal_call_id
-                                                                .clone(),
-                                                        },
-                                                    ));
-                                                }
-                                                turn_abandoned = true;
-                                                break 'turn;
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-
-                        if turn_abandoned {
-                            continue 'outer;
-                        }
-
-                        if let Some(err) = assembler.pending_delta_error() {
-                            yield Err(err.into());
-                            break 'outer;
-                        }
-
-                        if !completion_call_emitted {
-                            let completion_call =
-                                match run
-                                    .record_streamed_completion_call(crate::completion::Usage::new())
-                                {
-                                    Ok(call) => call,
-                                    Err(err) => {
-                                        yield Err(Box::new(err).into());
-                                        break 'outer;
-                                    }
-                                };
-                            yield Ok(MultiTurnStreamItem::CompletionCall(completion_call));
-                        }
-
-                        let final_turn_content = stream.choice.clone();
-                        tracing::Span::current().record(
-                            "gen_ai.completion",
-                            assistant_text_from_choice(&final_turn_content),
-                        );
-
-                        last_message_id = stream.message_id.clone();
-                        let streamed_turn =
-                            assembler.finish(stream.message_id.clone(), &final_turn_content);
-                        if let Err(err) = run.streamed_turn(streamed_turn) {
-                            yield Err(Box::new(err).into());
-                            break 'outer;
-                        }
-                        last_final_choice = final_turn_content;
-                    }
-                    AgentRunStep::CallTools { calls } => {
-                        let full_history_for_errors = run.full_history();
-
-                        if self.concurrency <= 1 {
-                            // Sequential default: one ToolCall/ToolResult pair per
-                            // tool, strictly interleaved. Byte-identical to the
-                            // pre-concurrency behavior.
-                            let mut results: Vec<UserContent> = Vec::with_capacity(calls.len());
-
-                            for pending in calls {
-                                let tool_call = pending.tool_call;
-                                if let Some(result) = pending.preresolved_result {
-                                    // Pre-resolved results only occur when invalid
-                                    // tool-call recovery suppressed execution; the
-                                    // streamed path abandons such turns instead, so
-                                    // this arm only serves machine-level drivers
-                                    // mixing streamed and non-streamed turns.
-                                    results.push(result);
-                                    continue;
-                                }
-                                let internal_call_id = pending
-                                    .internal_call_id
-                                    .unwrap_or_else(crate::id::generate);
-
-                                let tool_span = new_execute_tool_span();
-
-                                yield Ok(MultiTurnStreamItem::stream_item(
-                                    StreamedAssistantContent::ToolCall {
-                                        tool_call: tool_call.clone(),
-                                        internal_call_id: internal_call_id.clone(),
-                                    },
-                                ));
-
-                                // Shared with the blocking path: identical hooks,
-                                // fail-closed skip/terminate, and result shaping
-                                // (skip reason verbatim, real output parsed).
-                                let result = run_single_tool(
-                                    &self.hooks,
-                                    &tool_server_handle,
-                                    &tool_extensions,
-                                    &tool_call,
-                                    &internal_call_id,
-                                    &full_history_for_errors,
-                                )
-                                .instrument(tool_span)
-                                .await;
-
-                                match result {
-                                    Ok(content) => {
-                                        results.push(content.clone());
-                                        // Surface the shaped tool result as a stream item.
-                                        if let UserContent::ToolResult(tool_result) = content {
-                                            yield Ok(MultiTurnStreamItem::StreamUserItem(
-                                                StreamedUserContent::ToolResult {
-                                                    tool_result,
-                                                    internal_call_id,
-                                                },
-                                            ));
-                                        }
-                                    }
-                                    Err(err) => {
-                                        yield Err(StreamingError::Prompt(Box::new(err)));
-                                        break 'outer;
-                                    }
-                                }
-                            }
-
-                            if let Err(err) = run.tool_results(results) {
-                                yield Err(Box::new(err).into());
-                                break 'outer;
-                            }
-                        } else {
-                            // Concurrent path (`tool_concurrency(n)`, n > 1): emit
-                            // every ToolCall stream item eagerly in call order,
-                            // then run tools concurrently and surface each
-                            // ToolResult as soon as its tool finishes. Results are
-                            // still stored by original call index, so persisted
-                            // history remains deterministic and provider-facing
-                            // order stays unchanged.
-                            let call_count = calls.len();
-                            let mut indexed_calls: Vec<(
-                                usize,
-                                PendingToolCall,
-                                tracing::Span,
-                                Option<String>,
-                            )> = Vec::with_capacity(call_count);
-
-                            for (index, mut pending) in calls.into_iter().enumerate() {
-                                let tool_span = new_execute_tool_span();
-
-                                if pending.preresolved_result.is_some() {
-                                    // No ToolCall / ToolResult stream items, as in
-                                    // the sequential path; the executor returns the
-                                    // stored result so history stays consistent.
-                                    indexed_calls.push((index, pending, tool_span, None));
-                                    continue;
-                                }
-
-                                let internal_call_id = pending
-                                    .internal_call_id
-                                    .clone()
-                                    .unwrap_or_else(crate::id::generate);
-                                pending.internal_call_id = Some(internal_call_id.clone());
-
-                                yield Ok(MultiTurnStreamItem::stream_item(
-                                    StreamedAssistantContent::ToolCall {
-                                        tool_call: pending.tool_call.clone(),
-                                        internal_call_id: internal_call_id.clone(),
-                                    },
-                                ));
-
-                                indexed_calls.push((index, pending, tool_span, Some(internal_call_id)));
-                            }
-
-                            let unordered = stream::iter(indexed_calls)
-                                .map(|(index, pending, tool_span, yield_id)| {
-                                    let hooks = &self.hooks;
-                                    let tool_server_handle = &tool_server_handle;
-                                    let tool_extensions = &tool_extensions;
-                                    let full_history_for_errors = &full_history_for_errors;
-                                    async move {
-                                        if let Some(result) = pending.preresolved_result {
-                                            return (index, yield_id, Ok(result));
-                                        }
-
-                                        let internal_call_id = pending
-                                            .internal_call_id
-                                            .unwrap_or_else(crate::id::generate);
-                                        let result = run_single_tool(
-                                            hooks,
-                                            tool_server_handle,
-                                            tool_extensions,
-                                            &pending.tool_call,
-                                            &internal_call_id,
-                                            full_history_for_errors,
-                                        )
-                                        .await;
-                                        (index, yield_id, result)
-                                    }
-                                    .instrument(tool_span)
-                                })
-                                .buffer_unordered(self.concurrency);
-                            futures::pin_mut!(unordered);
-
-                            let mut results: Vec<Option<UserContent>> =
-                                Vec::with_capacity(call_count);
-                            results.resize_with(call_count, || None);
-                            // Hold the first error but keep draining so sibling
-                            // tools already in flight run to completion and fire
-                            // their hooks. Once terminating, drain without
-                            // surfacing further successful ToolResult items.
-                            let mut first_error: Option<PromptError> = None;
-                            while let Some((index, yield_id, result)) = unordered.next().await {
-                                if first_error.is_some() {
-                                    continue;
-                                }
-                                match result {
-                                    Ok(content) => {
-                                        let Some(slot) = results.get_mut(index) else {
-                                            first_error = Some(PromptError::CompletionError(
-                                                CompletionError::ResponseError(
-                                                    "tool execution returned an invalid result index"
-                                                        .to_string(),
-                                                ),
-                                            ));
-                                            continue;
-                                        };
-                                        *slot = Some(content.clone());
-                                        if let Some(internal_call_id) = yield_id
-                                            && let UserContent::ToolResult(tool_result) = content
-                                        {
-                                            yield Ok(MultiTurnStreamItem::StreamUserItem(
-                                                StreamedUserContent::ToolResult {
-                                                    tool_result,
-                                                    internal_call_id,
-                                                },
-                                            ));
-                                        }
-                                    }
-                                    Err(err) => first_error = Some(err),
-                                }
-                            }
-
-                            if let Some(err) = first_error {
-                                yield Err(StreamingError::Prompt(Box::new(err)));
-                                break 'outer;
-                            }
-
-                            let results: Vec<UserContent> = results
-                                .into_iter()
-                                .collect::<Option<Vec<_>>>()
-                                .ok_or_else(|| {
-                                    StreamingError::Prompt(Box::new(PromptError::CompletionError(
-                                        CompletionError::ResponseError(
-                                            "tool execution finished without producing every result"
-                                                .to_string(),
-                                        ),
-                                    )))
-                                })?;
-
-                            if let Err(err) = run.tool_results(results) {
-                                yield Err(Box::new(err).into());
-                                break 'outer;
-                            }
-                        }
-                    }
-                    AgentRunStep::Done(response) => {
-                        // Tool output mode (#1928): when the finishing turn made
-                        // the output-tool call, surface the run's structured
-                        // output as the final content (see `finalize_streamed_
-                        // choice`). Otherwise keep the turn's content as-is.
-                        let final_choice = finalize_streamed_choice(
-                            &last_final_choice,
-                            &response.output,
-                        )
-                        .unwrap_or_else(|| {
-                            if is_empty_assistant_turn(&last_final_choice) {
-                                tracing::warn!(
-                                    agent_name =
-                                        agent_name.as_deref().unwrap_or(UNKNOWN_AGENT_NAME),
-                                    message_id = ?last_message_id,
-                                    "Streaming turn completed without assistant text; final response will be empty"
-                                );
-                            }
-                            last_final_choice.clone()
-                        });
-
-                        if created_agent_span {
-                            let current_span = tracing::Span::current();
-                            record_usage_on_span(&current_span, response.usage);
-                        }
-                        tracing::info!("Agent multi-turn stream finished");
-                        append_run_messages(
-                            memory_handle.as_ref(),
-                            response.messages.clone().unwrap_or_default(),
-                        )
-                        .await;
-                        // Always surface the accumulated messages (parity with
-                        // the blocking `run()`, whose `PromptResponse.messages`
-                        // is always populated), regardless of whether the caller
-                        // supplied input history.
-                        let final_messages: Option<Vec<Message>> =
-                            Some(response.messages.clone().unwrap_or_default());
-                        yield Ok(MultiTurnStreamItem::final_response_with_completion_calls(
-                            final_choice,
-                            response.usage,
-                            response.completion_calls.clone(),
-                            final_messages,
-                        ));
-                        break 'outer;
-                    }
-                }
-            }
-        };
-
-        Box::pin(stream.instrument(agent_span))
+        Box::pin(driver.instrument(agent_span))
     }
 }
 

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -809,8 +809,8 @@ where
             results.resize_with(call_count, || None);
             // Hold the *lowest-index* error (call order), not the first to
             // complete, so the surfaced terminate reason is deterministic and
-            // matches the blocking buffered path; keep draining so in-flight
-            // siblings finish and fire their hooks.
+            // matches the sequential branch's call-order behavior; keep draining
+            // so in-flight siblings finish and fire their hooks.
             let mut first_error: Option<(usize, PromptError)> = None;
             while let Some((index, yield_id, result)) = unordered.next().await {
                 match result {

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -202,7 +202,7 @@ where
     Ok(crate::completion::Usage::new())
 }
 
-fn record_usage_on_span(span: &tracing::Span, usage: crate::completion::Usage) {
+pub(crate) fn record_usage_on_span(span: &tracing::Span, usage: crate::completion::Usage) {
     span.record("gen_ai.usage.input_tokens", usage.input_tokens);
     span.record("gen_ai.usage.output_tokens", usage.output_tokens);
     span.record(
@@ -407,17 +407,20 @@ pub(crate) type DriveStream<'a, R> =
 /// fold); `Done` carries both the canonical [`PromptResponse`] the blocking
 /// surface returns and the medium-specific final stream item the streaming
 /// surface yields.
+// The large `Item` variant is the per-delta hot path (one per streamed token);
+// boxing it to shrink the variant spread would add an allocation per delta,
+// which the streaming path is specifically tuned to avoid. `Done` is yielded
+// once per run, so the wasted space on that rare variant is irrelevant.
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum DriveItem<R> {
-    /// An intermediate stream item (assistant delta, tool call/result, or a
-    /// per-call `CompletionCall`).
+    /// An intermediate stream item (assistant delta, tool call/result, a
+    /// per-call `CompletionCall`, or — last, for the streaming surface — the
+    /// final response item).
     Item(MultiTurnStreamItem<R>),
-    /// The run finished.
-    Done {
-        /// Read by the blocking fold (`AgentRunner::run`); the streaming surface
-        /// uses only `final_item`.
-        response: Box<PromptResponse>,
-        final_item: MultiTurnStreamItem<R>,
-    },
+    /// The run finished; carries the canonical response the blocking fold
+    /// returns. The streaming surface has already received the final item as the
+    /// preceding `Item` and ignores this.
+    Done(Box<PromptResponse>),
 }
 
 /// The per-medium half of the agent loop: how a turn is fetched from the model,
@@ -471,9 +474,9 @@ where
         created_agent_span: bool,
     );
 
-    /// Build the final stream item surfaced at `Done` (medium-specific final
-    /// content shaping).
-    fn build_final_item(&self, response: &PromptResponse) -> MultiTurnStreamItem<Self::Raw>;
+    /// Build the final stream item surfaced at `Done`, or `None` when the
+    /// surface discards it (the blocking fold) so the engine skips the work.
+    fn final_item(&self, response: &PromptResponse) -> Option<MultiTurnStreamItem<Self::Raw>>;
 }
 
 /// Convert a [`StreamingError`] back into a [`PromptError`] for the blocking
@@ -621,11 +624,13 @@ where
                         response.messages.clone().unwrap_or_default(),
                     )
                     .await;
-                    let final_item = source.build_final_item(&response);
-                    yield Ok(DriveItem::Done {
-                        response: Box::new(response),
-                        final_item,
-                    });
+                    // Build the final item only when the surface forwards it
+                    // (streaming). The blocking fold discards it, so its source
+                    // returns `None` and the extra full-response clone is skipped.
+                    if let Some(final_item) = source.final_item(&response) {
+                        yield Ok(DriveItem::Item(final_item));
+                    }
+                    yield Ok(DriveItem::Done(Box::new(response)));
                     break 'outer;
                 }
             }
@@ -721,12 +726,15 @@ where
                 Vec::with_capacity(call_count);
 
             for (index, mut pending) in calls.into_iter().enumerate() {
-                let tool_span = chain_tool_span(new_execute_tool_span());
-
+                // Preresolved (invalid-tool-recovery) calls don't execute, so they
+                // emit and chain no tool span — matching the sequential branch,
+                // which `continue`s before span creation.
                 if pending.preresolved_result.is_some() {
-                    indexed_calls.push((index, pending, tool_span, None));
+                    indexed_calls.push((index, pending, tracing::Span::none(), None));
                     continue;
                 }
+
+                let tool_span = chain_tool_span(new_execute_tool_span());
 
                 let internal_call_id = pending
                     .internal_call_id
@@ -775,38 +783,51 @@ where
 
             let mut results: Vec<Option<UserContent>> = Vec::with_capacity(call_count);
             results.resize_with(call_count, || None);
-            let mut first_error: Option<PromptError> = None;
+            // Hold the *lowest-index* error (call order), not the first to
+            // complete, so the surfaced terminate reason is deterministic and
+            // matches the blocking buffered path; keep draining so in-flight
+            // siblings finish and fire their hooks.
+            let mut first_error: Option<(usize, PromptError)> = None;
             while let Some((index, yield_id, result)) = unordered.next().await {
-                if first_error.is_some() {
-                    continue;
-                }
                 match result {
-                    Ok(content) => {
-                        let Some(slot) = results.get_mut(index) else {
-                            first_error = Some(PromptError::CompletionError(
-                                CompletionError::ResponseError(
-                                    "tool execution returned an invalid result index".to_string(),
-                                ),
-                            ));
-                            continue;
-                        };
-                        *slot = Some(content.clone());
-                        if let Some(internal_call_id) = yield_id
-                            && let UserContent::ToolResult(tool_result) = content
-                        {
-                            yield Ok(MultiTurnStreamItem::StreamUserItem(
-                                StreamedUserContent::ToolResult {
-                                    tool_result,
-                                    internal_call_id,
-                                },
-                            ));
+                    Ok(content) => match results.get_mut(index) {
+                        Some(slot) => {
+                            *slot = Some(content.clone());
+                            // Once any tool has errored the run will terminate, so
+                            // stop surfacing successful results (but keep draining).
+                            if first_error.is_none()
+                                && let Some(internal_call_id) = yield_id
+                                && let UserContent::ToolResult(tool_result) = content
+                            {
+                                yield Ok(MultiTurnStreamItem::StreamUserItem(
+                                    StreamedUserContent::ToolResult {
+                                        tool_result,
+                                        internal_call_id,
+                                    },
+                                ));
+                            }
+                        }
+                        None => {
+                            if first_error.as_ref().is_none_or(|(i, _)| index < *i) {
+                                first_error = Some((
+                                    index,
+                                    PromptError::CompletionError(CompletionError::ResponseError(
+                                        "tool execution returned an invalid result index"
+                                            .to_string(),
+                                    )),
+                                ));
+                            }
+                        }
+                    },
+                    Err(err) => {
+                        if first_error.as_ref().is_none_or(|(i, _)| index < *i) {
+                            first_error = Some((index, err));
                         }
                     }
-                    Err(err) => first_error = Some(err),
                 }
             }
 
-            if let Some(err) = first_error {
+            if let Some((_, err)) = first_error {
                 yield Err(StreamingError::Prompt(Box::new(err)));
                 return;
             }
@@ -1200,10 +1221,10 @@ where
         }
     }
 
-    fn build_final_item(
+    fn final_item(
         &self,
         response: &PromptResponse,
-    ) -> MultiTurnStreamItem<M::StreamingResponse> {
+    ) -> Option<MultiTurnStreamItem<M::StreamingResponse>> {
         // Tool output mode (#1928): when the finishing turn made the output-tool
         // call, surface the run's structured output as the final content.
         let final_choice = finalize_streamed_choice(&self.last_final_choice, &response.output)
@@ -1220,12 +1241,12 @@ where
         // `run()`), regardless of whether the caller supplied input history.
         let final_messages: Option<Vec<Message>> =
             Some(response.messages.clone().unwrap_or_default());
-        MultiTurnStreamItem::final_response_with_completion_calls(
+        Some(MultiTurnStreamItem::final_response_with_completion_calls(
             final_choice,
             response.usage,
             response.completion_calls.clone(),
             final_messages,
-        )
+        ))
     }
 }
 
@@ -1276,7 +1297,8 @@ where
         let source = StreamingTurnSource::new(&self.hooks);
 
         // The blocking surface folds this same engine; the streaming surface
-        // forwards intermediate items and maps `Done` to the final item.
+        // forwards intermediate items (the final response item is the last one)
+        // and ends on `Done`.
         let driver = drive_agent(
             self,
             source,
@@ -1285,10 +1307,12 @@ where
             created_agent_span,
             memory_handle,
         )
-        .map(|item| match item {
-            Ok(DriveItem::Item(item)) => Ok(item),
-            Ok(DriveItem::Done { final_item, .. }) => Ok(final_item),
-            Err(err) => Err(err),
+        .filter_map(|item| {
+            std::future::ready(match item {
+                Ok(DriveItem::Item(item)) => Some(Ok(item)),
+                Ok(DriveItem::Done(_)) => None,
+                Err(err) => Some(Err(err)),
+            })
         });
 
         Box::pin(driver.instrument(agent_span))

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -669,10 +669,16 @@ where
 
         if runner.concurrency <= 1 {
             // Sequential default: one ToolCall/ToolResult pair per tool, strictly
-            // interleaved. Byte-identical to the pre-concurrency behavior.
+            // interleaved. Run-all-then-decide (matching the concurrent branch and
+            // the pre-refactor blocking driver's collect-all): every tool in the
+            // turn executes and fires its hooks, then the lowest-call-index
+            // terminate error is surfaced. Once the run is known to terminate we
+            // stop *surfacing* further stream items, but keep running the
+            // remaining tools so both surfaces are lock-step at any concurrency.
             let mut results: Vec<UserContent> = Vec::with_capacity(calls.len());
+            let mut first_error: Option<(usize, PromptError)> = None;
 
-            for pending in calls {
+            for (index, pending) in calls.into_iter().enumerate() {
                 let tool_call = pending.tool_call;
                 if let Some(result) = pending.preresolved_result {
                     results.push(result);
@@ -683,12 +689,14 @@ where
 
                 let tool_span = chain_tool_span(new_execute_tool_span());
 
-                yield Ok(MultiTurnStreamItem::stream_item(
-                    StreamedAssistantContent::ToolCall {
-                        tool_call: tool_call.clone(),
-                        internal_call_id: internal_call_id.clone(),
-                    },
-                ));
+                if first_error.is_none() {
+                    yield Ok(MultiTurnStreamItem::stream_item(
+                        StreamedAssistantContent::ToolCall {
+                            tool_call: tool_call.clone(),
+                            internal_call_id: internal_call_id.clone(),
+                        },
+                    ));
+                }
 
                 let result = run_single_tool(
                     &runner.hooks,
@@ -704,7 +712,9 @@ where
                 match result {
                     Ok(content) => {
                         results.push(content.clone());
-                        if let UserContent::ToolResult(tool_result) = content {
+                        if first_error.is_none()
+                            && let UserContent::ToolResult(tool_result) = content
+                        {
                             yield Ok(MultiTurnStreamItem::StreamUserItem(
                                 StreamedUserContent::ToolResult {
                                     tool_result,
@@ -714,10 +724,16 @@ where
                         }
                     }
                     Err(err) => {
-                        yield Err(StreamingError::Prompt(Box::new(err)));
-                        return;
+                        if first_error.as_ref().is_none_or(|(i, _)| index < *i) {
+                            first_error = Some((index, err));
+                        }
                     }
                 }
+            }
+
+            if let Some((_, err)) = first_error {
+                yield Err(StreamingError::Prompt(Box::new(err)));
+                return;
             }
 
             if let Err(err) = run.tool_results(results) {

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -618,6 +618,14 @@ where
                     }
                 }
                 AgentRunStep::Done(response) => {
+                    // Run-completion marker, unifying the blocking driver's
+                    // "Depth reached" and the streaming driver's "multi-turn
+                    // stream finished" logs into one shared event.
+                    tracing::info!(
+                        turn = run.turn(),
+                        max_turns = runner.max_turns,
+                        "Agent run finished"
+                    );
                     source.record_run_level_telemetry(&agent_span, &response, created_agent_span);
                     append_run_messages(
                         memory_handle.as_ref(),
@@ -859,6 +867,8 @@ pub(crate) struct StreamingTurnSource {
     /// surfaces it as-is, even when canonical reordering was recorded in history.
     last_final_choice: OneOrMany<AssistantContent>,
     last_message_id: Option<String>,
+    /// Resolved agent name, kept only for the empty-turn diagnostic warning.
+    agent_name: String,
     /// Hot-path interest gates, computed once: skip building/dispatching the
     /// high-frequency delta events when no hook observes them.
     observes_text_delta: bool,
@@ -869,10 +879,11 @@ pub(crate) struct StreamingTurnSource {
 }
 
 impl StreamingTurnSource {
-    pub(crate) fn new<M: CompletionModel>(hooks: &HookStack<M>) -> Self {
+    pub(crate) fn new<M: CompletionModel>(hooks: &HookStack<M>, agent_name: String) -> Self {
         Self {
             last_final_choice: OneOrMany::one(AssistantContent::text("")),
             last_message_id: None,
+            agent_name,
             observes_text_delta: hooks.observes(StepEventKind::TextDelta),
             observes_tool_call_delta: hooks.observes(StepEventKind::ToolCallDelta),
             has_hooks: !hooks.is_empty(),
@@ -1231,6 +1242,7 @@ where
             .unwrap_or_else(|| {
                 if is_empty_assistant_turn(&self.last_final_choice) {
                     tracing::warn!(
+                        agent_name = self.agent_name.as_str(),
                         message_id = ?self.last_message_id,
                         "Streaming turn completed without assistant text; final response will be empty"
                     );
@@ -1294,7 +1306,8 @@ where
         };
 
         let run = self.build_run(history_override);
-        let source = StreamingTurnSource::new(&self.hooks);
+        let source =
+            StreamingTurnSource::new(&self.hooks, self.agent_name_or_default().to_string());
 
         // The blocking surface folds this same engine; the streaming surface
         // forwards intermediate items (the final response item is the last one)

--- a/crates/rig-core/src/agent/runner.rs
+++ b/crates/rig-core/src/agent/runner.rs
@@ -40,7 +40,7 @@ use super::{
         PromptResponse,
         streaming::{
             DriveItem, DriveStream, MultiTurnStreamItem, StreamingError, TurnSource, drive_agent,
-            drive_tool_calls, streaming_error_into_prompt,
+            drive_tool_calls, record_usage_on_span, streaming_error_into_prompt,
         },
         tool_result_message, tool_result_output,
     },
@@ -49,11 +49,10 @@ use super::{
     },
 };
 use crate::{
-    OneOrMany,
     completion::{CompletionError, CompletionModel, Document, Message, PromptError},
     json_utils,
     memory::ConversationMemory,
-    message::{AssistantContent, ToolCall, ToolChoice, UserContent},
+    message::{ToolCall, ToolChoice, UserContent},
     tool::{ToolCallExtensions, server::ToolServerHandle},
 };
 
@@ -666,6 +665,12 @@ pub(crate) fn new_execute_tool_span() -> tracing::Span {
 pub(crate) struct UnaryTurnSource {
     /// Sequences chat and tool spans into a linear `follows_from` chain (the
     /// streaming surface parents into a tree instead and does not chain).
+    ///
+    /// Atomic rather than `Cell` despite being driven by a single sequential
+    /// task: `run_tool_calls` passes `chain_span` as a closure into
+    /// `drive_tool_calls`, whose returned `DriveStream` is `Send`. That makes the
+    /// closure capture `&self`, so `&UnaryTurnSource` must be `Send`, i.e.
+    /// `UnaryTurnSource: Sync` — which `AtomicU64` provides and `Cell` does not.
     current_span_id: AtomicU64,
 }
 
@@ -679,14 +684,12 @@ impl UnaryTurnSource {
     /// Chain `span` onto the previous step's span and record it as the new chain
     /// head, preserving the blocking driver's linear causal trace.
     fn chain_span(&self, span: tracing::Span) -> tracing::Span {
-        let span = if self.current_span_id.load(Ordering::SeqCst) != 0 {
-            let id = Id::from_u64(self.current_span_id.load(Ordering::SeqCst));
-            span.follows_from(id).to_owned()
-        } else {
-            span
+        let span = match self.current_span_id.load(Ordering::Relaxed) {
+            0 => span,
+            id => span.follows_from(Id::from_u64(id)).to_owned(),
         };
         if let Some(id) = span.id() {
-            self.current_span_id.store(id.into_u64(), Ordering::SeqCst);
+            self.current_span_id.store(id.into_u64(), Ordering::Relaxed);
         }
         span
     }
@@ -826,39 +829,19 @@ where
         created_agent_span: bool,
     ) {
         // Record run-level completion + usage onto the agent span, but only when
-        // we created it — never pollute a caller-supplied outer span.
+        // we created it — never pollute a caller-supplied outer span. The usage
+        // fields go through the same recorder the streaming surface uses; the
+        // blocking surface additionally records the final completion text.
         if created_agent_span {
-            let usage = response.usage;
             agent_span.record("gen_ai.completion", &response.output);
-            agent_span.record("gen_ai.usage.input_tokens", usage.input_tokens);
-            agent_span.record("gen_ai.usage.output_tokens", usage.output_tokens);
-            agent_span.record(
-                "gen_ai.usage.cache_read.input_tokens",
-                usage.cached_input_tokens,
-            );
-            agent_span.record(
-                "gen_ai.usage.cache_creation.input_tokens",
-                usage.cache_creation_input_tokens,
-            );
-            agent_span.record(
-                "gen_ai.usage.tool_use_prompt_tokens",
-                usage.tool_use_prompt_tokens,
-            );
-            agent_span.record("gen_ai.usage.reasoning_tokens", usage.reasoning_tokens);
+            record_usage_on_span(agent_span, response.usage);
         }
     }
 
-    fn build_final_item(&self, response: &PromptResponse) -> MultiTurnStreamItem<M::Response> {
-        // The blocking surface ignores this; it is surfaced only when a caller
-        // streams agent events over a unary model. The canonical history is the
-        // machine's, so reuse the run's output as the final text.
-        let content = OneOrMany::one(AssistantContent::text(response.output.clone()));
-        MultiTurnStreamItem::final_response_with_completion_calls(
-            content,
-            response.usage,
-            response.completion_calls.clone(),
-            Some(response.messages.clone().unwrap_or_default()),
-        )
+    fn final_item(&self, _response: &PromptResponse) -> Option<MultiTurnStreamItem<M::Response>> {
+        // The blocking surface folds the engine and discards the final item, so
+        // building it (an extra full-response clone) is skipped entirely.
+        None
     }
 }
 
@@ -911,7 +894,7 @@ where
         let mut response = None;
         while let Some(item) = driver.next().await {
             match item {
-                Ok(DriveItem::Done { response: done, .. }) => response = Some(*done),
+                Ok(DriveItem::Done(done)) => response = Some(*done),
                 Ok(DriveItem::Item(_)) => {}
                 Err(err) => return Err(streaming_error_into_prompt(err)),
             }
@@ -1938,6 +1921,129 @@ mod tests {
             completed.load(SeqCst),
             2,
             "the in-flight sibling must be drained to completion, not cancelled"
+        );
+    }
+
+    /// A `Flow::Terminate` from the `ToolCall` event with a reason keyed by the
+    /// call's `x` arg, forcing the `x == 2` call (tc2) to terminate *before* the
+    /// `x == 1` call (tc1): tc2 opens the gate after terminating, tc1 awaits it
+    /// first. So completion order (tc2) differs from call order (tc1).
+    struct OrderedTerminateHook {
+        gate: Arc<tokio::sync::Notify>,
+    }
+
+    impl<M: CompletionModel> AgentHook<M> for OrderedTerminateHook {
+        async fn on_event(&self, event: StepEvent<'_, M>) -> Flow {
+            if let StepEvent::ToolCall { args, .. } = event {
+                let x = serde_json::from_str::<serde_json::Value>(args)
+                    .ok()
+                    .and_then(|v| v.get("x").and_then(serde_json::Value::as_i64));
+                match x {
+                    Some(2) => {
+                        self.gate.notify_one();
+                        return Flow::Terminate {
+                            reason: "terminated-by-tc2".to_string(),
+                        };
+                    }
+                    Some(1) => {
+                        self.gate.notified().await;
+                        return Flow::Terminate {
+                            reason: "terminated-by-tc1".to_string(),
+                        };
+                    }
+                    _ => {}
+                }
+            }
+            Flow::cont()
+        }
+    }
+
+    fn two_terminating_tools_blocking_model() -> MockCompletionModel {
+        MockCompletionModel::from_turns([
+            MockTurn::from_contents([
+                tool_call_content("tc1", json!({"x": 1, "y": 1})),
+                tool_call_content("tc2", json!({"x": 2, "y": 2})),
+            ])
+            .expect("two tool calls is non-empty"),
+            MockTurn::text("unreachable"),
+        ])
+    }
+
+    fn two_terminating_tools_streaming_model() -> MockCompletionModel {
+        MockCompletionModel::from_stream_turns([
+            vec![
+                MockStreamEvent::tool_call("tc1", "add", json!({"x": 1, "y": 1})),
+                MockStreamEvent::tool_call("tc2", "add", json!({"x": 2, "y": 2})),
+                MockStreamEvent::final_response_with_total_tokens(0),
+            ],
+            vec![
+                MockStreamEvent::text("unreachable"),
+                MockStreamEvent::final_response_with_total_tokens(0),
+            ],
+        ])
+    }
+
+    /// When two tool calls in one turn both terminate the run under
+    /// `tool_concurrency > 1`, run() and stream() surface the **same** reason —
+    /// the first-called tool's (call order), not whichever finished first. tc2
+    /// terminates before tc1, so a completion-order pick would surface tc2's
+    /// reason and the two drivers would disagree.
+    #[tokio::test]
+    async fn concurrent_simultaneous_tool_terminations_pick_call_order_on_both_drivers() {
+        let run_err = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            AgentBuilder::new(two_terminating_tools_blocking_model())
+                .tool(MockAddTool)
+                .build()
+                .runner("go")
+                .max_turns(3)
+                .tool_concurrency(2)
+                .add_hook(OrderedTerminateHook {
+                    gate: Arc::new(tokio::sync::Notify::new()),
+                })
+                .run(),
+        )
+        .await
+        .expect("blocking run must not hang")
+        .expect_err("the run must terminate");
+
+        let mut stream = AgentBuilder::new(two_terminating_tools_streaming_model())
+            .tool(MockAddTool)
+            .build()
+            .runner("go")
+            .max_turns(3)
+            .tool_concurrency(2)
+            .add_hook(OrderedTerminateHook {
+                gate: Arc::new(tokio::sync::Notify::new()),
+            })
+            .stream()
+            .await;
+
+        let stream_err = tokio::time::timeout(std::time::Duration::from_secs(5), async move {
+            while let Some(item) = stream.next().await {
+                if let Err(err) = item {
+                    return Some(err);
+                }
+            }
+            None
+        })
+        .await
+        .expect("streamed run must not hang")
+        .expect("the stream must surface a terminate error");
+
+        let run_msg = run_err.to_string();
+        let stream_msg = stream_err.to_string();
+        assert!(
+            run_msg.contains("terminated-by-tc1"),
+            "blocking run should surface the first-called tool's reason, got: {run_msg}"
+        );
+        assert!(
+            stream_msg.contains("terminated-by-tc1"),
+            "stream should surface the first-called tool's reason, got: {stream_msg}"
+        );
+        assert!(
+            !run_msg.contains("terminated-by-tc2") && !stream_msg.contains("terminated-by-tc2"),
+            "neither driver should surface the later-completing tool's reason"
         );
     }
 

--- a/crates/rig-core/src/agent/runner.rs
+++ b/crates/rig-core/src/agent/runner.rs
@@ -34,19 +34,25 @@ use futures::{Stream, StreamExt, stream};
 use tracing::{Instrument, info_span, span::Id};
 
 use super::{
-    completion::{Agent, DynamicContextStore, build_prepared_completion_request},
+    completion::{Agent, DynamicContextStore, PreparedCompletionRequest},
     hook::{AgentHook, Flow, HookStack, InvalidToolCallHookAction, RequestOverride, StepEvent},
-    prompt_request::{PromptResponse, tool_result_message, tool_result_output},
+    prompt_request::{
+        PromptResponse, tool_result_message, tool_result_output,
+        streaming::{
+            DriveItem, DriveStream, MultiTurnStreamItem, StreamingError, TurnSource, drive_agent,
+            streaming_error_into_prompt,
+        },
+    },
     run::{
-        AgentRun, AgentRunStep, DEFAULT_OUTPUT_RETRIES, ModelTurn, ModelTurnOutcome, OutputMode,
-        PendingToolCall,
+        AgentRun, DEFAULT_OUTPUT_RETRIES, ModelTurn, ModelTurnOutcome, OutputMode, PendingToolCall,
     },
 };
 use crate::{
-    completion::{CompletionModel, Document, Message, PromptError},
+    OneOrMany,
+    completion::{CompletionError, CompletionModel, Document, Message, PromptError},
     json_utils,
     memory::ConversationMemory,
-    message::{ToolCall, ToolChoice, UserContent},
+    message::{AssistantContent, ToolCall, ToolChoice, UserContent},
     tool::{ToolCallExtensions, server::ToolServerHandle},
 };
 
@@ -705,6 +711,247 @@ where
         .buffered(concurrency)
 }
 
+/// [`TurnSource`] for the blocking surface: each turn issues a unary
+/// `model.completion()` request and feeds the whole response into the machine.
+/// Emits no intermediate items (the blocking surface folds the engine to its
+/// final response), but keeps the blocking driver's linear `follows_from` span
+/// chain across chat and tool spans.
+pub(crate) struct UnaryTurnSource {
+    /// Sequences chat and tool spans into a linear `follows_from` chain (the
+    /// streaming surface parents into a tree instead and does not chain).
+    current_span_id: AtomicU64,
+}
+
+impl UnaryTurnSource {
+    pub(crate) fn new() -> Self {
+        Self {
+            current_span_id: AtomicU64::new(0),
+        }
+    }
+
+    /// Chain `span` onto the previous step's span and record it as the new chain
+    /// head, preserving the blocking driver's linear causal trace.
+    fn chain_span(&self, span: tracing::Span) -> tracing::Span {
+        let span = if self.current_span_id.load(Ordering::SeqCst) != 0 {
+            let id = Id::from_u64(self.current_span_id.load(Ordering::SeqCst));
+            span.follows_from(id).to_owned()
+        } else {
+            span
+        };
+        if let Some(id) = span.id() {
+            self.current_span_id.store(id.into_u64(), Ordering::SeqCst);
+        }
+        span
+    }
+}
+
+impl<M> TurnSource<M> for UnaryTurnSource
+where
+    M: CompletionModel,
+{
+    type Raw = M::Response;
+
+    fn open_chat_span(
+        &self,
+        runner: &AgentRunner<M>,
+        effective_preamble: Option<&str>,
+    ) -> tracing::Span {
+        let chat_span = info_span!(
+            target: "rig::agent_chat",
+            parent: tracing::Span::current(),
+            "chat",
+            gen_ai.operation.name = "chat",
+            gen_ai.agent.name = runner.agent_name_or_default(),
+            gen_ai.system_instructions = effective_preamble,
+            gen_ai.provider.name = tracing::field::Empty,
+            gen_ai.request.model = tracing::field::Empty,
+            gen_ai.response.id = tracing::field::Empty,
+            gen_ai.response.model = tracing::field::Empty,
+            gen_ai.usage.output_tokens = tracing::field::Empty,
+            gen_ai.usage.input_tokens = tracing::field::Empty,
+            gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
+            gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
+            gen_ai.usage.tool_use_prompt_tokens = tracing::field::Empty,
+            gen_ai.usage.reasoning_tokens = tracing::field::Empty,
+            gen_ai.input.messages = tracing::field::Empty,
+            gen_ai.output.messages = tracing::field::Empty,
+        );
+        self.chain_span(chat_span)
+    }
+
+    fn run_model_turn<'a>(
+        &'a mut self,
+        runner: &'a AgentRunner<M>,
+        run: &'a mut AgentRun,
+        prepared: PreparedCompletionRequest<M>,
+        chat_span: tracing::Span,
+        _agent_span: &'a tracing::Span,
+        current_prompt: Message,
+    ) -> DriveStream<'a, M::Response> {
+        Box::pin(async_stream::stream! {
+            let resp = match prepared.builder.send().instrument(chat_span.clone()).await {
+                Ok(resp) => resp,
+                Err(err) => {
+                    yield Err(StreamingError::from(err));
+                    return;
+                }
+            };
+
+            let mut outcome = match run.model_response(ModelTurn::new(
+                resp.message_id.clone(),
+                resp.choice.clone(),
+                resp.usage,
+                prepared.executable_tool_names,
+                prepared.allowed_tool_names,
+            )) {
+                Ok(outcome) => outcome,
+                Err(err) => {
+                    yield Err(Box::new(err).into());
+                    return;
+                }
+            };
+
+            loop {
+                match outcome {
+                    ModelTurnOutcome::NeedsResolution(context) => {
+                        let flow = runner
+                            .hooks
+                            .on_event(StepEvent::InvalidToolCall(&context))
+                            .await;
+                        match flow_into_invalid(flow) {
+                            InvalidDecision::Terminate(reason) => {
+                                yield Err(StreamingError::Prompt(Box::new(
+                                    run.cancel_error(reason),
+                                )));
+                                return;
+                            }
+                            InvalidDecision::Action(action) => {
+                                outcome = match run.resolve_invalid_tool_call(action) {
+                                    Ok(outcome) => outcome,
+                                    Err(err) => {
+                                        yield Err(Box::new(err).into());
+                                        return;
+                                    }
+                                };
+                            }
+                        }
+                    }
+                    ModelTurnOutcome::TurnRetried => break,
+                    ModelTurnOutcome::Continue {
+                        response_hook_suppressed,
+                    } => {
+                        if !response_hook_suppressed
+                            && let Some(reason) = observe_flow(
+                                runner
+                                    .hooks
+                                    .on_event(StepEvent::CompletionResponse {
+                                        prompt: &current_prompt,
+                                        response: &resp,
+                                    })
+                                    .await,
+                            )
+                        {
+                            yield Err(StreamingError::Prompt(Box::new(run.cancel_error(reason))));
+                            return;
+                        }
+                        break;
+                    }
+                }
+            }
+        })
+    }
+
+    fn run_tool_calls<'a>(
+        &'a self,
+        runner: &'a AgentRunner<M>,
+        run: &'a mut AgentRun,
+        calls: Vec<PendingToolCall>,
+    ) -> DriveStream<'a, M::Response> {
+        Box::pin(async_stream::stream! {
+            // Materialize the diagnostic history once; tools only read it on a
+            // hook-terminate error path, so every tool future shares a single
+            // borrow instead of deep-cloning the conversation per call.
+            let full_history_for_errors = run.full_history();
+
+            // Build a `follows_from`-chained span per call, in call order, then
+            // hand the calls to the buffered executor.
+            let calls_with_spans: Vec<(PendingToolCall, tracing::Span)> = calls
+                .into_iter()
+                .map(|pending| (pending, self.chain_span(new_execute_tool_span())))
+                .collect();
+
+            let tool_results = execute_tools_buffered(
+                &runner.hooks,
+                &runner.tool_server_handle,
+                &runner.tool_extensions,
+                calls_with_spans,
+                &full_history_for_errors,
+                runner.concurrency,
+            )
+            .collect::<Vec<Result<UserContent, PromptError>>>()
+            .await;
+
+            let mut tool_content = Vec::with_capacity(tool_results.len());
+            for result in tool_results {
+                match result {
+                    Ok(content) => tool_content.push(content),
+                    Err(err) => {
+                        yield Err(StreamingError::Prompt(Box::new(err)));
+                        return;
+                    }
+                }
+            }
+
+            if let Err(err) = run.tool_results(tool_content) {
+                yield Err(Box::new(err).into());
+                return;
+            }
+        })
+    }
+
+    fn record_run_level_telemetry(
+        &self,
+        agent_span: &tracing::Span,
+        response: &PromptResponse,
+        created_agent_span: bool,
+    ) {
+        // Record run-level completion + usage onto the agent span, but only when
+        // we created it — never pollute a caller-supplied outer span.
+        if created_agent_span {
+            let usage = response.usage;
+            agent_span.record("gen_ai.completion", &response.output);
+            agent_span.record("gen_ai.usage.input_tokens", usage.input_tokens);
+            agent_span.record("gen_ai.usage.output_tokens", usage.output_tokens);
+            agent_span.record(
+                "gen_ai.usage.cache_read.input_tokens",
+                usage.cached_input_tokens,
+            );
+            agent_span.record(
+                "gen_ai.usage.cache_creation.input_tokens",
+                usage.cache_creation_input_tokens,
+            );
+            agent_span.record(
+                "gen_ai.usage.tool_use_prompt_tokens",
+                usage.tool_use_prompt_tokens,
+            );
+            agent_span.record("gen_ai.usage.reasoning_tokens", usage.reasoning_tokens);
+        }
+    }
+
+    fn build_final_item(&self, response: &PromptResponse) -> MultiTurnStreamItem<M::Response> {
+        // The blocking surface ignores this; it is surfaced only when a caller
+        // streams agent events over a unary model. The canonical history is the
+        // machine's, so reuse the run's output as the final text.
+        let content = OneOrMany::one(AssistantContent::text(response.output.clone()));
+        MultiTurnStreamItem::final_response_with_completion_calls(
+            content,
+            response.usage,
+            response.completion_calls.clone(),
+            Some(response.messages.clone().unwrap_or_default()),
+        )
+    }
+}
+
 impl<M> AgentRunner<M>
 where
     M: CompletionModel,
@@ -720,8 +967,6 @@ where
             agent_span.record("gen_ai.prompt", text);
         }
 
-        let agent_name_for_span = self.agent_name.clone();
-
         // When the caller passes explicit history, memory is fully bypassed for
         // this run (no load AND no save). Otherwise, if a memory backend and
         // conversation id are both configured, load prior history.
@@ -736,233 +981,38 @@ where
             },
         };
 
-        let mut run = self.build_run(history_override);
-        let current_span_id: AtomicU64 = AtomicU64::new(0);
+        let run = self.build_run(history_override);
 
-        loop {
-            match run.next_step()? {
-                AgentRunStep::CallModel {
-                    prompt,
-                    history,
-                    turn,
-                } => {
-                    if self.max_turns > 1 {
-                        tracing::info!("Current conversation depth: {}/{}", turn, self.max_turns);
-                    }
+        // Fold the shared engine to its final response. The blocking surface
+        // uses a unary model transport and ignores the intermediate items the
+        // engine yields; the engine is driven under the caller's ambient span
+        // (no `instrument`), keeping the agent span detached and the chat/tool
+        // spans on the blocking `follows_from` chain.
+        let driver = drive_agent(
+            self,
+            UnaryTurnSource::new(),
+            run,
+            agent_span,
+            created_agent_span,
+            memory_handle,
+        );
+        futures::pin_mut!(driver);
 
-                    let request_override =
-                        match resolve_completion_call(&self.hooks, &prompt, &history, turn).await {
-                            CompletionCallOutcome::Terminate(reason) => {
-                                return Err(run.cancel_error(reason));
-                            }
-                            CompletionCallOutcome::Proceed(request_override) => request_override,
-                        };
-
-                    // Record this turn's base system prompt — the override-or-baseline
-                    // preamble, before any output-mode augmentation the request
-                    // builder appends (the provider-level span records the final
-                    // value). A per-turn `RequestOverride` can replace it, and the
-                    // builder below resolves the same precedence; borrow rather than
-                    // clone since the value only needs to outlive span creation.
-                    let effective_preamble = request_override
-                        .as_ref()
-                        .and_then(|o| o.preamble.as_deref())
-                        .or(self.preamble.as_deref());
-
-                    let span = tracing::Span::current();
-                    let chat_span = info_span!(
-                        target: "rig::agent_chat",
-                        parent: &span,
-                        "chat",
-                        gen_ai.operation.name = "chat",
-                        gen_ai.agent.name = agent_name_for_span.as_deref().unwrap_or(UNKNOWN_AGENT_NAME),
-                        gen_ai.system_instructions = effective_preamble,
-                        gen_ai.provider.name = tracing::field::Empty,
-                        gen_ai.request.model = tracing::field::Empty,
-                        gen_ai.response.id = tracing::field::Empty,
-                        gen_ai.response.model = tracing::field::Empty,
-                        gen_ai.usage.output_tokens = tracing::field::Empty,
-                        gen_ai.usage.input_tokens = tracing::field::Empty,
-                        gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
-                        gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
-                        gen_ai.usage.tool_use_prompt_tokens = tracing::field::Empty,
-                        gen_ai.usage.reasoning_tokens = tracing::field::Empty,
-                        gen_ai.input.messages = tracing::field::Empty,
-                        gen_ai.output.messages = tracing::field::Empty,
-                    );
-
-                    let chat_span = if current_span_id.load(Ordering::SeqCst) != 0 {
-                        let id = Id::from_u64(current_span_id.load(Ordering::SeqCst));
-                        chat_span.follows_from(id).to_owned()
-                    } else {
-                        chat_span
-                    };
-
-                    if let Some(id) = chat_span.id() {
-                        current_span_id.store(id.into_u64(), Ordering::SeqCst);
-                    };
-
-                    // Pin Tool output mode once committed so later turns stay
-                    // consistent even if the per-turn tool set changes (#1928).
-                    let committed_output_tool = run.output_tool_name().map(str::to_owned);
-                    let prepared_request = build_prepared_completion_request(
-                        &self.model,
-                        prompt.clone(),
-                        &history,
-                        self.preamble.as_deref(),
-                        &self.static_context,
-                        self.temperature,
-                        self.max_tokens,
-                        self.additional_params.as_ref(),
-                        self.tool_choice.as_ref(),
-                        &self.tool_server_handle,
-                        &self.dynamic_context,
-                        self.output_schema.as_ref(),
-                        &self.output_mode,
-                        committed_output_tool.as_deref(),
-                        request_override.as_ref(),
-                    )
-                    .await?;
-
-                    let resp = prepared_request
-                        .builder
-                        .send()
-                        .instrument(chat_span.clone())
-                        .await?;
-
-                    run.set_output_tool_name(prepared_request.output_tool_name.clone());
-
-                    let mut outcome = run.model_response(ModelTurn::new(
-                        resp.message_id.clone(),
-                        resp.choice.clone(),
-                        resp.usage,
-                        prepared_request.executable_tool_names,
-                        prepared_request.allowed_tool_names,
-                    ))?;
-
-                    loop {
-                        match outcome {
-                            ModelTurnOutcome::NeedsResolution(context) => {
-                                let flow = self
-                                    .hooks
-                                    .on_event(StepEvent::InvalidToolCall(&context))
-                                    .await;
-                                match flow_into_invalid(flow) {
-                                    InvalidDecision::Terminate(reason) => {
-                                        return Err(run.cancel_error(reason));
-                                    }
-                                    InvalidDecision::Action(action) => {
-                                        outcome = run.resolve_invalid_tool_call(action)?;
-                                    }
-                                }
-                            }
-                            ModelTurnOutcome::TurnRetried => break,
-                            ModelTurnOutcome::Continue {
-                                response_hook_suppressed,
-                            } => {
-                                if !response_hook_suppressed
-                                    && let Some(reason) = observe_flow(
-                                        self.hooks
-                                            .on_event(StepEvent::CompletionResponse {
-                                                prompt: &prompt,
-                                                response: &resp,
-                                            })
-                                            .await,
-                                    )
-                                {
-                                    return Err(run.cancel_error(reason));
-                                }
-                                break;
-                            }
-                        }
-                    }
-                }
-                AgentRunStep::CallTools { calls } => {
-                    let hooks = &self.hooks;
-                    let tool_server = &self.tool_server_handle;
-                    let tool_extensions = &self.tool_extensions;
-                    // Materialize the diagnostic history once; tools only read it
-                    // (verbatim, on a hook-terminate error path), so every tool
-                    // future shares a single borrow instead of deep-cloning the
-                    // whole conversation per call on the common success path.
-                    let full_history_for_errors = run.full_history();
-                    let error_history: &[Message] = &full_history_for_errors;
-
-                    // Build a `follows_from`-chained span per call, in call order,
-                    // then hand the calls to the blocking driver's buffered executor.
-                    let calls_with_spans: Vec<(PendingToolCall, tracing::Span)> = calls
-                        .into_iter()
-                        .map(|pending| {
-                            let tool_span = new_execute_tool_span();
-
-                            let tool_span = if current_span_id.load(Ordering::SeqCst) != 0 {
-                                let id = Id::from_u64(current_span_id.load(Ordering::SeqCst));
-                                tool_span.follows_from(id).to_owned()
-                            } else {
-                                tool_span
-                            };
-
-                            if let Some(id) = tool_span.id() {
-                                current_span_id.store(id.into_u64(), Ordering::SeqCst);
-                            };
-
-                            (pending, tool_span)
-                        })
-                        .collect();
-
-                    let tool_content = execute_tools_buffered(
-                        hooks,
-                        tool_server,
-                        tool_extensions,
-                        calls_with_spans,
-                        error_history,
-                        self.concurrency,
-                    )
-                    .collect::<Vec<Result<UserContent, PromptError>>>()
-                    .await
-                    .into_iter()
-                    .collect::<Result<Vec<_>, _>>()?;
-
-                    run.tool_results(tool_content)?;
-                }
-                AgentRunStep::Done(response) => {
-                    if self.max_turns > 1 {
-                        tracing::info!("Depth reached: {}/{}", run.turn(), self.max_turns);
-                    }
-
-                    // Record run-level completion + usage onto the agent span, but
-                    // only when we created it — never pollute a caller-supplied
-                    // outer span (parity with the streaming driver's guard).
-                    if created_agent_span {
-                        let usage = response.usage;
-                        agent_span.record("gen_ai.completion", &response.output);
-                        agent_span.record("gen_ai.usage.input_tokens", usage.input_tokens);
-                        agent_span.record("gen_ai.usage.output_tokens", usage.output_tokens);
-                        agent_span.record(
-                            "gen_ai.usage.cache_read.input_tokens",
-                            usage.cached_input_tokens,
-                        );
-                        agent_span.record(
-                            "gen_ai.usage.cache_creation.input_tokens",
-                            usage.cache_creation_input_tokens,
-                        );
-                        agent_span.record(
-                            "gen_ai.usage.tool_use_prompt_tokens",
-                            usage.tool_use_prompt_tokens,
-                        );
-                        agent_span.record("gen_ai.usage.reasoning_tokens", usage.reasoning_tokens);
-                    }
-
-                    append_run_messages(
-                        memory_handle.as_ref(),
-                        response.messages.clone().unwrap_or_default(),
-                    )
-                    .await;
-
-                    return Ok(response);
-                }
+        let mut response = None;
+        while let Some(item) = driver.next().await {
+            match item {
+                Ok(DriveItem::Done { response: done, .. }) => response = Some(*done),
+                Ok(DriveItem::Item(_)) => {}
+                Err(err) => return Err(streaming_error_into_prompt(err)),
             }
         }
+
+        // The engine yields `Done` unless it errored (handled above).
+        response.ok_or_else(|| {
+            PromptError::CompletionError(CompletionError::ResponseError(
+                "agent run ended without producing a final response".to_string(),
+            ))
+        })
     }
 }
 

--- a/crates/rig-core/src/agent/runner.rs
+++ b/crates/rig-core/src/agent/runner.rs
@@ -349,8 +349,8 @@ where
     /// finishes, which may be completion order rather than call order. The
     /// persisted message history is unchanged.
     ///
-    /// A `concurrency` of 0 is clamped to 1: `buffered(0)` never makes progress,
-    /// so it would otherwise hang the run the first time the model calls a tool.
+    /// A `concurrency` of 0 is clamped to 1; `0` and `1` both run a turn's tools
+    /// sequentially (the `buffer_unordered` path is used only at `concurrency > 1`).
     pub fn tool_concurrency(mut self, concurrency: usize) -> Self {
         self.concurrency = concurrency.max(1);
         self
@@ -1388,7 +1388,8 @@ mod tests {
 
     /// Even with `run()` executing tools concurrently, the tool-result order —
     /// and so the whole message history — matches the sequential streaming
-    /// driver. (`run()` uses `buffered`, which preserves call order.)
+    /// driver. (`run()` runs tools with `buffer_unordered` but writes each result
+    /// into its original call-index slot, so results still land in call order.)
     #[tokio::test]
     async fn run_and_stream_same_message_history_for_parallel_tool_calls() {
         let blocking_model = MockCompletionModel::from_turns([
@@ -1448,10 +1449,11 @@ mod tests {
         );
     }
 
-    /// A tool whose first-*called* invocation completes *after* the second, so a
-    /// completion-ordered combinator (`buffer_unordered`) would reorder results
-    /// while call-ordered `buffered` does not. The first call (in poll/call
-    /// order) waits on a gate the second call releases.
+    /// A tool whose first-*called* invocation completes *after* the second, so
+    /// `buffer_unordered` yields the results in completion order — yet the
+    /// persisted history stays in call order because each result is written into
+    /// its original call-index slot. The first call (in poll/call order) waits on
+    /// a gate the second call releases.
     #[derive(Clone)]
     struct OutOfOrderTool {
         gate: Arc<tokio::sync::Notify>,
@@ -1481,10 +1483,11 @@ mod tests {
         }
     }
 
-    /// `run()` must surface tool results in tool-call (emission) order even when
-    /// tools complete out of order under concurrency — i.e. it uses `buffered`,
-    /// not `buffer_unordered`. (This is what keeps its message history identical
-    /// to the sequential streaming driver.)
+    /// `run()` must persist tool results in tool-call (emission) order even when
+    /// tools complete out of order under concurrency — it runs them with
+    /// `buffer_unordered` but reindexes each result into its original call-index
+    /// slot. (This is what keeps its message history identical to the sequential
+    /// streaming driver.)
     #[tokio::test]
     async fn run_preserves_tool_call_order_under_out_of_order_completion() {
         let model = MockCompletionModel::from_turns([
@@ -2105,11 +2108,18 @@ mod tests {
             .add_hook(TerminateOnFirstToolHook)
             .stream()
             .await;
+        let mut saw_error = false;
         while let Some(item) = stream.next().await {
-            if item.is_err() {
+            if let Err(err) = item {
+                saw_error = true;
+                assert!(
+                    err.to_string().contains("stop"),
+                    "stream() should surface the terminate reason, got: {err}"
+                );
                 break;
             }
         }
+        assert!(saw_error, "stream() must surface the terminate error");
         assert_eq!(
             streaming_calls.load(SeqCst),
             1,
@@ -2117,10 +2127,10 @@ mod tests {
         );
     }
 
-    /// `tool_concurrency(0)` is clamped to 1. Without the clamp the blocking
-    /// driver's `buffered(0)` never makes progress, so the run would hang the
-    /// first time the model calls a tool. The timeout turns a regression
-    /// (dropping the `.max(1)`) into a clean failure rather than a silent hang.
+    /// `tool_concurrency(0)` is clamped to 1 and runs to completion. The timeout
+    /// guards against a regression that lets `concurrency == 0` reach a
+    /// `buffer_unordered(0)` (which never makes progress) instead of the
+    /// sequential `concurrency <= 1` path.
     #[tokio::test]
     async fn tool_concurrency_zero_is_clamped_and_does_not_hang() {
         let model = MockCompletionModel::from_turns([
@@ -2137,7 +2147,7 @@ mod tests {
 
         let response = tokio::time::timeout(std::time::Duration::from_secs(5), run)
             .await
-            .expect("tool_concurrency(0) must clamp to 1, not hang on buffered(0)")
+            .expect("tool_concurrency(0) must clamp to 1, not hang on buffer_unordered(0)")
             .expect("run should succeed");
         assert_eq!(response.output, "done");
     }

--- a/crates/rig-core/src/agent/runner.rs
+++ b/crates/rig-core/src/agent/runner.rs
@@ -495,10 +495,12 @@ where
 /// proceeding on failure. Shared `Done`-arm behavior for both drivers.
 pub(crate) async fn append_run_messages(
     memory_handle: Option<&(Arc<dyn ConversationMemory>, String)>,
-    messages: Vec<Message>,
+    messages: &[Message],
 ) {
+    // Clone into an owned vec only when there is a backend to append to — the
+    // common no-memory path pays nothing.
     if let Some((memory, id)) = memory_handle
-        && let Err(err) = memory.append(id, messages).await
+        && let Err(err) = memory.append(id, messages.to_vec()).await
     {
         tracing::warn!(
             error = %err,
@@ -818,8 +820,9 @@ where
         calls: Vec<PendingToolCall>,
     ) -> DriveStream<'a, M::Response> {
         // The blocking surface chains tool spans into its linear `follows_from`
-        // sequence (chat -> tool -> chat).
-        drive_tool_calls(runner, run, calls, |span| self.chain_span(span))
+        // sequence (chat -> tool -> chat), and discards the yielded items, so it
+        // skips building them.
+        drive_tool_calls(runner, run, calls, |span| self.chain_span(span), false)
     }
 
     fn record_run_level_telemetry(
@@ -1323,7 +1326,15 @@ mod tests {
             tracing::callsite::rebuild_interest_cache();
             captured.clear();
 
-            let outer = tracing::info_span!("outer");
+            // Declare the fields the guard protects so a regression (recording
+            // onto a caller span) is actually observable rather than a silent
+            // no-op on an undeclared field.
+            let outer = tracing::info_span!(
+                "outer",
+                gen_ai.completion = tracing::field::Empty,
+                gen_ai.usage.input_tokens = tracing::field::Empty,
+                gen_ai.usage.output_tokens = tracing::field::Empty,
+            );
             async {
                 let agent = AgentBuilder::new(tool_then_text_model())
                     .tool(MockAddTool)
@@ -1354,6 +1365,10 @@ mod tests {
                     .iter()
                     .all(|name| !name.starts_with("gen_ai.usage.")),
                 "run-level usage must not be recorded onto a caller-supplied outer span"
+            );
+            assert!(
+                !outer_span.field_names.contains("gen_ai.completion"),
+                "run-level completion must not be recorded onto a caller-supplied outer span"
             );
         }
     }

--- a/crates/rig-core/src/agent/runner.rs
+++ b/crates/rig-core/src/agent/runner.rs
@@ -30,18 +30,19 @@ use std::sync::{
     atomic::{AtomicU64, Ordering},
 };
 
-use futures::{Stream, StreamExt, stream};
+use futures::StreamExt;
 use tracing::{Instrument, info_span, span::Id};
 
 use super::{
     completion::{Agent, DynamicContextStore, PreparedCompletionRequest},
     hook::{AgentHook, Flow, HookStack, InvalidToolCallHookAction, RequestOverride, StepEvent},
     prompt_request::{
-        PromptResponse, tool_result_message, tool_result_output,
+        PromptResponse,
         streaming::{
             DriveItem, DriveStream, MultiTurnStreamItem, StreamingError, TurnSource, drive_agent,
-            streaming_error_into_prompt,
+            drive_tool_calls, streaming_error_into_prompt,
         },
+        tool_result_message, tool_result_output,
     },
     run::{
         AgentRun, DEFAULT_OUTPUT_RETRIES, ModelTurn, ModelTurnOutcome, OutputMode, PendingToolCall,
@@ -430,7 +431,10 @@ pub(crate) fn build_agent_run(
 /// already inside a span we adopt it and report `false`, so the driver can avoid
 /// recording run-level usage onto a span it does not own (see the
 /// `created_agent_span` guard in both drivers' `Done` handling).
-pub(crate) fn acquire_agent_span(agent_name: &str, preamble: Option<&str>) -> (tracing::Span, bool) {
+pub(crate) fn acquire_agent_span(
+    agent_name: &str,
+    preamble: Option<&str>,
+) -> (tracing::Span, bool) {
     if tracing::Span::current().is_disabled() {
         let span = info_span!(
             "invoke_agent",
@@ -654,63 +658,6 @@ pub(crate) fn new_execute_tool_span() -> tracing::Span {
     )
 }
 
-/// Execute a turn's tool calls with up to `concurrency` running at once,
-/// yielding each result **in tool-call (emission) order**.
-///
-/// Uses `buffered` (not `buffer_unordered`), so results land in call order
-/// regardless of `concurrency` — keeping the blocking driver's message history
-/// deterministic. The streaming driver uses a completion-ordered stream for
-/// user-facing events, then reassembles the same call-ordered history before the
-/// next model turn. Each call runs inside its paired span; pre-resolved calls —
-/// those suppressed by invalid tool-call recovery — return their stored result
-/// without executing.
-pub(crate) fn execute_tools_buffered<'a, M>(
-    hooks: &'a HookStack<M>,
-    tool_server: &'a ToolServerHandle,
-    tool_extensions: &'a ToolCallExtensions,
-    calls: Vec<(PendingToolCall, tracing::Span)>,
-    error_history: &'a [Message],
-    concurrency: usize,
-) -> impl Stream<Item = Result<UserContent, PromptError>> + 'a
-where
-    M: CompletionModel,
-{
-    stream::iter(calls)
-        .map(move |(pending, tool_span)| {
-            async move {
-                let PendingToolCall {
-                    tool_call,
-                    preresolved_result,
-                    internal_call_id,
-                } = pending;
-                // Tool calls suppressed by invalid tool-call recovery come
-                // pre-resolved and must not execute.
-                if let Some(result) = preresolved_result {
-                    return Ok(result);
-                }
-                // Reuse the call's correlation id when it arrived via a streamed
-                // turn (so the blocking driver keeps the ids a consumer already
-                // saw), otherwise mint a fresh one — matching the prior
-                // always-fresh blocking behavior when none is present.
-                let internal_call_id = internal_call_id.unwrap_or_else(crate::id::generate);
-                run_single_tool(
-                    hooks,
-                    tool_server,
-                    tool_extensions,
-                    &tool_call,
-                    &internal_call_id,
-                    error_history,
-                )
-                .await
-            }
-            .instrument(tool_span)
-        })
-        // `buffered` (not `buffer_unordered`) so results land in tool-call
-        // emission order — matching the streaming driver's persisted history
-        // order, so both produce the same message history even at concurrency > 1.
-        .buffered(concurrency)
-}
-
 /// [`TurnSource`] for the blocking surface: each turn issues a unary
 /// `model.completion()` request and feeds the whole response into the machine.
 /// Emits no intermediate items (the blocking surface folds the engine to its
@@ -867,46 +814,9 @@ where
         run: &'a mut AgentRun,
         calls: Vec<PendingToolCall>,
     ) -> DriveStream<'a, M::Response> {
-        Box::pin(async_stream::stream! {
-            // Materialize the diagnostic history once; tools only read it on a
-            // hook-terminate error path, so every tool future shares a single
-            // borrow instead of deep-cloning the conversation per call.
-            let full_history_for_errors = run.full_history();
-
-            // Build a `follows_from`-chained span per call, in call order, then
-            // hand the calls to the buffered executor.
-            let calls_with_spans: Vec<(PendingToolCall, tracing::Span)> = calls
-                .into_iter()
-                .map(|pending| (pending, self.chain_span(new_execute_tool_span())))
-                .collect();
-
-            let tool_results = execute_tools_buffered(
-                &runner.hooks,
-                &runner.tool_server_handle,
-                &runner.tool_extensions,
-                calls_with_spans,
-                &full_history_for_errors,
-                runner.concurrency,
-            )
-            .collect::<Vec<Result<UserContent, PromptError>>>()
-            .await;
-
-            let mut tool_content = Vec::with_capacity(tool_results.len());
-            for result in tool_results {
-                match result {
-                    Ok(content) => tool_content.push(content),
-                    Err(err) => {
-                        yield Err(StreamingError::Prompt(Box::new(err)));
-                        return;
-                    }
-                }
-            }
-
-            if let Err(err) = run.tool_results(tool_content) {
-                yield Err(Box::new(err).into());
-                return;
-            }
-        })
+        // The blocking surface chains tool spans into its linear `follows_from`
+        // sequence (chat -> tool -> chat).
+        drive_tool_calls(runner, run, calls, |span| self.chain_span(span))
     }
 
     fn record_run_level_telemetry(
@@ -1370,7 +1280,8 @@ mod tests {
             let spans = captured.snapshot();
 
             // The blocking chat span is named "chat" (NOT "chat_streaming").
-            let chat_spans: Vec<&CapturedSpan> = spans.iter().filter(|s| s.name == "chat").collect();
+            let chat_spans: Vec<&CapturedSpan> =
+                spans.iter().filter(|s| s.name == "chat").collect();
             assert_eq!(chat_spans.len(), 2, "two model turns -> two chat spans");
             assert!(
                 spans.iter().all(|s| s.name != "chat_streaming"),

--- a/crates/rig-core/src/agent/runner.rs
+++ b/crates/rig-core/src/agent/runner.rs
@@ -2047,6 +2047,75 @@ mod tests {
         );
     }
 
+    /// Terminates the run from the `ToolCall` event of the first tool only
+    /// (`x == 1`), letting any later tool through.
+    struct TerminateOnFirstToolHook;
+    impl<M: CompletionModel> AgentHook<M> for TerminateOnFirstToolHook {
+        async fn on_event(&self, event: StepEvent<'_, M>) -> Flow {
+            if let StepEvent::ToolCall { args, .. } = event
+                && serde_json::from_str::<serde_json::Value>(args)
+                    .ok()
+                    .and_then(|v| v.get("x").and_then(serde_json::Value::as_i64))
+                    == Some(1)
+            {
+                return Flow::Terminate {
+                    reason: "stop".to_string(),
+                };
+            }
+            Flow::cont()
+        }
+    }
+
+    /// At the default `tool_concurrency(1)`, run() and stream() are lock-step on
+    /// a terminating multi-tool turn: when an early tool's hook terminates the
+    /// run, neither driver dispatches the remaining tools (the second tool's
+    /// `call` never runs). The pre-refactor blocking driver drained the whole
+    /// `buffered(1)` batch (so the second tool DID run); unifying both surfaces
+    /// onto one sequential path makes them match — and makes the lock-step
+    /// `tool_concurrency` documents actually hold for this case.
+    #[tokio::test]
+    async fn default_concurrency_terminate_stops_remaining_tools_on_both_drivers() {
+        let blocking_calls = Arc::new(AtomicU32::new(0));
+        AgentBuilder::new(two_terminating_tools_blocking_model())
+            .tool(CountingAddTool {
+                calls: blocking_calls.clone(),
+            })
+            .build()
+            .runner("go")
+            .max_turns(3)
+            .add_hook(TerminateOnFirstToolHook)
+            .run()
+            .await
+            .expect_err("the run terminates");
+        assert_eq!(
+            blocking_calls.load(SeqCst),
+            0,
+            "blocking run() must not dispatch the second tool after the first terminates"
+        );
+
+        let streaming_calls = Arc::new(AtomicU32::new(0));
+        let mut stream = AgentBuilder::new(two_terminating_tools_streaming_model())
+            .tool(CountingAddTool {
+                calls: streaming_calls.clone(),
+            })
+            .build()
+            .runner("go")
+            .max_turns(3)
+            .add_hook(TerminateOnFirstToolHook)
+            .stream()
+            .await;
+        while let Some(item) = stream.next().await {
+            if item.is_err() {
+                break;
+            }
+        }
+        assert_eq!(
+            streaming_calls.load(SeqCst),
+            0,
+            "stream() must not dispatch the second tool after the first terminates"
+        );
+    }
+
     /// `tool_concurrency(0)` is clamped to 1. Without the clamp the blocking
     /// driver's `buffered(0)` never makes progress, so the run would hang the
     /// first time the model calls a tool. The timeout turns a regression

--- a/crates/rig-core/src/agent/runner.rs
+++ b/crates/rig-core/src/agent/runner.rs
@@ -2066,15 +2066,16 @@ mod tests {
         }
     }
 
-    /// At the default `tool_concurrency(1)`, run() and stream() are lock-step on
-    /// a terminating multi-tool turn: when an early tool's hook terminates the
-    /// run, neither driver dispatches the remaining tools (the second tool's
-    /// `call` never runs). The pre-refactor blocking driver drained the whole
-    /// `buffered(1)` batch (so the second tool DID run); unifying both surfaces
-    /// onto one sequential path makes them match — and makes the lock-step
-    /// `tool_concurrency` documents actually hold for this case.
+    /// Run-all-then-decide, lock-step across surfaces: on a multi-tool turn whose
+    /// first tool's hook terminates the run, both run() and stream() still
+    /// execute the remaining tools (each tool is independently hook-gated), then
+    /// surface the first-called terminate reason. The terminating tool's own body
+    /// never runs (its `ToolCall` hook fired first), so only the second tool's
+    /// `call` increments — identically on both surfaces and at any concurrency.
+    /// This restores the pre-refactor blocking `collect`-all semantics and
+    /// matches the dominant agent-framework behavior.
     #[tokio::test]
-    async fn default_concurrency_terminate_stops_remaining_tools_on_both_drivers() {
+    async fn default_concurrency_terminate_runs_remaining_tools_on_both_drivers() {
         let blocking_calls = Arc::new(AtomicU32::new(0));
         AgentBuilder::new(two_terminating_tools_blocking_model())
             .tool(CountingAddTool {
@@ -2089,8 +2090,8 @@ mod tests {
             .expect_err("the run terminates");
         assert_eq!(
             blocking_calls.load(SeqCst),
-            0,
-            "blocking run() must not dispatch the second tool after the first terminates"
+            1,
+            "blocking run() must still run the second tool before surfacing the terminate"
         );
 
         let streaming_calls = Arc::new(AtomicU32::new(0));
@@ -2111,8 +2112,8 @@ mod tests {
         }
         assert_eq!(
             streaming_calls.load(SeqCst),
-            0,
-            "stream() must not dispatch the second tool after the first terminates"
+            1,
+            "stream() must still run the second tool before surfacing the terminate"
         );
     }
 

--- a/crates/rig-core/src/agent/runner.rs
+++ b/crates/rig-core/src/agent/runner.rs
@@ -417,6 +417,88 @@ pub(crate) fn build_agent_run(
     run
 }
 
+/// Build (or adopt) the top-level `invoke_agent` span for a run, shared by the
+/// blocking and streaming drivers so the run-level span shape is defined once.
+///
+/// Returns the span plus whether it was newly created. When the caller is
+/// already inside a span we adopt it and report `false`, so the driver can avoid
+/// recording run-level usage onto a span it does not own (see the
+/// `created_agent_span` guard in both drivers' `Done` handling).
+pub(crate) fn acquire_agent_span(agent_name: &str, preamble: Option<&str>) -> (tracing::Span, bool) {
+    if tracing::Span::current().is_disabled() {
+        let span = info_span!(
+            "invoke_agent",
+            gen_ai.operation.name = "invoke_agent",
+            gen_ai.agent.name = agent_name,
+            gen_ai.system_instructions = preamble,
+            gen_ai.prompt = tracing::field::Empty,
+            gen_ai.completion = tracing::field::Empty,
+            gen_ai.usage.input_tokens = tracing::field::Empty,
+            gen_ai.usage.output_tokens = tracing::field::Empty,
+            gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
+            gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
+            gen_ai.usage.tool_use_prompt_tokens = tracing::field::Empty,
+            gen_ai.usage.reasoning_tokens = tracing::field::Empty,
+        );
+        (span, true)
+    } else {
+        (tracing::Span::current(), false)
+    }
+}
+
+/// Outcome of firing the `CompletionCall` hook for a turn.
+pub(crate) enum CompletionCallOutcome {
+    /// Proceed, optionally applying a per-turn request override.
+    Proceed(Option<RequestOverride>),
+    /// Terminate the run with this reason.
+    Terminate(String),
+}
+
+/// Fire the `CompletionCall` hook for a turn and resolve its [`Flow`]
+/// (fail-closed). Shared by the blocking and streaming drivers so this steering
+/// event fires identically on both; each driver surfaces `Terminate` in its own
+/// medium (a returned `Err` vs. a yielded error item).
+pub(crate) async fn resolve_completion_call<M>(
+    hooks: &HookStack<M>,
+    prompt: &Message,
+    history: &[Message],
+    turn: usize,
+) -> CompletionCallOutcome
+where
+    M: CompletionModel,
+{
+    match flow_into_completion_call(
+        hooks
+            .on_event(StepEvent::CompletionCall {
+                prompt,
+                history,
+                turn,
+            })
+            .await,
+    ) {
+        CompletionCallDecision::Terminate(reason) => CompletionCallOutcome::Terminate(reason),
+        CompletionCallDecision::Override(request) => CompletionCallOutcome::Proceed(Some(request)),
+        CompletionCallDecision::Proceed => CompletionCallOutcome::Proceed(None),
+    }
+}
+
+/// Append a finished run's messages to conversation memory, logging and
+/// proceeding on failure. Shared `Done`-arm behavior for both drivers.
+pub(crate) async fn append_run_messages(
+    memory_handle: Option<&(Arc<dyn ConversationMemory>, String)>,
+    messages: Vec<Message>,
+) {
+    if let Some((memory, id)) = memory_handle
+        && let Err(err) = memory.append(id, messages).await
+    {
+        tracing::warn!(
+            error = %err,
+            conversation_id = %id,
+            "conversation memory append failed; surfacing final response anyway"
+        );
+    }
+}
+
 /// Execute a single tool call, firing the `ToolCall` and `ToolResult` hooks and
 /// shaping the result. **Shared by the blocking and streaming drivers** so a
 /// tool call behaves identically in both: same hook events, same fail-closed
@@ -631,24 +713,8 @@ where
     /// [`PromptResponse`]. Hooks fire at every observable point; the first hook
     /// to terminate cancels the run.
     pub async fn run(self) -> Result<PromptResponse, PromptError> {
-        let agent_span = if tracing::Span::current().is_disabled() {
-            info_span!(
-                "invoke_agent",
-                gen_ai.operation.name = "invoke_agent",
-                gen_ai.agent.name = self.agent_name_or_default(),
-                gen_ai.system_instructions = self.preamble,
-                gen_ai.prompt = tracing::field::Empty,
-                gen_ai.completion = tracing::field::Empty,
-                gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.output_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
-                gen_ai.usage.tool_use_prompt_tokens = tracing::field::Empty,
-                gen_ai.usage.reasoning_tokens = tracing::field::Empty,
-            )
-        } else {
-            tracing::Span::current()
-        };
+        let (agent_span, created_agent_span) =
+            acquire_agent_span(self.agent_name_or_default(), self.preamble.as_deref());
 
         if let Some(text) = self.prompt.rag_text() {
             agent_span.record("gen_ai.prompt", text);
@@ -684,21 +750,13 @@ where
                         tracing::info!("Current conversation depth: {}/{}", turn, self.max_turns);
                     }
 
-                    let request_override = match flow_into_completion_call(
-                        self.hooks
-                            .on_event(StepEvent::CompletionCall {
-                                prompt: &prompt,
-                                history: &history,
-                                turn,
-                            })
-                            .await,
-                    ) {
-                        CompletionCallDecision::Terminate(reason) => {
-                            return Err(run.cancel_error(reason));
-                        }
-                        CompletionCallDecision::Override(request) => Some(request),
-                        CompletionCallDecision::Proceed => None,
-                    };
+                    let request_override =
+                        match resolve_completion_call(&self.hooks, &prompt, &history, turn).await {
+                            CompletionCallOutcome::Terminate(reason) => {
+                                return Err(run.cancel_error(reason));
+                            }
+                            CompletionCallOutcome::Proceed(request_override) => request_override,
+                        };
 
                     // Record this turn's base system prompt — the override-or-baseline
                     // preamble, before any output-mode augmentation the request
@@ -872,35 +930,34 @@ where
                         tracing::info!("Depth reached: {}/{}", run.turn(), self.max_turns);
                     }
 
-                    let usage = response.usage;
-                    agent_span.record("gen_ai.completion", &response.output);
-                    agent_span.record("gen_ai.usage.input_tokens", usage.input_tokens);
-                    agent_span.record("gen_ai.usage.output_tokens", usage.output_tokens);
-                    agent_span.record(
-                        "gen_ai.usage.cache_read.input_tokens",
-                        usage.cached_input_tokens,
-                    );
-                    agent_span.record(
-                        "gen_ai.usage.cache_creation.input_tokens",
-                        usage.cache_creation_input_tokens,
-                    );
-                    agent_span.record(
-                        "gen_ai.usage.tool_use_prompt_tokens",
-                        usage.tool_use_prompt_tokens,
-                    );
-                    agent_span.record("gen_ai.usage.reasoning_tokens", usage.reasoning_tokens);
-
-                    if let Some((memory, id)) = memory_handle.as_ref()
-                        && let Err(err) = memory
-                            .append(id, response.messages.clone().unwrap_or_default())
-                            .await
-                    {
-                        tracing::warn!(
-                            error = %err,
-                            conversation_id = %id,
-                            "conversation memory append failed; returning model response anyway"
+                    // Record run-level completion + usage onto the agent span, but
+                    // only when we created it — never pollute a caller-supplied
+                    // outer span (parity with the streaming driver's guard).
+                    if created_agent_span {
+                        let usage = response.usage;
+                        agent_span.record("gen_ai.completion", &response.output);
+                        agent_span.record("gen_ai.usage.input_tokens", usage.input_tokens);
+                        agent_span.record("gen_ai.usage.output_tokens", usage.output_tokens);
+                        agent_span.record(
+                            "gen_ai.usage.cache_read.input_tokens",
+                            usage.cached_input_tokens,
                         );
+                        agent_span.record(
+                            "gen_ai.usage.cache_creation.input_tokens",
+                            usage.cache_creation_input_tokens,
+                        );
+                        agent_span.record(
+                            "gen_ai.usage.tool_use_prompt_tokens",
+                            usage.tool_use_prompt_tokens,
+                        );
+                        agent_span.record("gen_ai.usage.reasoning_tokens", usage.reasoning_tokens);
                     }
+
+                    append_run_messages(
+                        memory_handle.as_ref(),
+                        response.messages.clone().unwrap_or_default(),
+                    )
+                    .await;
 
                     return Ok(response);
                 }
@@ -1085,6 +1142,276 @@ mod tests {
             serde_json::to_value(&blocking_messages).expect("serialize blocking"),
             serde_json::to_value(&streaming_messages).expect("serialize streaming"),
         );
+    }
+
+    /// Safety net for the streaming/non-streaming unification: pins the blocking
+    /// driver's span topology (span name, `invoke_agent` creation, the
+    /// `follows_from` chain, and `created_agent_span`-gated run-level usage) so a
+    /// later refactor onto a shared engine cannot silently drift it. The
+    /// streaming side is already pinned by `assert_stream_usage_recorded_on_chat_spans`.
+    mod span_safety_net {
+        use std::collections::{HashMap, HashSet};
+        use std::sync::{Arc, Mutex};
+
+        use tracing::Instrument;
+        use tracing::field::{Field, Visit};
+        use tracing::span::{Attributes, Record};
+        use tracing::{Id, Subscriber};
+        use tracing_subscriber::layer::{Context, SubscriberExt};
+        use tracing_subscriber::{Layer, Registry, registry::LookupSpan};
+
+        use crate::agent::AgentBuilder;
+        use crate::completion::Usage;
+        use crate::test_utils::{MockAddTool, MockCompletionModel, MockTurn};
+
+        #[derive(Clone)]
+        struct CapturedSpan {
+            id: u64,
+            name: String,
+            field_names: HashSet<String>,
+            u64_fields: HashMap<String, u64>,
+        }
+
+        #[derive(Clone, Default)]
+        struct Captured {
+            spans: Arc<Mutex<Vec<CapturedSpan>>>,
+            /// `(span, follows_from)` pairs recorded via `Span::follows_from`.
+            follows: Arc<Mutex<Vec<(u64, u64)>>>,
+        }
+
+        impl Captured {
+            fn insert(&self, id: &Id, name: &str) {
+                self.spans.lock().expect("spans").push(CapturedSpan {
+                    id: id.into_u64(),
+                    name: name.to_string(),
+                    field_names: HashSet::new(),
+                    u64_fields: HashMap::new(),
+                });
+            }
+
+            fn record(&self, id: &Id, names: HashSet<String>, u64s: HashMap<String, u64>) {
+                let id = id.into_u64();
+                if let Ok(mut spans) = self.spans.lock()
+                    && let Some(span) = spans.iter_mut().find(|s| s.id == id)
+                {
+                    span.field_names.extend(names);
+                    span.u64_fields.extend(u64s);
+                }
+            }
+
+            fn follows_from(&self, span: &Id, follows: &Id) {
+                self.follows
+                    .lock()
+                    .expect("follows")
+                    .push((span.into_u64(), follows.into_u64()));
+            }
+
+            fn clear(&self) {
+                self.spans.lock().expect("spans").clear();
+                self.follows.lock().expect("follows").clear();
+            }
+
+            fn snapshot(&self) -> Vec<CapturedSpan> {
+                self.spans.lock().expect("spans").clone()
+            }
+
+            fn follows_edges(&self) -> Vec<(u64, u64)> {
+                self.follows.lock().expect("follows").clone()
+            }
+        }
+
+        struct CaptureLayer {
+            captured: Captured,
+        }
+
+        impl<S> Layer<S> for CaptureLayer
+        where
+            S: Subscriber + for<'l> LookupSpan<'l>,
+        {
+            fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, _ctx: Context<'_, S>) {
+                self.captured.insert(id, attrs.metadata().name());
+            }
+
+            fn on_record(&self, span: &Id, values: &Record<'_>, _ctx: Context<'_, S>) {
+                let mut visitor = FieldVisitor::default();
+                values.record(&mut visitor);
+                self.captured.record(span, visitor.names, visitor.u64s);
+            }
+
+            fn on_follows_from(&self, span: &Id, follows: &Id, _ctx: Context<'_, S>) {
+                self.captured.follows_from(span, follows);
+            }
+        }
+
+        #[derive(Default)]
+        struct FieldVisitor {
+            names: HashSet<String>,
+            u64s: HashMap<String, u64>,
+        }
+
+        impl Visit for FieldVisitor {
+            fn record_u64(&mut self, field: &Field, value: u64) {
+                self.names.insert(field.name().to_string());
+                self.u64s.insert(field.name().to_string(), value);
+            }
+
+            fn record_str(&mut self, field: &Field, _value: &str) {
+                self.names.insert(field.name().to_string());
+            }
+
+            fn record_debug(&mut self, field: &Field, _value: &dyn std::fmt::Debug) {
+                self.names.insert(field.name().to_string());
+            }
+        }
+
+        fn usage(input: u64, output: u64) -> Usage {
+            Usage {
+                input_tokens: input,
+                output_tokens: output,
+                ..Usage::new()
+            }
+        }
+
+        /// Two-turn tool scenario: the blocking driver emits chat -> execute_tool
+        /// -> chat, exercising the `follows_from` chain.
+        fn tool_then_text_model() -> MockCompletionModel {
+            MockCompletionModel::from_turns([
+                MockTurn::tool_call("tc1", "add", serde_json::json!({"x": 2, "y": 3}))
+                    .with_usage(usage(7, 11)),
+                MockTurn::text("the answer is 5").with_usage(usage(13, 17)),
+            ])
+        }
+
+        /// Register the blocking driver's span callsites against the scoped
+        /// subscriber before asserting, mirroring the streaming usage test's
+        /// interest-cache warm-up (a foreign thread without our subscriber can
+        /// otherwise cache `Interest::never` for these callsites).
+        async fn warm_blocking_callsites() {
+            let agent = AgentBuilder::new(tool_then_text_model())
+                .tool(MockAddTool)
+                .build();
+            let _ = agent.runner("add 2 and 3").max_turns(3).run().await;
+        }
+
+        #[tokio::test]
+        async fn run_records_usage_and_chains_chat_spans_on_a_created_agent_span() {
+            let _isolation = crate::test_utils::scoped_tracing_subscriber_guard().await;
+            let captured = Captured::default();
+            let subscriber = Registry::default().with(CaptureLayer {
+                captured: captured.clone(),
+            });
+            let _default = tracing::subscriber::set_default(subscriber);
+
+            warm_blocking_callsites().await;
+            tracing::callsite::rebuild_interest_cache();
+            captured.clear();
+
+            let agent = AgentBuilder::new(tool_then_text_model())
+                .tool(MockAddTool)
+                .build();
+            let response = agent
+                .runner("add 2 and 3")
+                .max_turns(3)
+                .run()
+                .await
+                .expect("blocking run should succeed");
+            assert_eq!(response.output, "the answer is 5");
+
+            let spans = captured.snapshot();
+
+            // The blocking chat span is named "chat" (NOT "chat_streaming").
+            let chat_spans: Vec<&CapturedSpan> = spans.iter().filter(|s| s.name == "chat").collect();
+            assert_eq!(chat_spans.len(), 2, "two model turns -> two chat spans");
+            assert!(
+                spans.iter().all(|s| s.name != "chat_streaming"),
+                "blocking driver must not emit chat_streaming spans"
+            );
+
+            // A run with no ambient span creates its own invoke_agent span...
+            let agent_span = spans
+                .iter()
+                .find(|s| s.name == "invoke_agent")
+                .expect("blocking run should create an invoke_agent span");
+
+            // ...and records aggregate usage + completion onto it (created_agent_span).
+            assert_eq!(
+                agent_span.u64_fields.get("gen_ai.usage.input_tokens"),
+                Some(&(7 + 13)),
+            );
+            assert_eq!(
+                agent_span.u64_fields.get("gen_ai.usage.output_tokens"),
+                Some(&(11 + 17)),
+            );
+            assert!(
+                agent_span.field_names.contains("gen_ai.completion"),
+                "the created agent span records the final completion text"
+            );
+
+            // The blocking driver links chat/tool spans into a linear
+            // follows_from chain (chat#1 -> execute_tool -> chat#2); the
+            // streaming driver does not, so this is a blocking-only invariant the
+            // unification must keep.
+            let tool_span = spans
+                .iter()
+                .find(|s| s.name == "execute_tool")
+                .expect("tool turn should emit an execute_tool span");
+            let edges = captured.follows_edges();
+            assert!(
+                edges.contains(&(tool_span.id, chat_spans[0].id)),
+                "execute_tool should follow_from the first chat span; edges={edges:?}"
+            );
+            assert!(
+                edges.contains(&(chat_spans[1].id, tool_span.id)),
+                "the second chat span should follow_from execute_tool; edges={edges:?}"
+            );
+        }
+
+        #[tokio::test]
+        async fn run_does_not_record_usage_onto_a_caller_supplied_outer_span() {
+            let _isolation = crate::test_utils::scoped_tracing_subscriber_guard().await;
+            let captured = Captured::default();
+            let subscriber = Registry::default().with(CaptureLayer {
+                captured: captured.clone(),
+            });
+            let _default = tracing::subscriber::set_default(subscriber);
+
+            warm_blocking_callsites().await;
+            tracing::callsite::rebuild_interest_cache();
+            captured.clear();
+
+            let outer = tracing::info_span!("outer");
+            async {
+                let agent = AgentBuilder::new(tool_then_text_model())
+                    .tool(MockAddTool)
+                    .build();
+                agent
+                    .runner("add 2 and 3")
+                    .max_turns(3)
+                    .run()
+                    .await
+                    .expect("blocking run should succeed");
+            }
+            .instrument(outer)
+            .await;
+
+            let spans = captured.snapshot();
+            // Under an ambient span the driver adopts it; no invoke_agent is created.
+            assert!(
+                spans.iter().all(|s| s.name != "invoke_agent"),
+                "an ambient outer span should be adopted, not wrapped in invoke_agent"
+            );
+            let outer_span = spans
+                .iter()
+                .find(|s| s.name == "outer")
+                .expect("outer span should be captured");
+            assert!(
+                outer_span
+                    .field_names
+                    .iter()
+                    .all(|name| !name.starts_with("gen_ai.usage.")),
+                "run-level usage must not be recorded onto a caller-supplied outer span"
+            );
+        }
     }
 
     fn tool_call_content(id: &str, args: serde_json::Value) -> AssistantContent {


### PR DESCRIPTION
## Summary

The non-streaming (`AgentRunner::run`) and streaming (`AgentRunner::stream`) agent
drivers each hand-rolled their own ~drive loop around the shared sans-IO
`AgentRun` machine — two near-identical loops that had to be kept in lock-step by
hand (the recurring source of run/stream drift). This collapses them onto **one
shared engine**, `drive_agent`, leaving only the genuinely irreducible per-medium
piece — the model transport — behind a small `TurnSource` trait.

After this change both surfaces share the entire loop: outer `next_step`
dispatch, the `CompletionCall` hook + request preparation, invalid tool-call
recovery wiring, tool execution, conversation memory, and finalization. `run()`
is now a fold over the engine; `stream()` forwards it.

This continues the driver-unification arc started by the `AgentRun` extraction
(#1899): that landed the shared *decision* machine; this lands the shared *driver*.

## How it's structured (reviewable commit-by-commit)

1. **Extract shared helpers; pin blocking span topology.** `acquire_agent_span`,
   `resolve_completion_call`, `append_run_messages` are shared by both drivers.
   Adds a span safety-net test pinning `run()`'s span shape (name `chat`,
   `invoke_agent` creation, the `follows_from` chain, and `created_agent_span`-gated
   usage) so the later cutover can't silently drift it — the streaming side was
   already pinned by `assert_stream_usage_recorded_on_chat_spans`.

2. **Introduce `drive_agent` + `TurnSource`; route streaming through it.** The
   medium-independent outer loop lives in `drive_agent`; `StreamingTurnSource`
   holds the assembler-driven turn, per-delta hot-path gating, mid-stream
   invalid-tool recovery, and the `chat_streaming` span. `stream()` becomes a thin
   shell.

3. **Drive `run()` as a fold over the engine.** `UnaryTurnSource` keeps the unary
   `model.completion()` transport, the `chat` span + `follows_from` chain, and
   run-level recording. `run()` folds `drive_agent` to its `Done` item.

4. **Unify tool execution into `drive_tool_calls`.** One implementation for both
   surfaces (the span-chaining difference is a closure parameter); the
   blocking-only `execute_tools_buffered` is deleted.

## What is deliberately *not* unified

The `CallModel` transport stays two-bodied behind `TurnSource`: streaming advances
the machine incrementally (`record_streamed_completion_call` / `streamed_turn` /
`resolve_streamed_invalid_tool_call`) while yielding deltas mid-stream, whereas
the unary path feeds a whole `ModelTurn` to `model_response`. That divergence is
intrinsic to the medium and is the one thing the trait isolates rather than
shares. Transport is kept decoupled from surface on purpose — `run()` still issues
a unary provider call (no "completion = drain the stream"), so providers whose
streaming and non-streaming endpoints differ see byte-identical behavior.

## Behavior changes (all intentional, called out for review)

- **Outer-span usage guard.** `run()` previously recorded run-level
  usage/completion onto a *caller-supplied* outer span unconditionally; it now
  guards on `created_agent_span`, matching `stream()`. A caller-owned span is no
  longer polluted. (No test pinned the old behavior; a new test pins the new one.)
- **Setup errors are surfaced.** A provider-stream / request-build error inside
  the streaming generator was silently swallowed by `?` (whose `Err` ends an
  `async_stream!` without yielding); these now surface as an error item, which
  the blocking fold also needs.
- **Cosmetic logs.** `run()`'s per-turn log now reads "Current conversation
  Turns: n/m" (was "…depth…"); the blocking "Depth reached" and streaming "Agent
  multi-turn stream finished" run-completion markers are unified into one shared
  "Agent run finished" event.
- **Blocking tool execution at `tool_concurrency > 1`** now uses
  `buffer_unordered` + call-order reindex (was `buffered`). Persisted history
  stays call-ordered; only internal completion ordering differs (unobservable to
  `run()`).
- **Multi-tool terminate → run-all-then-decide (streaming change only).** When a
  turn emits several tool calls and one tool's hook returns `Flow::Terminate`,
  both surfaces now run **all** of the turn's tools (each independently
  hook-gated, firing its hooks) before surfacing the lowest-call-index terminate
  error. `run()` is unchanged — this restores its pre-refactor `buffered(1)` +
  `collect`-all semantics; the change is that `stream()` no longer stops early at
  `tool_concurrency(1)`. This makes the two lock-step at **any** concurrency and
  matches the dominant agent-framework behavior (semantic-kernel, LangGraph,
  Vercel AI SDK, LangChain, pydantic-ai all run-all for a deliberate abort; only
  openai-agents short-circuits). Streaming's *surfaced items* are unchanged (post-
  error items are suppressed exactly as before); only a sibling's tool body +
  hooks now run. Pinned by a regression test.

## Invariants preserved

- Public API unchanged: `AgentRunner::run`/`stream`, `MultiTurnStreamItem`,
  `FinalResponse`, `PromptResponse`, the hook surface, and the sans-IO `AgentRun`
  surface keep their signatures. The new engine types are `pub(crate)`.
- The sans-IO serialize/resume keystone is untouched — `AgentRun` remains the
  sole owner of serializable state; `TurnSource`/sources hold only per-call
  presentation ephemera.
- R1 span identity: per-turn usage stays on the chat span and run-level recording
  on the agent span, each per-medium; `stream()` instruments the engine with the
  agent span, `run()` runs under the ambient span (agent span detached + linear
  `follows_from` chain). `test_span_context_isolation` semantics preserved.
- WASM: the new trait and `DriveStream` alias use the existing `WasmCompatSend`
  markers and cfg'd `Send` bounds; no `tokio`, no spawn.

## Testing

- `cargo test -p rig-core` — 1052 passed, 0 failed (incl. the full run/stream
  parity suite, the streaming usage-span tests, and the new blocking span test).
- `cargo clippy -p rig-core --all-targets` — clean (workspace's strict lint set).
- `cargo fmt` — clean.
- `cargo test -p rig --all-features --test gemini agent_run` (cassette replay) —
  18 passed, 0 failed (covers `agent_run_streamed::*`, `agent_run_resume::*`
  serialized-state resume, recovery, and hand-driven stepping — both streaming
  and non-streaming through real Gemini response shapes).

## Follow-ups enabled (not in this PR)

Because transport and surface are now independent type parameters of one engine,
two new capabilities fall out of a one-line type swap and could be added later as
additive API: streaming agent-level events over a *non-streaming* model
(`CompletionCall` + `FinalResponse`, no token deltas), and collecting a final
`PromptResponse` over a *streaming-only* provider. Left out here to keep the PR
focused on the refactor and free of new public surface.

This is a large diff for a refactor; happy to split it (e.g. land commits 1–2,
then 3–4) if the maintainers prefer smaller PRs.
