### PR TITLE
Release-N cleanup: correctness fixes + dead-code removal

### DIFF
--- a/crates/rig-core/src/agent/completion.rs
+++ b/crates/rig-core/src/agent/completion.rs
@@ -20,7 +20,7 @@ use std::{
     sync::Arc,
 };
 
-const UNKNOWN_AGENT_NAME: &str = "Unnamed Agent";
+use super::UNKNOWN_AGENT_NAME;
 
 pub type DynamicContextStore = Arc<
     Vec<(

--- a/crates/rig-core/src/agent/mod.rs
+++ b/crates/rig-core/src/agent/mod.rs
@@ -112,6 +112,10 @@ pub mod run;
 pub mod runner;
 mod tool;
 
+/// Fallback display name used in telemetry spans and logs when an agent has no
+/// configured name.
+pub(crate) const UNKNOWN_AGENT_NAME: &str = "Unnamed Agent";
+
 pub use crate::message::Text;
 pub use builder::{AgentBuilder, NoToolConfig, WithBuilderTools, WithToolServerHandle};
 pub use completion::Agent;

--- a/crates/rig-core/src/agent/runner.rs
+++ b/crates/rig-core/src/agent/runner.rs
@@ -56,7 +56,7 @@ use crate::{
     tool::{ToolCallExtensions, server::ToolServerHandle},
 };
 
-const UNKNOWN_AGENT_NAME: &str = "Unnamed Agent";
+use super::UNKNOWN_AGENT_NAME;
 
 /// Build the per-turn `chat` span shared by both turn sources.
 ///

--- a/crates/rig-core/src/client/mod.rs
+++ b/crates/rig-core/src/client/mod.rs
@@ -233,8 +233,6 @@ pub enum Transport {
     Http,
     /// Server-sent events streaming transport.
     Sse,
-    /// Newline-delimited JSON streaming transport.
-    NdJson,
 }
 
 /// An API provider extension, this abstracts over extensions which may be used in conjunction with

--- a/crates/rig-core/src/completion/message.rs
+++ b/crates/rig-core/src/completion/message.rs
@@ -10,17 +10,6 @@ use super::CompletionError;
 // Message models
 // ================================================================
 
-/// A useful trait to help convert `rig_core::completion::Message` to your own message type.
-///
-/// Particularly useful if you don't want to create a free-standing function as
-/// when trying to use `TryFrom<T>`, you would normally run into the orphan rule as Vec is
-/// technically considered a foreign type (it's owned by stdlib).
-pub trait ConvertMessage: Sized + Send + Sync {
-    type Error: std::error::Error + Send;
-
-    fn convert_from_message(message: Message) -> Result<Vec<Self>, Self::Error>;
-}
-
 /// A provider-agnostic chat message.
 ///
 /// Messages are role-tagged and may contain one or many content items, including

--- a/crates/rig-core/src/embeddings/distance.rs
+++ b/crates/rig-core/src/embeddings/distance.rs
@@ -26,70 +26,18 @@ pub trait VectorDistance {
     fn chebyshev_distance(&self, other: &Self) -> f64;
 }
 
-#[cfg(not(feature = "rayon"))]
-impl VectorDistance for crate::embeddings::Embedding {
-    fn dot_product(&self, other: &Self) -> f64 {
-        self.vec
-            .iter()
-            .zip(other.vec.iter())
-            .map(|(x, y)| x * y)
-            .sum()
-    }
-
-    fn cosine_similarity(&self, other: &Self, normalized: bool) -> f64 {
-        let dot_product = self.dot_product(other);
-
-        if normalized {
-            dot_product
-        } else {
-            let magnitude1: f64 = self.vec.iter().map(|x| x.powi(2)).sum::<f64>().sqrt();
-            let magnitude2: f64 = other.vec.iter().map(|x| x.powi(2)).sum::<f64>().sqrt();
-
-            dot_product / (magnitude1 * magnitude2)
-        }
-    }
-
-    fn angular_distance(&self, other: &Self, normalized: bool) -> f64 {
-        let cosine_sim = self.cosine_similarity(other, normalized);
-        cosine_sim.acos() / std::f64::consts::PI
-    }
-
-    fn euclidean_distance(&self, other: &Self) -> f64 {
-        self.vec
-            .iter()
-            .zip(other.vec.iter())
-            .map(|(x, y)| (x - y).powi(2))
-            .sum::<f64>()
-            .sqrt()
-    }
-
-    fn manhattan_distance(&self, other: &Self) -> f64 {
-        self.vec
-            .iter()
-            .zip(other.vec.iter())
-            .map(|(x, y)| (x - y).abs())
-            .sum()
-    }
-
-    fn chebyshev_distance(&self, other: &Self) -> f64 {
-        self.vec
-            .iter()
-            .zip(other.vec.iter())
-            .map(|(x, y)| (x - y).abs())
-            .fold(0.0, f64::max)
-    }
-}
-
-#[cfg(feature = "rayon")]
-mod rayon {
-    use crate::embeddings::{Embedding, distance::VectorDistance};
-    use rayon::prelude::*;
-
-    impl VectorDistance for Embedding {
+/// Generates the [`VectorDistance`] method bodies for [`Embedding`](crate::embeddings::Embedding).
+///
+/// The math is identical between the sequential and Rayon-backed implementations;
+/// only the iterator constructor (`iter` vs `par_iter`) and the max-reduction
+/// differ (`Iterator::fold` vs `ParallelIterator::reduce`), so both are supplied
+/// by the caller. Keeping one source prevents the two copies from drifting.
+macro_rules! impl_vector_distance {
+    ($iter:ident, $($max_reduce:tt)+) => {
         fn dot_product(&self, other: &Self) -> f64 {
             self.vec
-                .par_iter()
-                .zip(other.vec.par_iter())
+                .$iter()
+                .zip(other.vec.$iter())
                 .map(|(x, y)| x * y)
                 .sum()
         }
@@ -100,8 +48,8 @@ mod rayon {
             if normalized {
                 dot_product
             } else {
-                let magnitude1: f64 = self.vec.par_iter().map(|x| x.powi(2)).sum::<f64>().sqrt();
-                let magnitude2: f64 = other.vec.par_iter().map(|x| x.powi(2)).sum::<f64>().sqrt();
+                let magnitude1: f64 = self.vec.$iter().map(|x| x.powi(2)).sum::<f64>().sqrt();
+                let magnitude2: f64 = other.vec.$iter().map(|x| x.powi(2)).sum::<f64>().sqrt();
 
                 dot_product / (magnitude1 * magnitude2)
             }
@@ -114,8 +62,8 @@ mod rayon {
 
         fn euclidean_distance(&self, other: &Self) -> f64 {
             self.vec
-                .par_iter()
-                .zip(other.vec.par_iter())
+                .$iter()
+                .zip(other.vec.$iter())
                 .map(|(x, y)| (x - y).powi(2))
                 .sum::<f64>()
                 .sqrt()
@@ -123,19 +71,36 @@ mod rayon {
 
         fn manhattan_distance(&self, other: &Self) -> f64 {
             self.vec
-                .par_iter()
-                .zip(other.vec.par_iter())
+                .$iter()
+                .zip(other.vec.$iter())
                 .map(|(x, y)| (x - y).abs())
                 .sum()
         }
 
         fn chebyshev_distance(&self, other: &Self) -> f64 {
             self.vec
-                .iter()
-                .zip(other.vec.iter())
+                .$iter()
+                .zip(other.vec.$iter())
                 .map(|(x, y)| (x - y).abs())
-                .fold(0.0, f64::max)
+                .$($max_reduce)+
         }
+    };
+}
+
+#[cfg(not(feature = "rayon"))]
+impl VectorDistance for crate::embeddings::Embedding {
+    impl_vector_distance!(iter, fold(0.0, f64::max));
+}
+
+#[cfg(feature = "rayon")]
+mod rayon {
+    use crate::embeddings::{Embedding, distance::VectorDistance};
+    use rayon::prelude::*;
+
+    impl VectorDistance for Embedding {
+        // `ParallelIterator` has no scalar `fold`; use `reduce` (0.0 is a valid
+        // identity for `max` since every mapped value is a non-negative abs diff).
+        impl_vector_distance!(par_iter, reduce(|| 0.0, f64::max));
     }
 }
 

--- a/crates/rig-core/src/http_client/retry.rs
+++ b/crates/rig-core/src/http_client/retry.rs
@@ -70,53 +70,6 @@ impl RetryPolicy for ExponentialBackoff {
     }
 }
 
-/// A [`RetryPolicy`] which always emits the same delay
-#[derive(Debug, Clone)]
-pub struct Constant {
-    /// The delay to return
-    pub delay: Duration,
-    /// The maximum number of retries to return before giving up
-    pub max_retries: Option<usize>,
-}
-
-impl Constant {
-    /// Create a new constant retry policy
-    pub const fn new(delay: Duration, max_retries: Option<usize>) -> Self {
-        Self { delay, max_retries }
-    }
-}
-
-impl RetryPolicy for Constant {
-    fn retry(&self, _error: &Error, last_retry: Option<(usize, Duration)>) -> Option<Duration> {
-        if let Some((retry_num, _)) = last_retry {
-            if self
-                .max_retries
-                .is_none_or(|max_retries| retry_num < max_retries)
-            {
-                Some(self.delay)
-            } else {
-                None
-            }
-        } else {
-            Some(self.delay)
-        }
-    }
-    fn set_reconnection_time(&mut self, duration: Duration) {
-        self.delay = duration;
-    }
-}
-
-/// A [`RetryPolicy`] which never retries
-#[derive(Debug, Clone, Copy, Default)]
-pub struct Never;
-
-impl RetryPolicy for Never {
-    fn retry(&self, _error: &Error, _last_retry: Option<(usize, Duration)>) -> Option<Duration> {
-        None
-    }
-    fn set_reconnection_time(&mut self, _duration: Duration) {}
-}
-
 /// The default [`RetryPolicy`] when initializing an event source
 pub const DEFAULT_RETRY: ExponentialBackoff = ExponentialBackoff::new(
     Duration::from_millis(300),

--- a/crates/rig-core/src/http_client/sse.rs
+++ b/crates/rig-core/src/http_client/sse.rs
@@ -104,27 +104,6 @@ where
         }
     }
 
-    pub fn with_retry_policy<R>(
-        client: HttpClient,
-        req: Request<RequestBody>,
-        retry_policy: R,
-    ) -> GenericEventSource<HttpClient, RequestBody, R>
-    where
-        R: RetryPolicy,
-    {
-        let response_future = Self::create_response_future(&client, &req, None);
-        let state = SourceState::Connecting { response_future };
-
-        GenericEventSource {
-            client,
-            req,
-            retry_policy,
-            last_event_id: None,
-            allow_missing_content_type: false,
-            state,
-        }
-    }
-
     pub fn allow_missing_content_type(mut self) -> Self {
         self.allow_missing_content_type = true;
         self

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -1330,44 +1330,6 @@ impl TryFrom<(String, CoreCompletionRequest)> for CompletionRequest {
     }
 }
 
-impl crate::telemetry::ProviderRequestExt for CompletionRequest {
-    type InputMessage = Message;
-
-    fn get_input_messages(&self) -> Vec<Self::InputMessage> {
-        self.messages.clone()
-    }
-
-    fn get_system_prompt(&self) -> Option<String> {
-        let first_message = self.messages.first()?;
-
-        let Message::System { ref content, .. } = first_message.clone() else {
-            return None;
-        };
-
-        let SystemContent { text, .. } = content.first();
-
-        Some(text)
-    }
-
-    fn get_prompt(&self) -> Option<String> {
-        let last_message = self.messages.last()?;
-
-        let Message::User { ref content, .. } = last_message.clone() else {
-            return None;
-        };
-
-        let UserContent::Text { text, .. } = content.first() else {
-            return None;
-        };
-
-        Some(text)
-    }
-
-    fn get_model_name(&self) -> String {
-        self.model.clone()
-    }
-}
-
 impl GenericCompletionModel<super::OpenAICompletionsExt, reqwest::Client> {
     pub fn into_agent_builder(self) -> crate::agent::AgentBuilder<Self> {
         crate::agent::AgentBuilder::new(self)

--- a/crates/rig-core/src/streaming.rs
+++ b/crates/rig-core/src/streaming.rs
@@ -305,6 +305,16 @@ where
         self.pause_control.is_paused()
     }
 
+    /// Token usage reported by the provider for this response.
+    ///
+    /// Returns the usage carried by the final response once the stream has
+    /// produced it. Until then — or when the provider does not report streamed
+    /// usage — this returns [`Usage::new`], the zero-valued sentinel for missing
+    /// usage metrics.
+    pub fn usage(&self) -> Usage {
+        self.response.token_usage()
+    }
+
     fn append_text_chunk(&mut self, text: &str) {
         if let Some(index) = self.text_item_index
             && let Some(AssistantContent::Text(existing_text)) = self.assistant_items.get_mut(index)
@@ -406,7 +416,10 @@ where
     fn from(value: StreamingCompletionResponse<R>) -> CompletionResponse<Option<R>> {
         CompletionResponse {
             choice: value.choice,
-            usage: Usage::new(), // Usage is not tracked in streaming responses
+            // Derive usage from the final response. `Option<R>: GetTokenUsage`
+            // yields the provider's usage when present and the zero sentinel
+            // (`Usage::new`) when the stream produced no final response.
+            usage: value.response.token_usage(),
             raw_response: value.response,
             message_id: value.message_id,
         }
@@ -834,6 +847,30 @@ mod tests {
         };
 
         StreamingCompletionResponse::stream(to_stream_result(stream))
+    }
+
+    #[tokio::test]
+    async fn into_completion_response_derives_usage_from_final_response() {
+        let mut stream = create_mock_stream();
+
+        // Drain the stream so the final response (and its usage) is captured.
+        while stream.next().await.is_some() {}
+
+        // usage() surfaces the final response's token usage...
+        assert_eq!(stream.usage().total_tokens, 15);
+
+        // ...and the From conversion carries it instead of a zero sentinel.
+        let response: CompletionResponse<Option<MockResponse>> = stream.into();
+        assert_eq!(response.usage.total_tokens, 15);
+    }
+
+    #[tokio::test]
+    async fn usage_is_zero_sentinel_before_final_response() {
+        // A stream that never yields a FinalResponse reports the zero sentinel.
+        let stream = StreamingCompletionResponse::stream(to_stream_result(stream! {
+            yield Ok(RawStreamingChoice::Message("no final response".to_string()));
+        }));
+        assert_eq!(stream.usage().total_tokens, 0);
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/telemetry/mod.rs
+++ b/crates/rig-core/src/telemetry/mod.rs
@@ -6,21 +6,6 @@
 use crate::completion::GetTokenUsage;
 use serde::Serialize;
 
-/// Provider request metadata used to populate GenAI telemetry spans.
-pub trait ProviderRequestExt {
-    /// Provider-native message type used for serialized input messages.
-    type InputMessage: Serialize;
-
-    /// Returns serialized input messages sent to the provider.
-    fn get_input_messages(&self) -> Vec<Self::InputMessage>;
-    /// Returns the system prompt, if represented separately by the provider.
-    fn get_system_prompt(&self) -> Option<String>;
-    /// Returns the model name requested from the provider.
-    fn get_model_name(&self) -> String;
-    /// Returns the primary prompt text, when available.
-    fn get_prompt(&self) -> Option<String>;
-}
-
 /// Provider response metadata used to populate GenAI telemetry spans.
 pub trait ProviderResponseExt {
     /// Provider-native output message type.
@@ -56,11 +41,6 @@ pub trait SpanCombinator {
     fn record_response_metadata<R>(&self, response: &R)
     where
         R: ProviderResponseExt;
-
-    /// Record serialized model input messages.
-    fn record_model_input<T>(&self, messages: &T)
-    where
-        T: Serialize;
 
     /// Record serialized model output messages.
     fn record_model_output<T>(&self, messages: &T)
@@ -113,19 +93,6 @@ impl SpanCombinator for tracing::Span {
 
         if let Some(model_name) = response.get_response_model_name() {
             self.record("gen_ai.response.model", model_name);
-        }
-    }
-
-    fn record_model_input<T>(&self, input: &T)
-    where
-        T: Serialize,
-    {
-        if self.is_disabled() {
-            return;
-        }
-
-        if let Ok(input_as_json_string) = serde_json::to_string(input) {
-            self.record("gen_ai.input.messages", input_as_json_string);
         }
     }
 

--- a/crates/rig-core/src/vector_store/in_memory_store.rs
+++ b/crates/rig-core/src/vector_store/in_memory_store.rs
@@ -149,6 +149,53 @@ impl<D: Serialize + Eq> InMemoryVectorStore<D> {
         }
     }
 
+    /// Scores one candidate document against the query prompt.
+    ///
+    /// Returns the best similarity across the document's embeddings together with
+    /// the matching embedding text, or `None` when the document is filtered out,
+    /// has no embeddings, produces a non-finite similarity, or scores below the
+    /// threshold. Shared by the brute-force and LSH scans so the filter,
+    /// threshold, and NaN handling live in exactly one place.
+    fn score_candidate<'a>(
+        doc: &D,
+        embeddings: &'a OneOrMany<Embedding>,
+        prompt_embedding: &Embedding,
+        filter: Option<&Filter<serde_json::Value>>,
+        threshold: Option<f64>,
+    ) -> Result<Option<(OrderedFloat<f64>, &'a String)>, VectorStoreError> {
+        if !Self::satisfies_filter(doc, filter)? {
+            return Ok(None);
+        }
+
+        // Best (highest-similarity) embedding for this document.
+        let Some((distance, embed_doc)) = embeddings
+            .iter()
+            .map(|embedding| {
+                (
+                    OrderedFloat(embedding.cosine_similarity(prompt_embedding, false)),
+                    &embedding.document,
+                )
+            })
+            .max_by(|a, b| a.0.cmp(&b.0))
+        else {
+            return Ok(None);
+        };
+
+        // A zero-magnitude embedding yields a NaN similarity; NaN sorts as the
+        // maximum under `OrderedFloat` and slips past `distance < threshold`
+        // (every comparison with NaN is false), so it must be excluded here.
+        if !distance.0.is_finite() {
+            return Ok(None);
+        }
+
+        // Skip documents below the similarity threshold.
+        if threshold.is_some_and(|t| distance.0 < t) {
+            return Ok(None);
+        }
+
+        Ok(Some((distance, embed_doc)))
+    }
+
     /// Implement vector search on [InMemoryVectorStore].
     /// To be used by implementations of [VectorStoreIndex::top_n] and [VectorStoreIndex::top_n_ids] methods.
     ///
@@ -192,28 +239,13 @@ impl<D: Serialize + Eq> InMemoryVectorStore<D> {
         let mut docs = BinaryHeap::new();
 
         for (id, (doc, embeddings)) in self.embeddings.iter() {
-            // Skip documents that don't satisfy the metadata filter.
-            if !Self::satisfies_filter(doc, filter)? {
+            let Some((distance, embed_doc)) =
+                Self::score_candidate(doc, embeddings, prompt_embedding, filter, threshold)?
+            else {
                 continue;
-            }
-
-            // Get the best context for the document given the prompt
-            if let Some((distance, embed_doc)) = embeddings
-                .iter()
-                .map(|embedding| {
-                    (
-                        OrderedFloat(embedding.cosine_similarity(prompt_embedding, false)),
-                        &embedding.document,
-                    )
-                })
-                .max_by(|a, b| a.0.cmp(&b.0))
-            {
-                // Skip documents below the similarity threshold.
-                if threshold.is_some_and(|t| distance.0 < t) {
-                    continue;
-                }
-                docs.push(Reverse(RankingItem(distance, id, doc, embed_doc)));
             };
+
+            docs.push(Reverse(RankingItem(distance, id, doc, embed_doc)));
 
             // If the heap size exceeds n, pop the least old element.
             if docs.len() > n {
@@ -257,29 +289,11 @@ impl<D: Serialize + Eq> InMemoryVectorStore<D> {
         let mut scored_docs = Vec::new();
 
         for candidate_id in candidates {
-            if let Some((doc, embeddings)) = self.embeddings.get(&candidate_id) {
-                // Skip documents that don't satisfy the metadata filter.
-                if !Self::satisfies_filter(doc, filter)? {
-                    continue;
-                }
-
-                // Get the best context for the document given the prompt
-                if let Some((distance, embed_doc)) = embeddings
-                    .iter()
-                    .map(|embedding| {
-                        (
-                            OrderedFloat(embedding.cosine_similarity(prompt_embedding, false)),
-                            &embedding.document,
-                        )
-                    })
-                    .max_by(|a, b| a.0.cmp(&b.0))
-                {
-                    // Skip documents below the similarity threshold.
-                    if threshold.is_some_and(|t| distance.0 < t) {
-                        continue;
-                    }
-                    scored_docs.push((distance, candidate_id, doc, embed_doc));
-                }
+            if let Some((doc, embeddings)) = self.embeddings.get(&candidate_id)
+                && let Some((distance, embed_doc)) =
+                    Self::score_candidate(doc, embeddings, prompt_embedding, filter, threshold)?
+            {
+                scored_docs.push((distance, candidate_id, doc, embed_doc));
             }
         }
 
@@ -883,5 +897,53 @@ mod tests {
             .build())
         .await;
         assert_eq!(kept, vec!["a", "b", "c"]);
+    }
+
+    #[tokio::test]
+    async fn top_n_excludes_non_finite_similarity() {
+        use crate::test_utils::MockEmbeddingModel;
+        use crate::vector_store::VectorStoreIndex;
+        use crate::vector_store::request::VectorSearchRequest;
+
+        let embedding = |doc: &str, vec: Vec<f64>| {
+            OneOrMany::one(Embedding {
+                document: doc.to_string(),
+                vec,
+            })
+        };
+
+        // The zero-magnitude embedding produces a NaN cosine similarity, which
+        // sorts as the maximum under OrderedFloat. It must not rank first (or
+        // appear at all), even with no threshold set.
+        let index = InMemoryVectorStore::from_documents_with_ids(vec![
+            (
+                "good",
+                "good".to_string(),
+                embedding(
+                    "good",
+                    vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
+                ),
+            ),
+            (
+                "degenerate",
+                "degenerate".to_string(),
+                embedding("degenerate", vec![0.0; 10]),
+            ),
+        ])
+        .index(MockEmbeddingModel);
+
+        let ids: Vec<String> = index
+            .top_n_ids(
+                VectorSearchRequest::builder()
+                    .query("q")
+                    .samples(10)
+                    .build(),
+            )
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|(_, id)| id)
+            .collect();
+        assert_eq!(ids, vec!["good".to_string()]);
     }
 }

--- a/crates/rig-core/src/vector_store/in_memory_store.rs
+++ b/crates/rig-core/src/vector_store/in_memory_store.rs
@@ -153,9 +153,9 @@ impl<D: Serialize + Eq> InMemoryVectorStore<D> {
     ///
     /// Returns the best similarity across the document's embeddings together with
     /// the matching embedding text, or `None` when the document is filtered out,
-    /// has no embeddings, produces a non-finite similarity, or scores below the
-    /// threshold. Shared by the brute-force and LSH scans so the filter,
-    /// threshold, and NaN handling live in exactly one place.
+    /// has no finite-similarity embedding, or scores below the threshold. Shared
+    /// by the brute-force and LSH scans so the filter, threshold, and NaN
+    /// handling live in exactly one place.
     fn score_candidate<'a>(
         doc: &D,
         embeddings: &'a OneOrMany<Embedding>,
@@ -168,6 +168,13 @@ impl<D: Serialize + Eq> InMemoryVectorStore<D> {
         }
 
         // Best (highest-similarity) embedding for this document.
+        //
+        // A zero-magnitude embedding yields a NaN similarity, which sorts as the
+        // maximum under `OrderedFloat` and slips past `distance < threshold`
+        // (every comparison with NaN is false). Drop non-finite similarities
+        // *before* selecting the max so a document still ranks by its best
+        // finite embedding; the document is skipped only when it has no finite
+        // similarity at all.
         let Some((distance, embed_doc)) = embeddings
             .iter()
             .map(|embedding| {
@@ -176,17 +183,11 @@ impl<D: Serialize + Eq> InMemoryVectorStore<D> {
                     &embedding.document,
                 )
             })
+            .filter(|(distance, _)| distance.0.is_finite())
             .max_by(|a, b| a.0.cmp(&b.0))
         else {
             return Ok(None);
         };
-
-        // A zero-magnitude embedding yields a NaN similarity; NaN sorts as the
-        // maximum under `OrderedFloat` and slips past `distance < threshold`
-        // (every comparison with NaN is false), so it must be excluded here.
-        if !distance.0.is_finite() {
-            return Ok(None);
-        }
 
         // Skip documents below the similarity threshold.
         if threshold.is_some_and(|t| distance.0 < t) {
@@ -945,5 +946,45 @@ mod tests {
             .map(|(_, id)| id)
             .collect();
         assert_eq!(ids, vec!["good".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn top_n_ranks_document_by_best_finite_embedding() {
+        use crate::test_utils::MockEmbeddingModel;
+        use crate::vector_store::VectorStoreIndex;
+        use crate::vector_store::request::VectorSearchRequest;
+
+        // A document that owns both a strong finite embedding and a degenerate
+        // zero-magnitude (NaN) one must still be returned, ranked by the finite
+        // embedding — not dropped because NaN sorts as the OrderedFloat maximum.
+        let index = InMemoryVectorStore::from_documents_with_ids(vec![(
+            "mixed",
+            "mixed".to_string(),
+            OneOrMany::many(vec![
+                Embedding {
+                    document: "good-chunk".to_string(),
+                    vec: vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
+                },
+                Embedding {
+                    document: "empty-chunk".to_string(),
+                    vec: vec![0.0; 10],
+                },
+            ])
+            .unwrap(),
+        )])
+        .index(MockEmbeddingModel);
+
+        let results = index
+            .top_n_ids(
+                VectorSearchRequest::builder()
+                    .query("q")
+                    .samples(10)
+                    .build(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].1, "mixed");
+        assert!(results[0].0.is_finite());
     }
 }

--- a/crates/rig-core/src/vector_store/in_memory_store.rs
+++ b/crates/rig-core/src/vector_store/in_memory_store.rs
@@ -131,15 +131,52 @@ impl<D: Serialize + Eq> InMemoryVectorStore<D> {
         }
     }
 
+    /// Tests whether a document satisfies the (optional) metadata filter.
+    ///
+    /// Documents are serialized to JSON on demand and matched with
+    /// [`Filter::satisfies`]. Returns `Ok(true)` when no filter is set so the
+    /// serialization cost is only paid for filtered queries.
+    fn satisfies_filter(
+        doc: &D,
+        filter: Option<&Filter<serde_json::Value>>,
+    ) -> Result<bool, VectorStoreError> {
+        match filter {
+            None => Ok(true),
+            Some(filter) => {
+                let value = serde_json::to_value(doc).map_err(VectorStoreError::JsonError)?;
+                Ok(filter.satisfies(&value))
+            }
+        }
+    }
+
     /// Implement vector search on [InMemoryVectorStore].
     /// To be used by implementations of [VectorStoreIndex::top_n] and [VectorStoreIndex::top_n_ids] methods.
-    fn vector_search(&self, prompt_embedding: &Embedding, n: usize) -> EmbeddingRanking<'_, D> {
+    ///
+    /// The metadata `filter` and similarity `threshold` are applied *during* the
+    /// scan, before the top-`n` selection, so results match backends that filter
+    /// server-side rather than returning the unfiltered top-`n`.
+    fn vector_search(
+        &self,
+        prompt_embedding: &Embedding,
+        n: usize,
+        filter: Option<&Filter<serde_json::Value>>,
+        threshold: Option<f64>,
+    ) -> Result<EmbeddingRanking<'_, D>, VectorStoreError> {
         match &self.index_strategy {
-            IndexStrategy::BruteForce => self.vector_search_brute_force(prompt_embedding, n),
+            IndexStrategy::BruteForce => {
+                self.vector_search_brute_force(prompt_embedding, n, filter, threshold)
+            }
             IndexStrategy::LSH {
                 num_tables,
                 num_hyperplanes,
-            } => self.vector_search_lsh(prompt_embedding, n, *num_tables, *num_hyperplanes),
+            } => self.vector_search_lsh(
+                prompt_embedding,
+                n,
+                *num_tables,
+                *num_hyperplanes,
+                filter,
+                threshold,
+            ),
         }
     }
 
@@ -148,11 +185,18 @@ impl<D: Serialize + Eq> InMemoryVectorStore<D> {
         &self,
         prompt_embedding: &Embedding,
         n: usize,
-    ) -> EmbeddingRanking<'_, D> {
+        filter: Option<&Filter<serde_json::Value>>,
+        threshold: Option<f64>,
+    ) -> Result<EmbeddingRanking<'_, D>, VectorStoreError> {
         // Sort documents by best embedding distance
         let mut docs = BinaryHeap::new();
 
         for (id, (doc, embeddings)) in self.embeddings.iter() {
+            // Skip documents that don't satisfy the metadata filter.
+            if !Self::satisfies_filter(doc, filter)? {
+                continue;
+            }
+
             // Get the best context for the document given the prompt
             if let Some((distance, embed_doc)) = embeddings
                 .iter()
@@ -164,6 +208,10 @@ impl<D: Serialize + Eq> InMemoryVectorStore<D> {
                 })
                 .max_by(|a, b| a.0.cmp(&b.0))
             {
+                // Skip documents below the similarity threshold.
+                if threshold.is_some_and(|t| distance.0 < t) {
+                    continue;
+                }
                 docs.push(Reverse(RankingItem(distance, id, doc, embed_doc)));
             };
 
@@ -182,7 +230,7 @@ impl<D: Serialize + Eq> InMemoryVectorStore<D> {
                 .join(", ")
         );
 
-        docs
+        Ok(docs)
     }
 
     /// LSH-based vector search - uses LSH to find candidates then computes exact distances
@@ -192,11 +240,13 @@ impl<D: Serialize + Eq> InMemoryVectorStore<D> {
         n: usize,
         _num_tables: usize,
         _num_hyperplanes: usize,
-    ) -> EmbeddingRanking<'_, D> {
+        filter: Option<&Filter<serde_json::Value>>,
+        threshold: Option<f64>,
+    ) -> Result<EmbeddingRanking<'_, D>, VectorStoreError> {
         // If we don't have an LSH index yet, fall back to brute force
         let Some(lsh_index) = self.lsh_index.as_ref() else {
             tracing::warn!("LSH index not initialized, falling back to brute force search");
-            return self.vector_search_brute_force(prompt_embedding, n);
+            return self.vector_search_brute_force(prompt_embedding, n, filter, threshold);
         };
         let candidates = lsh_index.query(&prompt_embedding.vec);
 
@@ -208,6 +258,11 @@ impl<D: Serialize + Eq> InMemoryVectorStore<D> {
 
         for candidate_id in candidates {
             if let Some((doc, embeddings)) = self.embeddings.get(&candidate_id) {
+                // Skip documents that don't satisfy the metadata filter.
+                if !Self::satisfies_filter(doc, filter)? {
+                    continue;
+                }
+
                 // Get the best context for the document given the prompt
                 if let Some((distance, embed_doc)) = embeddings
                     .iter()
@@ -219,6 +274,10 @@ impl<D: Serialize + Eq> InMemoryVectorStore<D> {
                     })
                     .max_by(|a, b| a.0.cmp(&b.0))
                 {
+                    // Skip documents below the similarity threshold.
+                    if threshold.is_some_and(|t| distance.0 < t) {
+                        continue;
+                    }
                     scored_docs.push((distance, candidate_id, doc, embed_doc));
                 }
             }
@@ -244,7 +303,7 @@ impl<D: Serialize + Eq> InMemoryVectorStore<D> {
                 .join(", ")
         );
 
-        docs
+        Ok(docs)
     }
 
     /// Initialize LSH index from existing embeddings
@@ -426,9 +485,12 @@ impl<M: EmbeddingModel + Sync, D: Serialize + Sync + Send + Eq> VectorStoreIndex
     ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {
         let prompt_embedding = &self.model.embed_text(req.query()).await?;
 
-        let docs = self
-            .store
-            .vector_search(prompt_embedding, req.samples() as usize);
+        let docs = self.store.vector_search(
+            prompt_embedding,
+            req.samples() as usize,
+            req.filter().as_ref(),
+            req.threshold(),
+        )?;
 
         // Return n best
         docs.into_iter()
@@ -452,9 +514,12 @@ impl<M: EmbeddingModel + Sync, D: Serialize + Sync + Send + Eq> VectorStoreIndex
     ) -> Result<Vec<(f64, String)>, VectorStoreError> {
         let prompt_embedding = &self.model.embed_text(req.query()).await?;
 
-        let docs = self
-            .store
-            .vector_search(prompt_embedding, req.samples() as usize);
+        let docs = self.store.vector_search(
+            prompt_embedding,
+            req.samples() as usize,
+            req.filter().as_ref(),
+            req.threshold(),
+        )?;
 
         docs.into_iter()
             .map(|Reverse(RankingItem(distance, id, _, _))| Ok((distance.0, id.clone())))
@@ -614,13 +679,17 @@ mod tests {
             ])
             .build();
 
-        let ranking = vector_store.vector_search(
-            &Embedding {
-                document: "glarby-glarble".to_string(),
-                vec: vec![0.0, 0.1, 0.6],
-            },
-            1,
-        );
+        let ranking = vector_store
+            .vector_search(
+                &Embedding {
+                    document: "glarby-glarble".to_string(),
+                    vec: vec![0.0, 0.1, 0.6],
+                },
+                1,
+                None,
+                None,
+            )
+            .unwrap();
 
         assert_eq!(
             ranking
@@ -697,13 +766,17 @@ mod tests {
             ])
             .build();
 
-        let ranking = vector_store.vector_search(
-            &Embedding {
-                document: "glarby-glarble".to_string(),
-                vec: vec![0.0, 0.1, 0.6],
-            },
-            1,
-        );
+        let ranking = vector_store
+            .vector_search(
+                &Embedding {
+                    document: "glarby-glarble".to_string(),
+                    vec: vec![0.0, 0.1, 0.6],
+                },
+                1,
+                None,
+                None,
+            )
+            .unwrap();
 
         assert_eq!(
             ranking
@@ -722,5 +795,93 @@ mod tests {
                 "glarb-garb".to_string()
             )]
         )
+    }
+
+    #[tokio::test]
+    async fn top_n_honors_filter_and_threshold() {
+        use crate::test_utils::MockEmbeddingModel;
+        use crate::vector_store::VectorStoreIndex;
+        use crate::vector_store::request::{Filter, SearchFilter, VectorSearchRequest};
+        use serde::Serialize;
+        use serde_json::json;
+
+        // Document payloads carry metadata alongside content, like real backends.
+        #[derive(Clone, Serialize, PartialEq, Eq)]
+        struct Item {
+            category: String,
+            text: String,
+        }
+
+        fn item(category: &str, text: &str) -> Item {
+            Item {
+                category: category.to_string(),
+                text: text.to_string(),
+            }
+        }
+
+        // `MockEmbeddingModel` embeds every query as this fixed 10-dim vector; give
+        // every document the same embedding so all cosine similarities are 1.0 and
+        // only the filter/threshold decide the result set.
+        let vec = vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9];
+        let embedding = |doc: &str| {
+            OneOrMany::one(Embedding {
+                document: doc.to_string(),
+                vec: vec.clone(),
+            })
+        };
+
+        let index = InMemoryVectorStore::from_documents_with_ids(vec![
+            ("a", item("fruit", "banana"), embedding("banana")),
+            ("b", item("veg", "carrot"), embedding("carrot")),
+            ("c", item("fruit", "apple"), embedding("apple")),
+        ])
+        .index(MockEmbeddingModel);
+
+        let ids = |req| async {
+            let mut out: Vec<String> = index
+                .top_n_ids(req)
+                .await
+                .unwrap()
+                .into_iter()
+                .map(|(_, id)| id)
+                .collect();
+            out.sort();
+            out
+        };
+
+        // No filter: every document is returned.
+        let all = ids(VectorSearchRequest::builder()
+            .query("q")
+            .samples(10)
+            .build())
+        .await;
+        assert_eq!(all, vec!["a", "b", "c"]);
+
+        // Metadata filter: only documents whose `category` field is `fruit`.
+        let fruit = ids(VectorSearchRequest::builder()
+            .query("q")
+            .samples(10)
+            .filter(Filter::eq("category", json!("fruit")))
+            .build())
+        .await;
+        assert_eq!(fruit, vec!["a", "c"]);
+
+        // Threshold above the maximum similarity (1.0): nothing qualifies.
+        let none = ids(VectorSearchRequest::builder()
+            .query("q")
+            .samples(10)
+            .threshold(2.0)
+            .build())
+        .await;
+        assert!(none.is_empty());
+
+        // Threshold at or below the similarity keeps all matches.
+        let kept = ids(VectorSearchRequest::builder()
+            .query("q")
+            .samples(10)
+            .threshold(0.5)
+            .build())
+        .await;
+        assert_eq!(kept, vec!["a", "b", "c"]);
     }
 }

--- a/crates/rig-core/src/vector_store/request.rs
+++ b/crates/rig-core/src/vector_store/request.rs
@@ -193,10 +193,15 @@ where
 }
 
 impl Filter<serde_json::Value> {
-    /// Tests whether a JSON value satisfies this filter.
+    /// Tests whether a JSON document satisfies this filter.
+    ///
+    /// Leaf filters (`Eq`/`Gt`/`Lt`) look their key up in `value` (expected to be
+    /// a JSON object) and compare the resulting field against the filter operand.
+    /// A missing field, or an operand that is not order-comparable with the field,
+    /// never satisfies the leaf. `And`/`Or` combine leaf results.
     pub fn satisfies(&self, value: &serde_json::Value) -> bool {
         use Filter::*;
-        use serde_json::{Value, Value::*, json};
+        use serde_json::{Value, Value::*};
         use std::cmp::Ordering;
 
         fn compare_pair(l: &Value, r: &Value) -> Option<std::cmp::Ordering> {
@@ -215,13 +220,15 @@ impl Filter<serde_json::Value> {
         }
 
         match self {
-            Eq(k, v) => &json!({ k: v }) == value,
-            Gt(k, v) => {
-                compare_pair(&json!({k: v}), value).is_some_and(|ord| ord == Ordering::Greater)
-            }
-            Lt(k, v) => {
-                compare_pair(&json!({k: v}), value).is_some_and(|ord| ord == Ordering::Less)
-            }
+            Eq(k, v) => value.get(k) == Some(v),
+            Gt(k, v) => value
+                .get(k)
+                .and_then(|field| compare_pair(field, v))
+                .is_some_and(|ord| ord == Ordering::Greater),
+            Lt(k, v) => value
+                .get(k)
+                .and_then(|field| compare_pair(field, v))
+                .is_some_and(|ord| ord == Ordering::Less),
             And(l, r) => l.satisfies(value) && r.satisfies(value),
             Or(l, r) => l.satisfies(value) || r.satisfies(value),
         }
@@ -312,5 +319,47 @@ impl<F> VectorSearchRequestBuilder<F, Provided<String>, Provided<u64>> {
             additional_params: self.additional_params,
             filter: self.filter,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Filter, SearchFilter};
+    use serde_json::json;
+
+    type F = Filter<serde_json::Value>;
+
+    #[test]
+    fn eq_matches_field_within_multi_field_document() {
+        let doc = json!({ "category": "fruit", "text": "banana" });
+        assert!(F::eq("category", json!("fruit")).satisfies(&doc));
+        assert!(!F::eq("category", json!("veg")).satisfies(&doc));
+        // A field that does not exist never matches.
+        assert!(!F::eq("missing", json!("fruit")).satisfies(&doc));
+    }
+
+    #[test]
+    fn gt_and_lt_compare_the_named_field() {
+        let doc = json!({ "price": 10, "text": "banana" });
+        assert!(F::gt("price", json!(5)).satisfies(&doc));
+        assert!(!F::gt("price", json!(10)).satisfies(&doc));
+        assert!(F::lt("price", json!(20)).satisfies(&doc));
+        assert!(!F::lt("price", json!(10)).satisfies(&doc));
+        // Missing / non-comparable fields never satisfy an ordering filter.
+        assert!(!F::gt("missing", json!(1)).satisfies(&doc));
+        assert!(!F::gt("text", json!(1)).satisfies(&doc));
+    }
+
+    #[test]
+    fn and_or_combine_leaf_filters() {
+        let doc = json!({ "category": "fruit", "price": 10 });
+        let both = F::eq("category", json!("fruit")).and(F::gt("price", json!(5)));
+        assert!(both.satisfies(&doc));
+
+        let missing_branch = F::eq("category", json!("fruit")).and(F::gt("price", json!(50)));
+        assert!(!missing_branch.satisfies(&doc));
+
+        let either = F::eq("category", json!("veg")).or(F::lt("price", json!(50)));
+        assert!(either.satisfies(&doc));
     }
 }

--- a/crates/rig-core/src/vector_store/request.rs
+++ b/crates/rig-core/src/vector_store/request.rs
@@ -204,23 +204,36 @@ impl Filter<serde_json::Value> {
         use serde_json::{Value, Value::*};
         use std::cmp::Ordering;
 
-        fn compare_pair(l: &Value, r: &Value) -> Option<std::cmp::Ordering> {
+        fn compare_pair(l: &Value, r: &Value) -> Option<Ordering> {
             match (l, r) {
-                (Number(l), Number(r)) => l
-                    .as_f64()
-                    .zip(r.as_f64())
-                    .and_then(|(l, r)| l.partial_cmp(&r))
-                    .or(l.as_i64().zip(r.as_i64()).map(|(l, r)| l.cmp(&r)))
-                    .or(l.as_u64().zip(r.as_u64()).map(|(l, r)| l.cmp(&r))),
+                // Compare integers exactly; fall back to f64 only for floats or
+                // mixed int/float operands. Trying `as_f64` first (as the old
+                // code did) would lose precision for integers beyond 2^53.
+                (Number(l), Number(r)) => {
+                    if let (Some(l), Some(r)) = (l.as_i64(), r.as_i64()) {
+                        Some(l.cmp(&r))
+                    } else if let (Some(l), Some(r)) = (l.as_u64(), r.as_u64()) {
+                        Some(l.cmp(&r))
+                    } else {
+                        l.as_f64()
+                            .zip(r.as_f64())
+                            .and_then(|(l, r)| l.partial_cmp(&r))
+                    }
+                }
                 (String(l), String(r)) => Some(l.cmp(r)),
-                (Null, Null) => Some(std::cmp::Ordering::Equal),
+                (Null, Null) => Some(Ordering::Equal),
                 (Bool(l), Bool(r)) => Some(l.cmp(r)),
                 _ => None,
             }
         }
 
         match self {
-            Eq(k, v) => value.get(k) == Some(v),
+            // Numbers compare numerically so `5` matches `5.0`, consistent with
+            // `Gt`/`Lt`; other JSON types fall back to structural equality so
+            // strings/bools/arrays/objects still match exactly.
+            Eq(k, v) => value
+                .get(k)
+                .is_some_and(|field| compare_pair(field, v) == Some(Ordering::Equal) || field == v),
             Gt(k, v) => value
                 .get(k)
                 .and_then(|field| compare_pair(field, v))
@@ -348,6 +361,28 @@ mod tests {
         // Missing / non-comparable fields never satisfy an ordering filter.
         assert!(!F::gt("missing", json!(1)).satisfies(&doc));
         assert!(!F::gt("text", json!(1)).satisfies(&doc));
+    }
+
+    #[test]
+    fn eq_matches_integer_and_float_representations() {
+        // A field stored as a float still matches an integer operand and vice
+        // versa, consistent with Gt/Lt numeric coercion.
+        assert!(F::eq("score", json!(5)).satisfies(&json!({ "score": 5.0 })));
+        assert!(F::eq("score", json!(5.0)).satisfies(&json!({ "score": 5 })));
+        assert!(!F::eq("score", json!(6)).satisfies(&json!({ "score": 5.0 })));
+        // Non-numeric fields still use structural equality.
+        assert!(F::eq("tag", json!("a")).satisfies(&json!({ "tag": "a" })));
+        assert!(F::eq("tags", json!(["a", "b"])).satisfies(&json!({ "tags": ["a", "b"] })));
+        assert!(!F::eq("tags", json!(["a"])).satisfies(&json!({ "tags": ["a", "b"] })));
+    }
+
+    #[test]
+    fn ordering_compares_large_integers_exactly() {
+        // Integers beyond 2^53 must not collapse to the same f64.
+        let doc = json!({ "id": 9007199254740993_u64 }); // 2^53 + 1
+        assert!(F::gt("id", json!(9007199254740992_u64)).satisfies(&doc)); // > 2^53
+        assert!(!F::gt("id", json!(9007199254740993_u64)).satisfies(&doc));
+        assert!(F::lt("id", json!(9007199254740994_u64)).satisfies(&doc));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The first batch of "Release-N" quick wins from an architectural review of Rig — high-confidence correctness fixes plus dead-code removal. Each item is its own commit; the diff is net-negative in production code with new tests added.

## What's included

### 1. Vector store: honor `filter` + `threshold` in the in-memory index; fix `Filter::satisfies`
- `InMemoryVectorIndex::top_n`/`top_n_ids` ignored `req.filter()` and `req.threshold()`, so the **default** store returned unfiltered/un-thresholded results that diverged from every real backend. Both are now applied **during the scan** (before top-`n` selection), matching backends that filter server-side.
- `Filter::satisfies` was broken for realistic documents: `Eq(k,v)` compared a single-key `{k:v}` object against the **whole** document (only matched single-field docs), and `Gt`/`Lt` passed an object to `compare_pair`, which returns `None` for objects — so **`Gt`/`Lt` always returned `false`**. Rewrote leaf filters to look the key up in the document and compare the field. This also fixes `rig-helixdb`, which passes the full payload to `satisfies`.
- Added unit tests for `satisfies` (multi-field docs, `Gt`/`Lt`, `And`/`Or`) and a `top_n` filter/threshold conformance test.

### 2. Embeddings: de-duplicate `VectorDistance`; fix chebyshev rayon drift
- `distance.rs` carried two full copies of the impl (sequential + rayon) that had drifted: under the `rayon` feature, `chebyshev_distance` used sequential `.iter()` while every sibling used `par_iter()`, so one metric was silently unparallelized.
- Factored both impls through one macro parameterized by the iterator constructor **and** the max-reduction (`Iterator::fold` vs `ParallelIterator::reduce` — which is why the copy couldn't simply swap `iter` for `par_iter`). Verified identical results under both feature configs.

### 3. Streaming: derive real usage in the `From` impl; add `usage()`
- `From<StreamingCompletionResponse<R>> for CompletionResponse` hardcoded `Usage::new()`, so any caller using `.into()` on a completed stream silently got **zero usage** even though `R: GetTokenUsage` and the final response held the usage. Now derived via `Option<R>: GetTokenUsage` (zero sentinel when there is no final response).
- Added `StreamingCompletionResponse::usage()` and tests for both the populated and zero-sentinel paths.

### 4. Delete unwired abstractions; dedupe `UNKNOWN_AGENT_NAME`
Removed speculative/dead code with **no consumer anywhere in the workspace** (verified by a full-workspace reference sweep):
- `Transport::NdJson` (never constructed; all matches use wildcards)
- `ConvertMessage` trait (no impls, no consumer, not re-exported)
- telemetry `ProviderRequestExt` trait + its lone OpenAI impl (no consumer)
- `SpanCombinator::record_model_input` (zero call sites)
- SSE `with_retry_policy` + `RetryPolicy::{Constant, Never}` (never used; the `RetryPolicy` trait, `ExponentialBackoff`, and `DEFAULT_RETRY` stay)

Deduped the duplicated `UNKNOWN_AGENT_NAME` const into one `pub(crate)` const in `agent/mod.rs`.

## Not in this PR (remaining Release-N items)
- **CallWarning channel** — deferred to its own PR. Adding a `warnings` field to `CompletionResponse` touches ~110 construction sites across ~30 provider files; too invasive to bundle here.
- **Inline-test extraction** from the six oversized files (pure-move commits) — large mechanical diff, better as a standalone PR.
- **Wire-type hoist** (`ApiResponse` etc. into `internal/`) — the riskiest item (18 files; Azure/`together` are poorer fits); belongs in the shared-engine work.

## Testing
- `cargo test -p rig-core --lib` — 1061 passed
- `cargo build -p rig-helixdb` (consumes `Filter::satisfies`) — clean
- `cargo clippy -p rig-core --all-targets` and `--features rayon` — clean
- `cargo fmt --all` — no changes