### PR TITLE
test(gemini): production-grade generateContent cassette suite

### DIFF
--- a/tests/cassettes/gemini/generate_behaviors/max_tokens_truncation_preserves_finish_reason_and_partial_text.yaml
+++ b/tests/cassettes/gemini/generate_behaviors/max_tokens_truncation_preserves_finish_reason_and_partial_text.yaml
@@ -1,0 +1,18 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Write a story of at least 150 words about a lighthouse keeper.","thought":false}],"role":"user"}],"generationConfig":{"maxOutputTokens":48,"temperature":0.0,"thinkingConfig":{"thinkingBudget":0}},"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a storyteller.","thought":false}],"role":"model"},"toolConfig":null}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"Elara had seen a thousand storms, each one a furious ballet of wind and water against the unyielding stone of the lighthouse. Tonight, however, felt different. The air thrummed with an ancient energy, and the waves, usually"}],"role":"model"},"finishReason":"MAX_TOKENS","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":48,"promptTokenCount":23,"promptTokensDetails":[{"modality":"TEXT","tokenCount":23}],"serviceTier":"standard","totalTokenCount":71}}'

--- a/tests/cassettes/gemini/generate_behaviors/structured_output_nested_arrays_and_optional_fields.yaml
+++ b/tests/cassettes/gemini/generate_behaviors/structured_output_nested_arrays_and_optional_fields.yaml
@@ -1,0 +1,18 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Return an event record for a Rust meetup titled \"Rust Seattle June\" at the venue \"Fremont Hall\" in Seattle, with attendees Alice and Bob. No note is needed.","thought":false}],"role":"user"}],"generationConfig":{"maxOutputTokens":4096,"responseJsonSchema":{"$defs":{"EventLocation":{"properties":{"city":{"type":"string"},"venue":{"type":"string"}},"required":["city","venue"],"type":"object"}},"$schema":"https://json-schema.org/draft/2020-12/schema","properties":{"attendees":{"items":{"type":"string"},"type":"array"},"location":{"$ref":"#/$defs/EventLocation"},"note":{"type":"string"},"title":{"type":"string"}},"required":["title","location","attendees","note"],"title":"EventRecord","type":"object"},"responseMimeType":"application/json","temperature":0.0},"safetySettings":null,"systemInstruction":null,"toolConfig":null}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"{\"title\":\"Rust Seattle June\",\"location\":{\"city\":\"Seattle\",\"venue\":\"Fremont Hall\"},\"attendees\":[\"Alice\",\"Bob\"],\"note\":\"\"}"}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":32,"promptTokenCount":38,"promptTokensDetails":[{"modality":"TEXT","tokenCount":38}],"serviceTier":"standard","thoughtsTokenCount":115,"totalTokenCount":185}}'

--- a/tests/cassettes/gemini/generate_sessions/long_history_replay_nonstreaming.yaml
+++ b/tests/cassettes/gemini/generate_sessions/long_history_replay_nonstreaming.yaml
@@ -1,0 +1,18 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"My favorite color is teal. Please remember it.","thought":false}],"role":"user"},{"parts":[{"text":"Noted - your favorite color is teal.","thought":false}],"role":"model"},{"parts":[{"text":"Now look up the harbor label with the tool.","thought":false}],"role":"user"},{"parts":[{"text":"Checking the harbor label now.","thought":false},{"functionCall":{"args":{},"name":"lookup_harbor_label"},"thought":false}],"role":"model"},{"parts":[{"functionResponse":{"name":"lookup_harbor_label","response":{"result":"crimson-harbor"}},"thought":false}],"role":"user"},{"parts":[{"text":"The harbor label is crimson-harbor.","thought":false}],"role":"model"},{"parts":[{"text":"In one short sentence: what is my favorite color, and what was the harbor label you looked up earlier?","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a concise assistant with perfect recall of this conversation.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"properties":{},"required":[],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"Your favorite color is teal, and the harbor label looked up earlier was crimson-harbor."}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":19,"promptTokenCount":149,"promptTokensDetails":[{"modality":"TEXT","tokenCount":149}],"serviceTier":"standard","totalTokenCount":168}}'

--- a/tests/cassettes/gemini/generate_sessions/sequential_tool_calls_ordering_nonstreaming.yaml
+++ b/tests/cassettes/gemini/generate_sessions/sequential_tool_calls_ordering_nonstreaming.yaml
@@ -1,0 +1,56 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"First use the add tool to compute 3 + 4. After you receive that result, use the subtract tool to subtract 5 from it. Then state the final number in one short sentence.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":3,"y":4},"name":"add"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":18,"promptTokenCount":190,"promptTokensDetails":[{"modality":"TEXT","tokenCount":190}],"serviceTier":"standard","thoughtsTokenCount":68,"totalTokenCount":276}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"First use the add tool to compute 3 + 4. After you receive that result, use the subtract tool to subtract 5 from it. Then state the final number in one short sentence.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":3,"y":4},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":7}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":7,"y":5},"name":"subtract"},"thoughtSignature":"signature_REDACTED_2"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_2","usageMetadata":{"candidatesTokenCount":18,"promptTokenCount":221,"promptTokensDetails":[{"modality":"TEXT","tokenCount":221}],"serviceTier":"standard","thoughtsTokenCount":46,"totalTokenCount":285}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"First use the add tool to compute 3 + 4. After you receive that result, use the subtract tool to subtract 5 from it. Then state the final number in one short sentence.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":3,"y":4},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":7}},"thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":7,"y":5},"name":"subtract"},"thought":false,"thoughtSignature":"signature_REDACTED_2"}],"role":"model"},{"parts":[{"functionResponse":{"name":"subtract","response":{"result":2}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"The final number is 2.","thoughtSignature":"signature_REDACTED_3"}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_3","usageMetadata":{"candidatesTokenCount":7,"promptTokenCount":252,"promptTokensDetails":[{"modality":"TEXT","tokenCount":252}],"serviceTier":"standard","thoughtsTokenCount":27,"totalTokenCount":286}}'

--- a/tests/cassettes/gemini/generate_sessions/sequential_tool_calls_ordering_streaming.yaml
+++ b/tests/cassettes/gemini/generate_sessions/sequential_tool_calls_ordering_streaming.yaml
@@ -1,0 +1,62 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"First use the add tool to compute 3 + 4. After you receive that result, use the subtract tool to subtract 5 from it. Then state the final number in one short sentence.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"args\":{\"x\":3,\"y\":4},\"name\":\"add\"},\"thoughtSignature\":\"signature_REDACTED_1\"}],\"role\":\"model\"},\"finishMessage\":\"Model generated function call(s).\",\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_1\",\"usageMetadata\":{\"candidatesTokenCount\":18,\"promptTokenCount\":190,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":190}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":59,\"totalTokenCount\":267}}\r\n\r\n"
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"First use the add tool to compute 3 + 4. After you receive that result, use the subtract tool to subtract 5 from it. Then state the final number in one short sentence.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":3,"y":4},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":7}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"args\":{\"x\":7,\"y\":5},\"name\":\"subtract\"},\"thoughtSignature\":\"signature_REDACTED_2\"}],\"role\":\"model\"},\"finishMessage\":\"Model generated function call(s).\",\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_2\",\"usageMetadata\":{\"candidatesTokenCount\":18,\"promptTokenCount\":280,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":280}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":38,\"totalTokenCount\":336}}\r\n\r\n"
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"First use the add tool to compute 3 + 4. After you receive that result, use the subtract tool to subtract 5 from it. Then state the final number in one short sentence.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":3,"y":4},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":7}},"thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":7,"y":5},"name":"subtract"},"thought":false,"thoughtSignature":"signature_REDACTED_2"}],"role":"model"},{"parts":[{"functionResponse":{"name":"subtract","response":{"result":2}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"The final number is 2.\",\"thoughtSignature\":\"signature_REDACTED_3\"}],\"role\":\"model\"},\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_3\",\"usageMetadata\":{\"candidatesTokenCount\":7,\"promptTokenCount\":349,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":349}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":23,\"totalTokenCount\":379}}\r\n\r\n"

--- a/tests/cassettes/gemini/generate_sessions/thinking_session_reports_thought_tokens_in_usage.yaml
+++ b/tests/cassettes/gemini/generate_sessions/thinking_session_reports_thought_tokens_in_usage.yaml
@@ -1,0 +1,18 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"A farmer has 17 sheep. All but 9 run away. How many sheep are left? Think it through, then answer in one short sentence.","thought":false}],"role":"user"}],"generationConfig":{"temperature":0.0,"thinkingConfig":{"includeThoughts":true,"thinkingBudget":1024}},"safetySettings":null,"systemInstruction":null,"toolConfig":null}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"**My Analysis of the Sheep Problem**\n\nOkay, let''s break this down. The core question is about how many sheep remain. The critical piece of information is the phrase \"All but 9 run away.\" My expertise immediately flags this as a potential word trick. The initial number, 17, is likely a distraction. The crucial point is the phrase itself. \"All but 9\" implies that these are the *only* sheep that remain. The question explicitly asks how many are *left*. Therefore, the answer is directly embedded in that key phrase. Since \"all but 9\" clearly states the number that *didn''t* run away and the question focuses on the amount *left*, those nine sheep are the answer. Now, let me just make sure I hit the length constraint... *yup*, a single sentence will do. Therefore, the answer is nine sheep.\n","thought":true},{"text":"Nine sheep are left."}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":5,"promptTokenCount":33,"promptTokensDetails":[{"modality":"TEXT","tokenCount":33}],"serviceTier":"standard","thoughtsTokenCount":173,"totalTokenCount":211}}'

--- a/tests/cassettes/gemini/generate_tool_args/nested_arguments_roundtrip_nonstreaming.yaml
+++ b/tests/cassettes/gemini/generate_tool_args/nested_arguments_roundtrip_nonstreaming.yaml
@@ -1,0 +1,37 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Book this trip by calling the plan_trip tool exactly once with these exact values: itinerary.city = \"Kyoto\", itinerary.days = 3, itinerary.activities = [\"temples\", \"tea ceremony\"], itinerary.lodging.name = \"Sakura Inn\", itinerary.lodging.rooms = 2. After the tool returns, repeat its confirmation code in one short sentence.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a travel booking assistant. Use the plan_trip tool for every booking request and copy the requested values into the tool arguments exactly as given.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Book a trip from a nested itinerary object.","name":"plan_trip","parameters":{"properties":{"itinerary":{"description":"The trip to book.","properties":{"activities":{"items":{"type":"string"},"type":"array"},"city":{"type":"string"},"days":{"type":"integer"},"lodging":{"properties":{"name":{"type":"string"},"rooms":{"type":"integer"}},"required":["name","rooms"],"type":"object"}},"required":["city","days","activities","lodging"],"type":"object"}},"required":["itinerary"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"itinerary":{"activities":["temples","tea ceremony"],"city":"Kyoto","days":3,"lodging":{"name":"Sakura Inn","rooms":2}}},"name":"plan_trip"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":56,"promptTokenCount":301,"promptTokensDetails":[{"modality":"TEXT","tokenCount":301}],"serviceTier":"standard","thoughtsTokenCount":228,"totalTokenCount":585}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Book this trip by calling the plan_trip tool exactly once with these exact values: itinerary.city = \"Kyoto\", itinerary.days = 3, itinerary.activities = [\"temples\", \"tea ceremony\"], itinerary.lodging.name = \"Sakura Inn\", itinerary.lodging.rooms = 2. After the tool returns, repeat its confirmation code in one short sentence.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"itinerary":{"activities":["temples","tea ceremony"],"city":"Kyoto","days":3,"lodging":{"name":"Sakura Inn","rooms":2}}},"name":"plan_trip"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"plan_trip","response":{"result":"Booked Kyoto for 3 day(s), 2 room(s) at Sakura Inn, with 2 planned activities. Confirmation code SAKURA-77."}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a travel booking assistant. Use the plan_trip tool for every booking request and copy the requested values into the tool arguments exactly as given.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Book a trip from a nested itinerary object.","name":"plan_trip","parameters":{"properties":{"itinerary":{"description":"The trip to book.","properties":{"activities":{"items":{"type":"string"},"type":"array"},"city":{"type":"string"},"days":{"type":"integer"},"lodging":{"properties":{"name":{"type":"string"},"rooms":{"type":"integer"}},"required":["name","rooms"],"type":"object"}},"required":["city","days","activities","lodging"],"type":"object"}},"required":["itinerary"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"Your trip to Kyoto has been booked with confirmation code SAKURA-77."}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_2","usageMetadata":{"candidatesTokenCount":17,"promptTokenCount":406,"promptTokensDetails":[{"modality":"TEXT","tokenCount":406}],"serviceTier":"standard","totalTokenCount":423}}'

--- a/tests/cassettes/gemini/generate_tool_args/nested_arguments_streaming.yaml
+++ b/tests/cassettes/gemini/generate_tool_args/nested_arguments_streaming.yaml
@@ -1,0 +1,20 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Book this trip by calling the plan_trip tool exactly once with these exact values: itinerary.city = \"Kyoto\", itinerary.days = 3, itinerary.activities = [\"temples\", \"tea ceremony\"], itinerary.lodging.name = \"Sakura Inn\", itinerary.lodging.rooms = 2. After the tool returns, repeat its confirmation code in one short sentence.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a travel booking assistant. Use the plan_trip tool for every booking request and copy the requested values into the tool arguments exactly as given.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Book a trip from a nested itinerary object.","name":"plan_trip","parameters":{"properties":{"itinerary":{"description":"The trip to book.","properties":{"activities":{"items":{"type":"string"},"type":"array"},"city":{"type":"string"},"days":{"type":"integer"},"lodging":{"properties":{"name":{"type":"string"},"rooms":{"type":"integer"}},"required":["name","rooms"],"type":"object"}},"required":["city","days","activities","lodging"],"type":"object"}},"required":["itinerary"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"args\":{\"itinerary\":{\"activities\":[\"temples\",\"tea ceremony\"],\"city\":\"Kyoto\",\"days\":3,\"lodging\":{\"name\":\"Sakura Inn\",\"rooms\":2}}},\"name\":\"plan_trip\"},\"thoughtSignature\":\"signature_REDACTED_1\"}],\"role\":\"model\"},\"finishMessage\":\"Model generated function call(s).\",\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_1\",\"usageMetadata\":{\"candidatesTokenCount\":56,\"promptTokenCount\":301,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":301}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":165,\"totalTokenCount\":522}}\r\n\r\n"

--- a/tests/cassettes/gemini/generate_tool_args/optional_nullable_argument_omitted_when_not_requested.yaml
+++ b/tests/cassettes/gemini/generate_tool_args/optional_nullable_argument_omitted_when_not_requested.yaml
@@ -1,0 +1,18 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Log an event named \"deploy\" using the log_event tool. Do not attach a note.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"Use the log_event tool for every logging request. Only fill optional arguments when the user explicitly provides them.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Record an event with an optional free-form note.","name":"log_event","parameters":{"properties":{"name":{"type":"string"},"note":{"description":"Optional note; omit when the user gives none.","nullable":true,"type":"string"}},"required":["name"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"name":"deploy"},"name":"log_event"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":15,"promptTokenCount":111,"promptTokensDetails":[{"modality":"TEXT","tokenCount":111}],"serviceTier":"standard","thoughtsTokenCount":55,"totalTokenCount":181}}'

--- a/tests/cassettes/gemini/generate_tool_args/unicode_arguments_streaming.yaml
+++ b/tests/cassettes/gemini/generate_tool_args/unicode_arguments_streaming.yaml
@@ -1,0 +1,20 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Call the echo tool exactly once with the message argument set to exactly this text: Grüße aus 東京, from the \"naïve café\"!","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You must call the echo tool with the exact text the user provides. Do not translate, reword, or drop any characters.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Echo a message back to the user.","name":"echo","parameters":{"properties":{"message":{"type":"string"}},"required":["message"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"args\":{\"message\":\"Grüße aus 東京, from the \\\"naïve café\\\"!\"},\"name\":\"echo\"},\"thoughtSignature\":\"signature_REDACTED_1\"}],\"role\":\"model\"},\"finishMessage\":\"Model generated function call(s).\",\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_1\",\"usageMetadata\":{\"candidatesTokenCount\":27,\"promptTokenCount\":94,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":94}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":166,\"totalTokenCount\":287}}\r\n\r\n"

--- a/tests/cassettes/gemini/generate_tool_modes/required_maps_to_any_and_forces_function_call.yaml
+++ b/tests/cassettes/gemini/generate_tool_modes/required_maps_to_any_and_forces_function_call.yaml
@@ -1,0 +1,18 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Please greet me.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator here to help the user perform arithmetic operations. Use the tools provided to answer the user''s question.","thought":false}],"role":"model"},"toolConfig":{"functionCallingConfig":{"mode":"ANY"}},"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":1,"y":2},"name":"add"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":18,"promptTokenCount":85,"promptTokensDetails":[{"modality":"TEXT","tokenCount":85}],"serviceTier":"standard","thoughtsTokenCount":29,"totalTokenCount":132}}'

--- a/tests/providers/gemini/cassette/generate_behaviors.rs
+++ b/tests/providers/gemini/cassette/generate_behaviors.rs
@@ -1,0 +1,145 @@
+//! Gemini generateContent behavior regression tests.
+//!
+//! Locks down provider-response preservation for unusual but valid response
+//! shapes (`MAX_TOKENS` truncation with finish reason and model version
+//! intact) and structured output with nested objects, arrays, and optional
+//! fields.
+//!
+//! Run cassette tests in replay mode by default, or set
+//! `RIG_PROVIDER_TEST_MODE=record` to record against the real provider.
+
+use rig::client::CompletionClient;
+use rig::completion::{CompletionModel, Prompt};
+use rig::message::AssistantContent;
+use rig::providers::gemini;
+use rig::providers::gemini::completion::gemini_api_types::FinishReason;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use super::super::support::with_gemini_cassette;
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+struct EventLocation {
+    city: String,
+    venue: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+struct EventRecord {
+    title: String,
+    location: EventLocation,
+    attendees: Vec<String>,
+    #[schemars(required)]
+    note: Option<String>,
+}
+
+#[tokio::test]
+async fn max_tokens_truncation_preserves_finish_reason_and_partial_text() {
+    with_gemini_cassette(
+        "generate_behaviors/max_tokens_truncation_preserves_finish_reason_and_partial_text",
+        |client| async move {
+            let model = client.completion_model(gemini::completion::GEMINI_2_5_FLASH);
+            // Thinking is disabled so the token budget is spent on visible
+            // text and the truncated candidate still carries partial output.
+            let request = model
+                .completion_request(
+                    "Write a story of at least 150 words about a lighthouse keeper.",
+                )
+                .preamble("You are a storyteller.".to_string())
+                .temperature(0.0)
+                .max_tokens(48)
+                .additional_params(serde_json::json!({
+                    "generationConfig": {
+                        "thinkingConfig": { "thinkingBudget": 0 }
+                    }
+                }))
+                .build();
+
+            let response = model
+                .completion(request)
+                .await
+                .expect("a truncated response should still convert, not error");
+
+            let candidate = response
+                .raw_response
+                .candidates
+                .first()
+                .expect("response should carry a candidate");
+            assert!(
+                matches!(candidate.finish_reason, Some(FinishReason::MaxTokens)),
+                "hitting maxOutputTokens should preserve the MAX_TOKENS finish reason, \
+                 got {:?}",
+                candidate.finish_reason
+            );
+            let text: String = response
+                .choice
+                .iter()
+                .filter_map(|content| match content {
+                    AssistantContent::Text(text) => Some(text.text.as_str()),
+                    _ => None,
+                })
+                .collect();
+            assert!(
+                !text.trim().is_empty(),
+                "partial output text should still be surfaced"
+            );
+            assert!(
+                response
+                    .raw_response
+                    .model_version
+                    .as_deref()
+                    .is_some_and(|version| !version.is_empty()),
+                "provider response should preserve the model version"
+            );
+            assert!(
+                response.usage.output_tokens > 0,
+                "usage should reflect the truncated candidate, got {:?}",
+                response.usage
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn structured_output_nested_arrays_and_optional_fields() {
+    with_gemini_cassette(
+        "generate_behaviors/structured_output_nested_arrays_and_optional_fields",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .output_schema::<EventRecord>()
+                .temperature(0.0)
+                .build();
+
+            let response = agent
+                .prompt(
+                    "Return an event record for a Rust meetup titled \"Rust Seattle June\" \
+                     at the venue \"Fremont Hall\" in Seattle, with attendees Alice and Bob. \
+                     No note is needed.",
+                )
+                .await
+                .expect("structured output prompt should succeed");
+            let record: EventRecord =
+                serde_json::from_str(&response).expect("structured output should deserialize");
+
+            assert!(!record.title.trim().is_empty(), "title should be populated");
+            assert_eq!(
+                record.location.city.to_ascii_lowercase(),
+                "seattle",
+                "nested object field should follow the prompt"
+            );
+            assert!(
+                !record.location.venue.trim().is_empty(),
+                "nested venue should be populated"
+            );
+            assert_eq!(
+                record.attendees.len(),
+                2,
+                "array field should carry both attendees: {:?}",
+                record.attendees
+            );
+        },
+    )
+    .await;
+}

--- a/tests/providers/gemini/cassette/generate_sessions.rs
+++ b/tests/providers/gemini/cassette/generate_sessions.rs
@@ -1,0 +1,322 @@
+//! Gemini generateContent long-session regression tests.
+//!
+//! These tests lock down multi-turn, multi-tool agent sessions: sequential
+//! tool roundtrips with strict ordering, long client-owned history replay
+//! (model text before and after functionCall parts), and thinking-enabled
+//! usage accounting (thoughts token surfacing).
+//!
+//! Run cassette tests in replay mode by default, or set
+//! `RIG_PROVIDER_TEST_MODE=record` to record against the real provider.
+
+use rig::client::CompletionClient;
+use rig::completion::{Chat, CompletionModel, Message};
+use rig::message::{AssistantContent, UserContent};
+use rig::providers::gemini;
+use rig::streaming::StreamingChat;
+use rig::tool::Tool;
+
+use super::super::support::with_gemini_cassette;
+use crate::support::{
+    ALPHA_SIGNAL_OUTPUT, Adder, AlphaSignal, Subtract, assert_mentions_expected_number,
+    collect_stream_observation,
+};
+
+const SEQUENTIAL_TOOLS_PREAMBLE: &str = "\
+You are a calculator. Use the provided tools instead of doing arithmetic yourself. \
+Call exactly one tool at a time and wait for its result before deciding the next step.";
+
+const SEQUENTIAL_TOOLS_PROMPT: &str = "\
+First use the add tool to compute 3 + 4. After you receive that result, use the \
+subtract tool to subtract 5 from it. Then state the final number in one short sentence.";
+
+/// A recorded tool event from a caller-owned chat history: the message index
+/// it appeared at plus the identifiers needed to pair calls with results.
+struct ToolEvent {
+    message_index: usize,
+    name_or_id: String,
+    call_id: Option<String>,
+}
+
+fn history_tool_calls(history: &[Message]) -> Vec<ToolEvent> {
+    let mut calls = Vec::new();
+    for (message_index, message) in history.iter().enumerate() {
+        if let Message::Assistant { content, .. } = message {
+            for item in content.iter() {
+                if let AssistantContent::ToolCall(tool_call) = item {
+                    calls.push(ToolEvent {
+                        message_index,
+                        name_or_id: tool_call.function.name.clone(),
+                        call_id: tool_call.call_id.clone().or(Some(tool_call.id.clone())),
+                    });
+                }
+            }
+        }
+    }
+    calls
+}
+
+fn history_tool_results(history: &[Message]) -> Vec<ToolEvent> {
+    let mut results = Vec::new();
+    for (message_index, message) in history.iter().enumerate() {
+        if let Message::User { content } = message {
+            for item in content.iter() {
+                if let UserContent::ToolResult(tool_result) = item {
+                    results.push(ToolEvent {
+                        message_index,
+                        name_or_id: tool_result.id.clone(),
+                        call_id: tool_result.call_id.clone().or(Some(tool_result.id.clone())),
+                    });
+                }
+            }
+        }
+    }
+    results
+}
+
+fn result_index_for_call(results: &[ToolEvent], call: &ToolEvent) -> usize {
+    results
+        .iter()
+        .find(|result| result.call_id == call.call_id)
+        .unwrap_or_else(|| {
+            panic!(
+                "chat history is missing the tool result answering call {:?} (call_id {:?})",
+                call.name_or_id, call.call_id
+            )
+        })
+        .message_index
+}
+
+#[tokio::test]
+async fn sequential_tool_calls_ordering_nonstreaming() {
+    with_gemini_cassette(
+        "generate_sessions/sequential_tool_calls_ordering_nonstreaming",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .preamble(SEQUENTIAL_TOOLS_PREAMBLE)
+                .temperature(0.0)
+                .tool(Adder)
+                .tool(Subtract)
+                .default_max_turns(6)
+                .build();
+            let mut history = Vec::<Message>::new();
+
+            let result = agent
+                .chat(SEQUENTIAL_TOOLS_PROMPT, &mut history)
+                .await
+                .expect("sequential tool chat should succeed");
+
+            assert_mentions_expected_number(&result, 2);
+
+            let calls = history_tool_calls(&history);
+            let results = history_tool_results(&history);
+            let add_call = calls
+                .iter()
+                .find(|call| call.name_or_id == Adder::NAME)
+                .expect("history should contain an add tool call");
+            let subtract_call = calls
+                .iter()
+                .find(|call| call.name_or_id == Subtract::NAME)
+                .expect("history should contain a subtract tool call");
+            let add_result_index = result_index_for_call(&results, add_call);
+            let subtract_result_index = result_index_for_call(&results, subtract_call);
+
+            assert!(
+                add_call.message_index < add_result_index,
+                "add result should follow the add call"
+            );
+            assert!(
+                add_result_index < subtract_call.message_index,
+                "subtract call should only happen after the add result (sequential turns)"
+            );
+            assert!(
+                subtract_call.message_index < subtract_result_index,
+                "subtract result should follow the subtract call"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn sequential_tool_calls_ordering_streaming() {
+    with_gemini_cassette(
+        "generate_sessions/sequential_tool_calls_ordering_streaming",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .preamble(SEQUENTIAL_TOOLS_PREAMBLE)
+                .temperature(0.0)
+                .tool(Adder)
+                .tool(Subtract)
+                .build();
+
+            let mut stream = agent
+                .stream_chat(SEQUENTIAL_TOOLS_PROMPT, Vec::<Message>::new())
+                .multi_turn(6)
+                .await;
+            let observation = collect_stream_observation(&mut stream).await;
+
+            assert!(
+                observation.errors.is_empty(),
+                "stream should not emit errors: {:?}",
+                observation.errors
+            );
+            assert_eq!(
+                observation.tool_calls,
+                vec![Adder::NAME.to_string(), Subtract::NAME.to_string()],
+                "expected exactly one add call followed by one subtract call"
+            );
+            assert_eq!(
+                observation.tool_results, 2,
+                "expected one tool result per tool call"
+            );
+            assert!(
+                observation.got_final_response,
+                "stream should emit a final response"
+            );
+            let response = observation
+                .final_response_text
+                .as_deref()
+                .expect("stream should produce final response text");
+            assert_mentions_expected_number(response, 2);
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn long_history_replay_nonstreaming() {
+    with_gemini_cassette(
+        "generate_sessions/long_history_replay_nonstreaming",
+        |client| async move {
+            let model = client.completion_model(gemini::completion::GEMINI_2_5_FLASH);
+
+            // A finished prior session replayed statelessly: Gemini pairs
+            // functionResponse parts to functionCall parts by name, so a fully
+            // client-constructed history (including model text before the
+            // functionCall and after the functionResponse) must be accepted.
+            let request = model
+                .completion_request(
+                    "In one short sentence: what is my favorite color, and what was the \
+                     harbor label you looked up earlier?",
+                )
+                .preamble(
+                    "You are a concise assistant with perfect recall of this conversation."
+                        .to_string(),
+                )
+                .temperature(0.0)
+                .message(Message::user(
+                    "My favorite color is teal. Please remember it.",
+                ))
+                .message(Message::assistant("Noted - your favorite color is teal."))
+                .message(Message::user("Now look up the harbor label with the tool."))
+                .message(Message::Assistant {
+                    id: None,
+                    content: rig::OneOrMany::many(vec![
+                        AssistantContent::text("Checking the harbor label now."),
+                        AssistantContent::tool_call(
+                            AlphaSignal::NAME,
+                            AlphaSignal::NAME,
+                            serde_json::json!({}),
+                        ),
+                    ])
+                    .expect("assistant content should be non-empty"),
+                })
+                .message(Message::tool_result(AlphaSignal::NAME, ALPHA_SIGNAL_OUTPUT))
+                .message(Message::assistant("The harbor label is crimson-harbor."))
+                .tool(AlphaSignal.definition(String::new()).await)
+                .build();
+
+            let response = model
+                .completion(request)
+                .await
+                .expect("long history replay should be accepted by generateContent");
+
+            let text: String = response
+                .choice
+                .iter()
+                .filter_map(|content| match content {
+                    AssistantContent::Text(text) => Some(text.text.as_str()),
+                    _ => None,
+                })
+                .collect();
+            let lowered = text.to_ascii_lowercase();
+            assert!(
+                lowered.contains("teal"),
+                "answer should recall the user fact from early history, got {text:?}"
+            );
+            assert!(
+                lowered.contains(ALPHA_SIGNAL_OUTPUT),
+                "answer should recall the replayed tool result, got {text:?}"
+            );
+            assert!(
+                response.usage.input_tokens > 0 && response.usage.output_tokens > 0,
+                "usage should be populated, got {:?}",
+                response.usage
+            );
+            assert!(
+                response
+                    .raw_response
+                    .model_version
+                    .as_deref()
+                    .is_some_and(|version| !version.is_empty()),
+                "provider response should preserve the model version"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn thinking_session_reports_thought_tokens_in_usage() {
+    with_gemini_cassette(
+        "generate_sessions/thinking_session_reports_thought_tokens_in_usage",
+        |client| async move {
+            let model = client.completion_model(gemini::completion::GEMINI_2_5_FLASH);
+            let request = model
+                .completion_request(
+                    "A farmer has 17 sheep. All but 9 run away. How many sheep are left? \
+                     Think it through, then answer in one short sentence.",
+                )
+                .temperature(0.0)
+                .additional_params(serde_json::json!({
+                    "generationConfig": {
+                        "thinkingConfig": { "thinkingBudget": 1024, "includeThoughts": true }
+                    }
+                }))
+                .build();
+
+            let response = model
+                .completion(request)
+                .await
+                .expect("thinking-enabled completion should succeed");
+
+            let text: String = response
+                .choice
+                .iter()
+                .filter_map(|content| match content {
+                    AssistantContent::Text(text) => Some(text.text.as_str()),
+                    _ => None,
+                })
+                .collect();
+            let lowered = text.to_ascii_lowercase();
+            assert!(
+                lowered.contains('9') || lowered.contains("nine"),
+                "the visible answer should state the result, got {text:?}"
+            );
+            assert!(
+                response.usage.reasoning_tokens > 0,
+                "thoughtsTokenCount should surface as reasoning tokens: {:?}",
+                response.usage
+            );
+            assert!(
+                response.usage.total_tokens
+                    >= response.usage.input_tokens + response.usage.output_tokens,
+                "total tokens should cover prompt and candidate tokens: {:?}",
+                response.usage
+            );
+        },
+    )
+    .await;
+}

--- a/tests/providers/gemini/cassette/generate_tool_args.rs
+++ b/tests/providers/gemini/cassette/generate_tool_args.rs
@@ -1,0 +1,366 @@
+//! Gemini function-call argument shape regression tests.
+//!
+//! Locks down how functionCall args survive the generateContent wire format:
+//! deeply nested objects with arrays, non-ASCII/escaped strings, and optional
+//! (nullable) fields, in both streaming and non-streaming form. Zero-argument
+//! calls are already covered by `agent_tools` and `streaming_tools`.
+//!
+//! Run cassette tests in replay mode by default, or set
+//! `RIG_PROVIDER_TEST_MODE=record` to record against the real provider.
+
+use rig::client::CompletionClient;
+use rig::completion::{Chat, CompletionModel, Message, ToolDefinition};
+use rig::message::AssistantContent;
+use rig::providers::gemini;
+use rig::tool::Tool;
+use serde::Deserialize;
+use serde_json::json;
+
+use super::super::support::with_gemini_cassette;
+use crate::support::collect_raw_stream_observation;
+
+const NESTED_ARGS_PREAMBLE: &str = "\
+You are a travel booking assistant. Use the plan_trip tool for every booking request \
+and copy the requested values into the tool arguments exactly as given.";
+
+const NESTED_ARGS_PROMPT: &str = "\
+Book this trip by calling the plan_trip tool exactly once with these exact values: \
+itinerary.city = \"Kyoto\", itinerary.days = 3, \
+itinerary.activities = [\"temples\", \"tea ceremony\"], \
+itinerary.lodging.name = \"Sakura Inn\", itinerary.lodging.rooms = 2. \
+After the tool returns, repeat its confirmation code in one short sentence.";
+
+#[derive(Debug, thiserror::Error)]
+#[error("Trip planning failed")]
+struct PlanTripError;
+
+#[derive(Deserialize)]
+struct Lodging {
+    name: String,
+    rooms: u32,
+}
+
+#[derive(Deserialize)]
+struct Itinerary {
+    city: String,
+    days: u32,
+    activities: Vec<String>,
+    lodging: Lodging,
+}
+
+#[derive(Deserialize)]
+struct PlanTripArgs {
+    itinerary: Itinerary,
+}
+
+struct PlanTrip;
+
+impl Tool for PlanTrip {
+    const NAME: &'static str = "plan_trip";
+    type Error = PlanTripError;
+    type Args = PlanTripArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "Book a trip from a nested itinerary object.".to_string(),
+            parameters: plan_trip_parameters(),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        Ok(format!(
+            "Booked {} for {} day(s), {} room(s) at {}, with {} planned activities. \
+             Confirmation code SAKURA-77.",
+            args.itinerary.city,
+            args.itinerary.days,
+            args.itinerary.lodging.rooms,
+            args.itinerary.lodging.name,
+            args.itinerary.activities.len(),
+        ))
+    }
+}
+
+fn plan_trip_parameters() -> serde_json::Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "itinerary": {
+                "type": "object",
+                "description": "The trip to book.",
+                "properties": {
+                    "city": { "type": "string" },
+                    "days": { "type": "integer" },
+                    "activities": {
+                        "type": "array",
+                        "items": { "type": "string" }
+                    },
+                    "lodging": {
+                        "type": "object",
+                        "properties": {
+                            "name": { "type": "string" },
+                            "rooms": { "type": "integer" }
+                        },
+                        "required": ["name", "rooms"]
+                    }
+                },
+                "required": ["city", "days", "activities", "lodging"]
+            }
+        },
+        "required": ["itinerary"]
+    })
+}
+
+fn assert_expected_plan_trip_arguments(arguments: &serde_json::Value) {
+    let itinerary = arguments
+        .get("itinerary")
+        .expect("arguments should contain the nested itinerary object");
+    assert_eq!(
+        itinerary.get("city").and_then(|value| value.as_str()),
+        Some("Kyoto"),
+        "nested city should survive the wire format: {arguments:?}"
+    );
+    assert_eq!(
+        itinerary.get("days").and_then(|value| value.as_u64()),
+        Some(3),
+        "nested integer should survive the wire format: {arguments:?}"
+    );
+    assert_eq!(
+        itinerary.get("activities"),
+        Some(&json!(["temples", "tea ceremony"])),
+        "nested string array should survive the wire format: {arguments:?}"
+    );
+    let lodging = itinerary
+        .get("lodging")
+        .expect("arguments should contain the doubly nested lodging object");
+    assert_eq!(
+        lodging.get("name").and_then(|value| value.as_str()),
+        Some("Sakura Inn"),
+        "doubly nested string should survive the wire format: {arguments:?}"
+    );
+    assert_eq!(
+        lodging.get("rooms").and_then(|value| value.as_u64()),
+        Some(2),
+        "doubly nested integer should survive the wire format: {arguments:?}"
+    );
+}
+
+#[tokio::test]
+async fn nested_arguments_roundtrip_nonstreaming() {
+    with_gemini_cassette(
+        "generate_tool_args/nested_arguments_roundtrip_nonstreaming",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .preamble(NESTED_ARGS_PREAMBLE)
+                .temperature(0.0)
+                .tool(PlanTrip)
+                .default_max_turns(4)
+                .build();
+            let mut history = Vec::<Message>::new();
+
+            let result = agent
+                .chat(NESTED_ARGS_PROMPT, &mut history)
+                .await
+                .expect("nested-args tool chat should succeed");
+
+            assert!(
+                result.contains("SAKURA-77"),
+                "final answer should repeat the tool's confirmation code, got {result:?}"
+            );
+
+            let arguments = history
+                .iter()
+                .find_map(|message| match message {
+                    Message::Assistant { content, .. } => {
+                        content.iter().find_map(|item| match item {
+                            AssistantContent::ToolCall(tool_call)
+                                if tool_call.function.name == PlanTrip::NAME =>
+                            {
+                                Some(tool_call.function.arguments.clone())
+                            }
+                            _ => None,
+                        })
+                    }
+                    _ => None,
+                })
+                .expect("chat history should record the plan_trip tool call");
+            assert_expected_plan_trip_arguments(&arguments);
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn nested_arguments_streaming() {
+    with_gemini_cassette(
+        "generate_tool_args/nested_arguments_streaming",
+        |client| async move {
+            let model = client.completion_model(gemini::completion::GEMINI_2_5_FLASH);
+            let request = model
+                .completion_request(NESTED_ARGS_PROMPT)
+                .preamble(NESTED_ARGS_PREAMBLE.to_string())
+                .temperature(0.0)
+                .tool(PlanTrip.definition(String::new()).await)
+                .build();
+
+            let observation = collect_raw_stream_observation(
+                model
+                    .stream(request)
+                    .await
+                    .expect("nested-args streaming request should start"),
+            )
+            .await;
+
+            assert!(
+                observation.errors.is_empty(),
+                "stream should not emit errors: {:?}",
+                observation.errors
+            );
+            let tool_call = observation
+                .tool_calls
+                .iter()
+                .find(|tool_call| tool_call.function.name == PlanTrip::NAME)
+                .expect("stream should emit the plan_trip tool call");
+            assert_expected_plan_trip_arguments(&tool_call.function.arguments);
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn unicode_arguments_streaming() {
+    with_gemini_cassette(
+        "generate_tool_args/unicode_arguments_streaming",
+        |client| async move {
+            let model = client.completion_model(gemini::completion::GEMINI_2_5_FLASH);
+            let request = model
+                .completion_request(
+                    "Call the echo tool exactly once with the message argument set to \
+                     exactly this text: Grüße aus 東京, from the \"naïve café\"!",
+                )
+                .preamble(
+                    "You must call the echo tool with the exact text the user provides. \
+                     Do not translate, reword, or drop any characters."
+                        .to_string(),
+                )
+                .temperature(0.0)
+                .tool(ToolDefinition {
+                    name: "echo".to_string(),
+                    description: "Echo a message back to the user.".to_string(),
+                    parameters: json!({
+                        "type": "object",
+                        "properties": {
+                            "message": { "type": "string" }
+                        },
+                        "required": ["message"]
+                    }),
+                })
+                .build();
+
+            let observation = collect_raw_stream_observation(
+                model
+                    .stream(request)
+                    .await
+                    .expect("unicode-args streaming request should start"),
+            )
+            .await;
+
+            assert!(
+                observation.errors.is_empty(),
+                "stream should not emit errors: {:?}",
+                observation.errors
+            );
+            let tool_call = observation
+                .tool_calls
+                .iter()
+                .find(|tool_call| tool_call.function.name == "echo")
+                .expect("stream should emit the echo tool call");
+            let message = tool_call
+                .function
+                .arguments
+                .get("message")
+                .and_then(|value| value.as_str())
+                .expect("echo arguments should contain a message string");
+            for expected in ["Grüße", "東京", "naïve café"] {
+                assert!(
+                    message.contains(expected),
+                    "streamed unicode arguments should preserve {expected:?}, got {message:?}"
+                );
+            }
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn optional_nullable_argument_omitted_when_not_requested() {
+    with_gemini_cassette(
+        "generate_tool_args/optional_nullable_argument_omitted_when_not_requested",
+        |client| async move {
+            let model = client.completion_model(gemini::completion::GEMINI_2_5_FLASH);
+            let request = model
+                .completion_request(
+                    "Log an event named \"deploy\" using the log_event tool. \
+                     Do not attach a note.",
+                )
+                .preamble(
+                    "Use the log_event tool for every logging request. Only fill optional \
+                     arguments when the user explicitly provides them."
+                        .to_string(),
+                )
+                .temperature(0.0)
+                .tool(ToolDefinition {
+                    name: "log_event".to_string(),
+                    description: "Record an event with an optional free-form note.".to_string(),
+                    parameters: json!({
+                        "type": "object",
+                        "properties": {
+                            "name": { "type": "string" },
+                            "note": {
+                                "type": "string",
+                                "nullable": true,
+                                "description": "Optional note; omit when the user gives none."
+                            }
+                        },
+                        "required": ["name"]
+                    }),
+                })
+                .build();
+
+            let response = model
+                .completion(request)
+                .await
+                .expect("optional-arg completion should succeed");
+
+            let tool_call = response
+                .choice
+                .iter()
+                .find_map(|content| match content {
+                    AssistantContent::ToolCall(tool_call) => Some(tool_call.clone()),
+                    _ => None,
+                })
+                .expect("response should contain the log_event tool call");
+            assert_eq!(tool_call.function.name, "log_event");
+            assert_eq!(
+                tool_call
+                    .function
+                    .arguments
+                    .get("name")
+                    .and_then(|value| value.as_str()),
+                Some("deploy"),
+                "required argument should be present: {:?}",
+                tool_call.function.arguments
+            );
+            let note = tool_call.function.arguments.get("note");
+            assert!(
+                note.is_none() || note.is_some_and(serde_json::Value::is_null),
+                "optional nullable argument should be omitted or null when not requested, \
+                 got {:?}",
+                tool_call.function.arguments
+            );
+        },
+    )
+    .await;
+}

--- a/tests/providers/gemini/cassette/generate_tool_modes.rs
+++ b/tests/providers/gemini/cassette/generate_tool_modes.rs
@@ -1,0 +1,59 @@
+//! Gemini `toolConfig.functionCallingConfig` mode regression tests.
+//!
+//! Existing `tool_choice` cassettes cover `Specific` (ANY + allowed names) and
+//! `None`; this module locks the remaining `Required` mapping: bare
+//! `{"mode": "ANY"}` with no allowedFunctionNames must force a function call.
+//!
+//! Run cassette tests in replay mode by default, or set
+//! `RIG_PROVIDER_TEST_MODE=record` to record against the real provider.
+
+use rig::client::CompletionClient;
+use rig::completion::CompletionModel;
+use rig::message::{AssistantContent, ToolChoice};
+use rig::providers::gemini;
+use rig::tool::Tool;
+
+use super::super::support::with_gemini_cassette;
+use crate::support::{Adder, TOOLS_PREAMBLE};
+
+#[tokio::test]
+async fn required_maps_to_any_and_forces_function_call() {
+    with_gemini_cassette(
+        "generate_tool_modes/required_maps_to_any_and_forces_function_call",
+        |client| async move {
+            let model = client.completion_model(gemini::completion::GEMINI_2_5_FLASH);
+            let request = model
+                .completion_request("Please greet me.")
+                .preamble(TOOLS_PREAMBLE.to_string())
+                .temperature(0.0)
+                .tool(Adder.definition(String::new()).await)
+                .tool_choice(ToolChoice::Required)
+                .build();
+
+            let response = model
+                .completion(request)
+                .await
+                .expect("required tool choice completion should succeed");
+
+            let names: Vec<_> = response
+                .choice
+                .iter()
+                .filter_map(|content| match content {
+                    AssistantContent::ToolCall(tool_call) => Some(tool_call.function.name.clone()),
+                    _ => None,
+                })
+                .collect();
+            assert!(
+                !names.is_empty(),
+                "toolConfig mode ANY must force a function call even for a chat prompt, \
+                 got {:?}",
+                response.choice
+            );
+            assert!(
+                names.iter().all(|name| name == Adder::NAME),
+                "only the provided tool can be called, saw {names:?}"
+            );
+        },
+    )
+    .await;
+}

--- a/tests/providers/gemini/mod.rs
+++ b/tests/providers/gemini/mod.rs
@@ -14,6 +14,10 @@ mod cassette {
     mod dynamic_tools;
     mod embeddings;
     mod extractor;
+    mod generate_behaviors;
+    mod generate_sessions;
+    mod generate_tool_args;
+    mod generate_tool_modes;
     mod image_generation;
     mod interactions_api;
     mod models;


### PR DESCRIPTION
## Summary

Adds a live-recorded cassette regression suite (11 new cassette tests across 4 new modules, 11 committed fixtures) that locks down long, multi-turn, multi-tool Gemini generateContent sessions in Rig. Companion to #2002 (OpenAI Responses) and #2003 (Anthropic Messages) — same structure and assertion style, adapted to the Gemini wire format. Gemini already had the deepest existing coverage of the three providers (tool_choice Specific/None, parallel-call grouping, zero-arg roundtrips, reasoning roundtrips, 5-turn history stress), so this suite deliberately targets the remaining gaps rather than duplicating.

### New cassette scenarios

**`generate_sessions/`** — long multi-turn sessions
- Sequential tool calls across turns (add → result → subtract → result → final answer) with strict caller-owned-history ordering assertions (the subtract call may only appear *after* the add result), non-streaming and the streaming parity twin (exact call order `[add, subtract]`, one result per call).
- Long client-owned history replay: user fact, model text, an assistant message with **text before the `functionCall` part**, the `functionResponse`, **model text after the result**, then a new question — fully synthetic (Gemini pairs by function name, no ids). Asserts recall of both the early fact and the replayed tool output, populated usage, and `modelVersion` preservation. Cassette body hand-verified: strict user/model role alternation, `functionResponse` in a `user` content, `systemInstruction` top-level.
- Thinking-enabled session (`thinkingConfig{thinkingBudget:1024, includeThoughts:true}`): asserts `thoughtsTokenCount` surfaces as `usage.reasoning_tokens` (recorded fixture shows 173 thought tokens) and totals cover prompt + candidates.

**`generate_tool_args/`** — argument wire shapes
- Deeply nested arguments (object → object → array/object) through a full agent roundtrip (nested args recorded in caller history; final answer repeats the tool's confirmation code) and through raw streaming.
- Unicode/escaped strings (`Grüße`, `東京`, `naïve café`) preserved through streaming.
- Optional **nullable** field (`"nullable": true` schema): required arg present, optional arg omitted/null when the prompt says not to provide it.
- (Zero-arg `{}` calls intentionally not duplicated — covered by existing `agent_tools`/`streaming_tools` cassettes.)

**`generate_tool_modes/`**
- `ToolChoice::Required` → bare `{"mode":"ANY"}` (no `allowedFunctionNames`) forces a function call on a chat-y prompt. Completes the existing `tool_choice` coverage (Specific → ANY+allowedFunctionNames, None) — the request body locks the serialized shape.

**`generate_behaviors/`**
- `MAX_TOKENS` truncation: with thinking disabled (`thinkingBudget: 0`) so the cap lands on visible text, conversion does not error; the candidate preserves `finishReason: "MAX_TOKENS"`, partial text and usage survive, `modelVersion` is present.
- Structured output with a nested object, string array, and an optional (`Option<String>`) field — locks Gemini `responseSchema` handling beyond the existing flat smoke test.

## Bugs found and fixed

None — recording surfaced no Rig bugs. One prompt-determinism adjustment during recording: the thinking-session assertion originally required the digit `9` and the model answered "Nine sheep are left."; the assertion now accepts either form (kept deliberately loose per the no-prose-overfitting constraint).

## Inspiration references

Edge-case catalog mined from `/Users/kisaczka/Desktop/code/many_rigs/inspirations`:
- **Pydantic AI** — `pydantic-ai/pydantic_ai_slim/pydantic_ai/models/google.py` (`_map_messages` functionResponse grouping into one user content, tool-config AUTO/ANY/NONE mapping, thinkingConfig), `pydantic-ai/tests/models/test_google.py` (optional/nullable native-output schema matrix, `test_map_usage` thoughtsTokenCount accounting, MAX_TOKENS thinking-model empty-response cases, ANY-mode no-args tool).
- **Vercel AI SDK** — `vercel-ai-sdk/packages/google/src/convert-to-google-messages.test.ts` (systemInstruction placement, role mapping, functionCall/functionResponse shapes, thoughtSignature preservation), `google-prepare-tools.test.ts` (AUTO/ANY/NONE + allowedFunctionNames shapes), `google-language-model.test.ts` (MAX_TOKENS/finishReason mapping, usage extraction, streaming parity).
- **Semantic Kernel** — `semantic-kernel/python/tests/unit/connectors/ai/google/google_ai/services/test_google_ai_utils.py` (empty args `{}` serialization, finish-reason mapping) as cross-checks.
- LangChain has no google-genai partner package in this snapshot (only a grounding-metadata block translator) — noted, not used.

## Recording / replay commands run

```bash
# record (one module at a time, targeted)
RIG_PROVIDER_TEST_MODE=record cargo test -p rig --all-features --test gemini gemini::cassette::generate_tool_modes -- --nocapture --test-threads=1
RIG_PROVIDER_TEST_MODE=record cargo test -p rig --all-features --test gemini gemini::cassette::generate_tool_args  -- --nocapture --test-threads=1
RIG_PROVIDER_TEST_MODE=record cargo test -p rig --all-features --test gemini gemini::cassette::generate_behaviors  -- --nocapture --test-threads=1
RIG_PROVIDER_TEST_MODE=record cargo test -p rig --all-features --test gemini gemini::cassette::generate_sessions   -- --nocapture --test-threads=1

# replay without credentials (GEMINI_API_KEY unset): 85/85 cassette tests pass
env -u GEMINI_API_KEY cargo test -p rig --all-features --test gemini gemini::cassette -- --test-threads=1
env -u GEMINI_API_KEY cargo test -p rig --all-features --test gemini cassette_safety
```

## Manual cassette inspection

- No API keys (`key=`/`AIza…`), bearer tokens, cookies, or account identifiers in any new fixture (grep + committed cassette-safety tests pass).
- Request bodies verified by hand for the load-bearing contracts: user/model role alternation with model text before the `functionCall` part; `functionResponse` grouped under a `user` content; `systemInstruction` as a top-level field; `toolConfig.functionCallingConfig` exactly `{"mode":"ANY"}` with no allowed names; `nullable: true` on the optional arg schema; `thinkingConfig` with budget/includeThoughts; response bodies carrying `finishReason: "MAX_TOKENS"`, `thoughtsTokenCount`, and `modelVersion`.
- No unrelated fixture churn: only the 11 new YAMLs are added; no existing cassettes modified.

## Validation

- `cargo fmt` — clean
- `cargo clippy --all-targets --all-features` — no warnings
- `cargo test -p rig --all-features --test gemini -- --test-threads=1` — 116 passed, 0 failed (without `GEMINI_API_KEY`)
- `cargo test -p rig-core --lib providers::gemini` — 81 passed
- Full `cargo test -p rig --all-features -- --test-threads=1` with OpenAI/Anthropic/Gemini keys unset — all 31 test targets green, no failures

## Known gaps / non-goals

- Parallel function calls in one turn, zero-arg roundtrips, tool_choice Specific/None, reasoning/thought-signature roundtrips, multimodal tool results, document ordering, and the interactions API are already covered by the existing `agent_tools`, `streaming_tools`, `tool_choice`, `reasoning_*`, `streaming_multimodal_tool_results`, `document_ordering`, and `interactions_api` suites — intentionally not duplicated.
- `MALFORMED_FUNCTION_CALL`, `SAFETY` blocks, and grounding/citation metadata cannot be triggered deterministically against the live API and are not recorded; Rig's handling of those finish reasons is covered by existing unit tests in the provider.
- Gemini-3-specific behaviors (VALIDATED mode, thought-signature sentinel) are out of scope; the suite pins `gemini-2.5-flash` (temperature 0) to match existing cassettes.