### PR TITLE
fix(openai): preserve reasoning text content

### DIFF
--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -1100,10 +1100,11 @@ where
                                             .with_call_id(func.call_id.clone());
                                             tool_calls.push(RawStreamingChoice::ToolCall(raw_tool_call));
                                         }
-                                        StreamingItemDoneOutput { item: responses_api::Output::Reasoning { summary, id, encrypted_content, .. }, .. } => {
+                                        StreamingItemDoneOutput { item: responses_api::Output::Reasoning { summary, id, content, encrypted_content, .. }, .. } => {
                                             for reasoning_choice in responses_api::streaming::reasoning_choices_from_done_item(
                                                 id,
                                                 summary,
+                                                content,
                                                 encrypted_content.as_deref(),
                                             ) {
                                                 match reasoning_choice {

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -197,6 +197,8 @@ pub enum InputContent {
 pub struct OpenAIReasoning {
     id: String,
     pub summary: Vec<ReasoningSummary>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub content: Vec<OpenAIReasoningContent>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub encrypted_content: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -207,6 +209,27 @@ pub struct OpenAIReasoning {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ReasoningSummary {
     SummaryText { text: String },
+}
+
+/// Visible reasoning content inside an OpenAI Responses API `reasoning` item.
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum OpenAIReasoningContent {
+    /// Plain reasoning text emitted by OpenAI-compatible providers.
+    ReasoningText { text: String },
+}
+
+impl OpenAIReasoningContent {
+    fn new(input: &str) -> Self {
+        Self::ReasoningText {
+            text: input.to_string(),
+        }
+    }
+
+    fn text(self) -> String {
+        let Self::ReasoningText { text } = self;
+        text
+    }
 }
 
 impl ReasoningSummary {
@@ -539,11 +562,14 @@ fn openai_reasoning_from_core(
     };
 
     let mut summary = Vec::new();
+    let mut reasoning_content = Vec::new();
     let mut encrypted_content = None;
     for content in &reasoning.content {
         match content {
-            crate::message::ReasoningContent::Text { text, .. }
-            | crate::message::ReasoningContent::Summary(text) => {
+            crate::message::ReasoningContent::Text { text, .. } => {
+                reasoning_content.push(OpenAIReasoningContent::new(text));
+            }
+            crate::message::ReasoningContent::Summary(text) => {
                 summary.push(ReasoningSummary::new(text));
             }
             // OpenAI reasoning input has one opaque payload field; preserve either
@@ -558,6 +584,7 @@ fn openai_reasoning_from_core(
     Ok(Some(OpenAIReasoning {
         id,
         summary,
+        content: reasoning_content,
         encrypted_content,
         status: None,
     }))
@@ -1521,6 +1548,7 @@ pub enum Output {
     Reasoning {
         id: String,
         summary: Vec<ReasoningSummary>,
+        content: Vec<OpenAIReasoningContent>,
         encrypted_content: Option<String>,
         status: Option<ToolStatus>,
     },
@@ -1541,7 +1569,10 @@ pub enum Output {
 #[derive(Deserialize)]
 struct ReasoningFields {
     id: String,
+    #[serde(default)]
     summary: Vec<ReasoningSummary>,
+    #[serde(default)]
+    content: Vec<OpenAIReasoningContent>,
     #[serde(default)]
     encrypted_content: Option<String>,
     #[serde(default)]
@@ -1553,6 +1584,7 @@ impl From<ReasoningFields> for Output {
         Output::Reasoning {
             id: fields.id,
             summary: fields.summary,
+            content: fields.content,
             encrypted_content: fields.encrypted_content,
             status: fields.status,
         }
@@ -1592,15 +1624,28 @@ impl Serialize for Output {
             Output::Reasoning {
                 id,
                 summary,
+                content,
                 encrypted_content,
                 status,
-            } => Ok(serde_json::json!({
-                "type": "reasoning",
-                "id": id,
-                "summary": summary,
-                "encrypted_content": encrypted_content,
-                "status": status,
-            })),
+            } => {
+                let mut value = serde_json::json!({
+                    "type": "reasoning",
+                    "id": id,
+                    "summary": summary,
+                    "encrypted_content": encrypted_content,
+                    "status": status,
+                });
+                if !content.is_empty() {
+                    let map = value.as_object_mut().ok_or_else(|| {
+                        serde::ser::Error::custom("reasoning output must serialize to an object")
+                    })?;
+                    map.insert(
+                        "content".to_string(),
+                        serde_json::to_value(content).map_err(serde::ser::Error::custom)?,
+                    );
+                }
+                Ok(value)
+            }
             Output::Unknown(value) => return value.serialize(serializer),
         };
         value
@@ -1656,6 +1701,7 @@ impl From<Output> for Vec<completion::AssistantContent> {
             Output::Reasoning {
                 id,
                 summary,
+                content: reasoning_content,
                 encrypted_content,
                 ..
             } => {
@@ -1667,6 +1713,12 @@ impl From<Output> for Vec<completion::AssistantContent> {
                         }
                     })
                     .collect::<Vec<_>>();
+                content.extend(reasoning_content.into_iter().map(|content| {
+                    message::ReasoningContent::Text {
+                        text: content.text(),
+                        signature: None,
+                    }
+                }));
                 if let Some(encrypted_content) = encrypted_content {
                     content.push(message::ReasoningContent::Encrypted(encrypted_content));
                 }
@@ -3704,6 +3756,9 @@ mod tests {
             summary: vec![ReasoningSummary::SummaryText {
                 text: "weighing options".to_string(),
             }],
+            content: vec![OpenAIReasoningContent::ReasoningText {
+                text: "private reasoning".to_string(),
+            }],
             encrypted_content: Some("ENCRYPTED".to_string()),
             status: Some(ToolStatus::Completed),
         };
@@ -3725,6 +3780,7 @@ mod tests {
         let value = serde_json::to_value(Output::Reasoning {
             id: "reasoning_1".to_string(),
             summary: vec![],
+            content: vec![],
             encrypted_content: None,
             status: None,
         })

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -197,8 +197,13 @@ pub enum InputContent {
 pub struct OpenAIReasoning {
     id: String,
     pub summary: Vec<ReasoningSummary>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub content: Vec<OpenAIReasoningContent>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_reasoning_text_content",
+        serialize_with = "serialize_reasoning_text_content",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub content: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub encrypted_content: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -209,27 +214,6 @@ pub struct OpenAIReasoning {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ReasoningSummary {
     SummaryText { text: String },
-}
-
-/// Visible reasoning content inside an OpenAI Responses API `reasoning` item.
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
-#[serde(tag = "type", rename_all = "snake_case")]
-pub enum OpenAIReasoningContent {
-    /// Plain reasoning text emitted by OpenAI-compatible providers.
-    ReasoningText { text: String },
-}
-
-impl OpenAIReasoningContent {
-    fn new(input: &str) -> Self {
-        Self::ReasoningText {
-            text: input.to_string(),
-        }
-    }
-
-    fn text(self) -> String {
-        let Self::ReasoningText { text } = self;
-        text
-    }
 }
 
 impl ReasoningSummary {
@@ -243,6 +227,48 @@ impl ReasoningSummary {
         let ReasoningSummary::SummaryText { text } = self;
         text.clone()
     }
+}
+
+fn reasoning_text_content_json(content: &[String]) -> Value {
+    Value::Array(
+        content
+            .iter()
+            .map(|text| {
+                serde_json::json!({
+                    "type": "reasoning_text",
+                    "text": text,
+                })
+            })
+            .collect(),
+    )
+}
+
+fn serialize_reasoning_text_content<S>(content: &[String], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    reasoning_text_content_json(content).serialize(serializer)
+}
+
+fn deserialize_reasoning_text_content<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Value::deserialize(deserializer)?;
+    Ok(match value {
+        Value::Array(items) => items
+            .into_iter()
+            .filter_map(|item| match item {
+                Value::Object(mut item) => item
+                    .remove("text")
+                    .and_then(|text| text.as_str().map(ToOwned::to_owned)),
+                Value::String(text) => Some(text),
+                _ => None,
+            })
+            .collect(),
+        Value::String(text) => vec![text],
+        _ => Vec::new(),
+    })
 }
 
 /// A tool result.
@@ -567,7 +593,7 @@ fn openai_reasoning_from_core(
     for content in &reasoning.content {
         match content {
             crate::message::ReasoningContent::Text { text, .. } => {
-                reasoning_content.push(OpenAIReasoningContent::new(text));
+                reasoning_content.push(text.clone());
             }
             crate::message::ReasoningContent::Summary(text) => {
                 summary.push(ReasoningSummary::new(text));
@@ -1548,7 +1574,7 @@ pub enum Output {
     Reasoning {
         id: String,
         summary: Vec<ReasoningSummary>,
-        content: Vec<OpenAIReasoningContent>,
+        content: Vec<String>,
         encrypted_content: Option<String>,
         status: Option<ToolStatus>,
     },
@@ -1571,8 +1597,8 @@ struct ReasoningFields {
     id: String,
     #[serde(default)]
     summary: Vec<ReasoningSummary>,
-    #[serde(default)]
-    content: Vec<OpenAIReasoningContent>,
+    #[serde(default, deserialize_with = "deserialize_reasoning_text_content")]
+    content: Vec<String>,
     #[serde(default)]
     encrypted_content: Option<String>,
     #[serde(default)]
@@ -1639,10 +1665,7 @@ impl Serialize for Output {
                     let map = value.as_object_mut().ok_or_else(|| {
                         serde::ser::Error::custom("reasoning output must serialize to an object")
                     })?;
-                    map.insert(
-                        "content".to_string(),
-                        serde_json::to_value(content).map_err(serde::ser::Error::custom)?,
-                    );
+                    map.insert("content".to_string(), reasoning_text_content_json(content));
                 }
                 Ok(value)
             }
@@ -1713,9 +1736,9 @@ impl From<Output> for Vec<completion::AssistantContent> {
                         }
                     })
                     .collect::<Vec<_>>();
-                content.extend(reasoning_content.into_iter().map(|content| {
+                content.extend(reasoning_content.into_iter().map(|text| {
                     message::ReasoningContent::Text {
-                        text: content.text(),
+                        text,
                         signature: None,
                     }
                 }));
@@ -3746,7 +3769,7 @@ mod tests {
 
     #[test]
     fn output_reasoning_round_trips_value_equal() {
-        // Highest-value parity guard: the `Reasoning` struct variant threads four
+        // Highest-value parity guard: the `Reasoning` struct variant threads its
         // fields by hand in *both* directions. Populated `encrypted_content` /
         // `status` (the `#[serde(default)]` optionals) must survive
         // serialize -> deserialize unchanged — catching a dropped field or a
@@ -3756,9 +3779,7 @@ mod tests {
             summary: vec![ReasoningSummary::SummaryText {
                 text: "weighing options".to_string(),
             }],
-            content: vec![OpenAIReasoningContent::ReasoningText {
-                text: "private reasoning".to_string(),
-            }],
+            content: vec!["private reasoning".to_string()],
             encrypted_content: Some("ENCRYPTED".to_string()),
             status: Some(ToolStatus::Completed),
         };

--- a/crates/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -43,6 +43,7 @@ pub struct StreamingCompletionResponse {
 pub(crate) fn reasoning_choices_from_done_item(
     id: &str,
     summary: &[ReasoningSummary],
+    content: &[String],
     encrypted_content: Option<&str>,
 ) -> Vec<RawStreamingChoice<StreamingCompletionResponse>> {
     let mut choices = summary
@@ -54,6 +55,14 @@ pub(crate) fn reasoning_choices_from_done_item(
             },
         })
         .collect::<Vec<_>>();
+
+    choices.extend(content.iter().map(|text| RawStreamingChoice::Reasoning {
+        id: Some(id.to_owned()),
+        content: ReasoningContent::Text {
+            text: text.to_owned(),
+            signature: None,
+        },
+    }));
 
     if let Some(encrypted_content) = encrypted_content {
         choices.push(RawStreamingChoice::Reasoning {
@@ -261,6 +270,12 @@ impl RawChoiceAccumulator {
                     reasoning: delta.delta,
                 });
             }
+            ItemChunkKind::ReasoningTextDelta(delta) => {
+                immediate.push(streaming::RawStreamingChoice::ReasoningDelta {
+                    id: outer_item_id,
+                    reasoning: delta.delta,
+                });
+            }
             ItemChunkKind::RefusalDelta(delta) => {
                 immediate.push(streaming::RawStreamingChoice::Message(delta.delta));
             }
@@ -332,12 +347,14 @@ impl RawChoiceAccumulator {
             Output::Reasoning {
                 id,
                 summary,
+                content,
                 encrypted_content,
                 ..
             } => {
                 immediate.extend(reasoning_choices_from_done_item(
                     &id,
                     &summary,
+                    &content,
                     encrypted_content.as_deref(),
                 ));
             }
@@ -411,6 +428,17 @@ pub(crate) fn raw_choices_from_sse_body(
                 if let Some(delta) = value.get("delta").and_then(serde_json::Value::as_str) {
                     raw_choices.push(streaming::RawStreamingChoice::ReasoningDelta {
                         id: None,
+                        reasoning: delta.to_owned(),
+                    });
+                }
+            }
+            Some("response.reasoning_text.delta") => {
+                if let Some(delta) = value.get("delta").and_then(serde_json::Value::as_str) {
+                    raw_choices.push(streaming::RawStreamingChoice::ReasoningDelta {
+                        id: value
+                            .get("item_id")
+                            .and_then(serde_json::Value::as_str)
+                            .map(ToOwned::to_owned),
                         reasoning: delta.to_owned(),
                     });
                 }
@@ -717,6 +745,8 @@ pub enum ItemChunkKind {
     ReasoningSummaryTextDelta(SummaryTextChunk),
     #[serde(rename = "response.reasoning_summary_text.done")]
     ReasoningSummaryTextDone(SummaryTextChunk),
+    #[serde(rename = "response.reasoning_text.delta")]
+    ReasoningTextDelta(DeltaTextChunkWithItemId),
     /// Catch-all for unknown item chunk types (e.g., `web_search_call` events).
     /// This prevents unknown streaming events from breaking deserialization.
     #[serde(other)]
@@ -991,9 +1021,11 @@ mod tests {
                 text: "step 2".to_string(),
             },
         ];
-        let choices = reasoning_choices_from_done_item("rs_1", &summary, Some("enc_blob"));
+        let content = vec!["private reasoning".to_string()];
+        let choices =
+            reasoning_choices_from_done_item("rs_1", &summary, &content, Some("enc_blob"));
 
-        assert_eq!(choices.len(), 3);
+        assert_eq!(choices.len(), 4);
         assert!(matches!(
             choices.first(),
             Some(RawStreamingChoice::Reasoning {
@@ -1012,8 +1044,69 @@ mod tests {
             choices.get(2),
             Some(RawStreamingChoice::Reasoning {
                 id: Some(id),
+                content: ReasoningContent::Text { text, signature: None },
+            }) if id == "rs_1" && text == "private reasoning"
+        ));
+        assert!(matches!(
+            choices.get(3),
+            Some(RawStreamingChoice::Reasoning {
+                id: Some(id),
                 content: ReasoningContent::Encrypted(data),
             }) if id == "rs_1" && data == "enc_blob"
+        ));
+    }
+
+    #[test]
+    fn reasoning_output_item_done_emits_reasoning_text_content() {
+        let body = format!(
+            "data: {}\n",
+            json!({
+                "type": "response.output_item.done",
+                "output_index": 0,
+                "sequence_number": 1,
+                "item": {
+                    "type": "reasoning",
+                    "id": "rs_text_1",
+                    "summary": [],
+                    "content": [{ "type": "reasoning_text", "text": "visible reasoning" }],
+                    "status": "completed"
+                },
+            })
+        );
+
+        let choices = raw_choices_from_sse_body(&body, ResponsesUsage::new())
+            .expect("sse body should decode");
+
+        assert!(matches!(
+            choices.first(),
+            Some(RawStreamingChoice::Reasoning {
+                id: Some(id),
+                content: ReasoningContent::Text { text, signature: None },
+            }) if id == "rs_text_1" && text == "visible reasoning"
+        ));
+    }
+
+    #[test]
+    fn reasoning_text_delta_emits_reasoning_delta() {
+        let body = format!(
+            "data: {}\n",
+            json!({
+                "type": "response.reasoning_text.delta",
+                "item_id": "rs_delta_1",
+                "output_index": 0,
+                "content_index": 0,
+                "sequence_number": 1,
+                "delta": "thinking",
+            })
+        );
+
+        let choices = raw_choices_from_sse_body(&body, ResponsesUsage::new())
+            .expect("sse body should decode");
+
+        assert!(matches!(
+            choices.first(),
+            Some(RawStreamingChoice::ReasoningDelta { id: Some(id), reasoning })
+                if id == "rs_delta_1" && reasoning == "thinking"
         ));
     }
 
@@ -1058,7 +1151,7 @@ mod tests {
         let summary = vec![ReasoningSummary::SummaryText {
             text: "only summary".to_string(),
         }];
-        let choices = reasoning_choices_from_done_item("rs_2", &summary, None);
+        let choices = reasoning_choices_from_done_item("rs_2", &summary, &[], None);
 
         assert_eq!(choices.len(), 1);
         assert!(matches!(

--- a/crates/rig-core/src/providers/xai/streaming.rs
+++ b/crates/rig-core/src/providers/xai/streaming.rs
@@ -111,7 +111,7 @@ mod tests {
                 text: "s2".to_string(),
             },
         ];
-        let choices = reasoning_choices_from_done_item("xr_1", &summary, Some("enc"));
+        let choices = reasoning_choices_from_done_item("xr_1", &summary, &[], Some("enc"));
 
         assert_eq!(choices.len(), 3);
         assert!(matches!(

--- a/tests/cassettes/openai/openai_compatible/reasoning_content_tool_roundtrip.yaml
+++ b/tests/cassettes/openai/openai_compatible/reasoning_content_tool_roundtrip.yaml
@@ -1,0 +1,33 @@
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"I''m planning a trip. What is the current weather in Tokyo, Japan? Based on the weather conditions, should I pack an umbrella or sunscreen? Use the get_weather tool to check before answering.","type":"input_text"}],"role":"user","type":"message"}],"instructions":"You are a weather assistant. You have access to a get_weather tool. You must call the get_weather tool for any weather question and never guess weather data. After receiving the tool result, provide a concise summary of the weather.","model":"llama-cpp-reasoning-model","reasoning":{"effort":"medium"},"tools":[{"description":"Get the current weather for a city. Must be called for weather questions.","name":"get_weather","parameters":{"properties":{"city":{"description":"City name to get weather for","type":"string"}},"required":["city"],"type":"object"},"type":"function"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"created_at":0,"id":"resp_REDACTED_1","model":"llama-cpp-reasoning-model","object":"response","output":[{"content":[{"text":"The user asked for current weather, so I need to call get_weather before answering.","type":"reasoning_text"}],"encrypted_content":"encrypted_content_REDACTED_1","id":"rs_REDACTED_1","status":"completed","summary":[],"type":"reasoning"},{"arguments":"{\"city\":\"Tokyo, Japan\"}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"get_weather","status":"completed","type":"function_call"}],"status":"completed","usage":{"input_tokens":12,"output_tokens":8,"total_tokens":20}}'
+---
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"I''m planning a trip. What is the current weather in Tokyo, Japan? Based on the weather conditions, should I pack an umbrella or sunscreen? Use the get_weather tool to check before answering.","type":"input_text"}],"role":"user","type":"message"},{"content":[{"text":"The user asked for current weather, so I need to call get_weather before answering.","type":"reasoning_text"}],"encrypted_content":"encrypted_content_REDACTED_1","id":"rs_REDACTED_1","summary":[],"type":"reasoning"},{"arguments":"{\"city\":\"Tokyo, Japan\"}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"get_weather","status":"completed","type":"function_call"},{"call_id":"call_REDACTED_1","output":"Weather in Tokyo, Japan: 72F (22C), sunny with light clouds, humidity 45%, wind 8 mph NW","status":"completed","type":"function_call_output"}],"instructions":"You are a weather assistant. You have access to a get_weather tool. You must call the get_weather tool for any weather question and never guess weather data. After receiving the tool result, provide a concise summary of the weather.","model":"llama-cpp-reasoning-model","reasoning":{"effort":"medium"},"tools":[{"description":"Get the current weather for a city. Must be called for weather questions.","name":"get_weather","parameters":{"properties":{"city":{"description":"City name to get weather for","type":"string"}},"required":["city"],"type":"object"},"type":"function"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"created_at":0,"id":"resp_REDACTED_2","model":"llama-cpp-reasoning-model","object":"response","output":[{"content":[{"annotations":[],"text":"Tokyo, Japan is sunny at 72F (22C). Pack sunscreen; an umbrella is not needed based on the current weather.","type":"output_text"}],"id":"msg_REDACTED_1","role":"assistant","status":"completed","type":"message"}],"status":"completed","usage":{"input_tokens":25,"output_tokens":18,"total_tokens":43}}'

--- a/tests/common/cassette_safety.rs
+++ b/tests/common/cassette_safety.rs
@@ -26,6 +26,7 @@ const PROVIDER_CASSETTE_SUITES: &[ProviderCassetteSuite] = &[
             "with_openai_cassette_result",
             "with_openai_completions_cassette_result",
             "with_openai_vllm_cassette",
+            "with_local_reasoning_content_cassette",
         ],
     },
     ProviderCassetteSuite {

--- a/tests/providers/openai/cassette/openai_compatible_reasoning_content.rs
+++ b/tests/providers/openai/cassette/openai_compatible_reasoning_content.rs
@@ -1,0 +1,288 @@
+//! OpenAI-compatible Responses API reasoning-content roundtrip regression tests.
+//!
+//! This covers providers that return non-streaming reasoning items with a
+//! `content` array containing `reasoning_text`, as llama.cpp does.
+
+use std::future::Future;
+use std::net::SocketAddr;
+use std::panic::AssertUnwindSafe;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::{Json, Router, routing::post};
+use futures::FutureExt;
+use rig::client::CompletionClient;
+use rig::completion::{Chat, Message};
+use rig::providers::openai;
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+
+use crate::cassettes::{self, ProviderCassette};
+use crate::reasoning::{self, WeatherTool};
+
+const SCENARIO: &str = "openai_compatible/reasoning_content_tool_roundtrip";
+const REASONING_TEXT: &str =
+    "The user asked for current weather, so I need to call get_weather before answering.";
+
+#[tokio::test]
+async fn nonstreaming_reasoning_content_tool_roundtrip() {
+    with_local_reasoning_content_cassette(
+        "openai_compatible/reasoning_content_tool_roundtrip",
+        |client| async move {
+            let call_count = Arc::new(AtomicUsize::new(0));
+            let agent = client
+                .agent("llama-cpp-reasoning-model")
+                .preamble(reasoning::TOOL_SYSTEM_PROMPT)
+                .tool(WeatherTool::new(call_count.clone()))
+                .additional_params(json!({
+                    "reasoning": { "effort": "medium" }
+                }))
+                .build();
+
+            let result = agent
+                .chat(reasoning::TOOL_USER_PROMPT, &mut Vec::<Message>::new())
+                .await
+                .expect("OpenAI-compatible provider should accept replayed reasoning content");
+
+            reasoning::assert_nonstreaming_universal(&result, &call_count, "openai-compatible");
+        },
+    )
+    .await;
+
+    assert_cassette_preserves_reasoning_content(SCENARIO);
+}
+
+async fn with_local_reasoning_content_cassette<F, Fut>(scenario: &'static str, test_body: F)
+where
+    F: FnOnce(openai::Client) -> Fut,
+    Fut: Future<Output = ()>,
+{
+    let server = LocalReasoningContentServer::start().await;
+    let cassette = ProviderCassette::start("openai", scenario, &server.base_url()).await;
+    let client = openai::Client::builder()
+        .api_key("dummy-openai-compatible-key")
+        .base_url(cassette.base_url())
+        .build()
+        .expect("OpenAI-compatible cassette client should build");
+
+    let result = AssertUnwindSafe(test_body(client)).catch_unwind().await;
+    cassette.finish_after_test(result).await;
+}
+
+struct LocalReasoningContentServer {
+    addr: SocketAddr,
+    shutdown: Option<oneshot::Sender<()>>,
+    task: JoinHandle<()>,
+}
+
+impl LocalReasoningContentServer {
+    async fn start() -> Self {
+        let state = Arc::new(LocalState {
+            request_count: AtomicUsize::new(0),
+        });
+        let app = Router::new()
+            .route("/v1/responses", post(local_responses_api))
+            .with_state(state);
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("local OpenAI-compatible server should bind");
+        let addr = listener
+            .local_addr()
+            .expect("local OpenAI-compatible server address should be available");
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+                .expect("local OpenAI-compatible server should run");
+        });
+
+        Self {
+            addr,
+            shutdown: Some(shutdown_tx),
+            task,
+        }
+    }
+
+    fn base_url(&self) -> String {
+        format!("http://{}/v1", self.addr)
+    }
+}
+
+impl Drop for LocalReasoningContentServer {
+    fn drop(&mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+        self.task.abort();
+    }
+}
+
+struct LocalState {
+    request_count: AtomicUsize,
+}
+
+async fn local_responses_api(
+    State(state): State<Arc<LocalState>>,
+    Json(body): Json<Value>,
+) -> impl IntoResponse {
+    match state.request_count.fetch_add(1, Ordering::SeqCst) {
+        0 => first_tool_call_response(),
+        1 => continuation_response(body),
+        _ => (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": {
+                    "message": "unexpected extra request",
+                    "type": "invalid_request_error"
+                }
+            })),
+        ),
+    }
+}
+
+fn first_tool_call_response() -> (StatusCode, Json<Value>) {
+    (
+        StatusCode::OK,
+        Json(json!({
+            "id": "resp_llamacpp_1",
+            "object": "response",
+            "created_at": 0,
+            "status": "completed",
+            "model": "llama-cpp-reasoning-model",
+            "output": [
+                {
+                    "id": "rs_llamacpp_1",
+                    "summary": [],
+                    "type": "reasoning",
+                    "content": [
+                        {
+                            "text": REASONING_TEXT,
+                            "type": "reasoning_text"
+                        }
+                    ],
+                    "encrypted_content": "",
+                    "status": "completed"
+                },
+                {
+                    "arguments": "{\"city\":\"Tokyo, Japan\"}",
+                    "call_id": "call_llamacpp_1",
+                    "id": "fc_llamacpp_1",
+                    "name": "get_weather",
+                    "status": "completed",
+                    "type": "function_call"
+                }
+            ],
+            "usage": {
+                "input_tokens": 12,
+                "output_tokens": 8,
+                "total_tokens": 20
+            }
+        })),
+    )
+}
+
+fn continuation_response(body: Value) -> (StatusCode, Json<Value>) {
+    if !request_preserves_reasoning_content(&body) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": {
+                    "code": 400,
+                    "message": "item['content'] is not an array",
+                    "type": "invalid_request_error"
+                }
+            })),
+        );
+    }
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "id": "resp_llamacpp_2",
+            "object": "response",
+            "created_at": 0,
+            "status": "completed",
+            "model": "llama-cpp-reasoning-model",
+            "output": [
+                {
+                    "id": "msg_llamacpp_1",
+                    "role": "assistant",
+                    "status": "completed",
+                    "type": "message",
+                    "content": [
+                        {
+                            "annotations": [],
+                            "text": "Tokyo, Japan is sunny at 72F (22C). Pack sunscreen; an umbrella is not needed based on the current weather.",
+                            "type": "output_text"
+                        }
+                    ]
+                }
+            ],
+            "usage": {
+                "input_tokens": 25,
+                "output_tokens": 18,
+                "total_tokens": 43
+            }
+        })),
+    )
+}
+
+fn request_preserves_reasoning_content(body: &Value) -> bool {
+    body.get("input")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter(|item| item.get("type").and_then(Value::as_str) == Some("reasoning"))
+        .any(reasoning_item_preserves_content)
+}
+
+fn reasoning_item_preserves_content(item: &Value) -> bool {
+    item.get("content")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .any(|content| {
+            content.get("type").and_then(Value::as_str) == Some("reasoning_text")
+                && content.get("text").and_then(Value::as_str) == Some(REASONING_TEXT)
+        })
+}
+
+fn assert_cassette_preserves_reasoning_content(scenario: &str) {
+    let cassette_path = cassettes::cassette_path("openai", scenario);
+    let contents = std::fs::read_to_string(&cassette_path).unwrap_or_else(|error| {
+        panic!(
+            "provider cassette {} should be readable after recording: {error}",
+            cassette_path.display()
+        )
+    });
+    let interactions = serde_yaml::Deserializer::from_str(&contents)
+        .map(|document| serde_yaml::Value::deserialize(document).expect("cassette interaction"))
+        .collect::<Vec<_>>();
+
+    assert!(
+        interactions.iter().any(|interaction| {
+            let Some(body) = interaction
+                .get("when")
+                .and_then(|when| when.get("body"))
+                .and_then(serde_yaml::Value::as_str)
+            else {
+                return false;
+            };
+            let Ok(body) = serde_json::from_str::<Value>(body) else {
+                return false;
+            };
+            request_preserves_reasoning_content(&body)
+        }),
+        "expected cassette {} to contain a continuation request preserving reasoning.content",
+        cassette_path.display()
+    );
+}

--- a/tests/providers/openai/cassette/responses_input_item.rs
+++ b/tests/providers/openai/cassette/responses_input_item.rs
@@ -76,7 +76,7 @@ fn assistant_reasoning_encrypted_only_serializes_encrypted_content() {
 }
 
 #[test]
-fn assistant_reasoning_mixed_content_serializes_only_text_like_summaries() {
+fn assistant_reasoning_mixed_content_serializes_text_content_and_summaries() {
     let mut reasoning =
         Reasoning::new_with_signature("step-1", Some("sig-1".to_string())).with_id("rs_2".into());
     reasoning
@@ -100,6 +100,15 @@ fn assistant_reasoning_mixed_content_serializes_only_text_like_summaries() {
     assert_eq!(items.len(), 1);
 
     let item_json = serde_json::to_value(&items[0]).expect("serialize InputItem");
+    let content = item_json
+        .get("content")
+        .and_then(|value| value.as_array())
+        .expect("reasoning item should include reasoning content array");
+    let content_texts: Vec<&str> = content
+        .iter()
+        .filter(|entry| entry.get("type").and_then(|kind| kind.as_str()) == Some("reasoning_text"))
+        .filter_map(|entry| entry.get("text").and_then(|text| text.as_str()))
+        .collect();
     let summary = item_json
         .get("summary")
         .and_then(|value| value.as_array())
@@ -109,7 +118,8 @@ fn assistant_reasoning_mixed_content_serializes_only_text_like_summaries() {
         .filter_map(|entry| entry.get("text").and_then(|text| text.as_str()))
         .collect();
 
-    assert_eq!(summary_texts, vec!["step-1", "summary-2"]);
+    assert_eq!(content_texts, vec!["step-1"]);
+    assert_eq!(summary_texts, vec!["summary-2"]);
     assert_eq!(
         item_json
             .get("encrypted_content")
@@ -174,6 +184,31 @@ fn openai_responses_reasoning_output_preserves_encrypted_content() {
     assert!(matches!(
         reasoning.content.get(1),
         Some(ReasoningContent::Encrypted(value)) if value == "cipher_blob"
+    ));
+}
+
+#[test]
+fn openai_responses_reasoning_output_preserves_reasoning_text_content() {
+    let output: Output = serde_json::from_value(serde_json::json!({
+        "type": "reasoning",
+        "id": "rs_text_1",
+        "summary": [],
+        "content": [
+            { "type": "reasoning_text", "text": "visible reasoning" }
+        ],
+        "status": "completed"
+    }))
+    .expect("deserialize reasoning output");
+
+    let content: Vec<AssistantContent> = output.into();
+    assert_eq!(content.len(), 1);
+    let Some(AssistantContent::Reasoning(reasoning)) = content.first() else {
+        panic!("expected reasoning output content");
+    };
+    assert_eq!(reasoning.id.as_deref(), Some("rs_text_1"));
+    assert!(matches!(
+        reasoning.content.first(),
+        Some(ReasoningContent::Text { text, signature: None }) if text == "visible reasoning"
     ));
 }
 

--- a/tests/providers/openai/mod.rs
+++ b/tests/providers/openai/mod.rs
@@ -9,6 +9,7 @@ mod cassette {
     mod extractor_usage;
     mod models;
     mod multi_extract;
+    mod openai_compatible_reasoning_content;
     mod permission_control;
     mod reasoning_roundtrip;
     mod reasoning_tool_roundtrip;


### PR DESCRIPTION
## Summary
- preserve OpenAI Responses reasoning `content` items with `reasoning_text` through non-streaming response parsing and replay
- serialize core reasoning text back into Responses API reasoning `content` while keeping summaries in `summary`
- handle OpenAI-compatible streaming reasoning text payloads/`response.reasoning_text.delta`, following Vercel AI SDK's LM Studio-compatible behavior
- add a cassette-backed OpenAI-compatible regression for #1998, including a recorded continuation request that carries `reasoning.content`

## Validation
- Recorded the regression pre-fix and observed the second cassette request omitted `content` and received `400 item['content'] is not an array`.
- Re-recorded after the fix; cassette now shows the continuation request includes `content: [{ type: reasoning_text, ... }]` and receives 200.
- `cargo fmt`
- `cargo clippy --all-targets --all-features`
- `cargo test -p rig-core providers::openai::responses_api -- --nocapture`
- `cargo test -p rig-core providers::openai::responses_api::streaming -- --nocapture`
- `cargo test -p rig-core providers::xai::streaming -- --nocapture`
- `RIG_PROVIDER_TEST_MODE=record cargo test -p rig --all-features --test openai nonstreaming_reasoning_content_tool_roundtrip -- --nocapture --test-threads=1`
- `cargo test -p rig --all-features --test openai nonstreaming_reasoning_content_tool_roundtrip -- --nocapture --test-threads=1`
- `cargo test -p rig --all-features --test openai cassette_safety -- --nocapture`
- `cargo test -p rig --all-features --test openai openai::cassette -- --nocapture --test-threads=1`

Note: `cargo test` without features currently fails to compile existing Gemini image-generation cassette tests because image APIs are feature-gated; not caused by this change.