### PR TITLE
test(anthropic): production-grade Messages API cassette suite

### DIFF
--- a/tests/cassettes/anthropic/messages_behaviors/max_tokens_truncation_preserves_stop_reason_and_partial_text.yaml
+++ b/tests/cassettes/anthropic/messages_behaviors/max_tokens_truncation_preserves_stop_reason_and_partial_text.yaml
@@ -1,0 +1,18 @@
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":64,"messages":[{"content":[{"text":"Write a story of at least 150 words about a lighthouse keeper.","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","system":[{"text":"You are a storyteller.","type":"text"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"content":[{"text":"# The Last Light of Kettle Point\n\nEvery evening, without fail, old Magnus Calloway climbed the one hundred and twelve steps of the Kettle Point lighthouse. He had counted them so many times over thirty-seven years that the number lived in his bones rather than his mind.\n\nThe lamp","type":"text"}],"id":"msg_REDACTED_1","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":"max_tokens","stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":29,"output_tokens":64,"service_tier":"standard"}}'

--- a/tests/cassettes/anthropic/messages_sessions/long_history_replay_nonstreaming.yaml
+++ b/tests/cassettes/anthropic/messages_sessions/long_history_replay_nonstreaming.yaml
@@ -1,0 +1,37 @@
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":1024,"messages":[{"content":[{"text":"Look up the harbor label with the tool.","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","system":[{"text":"You are a concise assistant with perfect recall of this conversation.","type":"text"}],"tools":[{"description":"Return the alpha signal marker.","input_schema":{"properties":{},"required":[],"type":"object"},"name":"lookup_harbor_label"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"content":[{"text":"Sure! Let me look that up right away.","type":"text"},{"caller":{"type":"direct"},"id":"toolu_REDACTED_1","input":{},"name":"lookup_harbor_label","type":"tool_use"}],"id":"msg_REDACTED_1","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":"tool_use","stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":572,"output_tokens":49,"service_tier":"standard"}}'
+---
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":1024,"messages":[{"content":[{"text":"My favorite color is teal. Please remember it.","type":"text"}],"role":"user"},{"content":[{"text":"Noted - your favorite color is teal.","type":"text"}],"role":"assistant"},{"content":[{"text":"Now look up the harbor label with the tool.","type":"text"}],"role":"user"},{"content":[{"text":"Checking the harbor label now.","type":"text"},{"id":"toolu_REDACTED_1","input":{},"name":"lookup_harbor_label","type":"tool_use"}],"role":"assistant"},{"content":[{"content":[{"text":"crimson-harbor","type":"text"}],"tool_use_id":"toolu_REDACTED_1","type":"tool_result"}],"role":"user"},{"content":[{"text":"The harbor label is crimson-harbor.","type":"text"}],"role":"assistant"},{"content":[{"text":"In one short sentence: what is my favorite color, and what was the harbor label you looked up earlier?","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","system":[{"text":"You are a concise assistant with perfect recall of this conversation.","type":"text"}],"tools":[{"description":"Return the alpha signal marker.","input_schema":{"properties":{},"required":[],"type":"object"},"name":"lookup_harbor_label"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"content":[{"text":"Your favorite color is teal, and the harbor label is crimson-harbor.","type":"text"}],"id":"msg_REDACTED_2","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":"end_turn","stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":699,"output_tokens":20,"service_tier":"standard"}}'

--- a/tests/cassettes/anthropic/messages_sessions/parallel_tool_use_single_turn_nonstreaming.yaml
+++ b/tests/cassettes/anthropic/messages_sessions/parallel_tool_use_single_turn_nonstreaming.yaml
@@ -1,0 +1,37 @@
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":2048,"messages":[{"content":[{"text":"Call `lookup_harbor_label` and `lookup_orchard_label` exactly once each before answering. After both tool results are available, stop calling tools and respond in one short sentence that includes both exact tool outputs.","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","system":[{"text":"You are a precise assistant. When tools are available, you must use them instead of guessing. Call both `lookup_harbor_label` and `lookup_orchard_label` before writing any normal text. Never call the same tool twice once you already have its result.","type":"text"}],"tools":[{"description":"Return the alpha signal marker.","input_schema":{"properties":{},"required":[],"type":"object"},"name":"lookup_harbor_label"},{"description":"Return the beta signal marker.","input_schema":{"properties":{},"required":[],"type":"object"},"name":"lookup_orchard_label"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"content":[{"text":"I''ll call both tools simultaneously right away!","type":"text"},{"caller":{"type":"direct"},"id":"toolu_REDACTED_1","input":{},"name":"lookup_harbor_label","type":"tool_use"},{"caller":{"type":"direct"},"id":"toolu_REDACTED_2","input":{},"name":"lookup_orchard_label","type":"tool_use"}],"id":"msg_REDACTED_1","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":"tool_use","stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":700,"output_tokens":70,"service_tier":"standard"}}'
+---
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":2048,"messages":[{"content":[{"text":"Call `lookup_harbor_label` and `lookup_orchard_label` exactly once each before answering. After both tool results are available, stop calling tools and respond in one short sentence that includes both exact tool outputs.","type":"text"}],"role":"user"},{"content":[{"text":"I''ll call both tools simultaneously right away!","type":"text"},{"id":"toolu_REDACTED_1","input":{},"name":"lookup_harbor_label","type":"tool_use"},{"id":"toolu_REDACTED_2","input":{},"name":"lookup_orchard_label","type":"tool_use"}],"role":"assistant"},{"content":[{"content":[{"text":"crimson-harbor","type":"text"}],"tool_use_id":"toolu_REDACTED_1","type":"tool_result"},{"content":[{"text":"silver-orchard","type":"text"}],"tool_use_id":"toolu_REDACTED_2","type":"tool_result"}],"role":"user"}],"model":"claude-sonnet-4-6","system":[{"text":"You are a precise assistant. When tools are available, you must use them instead of guessing. Call both `lookup_harbor_label` and `lookup_orchard_label` before writing any normal text. Never call the same tool twice once you already have its result.","type":"text"}],"tools":[{"description":"Return the alpha signal marker.","input_schema":{"properties":{},"required":[],"type":"object"},"name":"lookup_harbor_label"},{"description":"Return the beta signal marker.","input_schema":{"properties":{},"required":[],"type":"object"},"name":"lookup_orchard_label"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"content":[{"text":"The alpha signal marker is **crimson-harbor** and the beta signal marker is **silver-orchard**.","type":"text"}],"id":"msg_REDACTED_2","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":"end_turn","stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":846,"output_tokens":26,"service_tier":"standard"}}'

--- a/tests/cassettes/anthropic/messages_sessions/sequential_tool_calls_nonstreaming.yaml
+++ b/tests/cassettes/anthropic/messages_sessions/sequential_tool_calls_nonstreaming.yaml
@@ -1,0 +1,56 @@
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":2048,"messages":[{"content":[{"text":"First use the add tool to compute 3 + 4. After you receive that result, use the subtract tool to subtract 5 from it. Then state the final number in one short sentence.","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","system":[{"text":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","type":"text"}],"tools":[{"description":"Add x and y together","input_schema":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"name":"add"},{"description":"Subtract y from x (i.e.: x - y)","input_schema":{"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"name":"subtract"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"content":[{"text":"I''ll start by adding 3 + 4 right away!","type":"text"},{"caller":{"type":"direct"},"id":"toolu_REDACTED_1","input":{"x":3,"y":4},"name":"add","type":"tool_use"}],"id":"msg_REDACTED_1","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":"tool_use","stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":755,"output_tokens":84,"service_tier":"standard"}}'
+---
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":2048,"messages":[{"content":[{"text":"First use the add tool to compute 3 + 4. After you receive that result, use the subtract tool to subtract 5 from it. Then state the final number in one short sentence.","type":"text"}],"role":"user"},{"content":[{"text":"I''ll start by adding 3 + 4 right away!","type":"text"},{"id":"toolu_REDACTED_1","input":{"x":3,"y":4},"name":"add","type":"tool_use"}],"role":"assistant"},{"content":[{"content":[{"text":"7","type":"text"}],"tool_use_id":"toolu_REDACTED_1","type":"tool_result"}],"role":"user"}],"model":"claude-sonnet-4-6","system":[{"text":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","type":"text"}],"tools":[{"description":"Add x and y together","input_schema":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"name":"add"},{"description":"Subtract y from x (i.e.: x - y)","input_schema":{"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"name":"subtract"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"content":[{"text":"3 + 4 = 7. Now I''ll subtract 5 from that result!","type":"text"},{"caller":{"type":"direct"},"id":"toolu_REDACTED_2","input":{"x":7,"y":5},"name":"subtract","type":"tool_use"}],"id":"msg_REDACTED_2","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":"tool_use","stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":852,"output_tokens":90,"service_tier":"standard"}}'
+---
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":2048,"messages":[{"content":[{"text":"First use the add tool to compute 3 + 4. After you receive that result, use the subtract tool to subtract 5 from it. Then state the final number in one short sentence.","type":"text"}],"role":"user"},{"content":[{"text":"I''ll start by adding 3 + 4 right away!","type":"text"},{"id":"toolu_REDACTED_1","input":{"x":3,"y":4},"name":"add","type":"tool_use"}],"role":"assistant"},{"content":[{"content":[{"text":"7","type":"text"}],"tool_use_id":"toolu_REDACTED_1","type":"tool_result"}],"role":"user"},{"content":[{"text":"3 + 4 = 7. Now I''ll subtract 5 from that result!","type":"text"},{"id":"toolu_REDACTED_2","input":{"x":7,"y":5},"name":"subtract","type":"tool_use"}],"role":"assistant"},{"content":[{"content":[{"text":"2","type":"text"}],"tool_use_id":"toolu_REDACTED_2","type":"tool_result"}],"role":"user"}],"model":"claude-sonnet-4-6","system":[{"text":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","type":"text"}],"tools":[{"description":"Add x and y together","input_schema":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"name":"add"},{"description":"Subtract y from x (i.e.: x - y)","input_schema":{"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"name":"subtract"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"content":[{"text":"The final number is **2**!","type":"text"}],"id":"msg_REDACTED_3","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":"end_turn","stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":955,"output_tokens":11,"service_tier":"standard"}}'

--- a/tests/cassettes/anthropic/messages_sessions/sequential_tool_calls_streaming.yaml
+++ b/tests/cassettes/anthropic/messages_sessions/sequential_tool_calls_streaming.yaml
@@ -1,0 +1,155 @@
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":2048,"messages":[{"content":[{"text":"First use the add tool to compute 3 + 4. After you receive that result, use the subtract tool to subtract 5 from it. Then state the final number in one short sentence.","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","stream":true,"system":[{"text":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","type":"text"}],"tool_choice":{"type":"auto"},"tools":[{"description":"Add x and y together","input_schema":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"name":"add"},{"description":"Subtract y from x (i.e.: x - y)","input_schema":{"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"name":"subtract"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream; charset=utf-8
+  body: |+
+    event: message_start
+    data: {"message":{"content":[],"id":"msg_REDACTED_1","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":755,"output_tokens":3,"service_tier":"standard"}},"type":"message_start"}
+
+    event: content_block_start
+    data: {"content_block":{"text":"","type":"text"},"index":0,"type":"content_block_start"}
+
+    event: ping
+    data: {"type":"ping"}
+
+    event: content_block_delta
+    data: {"delta":{"text":"I'll start","type":"text_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"text":" by adding 3 + 4 right away!","type":"text_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_stop
+    data: {"index":0,"type":"content_block_stop"}
+
+    event: content_block_start
+    data: {"content_block":{"caller":{"type":"direct"},"id":"toolu_REDACTED_1","input":{},"name":"add","type":"tool_use"},"index":1,"type":"content_block_start"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"{\"x\": 3","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":", \"y\": 4}","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+
+    event: content_block_stop
+    data: {"index":1,"type":"content_block_stop"}
+
+    event: message_delta
+    data: {"delta":{"stop_details":null,"stop_reason":"tool_use","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":755,"output_tokens":84}}
+
+    event: message_stop
+    data: {"type":"message_stop"}
+
+---
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":2048,"messages":[{"content":[{"text":"First use the add tool to compute 3 + 4. After you receive that result, use the subtract tool to subtract 5 from it. Then state the final number in one short sentence.","type":"text"}],"role":"user"},{"content":[{"text":"I''ll start by adding 3 + 4 right away!","type":"text"},{"id":"toolu_REDACTED_1","input":{"x":3,"y":4},"name":"add","type":"tool_use"}],"role":"assistant"},{"content":[{"content":[{"text":"7","type":"text"}],"tool_use_id":"toolu_REDACTED_1","type":"tool_result"}],"role":"user"}],"model":"claude-sonnet-4-6","stream":true,"system":[{"text":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","type":"text"}],"tool_choice":{"type":"auto"},"tools":[{"description":"Add x and y together","input_schema":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"name":"add"},{"description":"Subtract y from x (i.e.: x - y)","input_schema":{"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"name":"subtract"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream; charset=utf-8
+  body: |+
+    event: message_start
+    data: {"message":{"content":[],"id":"msg_REDACTED_2","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":852,"output_tokens":1,"service_tier":"standard"}},"type":"message_start"}
+
+    event: content_block_start
+    data: {"content_block":{"text":"","type":"text"},"index":0,"type":"content_block_start"}
+
+    event: ping
+    data: {"type":"ping"}
+
+    event: content_block_delta
+    data: {"delta":{"text":"3","type":"text_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"text":" + 4 = 7. Now I'll subtract 5 from that result!","type":"text_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_stop
+    data: {"index":0,"type":"content_block_stop"}
+
+    event: content_block_start
+    data: {"content_block":{"caller":{"type":"direct"},"id":"toolu_REDACTED_2","input":{},"name":"subtract","type":"tool_use"},"index":1,"type":"content_block_start"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"{\"x\": 7","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":", \"y\": 5}","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+
+    event: content_block_stop
+    data: {"index":1,"type":"content_block_stop"}
+
+    event: message_delta
+    data: {"delta":{"stop_details":null,"stop_reason":"tool_use","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":852,"output_tokens":90}}
+
+    event: message_stop
+    data: {"type":"message_stop"}
+
+---
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":2048,"messages":[{"content":[{"text":"First use the add tool to compute 3 + 4. After you receive that result, use the subtract tool to subtract 5 from it. Then state the final number in one short sentence.","type":"text"}],"role":"user"},{"content":[{"text":"I''ll start by adding 3 + 4 right away!","type":"text"},{"id":"toolu_REDACTED_1","input":{"x":3,"y":4},"name":"add","type":"tool_use"}],"role":"assistant"},{"content":[{"content":[{"text":"7","type":"text"}],"tool_use_id":"toolu_REDACTED_1","type":"tool_result"}],"role":"user"},{"content":[{"text":"3 + 4 = 7. Now I''ll subtract 5 from that result!","type":"text"},{"id":"toolu_REDACTED_2","input":{"x":7,"y":5},"name":"subtract","type":"tool_use"}],"role":"assistant"},{"content":[{"content":[{"text":"2","type":"text"}],"tool_use_id":"toolu_REDACTED_2","type":"tool_result"}],"role":"user"}],"model":"claude-sonnet-4-6","stream":true,"system":[{"text":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","type":"text"}],"tool_choice":{"type":"auto"},"tools":[{"description":"Add x and y together","input_schema":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"name":"add"},{"description":"Subtract y from x (i.e.: x - y)","input_schema":{"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"name":"subtract"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream; charset=utf-8
+  body: |+
+    event: message_start
+    data: {"message":{"content":[],"id":"msg_REDACTED_3","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":955,"output_tokens":7,"service_tier":"standard"}},"type":"message_start"}
+
+    event: content_block_start
+    data: {"content_block":{"text":"","type":"text"},"index":0,"type":"content_block_start"}
+
+    event: ping
+    data: {"type":"ping"}
+
+    event: content_block_delta
+    data: {"delta":{"text":"The final number is **2**.","type":"text_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_stop
+    data: {"index":0,"type":"content_block_stop"}
+
+    event: message_delta
+    data: {"delta":{"stop_details":null,"stop_reason":"end_turn","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":955,"output_tokens":10}}
+
+    event: message_stop
+    data: {"type":"message_stop"}
+

--- a/tests/cassettes/anthropic/messages_sessions/usage_accumulates_across_streaming_multi_turn.yaml
+++ b/tests/cassettes/anthropic/messages_sessions/usage_accumulates_across_streaming_multi_turn.yaml
@@ -1,0 +1,82 @@
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":2048,"messages":[{"content":[{"text":"Call `lookup_harbor_label` exactly once before answering. After the tool result is available, answer in one short sentence that includes the exact tool output.","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","stream":true,"system":[{"text":"You must call the requested tool before writing any normal text. After the tool result is available, do not call any more tools and answer in one short sentence that includes the exact tool output.","type":"text"}],"tool_choice":{"type":"auto"},"tools":[{"description":"Return the alpha signal marker.","input_schema":{"properties":{},"required":[],"type":"object"},"name":"lookup_harbor_label"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream; charset=utf-8
+  body: |+
+    event: message_start
+    data: {"message":{"content":[],"id":"msg_REDACTED_1","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":621,"output_tokens":39,"service_tier":"standard"}},"type":"message_start"}
+
+    event: content_block_start
+    data: {"content_block":{"caller":{"type":"direct"},"id":"toolu_REDACTED_1","input":{},"name":"lookup_harbor_label","type":"tool_use"},"index":0,"type":"content_block_start"}
+
+    event: ping
+    data: {"type":"ping"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"","type":"input_json_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_stop
+    data: {"index":0,"type":"content_block_stop"}
+
+    event: message_delta
+    data: {"delta":{"stop_details":null,"stop_reason":"tool_use","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":621,"output_tokens":39}}
+
+    event: message_stop
+    data: {"type":"message_stop"}
+
+---
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":2048,"messages":[{"content":[{"text":"Call `lookup_harbor_label` exactly once before answering. After the tool result is available, answer in one short sentence that includes the exact tool output.","type":"text"}],"role":"user"},{"content":[{"id":"toolu_REDACTED_1","input":{},"name":"lookup_harbor_label","type":"tool_use"}],"role":"assistant"},{"content":[{"content":[{"text":"crimson-harbor","type":"text"}],"tool_use_id":"toolu_REDACTED_1","type":"tool_result"}],"role":"user"}],"model":"claude-sonnet-4-6","stream":true,"system":[{"text":"You must call the requested tool before writing any normal text. After the tool result is available, do not call any more tools and answer in one short sentence that includes the exact tool output.","type":"text"}],"tool_choice":{"type":"auto"},"tools":[{"description":"Return the alpha signal marker.","input_schema":{"properties":{},"required":[],"type":"object"},"name":"lookup_harbor_label"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream; charset=utf-8
+  body: |+
+    event: message_start
+    data: {"message":{"content":[],"id":"msg_REDACTED_2","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":676,"output_tokens":2,"service_tier":"standard"}},"type":"message_start"}
+
+    event: content_block_start
+    data: {"content_block":{"text":"","type":"text"},"index":0,"type":"content_block_start"}
+
+    event: ping
+    data: {"type":"ping"}
+
+    event: content_block_delta
+    data: {"delta":{"text":"The alpha","type":"text_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"text":" signal marker returned by the tool is **crimson-harbor**.","type":"text_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_stop
+    data: {"index":0,"type":"content_block_stop"}
+
+    event: message_delta
+    data: {"delta":{"stop_details":null,"stop_reason":"end_turn","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":676,"output_tokens":18}}
+
+    event: message_stop
+    data: {"type":"message_stop"}
+

--- a/tests/cassettes/anthropic/messages_thinking/redacted_thinking_roundtrip_nonstreaming.yaml
+++ b/tests/cassettes/anthropic/messages_thinking/redacted_thinking_roundtrip_nonstreaming.yaml
@@ -1,0 +1,37 @@
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":4096,"messages":[{"content":[{"text":"ANTHROPIC_MAGIC_STRING_TRIGGER_REDACTED_THINKING_46C9A13E193C177646C7398A98432ECCCE4C1253D5E2D82641AC0E52CC2876CB Reply with the single word OK.","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","thinking":{"budget_tokens":1024,"type":"enabled"}}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"content":[{"data":"redacted_thinking_REDACTED_1","type":"redacted_thinking"},{"text":"OK","type":"text"}],"id":"msg_REDACTED_1","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":"end_turn","stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":100,"output_tokens":13,"output_tokens_details":{"thinking_tokens":7},"service_tier":"standard"}}'
+---
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":4096,"messages":[{"content":[{"text":"ANTHROPIC_MAGIC_STRING_TRIGGER_REDACTED_THINKING_46C9A13E193C177646C7398A98432ECCCE4C1253D5E2D82641AC0E52CC2876CB Reply with the single word OK.","type":"text"}],"role":"user"},{"content":[{"data":"redacted_thinking_REDACTED_1","type":"redacted_thinking"},{"text":"OK","type":"text"}],"role":"assistant"},{"content":[{"text":"Thanks. Now reply with the single word DONE.","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","thinking":{"budget_tokens":1024,"type":"enabled"}}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"content":[{"data":"redacted_thinking_REDACTED_2","type":"redacted_thinking"},{"text":"DONE","type":"text"}],"id":"msg_REDACTED_2","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":"end_turn","stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":134,"output_tokens":15,"output_tokens_details":{"thinking_tokens":8},"service_tier":"standard"}}'

--- a/tests/cassettes/anthropic/messages_thinking/redacted_thinking_streaming.yaml
+++ b/tests/cassettes/anthropic/messages_thinking/redacted_thinking_streaming.yaml
@@ -1,0 +1,51 @@
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":4096,"messages":[{"content":[{"text":"ANTHROPIC_MAGIC_STRING_TRIGGER_REDACTED_THINKING_46C9A13E193C177646C7398A98432ECCCE4C1253D5E2D82641AC0E52CC2876CB Reply with the single word OK.","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","stream":true,"thinking":{"budget_tokens":1024,"type":"enabled"}}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream; charset=utf-8
+  body: |+
+    event: message_start
+    data: {"message":{"content":[],"id":"msg_REDACTED_1","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":100,"output_tokens":1,"service_tier":"standard"}},"type":"message_start"}
+
+    event: content_block_start
+    data: {"content_block":{"data":"redacted_thinking_REDACTED_1","type":"redacted_thinking"},"index":0,"type":"content_block_start"}
+
+    event: ping
+    data: {"type":"ping"}
+
+    event: content_block_stop
+    data: {"index":0,"type":"content_block_stop"}
+
+    event: content_block_start
+    data: {"content_block":{"data":"redacted_thinking_REDACTED_2","type":"redacted_thinking"},"index":1,"type":"content_block_start"}
+
+    event: content_block_stop
+    data: {"index":1,"type":"content_block_stop"}
+
+    event: content_block_start
+    data: {"content_block":{"text":"","type":"text"},"index":2,"type":"content_block_start"}
+
+    event: content_block_delta
+    data: {"delta":{"text":"OK","type":"text_delta"},"index":2,"type":"content_block_delta"}
+
+    event: content_block_stop
+    data: {"index":2,"type":"content_block_stop"}
+
+    event: message_delta
+    data: {"delta":{"stop_details":null,"stop_reason":"end_turn","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":100,"output_tokens":13,"output_tokens_details":{"thinking_tokens":7}}}
+
+    event: message_stop
+    data: {"type":"message_stop"}
+

--- a/tests/cassettes/anthropic/messages_tool_args/nested_arguments_roundtrip_nonstreaming.yaml
+++ b/tests/cassettes/anthropic/messages_tool_args/nested_arguments_roundtrip_nonstreaming.yaml
@@ -1,0 +1,37 @@
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":2048,"messages":[{"content":[{"text":"Book this trip by calling the plan_trip tool exactly once with these exact values: itinerary.city = \"Kyoto\", itinerary.days = 3, itinerary.activities = [\"temples\", \"tea ceremony\"], itinerary.lodging.name = \"Sakura Inn\", itinerary.lodging.rooms = 2. After the tool returns, repeat its confirmation code in one short sentence.","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","system":[{"text":"You are a travel booking assistant. Use the plan_trip tool for every booking request and copy the requested values into the tool arguments exactly as given.","type":"text"}],"tools":[{"description":"Book a trip from a nested itinerary object.","input_schema":{"properties":{"itinerary":{"description":"The trip to book.","properties":{"activities":{"items":{"type":"string"},"type":"array"},"city":{"type":"string"},"days":{"type":"integer"},"lodging":{"properties":{"name":{"type":"string"},"rooms":{"type":"integer"}},"required":["name","rooms"],"type":"object"}},"required":["city","days","activities","lodging"],"type":"object"}},"required":["itinerary"],"type":"object"},"name":"plan_trip"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"content":[{"text":"I''ll book that trip to Kyoto right away!","type":"text"},{"caller":{"type":"direct"},"id":"toolu_REDACTED_1","input":{"itinerary":{"activities":["temples","tea ceremony"],"city":"Kyoto","days":3,"lodging":{"name":"Sakura Inn","rooms":2}}},"name":"plan_trip","type":"tool_use"}],"id":"msg_REDACTED_1","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":"tool_use","stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":799,"output_tokens":110,"service_tier":"standard"}}'
+---
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":2048,"messages":[{"content":[{"text":"Book this trip by calling the plan_trip tool exactly once with these exact values: itinerary.city = \"Kyoto\", itinerary.days = 3, itinerary.activities = [\"temples\", \"tea ceremony\"], itinerary.lodging.name = \"Sakura Inn\", itinerary.lodging.rooms = 2. After the tool returns, repeat its confirmation code in one short sentence.","type":"text"}],"role":"user"},{"content":[{"text":"I''ll book that trip to Kyoto right away!","type":"text"},{"id":"toolu_REDACTED_1","input":{"itinerary":{"activities":["temples","tea ceremony"],"city":"Kyoto","days":3,"lodging":{"name":"Sakura Inn","rooms":2}}},"name":"plan_trip","type":"tool_use"}],"role":"assistant"},{"content":[{"content":[{"text":"Booked Kyoto for 3 day(s), 2 room(s) at Sakura Inn, with 2 planned activities. Confirmation code SAKURA-77.","type":"text"}],"tool_use_id":"toolu_REDACTED_1","type":"tool_result"}],"role":"user"}],"model":"claude-sonnet-4-6","system":[{"text":"You are a travel booking assistant. Use the plan_trip tool for every booking request and copy the requested values into the tool arguments exactly as given.","type":"text"}],"tools":[{"description":"Book a trip from a nested itinerary object.","input_schema":{"properties":{"itinerary":{"description":"The trip to book.","properties":{"activities":{"items":{"type":"string"},"type":"array"},"city":{"type":"string"},"days":{"type":"integer"},"lodging":{"properties":{"name":{"type":"string"},"rooms":{"type":"integer"}},"required":["name","rooms"],"type":"object"}},"required":["city","days","activities","lodging"],"type":"object"}},"required":["itinerary"],"type":"object"},"name":"plan_trip"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"content":[{"text":"Your trip is all set — your confirmation code is **SAKURA-77**! 🎉","type":"text"}],"id":"msg_REDACTED_2","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":"end_turn","stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":963,"output_tokens":25,"service_tier":"standard"}}'

--- a/tests/cassettes/anthropic/messages_tool_args/nested_arguments_streaming.yaml
+++ b/tests/cassettes/anthropic/messages_tool_args/nested_arguments_streaming.yaml
@@ -1,0 +1,102 @@
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":2048,"messages":[{"content":[{"text":"Book this trip by calling the plan_trip tool exactly once with these exact values: itinerary.city = \"Kyoto\", itinerary.days = 3, itinerary.activities = [\"temples\", \"tea ceremony\"], itinerary.lodging.name = \"Sakura Inn\", itinerary.lodging.rooms = 2. After the tool returns, repeat its confirmation code in one short sentence.","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","stream":true,"system":[{"text":"You are a travel booking assistant. Use the plan_trip tool for every booking request and copy the requested values into the tool arguments exactly as given.","type":"text"}],"tool_choice":{"type":"auto"},"tools":[{"description":"Book a trip from a nested itinerary object.","input_schema":{"properties":{"itinerary":{"description":"The trip to book.","properties":{"activities":{"items":{"type":"string"},"type":"array"},"city":{"type":"string"},"days":{"type":"integer"},"lodging":{"properties":{"name":{"type":"string"},"rooms":{"type":"integer"}},"required":["name","rooms"],"type":"object"}},"required":["city","days","activities","lodging"],"type":"object"}},"required":["itinerary"],"type":"object"},"name":"plan_trip"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream; charset=utf-8
+  body: |+
+    event: message_start
+    data: {"message":{"content":[],"id":"msg_REDACTED_1","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":799,"output_tokens":6,"service_tier":"standard"}},"type":"message_start"}
+
+    event: content_block_start
+    data: {"content_block":{"text":"","type":"text"},"index":0,"type":"content_block_start"}
+
+    event: ping
+    data: {"type":"ping"}
+
+    event: content_block_delta
+    data: {"delta":{"text":"I'll book this trip right","type":"text_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"text":" away with exactly the values you specified!","type":"text_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_stop
+    data: {"index":0,"type":"content_block_stop"}
+
+    event: content_block_start
+    data: {"content_block":{"caller":{"type":"direct"},"id":"toolu_REDACTED_1","input":{},"name":"plan_trip","type":"tool_use"},"index":1,"type":"content_block_start"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"{\"i","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"tinerary\": ","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"{\"city\"","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":":\"Kyoto\",\"","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"days\":3,\"","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"activities","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"\":[\"temples\"","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":",\"tea cere","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"mon","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"y\"],\"lodgin","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"g\":","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"{\"name\":\"","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"Saku","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"ra","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":" Inn\",\"","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"rooms\":","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"2}}}","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
+
+    event: content_block_stop
+    data: {"index":1,"type":"content_block_stop"}
+
+    event: message_delta
+    data: {"delta":{"stop_details":null,"stop_reason":"tool_use","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":799,"output_tokens":112}}
+
+    event: message_stop
+    data: {"type":"message_stop"}
+

--- a/tests/cassettes/anthropic/messages_tool_args/unicode_arguments_streaming.yaml
+++ b/tests/cassettes/anthropic/messages_tool_args/unicode_arguments_streaming.yaml
@@ -1,0 +1,63 @@
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":1024,"messages":[{"content":[{"text":"Call the echo tool exactly once with the message argument set to exactly this text: Grüße aus 東京, from the \"naïve café\"!","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","stream":true,"system":[{"text":"You must call the echo tool with the exact text the user provides. Do not translate, reword, or drop any characters.","type":"text"}],"tool_choice":{"type":"auto"},"tools":[{"description":"Echo a message back to the user.","input_schema":{"properties":{"message":{"type":"string"}},"required":["message"],"type":"object"},"name":"echo"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream; charset=utf-8
+  body: |+
+    event: message_start
+    data: {"message":{"content":[],"id":"msg_REDACTED_1","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":618,"output_tokens":68,"service_tier":"standard"}},"type":"message_start"}
+
+    event: content_block_start
+    data: {"content_block":{"caller":{"type":"direct"},"id":"toolu_REDACTED_1","input":{},"name":"echo","type":"tool_use"},"index":0,"type":"content_block_start"}
+
+    event: ping
+    data: {"type":"ping"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"","type":"input_json_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"{\"messag","type":"input_json_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"e\": \"","type":"input_json_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"Grüße aus 東","type":"input_json_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"京, from the","type":"input_json_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":" \\\"na","type":"input_json_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"ïve caf","type":"input_json_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"é\\","type":"input_json_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"\"!\"}","type":"input_json_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_stop
+    data: {"index":0,"type":"content_block_stop"}
+
+    event: message_delta
+    data: {"delta":{"stop_details":null,"stop_reason":"tool_use","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":618,"output_tokens":68}}
+
+    event: message_stop
+    data: {"type":"message_stop"}
+

--- a/tests/cassettes/anthropic/messages_tool_args/zero_argument_tool_use_nonstreaming.yaml
+++ b/tests/cassettes/anthropic/messages_tool_args/zero_argument_tool_use_nonstreaming.yaml
@@ -1,0 +1,18 @@
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":1024,"messages":[{"content":[{"text":"Call the ping tool with no arguments. Do not answer with normal text before the tool call.","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","system":[{"text":"Follow the tool-calling instructions exactly.","type":"text"}],"tools":[{"description":"A zero-argument tool named ping.","input_schema":{"properties":{},"required":[],"type":"object"},"name":"ping"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"content":[{"caller":{"type":"direct"},"id":"toolu_REDACTED_1","input":{},"name":"ping","type":"tool_use"}],"id":"msg_REDACTED_1","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":"tool_use","stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":575,"output_tokens":35,"service_tier":"standard"}}'

--- a/tests/cassettes/anthropic/messages_tool_args/zero_argument_tool_use_streaming.yaml
+++ b/tests/cassettes/anthropic/messages_tool_args/zero_argument_tool_use_streaming.yaml
@@ -1,0 +1,39 @@
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":1024,"messages":[{"content":[{"text":"Call the ping tool with no arguments. Do not answer with normal text before the tool call.","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","stream":true,"system":[{"text":"Follow the tool-calling instructions exactly.","type":"text"}],"tool_choice":{"type":"auto"},"tools":[{"description":"A zero-argument tool named ping.","input_schema":{"properties":{},"required":[],"type":"object"},"name":"ping"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream; charset=utf-8
+  body: |+
+    event: message_start
+    data: {"message":{"content":[],"id":"msg_REDACTED_1","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":575,"output_tokens":35,"service_tier":"standard"}},"type":"message_start"}
+
+    event: content_block_start
+    data: {"content_block":{"caller":{"type":"direct"},"id":"toolu_REDACTED_1","input":{},"name":"ping","type":"tool_use"},"index":0,"type":"content_block_start"}
+
+    event: ping
+    data: {"type":"ping"}
+
+    event: content_block_delta
+    data: {"delta":{"partial_json":"","type":"input_json_delta"},"index":0,"type":"content_block_delta"}
+
+    event: content_block_stop
+    data: {"index":0,"type":"content_block_stop"}
+
+    event: message_delta
+    data: {"delta":{"stop_details":null,"stop_reason":"tool_use","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":575,"output_tokens":35}}
+
+    event: message_stop
+    data: {"type":"message_stop"}
+

--- a/tests/cassettes/anthropic/messages_tool_choice/none_suppresses_tool_use.yaml
+++ b/tests/cassettes/anthropic/messages_tool_choice/none_suppresses_tool_use.yaml
@@ -1,0 +1,18 @@
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":1024,"messages":[{"content":[{"text":"Name the capital of France in one word.","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","system":[{"text":"You are a concise assistant. Answer directly.","type":"text"}],"tool_choice":{"type":"none"},"tools":[{"description":"Add x and y together","input_schema":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"name":"add"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"content":[{"text":"Paris.","type":"text"}],"id":"msg_REDACTED_1","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":"end_turn","stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":608,"output_tokens":5,"service_tier":"standard"}}'

--- a/tests/cassettes/anthropic/messages_tool_choice/required_maps_to_any_and_forces_tool_use.yaml
+++ b/tests/cassettes/anthropic/messages_tool_choice/required_maps_to_any_and_forces_tool_use.yaml
@@ -1,0 +1,18 @@
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":1024,"messages":[{"content":[{"text":"Please greet me.","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","system":[{"text":"You are a calculator here to help the user perform arithmetic operations. Use the tools provided to answer the user''s question.","type":"text"}],"tool_choice":{"type":"any"},"tools":[{"description":"Add x and y together","input_schema":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"name":"add"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"content":[{"caller":{"type":"direct"},"id":"toolu_REDACTED_1","input":{"x":"<UNKNOWN>","y":"<UNKNOWN>"},"name":"add","type":"tool_use"}],"id":"msg_REDACTED_1","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":"tool_use","stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":710,"output_tokens":55,"service_tier":"standard"}}'

--- a/tests/cassettes/anthropic/messages_tool_choice/specific_tool_targets_named_tool.yaml
+++ b/tests/cassettes/anthropic/messages_tool_choice/specific_tool_targets_named_tool.yaml
@@ -1,0 +1,18 @@
+when:
+  path: /v1/messages
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  - name: anthropic-version
+    value: 2023-06-01
+  body: '{"max_tokens":1024,"messages":[{"content":[{"text":"Compute 9 minus 4 using a tool.","type":"text"}],"role":"user"}],"model":"claude-sonnet-4-6","system":[{"text":"You are a calculator here to help the user perform arithmetic operations. Use the tools provided to answer the user''s question.","type":"text"}],"tool_choice":{"name":"subtract","type":"tool"},"tools":[{"description":"Add x and y together","input_schema":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"name":"add"},{"description":"Subtract y from x (i.e.: x - y)","input_schema":{"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"name":"subtract"}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"content":[{"caller":{"type":"direct"},"id":"toolu_REDACTED_1","input":{"x":9,"y":4},"name":"subtract","type":"tool_use"}],"id":"msg_REDACTED_1","model":"claude-sonnet-4-6","role":"assistant","stop_details":null,"stop_reason":"tool_use","stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"inference_geo":"global","input_tokens":812,"output_tokens":50,"service_tier":"standard"}}'

--- a/tests/common/cassettes.rs
+++ b/tests/common/cassettes.rs
@@ -1544,6 +1544,16 @@ impl CassetteScrubber {
                         continue;
                     }
 
+                    // Anthropic redacted thinking carries an opaque encrypted
+                    // blob; placeholder it like OpenAI encrypted reasoning so
+                    // fixtures never commit provider ciphertext.
+                    if key == "data" && object_type.as_deref() == Some("redacted_thinking") {
+                        if let Value::String(data) = value {
+                            *data = self.placeholder(data, "redacted_thinking_");
+                        }
+                        continue;
+                    }
+
                     if key == "id"
                         && should_scrub_id_for_object(
                             self.policy,

--- a/tests/providers/anthropic/cassette/messages_behaviors.rs
+++ b/tests/providers/anthropic/cassette/messages_behaviors.rs
@@ -1,0 +1,61 @@
+//! Anthropic Messages API behavior regression tests.
+//!
+//! Locks down provider-response preservation for unusual but valid response
+//! shapes: `max_tokens` truncation surfacing partial output with its stop
+//! reason intact.
+//!
+//! Run cassette tests in replay mode by default, or set
+//! `RIG_PROVIDER_TEST_MODE=record` to record against the real provider.
+
+use rig::client::CompletionClient;
+use rig::completion::CompletionModel;
+use rig::message::AssistantContent;
+use rig::providers::anthropic;
+
+use super::super::support::with_anthropic_cassette;
+
+#[tokio::test]
+async fn max_tokens_truncation_preserves_stop_reason_and_partial_text() {
+    with_anthropic_cassette(
+        "messages_behaviors/max_tokens_truncation_preserves_stop_reason_and_partial_text",
+        |client| async move {
+            let model = client.completion_model(anthropic::completion::CLAUDE_SONNET_4_6);
+            let request = model
+                .completion_request(
+                    "Write a story of at least 150 words about a lighthouse keeper.",
+                )
+                .preamble("You are a storyteller.".to_string())
+                .max_tokens(64)
+                .build();
+
+            let response = model
+                .completion(request)
+                .await
+                .expect("a truncated response should still convert, not error");
+
+            assert_eq!(
+                response.raw_response.stop_reason.as_deref(),
+                Some("max_tokens"),
+                "hitting max_tokens should preserve the max_tokens stop reason"
+            );
+            let text: String = response
+                .choice
+                .iter()
+                .filter_map(|content| match content {
+                    AssistantContent::Text(text) => Some(text.text.as_str()),
+                    _ => None,
+                })
+                .collect();
+            assert!(
+                !text.trim().is_empty(),
+                "partial output text should still be surfaced"
+            );
+            assert!(
+                response.usage.output_tokens > 0 && response.usage.output_tokens <= 64,
+                "output tokens should reflect the truncation cap, got {:?}",
+                response.usage
+            );
+        },
+    )
+    .await;
+}

--- a/tests/providers/anthropic/cassette/messages_sessions.rs
+++ b/tests/providers/anthropic/cassette/messages_sessions.rs
@@ -1,0 +1,419 @@
+//! Anthropic Messages API long-session regression tests.
+//!
+//! These tests lock down multi-turn, multi-tool agent sessions against the
+//! Messages API: sequential tool roundtrips, parallel tool_use blocks in a
+//! single assistant turn with batched tool_result grouping, long chat-history
+//! replay (including assistant text before and after tool use), and usage
+//! accounting across turns.
+//!
+//! Run cassette tests in replay mode by default, or set
+//! `RIG_PROVIDER_TEST_MODE=record` to record against the real provider.
+
+use futures::StreamExt;
+use rig::agent::MultiTurnStreamItem;
+use rig::client::CompletionClient;
+use rig::completion::{Chat, CompletionModel, Message};
+use rig::message::{AssistantContent, UserContent};
+use rig::providers::anthropic;
+use rig::streaming::{StreamingChat, StreamingPrompt};
+use rig::tool::Tool;
+
+use super::super::support::with_anthropic_cassette;
+use super::streaming_tools::assert_cassette_groups_multiple_tool_results;
+use crate::support::{
+    ALPHA_SIGNAL_OUTPUT, Adder, AlphaSignal, BETA_SIGNAL_OUTPUT, BetaSignal,
+    ORDERED_TOOL_STREAM_PREAMBLE, ORDERED_TOOL_STREAM_PROMPT, Subtract, TWO_TOOL_STREAM_PREAMBLE,
+    TWO_TOOL_STREAM_PROMPT, assert_mentions_expected_number, collect_stream_observation,
+};
+
+const SEQUENTIAL_TOOLS_PREAMBLE: &str = "\
+You are a calculator. Use the provided tools instead of doing arithmetic yourself. \
+Call exactly one tool at a time and wait for its result before deciding the next step.";
+
+const SEQUENTIAL_TOOLS_PROMPT: &str = "\
+First use the add tool to compute 3 + 4. After you receive that result, use the \
+subtract tool to subtract 5 from it. Then state the final number in one short sentence.";
+
+/// A recorded tool event from a caller-owned chat history: the message index
+/// it appeared at plus the identifiers needed to pair calls with results.
+struct ToolEvent {
+    message_index: usize,
+    name_or_id: String,
+    call_id: Option<String>,
+}
+
+fn history_tool_calls(history: &[Message]) -> Vec<ToolEvent> {
+    let mut calls = Vec::new();
+    for (message_index, message) in history.iter().enumerate() {
+        if let Message::Assistant { content, .. } = message {
+            for item in content.iter() {
+                if let AssistantContent::ToolCall(tool_call) = item {
+                    calls.push(ToolEvent {
+                        message_index,
+                        name_or_id: tool_call.function.name.clone(),
+                        call_id: tool_call.call_id.clone().or(Some(tool_call.id.clone())),
+                    });
+                }
+            }
+        }
+    }
+    calls
+}
+
+fn history_tool_results(history: &[Message]) -> Vec<ToolEvent> {
+    let mut results = Vec::new();
+    for (message_index, message) in history.iter().enumerate() {
+        if let Message::User { content } = message {
+            for item in content.iter() {
+                if let UserContent::ToolResult(tool_result) = item {
+                    results.push(ToolEvent {
+                        message_index,
+                        name_or_id: tool_result.id.clone(),
+                        call_id: tool_result.call_id.clone().or(Some(tool_result.id.clone())),
+                    });
+                }
+            }
+        }
+    }
+    results
+}
+
+fn result_index_for_call(results: &[ToolEvent], call: &ToolEvent) -> usize {
+    results
+        .iter()
+        .find(|result| result.call_id == call.call_id)
+        .unwrap_or_else(|| {
+            panic!(
+                "chat history is missing the tool result answering call {:?} (call_id {:?})",
+                call.name_or_id, call.call_id
+            )
+        })
+        .message_index
+}
+
+#[tokio::test]
+async fn sequential_tool_calls_nonstreaming() {
+    with_anthropic_cassette(
+        "messages_sessions/sequential_tool_calls_nonstreaming",
+        |client| async move {
+            let agent = client
+                .agent(anthropic::completion::CLAUDE_SONNET_4_6)
+                .preamble(SEQUENTIAL_TOOLS_PREAMBLE)
+                .max_tokens(2048)
+                .tool(Adder)
+                .tool(Subtract)
+                .default_max_turns(6)
+                .build();
+            let mut history = Vec::<Message>::new();
+
+            let result = agent
+                .chat(SEQUENTIAL_TOOLS_PROMPT, &mut history)
+                .await
+                .expect("sequential tool chat should succeed");
+
+            assert_mentions_expected_number(&result, 2);
+
+            let calls = history_tool_calls(&history);
+            let results = history_tool_results(&history);
+            let add_call = calls
+                .iter()
+                .find(|call| call.name_or_id == Adder::NAME)
+                .expect("history should contain an add tool call");
+            let subtract_call = calls
+                .iter()
+                .find(|call| call.name_or_id == Subtract::NAME)
+                .expect("history should contain a subtract tool call");
+            let add_result_index = result_index_for_call(&results, add_call);
+            let subtract_result_index = result_index_for_call(&results, subtract_call);
+
+            assert!(
+                add_call.message_index < add_result_index,
+                "add result should follow the add call"
+            );
+            assert!(
+                add_result_index < subtract_call.message_index,
+                "subtract call should only happen after the add result (sequential turns)"
+            );
+            assert!(
+                subtract_call.message_index < subtract_result_index,
+                "subtract result should follow the subtract call"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn sequential_tool_calls_streaming() {
+    with_anthropic_cassette(
+        "messages_sessions/sequential_tool_calls_streaming",
+        |client| async move {
+            let agent = client
+                .agent(anthropic::completion::CLAUDE_SONNET_4_6)
+                .preamble(SEQUENTIAL_TOOLS_PREAMBLE)
+                .max_tokens(2048)
+                .tool(Adder)
+                .tool(Subtract)
+                .build();
+
+            let mut stream = agent
+                .stream_chat(SEQUENTIAL_TOOLS_PROMPT, Vec::<Message>::new())
+                .multi_turn(6)
+                .await;
+            let observation = collect_stream_observation(&mut stream).await;
+
+            assert!(
+                observation.errors.is_empty(),
+                "stream should not emit errors: {:?}",
+                observation.errors
+            );
+            assert_eq!(
+                observation.tool_calls,
+                vec![Adder::NAME.to_string(), Subtract::NAME.to_string()],
+                "expected exactly one add call followed by one subtract call"
+            );
+            assert_eq!(
+                observation.tool_results, 2,
+                "expected one tool result per tool call"
+            );
+            assert!(
+                observation.got_final_response,
+                "stream should emit a final response"
+            );
+            let response = observation
+                .final_response_text
+                .as_deref()
+                .expect("stream should produce final response text");
+            assert_mentions_expected_number(response, 2);
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn parallel_tool_use_single_turn_nonstreaming() {
+    with_anthropic_cassette(
+        "messages_sessions/parallel_tool_use_single_turn_nonstreaming",
+        |client| async move {
+            let agent = client
+                .agent(anthropic::completion::CLAUDE_SONNET_4_6)
+                .preamble(TWO_TOOL_STREAM_PREAMBLE)
+                .max_tokens(2048)
+                .tool(AlphaSignal)
+                .tool(BetaSignal)
+                .default_max_turns(5)
+                .build();
+            let mut history = Vec::<Message>::new();
+
+            let result = agent
+                .chat(TWO_TOOL_STREAM_PROMPT, &mut history)
+                .await
+                .expect("parallel tool chat should succeed");
+
+            let lowered = result.to_ascii_lowercase();
+            assert!(
+                lowered.contains(ALPHA_SIGNAL_OUTPUT) && lowered.contains(BETA_SIGNAL_OUTPUT),
+                "final response should include both tool outputs, got {result:?}"
+            );
+
+            let calls = history_tool_calls(&history);
+            let results = history_tool_results(&history);
+            assert_eq!(
+                calls.len(),
+                2,
+                "expected exactly two tool calls in history, got {:?}",
+                calls
+                    .iter()
+                    .map(|call| call.name_or_id.as_str())
+                    .collect::<Vec<_>>()
+            );
+            assert_eq!(results.len(), 2, "expected exactly two tool results");
+
+            for call in &calls {
+                let result_index = result_index_for_call(&results, call);
+                assert!(
+                    call.message_index < result_index,
+                    "each tool result should follow its call"
+                );
+            }
+
+            // Results must come back in the same order as the calls they answer.
+            let call_order: Vec<_> = calls.iter().map(|call| call.call_id.clone()).collect();
+            let result_order: Vec<_> = results
+                .iter()
+                .map(|result| result.call_id.clone())
+                .collect();
+            assert_eq!(
+                call_order, result_order,
+                "tool results should be recorded in tool-call order"
+            );
+        },
+    )
+    .await;
+
+    // Wire-format contract: the non-streaming agent loop must also batch both
+    // tool_result blocks from one assistant turn into a single user message.
+    assert_cassette_groups_multiple_tool_results(
+        "messages_sessions/parallel_tool_use_single_turn_nonstreaming",
+        &[AlphaSignal::NAME, BetaSignal::NAME],
+    );
+}
+
+#[tokio::test]
+async fn long_history_replay_nonstreaming() {
+    with_anthropic_cassette(
+        "messages_sessions/long_history_replay_nonstreaming",
+        |client| async move {
+            let model = client.completion_model(anthropic::completion::CLAUDE_SONNET_4_6);
+            let preamble = "You are a concise assistant with perfect recall of this conversation.";
+
+            // First turn: obtain a real tool_use so the follow-up can echo its
+            // id back, the way a caller-owned history would.
+            let first_request = model
+                .completion_request("Look up the harbor label with the tool.")
+                .preamble(preamble.to_string())
+                .max_tokens(1024)
+                .tool(AlphaSignal.definition(String::new()).await)
+                .build();
+            let first_response = model
+                .completion(first_request)
+                .await
+                .expect("first turn should succeed");
+            let tool_call = first_response
+                .choice
+                .iter()
+                .find_map(|content| match content {
+                    AssistantContent::ToolCall(tool_call) => Some(tool_call.clone()),
+                    _ => None,
+                })
+                .expect("first turn should call lookup_harbor_label");
+            assert_eq!(
+                first_response.raw_response.stop_reason.as_deref(),
+                Some("tool_use"),
+                "a tool-using turn should preserve the tool_use stop reason"
+            );
+
+            // Follow-up: replay a long client-owned history around that tool
+            // roundtrip, including assistant text before the tool_use (in the
+            // same assistant message) and assistant text after the result.
+            let request = model
+                .completion_request(
+                    "In one short sentence: what is my favorite color, and what was the \
+                     harbor label you looked up earlier?",
+                )
+                .preamble(preamble.to_string())
+                .max_tokens(1024)
+                .message(Message::user(
+                    "My favorite color is teal. Please remember it.",
+                ))
+                .message(Message::assistant("Noted - your favorite color is teal."))
+                .message(Message::user("Now look up the harbor label with the tool."))
+                .message(Message::Assistant {
+                    id: None,
+                    content: rig::OneOrMany::many(vec![
+                        AssistantContent::text("Checking the harbor label now."),
+                        AssistantContent::ToolCall(tool_call.clone()),
+                    ])
+                    .expect("assistant content should be non-empty"),
+                })
+                .message(Message::tool_result_with_call_id(
+                    tool_call.id.clone(),
+                    tool_call.call_id.clone(),
+                    ALPHA_SIGNAL_OUTPUT,
+                ))
+                .message(Message::assistant("The harbor label is crimson-harbor."))
+                .tool(AlphaSignal.definition(String::new()).await)
+                .build();
+
+            let response = model
+                .completion(request)
+                .await
+                .expect("long history replay should be accepted by the Messages API");
+
+            let text: String = response
+                .choice
+                .iter()
+                .filter_map(|content| match content {
+                    AssistantContent::Text(text) => Some(text.text.as_str()),
+                    _ => None,
+                })
+                .collect();
+            let lowered = text.to_ascii_lowercase();
+            assert!(
+                lowered.contains("teal"),
+                "answer should recall the user fact from early history, got {text:?}"
+            );
+            assert!(
+                lowered.contains(ALPHA_SIGNAL_OUTPUT),
+                "answer should recall the replayed tool result, got {text:?}"
+            );
+            assert_eq!(
+                response.raw_response.stop_reason.as_deref(),
+                Some("end_turn"),
+                "a plain answer should preserve the end_turn stop reason"
+            );
+            assert!(
+                !response.raw_response.model.is_empty() && !response.raw_response.id.is_empty(),
+                "provider response should preserve model and message id"
+            );
+            assert!(
+                response.usage.input_tokens > 0 && response.usage.output_tokens > 0,
+                "usage should be populated, got {:?}",
+                response.usage
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn usage_accumulates_across_streaming_multi_turn() {
+    with_anthropic_cassette(
+        "messages_sessions/usage_accumulates_across_streaming_multi_turn",
+        |client| async move {
+            let agent = client
+                .agent(anthropic::completion::CLAUDE_SONNET_4_6)
+                .preamble(ORDERED_TOOL_STREAM_PREAMBLE)
+                .max_tokens(2048)
+                .tool(AlphaSignal)
+                .build();
+
+            let mut stream = agent
+                .stream_prompt(ORDERED_TOOL_STREAM_PROMPT)
+                .multi_turn(5)
+                .await;
+
+            let mut saw_tool_result = false;
+            let mut final_usage = None;
+
+            while let Some(item) = stream.next().await {
+                match item.expect("stream item should be ok") {
+                    MultiTurnStreamItem::StreamUserItem(_) => saw_tool_result = true,
+                    MultiTurnStreamItem::FinalResponse(response) => {
+                        final_usage = Some(response.usage());
+                    }
+                    _ => {}
+                }
+            }
+
+            assert!(
+                saw_tool_result,
+                "session should include a tool roundtrip so usage spans two model turns"
+            );
+            let usage = final_usage.expect("stream should emit a final response with usage");
+            assert!(
+                usage.input_tokens > 0,
+                "aggregated input tokens should be nonzero: {usage:?}"
+            );
+            assert!(
+                usage.output_tokens > 0,
+                "aggregated output tokens should be nonzero: {usage:?}"
+            );
+            assert!(
+                usage.total_tokens >= usage.output_tokens,
+                "total tokens should cover output tokens: {usage:?}"
+            );
+        },
+    )
+    .await;
+}

--- a/tests/providers/anthropic/cassette/messages_thinking.rs
+++ b/tests/providers/anthropic/cassette/messages_thinking.rs
@@ -1,0 +1,150 @@
+//! Anthropic redacted-thinking regression tests.
+//!
+//! Uses Anthropic's documented magic string to deterministically trigger
+//! `redacted_thinking` blocks, then locks down that Rig surfaces them as
+//! redacted reasoning and replays them back across turns without the API
+//! rejecting the history.
+//!
+//! Run cassette tests in replay mode by default, or set
+//! `RIG_PROVIDER_TEST_MODE=record` to record against the real provider.
+
+use futures::StreamExt;
+use rig::client::CompletionClient;
+use rig::completion::{CompletionModel, Message};
+use rig::message::{AssistantContent, ReasoningContent};
+use rig::providers::anthropic;
+use rig::streaming::StreamedAssistantContent;
+
+use super::super::support::with_anthropic_cassette;
+
+/// Anthropic's documented test string that forces the model to emit
+/// `redacted_thinking` blocks when extended thinking is enabled.
+const REDACTED_THINKING_MAGIC_STRING: &str = "ANTHROPIC_MAGIC_STRING_TRIGGER_REDACTED_THINKING_46C9A13E193C177646C7398A98432ECCCE4C1253D5E2D82641AC0E52CC2876CB";
+
+fn redacted_thinking_prompt() -> String {
+    format!("{REDACTED_THINKING_MAGIC_STRING} Reply with the single word OK.")
+}
+
+fn thinking_params() -> serde_json::Value {
+    serde_json::json!({
+        "thinking": { "type": "enabled", "budget_tokens": 1024 }
+    })
+}
+
+fn has_redacted_reasoning(content: &AssistantContent) -> bool {
+    matches!(
+        content,
+        AssistantContent::Reasoning(reasoning)
+            if reasoning
+                .content
+                .iter()
+                .any(|item| matches!(item, ReasoningContent::Redacted { .. }))
+    )
+}
+
+#[tokio::test]
+async fn redacted_thinking_roundtrip_nonstreaming() {
+    with_anthropic_cassette(
+        "messages_thinking/redacted_thinking_roundtrip_nonstreaming",
+        |client| async move {
+            let model = client.completion_model(anthropic::completion::CLAUDE_SONNET_4_6);
+
+            let first_request = model
+                .completion_request(redacted_thinking_prompt())
+                .max_tokens(4096)
+                .additional_params(thinking_params())
+                .build();
+            let first_response = model
+                .completion(first_request)
+                .await
+                .expect("redacted-thinking completion should succeed");
+
+            assert!(
+                first_response.choice.iter().any(has_redacted_reasoning),
+                "the magic string must surface a redacted reasoning block, got {:?}",
+                first_response.choice
+            );
+
+            // Replay the redacted thinking block back in a follow-up turn; the
+            // API must accept the opaque data verbatim.
+            let second_request = model
+                .completion_request("Thanks. Now reply with the single word DONE.")
+                .max_tokens(4096)
+                .additional_params(thinking_params())
+                .message(Message::user(redacted_thinking_prompt()))
+                .message(Message::Assistant {
+                    id: first_response.message_id.clone(),
+                    content: first_response.choice.clone(),
+                })
+                .build();
+
+            let second_response = model
+                .completion(second_request)
+                .await
+                .expect("history containing redacted_thinking should be accepted");
+
+            let text: String = second_response
+                .choice
+                .iter()
+                .filter_map(|content| match content {
+                    AssistantContent::Text(text) => Some(text.text.as_str()),
+                    _ => None,
+                })
+                .collect();
+            assert!(
+                !text.trim().is_empty(),
+                "follow-up turn should produce text after replaying redacted thinking"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn redacted_thinking_streaming() {
+    with_anthropic_cassette(
+        "messages_thinking/redacted_thinking_streaming",
+        |client| async move {
+            let model = client.completion_model(anthropic::completion::CLAUDE_SONNET_4_6);
+            let request = model
+                .completion_request(redacted_thinking_prompt())
+                .max_tokens(4096)
+                .additional_params(thinking_params())
+                .build();
+
+            let mut stream = model
+                .stream(request)
+                .await
+                .expect("redacted-thinking streaming request should start");
+
+            let mut saw_redacted_reasoning = false;
+            let mut streamed_text = String::new();
+
+            while let Some(item) = stream.next().await {
+                match item.expect("stream item should be ok") {
+                    StreamedAssistantContent::Reasoning(reasoning) => {
+                        if reasoning
+                            .content
+                            .iter()
+                            .any(|item| matches!(item, ReasoningContent::Redacted { .. }))
+                        {
+                            saw_redacted_reasoning = true;
+                        }
+                    }
+                    StreamedAssistantContent::Text(text) => streamed_text.push_str(&text.text),
+                    _ => {}
+                }
+            }
+
+            assert!(
+                saw_redacted_reasoning,
+                "the stream should surface a redacted reasoning block"
+            );
+            assert!(
+                !streamed_text.trim().is_empty(),
+                "the stream should still produce the visible answer text"
+            );
+        },
+    )
+    .await;
+}

--- a/tests/providers/anthropic/cassette/messages_tool_args.rs
+++ b/tests/providers/anthropic/cassette/messages_tool_args.rs
@@ -1,0 +1,359 @@
+//! Anthropic Messages API tool-argument shape regression tests.
+//!
+//! Locks down how tool_use inputs survive the Messages API wire format: empty
+//! `{}` arguments, deeply nested objects with arrays, and non-ASCII/escaped
+//! strings, in both streaming (fragmented `input_json_delta` reassembly) and
+//! non-streaming form.
+//!
+//! Run cassette tests in replay mode by default, or set
+//! `RIG_PROVIDER_TEST_MODE=record` to record against the real provider.
+
+use rig::client::CompletionClient;
+use rig::completion::{Chat, CompletionModel, Message, ToolDefinition};
+use rig::message::AssistantContent;
+use rig::providers::anthropic;
+use rig::tool::Tool;
+use serde::Deserialize;
+use serde_json::json;
+
+use super::super::support::with_anthropic_cassette;
+use crate::support::{
+    REQUIRED_ZERO_ARG_TOOL_PROMPT, assert_stream_contains_zero_arg_tool_call_named,
+    collect_raw_stream_observation, zero_arg_tool_definition,
+};
+
+const NESTED_ARGS_PREAMBLE: &str = "\
+You are a travel booking assistant. Use the plan_trip tool for every booking request \
+and copy the requested values into the tool arguments exactly as given.";
+
+const NESTED_ARGS_PROMPT: &str = "\
+Book this trip by calling the plan_trip tool exactly once with these exact values: \
+itinerary.city = \"Kyoto\", itinerary.days = 3, \
+itinerary.activities = [\"temples\", \"tea ceremony\"], \
+itinerary.lodging.name = \"Sakura Inn\", itinerary.lodging.rooms = 2. \
+After the tool returns, repeat its confirmation code in one short sentence.";
+
+#[derive(Debug, thiserror::Error)]
+#[error("Trip planning failed")]
+struct PlanTripError;
+
+#[derive(Deserialize)]
+struct Lodging {
+    name: String,
+    rooms: u32,
+}
+
+#[derive(Deserialize)]
+struct Itinerary {
+    city: String,
+    days: u32,
+    activities: Vec<String>,
+    lodging: Lodging,
+}
+
+#[derive(Deserialize)]
+struct PlanTripArgs {
+    itinerary: Itinerary,
+}
+
+struct PlanTrip;
+
+impl Tool for PlanTrip {
+    const NAME: &'static str = "plan_trip";
+    type Error = PlanTripError;
+    type Args = PlanTripArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "Book a trip from a nested itinerary object.".to_string(),
+            parameters: plan_trip_parameters(),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        Ok(format!(
+            "Booked {} for {} day(s), {} room(s) at {}, with {} planned activities. \
+             Confirmation code SAKURA-77.",
+            args.itinerary.city,
+            args.itinerary.days,
+            args.itinerary.lodging.rooms,
+            args.itinerary.lodging.name,
+            args.itinerary.activities.len(),
+        ))
+    }
+}
+
+fn plan_trip_parameters() -> serde_json::Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "itinerary": {
+                "type": "object",
+                "description": "The trip to book.",
+                "properties": {
+                    "city": { "type": "string" },
+                    "days": { "type": "integer" },
+                    "activities": {
+                        "type": "array",
+                        "items": { "type": "string" }
+                    },
+                    "lodging": {
+                        "type": "object",
+                        "properties": {
+                            "name": { "type": "string" },
+                            "rooms": { "type": "integer" }
+                        },
+                        "required": ["name", "rooms"]
+                    }
+                },
+                "required": ["city", "days", "activities", "lodging"]
+            }
+        },
+        "required": ["itinerary"]
+    })
+}
+
+fn assert_expected_plan_trip_arguments(arguments: &serde_json::Value) {
+    let itinerary = arguments
+        .get("itinerary")
+        .expect("arguments should contain the nested itinerary object");
+    assert_eq!(
+        itinerary.get("city").and_then(|value| value.as_str()),
+        Some("Kyoto"),
+        "nested city should survive the wire format: {arguments:?}"
+    );
+    assert_eq!(
+        itinerary.get("days").and_then(|value| value.as_u64()),
+        Some(3),
+        "nested integer should survive the wire format: {arguments:?}"
+    );
+    assert_eq!(
+        itinerary.get("activities"),
+        Some(&json!(["temples", "tea ceremony"])),
+        "nested string array should survive the wire format: {arguments:?}"
+    );
+    let lodging = itinerary
+        .get("lodging")
+        .expect("arguments should contain the doubly nested lodging object");
+    assert_eq!(
+        lodging.get("name").and_then(|value| value.as_str()),
+        Some("Sakura Inn"),
+        "doubly nested string should survive the wire format: {arguments:?}"
+    );
+    assert_eq!(
+        lodging.get("rooms").and_then(|value| value.as_u64()),
+        Some(2),
+        "doubly nested integer should survive the wire format: {arguments:?}"
+    );
+}
+
+#[tokio::test]
+async fn zero_argument_tool_use_streaming() {
+    with_anthropic_cassette(
+        "messages_tool_args/zero_argument_tool_use_streaming",
+        |client| async move {
+            let model = client.completion_model(anthropic::completion::CLAUDE_SONNET_4_6);
+            let request = model
+                .completion_request(REQUIRED_ZERO_ARG_TOOL_PROMPT)
+                .preamble("Follow the tool-calling instructions exactly.".to_string())
+                .max_tokens(1024)
+                .tool(zero_arg_tool_definition("ping"))
+                .build();
+
+            let stream = model
+                .stream(request)
+                .await
+                .expect("zero-arg streaming request should start");
+
+            assert_stream_contains_zero_arg_tool_call_named(stream, "ping", true).await;
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn zero_argument_tool_use_nonstreaming() {
+    with_anthropic_cassette(
+        "messages_tool_args/zero_argument_tool_use_nonstreaming",
+        |client| async move {
+            let model = client.completion_model(anthropic::completion::CLAUDE_SONNET_4_6);
+            let request = model
+                .completion_request(REQUIRED_ZERO_ARG_TOOL_PROMPT)
+                .preamble("Follow the tool-calling instructions exactly.".to_string())
+                .max_tokens(1024)
+                .tool(zero_arg_tool_definition("ping"))
+                .build();
+
+            let response = model
+                .completion(request)
+                .await
+                .expect("zero-arg completion should succeed");
+
+            let tool_call = response
+                .choice
+                .iter()
+                .find_map(|content| match content {
+                    AssistantContent::ToolCall(tool_call) => Some(tool_call.clone()),
+                    _ => None,
+                })
+                .expect("response should contain the ping tool call");
+            assert_eq!(tool_call.function.name, "ping");
+            assert_eq!(
+                tool_call.function.arguments,
+                json!({}),
+                "zero-argument tool_use should surface empty-object arguments"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn nested_arguments_roundtrip_nonstreaming() {
+    with_anthropic_cassette(
+        "messages_tool_args/nested_arguments_roundtrip_nonstreaming",
+        |client| async move {
+            let agent = client
+                .agent(anthropic::completion::CLAUDE_SONNET_4_6)
+                .preamble(NESTED_ARGS_PREAMBLE)
+                .max_tokens(2048)
+                .tool(PlanTrip)
+                .default_max_turns(4)
+                .build();
+            let mut history = Vec::<Message>::new();
+
+            let result = agent
+                .chat(NESTED_ARGS_PROMPT, &mut history)
+                .await
+                .expect("nested-args tool chat should succeed");
+
+            assert!(
+                result.contains("SAKURA-77"),
+                "final answer should repeat the tool's confirmation code, got {result:?}"
+            );
+
+            let arguments = history
+                .iter()
+                .find_map(|message| match message {
+                    Message::Assistant { content, .. } => {
+                        content.iter().find_map(|item| match item {
+                            AssistantContent::ToolCall(tool_call)
+                                if tool_call.function.name == PlanTrip::NAME =>
+                            {
+                                Some(tool_call.function.arguments.clone())
+                            }
+                            _ => None,
+                        })
+                    }
+                    _ => None,
+                })
+                .expect("chat history should record the plan_trip tool call");
+            assert_expected_plan_trip_arguments(&arguments);
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn nested_arguments_streaming() {
+    with_anthropic_cassette(
+        "messages_tool_args/nested_arguments_streaming",
+        |client| async move {
+            let model = client.completion_model(anthropic::completion::CLAUDE_SONNET_4_6);
+            let request = model
+                .completion_request(NESTED_ARGS_PROMPT)
+                .preamble(NESTED_ARGS_PREAMBLE.to_string())
+                .max_tokens(2048)
+                .tool(PlanTrip.definition(String::new()).await)
+                .build();
+
+            let observation = collect_raw_stream_observation(
+                model
+                    .stream(request)
+                    .await
+                    .expect("nested-args streaming request should start"),
+            )
+            .await;
+
+            assert!(
+                observation.errors.is_empty(),
+                "stream should not emit errors: {:?}",
+                observation.errors
+            );
+            let tool_call = observation
+                .tool_calls
+                .iter()
+                .find(|tool_call| tool_call.function.name == PlanTrip::NAME)
+                .expect("stream should emit the plan_trip tool call");
+            assert_expected_plan_trip_arguments(&tool_call.function.arguments);
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn unicode_arguments_streaming() {
+    with_anthropic_cassette(
+        "messages_tool_args/unicode_arguments_streaming",
+        |client| async move {
+            let model = client.completion_model(anthropic::completion::CLAUDE_SONNET_4_6);
+            let request = model
+                .completion_request(
+                    "Call the echo tool exactly once with the message argument set to \
+                     exactly this text: Grüße aus 東京, from the \"naïve café\"!",
+                )
+                .preamble(
+                    "You must call the echo tool with the exact text the user provides. \
+                     Do not translate, reword, or drop any characters."
+                        .to_string(),
+                )
+                .max_tokens(1024)
+                .tool(ToolDefinition {
+                    name: "echo".to_string(),
+                    description: "Echo a message back to the user.".to_string(),
+                    parameters: json!({
+                        "type": "object",
+                        "properties": {
+                            "message": { "type": "string" }
+                        },
+                        "required": ["message"]
+                    }),
+                })
+                .build();
+
+            let observation = collect_raw_stream_observation(
+                model
+                    .stream(request)
+                    .await
+                    .expect("unicode-args streaming request should start"),
+            )
+            .await;
+
+            assert!(
+                observation.errors.is_empty(),
+                "stream should not emit errors: {:?}",
+                observation.errors
+            );
+            let tool_call = observation
+                .tool_calls
+                .iter()
+                .find(|tool_call| tool_call.function.name == "echo")
+                .expect("stream should emit the echo tool call");
+            let message = tool_call
+                .function
+                .arguments
+                .get("message")
+                .and_then(|value| value.as_str())
+                .expect("echo arguments should contain a message string");
+            for expected in ["Grüße", "東京", "naïve café"] {
+                assert!(
+                    message.contains(expected),
+                    "streamed unicode arguments should preserve {expected:?}, got {message:?}"
+                );
+            }
+        },
+    )
+    .await;
+}

--- a/tests/providers/anthropic/cassette/messages_tool_choice.rs
+++ b/tests/providers/anthropic/cassette/messages_tool_choice.rs
@@ -1,0 +1,176 @@
+//! Anthropic Messages API `tool_choice` regression tests.
+//!
+//! Locks down every `tool_choice` shape Rig sends to the Messages API:
+//! `required` (mapped to Anthropic's `{"type": "any"}`), `none`, and a
+//! specific named tool (`{"type": "tool", "name": ...}`).
+//!
+//! Run cassette tests in replay mode by default, or set
+//! `RIG_PROVIDER_TEST_MODE=record` to record against the real provider.
+
+use rig::client::CompletionClient;
+use rig::completion::CompletionModel;
+use rig::message::{AssistantContent, ToolChoice};
+use rig::providers::anthropic;
+use rig::tool::Tool;
+
+use super::super::support::with_anthropic_cassette;
+use crate::support::{Adder, Subtract, TOOLS_PREAMBLE};
+
+fn tool_call_names(choice: &rig::OneOrMany<AssistantContent>) -> Vec<String> {
+    choice
+        .iter()
+        .filter_map(|content| match content {
+            AssistantContent::ToolCall(tool_call) => Some(tool_call.function.name.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn required_maps_to_any_and_forces_tool_use() {
+    with_anthropic_cassette(
+        "messages_tool_choice/required_maps_to_any_and_forces_tool_use",
+        |client| async move {
+            let model = client.completion_model(anthropic::completion::CLAUDE_SONNET_4_6);
+            let request = model
+                .completion_request("Please greet me.")
+                .preamble(TOOLS_PREAMBLE.to_string())
+                .max_tokens(1024)
+                .tool(Adder.definition(String::new()).await)
+                .tool_choice(ToolChoice::Required)
+                .build();
+
+            let response = model
+                .completion(request)
+                .await
+                .expect("required tool choice completion should succeed");
+
+            let names = tool_call_names(&response.choice);
+            assert!(
+                !names.is_empty(),
+                "tool_choice=required (Anthropic `any`) must force a tool_use even for a \
+                 chat prompt, got {:?}",
+                response.choice
+            );
+            assert!(
+                names.iter().all(|name| name == Adder::NAME),
+                "only the provided tool can be called, saw {names:?}"
+            );
+            assert_eq!(
+                response.raw_response.stop_reason.as_deref(),
+                Some("tool_use"),
+                "a forced tool_use turn should preserve the tool_use stop reason"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn none_suppresses_tool_use() {
+    with_anthropic_cassette(
+        "messages_tool_choice/none_suppresses_tool_use",
+        |client| async move {
+            let model = client.completion_model(anthropic::completion::CLAUDE_SONNET_4_6);
+            // The question must not match the forbidden tool: asking arithmetic
+            // with the add tool blocked makes Anthropic return an empty
+            // end_turn message instead of answering in text.
+            let request = model
+                .completion_request("Name the capital of France in one word.")
+                .preamble("You are a concise assistant. Answer directly.".to_string())
+                .max_tokens(1024)
+                .tool(Adder.definition(String::new()).await)
+                .tool_choice(ToolChoice::None)
+                .build();
+
+            let response = model
+                .completion(request)
+                .await
+                .expect("none tool choice completion should succeed");
+
+            let names = tool_call_names(&response.choice);
+            assert!(
+                names.is_empty(),
+                "tool_choice=none must suppress tool_use, saw {names:?}"
+            );
+            let text: String = response
+                .choice
+                .iter()
+                .filter_map(|content| match content {
+                    AssistantContent::Text(text) => Some(text.text.as_str()),
+                    _ => None,
+                })
+                .collect();
+            assert!(
+                text.to_ascii_lowercase().contains("paris"),
+                "model should answer directly without tools, got {text:?}"
+            );
+            assert_eq!(
+                response.raw_response.stop_reason.as_deref(),
+                Some("end_turn"),
+                "a plain answer should preserve the end_turn stop reason"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn specific_tool_targets_named_tool() {
+    with_anthropic_cassette(
+        "messages_tool_choice/specific_tool_targets_named_tool",
+        |client| async move {
+            let model = client.completion_model(anthropic::completion::CLAUDE_SONNET_4_6);
+            let request = model
+                .completion_request("Compute 9 minus 4 using a tool.")
+                .preamble(TOOLS_PREAMBLE.to_string())
+                .max_tokens(1024)
+                .tool(Adder.definition(String::new()).await)
+                .tool(Subtract.definition(String::new()).await)
+                .tool_choice(ToolChoice::Specific {
+                    function_names: vec![Subtract::NAME.to_string()],
+                })
+                .build();
+
+            let response = model
+                .completion(request)
+                .await
+                .expect("specific tool choice completion should succeed");
+
+            let tool_call = response
+                .choice
+                .iter()
+                .find_map(|content| match content {
+                    AssistantContent::ToolCall(tool_call) => Some(tool_call.clone()),
+                    _ => None,
+                })
+                .expect("a specific tool choice must produce a tool_use");
+            assert_eq!(
+                tool_call.function.name,
+                Subtract::NAME,
+                "the named tool must be the one called"
+            );
+            assert_eq!(
+                tool_call
+                    .function
+                    .arguments
+                    .get("x")
+                    .and_then(|value| value.as_f64()),
+                Some(9.0),
+                "arguments should reflect the prompt: {:?}",
+                tool_call.function.arguments
+            );
+            assert_eq!(
+                tool_call
+                    .function
+                    .arguments
+                    .get("y")
+                    .and_then(|value| value.as_f64()),
+                Some(4.0),
+                "arguments should reflect the prompt: {:?}",
+                tool_call.function.arguments
+            );
+        },
+    )
+    .await;
+}

--- a/tests/providers/anthropic/cassette/streaming_tools.rs
+++ b/tests/providers/anthropic/cassette/streaming_tools.rs
@@ -402,7 +402,10 @@ struct RecordedRequest {
     body: Option<String>,
 }
 
-fn assert_cassette_groups_multiple_tool_results(scenario: &str, expected_tools: &[&str]) {
+pub(super) fn assert_cassette_groups_multiple_tool_results(
+    scenario: &str,
+    expected_tools: &[&str],
+) {
     let cassette_path = crate::cassettes::cassette_path("anthropic", scenario);
     let contents = std::fs::read_to_string(&cassette_path).unwrap_or_else(|error| {
         panic!(
@@ -449,7 +452,7 @@ fn messages_group_tool_results(messages: &[Value], expected_tools: &[&str]) -> b
     })
 }
 
-fn assert_cassette_tool_results_follow_assistant_tool_use_order(
+pub(super) fn assert_cassette_tool_results_follow_assistant_tool_use_order(
     scenario: &str,
     expected_tools: &[&str],
 ) {

--- a/tests/providers/anthropic/mod.rs
+++ b/tests/providers/anthropic/mod.rs
@@ -6,6 +6,11 @@ mod cassette {
     mod document_file_id;
     mod empty_end_turn;
     mod image;
+    mod messages_behaviors;
+    mod messages_sessions;
+    mod messages_thinking;
+    mod messages_tool_args;
+    mod messages_tool_choice;
     mod models;
     mod multi_turn_streaming;
     mod opus_4_7;


### PR DESCRIPTION
## Summary

Adds a broad, live-recorded cassette regression suite (14 new cassette tests across 5 new modules, 16 committed fixtures) that locks down long, multi-turn, multi-tool Anthropic Messages API sessions in Rig. Companion to #2002 (the OpenAI Responses suite) — same structure and assertion style, adapted to the Anthropic wire format.

### New cassette scenarios

**`messages_sessions/`** — long multi-turn sessions
- Sequential tool calls across turns (add → result → subtract → result → final answer), non-streaming with caller-owned-history ordering assertions (subtract call must come *after* the add result), plus the streaming parity twin.
- Parallel `tool_use` in a single assistant turn, non-streaming: history holds exactly two calls before two results, results recorded in tool-call order paired by id — and a **wire-format assertion on the recorded cassette** that both `tool_result` blocks are batched into ONE user message (reuses `assert_cassette_groups_multiple_tool_results`, previously only exercised on the streaming path; made `pub(super)` for reuse).
- Long client-owned history replay: prior user/assistant text turns, an assistant message with **text before the `tool_use` block**, the batched `tool_result`, **assistant text after the tool result**, then a new question. Asserts the model recalls both the early user fact and the replayed tool output, `stop_reason` preservation (`tool_use` on turn 1, `end_turn` on the answer), model/message-id preservation, and populated usage. Cassette body manually verified: assistant `[text, tool_use]` in one message, `tool_result` grouped into a user message, system prompt as top-level blocks.
- Usage accounting across a streaming multi-turn tool session via `FinalResponse::usage()`.

**`messages_tool_args/`** — argument wire shapes
- Empty `{}` `tool_use` input, streaming and non-streaming.
- Deeply nested arguments (object → object → array/object) through a full agent roundtrip (nested args recorded in history; final answer repeats the tool's confirmation code) and through raw streaming — the recorded cassette carries **18 fragmented `input_json_delta` events**, and the replay server re-chunks SSE bytes at 1–21-byte boundaries, exercising partial-JSON reassembly hard.
- Unicode/escaped strings (`Grüße`, `東京`, `naïve café`) surviving fragmented streaming JSON assembly.

**`messages_tool_choice/`** — every shape Rig can send
- `ToolChoice::Required` → `{"type":"any"}` forces a `tool_use` on a chat-y prompt (also asserts `stop_reason: tool_use`).
- `ToolChoice::None` → `{"type":"none"}` suppresses tool use and yields a text answer (`stop_reason: end_turn`).
- `ToolChoice::Specific` (one name) → `{"type":"tool","name":"subtract"}` targets the named tool with the prompt's arguments. All three serialized shapes are locked in the recorded request bodies.

**`messages_thinking/`** — deterministic redacted thinking
- Uses Anthropic's documented magic string to force `redacted_thinking` blocks. Non-streaming: the block surfaces as `ReasoningContent::Redacted`, and a second turn **replays the opaque blob back** — the API accepts the history. Streaming: the `content_block_start` redacted block surfaces as a redacted reasoning event while visible answer text still streams.

**`messages_behaviors/`**
- `max_tokens` truncation: conversion does not error; `stop_reason: "max_tokens"` is preserved with partial text intact and `output_tokens ≤ cap`.

### Test-infra change (in support of the above)

`tests/common/cassettes.rs`: the scrubber now placeholders the `data` field of `redacted_thinking` blocks (mirroring the existing `reasoning.encrypted` rule for OpenAI), so fixtures never commit provider ciphertext. Placeholder consistency keeps the turn-2 replay matching. No existing fixtures were affected (verified by the committed cassette-safety tests across all providers).

## Bugs found and fixed

No Rig bugs this time — the suite surfaced two **live API quirks** now documented and locked by cassettes instead:
- With `tool_choice: {"type":"none"}`, if the user's question matches the forbidden tool (e.g. asking arithmetic with only an `add` tool available), claude-sonnet-4-6 returns an **empty `content: []` with `stop_reason: end_turn`** rather than answering in text (verified with direct curl probes). Rig already normalizes empty end_turn responses to an empty-text sentinel (documented behavior); the cassette test uses a tool-unrelated question and a comment explains the trap.
- Empty end_turn assistant turns after tool use were already covered by the existing `empty_end_turn` cassettes, so no new coverage was added there.

## Inspiration references

Edge-case catalog mined from `/Users/kisaczka/Desktop/code/many_rigs/inspirations`:
- **Vercel AI SDK** — `vercel-ai-sdk/packages/anthropic/src/convert-to-anthropic-prompt.test.ts` (tool_result batching into one user message; text + multiple tool_use in one assistant message; thinking/redacted_thinking replay; cache_control placement), `anthropic-language-model.test.ts` (fragmented `input_json_delta` reassembly incl. empty `{}`; streaming thinking/signature/redacted lifecycles; stop_reason table incl. `max_tokens`; usage cache fields), `anthropic-prepare-tools.test.ts` (tool_choice `auto/any/none/tool` shapes), `map-anthropic-stop-reason.ts`.
- **LangChain** — `langchain/libs/partners/anthropic/tests/unit_tests/test_chat_models.py` (`_merge_messages` batching of consecutive tool messages into one user message with ordered `tool_result` blocks; empty assistant handling; per-model max_tokens defaults).
- Semantic Kernel — `semantic-kernel/python/semantic_kernel/connectors/ai/anthropic/services/utils.py` as a grouping cross-check; no unique wire cases.

## Recording / replay commands run

```bash
# record (one module at a time, targeted)
RIG_PROVIDER_TEST_MODE=record cargo test -p rig --all-features --test anthropic anthropic::cassette::messages_tool_choice -- --nocapture --test-threads=1
RIG_PROVIDER_TEST_MODE=record cargo test -p rig --all-features --test anthropic anthropic::cassette::messages_tool_args   -- --nocapture --test-threads=1
RIG_PROVIDER_TEST_MODE=record cargo test -p rig --all-features --test anthropic anthropic::cassette::messages_behaviors   -- --nocapture --test-threads=1
RIG_PROVIDER_TEST_MODE=record cargo test -p rig --all-features --test anthropic anthropic::cassette::messages_thinking    -- --nocapture --test-threads=1
RIG_PROVIDER_TEST_MODE=record cargo test -p rig --all-features --test anthropic anthropic::cassette::messages_sessions    -- --nocapture --test-threads=1

# replay without credentials (ANTHROPIC_API_KEY unset): 65/65 cassette tests pass
env -u ANTHROPIC_API_KEY cargo test -p rig --all-features --test anthropic anthropic::cassette -- --test-threads=1
env -u ANTHROPIC_API_KEY cargo test -p rig --all-features --test anthropic cassette_safety
```

## Manual cassette inspection

- No `x-api-key`/bearer/cookie/organization values or `sk-ant` tokens in any new fixture (grep + committed cassette-safety tests pass across all providers).
- All `msg_`/`toolu_` ids, thinking `signature`s, and `redacted_thinking` `data` blobs are placeholder-redacted.
- Request bodies verified by hand for the load-bearing contracts: assistant `[text, tool_use, tool_use]` in one message with both `tool_result` blocks batched into the following single user message; the full 7-message replay history with text-before/after-tool_use; `tool_choice` shapes `{"type":"any"}` / `{"type":"none"}` / `{"type":"tool","name":"subtract"}`; 18 `input_json_delta` fragments in the nested-args streaming fixture; system prompt as top-level content blocks.
- No unrelated fixture churn: only the 16 new YAMLs are added; no existing cassettes modified.

## Validation

- `cargo fmt` — clean
- `cargo clippy --all-targets --all-features` — no warnings
- `cargo test -p rig --all-features --test anthropic -- --test-threads=1` — 96 passed, 0 failed (without `ANTHROPIC_API_KEY`)
- `cargo test -p rig-core --lib providers::anthropic` — 133 passed
- Full `cargo test -p rig --all-features -- --test-threads=1` with all provider keys unset — every target green (including all providers' cassette-safety checks against the scrubber change)

## Known gaps / non-goals

- Prompt caching (manual + automatic, streaming), mid-conversation system-role handling (Opus 4.8 vs lifted), empty terminal assistant turns, thinking-signature roundtrips, and think-tool interplay are already covered by the existing `prompt_caching`, `opus_4_8`, `empty_end_turn`, `reasoning_*`, and `think_tool*` suites — intentionally not duplicated.
- Citations/document blocks and server tools (web_search) are not recorded live (nondeterministic/billable); `server_tool_use`/`web_search_tool_result` preservation is covered by existing unit tests in the provider.
- `pause_turn`/`refusal` stop reasons can't be triggered deterministically and are not exercised live.