### PR TITLE
fix(openai): accept null Responses metadata

### DIFF
--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -1157,7 +1157,11 @@ pub struct AdditionalParameters {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prompt_cache_retention: Option<String>,
     /// Any additional metadata you'd like to add. This will additionally be returned by the response.
-    #[serde(skip_serializing_if = "Map::is_empty", default)]
+    #[serde(
+        skip_serializing_if = "Map::is_empty",
+        default,
+        deserialize_with = "deserialize_metadata"
+    )]
     pub metadata: serde_json::Map<String, serde_json::Value>,
     /// Whether or not you want tool calls to run in parallel.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1174,6 +1178,18 @@ pub struct AdditionalParameters {
     /// Whether or not to store the response for later retrieval by API.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub store: Option<bool>,
+}
+
+fn deserialize_metadata<'de, D>(
+    deserializer: D,
+) -> Result<serde_json::Map<String, serde_json::Value>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(
+        Option::<serde_json::Map<String, serde_json::Value>>::deserialize(deserializer)?
+            .unwrap_or_default(),
+    )
 }
 
 impl AdditionalParameters {
@@ -2587,6 +2603,33 @@ mod tests {
             completion::AssistantContent::Reasoning(_)
         ));
         assert!(matches!(items[1], completion::AssistantContent::Text(_)));
+    }
+
+    #[test]
+    fn completion_response_accepts_null_metadata() {
+        let response: CompletionResponse = serde_json::from_value(json!({
+            "id": "resp_123",
+            "object": "response",
+            "created_at": 0,
+            "status": "completed",
+            "model": "openai-compatible-model",
+            "metadata": null,
+            "output": [{
+                "type": "message",
+                "id": "msg_123",
+                "status": "completed",
+                "role": "assistant",
+                "content": [{
+                    "type": "output_text",
+                    "annotations": [],
+                    "text": "done"
+                }]
+            }],
+            "tools": []
+        }))
+        .expect("response with null metadata should deserialize");
+
+        assert!(response.additional_parameters.metadata.is_empty());
     }
 
     #[test]

--- a/tests/cassettes/openai/vllm/responses_api_accepts_null_metadata.yaml
+++ b/tests/cassettes/openai/vllm/responses_api_accepts_null_metadata.yaml
@@ -1,0 +1,16 @@
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"input":[{"content":[{"text":"Reply with a short acknowledgement.","type":"input_text"}],"role":"user","type":"message"}],"max_output_tokens":8,"model":"Qwen/Qwen3-0.6B"}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"background":false,"created_at":0,"id":"resp_REDACTED_1","incomplete_details":null,"input_messages":null,"instructions":null,"max_output_tokens":8,"max_tool_calls":null,"metadata":null,"model":"Qwen/Qwen3-0.6B","object":"response","output":[{"content":[{"annotations":[],"logprobs":null,"text":"<think>\nOkay, the user wants me","type":"output_text"}],"id":"msg_REDACTED_1","phase":null,"role":"assistant","status":"completed","type":"message"}],"output_messages":null,"parallel_tool_calls":true,"previous_response_id":null,"prompt":null,"reasoning":null,"service_tier":"auto","status":"completed","temperature":0.6,"text":null,"tool_choice":"auto","tools":[],"top_logprobs":null,"top_p":0.95,"truncation":"disabled","usage":{"input_tokens":14,"input_tokens_details":{"cached_tokens":0},"output_tokens":8,"output_tokens_details":{"reasoning_tokens":0,"tool_output_tokens":0},"total_tokens":22},"user":null}'

--- a/tests/common/cassette_safety.rs
+++ b/tests/common/cassette_safety.rs
@@ -25,6 +25,7 @@ const PROVIDER_CASSETTE_SUITES: &[ProviderCassetteSuite] = &[
             "with_openai_completions_cassette",
             "with_openai_cassette_result",
             "with_openai_completions_cassette_result",
+            "with_openai_vllm_cassette",
         ],
     },
     ProviderCassetteSuite {

--- a/tests/providers/openai/cassette/vllm.rs
+++ b/tests/providers/openai/cassette/vllm.rs
@@ -1,0 +1,61 @@
+//! vLLM OpenAI-compatible Responses API regression tests.
+
+use rig::client::CompletionClient;
+use rig::completion::CompletionModel;
+use rig::providers::openai;
+use std::future::Future;
+use std::panic::AssertUnwindSafe;
+
+use crate::cassettes::ProviderCassette;
+use futures::FutureExt;
+
+async fn with_openai_vllm_cassette<F, Fut>(scenario: &'static str, test_body: F)
+where
+    F: FnOnce(openai::Client) -> Fut,
+    Fut: Future<Output = ()>,
+{
+    let base_url =
+        std::env::var("VLLM_BASE_URL").unwrap_or_else(|_| "http://127.0.0.1:8000/v1".to_string());
+    let cassette = ProviderCassette::start("openai", scenario, &base_url).await;
+    let client = openai::Client::builder()
+        .api_key("dummy-vllm-key")
+        .base_url(cassette.base_url())
+        .build()
+        .expect("vLLM OpenAI-compatible client should build");
+
+    let result = AssertUnwindSafe(test_body(client)).catch_unwind().await;
+    cassette.finish_after_test(result).await;
+}
+
+#[tokio::test]
+async fn responses_api_accepts_null_metadata() {
+    with_openai_vllm_cassette(
+        "vllm/responses_api_accepts_null_metadata",
+        |client| async move {
+            let model = client.completion_model("Qwen/Qwen3-0.6B");
+            let request = model
+                .completion_request("Reply with a short acknowledgement.")
+                .max_tokens(8)
+                .build();
+
+            let response = model
+                .completion(request)
+                .await
+                .expect("vLLM Responses API completion with null metadata should deserialize");
+
+            assert!(
+                response
+                    .raw_response
+                    .additional_parameters
+                    .metadata
+                    .is_empty(),
+                "vLLM returns metadata: null; Rig should preserve the public map API as an empty map"
+            );
+            assert!(
+                response.choice.iter().next().is_some(),
+                "response should contain assistant content"
+            );
+        },
+    )
+    .await;
+}

--- a/tests/providers/openai/mod.rs
+++ b/tests/providers/openai/mod.rs
@@ -19,6 +19,7 @@ mod cassette {
     mod streaming_tools;
     mod structured_output;
     mod typed_prompt_tools;
+    mod vllm;
 }
 
 mod live {


### PR DESCRIPTION
## Summary
- deserialize OpenAI Responses API `metadata: null` as an empty metadata map
- keep the public `AdditionalParameters::metadata` type as `serde_json::Map`
- add a focused unit regression test for null metadata in a Responses payload
- add a vLLM-recorded cassette test proving an OpenAI-compatible Responses endpoint returns `metadata: null` and Rig now handles it

Fixes #1538.

## Verification
- `cargo fmt`
- `cargo test -p rig-core providers::openai::responses_api::tests::completion_response_accepts_null_metadata`
- `cargo test -p rig-core providers::openai::responses_api::tests -- --nocapture`
- `cargo clippy -p rig-core --lib -- -D warnings`
- `RIG_PROVIDER_TEST_MODE=record VLLM_BASE_URL=http://127.0.0.1:8000/v1 cargo test -p rig --test openai openai::cassette::vllm::responses_api_accepts_null_metadata -- --nocapture --test-threads=1`
- `RIG_PROVIDER_TEST_MODE=replay cargo test -p rig --test openai openai::cassette::vllm::responses_api_accepts_null_metadata -- --nocapture --test-threads=1`
- `RIG_PROVIDER_TEST_MODE=replay cargo test -p rig --test openai cassette_safety::cassette_files_match_registered_scenarios -- --nocapture`
- `cargo clippy -p rig --test openai -- -D warnings`
