### PR TITLE
fix(ollama): omit `think` when unset so the model default applies

### DIFF
--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -410,7 +410,8 @@ pub(super) struct OllamaCompletionRequest {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     tools: Vec<ToolDefinition>,
     pub stream: bool,
-    think: Think,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    think: Option<Think>,
     #[serde(skip_serializing_if = "Option::is_none")]
     max_tokens: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -450,7 +451,7 @@ impl TryFrom<(&str, CompletionRequest)> for OllamaCompletionRequest {
                 .collect::<Vec<_>>(),
         );
 
-        let mut think = Think::Bool(false);
+        let mut think: Option<Think> = None;
         let mut keep_alive: Option<String> = None;
 
         let options = if let Some(mut extra) = req.additional_params {
@@ -458,7 +459,7 @@ impl TryFrom<(&str, CompletionRequest)> for OllamaCompletionRequest {
             if let Some(obj) = extra.as_object_mut() {
                 // Extract `think` parameter
                 if let Some(think_val) = obj.remove("think") {
-                    think = match think_val {
+                    think = Some(match think_val {
                         Value::Bool(think) => Think::Bool(think),
                         Value::String(think) => Think::Level(match think.to_lowercase().as_str() {
                             "low" => Level::Low,
@@ -475,7 +476,7 @@ impl TryFrom<(&str, CompletionRequest)> for OllamaCompletionRequest {
                                 "`think` must be a 'low', 'medium', 'high', or bool".into(),
                             ));
                         }
-                    };
+                    });
                 }
 
                 // Extract `keep_alive` parameter
@@ -1962,9 +1963,10 @@ mod tests {
         assert!(ollama_request.is_err())
     }
 
-    // Test that `think` defaults to false when not specified
+    // Test that `think` is omitted when not specified, so Ollama applies the
+    // model's default thinking behavior (issue #1970)
     #[test]
-    fn test_completion_request_with_think_false_default() {
+    fn test_completion_request_with_think_omitted_by_default() {
         use crate::OneOrMany;
         use crate::completion::Message as CompletionMessage;
         use crate::message::{Text, UserContent};
@@ -1993,7 +1995,8 @@ mod tests {
         let serialized =
             serde_json::to_value(&ollama_request).expect("Failed to serialize request");
 
-        // Assert that "think" defaults to false and "keep_alive" is not present
+        // Assert that "think" is absent (so Ollama uses the model default) and
+        // "keep_alive" is not present
         let expected = json!({
             "model": "llama3.2",
             "messages": [
@@ -2008,7 +2011,6 @@ mod tests {
             ],
             "temperature": 0.5,
             "stream": false,
-            "think": false,
             "options": {
                 "temperature": 0.5
             }


### PR DESCRIPTION
# fix(ollama): omit `think` when unset so the model default applies

## Description

The Ollama provider always serialized a `think` field, defaulting it to `false` when the
caller did not set one. Ollama's `/api/chat` treats `think` as tri-state: an absent field
means "use the model's default", `false` suppresses thinking, and `true`/level forces it.
By always sending `false`, rig turned off thinking that a model would otherwise do by default,
and there was no way to express the neutral absent state.

This makes `OllamaCompletionRequest.think` optional and skips serialization when it is unset,
so a request built without an explicit `think` omits the field entirely. Explicit
`think: true | "low" | "medium" | "high"` requests are unaffected.

Fixes #1970

## Type of change

- [x] Bug fix

## Testing

- [x] `cargo test -p rig-core --lib providers::ollama::tests::`: 28 passed, 0 failed.
- [x] Verified the no-`think` case omits the field, and the explicit `true`/`low`/`medium`/`high` cases still serialize the expected top-level value.

## AI assistance

This PR was written with the assistance of AI tools (Claude Code).

## Notes

PR #1982 also edits `crates/rig-core/src/providers/ollama.rs` (adding a `max` think level). The scope here is disjoint (default/omission only), but a small rebase conflict near the `Think` handling is possible if both land; happy to rebase on whichever merges first.
