### PR TITLE
Fix provider ClientBuilder API key aliases

### DIFF
--- a/crates/rig-core/src/providers/deepseek.rs
+++ b/crates/rig-core/src/providers/deepseek.rs
@@ -89,7 +89,7 @@ impl ProviderBuilder for DeepSeekExtBuilder {
 
 pub type Client<H = reqwest::Client> = client::Client<DeepSeekExt, H>;
 pub type ClientBuilder<H = crate::markers::Missing> =
-    client::ClientBuilder<DeepSeekExtBuilder, String, H>;
+    client::ClientBuilder<DeepSeekExtBuilder, DeepSeekApiKey, H>;
 
 impl ProviderClient for Client {
     type Input = DeepSeekApiKey;
@@ -1147,10 +1147,9 @@ mod tests {
     fn test_client_initialization() {
         let _client =
             crate::providers::deepseek::Client::new("dummy-key").expect("Client::new() failed");
-        let _client_from_builder = crate::providers::deepseek::Client::builder()
-            .api_key("dummy-key")
-            .build()
-            .expect("Client::builder() failed");
+        let builder: crate::providers::deepseek::ClientBuilder =
+            crate::providers::deepseek::Client::builder().api_key("dummy-key");
+        let _client_from_builder = builder.build().expect("Client::builder() failed");
     }
 
     #[test]

--- a/crates/rig-core/src/providers/groq.rs
+++ b/crates/rig-core/src/providers/groq.rs
@@ -91,7 +91,8 @@ impl ProviderBuilder for GroqBuilder {
 }
 
 pub type Client<H = reqwest::Client> = client::Client<GroqExt, H>;
-pub type ClientBuilder<H = crate::markers::Missing> = client::ClientBuilder<GroqBuilder, String, H>;
+pub type ClientBuilder<H = crate::markers::Missing> =
+    client::ClientBuilder<GroqBuilder, GroqApiKey, H>;
 
 impl ProviderClient for Client {
     type Input = String;
@@ -793,10 +794,9 @@ mod tests {
     fn test_client_initialization() {
         let _client =
             crate::providers::groq::Client::new("dummy-key").expect("Client::new() failed");
-        let _client_from_builder = crate::providers::groq::Client::builder()
-            .api_key("dummy-key")
-            .build()
-            .expect("Client::builder() failed");
+        let builder: crate::providers::groq::ClientBuilder =
+            crate::providers::groq::Client::builder().api_key("dummy-key");
+        let _client_from_builder = builder.build().expect("Client::builder() failed");
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/providers/hyperbolic.rs
+++ b/crates/rig-core/src/providers/hyperbolic.rs
@@ -80,7 +80,7 @@ impl ProviderBuilder for HyperbolicBuilder {
 
 pub type Client<H = reqwest::Client> = client::Client<HyperbolicExt, H>;
 pub type ClientBuilder<H = crate::markers::Missing> =
-    client::ClientBuilder<HyperbolicBuilder, String, H>;
+    client::ClientBuilder<HyperbolicBuilder, HyperbolicApiKey, H>;
 
 impl ProviderClient for Client {
     type Input = HyperbolicApiKey;
@@ -730,10 +730,9 @@ mod tests {
     fn test_client_initialization() {
         let _client =
             crate::providers::hyperbolic::Client::new("dummy-key").expect("Client::new() failed");
-        let _client_from_builder = crate::providers::hyperbolic::Client::builder()
-            .api_key("dummy-key")
-            .build()
-            .expect("Client::builder() failed");
+        let builder: crate::providers::hyperbolic::ClientBuilder =
+            crate::providers::hyperbolic::Client::builder().api_key("dummy-key");
+        let _client_from_builder = builder.build().expect("Client::builder() failed");
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/providers/mistral/client.rs
+++ b/crates/rig-core/src/providers/mistral/client.rs
@@ -20,7 +20,7 @@ type MistralApiKey = BearerAuth;
 
 pub type Client<H = reqwest::Client> = client::Client<MistralExt, H>;
 pub type ClientBuilder<H = crate::markers::Missing> =
-    client::ClientBuilder<MistralBuilder, String, H>;
+    client::ClientBuilder<MistralBuilder, MistralApiKey, H>;
 
 impl Provider for MistralExt {
     type Builder = MistralBuilder;
@@ -161,9 +161,8 @@ mod tests {
     fn test_client_initialization() {
         let _client =
             crate::providers::mistral::Client::new("dummy-key").expect("Client::new() failed");
-        let _client_from_builder = crate::providers::mistral::Client::builder()
-            .api_key("dummy-key")
-            .build()
-            .expect("Client::builder() failed");
+        let builder: crate::providers::mistral::ClientBuilder =
+            crate::providers::mistral::Client::builder().api_key("dummy-key");
+        let _client_from_builder = builder.build().expect("Client::builder() failed");
     }
 }


### PR DESCRIPTION
## Summary
- Update DeepSeek, Groq, Hyperbolic, and Mistral public ClientBuilder aliases to use their provider API-key aliases instead of String.
- Add explicit typed-builder coverage in each provider's client initialization test.

## Validation
- cargo fmt
- cargo check -p rig-core
- cargo test -p rig-core test_client_initialization