### PR TITLE
fix(chatgpt): fallback on empty SSE output

### DIFF
--- a/crates/rig-core/src/providers/chatgpt/mod.rs
+++ b/crates/rig-core/src/providers/chatgpt/mod.rs
@@ -447,9 +447,7 @@ where
 
         match raw_response.clone().try_into() {
             Ok(response) => Ok(response),
-            Err(CompletionError::ResponseError(message))
-                if message == "Response contained no parts" =>
-            {
+            Err(CompletionError::ResponseError(_)) if raw_response.output.is_empty() => {
                 responses_api::streaming::completion_response_from_sse_body(&text, raw_response)
                     .await
             }

--- a/tests/providers/chatgpt/cassette/streaming_tools.rs
+++ b/tests/providers/chatgpt/cassette/streaming_tools.rs
@@ -3,13 +3,55 @@
 use futures::StreamExt;
 use rig::client::CompletionClient;
 use rig::completion::CompletionModel;
-use rig::message::ToolChoice;
+use rig::message::{AssistantContent, ToolChoice};
 use rig::providers::chatgpt;
 use rig::streaming::StreamedAssistantContent;
 use serde_json::json;
 
 use super::super::support::with_chatgpt_cassette;
 use crate::support::zero_arg_tool_definition;
+
+#[tokio::test]
+async fn nonstreaming_tool_call_completed_response_without_output() {
+    with_chatgpt_cassette(
+        "streaming_tools/tool_call_completed_response_without_output",
+        |client| async move {
+            let model = client.completion_model(chatgpt::GPT_5_4);
+            let request = model
+                .completion_request(
+                    "Call the ping tool with no arguments. Do not write any normal text before the tool call.",
+                )
+                .tool(zero_arg_tool_definition("ping"))
+                .tool_choice(ToolChoice::Required)
+                .build();
+
+            let response = model
+                .completion(request)
+                .await
+                .expect("non-streaming completion should reconstruct streamed tool call");
+
+            assert!(
+                response.raw_response.output.is_empty(),
+                "cassette should keep the terminal response.completed output empty"
+            );
+
+            let tool_call = response.choice.iter().find_map(|content| match content {
+                AssistantContent::ToolCall(tool_call) if tool_call.function.name == "ping" => {
+                    Some(tool_call)
+                }
+                _ => None,
+            });
+            let tool_call = tool_call.expect("completion should include the ping tool call");
+            assert_eq!(tool_call.function.arguments, json!({}));
+            assert!(response.usage.input_tokens > 0, "usage should have input tokens");
+            assert!(
+                response.usage.output_tokens > 0,
+                "usage should have output tokens"
+            );
+        },
+    )
+    .await;
+}
 
 #[tokio::test]
 async fn stream_tool_call_completed_response_without_output() {


### PR DESCRIPTION
## Summary
- add a ChatGPT cassette regression for non-streaming tool-call completions where the terminal `response.completed` has `output: []`
- make ChatGPT non-streaming SSE completion reconstruct from streamed events whenever the terminal raw response has empty output instead of matching a brittle error string
- follows the OpenAI Responses/Vercel-style pattern of treating streamed `response.output_item.done` events as the source of tool-call content when terminal output is absent

## Regression evidence
- The existing live-recorded ChatGPT cassette `tests/cassettes/chatgpt/streaming_tools/tool_call_completed_response_without_output.yaml` contains streamed `response.output_item.done` function_call data followed by terminal `response.completed` with `output: []`.
- Before the fix, the new non-streaming cassette test failed with: `ResponseError("Response contained no message or tool call (empty)")`.
- After the fix, the same cassette reconstructs the `ping` tool call and preserves usage.

## Validation
- `cargo fmt`
- `cargo test -p rig --all-features --test chatgpt nonstreaming_tool_call_completed_response_without_output -- --nocapture --test-threads=1`
- `cargo test -p rig --all-features --test chatgpt chatgpt::cassette -- --nocapture --test-threads=1`
- `cargo test -p rig-core providers::chatgpt -- --nocapture`
- `cargo clippy --all-targets --all-features`
- Re-recorded `nonstreaming_tool_call_completed_response_without_output` using the local ChatGPT OAuth credentials available to the Pi agent; the scrubbed fixture was unchanged and still shows streamed `response.output_item.done` followed by terminal `output: []`.
