### PR TITLE
refactor(agent): unify streaming/non-streaming seams; fix Anthropic streaming output_schema drop

### DIFF
--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -11,6 +11,72 @@ use crate::{
 use serde::{Deserialize, Serialize};
 use std::{future::IntoFuture, marker::PhantomData};
 
+/// Generate the request-builder setters that forward verbatim to an inner
+/// receiver — `AgentRunner` for the blocking builder, the wrapped
+/// `PromptRequest` for the typed builder. Only the setters whose signature *and*
+/// documentation are identical across builders live here; `max_turns` and
+/// `add_hook`, whose docs are builder-specific, stay hand-written. `$recv` is
+/// the field name to delegate through (`runner` or `inner`).
+macro_rules! forward_prompt_setters {
+    ($recv:ident) => {
+        /// Execute up to `concurrency` of a turn's tool calls at once.
+        ///
+        /// See [`AgentRunner::tool_concurrency`] for ordering guarantees: persisted
+        /// history remains in tool-call order, while streaming requests may surface
+        /// tool results in completion order.
+        pub fn tool_concurrency(mut self, concurrency: usize) -> Self {
+            self.$recv = self.$recv.tool_concurrency(concurrency);
+            self
+        }
+
+        /// Attach a per-call [`ToolCallExtensions`] for this request.
+        ///
+        /// Every tool the agent executes during this request can read the
+        /// caller-provided values (auth tokens, session IDs, conversation state, …)
+        /// via [`Tool::call_with_extensions`](crate::tool::Tool::call_with_extensions),
+        /// without the model ever seeing them.
+        pub fn tool_extensions(mut self, extensions: ToolCallExtensions) -> Self {
+            self.$recv = self.$recv.tool_extensions(extensions);
+            self
+        }
+
+        /// Add chat history to the prompt request.
+        pub fn history<H, Item>(mut self, history: H) -> Self
+        where
+            H: IntoIterator<Item = Item>,
+            Item: Into<Message>,
+        {
+            self.$recv = self.$recv.history(history);
+            self
+        }
+
+        /// Set the conversation id used to load and persist memory for this request.
+        ///
+        /// Overrides any default conversation id set on the agent. If memory is not
+        /// configured on the agent, this has no effect.
+        pub fn conversation(mut self, id: impl Into<String>) -> Self {
+            self.$recv = self.$recv.conversation(id);
+            self
+        }
+
+        /// Disable conversation memory for this request.
+        ///
+        /// History will neither be loaded from nor saved to the agent's memory backend.
+        pub fn without_memory(mut self) -> Self {
+            self.$recv = self.$recv.without_memory();
+            self
+        }
+
+        /// Set the retry budget for invalid tool-call recovery.
+        ///
+        /// Invalid tool-call retries also consume normal multi-turn depth.
+        pub fn max_invalid_tool_call_retries(mut self, retries: usize) -> Self {
+            self.$recv = self.$recv.max_invalid_tool_call_retries(retries);
+            self
+        }
+    };
+}
+
 pub trait PromptType {}
 pub struct Standard;
 pub struct Extended;
@@ -76,54 +142,6 @@ where
         self
     }
 
-    /// Execute up to `concurrency` of a turn's tool calls at once.
-    ///
-    /// See [`AgentRunner::tool_concurrency`] for ordering guarantees: persisted
-    /// history remains in tool-call order, while streaming requests may surface
-    /// tool results in completion order.
-    pub fn tool_concurrency(mut self, concurrency: usize) -> Self {
-        self.runner = self.runner.tool_concurrency(concurrency);
-        self
-    }
-
-    /// Attach a per-call [`ToolCallExtensions`] for this request.
-    ///
-    /// Every tool the agent executes during this request can read the
-    /// caller-provided values (auth tokens, session IDs, conversation state, …)
-    /// via [`Tool::call_with_extensions`](crate::tool::Tool::call_with_extensions),
-    /// without the model ever seeing them.
-    pub fn tool_extensions(mut self, extensions: ToolCallExtensions) -> Self {
-        self.runner = self.runner.tool_extensions(extensions);
-        self
-    }
-
-    /// Add chat history to the prompt request.
-    pub fn history<H, T>(mut self, history: H) -> Self
-    where
-        H: IntoIterator<Item = T>,
-        T: Into<Message>,
-    {
-        self.runner = self.runner.history(history);
-        self
-    }
-
-    /// Set the conversation id used to load and persist memory for this request.
-    ///
-    /// Overrides any default conversation id set on the agent. If memory is not
-    /// configured on the agent, this has no effect.
-    pub fn conversation(mut self, id: impl Into<String>) -> Self {
-        self.runner = self.runner.conversation(id);
-        self
-    }
-
-    /// Disable conversation memory for this request.
-    ///
-    /// History will neither be loaded from nor saved to the agent's memory backend.
-    pub fn without_memory(mut self) -> Self {
-        self.runner = self.runner.without_memory();
-        self
-    }
-
     /// Append a hook for this request (on top of any the agent already carries).
     /// Hooks run in registration order; the first to return a non-`Continue`
     /// result short-circuits the rest.
@@ -135,13 +153,7 @@ where
         self
     }
 
-    /// Set the retry budget for invalid tool-call recovery.
-    ///
-    /// Invalid tool-call retries also consume normal multi-turn depth.
-    pub fn max_invalid_tool_call_retries(mut self, retries: usize) -> Self {
-        self.runner = self.runner.max_invalid_tool_call_retries(retries);
-        self
-    }
+    forward_prompt_setters!(runner);
 }
 
 /// Due to: [RFC 2515](https://github.com/rust-lang/rust/issues/63063), we have to use a `BoxFuture`
@@ -522,62 +534,6 @@ where
         self
     }
 
-    /// Set the retry budget for invalid tool-call recovery.
-    ///
-    /// Invalid tool-call retries also consume normal multi-turn depth.
-    pub fn max_invalid_tool_call_retries(mut self, retries: usize) -> Self {
-        self.inner = self.inner.max_invalid_tool_call_retries(retries);
-        self
-    }
-
-    /// Execute up to `concurrency` of a turn's tool calls at once.
-    ///
-    /// See [`AgentRunner::tool_concurrency`] for ordering guarantees: persisted
-    /// history remains in tool-call order, while streaming requests may surface
-    /// tool results in completion order.
-    pub fn tool_concurrency(mut self, concurrency: usize) -> Self {
-        self.inner = self.inner.tool_concurrency(concurrency);
-        self
-    }
-
-    /// Attach a per-call [`ToolCallExtensions`] for this request.
-    ///
-    /// Every tool the agent executes during this request can read the
-    /// caller-provided values (auth tokens, session IDs, conversation state, …)
-    /// via [`Tool::call_with_extensions`](crate::tool::Tool::call_with_extensions),
-    /// without the model ever seeing them.
-    pub fn tool_extensions(mut self, extensions: ToolCallExtensions) -> Self {
-        self.inner = self.inner.tool_extensions(extensions);
-        self
-    }
-
-    /// Add chat history to the prompt request.
-    pub fn history<H, U>(mut self, history: H) -> Self
-    where
-        H: IntoIterator<Item = U>,
-        U: Into<Message>,
-    {
-        self.inner = self.inner.history(history);
-        self
-    }
-
-    /// Set the conversation id used to load and persist memory for this request.
-    ///
-    /// Overrides any default conversation id set on the agent. If memory is not
-    /// configured on the agent, this has no effect.
-    pub fn conversation(mut self, id: impl Into<String>) -> Self {
-        self.inner = self.inner.conversation(id);
-        self
-    }
-
-    /// Disable conversation memory for this request.
-    ///
-    /// History will neither be loaded from nor saved to the agent's memory backend.
-    pub fn without_memory(mut self) -> Self {
-        self.inner = self.inner.without_memory();
-        self
-    }
-
     /// Append a hook to this request's hook stack (on top of any the agent
     /// already carries).
     pub fn add_hook<H>(mut self, hook: H) -> Self
@@ -587,6 +543,8 @@ where
         self.inner = self.inner.add_hook(hook);
         self
     }
+
+    forward_prompt_setters!(inner);
 }
 
 /// Deserialize a typed structured response from the model's final text.

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -9,8 +9,8 @@ use crate::{
     },
     agent::runner::{
         AgentRunner, CompletionCallOutcome, InvalidDecision, acquire_agent_span,
-        append_run_messages, flow_into_invalid, new_execute_tool_span, observe_flow,
-        resolve_completion_call, run_single_tool,
+        append_run_messages, build_chat_span, flow_into_invalid, new_execute_tool_span,
+        observe_flow, resolve_completion_call, run_single_tool,
     },
     completion::GetTokenUsage,
     message::{AssistantContent, UserContent},
@@ -21,7 +21,6 @@ use crate::{
 use futures::{Stream, StreamExt, stream};
 use serde::{Deserialize, Serialize};
 use std::{collections::VecDeque, pin::Pin, sync::Arc};
-use tracing::info_span;
 use tracing_futures::Instrument;
 
 use super::{CompletionCall, PromptResponse};
@@ -318,6 +317,17 @@ where
     /// Set the maximum Turns for multi-turn conversations (the maximum number of
     /// turns an LLM can take calling tools before writing a text response).
     pub fn multi_turn(mut self, turns: usize) -> Self {
+        self.runner = self.runner.max_turns(turns);
+        self
+    }
+
+    /// Set the maximum number of turns for multi-turn tool-calling.
+    ///
+    /// Alias for [`Self::multi_turn`], named to match the blocking
+    /// [`PromptRequest::max_turns`](super::PromptRequest::max_turns) and
+    /// [`TypedPromptRequest::max_turns`](super::TypedPromptRequest::max_turns)
+    /// builders so the same call reads identically on either surface.
+    pub fn max_turns(mut self, turns: usize) -> Self {
         self.runner = self.runner.max_turns(turns);
         self
     }
@@ -944,26 +954,7 @@ where
         runner: &AgentRunner<M>,
         effective_preamble: Option<&str>,
     ) -> tracing::Span {
-        info_span!(
-            target: "rig::agent_chat",
-            parent: tracing::Span::current(),
-            "chat_streaming",
-            gen_ai.operation.name = "chat",
-            gen_ai.agent.name = runner.agent_name_or_default(),
-            gen_ai.system_instructions = effective_preamble,
-            gen_ai.provider.name = tracing::field::Empty,
-            gen_ai.request.model = tracing::field::Empty,
-            gen_ai.response.id = tracing::field::Empty,
-            gen_ai.response.model = tracing::field::Empty,
-            gen_ai.usage.output_tokens = tracing::field::Empty,
-            gen_ai.usage.input_tokens = tracing::field::Empty,
-            gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
-            gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
-            gen_ai.usage.tool_use_prompt_tokens = tracing::field::Empty,
-            gen_ai.usage.reasoning_tokens = tracing::field::Empty,
-            gen_ai.input.messages = tracing::field::Empty,
-            gen_ai.output.messages = tracing::field::Empty,
-        )
+        build_chat_span!(runner, effective_preamble, "chat_streaming")
     }
 
     fn run_model_turn<'a>(
@@ -999,6 +990,33 @@ where
             // whose invalid tool call was repaired is a recovered turn, so its
             // response-finish hook is suppressed.
             let mut turn_recovered = false;
+
+            // Emit the turn's single `CompletionCall` exactly once, recording its
+            // usage onto the chat span and into the run. Defined here (not a free
+            // fn) so it captures `completion_call_emitted`/`chat_span`/`run`; the
+            // `yield` stays at each call site because `async_stream::stream!`
+            // cannot see a `yield` produced inside a nested macro expansion.
+            // Returns the item to yield (`Some` the first time, `None` after), or
+            // the terminal error to surface.
+            macro_rules! emit_completion_call {
+                ($usage:expr) => {{
+                    let usage = $usage;
+                    if !completion_call_emitted {
+                        if usage.has_values() {
+                            record_usage_on_span(&chat_span, usage);
+                        }
+                        match run.record_streamed_completion_call(usage) {
+                            Ok(call) => {
+                                completion_call_emitted = true;
+                                Ok(Some(MultiTurnStreamItem::CompletionCall(call)))
+                            }
+                            Err(err) => Err(Box::new(err).into()),
+                        }
+                    } else {
+                        Ok(None)
+                    }
+                }};
+            }
 
             'turn: while let Some(item) = stream.next().await {
                 let item = match item {
@@ -1080,20 +1098,13 @@ where
                             ));
                         }
                         StreamedTurnEvent::Completed { usage, emit_final } => {
-                            if !completion_call_emitted {
-                                if usage.has_values() {
-                                    record_usage_on_span(&chat_span, usage);
+                            match emit_completion_call!(usage) {
+                                Ok(Some(item)) => yield Ok(item),
+                                Ok(None) => {}
+                                Err(err) => {
+                                    yield Err(err);
+                                    return;
                                 }
-                                let completion_call =
-                                    match run.record_streamed_completion_call(usage) {
-                                        Ok(call) => call,
-                                        Err(err) => {
-                                            yield Err(Box::new(err).into());
-                                            return;
-                                        }
-                                    };
-                                completion_call_emitted = true;
-                                yield Ok(MultiTurnStreamItem::CompletionCall(completion_call));
                             }
 
                             if emit_final
@@ -1181,22 +1192,13 @@ where
                                             return;
                                         }
                                     };
-                                    if !completion_call_emitted {
-                                        if drained_usage.has_values() {
-                                            record_usage_on_span(&chat_span, drained_usage);
+                                    match emit_completion_call!(drained_usage) {
+                                        Ok(Some(item)) => yield Ok(item),
+                                        Ok(None) => {}
+                                        Err(err) => {
+                                            yield Err(err);
+                                            return;
                                         }
-                                        let completion_call =
-                                            match run.record_streamed_completion_call(drained_usage) {
-                                                Ok(call) => call,
-                                                Err(err) => {
-                                                    yield Err(Box::new(err).into());
-                                                    return;
-                                                }
-                                            };
-                                        completion_call_emitted = true;
-                                        yield Ok(MultiTurnStreamItem::CompletionCall(
-                                            completion_call,
-                                        ));
                                     }
                                     if let Some(tool_result) = skipped_tool_result {
                                         yield Ok(MultiTurnStreamItem::StreamUserItem(
@@ -1224,16 +1226,18 @@ where
                 return;
             }
 
+            // Final fallback: no usage was ever learned, so there is nothing to
+            // record onto the span and this is the last read of the flag — kept
+            // inline (not `emit_completion_call!`) so it doesn't emit a dead
+            // `completion_call_emitted = true` write.
             if !completion_call_emitted {
-                let completion_call =
-                    match run.record_streamed_completion_call(crate::completion::Usage::new()) {
-                        Ok(call) => call,
-                        Err(err) => {
-                            yield Err(Box::new(err).into());
-                            return;
-                        }
-                    };
-                yield Ok(MultiTurnStreamItem::CompletionCall(completion_call));
+                match run.record_streamed_completion_call(crate::completion::Usage::new()) {
+                    Ok(call) => yield Ok(MultiTurnStreamItem::CompletionCall(call)),
+                    Err(err) => {
+                        yield Err(Box::new(err).into());
+                        return;
+                    }
+                }
             }
 
             let final_turn_content = stream.choice.clone();

--- a/crates/rig-core/src/agent/run/mod.rs
+++ b/crates/rig-core/src/agent/run/mod.rs
@@ -80,6 +80,25 @@ pub use streamed::{
     StreamedTurnAssembler, StreamedTurnEvent,
 };
 
+/// Build the canonical "the model called a tool that isn't available" error.
+/// The identical shape is raised from every recovery-rejection path
+/// (`resolve_invalid_tool_call`, `resolve_streamed_invalid_tool_call`) and the
+/// streamed fail-fast in `streamed_turn`; this collapses the copied struct
+/// literal to one place while leaving each caller's control flow untouched.
+fn unknown_tool_call_error(
+    tool_name: String,
+    available_tools: Vec<String>,
+    allowed_tools: Vec<String>,
+    chat_history: Vec<Message>,
+) -> PromptError {
+    PromptError::UnknownToolCall {
+        tool_name,
+        available_tools,
+        allowed_tools,
+        chat_history: Box::new(chat_history),
+    }
+}
+
 /// Default number of times Tool output mode re-prompts the model for valid
 /// structured output before finalizing best-effort (see #1928). Mirrors
 /// pydantic-ai's default output-retry budget of 1.
@@ -747,10 +766,7 @@ impl AgentRun {
             ));
         }
 
-        self.completion_calls
-            .push(CompletionCall::new(self.completion_call_index, turn.usage));
-        self.completion_call_index += 1;
-        self.usage += turn.usage;
+        self.record_completion_call(turn.usage);
 
         let items: Vec<AssistantContent> = turn.choice.iter().cloned().collect();
         let has_tool_calls = items
@@ -771,6 +787,41 @@ impl AgentRun {
         }));
 
         self.advance_resolution()
+    }
+
+    /// Record one provider completion call: assign it the next call index,
+    /// push it, and aggregate its usage into the run total. The single home for
+    /// this accounting arithmetic, shared by the non-streamed and streamed
+    /// ingestion paths. Callers own the once-per-turn `streamed_completion_call_recorded`
+    /// guard/flag; this helper never touches it, so it cannot be mistaken for
+    /// "a completion call happened" and re-introduce a double count.
+    fn record_completion_call(&mut self, usage: Usage) -> CompletionCall {
+        let call = CompletionCall::new(self.completion_call_index, usage);
+        self.completion_call_index += 1;
+        self.completion_calls.push(call);
+        self.usage += usage;
+        call
+    }
+
+    /// Park an accepted model turn in [`RunState::AwaitingAdvance`]. Both the
+    /// non-streamed (`advance_resolution`) and streamed (`streamed_turn`)
+    /// ingestion paths converge here, differing only in the `skipped` map and
+    /// the streamed `internal_call_ids`.
+    fn finalize_turn(
+        &mut self,
+        message_id: Option<String>,
+        items: Vec<AssistantContent>,
+        has_tool_calls: bool,
+        skipped: BTreeMap<String, UserContent>,
+        internal_call_ids: Vec<(String, String)>,
+    ) {
+        self.state = RunState::AwaitingAdvance(Box::new(TurnState {
+            message_id,
+            items,
+            has_tool_calls,
+            skipped,
+            internal_call_ids,
+        }));
     }
 
     /// Answer a pending [`ModelTurnOutcome::NeedsResolution`].
@@ -823,20 +874,20 @@ impl AgentRun {
             resolving.allowed_tool_names.iter().cloned().collect();
 
         match action {
-            InvalidToolCallHookAction::Fail => Err(PromptError::UnknownToolCall {
-                tool_name: tool_call.function.name,
-                available_tools: executable_tool_names,
-                allowed_tools: allowed_tool_names,
-                chat_history: Box::new(diagnostic_history),
-            }),
+            InvalidToolCallHookAction::Fail => Err(unknown_tool_call_error(
+                tool_call.function.name,
+                executable_tool_names,
+                allowed_tool_names,
+                diagnostic_history,
+            )),
             InvalidToolCallHookAction::Retry { feedback } => {
                 if self.invalid_tool_call_retries >= self.max_invalid_tool_call_retries {
-                    return Err(PromptError::UnknownToolCall {
-                        tool_name: tool_call.function.name,
-                        available_tools: executable_tool_names,
-                        allowed_tools: allowed_tool_names,
-                        chat_history: Box::new(diagnostic_history),
-                    });
+                    return Err(unknown_tool_call_error(
+                        tool_call.function.name,
+                        executable_tool_names,
+                        allowed_tool_names,
+                        diagnostic_history,
+                    ));
                 }
                 self.invalid_tool_call_retries += 1;
 
@@ -860,12 +911,12 @@ impl AgentRun {
             }
             InvalidToolCallHookAction::Repair { tool_name } => {
                 if !allowed_tool_names.contains(&tool_name) {
-                    return Err(PromptError::UnknownToolCall {
+                    return Err(unknown_tool_call_error(
                         tool_name,
-                        available_tools: executable_tool_names,
-                        allowed_tools: allowed_tool_names,
-                        chat_history: Box::new(diagnostic_history),
-                    });
+                        executable_tool_names,
+                        allowed_tool_names,
+                        diagnostic_history,
+                    ));
                 }
                 if let Some(AssistantContent::ToolCall(tool_call)) =
                     resolving.items.get_mut(resolving.next_index)
@@ -878,12 +929,12 @@ impl AgentRun {
             }
             InvalidToolCallHookAction::Skip { reason } => {
                 if matches!(self.tool_choice, Some(ToolChoice::None)) {
-                    return Err(PromptError::UnknownToolCall {
-                        tool_name: tool_call.function.name,
-                        available_tools: executable_tool_names,
-                        allowed_tools: allowed_tool_names,
-                        chat_history: Box::new(diagnostic_history),
-                    });
+                    return Err(unknown_tool_call_error(
+                        tool_call.function.name,
+                        executable_tool_names,
+                        allowed_tool_names,
+                        diagnostic_history,
+                    ));
                 }
                 let user_content = if let Some(call_id) = tool_call.call_id.clone() {
                     UserContent::tool_result_with_call_id(
@@ -1024,13 +1075,7 @@ impl AgentRun {
             }
         }
 
-        self.state = RunState::AwaitingAdvance(Box::new(TurnState {
-            message_id,
-            items,
-            has_tool_calls,
-            skipped,
-            internal_call_ids: Vec::new(),
-        }));
+        self.finalize_turn(message_id, items, has_tool_calls, skipped, Vec::new());
         Ok(ModelTurnOutcome::Continue {
             response_hook_suppressed: recovered,
         })
@@ -1067,11 +1112,7 @@ impl AgentRun {
         }
         self.streamed_completion_call_recorded = true;
 
-        let call = CompletionCall::new(self.completion_call_index, usage);
-        self.completion_call_index += 1;
-        self.completion_calls.push(call);
-        self.usage += usage;
-        Ok(call)
+        Ok(self.record_completion_call(usage))
     }
 
     /// The recovery-hook context for an invalid tool call surfaced
@@ -1123,22 +1164,22 @@ impl AgentRun {
         match action {
             InvalidToolCallHookAction::Fail => {
                 self.state = RunState::Failed;
-                Err(PromptError::UnknownToolCall {
-                    tool_name: invalid.tool_call.function.name.clone(),
-                    available_tools: executable_tool_names,
-                    allowed_tools: allowed_tool_names,
-                    chat_history: Box::new(diagnostic_history),
-                })
+                Err(unknown_tool_call_error(
+                    invalid.tool_call.function.name.clone(),
+                    executable_tool_names,
+                    allowed_tool_names,
+                    diagnostic_history,
+                ))
             }
             InvalidToolCallHookAction::Retry { feedback } => {
                 if self.invalid_tool_call_retries >= self.max_invalid_tool_call_retries {
                     self.state = RunState::Failed;
-                    return Err(PromptError::UnknownToolCall {
-                        tool_name: invalid.tool_call.function.name.clone(),
-                        available_tools: executable_tool_names,
-                        allowed_tools: allowed_tool_names,
-                        chat_history: Box::new(diagnostic_history),
-                    });
+                    return Err(unknown_tool_call_error(
+                        invalid.tool_call.function.name.clone(),
+                        executable_tool_names,
+                        allowed_tool_names,
+                        diagnostic_history,
+                    ));
                 }
                 self.invalid_tool_call_retries += 1;
 
@@ -1162,24 +1203,24 @@ impl AgentRun {
             InvalidToolCallHookAction::Repair { tool_name } => {
                 if !invalid.allowed_tool_names.contains(&tool_name) {
                     self.state = RunState::Failed;
-                    return Err(PromptError::UnknownToolCall {
+                    return Err(unknown_tool_call_error(
                         tool_name,
-                        available_tools: executable_tool_names,
-                        allowed_tools: allowed_tool_names,
-                        chat_history: Box::new(diagnostic_history),
-                    });
+                        executable_tool_names,
+                        allowed_tool_names,
+                        diagnostic_history,
+                    ));
                 }
                 Ok(StreamedResolution::Repaired { tool_name })
             }
             InvalidToolCallHookAction::Skip { reason } => {
                 if matches!(self.tool_choice, Some(ToolChoice::None)) {
                     self.state = RunState::Failed;
-                    return Err(PromptError::UnknownToolCall {
-                        tool_name: invalid.tool_call.function.name.clone(),
-                        available_tools: executable_tool_names,
-                        allowed_tools: allowed_tool_names,
-                        chat_history: Box::new(diagnostic_history),
-                    });
+                    return Err(unknown_tool_call_error(
+                        invalid.tool_call.function.name.clone(),
+                        executable_tool_names,
+                        allowed_tool_names,
+                        diagnostic_history,
+                    ));
                 }
 
                 // Synthetic skip reason: emit verbatim text, matching the
@@ -1227,11 +1268,10 @@ impl AgentRun {
         // never learned usage (no record before the turn completed) still get
         // the call recorded, with no reported usage.
         if !self.streamed_completion_call_recorded {
-            self.completion_calls.push(CompletionCall::new(
-                self.completion_call_index,
-                Usage::new(),
-            ));
-            self.completion_call_index += 1;
+            // `Usage::new()` is the additive identity for `Usage`'s `AddAssign`,
+            // so routing the no-usage fallback through `record_completion_call`
+            // leaves the run total unchanged while unifying the accounting.
+            self.record_completion_call(Usage::new());
             self.streamed_completion_call_recorded = true;
         }
 
@@ -1255,22 +1295,22 @@ impl AgentRun {
                 let diagnostic_history =
                     build_full_history(self.chat_history.as_deref(), diagnostic_messages);
                 self.state = RunState::Failed;
-                return Err(PromptError::UnknownToolCall {
-                    tool_name: tool_call.function.name.clone(),
-                    available_tools: turn.executable_tool_names.iter().cloned().collect(),
-                    allowed_tools: turn.allowed_tool_names.iter().cloned().collect(),
-                    chat_history: Box::new(diagnostic_history),
-                });
+                return Err(unknown_tool_call_error(
+                    tool_call.function.name.clone(),
+                    turn.executable_tool_names.iter().cloned().collect(),
+                    turn.allowed_tool_names.iter().cloned().collect(),
+                    diagnostic_history,
+                ));
             }
         }
 
-        self.state = RunState::AwaitingAdvance(Box::new(TurnState {
-            message_id: turn.message_id,
+        self.finalize_turn(
+            turn.message_id,
             items,
             has_tool_calls,
-            skipped: BTreeMap::new(),
-            internal_call_ids: turn.internal_call_ids,
-        }));
+            BTreeMap::new(),
+            turn.internal_call_ids,
+        );
         Ok(())
     }
 

--- a/crates/rig-core/src/agent/runner.rs
+++ b/crates/rig-core/src/agent/runner.rs
@@ -58,6 +58,40 @@ use crate::{
 
 const UNKNOWN_AGENT_NAME: &str = "Unnamed Agent";
 
+/// Build the per-turn `chat` span shared by both turn sources.
+///
+/// The span *name* must be a string literal — `tracing` bakes it into static
+/// metadata — so this is a macro parameterized by the name rather than a
+/// function (the two surfaces keep distinct names, `chat` vs `chat_streaming`,
+/// which dashboards split on). Every other field is identical across the
+/// blocking and streaming surfaces, so it lives here once instead of being
+/// copy-pasted into each `TurnSource::open_chat_span`.
+macro_rules! build_chat_span {
+    ($runner:expr, $effective_preamble:expr, $name:literal) => {
+        ::tracing::info_span!(
+            target: "rig::agent_chat",
+            parent: ::tracing::Span::current(),
+            $name,
+            gen_ai.operation.name = "chat",
+            gen_ai.agent.name = $runner.agent_name_or_default(),
+            gen_ai.system_instructions = $effective_preamble,
+            gen_ai.provider.name = ::tracing::field::Empty,
+            gen_ai.request.model = ::tracing::field::Empty,
+            gen_ai.response.id = ::tracing::field::Empty,
+            gen_ai.response.model = ::tracing::field::Empty,
+            gen_ai.usage.output_tokens = ::tracing::field::Empty,
+            gen_ai.usage.input_tokens = ::tracing::field::Empty,
+            gen_ai.usage.cache_read.input_tokens = ::tracing::field::Empty,
+            gen_ai.usage.cache_creation.input_tokens = ::tracing::field::Empty,
+            gen_ai.usage.tool_use_prompt_tokens = ::tracing::field::Empty,
+            gen_ai.usage.reasoning_tokens = ::tracing::field::Empty,
+            gen_ai.input.messages = ::tracing::field::Empty,
+            gen_ai.output.messages = ::tracing::field::Empty,
+        )
+    };
+}
+pub(crate) use build_chat_span;
+
 /// Human-readable name of a [`Flow`] variant, for fail-closed diagnostics.
 fn flow_name(flow: &Flow) -> &'static str {
     match flow {
@@ -708,26 +742,7 @@ where
         runner: &AgentRunner<M>,
         effective_preamble: Option<&str>,
     ) -> tracing::Span {
-        let chat_span = info_span!(
-            target: "rig::agent_chat",
-            parent: tracing::Span::current(),
-            "chat",
-            gen_ai.operation.name = "chat",
-            gen_ai.agent.name = runner.agent_name_or_default(),
-            gen_ai.system_instructions = effective_preamble,
-            gen_ai.provider.name = tracing::field::Empty,
-            gen_ai.request.model = tracing::field::Empty,
-            gen_ai.response.id = tracing::field::Empty,
-            gen_ai.response.model = tracing::field::Empty,
-            gen_ai.usage.output_tokens = tracing::field::Empty,
-            gen_ai.usage.input_tokens = tracing::field::Empty,
-            gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
-            gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
-            gen_ai.usage.tool_use_prompt_tokens = tracing::field::Empty,
-            gen_ai.usage.reasoning_tokens = tracing::field::Empty,
-            gen_ai.input.messages = tracing::field::Empty,
-            gen_ai.output.messages = tracing::field::Empty,
-        );
+        let chat_span = build_chat_span!(runner, effective_preamble, "chat");
         self.chain_span(chat_span)
     }
 

--- a/crates/rig-core/src/json_utils.rs
+++ b/crates/rig-core/src/json_utils.rs
@@ -17,6 +17,10 @@ pub fn merge(a: serde_json::Value, b: serde_json::Value) -> serde_json::Value {
     }
 }
 
+// Only the feature-gated `image` / `audio` provider request builders call this
+// now; the default feature set has no caller, so allow it to be unused there
+// rather than warning on an otherwise-live utility.
+#[cfg_attr(not(any(feature = "image", feature = "audio")), allow(dead_code))]
 pub fn merge_inplace(a: &mut serde_json::Value, b: serde_json::Value) {
     if let (serde_json::Value::Object(a_map), serde_json::Value::Object(b_map)) = (a, b) {
         b_map.into_iter().for_each(|(key, value)| {

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -1826,7 +1826,7 @@ struct OutputConfig {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-struct AnthropicCompletionRequest {
+pub(super) struct AnthropicCompletionRequest {
     model: String,
     messages: Vec<Message>,
     max_tokens: u64,

--- a/crates/rig-core/src/providers/anthropic/streaming.rs
+++ b/crates/rig-core/src/providers/anthropic/streaming.rs
@@ -6,15 +6,12 @@ use tracing::{Level, enabled, info_span};
 use tracing_futures::Instrument;
 
 use super::completion::{
-    AnthropicCompatibleProvider, CacheTtl, Content, GenericCompletionModel, Message, SystemContent,
-    ToolChoice, Usage, apply_prompt_cache_control, build_tool_definitions,
-    resolve_top_level_cache_control, split_system_messages_from_history,
-    supports_mid_conversation_system_messages,
+    AnthropicCompatibleProvider, AnthropicCompletionRequest, AnthropicRequestParams, CacheTtl,
+    Content, GenericCompletionModel, Usage,
 };
 use crate::completion::{CompletionError, CompletionRequest, GetTokenUsage};
 use crate::http_client::sse::{Event, GenericEventSource};
 use crate::http_client::{self, HttpClientExt};
-use crate::json_utils::merge_inplace;
 use crate::message::ReasoningContent;
 use crate::streaming::{
     self, RawStreamingChoice, RawStreamingToolCall, StreamingResult, ToolCallDeltaContent,
@@ -23,118 +20,40 @@ use crate::telemetry::SpanCombinator;
 use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
 use std::collections::HashMap;
 
+/// Build the Anthropic streaming request body.
+///
+/// Derives it from the *same* typed [`AnthropicCompletionRequest`] the blocking
+/// path builds (in `completion.rs`), then flips `stream: true` on the serialized
+/// object. Previously this was a second, hand-assembled `json!` body that had to
+/// be kept in sync by hand — and had drifted: it silently dropped `output_schema`
+/// (structured-output config) and defaulted `tool_choice` differently from the
+/// blocking path. Going through the typed struct makes the two wire formats
+/// identical apart from the `stream` flag.
 fn create_streaming_request_body(
     request_model: String,
-    completion_request: &mut CompletionRequest,
+    mut completion_request: CompletionRequest,
     max_tokens: u64,
     prompt_caching: bool,
     automatic_caching: bool,
     automatic_caching_ttl: Option<CacheTtl>,
 ) -> Result<Value, CompletionError> {
-    let chat_history = completion_request.chat_history_with_documents();
-    let (history_system, chat_history) = split_system_messages_from_history(
-        chat_history,
-        supports_mid_conversation_system_messages(&request_model),
-    );
-    let mut full_history = vec![];
-    full_history.extend(chat_history);
+    // The typed request's `TryFrom` requires `max_tokens`; feed it the value the
+    // caller already resolved (the request's own value, else the model default).
+    completion_request.max_tokens = Some(max_tokens);
 
-    let mut messages = full_history
-        .into_iter()
-        .map(Message::try_from)
-        .collect::<Result<Vec<Message>, _>>()?;
-
-    // Convert system prompt to array format for cache_control support.
-    let mut system: Vec<SystemContent> =
-        if let Some(preamble) = completion_request.preamble.as_ref() {
-            if preamble.is_empty() {
-                vec![]
-            } else {
-                vec![SystemContent::Text {
-                    text: preamble.clone(),
-                    cache_control: None,
-                }]
-            }
-        } else {
-            vec![]
-        };
-    system.extend(history_system);
-
-    let mut additional_params_payload = completion_request
-        .additional_params
-        .take()
-        .unwrap_or(Value::Null);
-    let top_level_cache_control = resolve_top_level_cache_control(
+    let request = AnthropicCompletionRequest::try_from(AnthropicRequestParams {
+        model: &request_model,
+        request: completion_request,
+        prompt_caching,
         automatic_caching,
         automatic_caching_ttl,
-        &mut additional_params_payload,
-    )?;
-    let mut tools = build_tool_definitions(
-        std::mem::take(&mut completion_request.tools),
-        &mut additional_params_payload,
-    )?;
+    })?;
 
-    apply_prompt_cache_control(
-        &mut system,
-        &mut messages,
-        &mut tools,
-        prompt_caching,
-        top_level_cache_control.as_ref(),
-    )?;
-
-    let mut body = json!({
-        "model": request_model,
-        "messages": messages,
-        "max_tokens": max_tokens,
-        "stream": true,
-    });
-
-    // Automatic caching: one top-level field; the API moves the breakpoint automatically.
-    // No beta header is required.
-    if let Some(cache_control) = top_level_cache_control {
-        merge_inplace(
-            &mut body,
-            json!({ "cache_control": serde_json::to_value(&cache_control)? }),
-        );
-    }
-
-    // Add system prompt if non-empty.
-    if !system.is_empty() {
-        merge_inplace(&mut body, json!({ "system": system }));
-    }
-
-    if let Some(temperature) = completion_request.temperature {
-        merge_inplace(&mut body, json!({ "temperature": temperature }));
-    }
-
-    // Convert the request's tool choice unconditionally so a choice Anthropic
-    // cannot represent (e.g. a multi-name `Specific`) fails closed with a request
-    // error exactly like the blocking path (completion.rs), even when no tools are
-    // advertised this turn — rather than being silently dropped on streaming only.
-    let tool_choice = completion_request
-        .tool_choice
-        .take()
-        .map(ToolChoice::try_from)
-        .transpose()?;
-
-    if !tools.is_empty() {
-        // Carry the request's tool choice (defaulting to Auto when unset) rather
-        // than hardcoding Auto — otherwise a caller's `tool_choice` (including one
-        // set per-turn via a `RequestOverride`) is silently dropped on the
-        // streaming path, unlike the non-streaming path which honors it. Anthropic
-        // only accepts `tool_choice` alongside a non-empty tool set, so it is sent
-        // only here.
-        merge_inplace(
-            &mut body,
-            json!({
-                "tools": tools,
-                "tool_choice": tool_choice.unwrap_or(ToolChoice::Auto),
-            }),
-        );
-    }
-
-    if !additional_params_payload.is_null() {
-        merge_inplace(&mut body, additional_params_payload)
+    let mut body = serde_json::to_value(&request)?;
+    // `AnthropicCompletionRequest` has no `stream` field (the blocking path omits
+    // it, defaulting to non-streaming); set it here for the streaming endpoint.
+    if let Some(map) = body.as_object_mut() {
+        map.insert("stream".to_string(), Value::Bool(true));
     }
 
     Ok(body)
@@ -285,7 +204,7 @@ where
 {
     pub(crate) async fn stream(
         &self,
-        mut completion_request: CompletionRequest,
+        completion_request: CompletionRequest,
     ) -> Result<streaming::StreamingCompletionResponse<StreamingCompletionResponse>, CompletionError>
     {
         let request_model = completion_request
@@ -324,7 +243,7 @@ where
 
         let body = create_streaming_request_body(
             request_model,
-            &mut completion_request,
+            completion_request,
             max_tokens,
             self.prompt_caching,
             self.automatic_caching,
@@ -622,7 +541,10 @@ fn handle_event(
 
 #[cfg(test)]
 mod tests {
-    use super::super::completion::{CLAUDE_OPUS_4_8, CacheControl, CacheTtl};
+    use super::super::completion::{
+        CLAUDE_OPUS_4_8, CacheControl, CacheTtl, Message, SystemContent, apply_prompt_cache_control,
+        build_tool_definitions, resolve_top_level_cache_control,
+    };
     use super::*;
     use crate::OneOrMany;
     use crate::completion::Message as RigMessage;
@@ -680,7 +602,7 @@ mod tests {
 
     #[test]
     fn streaming_request_keeps_documents_after_leading_system_messages() {
-        let mut request = CompletionRequest {
+        let request = CompletionRequest {
             model: None,
             preamble: None,
             chat_history: OneOrMany::many(vec![
@@ -705,7 +627,7 @@ mod tests {
 
         let body = create_streaming_request_body(
             CLAUDE_OPUS_4_8.to_string(),
-            &mut request,
+            request,
             64,
             false,
             false,
@@ -734,6 +656,73 @@ mod tests {
             1,
             "document message should appear exactly once: {messages:?}"
         );
+    }
+
+    #[test]
+    fn streaming_body_is_blocking_body_plus_stream_flag_and_carries_output_schema() {
+        let schema: schemars::Schema = serde_json::from_value(json!({
+            "title": "WeatherResponse",
+            "type": "object",
+            "properties": { "city": { "type": "string" } }
+        }))
+        .expect("schema should deserialize");
+
+        let request = CompletionRequest {
+            model: None,
+            preamble: Some("You are helpful".to_string()),
+            chat_history: OneOrMany::one(RigMessage::user("What's the weather?")),
+            documents: vec![],
+            tools: vec![],
+            temperature: Some(0.5),
+            max_tokens: Some(64),
+            tool_choice: None,
+            additional_params: None,
+            output_schema: Some(schema),
+        };
+
+        let streaming_body = create_streaming_request_body(
+            CLAUDE_OPUS_4_8.to_string(),
+            request.clone(),
+            64,
+            false,
+            false,
+            None,
+        )
+        .expect("streaming request body should build");
+
+        // The streaming endpoint flag is set.
+        assert_eq!(streaming_body["stream"], serde_json::Value::Bool(true));
+
+        // Regression: `output_schema` now reaches the streaming wire as
+        // `output_config` (the hand-rolled body dropped it entirely, so this
+        // assertion would have failed before the typed-request unification).
+        assert_eq!(
+            streaming_body["output_config"]["format"]["type"],
+            "json_schema"
+        );
+        assert!(
+            streaming_body["output_config"]["format"]["schema"].is_object(),
+            "streaming body must carry the structured-output schema: {streaming_body}"
+        );
+
+        // Unification invariant: the streaming body is exactly the blocking body
+        // (built via the same typed request) plus `stream: true`. Pins the two
+        // wire formats together so a future edit can't reintroduce drift.
+        let blocking = AnthropicCompletionRequest::try_from(AnthropicRequestParams {
+            model: CLAUDE_OPUS_4_8,
+            request,
+            prompt_caching: false,
+            automatic_caching: false,
+            automatic_caching_ttl: None,
+        })
+        .expect("blocking request body should build");
+        let mut expected = serde_json::to_value(&blocking).expect("serialize blocking body");
+        expected
+            .as_object_mut()
+            .expect("body is an object")
+            .insert("stream".to_string(), serde_json::Value::Bool(true));
+
+        assert_eq!(streaming_body, expected);
     }
 
     #[test]

--- a/crates/rig-core/src/providers/anthropic/streaming.rs
+++ b/crates/rig-core/src/providers/anthropic/streaming.rs
@@ -56,14 +56,20 @@ fn create_streaming_request_body(
         // omits it, defaulting to non-streaming); set it for the streaming endpoint.
         map.insert("stream".to_string(), Value::Bool(true));
 
-        // The streaming path has always sent an explicit `tool_choice: auto`
-        // whenever tools are advertised but the caller left the choice unset. This
-        // is equivalent to Anthropic's default (auto, when tools are present), but
-        // the blocking typed request omits it — so re-apply the explicit form here
-        // to keep the streaming request bytes stable rather than silently changing
-        // them out from under recorded fixtures and downstream expectations.
-        if map.contains_key("tools") && !map.contains_key("tool_choice") {
-            map.insert("tool_choice".to_string(), json!({ "type": "auto" }));
+        // Preserve the streaming path's long-standing `tool_choice` shape, which
+        // emitted `tool_choice` *iff* a non-empty tool set was advertised (Anthropic
+        // rejects `tool_choice` without `tools`). The blocking typed request instead
+        // serializes any caller-set `tool_choice` regardless of tools and omits it
+        // when unset, so reconcile here:
+        //   - tools present, choice unset -> add the explicit `auto` the streaming
+        //     wire has always carried (equivalent to Anthropic's default);
+        //   - tools absent -> drop a caller-set `tool_choice` that would otherwise
+        //     be sent without `tools` and rejected.
+        if map.contains_key("tools") {
+            map.entry("tool_choice")
+                .or_insert_with(|| json!({ "type": "auto" }));
+        } else {
+            map.remove("tool_choice");
         }
     }
 
@@ -773,6 +779,42 @@ mod tests {
         // fixtures), even though the blocking typed request omits it.
         assert_eq!(body["tool_choice"], json!({ "type": "auto" }));
         assert!(body["tools"].is_array());
+    }
+
+    #[test]
+    fn streaming_body_drops_tool_choice_when_no_tools_are_advertised() {
+        // The typed request serializes a caller-set `tool_choice` regardless of
+        // whether tools are present, but the streaming path has always emitted
+        // `tool_choice` *only* alongside a non-empty tool set (Anthropic rejects it
+        // otherwise). A `tool_choice` set with no tools must not reach the wire.
+        let request = CompletionRequest {
+            model: None,
+            preamble: None,
+            chat_history: OneOrMany::one(RigMessage::user("Hi")),
+            documents: vec![],
+            tools: vec![],
+            temperature: None,
+            max_tokens: Some(64),
+            tool_choice: Some(crate::message::ToolChoice::Auto),
+            additional_params: None,
+            output_schema: None,
+        };
+
+        let body = create_streaming_request_body(
+            CLAUDE_OPUS_4_8.to_string(),
+            request,
+            64,
+            false,
+            false,
+            None,
+        )
+        .expect("streaming request body should build");
+
+        assert!(
+            body.get("tool_choice").is_none(),
+            "tool_choice must be omitted when no tools are advertised: {body}"
+        );
+        assert!(body.get("tools").is_none());
     }
 
     #[test]

--- a/crates/rig-core/src/providers/anthropic/streaming.rs
+++ b/crates/rig-core/src/providers/anthropic/streaming.rs
@@ -23,12 +23,13 @@ use std::collections::HashMap;
 /// Build the Anthropic streaming request body.
 ///
 /// Derives it from the *same* typed [`AnthropicCompletionRequest`] the blocking
-/// path builds (in `completion.rs`), then flips `stream: true` on the serialized
-/// object. Previously this was a second, hand-assembled `json!` body that had to
-/// be kept in sync by hand — and had drifted: it silently dropped `output_schema`
-/// (structured-output config) and defaulted `tool_choice` differently from the
-/// blocking path. Going through the typed struct makes the two wire formats
-/// identical apart from the `stream` flag.
+/// path builds (in `completion.rs`), rather than re-assembling the body by hand.
+/// The previous hand-rolled `json!` body had drifted from the blocking one and
+/// silently dropped `output_schema` (structured-output config); reaching for the
+/// typed request fixes that and keeps the two in lockstep. The one intentional
+/// streaming-only difference — an explicit `tool_choice: auto` when tools are
+/// advertised but the caller left the choice unset — is re-applied below so the
+/// streaming request bytes stay stable.
 fn create_streaming_request_body(
     request_model: String,
     mut completion_request: CompletionRequest,
@@ -50,10 +51,20 @@ fn create_streaming_request_body(
     })?;
 
     let mut body = serde_json::to_value(&request)?;
-    // `AnthropicCompletionRequest` has no `stream` field (the blocking path omits
-    // it, defaulting to non-streaming); set it here for the streaming endpoint.
     if let Some(map) = body.as_object_mut() {
+        // `AnthropicCompletionRequest` has no `stream` field (the blocking path
+        // omits it, defaulting to non-streaming); set it for the streaming endpoint.
         map.insert("stream".to_string(), Value::Bool(true));
+
+        // The streaming path has always sent an explicit `tool_choice: auto`
+        // whenever tools are advertised but the caller left the choice unset. This
+        // is equivalent to Anthropic's default (auto, when tools are present), but
+        // the blocking typed request omits it — so re-apply the explicit form here
+        // to keep the streaming request bytes stable rather than silently changing
+        // them out from under recorded fixtures and downstream expectations.
+        if map.contains_key("tools") && !map.contains_key("tool_choice") {
+            map.insert("tool_choice".to_string(), json!({ "type": "auto" }));
+        }
     }
 
     Ok(body)
@@ -542,8 +553,8 @@ fn handle_event(
 #[cfg(test)]
 mod tests {
     use super::super::completion::{
-        CLAUDE_OPUS_4_8, CacheControl, CacheTtl, Message, SystemContent, apply_prompt_cache_control,
-        build_tool_definitions, resolve_top_level_cache_control,
+        CLAUDE_OPUS_4_8, CacheControl, CacheTtl, Message, SystemContent,
+        apply_prompt_cache_control, build_tool_definitions, resolve_top_level_cache_control,
     };
     use super::*;
     use crate::OneOrMany;
@@ -723,6 +734,45 @@ mod tests {
             .insert("stream".to_string(), serde_json::Value::Bool(true));
 
         assert_eq!(streaming_body, expected);
+    }
+
+    #[test]
+    fn streaming_body_keeps_explicit_tool_choice_auto_when_tools_present_but_unset() {
+        let request = CompletionRequest {
+            model: None,
+            preamble: None,
+            chat_history: OneOrMany::one(RigMessage::user("Add 2 and 3")),
+            documents: vec![],
+            tools: vec![crate::completion::ToolDefinition {
+                name: "add".to_string(),
+                description: "Add x and y".to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": { "x": { "type": "integer" } }
+                }),
+            }],
+            temperature: None,
+            max_tokens: Some(64),
+            tool_choice: None,
+            additional_params: None,
+            output_schema: None,
+        };
+
+        let body = create_streaming_request_body(
+            CLAUDE_OPUS_4_8.to_string(),
+            request,
+            64,
+            false,
+            false,
+            None,
+        )
+        .expect("streaming request body should build");
+
+        // Tools advertised + `tool_choice` unset must still carry the explicit
+        // `auto` the streaming wire format has always sent (parity with recorded
+        // fixtures), even though the blocking typed request omits it.
+        assert_eq!(body["tool_choice"], json!({ "type": "auto" }));
+        assert!(body["tools"].is_array());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to #1985. That PR unified the streaming and blocking agent **drivers** over one `drive_agent` engine. This pass removes the incidental plumbing still duplicated across the two surfaces — naming the seams #1985 exposed — and fixes **one live provider drift bug** (Anthropic streaming silently dropping `output_schema`).

It deliberately **stops short** of the two *essential* divergences that are load-bearing and must survive: the `CompletionModel` two-associated-types split (`Response` vs `StreamingResponse`) and the deliberately different blocking-vs-streaming invalid-tool-call recovery semantics.

## The six steps

Each is behavior-preserving on the wire.

| # | Change | Notes |
|---|--------|-------|
| **1** | `AgentRun::record_completion_call` + `finalize_turn` seams | Both ingestion paths already ended at a byte-identical `AwaitingAdvance(TurnState{..})`; the `CompletionCall::new; idx+=1; push; usage+=` arithmetic was copied 3×. The once-per-turn `streamed_completion_call_recorded` guard stays **outside** the helper so it can't be mistaken for "a completion call happened". `Usage::new()` is the additive identity, so the no-usage fallback routes through it unchanged. |
| **2** | `forward_prompt_setters!` builder macro | Collapses the 6 identical setters (docs included) shared by `PromptRequest` and `TypedPromptRequest`. Scoped to those two — the streaming builder keeps its medium-specific setter docs. Adds `max_turns` to `StreamingPromptRequest` as an additive alias of `multi_turn` (**no deprecation** — `multi_turn` has 40+ in-crate call sites). |
| **3** | `emit_completion_call!` macro | Collapses the two substantive completion-call emission sites in `StreamingTurnSource::run_model_turn`. The macro returns item/None/error; the `yield` stays at the call site because `async_stream::stream!` **cannot see a `yield` produced inside a nested macro expansion**. The trivial no-usage fallback stays inline (it must not set the now-dead flag). |
| **4** | Anthropic single request builder — **fixes a live bug** | Streaming derived its body from a hand-assembled `json!` that had drifted from the blocking typed request and silently **dropped `output_schema`** (structured-output config). It now derives from the same `AnthropicCompletionRequest` + `stream: true`, so the two can't drift again. `default_max_tokens` pre-resolution is preserved (the typed `TryFrom` errors on `None`). The streaming request bytes are held stable: the explicit `tool_choice: auto` the streaming path has always sent (tools present, choice unset) is re-applied, so the only wire change is the `output_schema` bug fix. Pinned by two unit tests (blocking-body parity + preserved `tool_choice: auto`). |
| **5** | `unknown_tool_call_error` leaf helper | Collapses the 9 identical `PromptError::UnknownToolCall { .. }` constructions across both recovery functions and the streamed fail-fast. Control flow, recovery semantics, and — critically — the streamed fail-fast staying a **real release-mode `return Err`** are untouched. |
| **6** | `build_chat_span!` macro | The identical 15-field chat span was duplicated in both `TurnSource::open_chat_span` impls. A macro (not a fn) because `tracing` requires a **static** span-name literal; the two distinct names (`chat` / `chat_streaming`, which dashboards split on) are preserved. |

## Deliberately *not* done

Merging `ModelTurn`/`StreamedTurn`, forcing the blocking driver through stream-and-collect, deprecating `multi_turn`, unifying the span names, and making `stream()` the sole `CompletionModel` primitive with `completion()` defaulted by aggregation — each is either net-negative, a dashboard/semconv break, or dead code for the existing provider tree (the only `From<StreamingCompletionResponse>` bridge yields `CompletionResponse<Option<R>>`, not any provider's real `Response`).

## Testing

- `cargo test -p rig-core --lib` — **1054 passed**, including every `*_parity_across_run_and_stream` guard, the span safety-net tests, and two new Anthropic tests (blocking-body parity + preserved `tool_choice: auto`).
- `cargo clippy -p rig-core --lib` — clean.
- `cargo fmt --all --check` — clean.
- Warning-free under both default and `image,audio` features.

No public API removals.