### PR TITLE
Add ChatGPT Codex cassette regression suite

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -41,6 +41,7 @@ Replay the migrated provider suites with:
 cargo test -p rig --all-features --test openai openai::cassette -- --nocapture --test-threads=1
 cargo test -p rig --all-features --test anthropic anthropic::cassette -- --nocapture --test-threads=1
 cargo test -p rig --all-features --test gemini gemini::cassette -- --nocapture --test-threads=1
+cargo test -p rig --all-features --test chatgpt chatgpt::cassette -- --nocapture --test-threads=1
 ```
 
 Record mode requires the relevant provider API key in the environment and overwrites existing
@@ -59,6 +60,11 @@ cargo test -p rig --all-features --test anthropic anthropic::cassette -- --nocap
 ```bash
 RIG_PROVIDER_TEST_MODE=record \
 cargo test -p rig --all-features --test gemini gemini::cassette -- --nocapture --test-threads=1
+```
+
+```bash
+CHATGPT_ACCESS_TOKEN=... CHATGPT_ACCOUNT_ID=... RIG_PROVIDER_TEST_MODE=record \
+cargo test -p rig --all-features --test chatgpt chatgpt::cassette -- --nocapture --test-threads=1
 ```
 
 Run one cassette test by passing a test-name substring:

--- a/tests/cassettes/chatgpt/codex_behaviors/default_instructions_merge_with_explicit_preamble.yaml
+++ b/tests/cassettes/chatgpt/codex_behaviors/default_instructions_merge_with_explicit_preamble.yaml
@@ -1,0 +1,86 @@
+when:
+  path: /backend-api/codex/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"List the default marker and the explicit marker, and nothing else.","type":"input_text"}],"role":"user","type":"message"}],"instructions":"Default instruction marker: always include DEFAULT-CODEX-MARKER when asked for the default marker.\n\nExplicit instruction marker: also include EXPLICIT-CODEX-MARKER.","model":"gpt-5.4","store":false,"stream":true}'
+then:
+  status: 200
+  header: []
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"Default instruction marker: always include DEFAULT-CODEX-MARKER when asked for the default marker.\n\nExplicit instruction marker: also include EXPLICIT-CODEX-MARKER.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"Default instruction marker: always include DEFAULT-CODEX-MARKER when asked for the default marker.\n\nExplicit instruction marker: also include EXPLICIT-CODEX-MARKER.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"content":[],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"in_progress","type":"message"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.content_part.added
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"","type":"output_text"},"sequence_number":3,"type":"response.content_part.added"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"DEFAULT","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_1","output_index":0,"sequence_number":4,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"-C","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_2","output_index":0,"sequence_number":5,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"ODE","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_3","output_index":0,"sequence_number":6,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"X","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_4","output_index":0,"sequence_number":7,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"-M","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_5","output_index":0,"sequence_number":8,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"ARK","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_6","output_index":0,"sequence_number":9,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"ER","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_7","output_index":0,"sequence_number":10,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"\n","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_8","output_index":0,"sequence_number":11,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"EX","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_9","output_index":0,"sequence_number":12,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"PLICIT","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_10","output_index":0,"sequence_number":13,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"-C","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_11","output_index":0,"sequence_number":14,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"ODE","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_12","output_index":0,"sequence_number":15,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"X","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_13","output_index":0,"sequence_number":16,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"-M","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_14","output_index":0,"sequence_number":17,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"ARK","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_15","output_index":0,"sequence_number":18,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"ER","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_16","output_index":0,"sequence_number":19,"type":"response.output_text.delta"}
+
+    event: response.output_text.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","logprobs":[],"output_index":0,"sequence_number":20,"text":"DEFAULT-CODEX-MARKER\nEXPLICIT-CODEX-MARKER","type":"response.output_text.done"}
+
+    event: response.content_part.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"DEFAULT-CODEX-MARKER\nEXPLICIT-CODEX-MARKER","type":"output_text"},"sequence_number":21,"type":"response.content_part.done"}
+
+    event: response.output_item.done
+    data: {"item":{"content":[{"annotations":[],"logprobs":[],"text":"DEFAULT-CODEX-MARKER\nEXPLICIT-CODEX-MARKER","type":"output_text"}],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"completed","type":"message"},"output_index":0,"sequence_number":22,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"Default instruction marker: always include DEFAULT-CODEX-MARKER when asked for the default marker.\n\nExplicit instruction marker: also include EXPLICIT-CODEX-MARKER.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"default","status":"completed","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":58,"input_tokens_details":{"cached_tokens":0},"output_tokens":20,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":78},"user":null},"sequence_number":23,"type":"response.completed"}
+

--- a/tests/cassettes/chatgpt/codex_behaviors/explicit_preamble_and_mid_conversation_system_messages_are_instructions.yaml
+++ b/tests/cassettes/chatgpt/codex_behaviors/explicit_preamble_and_mid_conversation_system_messages_are_instructions.yaml
@@ -1,0 +1,68 @@
+when:
+  path: /backend-api/codex/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Hello!","type":"input_text"}],"role":"user","type":"message"},{"content":"Hi! How can I help you today?","role":"assistant","type":"message"},{"content":[{"text":"What is my codename?","type":"input_text"}],"role":"user","type":"message"}],"instructions":"You are a concise assistant.\n\nThe user''s codename is FALCON-9. Always refer to the user by codename.","model":"gpt-5.4","store":false,"stream":true}'
+then:
+  status: 200
+  header: []
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a concise assistant.\n\nThe user's codename is FALCON-9. Always refer to the user by codename.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a concise assistant.\n\nThe user's codename is FALCON-9. Always refer to the user by codename.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"content":[],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"in_progress","type":"message"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.content_part.added
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"","type":"output_text"},"sequence_number":3,"type":"response.content_part.added"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"Your","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_1","output_index":0,"sequence_number":4,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" cod","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_2","output_index":0,"sequence_number":5,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"ename","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_3","output_index":0,"sequence_number":6,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" is","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_4","output_index":0,"sequence_number":7,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" F","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_5","output_index":0,"sequence_number":8,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"AL","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_6","output_index":0,"sequence_number":9,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"CON","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_7","output_index":0,"sequence_number":10,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"-","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_8","output_index":0,"sequence_number":11,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"9","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_9","output_index":0,"sequence_number":12,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":".","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_10","output_index":0,"sequence_number":13,"type":"response.output_text.delta"}
+
+    event: response.output_text.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","logprobs":[],"output_index":0,"sequence_number":14,"text":"Your codename is FALCON-9.","type":"response.output_text.done"}
+
+    event: response.content_part.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"Your codename is FALCON-9.","type":"output_text"},"sequence_number":15,"type":"response.content_part.done"}
+
+    event: response.output_item.done
+    data: {"item":{"content":[{"annotations":[],"logprobs":[],"text":"Your codename is FALCON-9.","type":"output_text"}],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"completed","type":"message"},"output_index":0,"sequence_number":16,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a concise assistant.\n\nThe user's codename is FALCON-9. Always refer to the user by codename.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"default","status":"completed","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":63,"input_tokens_details":{"cached_tokens":0},"output_tokens":14,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":77},"user":null},"sequence_number":17,"type":"response.completed"}
+

--- a/tests/cassettes/chatgpt/codex_behaviors/store_false_and_prompt_cache_fields_roundtrip.yaml
+++ b/tests/cassettes/chatgpt/codex_behaviors/store_false_and_prompt_cache_fields_roundtrip.yaml
@@ -1,0 +1,56 @@
+when:
+  path: /backend-api/codex/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Reply with exactly this marker: CODEX-STORE-FALSE","type":"input_text"}],"role":"user","type":"message"}],"instructions":"Return only the requested marker.","model":"gpt-5.4","store":false,"stream":true}'
+then:
+  status: 200
+  header: []
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"Return only the requested marker.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"Return only the requested marker.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"content":[],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"in_progress","type":"message"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.content_part.added
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"","type":"output_text"},"sequence_number":3,"type":"response.content_part.added"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"CODE","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_1","output_index":0,"sequence_number":4,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"X","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_2","output_index":0,"sequence_number":5,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"-","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_3","output_index":0,"sequence_number":6,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"STORE","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_4","output_index":0,"sequence_number":7,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"-F","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_5","output_index":0,"sequence_number":8,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"ALSE","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_6","output_index":0,"sequence_number":9,"type":"response.output_text.delta"}
+
+    event: response.output_text.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","logprobs":[],"output_index":0,"sequence_number":10,"text":"CODEX-STORE-FALSE","type":"response.output_text.done"}
+
+    event: response.content_part.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"CODEX-STORE-FALSE","type":"output_text"},"sequence_number":11,"type":"response.content_part.done"}
+
+    event: response.output_item.done
+    data: {"item":{"content":[{"annotations":[],"logprobs":[],"text":"CODEX-STORE-FALSE","type":"output_text"}],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"completed","type":"message"},"output_index":0,"sequence_number":12,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"Return only the requested marker.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"default","status":"completed","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":28,"input_tokens_details":{"cached_tokens":0},"output_tokens":10,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":38},"user":null},"sequence_number":13,"type":"response.completed"}
+

--- a/tests/cassettes/chatgpt/codex_behaviors/strict_tools_opt_in_roundtrip.yaml
+++ b/tests/cassettes/chatgpt/codex_behaviors/strict_tools_opt_in_roundtrip.yaml
@@ -1,0 +1,59 @@
+when:
+  path: /backend-api/codex/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Use the add tool to add 7 and 5.","type":"input_text"}],"role":"user","type":"message"}],"instructions":"You are a calculator here to help the user perform arithmetic operations. Use the tools provided to answer the user''s question.","model":"gpt-5.4","store":false,"stream":true,"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}]}'
+then:
+  status: 200
+  header: []
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a calculator here to help the user perform arithmetic operations. Use the tools provided to answer the user's question.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a calculator here to help the user perform arithmetic operations. Use the tools provided to answer the user's question.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"arguments":"","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"add","status":"in_progress","type":"function_call"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"{\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_1","output_index":0,"sequence_number":3,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"x","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_2","output_index":0,"sequence_number":4,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_3","output_index":0,"sequence_number":5,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"7","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_4","output_index":0,"sequence_number":6,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":",\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_5","output_index":0,"sequence_number":7,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"y","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_6","output_index":0,"sequence_number":8,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_7","output_index":0,"sequence_number":9,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"5","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_8","output_index":0,"sequence_number":10,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"}","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_9","output_index":0,"sequence_number":11,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.done
+    data: {"arguments":"{\"x\":7,\"y\":5}","item_id":"fc_REDACTED_1","output_index":0,"sequence_number":12,"type":"response.function_call_arguments.done"}
+
+    event: response.output_item.done
+    data: {"item":{"arguments":"{\"x\":7,\"y\":5}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"add","status":"completed","type":"function_call"},"output_index":0,"sequence_number":13,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a calculator here to help the user perform arithmetic operations. Use the tools provided to answer the user's question.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"default","status":"completed","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":97,"input_tokens_details":{"cached_tokens":0},"output_tokens":21,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":118},"user":null},"sequence_number":14,"type":"response.completed"}
+

--- a/tests/cassettes/chatgpt/codex_sessions/long_history_replay_nonstreaming.yaml
+++ b/tests/cassettes/chatgpt/codex_sessions/long_history_replay_nonstreaming.yaml
@@ -1,0 +1,122 @@
+when:
+  path: /backend-api/codex/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Look up the harbor label with the tool.","type":"input_text"}],"role":"user","type":"message"}],"instructions":"You are a concise assistant with perfect recall of this conversation.","model":"gpt-5.4","store":false,"stream":true,"tools":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"properties":{},"required":[],"type":"object"},"type":"function"}]}'
+then:
+  status: 200
+  header: []
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a concise assistant with perfect recall of this conversation.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a concise assistant with perfect recall of this conversation.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"arguments":"","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"lookup_harbor_label","status":"in_progress","type":"function_call"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"{}","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_1","output_index":0,"sequence_number":3,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.done
+    data: {"arguments":"{}","item_id":"fc_REDACTED_1","output_index":0,"sequence_number":4,"type":"response.function_call_arguments.done"}
+
+    event: response.output_item.done
+    data: {"item":{"arguments":"{}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"lookup_harbor_label","status":"completed","type":"function_call"},"output_index":0,"sequence_number":5,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a concise assistant with perfect recall of this conversation.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"default","status":"completed","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":64,"input_tokens_details":{"cached_tokens":0},"output_tokens":17,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":81},"user":null},"sequence_number":6,"type":"response.completed"}
+
+---
+when:
+  path: /backend-api/codex/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"My favorite color is teal. Please remember it.","type":"input_text"}],"role":"user","type":"message"},{"content":"Noted - your favorite color is teal.","role":"assistant","type":"message"},{"content":[{"text":"Now look up the harbor label with the tool.","type":"input_text"}],"role":"user","type":"message"},{"arguments":"{}","call_id":"call_REDACTED_1","name":"lookup_harbor_label","status":"completed","type":"function_call"},{"call_id":"call_REDACTED_1","output":"crimson-harbor","status":"completed","type":"function_call_output"},{"content":"The harbor label is crimson-harbor.","role":"assistant","type":"message"},{"content":[{"text":"In one short sentence: what is my favorite color, and what was the harbor label you looked up earlier?","type":"input_text"}],"role":"user","type":"message"}],"instructions":"You are a concise assistant with perfect recall of this conversation.","model":"gpt-5.4","store":false,"stream":true,"tools":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"properties":{},"required":[],"type":"object"},"type":"function"}]}'
+then:
+  status: 200
+  header: []
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":"You are a concise assistant with perfect recall of this conversation.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_3","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":"You are a concise assistant with perfect recall of this conversation.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_3","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"content":[],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"in_progress","type":"message"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.content_part.added
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"","type":"output_text"},"sequence_number":3,"type":"response.content_part.added"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"Your","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_2","output_index":0,"sequence_number":4,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" favorite","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_3","output_index":0,"sequence_number":5,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" color","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_4","output_index":0,"sequence_number":6,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" is","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_5","output_index":0,"sequence_number":7,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" teal","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_6","output_index":0,"sequence_number":8,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":",","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_7","output_index":0,"sequence_number":9,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" and","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_8","output_index":0,"sequence_number":10,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" the","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_9","output_index":0,"sequence_number":11,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" harbor","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_10","output_index":0,"sequence_number":12,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" label","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_11","output_index":0,"sequence_number":13,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" was","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_12","output_index":0,"sequence_number":14,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" crimson","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_13","output_index":0,"sequence_number":15,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"-h","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_14","output_index":0,"sequence_number":16,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"ar","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_15","output_index":0,"sequence_number":17,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"bor","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_16","output_index":0,"sequence_number":18,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":".","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_17","output_index":0,"sequence_number":19,"type":"response.output_text.delta"}
+
+    event: response.output_text.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","logprobs":[],"output_index":0,"sequence_number":20,"text":"Your favorite color is teal, and the harbor label was crimson-harbor.","type":"response.output_text.done"}
+
+    event: response.content_part.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"Your favorite color is teal, and the harbor label was crimson-harbor.","type":"output_text"},"sequence_number":21,"type":"response.content_part.done"}
+
+    event: response.output_item.done
+    data: {"item":{"content":[{"annotations":[],"logprobs":[],"text":"Your favorite color is teal, and the harbor label was crimson-harbor.","type":"output_text"}],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"completed","type":"message"},"output_index":0,"sequence_number":22,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":"You are a concise assistant with perfect recall of this conversation.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_3","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"default","status":"completed","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":171,"input_tokens_details":{"cached_tokens":0},"output_tokens":20,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":191},"user":null},"sequence_number":23,"type":"response.completed"}
+

--- a/tests/cassettes/chatgpt/codex_sessions/parallel_tool_calls_single_turn_nonstreaming.yaml
+++ b/tests/cassettes/chatgpt/codex_sessions/parallel_tool_calls_single_turn_nonstreaming.yaml
@@ -1,0 +1,119 @@
+when:
+  path: /backend-api/codex/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Call `lookup_harbor_label` and `lookup_orchard_label` exactly once each before answering. After both tool results are available, stop calling tools and respond in one short sentence that includes both exact tool outputs.","type":"input_text"}],"role":"user","type":"message"}],"instructions":"You are a precise assistant. When tools are available, you must use them instead of guessing. Call both `lookup_harbor_label` and `lookup_orchard_label` before writing any normal text. Never call the same tool twice once you already have its result.","model":"gpt-5.4","store":false,"stream":true,"tools":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"properties":{},"required":[],"type":"object"},"type":"function"},{"description":"Return the beta signal marker.","name":"lookup_orchard_label","parameters":{"properties":{},"required":[],"type":"object"},"type":"function"}]}'
+then:
+  status: 200
+  header: []
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a precise assistant. When tools are available, you must use them instead of guessing. Call both `lookup_harbor_label` and `lookup_orchard_label` before writing any normal text. Never call the same tool twice once you already have its result.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"},{"description":"Return the beta signal marker.","name":"lookup_orchard_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a precise assistant. When tools are available, you must use them instead of guessing. Call both `lookup_harbor_label` and `lookup_orchard_label` before writing any normal text. Never call the same tool twice once you already have its result.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"},{"description":"Return the beta signal marker.","name":"lookup_orchard_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"arguments":"","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"lookup_harbor_label","status":"in_progress","type":"function_call"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"{}","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_1","output_index":0,"sequence_number":3,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.done
+    data: {"arguments":"{}","item_id":"fc_REDACTED_1","output_index":0,"sequence_number":4,"type":"response.function_call_arguments.done"}
+
+    event: response.output_item.done
+    data: {"item":{"arguments":"{}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"lookup_harbor_label","status":"completed","type":"function_call"},"output_index":0,"sequence_number":5,"type":"response.output_item.done"}
+
+    event: response.output_item.added
+    data: {"item":{"arguments":"","call_id":"call_REDACTED_2","id":"fc_REDACTED_2","name":"lookup_orchard_label","status":"in_progress","type":"function_call"},"output_index":1,"sequence_number":6,"type":"response.output_item.added"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"{}","item_id":"fc_REDACTED_2","obfuscation":"obfuscation_REDACTED_2","output_index":1,"sequence_number":7,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.done
+    data: {"arguments":"{}","item_id":"fc_REDACTED_2","output_index":1,"sequence_number":8,"type":"response.function_call_arguments.done"}
+
+    event: response.output_item.done
+    data: {"item":{"arguments":"{}","call_id":"call_REDACTED_2","id":"fc_REDACTED_2","name":"lookup_orchard_label","status":"completed","type":"function_call"},"output_index":1,"sequence_number":9,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a precise assistant. When tools are available, you must use them instead of guessing. Call both `lookup_harbor_label` and `lookup_orchard_label` before writing any normal text. Never call the same tool twice once you already have its result.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"default","status":"completed","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"},{"description":"Return the beta signal marker.","name":"lookup_orchard_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":160,"input_tokens_details":{"cached_tokens":0},"output_tokens":49,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":209},"user":null},"sequence_number":10,"type":"response.completed"}
+
+---
+when:
+  path: /backend-api/codex/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Call `lookup_harbor_label` and `lookup_orchard_label` exactly once each before answering. After both tool results are available, stop calling tools and respond in one short sentence that includes both exact tool outputs.","type":"input_text"}],"role":"user","type":"message"},{"arguments":"{}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"lookup_harbor_label","status":"completed","type":"function_call"},{"arguments":"{}","call_id":"call_REDACTED_2","id":"fc_REDACTED_2","name":"lookup_orchard_label","status":"completed","type":"function_call"},{"call_id":"call_REDACTED_1","output":"crimson-harbor","status":"completed","type":"function_call_output"},{"call_id":"call_REDACTED_2","output":"silver-orchard","status":"completed","type":"function_call_output"}],"instructions":"You are a precise assistant. When tools are available, you must use them instead of guessing. Call both `lookup_harbor_label` and `lookup_orchard_label` before writing any normal text. Never call the same tool twice once you already have its result.","model":"gpt-5.4","store":false,"stream":true,"tools":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"properties":{},"required":[],"type":"object"},"type":"function"},{"description":"Return the beta signal marker.","name":"lookup_orchard_label","parameters":{"properties":{},"required":[],"type":"object"},"type":"function"}]}'
+then:
+  status: 200
+  header: []
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":"You are a precise assistant. When tools are available, you must use them instead of guessing. Call both `lookup_harbor_label` and `lookup_orchard_label` before writing any normal text. Never call the same tool twice once you already have its result.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_3","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"},{"description":"Return the beta signal marker.","name":"lookup_orchard_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":"You are a precise assistant. When tools are available, you must use them instead of guessing. Call both `lookup_harbor_label` and `lookup_orchard_label` before writing any normal text. Never call the same tool twice once you already have its result.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_3","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"},{"description":"Return the beta signal marker.","name":"lookup_orchard_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"content":[],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"in_progress","type":"message"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.content_part.added
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"","type":"output_text"},"sequence_number":3,"type":"response.content_part.added"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"cr","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_3","output_index":0,"sequence_number":4,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"imson","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_4","output_index":0,"sequence_number":5,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"-h","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_5","output_index":0,"sequence_number":6,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"ar","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_6","output_index":0,"sequence_number":7,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"bor","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_7","output_index":0,"sequence_number":8,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" and","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_8","output_index":0,"sequence_number":9,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" silver","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_9","output_index":0,"sequence_number":10,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"-or","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_10","output_index":0,"sequence_number":11,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"ch","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_11","output_index":0,"sequence_number":12,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"ard","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_12","output_index":0,"sequence_number":13,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":".","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_13","output_index":0,"sequence_number":14,"type":"response.output_text.delta"}
+
+    event: response.output_text.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","logprobs":[],"output_index":0,"sequence_number":15,"text":"crimson-harbor and silver-orchard.","type":"response.output_text.done"}
+
+    event: response.content_part.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"crimson-harbor and silver-orchard.","type":"output_text"},"sequence_number":16,"type":"response.content_part.done"}
+
+    event: response.output_item.done
+    data: {"item":{"content":[{"annotations":[],"logprobs":[],"text":"crimson-harbor and silver-orchard.","type":"output_text"}],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"completed","type":"message"},"output_index":0,"sequence_number":17,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":"You are a precise assistant. When tools are available, you must use them instead of guessing. Call both `lookup_harbor_label` and `lookup_orchard_label` before writing any normal text. Never call the same tool twice once you already have its result.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_3","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"default","status":"completed","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"},{"description":"Return the beta signal marker.","name":"lookup_orchard_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":244,"input_tokens_details":{"cached_tokens":0},"output_tokens":15,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":259},"user":null},"sequence_number":18,"type":"response.completed"}
+

--- a/tests/cassettes/chatgpt/codex_sessions/parallel_tool_calls_single_turn_streaming.yaml
+++ b/tests/cassettes/chatgpt/codex_sessions/parallel_tool_calls_single_turn_streaming.yaml
@@ -1,0 +1,119 @@
+when:
+  path: /backend-api/codex/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Call `lookup_harbor_label` and `lookup_orchard_label` exactly once each before answering. After both tool results are available, stop calling tools and respond in one short sentence that includes both exact tool outputs.","type":"input_text"}],"role":"user","type":"message"}],"instructions":"You are a precise assistant. When tools are available, you must use them instead of guessing. Call both `lookup_harbor_label` and `lookup_orchard_label` before writing any normal text. Never call the same tool twice once you already have its result.","model":"gpt-5.4","store":false,"stream":true,"tools":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"properties":{},"required":[],"type":"object"},"type":"function"},{"description":"Return the beta signal marker.","name":"lookup_orchard_label","parameters":{"properties":{},"required":[],"type":"object"},"type":"function"}]}'
+then:
+  status: 200
+  header: []
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a precise assistant. When tools are available, you must use them instead of guessing. Call both `lookup_harbor_label` and `lookup_orchard_label` before writing any normal text. Never call the same tool twice once you already have its result.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"},{"description":"Return the beta signal marker.","name":"lookup_orchard_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a precise assistant. When tools are available, you must use them instead of guessing. Call both `lookup_harbor_label` and `lookup_orchard_label` before writing any normal text. Never call the same tool twice once you already have its result.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"},{"description":"Return the beta signal marker.","name":"lookup_orchard_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"arguments":"","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"lookup_harbor_label","status":"in_progress","type":"function_call"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"{}","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_1","output_index":0,"sequence_number":3,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.done
+    data: {"arguments":"{}","item_id":"fc_REDACTED_1","output_index":0,"sequence_number":4,"type":"response.function_call_arguments.done"}
+
+    event: response.output_item.done
+    data: {"item":{"arguments":"{}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"lookup_harbor_label","status":"completed","type":"function_call"},"output_index":0,"sequence_number":5,"type":"response.output_item.done"}
+
+    event: response.output_item.added
+    data: {"item":{"arguments":"","call_id":"call_REDACTED_2","id":"fc_REDACTED_2","name":"lookup_orchard_label","status":"in_progress","type":"function_call"},"output_index":1,"sequence_number":6,"type":"response.output_item.added"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"{}","item_id":"fc_REDACTED_2","obfuscation":"obfuscation_REDACTED_2","output_index":1,"sequence_number":7,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.done
+    data: {"arguments":"{}","item_id":"fc_REDACTED_2","output_index":1,"sequence_number":8,"type":"response.function_call_arguments.done"}
+
+    event: response.output_item.done
+    data: {"item":{"arguments":"{}","call_id":"call_REDACTED_2","id":"fc_REDACTED_2","name":"lookup_orchard_label","status":"completed","type":"function_call"},"output_index":1,"sequence_number":9,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a precise assistant. When tools are available, you must use them instead of guessing. Call both `lookup_harbor_label` and `lookup_orchard_label` before writing any normal text. Never call the same tool twice once you already have its result.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"default","status":"completed","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"},{"description":"Return the beta signal marker.","name":"lookup_orchard_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":160,"input_tokens_details":{"cached_tokens":0},"output_tokens":49,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":209},"user":null},"sequence_number":10,"type":"response.completed"}
+
+---
+when:
+  path: /backend-api/codex/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Call `lookup_harbor_label` and `lookup_orchard_label` exactly once each before answering. After both tool results are available, stop calling tools and respond in one short sentence that includes both exact tool outputs.","type":"input_text"}],"role":"user","type":"message"},{"arguments":"{}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"lookup_harbor_label","status":"completed","type":"function_call"},{"arguments":"{}","call_id":"call_REDACTED_2","id":"fc_REDACTED_2","name":"lookup_orchard_label","status":"completed","type":"function_call"},{"call_id":"call_REDACTED_1","output":"crimson-harbor","status":"completed","type":"function_call_output"},{"call_id":"call_REDACTED_2","output":"silver-orchard","status":"completed","type":"function_call_output"}],"instructions":"You are a precise assistant. When tools are available, you must use them instead of guessing. Call both `lookup_harbor_label` and `lookup_orchard_label` before writing any normal text. Never call the same tool twice once you already have its result.","model":"gpt-5.4","store":false,"stream":true,"tools":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"properties":{},"required":[],"type":"object"},"type":"function"},{"description":"Return the beta signal marker.","name":"lookup_orchard_label","parameters":{"properties":{},"required":[],"type":"object"},"type":"function"}]}'
+then:
+  status: 200
+  header: []
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":"You are a precise assistant. When tools are available, you must use them instead of guessing. Call both `lookup_harbor_label` and `lookup_orchard_label` before writing any normal text. Never call the same tool twice once you already have its result.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_3","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"},{"description":"Return the beta signal marker.","name":"lookup_orchard_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":"You are a precise assistant. When tools are available, you must use them instead of guessing. Call both `lookup_harbor_label` and `lookup_orchard_label` before writing any normal text. Never call the same tool twice once you already have its result.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_3","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"},{"description":"Return the beta signal marker.","name":"lookup_orchard_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"content":[],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"in_progress","type":"message"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.content_part.added
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"","type":"output_text"},"sequence_number":3,"type":"response.content_part.added"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"cr","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_3","output_index":0,"sequence_number":4,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"imson","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_4","output_index":0,"sequence_number":5,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"-h","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_5","output_index":0,"sequence_number":6,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"ar","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_6","output_index":0,"sequence_number":7,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"bor","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_7","output_index":0,"sequence_number":8,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" and","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_8","output_index":0,"sequence_number":9,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" silver","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_9","output_index":0,"sequence_number":10,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"-or","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_10","output_index":0,"sequence_number":11,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"ch","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_11","output_index":0,"sequence_number":12,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"ard","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_12","output_index":0,"sequence_number":13,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":".","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_13","output_index":0,"sequence_number":14,"type":"response.output_text.delta"}
+
+    event: response.output_text.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","logprobs":[],"output_index":0,"sequence_number":15,"text":"crimson-harbor and silver-orchard.","type":"response.output_text.done"}
+
+    event: response.content_part.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"crimson-harbor and silver-orchard.","type":"output_text"},"sequence_number":16,"type":"response.content_part.done"}
+
+    event: response.output_item.done
+    data: {"item":{"content":[{"annotations":[],"logprobs":[],"text":"crimson-harbor and silver-orchard.","type":"output_text"}],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"completed","type":"message"},"output_index":0,"sequence_number":17,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":"You are a precise assistant. When tools are available, you must use them instead of guessing. Call both `lookup_harbor_label` and `lookup_orchard_label` before writing any normal text. Never call the same tool twice once you already have its result.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_3","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"default","status":"completed","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"},{"description":"Return the beta signal marker.","name":"lookup_orchard_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":244,"input_tokens_details":{"cached_tokens":0},"output_tokens":15,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":259},"user":null},"sequence_number":18,"type":"response.completed"}
+

--- a/tests/cassettes/chatgpt/codex_sessions/reasoning_session_two_tool_calls_streaming.yaml
+++ b/tests/cassettes/chatgpt/codex_sessions/reasoning_session_two_tool_calls_streaming.yaml
@@ -1,0 +1,257 @@
+when:
+  path: /backend-api/codex/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"I need the current weather in Tokyo and in Paris. Use the get_weather tool once per city, then compare the two cities in one short paragraph that mentions both city names.","type":"input_text"}],"role":"user","type":"message"}],"instructions":"You are a weather assistant. You have access to a get_weather tool. You must call the get_weather tool for any weather question and never guess weather data. After receiving the tool result, provide a concise summary of the weather.","model":"gpt-5.4","reasoning":{"effort":"low"},"store":false,"stream":true,"tools":[{"description":"Get the current weather for a city. Must be called for weather questions.","name":"get_weather","parameters":{"properties":{"city":{"description":"City name to get weather for","type":"string"}},"required":["city"],"type":"object"},"type":"function"}]}'
+then:
+  status: 200
+  header: []
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a weather assistant. You have access to a get_weather tool. You must call the get_weather tool for any weather question and never guess weather data. After receiving the tool result, provide a concise summary of the weather.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"low","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Get the current weather for a city. Must be called for weather questions.","name":"get_weather","parameters":{"additionalProperties":false,"properties":{"city":{"description":"City name to get weather for","type":"string"}},"required":["city"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a weather assistant. You have access to a get_weather tool. You must call the get_weather tool for any weather question and never guess weather data. After receiving the tool result, provide a concise summary of the weather.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"low","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Get the current weather for a city. Must be called for weather questions.","name":"get_weather","parameters":{"additionalProperties":false,"properties":{"city":{"description":"City name to get weather for","type":"string"}},"required":["city"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"content":[],"encrypted_content":"encrypted_content_REDACTED_1","id":"rs_REDACTED_1","summary":[],"type":"reasoning"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.output_item.done
+    data: {"item":{"content":[],"encrypted_content":"encrypted_content_REDACTED_2","id":"rs_REDACTED_1","summary":[],"type":"reasoning"},"output_index":0,"sequence_number":3,"type":"response.output_item.done"}
+
+    event: response.output_item.added
+    data: {"item":{"arguments":"","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"get_weather","status":"in_progress","type":"function_call"},"output_index":1,"sequence_number":4,"type":"response.output_item.added"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"{\"city\":\"Tokyo\"}","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_1","output_index":1,"sequence_number":5,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.done
+    data: {"arguments":"{\"city\":\"Tokyo\"}","item_id":"fc_REDACTED_1","output_index":1,"sequence_number":6,"type":"response.function_call_arguments.done"}
+
+    event: response.output_item.done
+    data: {"item":{"arguments":"{\"city\":\"Tokyo\"}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"get_weather","status":"completed","type":"function_call"},"output_index":1,"sequence_number":7,"type":"response.output_item.done"}
+
+    event: response.output_item.added
+    data: {"item":{"arguments":"","call_id":"call_REDACTED_2","id":"fc_REDACTED_2","name":"get_weather","status":"in_progress","type":"function_call"},"output_index":2,"sequence_number":8,"type":"response.output_item.added"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"{\"city\":\"Paris\"}","item_id":"fc_REDACTED_2","obfuscation":"obfuscation_REDACTED_1","output_index":2,"sequence_number":9,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.done
+    data: {"arguments":"{\"city\":\"Paris\"}","item_id":"fc_REDACTED_2","output_index":2,"sequence_number":10,"type":"response.function_call_arguments.done"}
+
+    event: response.output_item.done
+    data: {"item":{"arguments":"{\"city\":\"Paris\"}","call_id":"call_REDACTED_2","id":"fc_REDACTED_2","name":"get_weather","status":"completed","type":"function_call"},"output_index":2,"sequence_number":11,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a weather assistant. You have access to a get_weather tool. You must call the get_weather tool for any weather question and never guess weather data. After receiving the tool result, provide a concise summary of the weather.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"low","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"default","status":"completed","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Get the current weather for a city. Must be called for weather questions.","name":"get_weather","parameters":{"additionalProperties":false,"properties":{"city":{"description":"City name to get weather for","type":"string"}},"required":["city"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":144,"input_tokens_details":{"cached_tokens":0},"output_tokens":61,"output_tokens_details":{"reasoning_tokens":11},"total_tokens":205},"user":null},"sequence_number":12,"type":"response.completed"}
+
+---
+when:
+  path: /backend-api/codex/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"I need the current weather in Tokyo and in Paris. Use the get_weather tool once per city, then compare the two cities in one short paragraph that mentions both city names.","type":"input_text"}],"role":"user","type":"message"},{"encrypted_content":"encrypted_content_REDACTED_2","id":"rs_REDACTED_1","summary":[],"type":"reasoning"},{"arguments":"{\"city\":\"Tokyo\"}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"get_weather","status":"completed","type":"function_call"},{"arguments":"{\"city\":\"Paris\"}","call_id":"call_REDACTED_2","id":"fc_REDACTED_2","name":"get_weather","status":"completed","type":"function_call"},{"call_id":"call_REDACTED_1","output":"Weather in Tokyo: 72F (22C), sunny with light clouds, humidity 45%, wind 8 mph NW","status":"completed","type":"function_call_output"},{"call_id":"call_REDACTED_2","output":"Weather in Paris: 72F (22C), sunny with light clouds, humidity 45%, wind 8 mph NW","status":"completed","type":"function_call_output"}],"instructions":"You are a weather assistant. You have access to a get_weather tool. You must call the get_weather tool for any weather question and never guess weather data. After receiving the tool result, provide a concise summary of the weather.","model":"gpt-5.4","reasoning":{"effort":"low"},"store":false,"stream":true,"tools":[{"description":"Get the current weather for a city. Must be called for weather questions.","name":"get_weather","parameters":{"properties":{"city":{"description":"City name to get weather for","type":"string"}},"required":["city"],"type":"object"},"type":"function"}]}'
+then:
+  status: 200
+  header: []
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":"You are a weather assistant. You have access to a get_weather tool. You must call the get_weather tool for any weather question and never guess weather data. After receiving the tool result, provide a concise summary of the weather.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_3","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"low","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Get the current weather for a city. Must be called for weather questions.","name":"get_weather","parameters":{"additionalProperties":false,"properties":{"city":{"description":"City name to get weather for","type":"string"}},"required":["city"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":"You are a weather assistant. You have access to a get_weather tool. You must call the get_weather tool for any weather question and never guess weather data. After receiving the tool result, provide a concise summary of the weather.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_3","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"low","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Get the current weather for a city. Must be called for weather questions.","name":"get_weather","parameters":{"additionalProperties":false,"properties":{"city":{"description":"City name to get weather for","type":"string"}},"required":["city"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"content":[],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"in_progress","type":"message"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.content_part.added
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"","type":"output_text"},"sequence_number":3,"type":"response.content_part.added"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"Tokyo","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_2","output_index":0,"sequence_number":4,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" and","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_3","output_index":0,"sequence_number":5,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" Paris","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_4","output_index":0,"sequence_number":6,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" currently","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_5","output_index":0,"sequence_number":7,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" have","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_6","output_index":0,"sequence_number":8,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" identical","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_7","output_index":0,"sequence_number":9,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" weather","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_8","output_index":0,"sequence_number":10,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":":","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_9","output_index":0,"sequence_number":11,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" both","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_10","output_index":0,"sequence_number":12,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" are","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_11","output_index":0,"sequence_number":13,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" ","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_12","output_index":0,"sequence_number":14,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"72","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_13","output_index":0,"sequence_number":15,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"°F","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_14","output_index":0,"sequence_number":16,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" (","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_15","output_index":0,"sequence_number":17,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"22","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_16","output_index":0,"sequence_number":18,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"°C","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_17","output_index":0,"sequence_number":19,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":")","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_18","output_index":0,"sequence_number":20,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" with","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_19","output_index":0,"sequence_number":21,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" sunny","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_20","output_index":0,"sequence_number":22,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" skies","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_21","output_index":0,"sequence_number":23,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" and","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_22","output_index":0,"sequence_number":24,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" light","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_23","output_index":0,"sequence_number":25,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" clouds","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_24","output_index":0,"sequence_number":26,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":",","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_25","output_index":0,"sequence_number":27,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" ","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_26","output_index":0,"sequence_number":28,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"45","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_27","output_index":0,"sequence_number":29,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"%","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_28","output_index":0,"sequence_number":30,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" humidity","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_29","output_index":0,"sequence_number":31,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":",","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_30","output_index":0,"sequence_number":32,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" and","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_31","output_index":0,"sequence_number":33,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" northwest","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_32","output_index":0,"sequence_number":34,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" winds","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_33","output_index":0,"sequence_number":35,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" at","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_34","output_index":0,"sequence_number":36,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" ","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_35","output_index":0,"sequence_number":37,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"8","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_36","output_index":0,"sequence_number":38,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" mph","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_37","output_index":0,"sequence_number":39,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":",","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_38","output_index":0,"sequence_number":40,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" so","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_39","output_index":0,"sequence_number":41,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" neither","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_40","output_index":0,"sequence_number":42,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" city","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_41","output_index":0,"sequence_number":43,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" is","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_42","output_index":0,"sequence_number":44,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" warmer","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_43","output_index":0,"sequence_number":45,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":",","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_44","output_index":0,"sequence_number":46,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" wind","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_45","output_index":0,"sequence_number":47,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"ier","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_46","output_index":0,"sequence_number":48,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":",","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_47","output_index":0,"sequence_number":49,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" or","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_48","output_index":0,"sequence_number":50,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" more","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_49","output_index":0,"sequence_number":51,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" humid","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_50","output_index":0,"sequence_number":52,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" than","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_51","output_index":0,"sequence_number":53,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" the","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_52","output_index":0,"sequence_number":54,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" other","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_53","output_index":0,"sequence_number":55,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" right","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_54","output_index":0,"sequence_number":56,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" now","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_55","output_index":0,"sequence_number":57,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":".","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_56","output_index":0,"sequence_number":58,"type":"response.output_text.delta"}
+
+    event: response.output_text.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","logprobs":[],"output_index":0,"sequence_number":59,"text":"Tokyo and Paris currently have identical weather: both are 72°F (22°C) with sunny skies and light clouds, 45% humidity, and northwest winds at 8 mph, so neither city is warmer, windier, or more humid than the other right now.","type":"response.output_text.done"}
+
+    event: response.content_part.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"Tokyo and Paris currently have identical weather: both are 72°F (22°C) with sunny skies and light clouds, 45% humidity, and northwest winds at 8 mph, so neither city is warmer, windier, or more humid than the other right now.","type":"output_text"},"sequence_number":60,"type":"response.content_part.done"}
+
+    event: response.output_item.done
+    data: {"item":{"content":[{"annotations":[],"logprobs":[],"text":"Tokyo and Paris currently have identical weather: both are 72°F (22°C) with sunny skies and light clouds, 45% humidity, and northwest winds at 8 mph, so neither city is warmer, windier, or more humid than the other right now.","type":"output_text"}],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"completed","type":"message"},"output_index":0,"sequence_number":61,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":"You are a weather assistant. You have access to a get_weather tool. You must call the get_weather tool for any weather question and never guess weather data. After receiving the tool result, provide a concise summary of the weather.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_3","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"low","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"default","status":"completed","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Get the current weather for a city. Must be called for weather questions.","name":"get_weather","parameters":{"additionalProperties":false,"properties":{"city":{"description":"City name to get weather for","type":"string"}},"required":["city"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":275,"input_tokens_details":{"cached_tokens":0},"output_tokens":59,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":334},"user":null},"sequence_number":62,"type":"response.completed"}
+

--- a/tests/cassettes/chatgpt/codex_sessions/sequential_tool_calls_nonstreaming.yaml
+++ b/tests/cassettes/chatgpt/codex_sessions/sequential_tool_calls_nonstreaming.yaml
@@ -1,0 +1,179 @@
+when:
+  path: /backend-api/codex/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"First use the add tool to compute 3 + 4. After you receive that result, use the subtract tool to subtract 5 from it. Then state the final number in one short sentence.","type":"input_text"}],"role":"user","type":"message"}],"instructions":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","model":"gpt-5.4","store":false,"stream":true,"tools":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"type":"function"},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"type":"function"}]}'
+then:
+  status: 200
+  header: []
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"arguments":"","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"add","status":"in_progress","type":"function_call"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"{\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_1","output_index":0,"sequence_number":3,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"x","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_2","output_index":0,"sequence_number":4,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_3","output_index":0,"sequence_number":5,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"3","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_4","output_index":0,"sequence_number":6,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":",\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_5","output_index":0,"sequence_number":7,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"y","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_6","output_index":0,"sequence_number":8,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_7","output_index":0,"sequence_number":9,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"4","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_8","output_index":0,"sequence_number":10,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"}","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_9","output_index":0,"sequence_number":11,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.done
+    data: {"arguments":"{\"x\":3,\"y\":4}","item_id":"fc_REDACTED_1","output_index":0,"sequence_number":12,"type":"response.function_call_arguments.done"}
+
+    event: response.output_item.done
+    data: {"item":{"arguments":"{\"x\":3,\"y\":4}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"add","status":"completed","type":"function_call"},"output_index":0,"sequence_number":13,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"default","status":"completed","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":177,"input_tokens_details":{"cached_tokens":0},"output_tokens":21,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":198},"user":null},"sequence_number":14,"type":"response.completed"}
+
+---
+when:
+  path: /backend-api/codex/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"First use the add tool to compute 3 + 4. After you receive that result, use the subtract tool to subtract 5 from it. Then state the final number in one short sentence.","type":"input_text"}],"role":"user","type":"message"},{"arguments":"{\"x\":3,\"y\":4}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"add","status":"completed","type":"function_call"},{"call_id":"call_REDACTED_1","output":"7","status":"completed","type":"function_call_output"}],"instructions":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","model":"gpt-5.4","store":false,"stream":true,"tools":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"type":"function"},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"type":"function"}]}'
+then:
+  status: 200
+  header: []
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_3","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_3","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"arguments":"","call_id":"call_REDACTED_2","id":"fc_REDACTED_2","name":"subtract","status":"in_progress","type":"function_call"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"{\"","item_id":"fc_REDACTED_2","obfuscation":"obfuscation_REDACTED_10","output_index":0,"sequence_number":3,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"x","item_id":"fc_REDACTED_2","obfuscation":"obfuscation_REDACTED_11","output_index":0,"sequence_number":4,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":","item_id":"fc_REDACTED_2","obfuscation":"obfuscation_REDACTED_12","output_index":0,"sequence_number":5,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"7","item_id":"fc_REDACTED_2","obfuscation":"obfuscation_REDACTED_13","output_index":0,"sequence_number":6,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":",\"","item_id":"fc_REDACTED_2","obfuscation":"obfuscation_REDACTED_14","output_index":0,"sequence_number":7,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"y","item_id":"fc_REDACTED_2","obfuscation":"obfuscation_REDACTED_15","output_index":0,"sequence_number":8,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":","item_id":"fc_REDACTED_2","obfuscation":"obfuscation_REDACTED_16","output_index":0,"sequence_number":9,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"5","item_id":"fc_REDACTED_2","obfuscation":"obfuscation_REDACTED_17","output_index":0,"sequence_number":10,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"}","item_id":"fc_REDACTED_2","obfuscation":"obfuscation_REDACTED_18","output_index":0,"sequence_number":11,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.done
+    data: {"arguments":"{\"x\":7,\"y\":5}","item_id":"fc_REDACTED_2","output_index":0,"sequence_number":12,"type":"response.function_call_arguments.done"}
+
+    event: response.output_item.done
+    data: {"item":{"arguments":"{\"x\":7,\"y\":5}","call_id":"call_REDACTED_2","id":"fc_REDACTED_2","name":"subtract","status":"completed","type":"function_call"},"output_index":0,"sequence_number":13,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_3","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"default","status":"completed","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":209,"input_tokens_details":{"cached_tokens":0},"output_tokens":21,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":230},"user":null},"sequence_number":14,"type":"response.completed"}
+
+---
+when:
+  path: /backend-api/codex/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"First use the add tool to compute 3 + 4. After you receive that result, use the subtract tool to subtract 5 from it. Then state the final number in one short sentence.","type":"input_text"}],"role":"user","type":"message"},{"arguments":"{\"x\":3,\"y\":4}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"add","status":"completed","type":"function_call"},{"call_id":"call_REDACTED_1","output":"7","status":"completed","type":"function_call_output"},{"arguments":"{\"x\":7,\"y\":5}","call_id":"call_REDACTED_2","id":"fc_REDACTED_2","name":"subtract","status":"completed","type":"function_call"},{"call_id":"call_REDACTED_2","output":"2","status":"completed","type":"function_call_output"}],"instructions":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","model":"gpt-5.4","store":false,"stream":true,"tools":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"type":"function"},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"type":"function"}]}'
+then:
+  status: 200
+  header: []
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_3","incomplete_details":null,"instructions":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_4","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_3","incomplete_details":null,"instructions":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_4","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"content":[],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"in_progress","type":"message"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.content_part.added
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"","type":"output_text"},"sequence_number":3,"type":"response.content_part.added"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"The","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_19","output_index":0,"sequence_number":4,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" final","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_20","output_index":0,"sequence_number":5,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" number","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_21","output_index":0,"sequence_number":6,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" is","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_22","output_index":0,"sequence_number":7,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" ","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_23","output_index":0,"sequence_number":8,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"2","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_24","output_index":0,"sequence_number":9,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":".","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_25","output_index":0,"sequence_number":10,"type":"response.output_text.delta"}
+
+    event: response.output_text.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","logprobs":[],"output_index":0,"sequence_number":11,"text":"The final number is 2.","type":"response.output_text.done"}
+
+    event: response.content_part.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"The final number is 2.","type":"output_text"},"sequence_number":12,"type":"response.content_part.done"}
+
+    event: response.output_item.done
+    data: {"item":{"content":[{"annotations":[],"logprobs":[],"text":"The final number is 2.","type":"output_text"}],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"completed","type":"message"},"output_index":0,"sequence_number":13,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_3","incomplete_details":null,"instructions":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_4","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"default","status":"completed","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":241,"input_tokens_details":{"cached_tokens":0},"output_tokens":11,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":252},"user":null},"sequence_number":14,"type":"response.completed"}
+

--- a/tests/cassettes/chatgpt/codex_sessions/sequential_tool_calls_streaming.yaml
+++ b/tests/cassettes/chatgpt/codex_sessions/sequential_tool_calls_streaming.yaml
@@ -1,0 +1,179 @@
+when:
+  path: /backend-api/codex/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"First use the add tool to compute 3 + 4. After you receive that result, use the subtract tool to subtract 5 from it. Then state the final number in one short sentence.","type":"input_text"}],"role":"user","type":"message"}],"instructions":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","model":"gpt-5.4","store":false,"stream":true,"tools":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"type":"function"},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"type":"function"}]}'
+then:
+  status: 200
+  header: []
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"arguments":"","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"add","status":"in_progress","type":"function_call"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"{\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_1","output_index":0,"sequence_number":3,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"x","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_2","output_index":0,"sequence_number":4,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_3","output_index":0,"sequence_number":5,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"3","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_4","output_index":0,"sequence_number":6,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":",\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_5","output_index":0,"sequence_number":7,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"y","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_6","output_index":0,"sequence_number":8,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_7","output_index":0,"sequence_number":9,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"4","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_8","output_index":0,"sequence_number":10,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"}","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_9","output_index":0,"sequence_number":11,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.done
+    data: {"arguments":"{\"x\":3,\"y\":4}","item_id":"fc_REDACTED_1","output_index":0,"sequence_number":12,"type":"response.function_call_arguments.done"}
+
+    event: response.output_item.done
+    data: {"item":{"arguments":"{\"x\":3,\"y\":4}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"add","status":"completed","type":"function_call"},"output_index":0,"sequence_number":13,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"default","status":"completed","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":177,"input_tokens_details":{"cached_tokens":0},"output_tokens":21,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":198},"user":null},"sequence_number":14,"type":"response.completed"}
+
+---
+when:
+  path: /backend-api/codex/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"First use the add tool to compute 3 + 4. After you receive that result, use the subtract tool to subtract 5 from it. Then state the final number in one short sentence.","type":"input_text"}],"role":"user","type":"message"},{"arguments":"{\"x\":3,\"y\":4}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"add","status":"completed","type":"function_call"},{"call_id":"call_REDACTED_1","output":"7","status":"completed","type":"function_call_output"}],"instructions":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","model":"gpt-5.4","store":false,"stream":true,"tools":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"type":"function"},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"type":"function"}]}'
+then:
+  status: 200
+  header: []
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_3","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_3","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"arguments":"","call_id":"call_REDACTED_2","id":"fc_REDACTED_2","name":"subtract","status":"in_progress","type":"function_call"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"{\"","item_id":"fc_REDACTED_2","obfuscation":"obfuscation_REDACTED_10","output_index":0,"sequence_number":3,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"x","item_id":"fc_REDACTED_2","obfuscation":"obfuscation_REDACTED_11","output_index":0,"sequence_number":4,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":","item_id":"fc_REDACTED_2","obfuscation":"obfuscation_REDACTED_12","output_index":0,"sequence_number":5,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"7","item_id":"fc_REDACTED_2","obfuscation":"obfuscation_REDACTED_13","output_index":0,"sequence_number":6,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":",\"","item_id":"fc_REDACTED_2","obfuscation":"obfuscation_REDACTED_14","output_index":0,"sequence_number":7,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"y","item_id":"fc_REDACTED_2","obfuscation":"obfuscation_REDACTED_15","output_index":0,"sequence_number":8,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":","item_id":"fc_REDACTED_2","obfuscation":"obfuscation_REDACTED_16","output_index":0,"sequence_number":9,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"5","item_id":"fc_REDACTED_2","obfuscation":"obfuscation_REDACTED_17","output_index":0,"sequence_number":10,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"}","item_id":"fc_REDACTED_2","obfuscation":"obfuscation_REDACTED_18","output_index":0,"sequence_number":11,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.done
+    data: {"arguments":"{\"x\":7,\"y\":5}","item_id":"fc_REDACTED_2","output_index":0,"sequence_number":12,"type":"response.function_call_arguments.done"}
+
+    event: response.output_item.done
+    data: {"item":{"arguments":"{\"x\":7,\"y\":5}","call_id":"call_REDACTED_2","id":"fc_REDACTED_2","name":"subtract","status":"completed","type":"function_call"},"output_index":0,"sequence_number":13,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_3","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"default","status":"completed","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":209,"input_tokens_details":{"cached_tokens":0},"output_tokens":21,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":230},"user":null},"sequence_number":14,"type":"response.completed"}
+
+---
+when:
+  path: /backend-api/codex/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"First use the add tool to compute 3 + 4. After you receive that result, use the subtract tool to subtract 5 from it. Then state the final number in one short sentence.","type":"input_text"}],"role":"user","type":"message"},{"arguments":"{\"x\":3,\"y\":4}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"add","status":"completed","type":"function_call"},{"call_id":"call_REDACTED_1","output":"7","status":"completed","type":"function_call_output"},{"arguments":"{\"x\":7,\"y\":5}","call_id":"call_REDACTED_2","id":"fc_REDACTED_2","name":"subtract","status":"completed","type":"function_call"},{"call_id":"call_REDACTED_2","output":"2","status":"completed","type":"function_call_output"}],"instructions":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","model":"gpt-5.4","store":false,"stream":true,"tools":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"type":"function"},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"type":"function"}]}'
+then:
+  status: 200
+  header: []
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_3","incomplete_details":null,"instructions":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_4","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_3","incomplete_details":null,"instructions":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_4","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"content":[],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"in_progress","type":"message"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.content_part.added
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"","type":"output_text"},"sequence_number":3,"type":"response.content_part.added"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"The","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_19","output_index":0,"sequence_number":4,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" final","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_20","output_index":0,"sequence_number":5,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" number","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_21","output_index":0,"sequence_number":6,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" is","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_22","output_index":0,"sequence_number":7,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" ","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_23","output_index":0,"sequence_number":8,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"2","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_24","output_index":0,"sequence_number":9,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":".","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_25","output_index":0,"sequence_number":10,"type":"response.output_text.delta"}
+
+    event: response.output_text.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","logprobs":[],"output_index":0,"sequence_number":11,"text":"The final number is 2.","type":"response.output_text.done"}
+
+    event: response.content_part.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"The final number is 2.","type":"output_text"},"sequence_number":12,"type":"response.content_part.done"}
+
+    event: response.output_item.done
+    data: {"item":{"content":[{"annotations":[],"logprobs":[],"text":"The final number is 2.","type":"output_text"}],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"completed","type":"message"},"output_index":0,"sequence_number":13,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_3","incomplete_details":null,"instructions":"You are a calculator. Use the provided tools instead of doing arithmetic yourself. Call exactly one tool at a time and wait for its result before deciding the next step.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_4","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"default","status":"completed","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":241,"input_tokens_details":{"cached_tokens":0},"output_tokens":11,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":252},"user":null},"sequence_number":14,"type":"response.completed"}
+

--- a/tests/cassettes/chatgpt/codex_sessions/usage_accumulates_across_streaming_multi_turn.yaml
+++ b/tests/cassettes/chatgpt/codex_sessions/usage_accumulates_across_streaming_multi_turn.yaml
@@ -1,0 +1,101 @@
+when:
+  path: /backend-api/codex/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Call `lookup_harbor_label` exactly once before answering. After the tool result is available, answer in one short sentence that includes the exact tool output.","type":"input_text"}],"role":"user","type":"message"}],"instructions":"You must call the requested tool before writing any normal text. After the tool result is available, do not call any more tools and answer in one short sentence that includes the exact tool output.","model":"gpt-5.4","store":false,"stream":true,"tools":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"properties":{},"required":[],"type":"object"},"type":"function"}]}'
+then:
+  status: 200
+  header: []
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You must call the requested tool before writing any normal text. After the tool result is available, do not call any more tools and answer in one short sentence that includes the exact tool output.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You must call the requested tool before writing any normal text. After the tool result is available, do not call any more tools and answer in one short sentence that includes the exact tool output.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"arguments":"","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"lookup_harbor_label","status":"in_progress","type":"function_call"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"{}","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_1","output_index":0,"sequence_number":3,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.done
+    data: {"arguments":"{}","item_id":"fc_REDACTED_1","output_index":0,"sequence_number":4,"type":"response.function_call_arguments.done"}
+
+    event: response.output_item.done
+    data: {"item":{"arguments":"{}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"lookup_harbor_label","status":"completed","type":"function_call"},"output_index":0,"sequence_number":5,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You must call the requested tool before writing any normal text. After the tool result is available, do not call any more tools and answer in one short sentence that includes the exact tool output.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"default","status":"completed","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":113,"input_tokens_details":{"cached_tokens":0},"output_tokens":17,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":130},"user":null},"sequence_number":6,"type":"response.completed"}
+
+---
+when:
+  path: /backend-api/codex/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Call `lookup_harbor_label` exactly once before answering. After the tool result is available, answer in one short sentence that includes the exact tool output.","type":"input_text"}],"role":"user","type":"message"},{"arguments":"{}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"lookup_harbor_label","status":"completed","type":"function_call"},{"call_id":"call_REDACTED_1","output":"crimson-harbor","status":"completed","type":"function_call_output"}],"instructions":"You must call the requested tool before writing any normal text. After the tool result is available, do not call any more tools and answer in one short sentence that includes the exact tool output.","model":"gpt-5.4","store":false,"stream":true,"tools":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"properties":{},"required":[],"type":"object"},"type":"function"}]}'
+then:
+  status: 200
+  header: []
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":"You must call the requested tool before writing any normal text. After the tool result is available, do not call any more tools and answer in one short sentence that includes the exact tool output.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_3","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":"You must call the requested tool before writing any normal text. After the tool result is available, do not call any more tools and answer in one short sentence that includes the exact tool output.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_3","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"content":[],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"in_progress","type":"message"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.content_part.added
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"","type":"output_text"},"sequence_number":3,"type":"response.content_part.added"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"The","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_2","output_index":0,"sequence_number":4,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" harbor","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_3","output_index":0,"sequence_number":5,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" label","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_4","output_index":0,"sequence_number":6,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" is","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_5","output_index":0,"sequence_number":7,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" crimson","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_6","output_index":0,"sequence_number":8,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"-h","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_7","output_index":0,"sequence_number":9,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"ar","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_8","output_index":0,"sequence_number":10,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"bor","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_9","output_index":0,"sequence_number":11,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":".","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_10","output_index":0,"sequence_number":12,"type":"response.output_text.delta"}
+
+    event: response.output_text.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","logprobs":[],"output_index":0,"sequence_number":13,"text":"The harbor label is crimson-harbor.","type":"response.output_text.done"}
+
+    event: response.content_part.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"The harbor label is crimson-harbor.","type":"output_text"},"sequence_number":14,"type":"response.content_part.done"}
+
+    event: response.output_item.done
+    data: {"item":{"content":[{"annotations":[],"logprobs":[],"text":"The harbor label is crimson-harbor.","type":"output_text"}],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"completed","type":"message"},"output_index":0,"sequence_number":15,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":"You must call the requested tool before writing any normal text. After the tool result is available, do not call any more tools and answer in one short sentence that includes the exact tool output.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_3","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"default","status":"completed","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":149,"input_tokens_details":{"cached_tokens":0},"output_tokens":13,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":162},"user":null},"sequence_number":16,"type":"response.completed"}
+

--- a/tests/cassettes/chatgpt/codex_tool_args/nested_arguments_roundtrip_nonstreaming.yaml
+++ b/tests/cassettes/chatgpt/codex_tool_args/nested_arguments_roundtrip_nonstreaming.yaml
@@ -1,0 +1,206 @@
+when:
+  path: /backend-api/codex/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Book this trip by calling the plan_trip tool exactly once with these exact values: itinerary.city = \"Kyoto\", itinerary.days = 3, itinerary.activities = [\"temples\", \"tea ceremony\"], itinerary.lodging.name = \"Sakura Inn\", itinerary.lodging.rooms = 2. After the tool returns, repeat its confirmation code in one short sentence.","type":"input_text"}],"role":"user","type":"message"}],"instructions":"You are a travel booking assistant. Use the plan_trip tool for every booking request and copy the requested values into the tool arguments exactly as given.","model":"gpt-5.4","store":false,"stream":true,"tools":[{"description":"Book a trip from a nested itinerary object.","name":"plan_trip","parameters":{"properties":{"itinerary":{"description":"The trip to book.","properties":{"activities":{"items":{"type":"string"},"type":"array"},"city":{"type":"string"},"days":{"type":"integer"},"lodging":{"properties":{"name":{"type":"string"},"rooms":{"type":"integer"}},"required":["name","rooms"],"type":"object"}},"required":["city","days","activities","lodging"],"type":"object"}},"required":["itinerary"],"type":"object"},"type":"function"}]}'
+then:
+  status: 200
+  header: []
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a travel booking assistant. Use the plan_trip tool for every booking request and copy the requested values into the tool arguments exactly as given.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Book a trip from a nested itinerary object.","name":"plan_trip","parameters":{"additionalProperties":false,"properties":{"itinerary":{"additionalProperties":false,"description":"The trip to book.","properties":{"activities":{"items":{"type":"string"},"type":"array"},"city":{"type":"string"},"days":{"type":"integer"},"lodging":{"additionalProperties":false,"properties":{"name":{"type":"string"},"rooms":{"type":"integer"}},"required":["name","rooms"],"type":"object"}},"required":["city","days","activities","lodging"],"type":"object"}},"required":["itinerary"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a travel booking assistant. Use the plan_trip tool for every booking request and copy the requested values into the tool arguments exactly as given.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Book a trip from a nested itinerary object.","name":"plan_trip","parameters":{"additionalProperties":false,"properties":{"itinerary":{"additionalProperties":false,"description":"The trip to book.","properties":{"activities":{"items":{"type":"string"},"type":"array"},"city":{"type":"string"},"days":{"type":"integer"},"lodging":{"additionalProperties":false,"properties":{"name":{"type":"string"},"rooms":{"type":"integer"}},"required":["name","rooms"],"type":"object"}},"required":["city","days","activities","lodging"],"type":"object"}},"required":["itinerary"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"arguments":"","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"plan_trip","status":"in_progress","type":"function_call"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"{\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_1","output_index":0,"sequence_number":3,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"it","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_2","output_index":0,"sequence_number":4,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"inerary","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_3","output_index":0,"sequence_number":5,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":{\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_4","output_index":0,"sequence_number":6,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"city","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_5","output_index":0,"sequence_number":7,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_6","output_index":0,"sequence_number":8,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"Ky","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_7","output_index":0,"sequence_number":9,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"oto","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_8","output_index":0,"sequence_number":10,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\",\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_9","output_index":0,"sequence_number":11,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"days","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_10","output_index":0,"sequence_number":12,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_11","output_index":0,"sequence_number":13,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"3","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_12","output_index":0,"sequence_number":14,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":",\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_13","output_index":0,"sequence_number":15,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"activities","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_14","output_index":0,"sequence_number":16,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":[\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_15","output_index":0,"sequence_number":17,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"tem","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_16","output_index":0,"sequence_number":18,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"ples","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_17","output_index":0,"sequence_number":19,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\",\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_18","output_index":0,"sequence_number":20,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"tea","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_19","output_index":0,"sequence_number":21,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":" ceremony","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_20","output_index":0,"sequence_number":22,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\"],","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_21","output_index":0,"sequence_number":23,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_22","output_index":0,"sequence_number":24,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"lod","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_23","output_index":0,"sequence_number":25,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"ging","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_24","output_index":0,"sequence_number":26,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":{\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_25","output_index":0,"sequence_number":27,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"name","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_26","output_index":0,"sequence_number":28,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_27","output_index":0,"sequence_number":29,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"S","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_28","output_index":0,"sequence_number":30,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"akura","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_29","output_index":0,"sequence_number":31,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":" Inn","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_30","output_index":0,"sequence_number":32,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\",\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_31","output_index":0,"sequence_number":33,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"rooms","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_32","output_index":0,"sequence_number":34,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_33","output_index":0,"sequence_number":35,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"2","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_34","output_index":0,"sequence_number":36,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"}}","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_35","output_index":0,"sequence_number":37,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"}","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_36","output_index":0,"sequence_number":38,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.done
+    data: {"arguments":"{\"itinerary\":{\"city\":\"Kyoto\",\"days\":3,\"activities\":[\"temples\",\"tea ceremony\"],\"lodging\":{\"name\":\"Sakura Inn\",\"rooms\":2}}}","item_id":"fc_REDACTED_1","output_index":0,"sequence_number":39,"type":"response.function_call_arguments.done"}
+
+    event: response.output_item.done
+    data: {"item":{"arguments":"{\"itinerary\":{\"city\":\"Kyoto\",\"days\":3,\"activities\":[\"temples\",\"tea ceremony\"],\"lodging\":{\"name\":\"Sakura Inn\",\"rooms\":2}}}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"plan_trip","status":"completed","type":"function_call"},"output_index":0,"sequence_number":40,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a travel booking assistant. Use the plan_trip tool for every booking request and copy the requested values into the tool arguments exactly as given.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"default","status":"completed","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Book a trip from a nested itinerary object.","name":"plan_trip","parameters":{"additionalProperties":false,"properties":{"itinerary":{"additionalProperties":false,"description":"The trip to book.","properties":{"activities":{"items":{"type":"string"},"type":"array"},"city":{"type":"string"},"days":{"type":"integer"},"lodging":{"additionalProperties":false,"properties":{"name":{"type":"string"},"rooms":{"type":"integer"}},"required":["name","rooms"],"type":"object"}},"required":["city","days","activities","lodging"],"type":"object"}},"required":["itinerary"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":182,"input_tokens_details":{"cached_tokens":0},"output_tokens":49,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":231},"user":null},"sequence_number":41,"type":"response.completed"}
+
+---
+when:
+  path: /backend-api/codex/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Book this trip by calling the plan_trip tool exactly once with these exact values: itinerary.city = \"Kyoto\", itinerary.days = 3, itinerary.activities = [\"temples\", \"tea ceremony\"], itinerary.lodging.name = \"Sakura Inn\", itinerary.lodging.rooms = 2. After the tool returns, repeat its confirmation code in one short sentence.","type":"input_text"}],"role":"user","type":"message"},{"arguments":"{\"itinerary\":{\"city\":\"Kyoto\",\"days\":3,\"activities\":[\"temples\",\"tea ceremony\"],\"lodging\":{\"name\":\"Sakura Inn\",\"rooms\":2}}}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"plan_trip","status":"completed","type":"function_call"},{"call_id":"call_REDACTED_1","output":"Booked Kyoto for 3 day(s), 2 room(s) at Sakura Inn, with 2 planned activities. Confirmation code SAKURA-77.","status":"completed","type":"function_call_output"}],"instructions":"You are a travel booking assistant. Use the plan_trip tool for every booking request and copy the requested values into the tool arguments exactly as given.","model":"gpt-5.4","store":false,"stream":true,"tools":[{"description":"Book a trip from a nested itinerary object.","name":"plan_trip","parameters":{"properties":{"itinerary":{"description":"The trip to book.","properties":{"activities":{"items":{"type":"string"},"type":"array"},"city":{"type":"string"},"days":{"type":"integer"},"lodging":{"properties":{"name":{"type":"string"},"rooms":{"type":"integer"}},"required":["name","rooms"],"type":"object"}},"required":["city","days","activities","lodging"],"type":"object"}},"required":["itinerary"],"type":"object"},"type":"function"}]}'
+then:
+  status: 200
+  header: []
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":"You are a travel booking assistant. Use the plan_trip tool for every booking request and copy the requested values into the tool arguments exactly as given.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_3","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Book a trip from a nested itinerary object.","name":"plan_trip","parameters":{"additionalProperties":false,"properties":{"itinerary":{"additionalProperties":false,"description":"The trip to book.","properties":{"activities":{"items":{"type":"string"},"type":"array"},"city":{"type":"string"},"days":{"type":"integer"},"lodging":{"additionalProperties":false,"properties":{"name":{"type":"string"},"rooms":{"type":"integer"}},"required":["name","rooms"],"type":"object"}},"required":["city","days","activities","lodging"],"type":"object"}},"required":["itinerary"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":"You are a travel booking assistant. Use the plan_trip tool for every booking request and copy the requested values into the tool arguments exactly as given.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_3","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Book a trip from a nested itinerary object.","name":"plan_trip","parameters":{"additionalProperties":false,"properties":{"itinerary":{"additionalProperties":false,"description":"The trip to book.","properties":{"activities":{"items":{"type":"string"},"type":"array"},"city":{"type":"string"},"days":{"type":"integer"},"lodging":{"additionalProperties":false,"properties":{"name":{"type":"string"},"rooms":{"type":"integer"}},"required":["name","rooms"],"type":"object"}},"required":["city","days","activities","lodging"],"type":"object"}},"required":["itinerary"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"content":[],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"in_progress","type":"message"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.content_part.added
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"","type":"output_text"},"sequence_number":3,"type":"response.content_part.added"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"Confirmation","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_37","output_index":0,"sequence_number":4,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" code","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_38","output_index":0,"sequence_number":5,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":":","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_39","output_index":0,"sequence_number":6,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":" S","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_40","output_index":0,"sequence_number":7,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"AK","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_41","output_index":0,"sequence_number":8,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"URA","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_42","output_index":0,"sequence_number":9,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"-","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_43","output_index":0,"sequence_number":10,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"77","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_44","output_index":0,"sequence_number":11,"type":"response.output_text.delta"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":".","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_45","output_index":0,"sequence_number":12,"type":"response.output_text.delta"}
+
+    event: response.output_text.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","logprobs":[],"output_index":0,"sequence_number":13,"text":"Confirmation code: SAKURA-77.","type":"response.output_text.done"}
+
+    event: response.content_part.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"Confirmation code: SAKURA-77.","type":"output_text"},"sequence_number":14,"type":"response.content_part.done"}
+
+    event: response.output_item.done
+    data: {"item":{"content":[{"annotations":[],"logprobs":[],"text":"Confirmation code: SAKURA-77.","type":"output_text"}],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"completed","type":"message"},"output_index":0,"sequence_number":15,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":"You are a travel booking assistant. Use the plan_trip tool for every booking request and copy the requested values into the tool arguments exactly as given.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_3","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"default","status":"completed","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Book a trip from a nested itinerary object.","name":"plan_trip","parameters":{"additionalProperties":false,"properties":{"itinerary":{"additionalProperties":false,"description":"The trip to book.","properties":{"activities":{"items":{"type":"string"},"type":"array"},"city":{"type":"string"},"days":{"type":"integer"},"lodging":{"additionalProperties":false,"properties":{"name":{"type":"string"},"rooms":{"type":"integer"}},"required":["name","rooms"],"type":"object"}},"required":["city","days","activities","lodging"],"type":"object"}},"required":["itinerary"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":273,"input_tokens_details":{"cached_tokens":0},"output_tokens":13,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":286},"user":null},"sequence_number":16,"type":"response.completed"}
+

--- a/tests/cassettes/chatgpt/codex_tool_args/nested_arguments_streaming.yaml
+++ b/tests/cassettes/chatgpt/codex_tool_args/nested_arguments_streaming.yaml
@@ -1,0 +1,140 @@
+when:
+  path: /backend-api/codex/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Book this trip by calling the plan_trip tool exactly once with these exact values: itinerary.city = \"Kyoto\", itinerary.days = 3, itinerary.activities = [\"temples\", \"tea ceremony\"], itinerary.lodging.name = \"Sakura Inn\", itinerary.lodging.rooms = 2. After the tool returns, repeat its confirmation code in one short sentence.","type":"input_text"}],"role":"user","type":"message"}],"instructions":"You are a travel booking assistant. Use the plan_trip tool for every booking request and copy the requested values into the tool arguments exactly as given.","model":"gpt-5.4","store":false,"stream":true,"tools":[{"description":"Book a trip from a nested itinerary object.","name":"plan_trip","parameters":{"properties":{"itinerary":{"description":"The trip to book.","properties":{"activities":{"items":{"type":"string"},"type":"array"},"city":{"type":"string"},"days":{"type":"integer"},"lodging":{"properties":{"name":{"type":"string"},"rooms":{"type":"integer"}},"required":["name","rooms"],"type":"object"}},"required":["city","days","activities","lodging"],"type":"object"}},"required":["itinerary"],"type":"object"},"type":"function"}]}'
+then:
+  status: 200
+  header: []
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a travel booking assistant. Use the plan_trip tool for every booking request and copy the requested values into the tool arguments exactly as given.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Book a trip from a nested itinerary object.","name":"plan_trip","parameters":{"additionalProperties":false,"properties":{"itinerary":{"additionalProperties":false,"description":"The trip to book.","properties":{"activities":{"items":{"type":"string"},"type":"array"},"city":{"type":"string"},"days":{"type":"integer"},"lodging":{"additionalProperties":false,"properties":{"name":{"type":"string"},"rooms":{"type":"integer"}},"required":["name","rooms"],"type":"object"}},"required":["city","days","activities","lodging"],"type":"object"}},"required":["itinerary"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a travel booking assistant. Use the plan_trip tool for every booking request and copy the requested values into the tool arguments exactly as given.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Book a trip from a nested itinerary object.","name":"plan_trip","parameters":{"additionalProperties":false,"properties":{"itinerary":{"additionalProperties":false,"description":"The trip to book.","properties":{"activities":{"items":{"type":"string"},"type":"array"},"city":{"type":"string"},"days":{"type":"integer"},"lodging":{"additionalProperties":false,"properties":{"name":{"type":"string"},"rooms":{"type":"integer"}},"required":["name","rooms"],"type":"object"}},"required":["city","days","activities","lodging"],"type":"object"}},"required":["itinerary"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"arguments":"","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"plan_trip","status":"in_progress","type":"function_call"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"{\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_1","output_index":0,"sequence_number":3,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"it","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_2","output_index":0,"sequence_number":4,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"inerary","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_3","output_index":0,"sequence_number":5,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":{\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_4","output_index":0,"sequence_number":6,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"city","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_5","output_index":0,"sequence_number":7,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_6","output_index":0,"sequence_number":8,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"Ky","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_7","output_index":0,"sequence_number":9,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"oto","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_8","output_index":0,"sequence_number":10,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\",\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_9","output_index":0,"sequence_number":11,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"days","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_10","output_index":0,"sequence_number":12,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_11","output_index":0,"sequence_number":13,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"3","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_12","output_index":0,"sequence_number":14,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":",\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_13","output_index":0,"sequence_number":15,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"activities","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_14","output_index":0,"sequence_number":16,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":[\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_15","output_index":0,"sequence_number":17,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"tem","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_16","output_index":0,"sequence_number":18,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"ples","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_17","output_index":0,"sequence_number":19,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\",\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_18","output_index":0,"sequence_number":20,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"tea","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_19","output_index":0,"sequence_number":21,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":" ceremony","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_20","output_index":0,"sequence_number":22,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\"],","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_21","output_index":0,"sequence_number":23,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_22","output_index":0,"sequence_number":24,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"lod","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_23","output_index":0,"sequence_number":25,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"ging","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_24","output_index":0,"sequence_number":26,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":{\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_25","output_index":0,"sequence_number":27,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"name","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_26","output_index":0,"sequence_number":28,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_27","output_index":0,"sequence_number":29,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"S","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_28","output_index":0,"sequence_number":30,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"akura","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_29","output_index":0,"sequence_number":31,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":" Inn","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_30","output_index":0,"sequence_number":32,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\",\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_31","output_index":0,"sequence_number":33,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"rooms","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_32","output_index":0,"sequence_number":34,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_33","output_index":0,"sequence_number":35,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"2","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_34","output_index":0,"sequence_number":36,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"}}","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_35","output_index":0,"sequence_number":37,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"}","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_36","output_index":0,"sequence_number":38,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.done
+    data: {"arguments":"{\"itinerary\":{\"city\":\"Kyoto\",\"days\":3,\"activities\":[\"temples\",\"tea ceremony\"],\"lodging\":{\"name\":\"Sakura Inn\",\"rooms\":2}}}","item_id":"fc_REDACTED_1","output_index":0,"sequence_number":39,"type":"response.function_call_arguments.done"}
+
+    event: response.output_item.done
+    data: {"item":{"arguments":"{\"itinerary\":{\"city\":\"Kyoto\",\"days\":3,\"activities\":[\"temples\",\"tea ceremony\"],\"lodging\":{\"name\":\"Sakura Inn\",\"rooms\":2}}}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"plan_trip","status":"completed","type":"function_call"},"output_index":0,"sequence_number":40,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a travel booking assistant. Use the plan_trip tool for every booking request and copy the requested values into the tool arguments exactly as given.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"default","status":"completed","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Book a trip from a nested itinerary object.","name":"plan_trip","parameters":{"additionalProperties":false,"properties":{"itinerary":{"additionalProperties":false,"description":"The trip to book.","properties":{"activities":{"items":{"type":"string"},"type":"array"},"city":{"type":"string"},"days":{"type":"integer"},"lodging":{"additionalProperties":false,"properties":{"name":{"type":"string"},"rooms":{"type":"integer"}},"required":["name","rooms"],"type":"object"}},"required":["city","days","activities","lodging"],"type":"object"}},"required":["itinerary"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":182,"input_tokens_details":{"cached_tokens":0},"output_tokens":49,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":231},"user":null},"sequence_number":41,"type":"response.completed"}
+

--- a/tests/cassettes/chatgpt/codex_tool_args/unicode_arguments_streaming.yaml
+++ b/tests/cassettes/chatgpt/codex_tool_args/unicode_arguments_streaming.yaml
@@ -1,0 +1,89 @@
+when:
+  path: /backend-api/codex/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Call the echo tool exactly once with the message argument set to exactly this text: Grüße aus 東京, from the \"naïve café\"!","type":"input_text"}],"role":"user","type":"message"}],"instructions":"You must call the echo tool with the exact text the user provides. Do not translate, reword, or drop any characters.","model":"gpt-5.4","store":false,"stream":true,"tools":[{"description":"Echo a message back to the user.","name":"echo","parameters":{"properties":{"message":{"type":"string"}},"required":["message"],"type":"object"},"type":"function"}]}'
+then:
+  status: 200
+  header: []
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You must call the echo tool with the exact text the user provides. Do not translate, reword, or drop any characters.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Echo a message back to the user.","name":"echo","parameters":{"additionalProperties":false,"properties":{"message":{"type":"string"}},"required":["message"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You must call the echo tool with the exact text the user provides. Do not translate, reword, or drop any characters.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Echo a message back to the user.","name":"echo","parameters":{"additionalProperties":false,"properties":{"message":{"type":"string"}},"required":["message"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"arguments":"","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"echo","status":"in_progress","type":"function_call"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"{\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_1","output_index":0,"sequence_number":3,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"message","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_2","output_index":0,"sequence_number":4,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_3","output_index":0,"sequence_number":5,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"Gr","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_4","output_index":0,"sequence_number":6,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"ü","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_5","output_index":0,"sequence_number":7,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"ße","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_6","output_index":0,"sequence_number":8,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":" aus","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_7","output_index":0,"sequence_number":9,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":" 東京","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_8","output_index":0,"sequence_number":10,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":",","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_9","output_index":0,"sequence_number":11,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":" from","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_10","output_index":0,"sequence_number":12,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":" the","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_11","output_index":0,"sequence_number":13,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":" \\\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_12","output_index":0,"sequence_number":14,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"na","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_13","output_index":0,"sequence_number":15,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"ï","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_14","output_index":0,"sequence_number":16,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"ve","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_15","output_index":0,"sequence_number":17,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":" café","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_16","output_index":0,"sequence_number":18,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\\\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_17","output_index":0,"sequence_number":19,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"!\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_18","output_index":0,"sequence_number":20,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"}","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_19","output_index":0,"sequence_number":21,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.done
+    data: {"arguments":"{\"message\":\"Grüße aus 東京, from the \\\"naïve café\\\"!\"}","item_id":"fc_REDACTED_1","output_index":0,"sequence_number":22,"type":"response.function_call_arguments.done"}
+
+    event: response.output_item.done
+    data: {"item":{"arguments":"{\"message\":\"Grüße aus 東京, from the \\\"naïve café\\\"!\"}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"echo","status":"completed","type":"function_call"},"output_index":0,"sequence_number":23,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You must call the echo tool with the exact text the user provides. Do not translate, reword, or drop any characters.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"default","status":"completed","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Echo a message back to the user.","name":"echo","parameters":{"additionalProperties":false,"properties":{"message":{"type":"string"}},"required":["message"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":101,"input_tokens_details":{"cached_tokens":0},"output_tokens":31,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":132},"user":null},"sequence_number":24,"type":"response.completed"}
+

--- a/tests/cassettes/chatgpt/codex_tool_args/zero_argument_tool_call_nonstreaming.yaml
+++ b/tests/cassettes/chatgpt/codex_tool_args/zero_argument_tool_call_nonstreaming.yaml
@@ -1,0 +1,35 @@
+when:
+  path: /backend-api/codex/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Call the ping tool with no arguments. Do not answer with normal text before the tool call.","type":"input_text"}],"role":"user","type":"message"}],"instructions":"Follow the tool-calling instructions exactly.","model":"gpt-5.4","store":false,"stream":true,"tools":[{"description":"A zero-argument tool named ping.","name":"ping","parameters":{"properties":{},"required":[],"type":"object"},"type":"function"}]}'
+then:
+  status: 200
+  header: []
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"Follow the tool-calling instructions exactly.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"A zero-argument tool named ping.","name":"ping","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"Follow the tool-calling instructions exactly.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"A zero-argument tool named ping.","name":"ping","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"arguments":"","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"ping","status":"in_progress","type":"function_call"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"{}","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_1","output_index":0,"sequence_number":3,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.done
+    data: {"arguments":"{}","item_id":"fc_REDACTED_1","output_index":0,"sequence_number":4,"type":"response.function_call_arguments.done"}
+
+    event: response.output_item.done
+    data: {"item":{"arguments":"{}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"ping","status":"completed","type":"function_call"},"output_index":0,"sequence_number":5,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"Follow the tool-calling instructions exactly.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"default","status":"completed","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"A zero-argument tool named ping.","name":"ping","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":68,"input_tokens_details":{"cached_tokens":0},"output_tokens":14,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":82},"user":null},"sequence_number":6,"type":"response.completed"}
+

--- a/tests/cassettes/chatgpt/codex_tool_args/zero_argument_tool_call_streaming.yaml
+++ b/tests/cassettes/chatgpt/codex_tool_args/zero_argument_tool_call_streaming.yaml
@@ -1,0 +1,35 @@
+when:
+  path: /backend-api/codex/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Call the ping tool with no arguments. Do not answer with normal text before the tool call.","type":"input_text"}],"role":"user","type":"message"}],"instructions":"Follow the tool-calling instructions exactly.","model":"gpt-5.4","store":false,"stream":true,"tools":[{"description":"A zero-argument tool named ping.","name":"ping","parameters":{"properties":{},"required":[],"type":"object"},"type":"function"}]}'
+then:
+  status: 200
+  header: []
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"Follow the tool-calling instructions exactly.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"A zero-argument tool named ping.","name":"ping","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"Follow the tool-calling instructions exactly.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"A zero-argument tool named ping.","name":"ping","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"arguments":"","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"ping","status":"in_progress","type":"function_call"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"{}","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_1","output_index":0,"sequence_number":3,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.done
+    data: {"arguments":"{}","item_id":"fc_REDACTED_1","output_index":0,"sequence_number":4,"type":"response.function_call_arguments.done"}
+
+    event: response.output_item.done
+    data: {"item":{"arguments":"{}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"ping","status":"completed","type":"function_call"},"output_index":0,"sequence_number":5,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"Follow the tool-calling instructions exactly.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"default","status":"completed","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"A zero-argument tool named ping.","name":"ping","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":68,"input_tokens_details":{"cached_tokens":0},"output_tokens":14,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":82},"user":null},"sequence_number":6,"type":"response.completed"}
+

--- a/tests/cassettes/chatgpt/codex_tool_choice/none_suppresses_tool_calls.yaml
+++ b/tests/cassettes/chatgpt/codex_tool_choice/none_suppresses_tool_calls.yaml
@@ -1,0 +1,41 @@
+when:
+  path: /backend-api/codex/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"What is 2 plus 3? Reply with just the number.","type":"input_text"}],"role":"user","type":"message"}],"instructions":"You are a calculator here to help the user perform arithmetic operations. Use the tools provided to answer the user''s question.","model":"gpt-5.4","store":false,"stream":true,"tool_choice":"none","tools":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"type":"function"}]}'
+then:
+  status: 200
+  header: []
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a calculator here to help the user perform arithmetic operations. Use the tools provided to answer the user's question.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"none","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a calculator here to help the user perform arithmetic operations. Use the tools provided to answer the user's question.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"none","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"content":[],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"in_progress","type":"message"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.content_part.added
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"","type":"output_text"},"sequence_number":3,"type":"response.content_part.added"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"5","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_1","output_index":0,"sequence_number":4,"type":"response.output_text.delta"}
+
+    event: response.output_text.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","logprobs":[],"output_index":0,"sequence_number":5,"text":"5","type":"response.output_text.done"}
+
+    event: response.content_part.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"5","type":"output_text"},"sequence_number":6,"type":"response.content_part.done"}
+
+    event: response.output_item.done
+    data: {"item":{"content":[{"annotations":[],"logprobs":[],"text":"5","type":"output_text"}],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"completed","type":"message"},"output_index":0,"sequence_number":7,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a calculator here to help the user perform arithmetic operations. Use the tools provided to answer the user's question.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"default","status":"completed","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"none","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":99,"input_tokens_details":{"cached_tokens":0},"output_tokens":5,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":104},"user":null},"sequence_number":8,"type":"response.completed"}
+

--- a/tests/cassettes/chatgpt/codex_tool_choice/required_forces_a_tool_call.yaml
+++ b/tests/cassettes/chatgpt/codex_tool_choice/required_forces_a_tool_call.yaml
@@ -1,0 +1,59 @@
+when:
+  path: /backend-api/codex/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Please greet me.","type":"input_text"}],"role":"user","type":"message"}],"instructions":"You are a calculator here to help the user perform arithmetic operations. Use the tools provided to answer the user''s question.","model":"gpt-5.4","store":false,"stream":true,"tool_choice":"required","tools":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"type":"function"}]}'
+then:
+  status: 200
+  header: []
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a calculator here to help the user perform arithmetic operations. Use the tools provided to answer the user's question.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"required","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a calculator here to help the user perform arithmetic operations. Use the tools provided to answer the user's question.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"required","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"arguments":"","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"add","status":"in_progress","type":"function_call"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"{\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_1","output_index":0,"sequence_number":3,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"x","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_2","output_index":0,"sequence_number":4,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_3","output_index":0,"sequence_number":5,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"0","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_4","output_index":0,"sequence_number":6,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":",\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_5","output_index":0,"sequence_number":7,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"y","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_6","output_index":0,"sequence_number":8,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_7","output_index":0,"sequence_number":9,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"0","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_8","output_index":0,"sequence_number":10,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"}","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_9","output_index":0,"sequence_number":11,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.done
+    data: {"arguments":"{\"x\":0,\"y\":0}","item_id":"fc_REDACTED_1","output_index":0,"sequence_number":12,"type":"response.function_call_arguments.done"}
+
+    event: response.output_item.done
+    data: {"item":{"arguments":"{\"x\":0,\"y\":0}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"add","status":"completed","type":"function_call"},"output_index":0,"sequence_number":13,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a calculator here to help the user perform arithmetic operations. Use the tools provided to answer the user's question.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"default","status":"completed","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"required","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":89,"input_tokens_details":{"cached_tokens":0},"output_tokens":21,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":110},"user":null},"sequence_number":14,"type":"response.completed"}
+

--- a/tests/cassettes/chatgpt/codex_tool_choice/specific_multiple_functions_use_allowed_tools.yaml
+++ b/tests/cassettes/chatgpt/codex_tool_choice/specific_multiple_functions_use_allowed_tools.yaml
@@ -1,0 +1,59 @@
+when:
+  path: /backend-api/codex/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"What is 2 plus 3? Use exactly one tool.","type":"input_text"}],"role":"user","type":"message"}],"instructions":"You are a calculator here to help the user perform arithmetic operations. Use the tools provided to answer the user''s question.","model":"gpt-5.4","store":false,"stream":true,"tool_choice":{"mode":"required","tools":[{"name":"add","type":"function"},{"name":"subtract","type":"function"}],"type":"allowed_tools"},"tools":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"type":"function"},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"type":"function"},{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"properties":{},"required":[],"type":"object"},"type":"function"}]}'
+then:
+  status: 200
+  header: []
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a calculator here to help the user perform arithmetic operations. Use the tools provided to answer the user's question.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"mode":"required","tools":[{"name":"add","type":"function"},{"name":"subtract","type":"function"}],"type":"allowed_tools"},"tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"},{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a calculator here to help the user perform arithmetic operations. Use the tools provided to answer the user's question.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"mode":"required","tools":[{"name":"add","type":"function"},{"name":"subtract","type":"function"}],"type":"allowed_tools"},"tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"},{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"arguments":"","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"add","status":"in_progress","type":"function_call"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"{\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_1","output_index":0,"sequence_number":3,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"x","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_2","output_index":0,"sequence_number":4,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_3","output_index":0,"sequence_number":5,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"2","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_4","output_index":0,"sequence_number":6,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":",\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_5","output_index":0,"sequence_number":7,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"y","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_6","output_index":0,"sequence_number":8,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_7","output_index":0,"sequence_number":9,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"3","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_8","output_index":0,"sequence_number":10,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"}","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_9","output_index":0,"sequence_number":11,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.done
+    data: {"arguments":"{\"x\":2,\"y\":3}","item_id":"fc_REDACTED_1","output_index":0,"sequence_number":12,"type":"response.function_call_arguments.done"}
+
+    event: response.output_item.done
+    data: {"item":{"arguments":"{\"x\":2,\"y\":3}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"add","status":"completed","type":"function_call"},"output_index":0,"sequence_number":13,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a calculator here to help the user perform arithmetic operations. Use the tools provided to answer the user's question.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"default","status":"completed","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"mode":"required","tools":[{"name":"add","type":"function"},{"name":"subtract","type":"function"}],"type":"allowed_tools"},"tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"},{"description":"Return the alpha signal marker.","name":"lookup_harbor_label","parameters":{"additionalProperties":false,"properties":{},"required":[],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":157,"input_tokens_details":{"cached_tokens":0},"output_tokens":21,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":178},"user":null},"sequence_number":14,"type":"response.completed"}
+

--- a/tests/cassettes/chatgpt/codex_tool_choice/specific_single_function_targets_named_tool.yaml
+++ b/tests/cassettes/chatgpt/codex_tool_choice/specific_single_function_targets_named_tool.yaml
@@ -1,0 +1,59 @@
+when:
+  path: /backend-api/codex/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Compute 9 minus 4 using a tool.","type":"input_text"}],"role":"user","type":"message"}],"instructions":"You are a calculator here to help the user perform arithmetic operations. Use the tools provided to answer the user''s question.","model":"gpt-5.4","store":false,"stream":true,"tool_choice":{"name":"subtract","type":"function"},"tools":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"type":"function"},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"type":"function"}]}'
+then:
+  status: 200
+  header: []
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a calculator here to help the user perform arithmetic operations. Use the tools provided to answer the user's question.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"name":"subtract","type":"function"},"tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a calculator here to help the user perform arithmetic operations. Use the tools provided to answer the user's question.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"auto","status":"in_progress","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"name":"subtract","type":"function"},"tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"arguments":"","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"subtract","status":"in_progress","type":"function_call"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"{\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_1","output_index":0,"sequence_number":3,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"x","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_2","output_index":0,"sequence_number":4,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_3","output_index":0,"sequence_number":5,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"9","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_4","output_index":0,"sequence_number":6,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":",\"","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_5","output_index":0,"sequence_number":7,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"y","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_6","output_index":0,"sequence_number":8,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"\":","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_7","output_index":0,"sequence_number":9,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"4","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_8","output_index":0,"sequence_number":10,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.delta
+    data: {"delta":"}","item_id":"fc_REDACTED_1","obfuscation":"obfuscation_REDACTED_9","output_index":0,"sequence_number":11,"type":"response.function_call_arguments.delta"}
+
+    event: response.function_call_arguments.done
+    data: {"arguments":"{\"x\":9,\"y\":4}","item_id":"fc_REDACTED_1","output_index":0,"sequence_number":12,"type":"response.function_call_arguments.done"}
+
+    event: response.output_item.done
+    data: {"item":{"arguments":"{\"x\":9,\"y\":4}","call_id":"call_REDACTED_1","id":"fc_REDACTED_1","name":"subtract","status":"completed","type":"function_call"},"output_index":0,"sequence_number":13,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a calculator here to help the user perform arithmetic operations. Use the tools provided to answer the user's question.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.4","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":"id_REDACTED_1","prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"none","mode":"standard","summary":null},"safety_identifier":"id_REDACTED_2","service_tier":"default","status":"completed","store":false,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"name":"subtract","type":"function"},"tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[{"description":"Add x and y together","name":"add","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The first number to add","type":"number"},"y":{"description":"The second number to add","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"},{"description":"Subtract y from x (i.e.: x - y)","name":"subtract","parameters":{"additionalProperties":false,"properties":{"x":{"description":"The number to subtract from","type":"number"},"y":{"description":"The number to subtract","type":"number"}},"required":["x","y"],"type":"object"},"strict":true,"type":"function"}],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":137,"input_tokens_details":{"cached_tokens":0},"output_tokens":21,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":158},"user":null},"sequence_number":14,"type":"response.completed"}
+

--- a/tests/common/cassette_safety.rs
+++ b/tests/common/cassette_safety.rs
@@ -32,7 +32,10 @@ const PROVIDER_CASSETTE_SUITES: &[ProviderCassetteSuite] = &[
     ProviderCassetteSuite {
         provider: "chatgpt",
         source_dir: "tests/providers/chatgpt/cassette",
-        wrapper_names: &["with_chatgpt_cassette"],
+        wrapper_names: &[
+            "with_chatgpt_cassette",
+            "with_chatgpt_cassette_default_instructions",
+        ],
     },
     ProviderCassetteSuite {
         provider: "copilot",

--- a/tests/providers/chatgpt/cassette/codex_behaviors.rs
+++ b/tests/providers/chatgpt/cassette/codex_behaviors.rs
@@ -1,0 +1,178 @@
+//! ChatGPT/Codex Responses backend behavior regression tests.
+//!
+//! Locks down strict tool schemas, ChatGPT-specific request shaping, SSE
+//! reconstruction, and system/default instruction behavior.
+//!
+//! Run cassette tests in replay mode by default, or set
+//! `RIG_PROVIDER_TEST_MODE=record` to record against the real provider.
+
+use rig::client::CompletionClient;
+use rig::completion::{Chat, CompletionModel, Message};
+use rig::message::AssistantContent;
+use rig::providers::chatgpt;
+use rig::tool::Tool;
+
+use super::super::support::{with_chatgpt_cassette, with_chatgpt_cassette_default_instructions};
+use crate::support::{Adder, TOOLS_PREAMBLE, assistant_text_response};
+
+#[tokio::test]
+async fn strict_tools_opt_in_roundtrip() {
+    with_chatgpt_cassette(
+        "codex_behaviors/strict_tools_opt_in_roundtrip",
+        |client| async move {
+            // The recorded request body locks the strict-tools contract:
+            // `strict: true` plus the sanitized schema (additionalProperties
+            // false, all properties required) must be accepted by the backend.
+            let model = client
+                .completion_model(chatgpt::GPT_5_4)
+                .with_strict_tools();
+            let request = model
+                .completion_request("Use the add tool to add 7 and 5.")
+                .preamble(TOOLS_PREAMBLE.to_string())
+                .tool(Adder.definition(String::new()).await)
+                .build();
+
+            let response = model
+                .completion(request)
+                .await
+                .expect("strict-tools completion should succeed");
+
+            let tool_call = response
+                .choice
+                .iter()
+                .find_map(|content| match content {
+                    AssistantContent::ToolCall(tool_call) => Some(tool_call.clone()),
+                    _ => None,
+                })
+                .expect("strict tool call should be produced");
+            assert_eq!(tool_call.function.name, Adder::NAME);
+            assert_eq!(
+                tool_call
+                    .function
+                    .arguments
+                    .get("x")
+                    .and_then(|value| value.as_f64()),
+                Some(7.0),
+                "strict-mode arguments should carry both required fields: {:?}",
+                tool_call.function.arguments
+            );
+            assert_eq!(
+                tool_call
+                    .function
+                    .arguments
+                    .get("y")
+                    .and_then(|value| value.as_f64()),
+                Some(5.0),
+                "strict-mode arguments should carry both required fields: {:?}",
+                tool_call.function.arguments
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn store_false_and_prompt_cache_fields_roundtrip() {
+    with_chatgpt_cassette(
+        "codex_behaviors/store_false_and_prompt_cache_fields_roundtrip",
+        |client| async move {
+            let model = client.completion_model(chatgpt::GPT_5_4);
+            let response = model
+                .completion(
+                    model
+                        .completion_request("Reply with exactly this marker: CODEX-STORE-FALSE")
+                        .preamble("Return only the requested marker.".to_string())
+                        .build(),
+                )
+                .await
+                .expect("basic ChatGPT/Codex completion should succeed");
+
+            let text = assistant_text_response(&response.choice).expect("response text");
+            assert!(
+                text.contains("CODEX-STORE-FALSE"),
+                "final answer should preserve the requested marker, got {text:?}"
+            );
+            assert_eq!(
+                response.raw_response.additional_parameters.store,
+                Some(false),
+                "ChatGPT provider must force store=false"
+            );
+            assert!(
+                response
+                    .raw_response
+                    .additional_parameters
+                    .prompt_cache_key
+                    .as_deref()
+                    .is_some_and(|value| !value.is_empty()),
+                "ChatGPT backend should return a prompt cache key that cassettes scrub"
+            );
+            assert!(response.usage.input_tokens > 0);
+            assert!(response.usage.output_tokens > 0);
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn explicit_preamble_and_mid_conversation_system_messages_are_instructions() {
+    with_chatgpt_cassette(
+        "codex_behaviors/explicit_preamble_and_mid_conversation_system_messages_are_instructions",
+        |client| async move {
+            // ChatGPT rejects `system` items in `input`; the recorded request
+            // body locks that the provider lifts both the preamble and later
+            // system messages into the top-level `instructions` field.
+            let agent = client
+                .agent(chatgpt::GPT_5_4)
+                .preamble("You are a concise assistant.")
+                .build();
+            let mut history = vec![
+                Message::user("Hello!"),
+                Message::assistant("Hi! How can I help you today?"),
+                Message::system(
+                    "The user's codename is FALCON-9. Always refer to the user by codename.",
+                ),
+            ];
+
+            let result = agent
+                .chat("What is my codename?", &mut history)
+                .await
+                .expect("chat with a mid-conversation system message should succeed");
+
+            assert!(
+                result.contains("FALCON-9"),
+                "the mid-conversation system message must reach the model, got {result:?}"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn default_instructions_merge_with_explicit_preamble() {
+    with_chatgpt_cassette_default_instructions(
+        "codex_behaviors/default_instructions_merge_with_explicit_preamble",
+        "Default instruction marker: always include DEFAULT-CODEX-MARKER when asked for the default marker.",
+        |client| async move {
+            let agent = client
+                .agent(chatgpt::GPT_5_4)
+                .preamble("Explicit instruction marker: also include EXPLICIT-CODEX-MARKER.")
+                .build();
+            let mut history = Vec::<Message>::new();
+
+            let result = agent
+                .chat(
+                    "List the default marker and the explicit marker, and nothing else.",
+                    &mut history,
+                )
+                .await
+                .expect("default and explicit instructions should both reach the backend");
+
+            assert!(
+                result.contains("DEFAULT-CODEX-MARKER")
+                    && result.contains("EXPLICIT-CODEX-MARKER"),
+                "merged instructions should influence the answer, got {result:?}"
+            );
+        },
+    )
+    .await;
+}

--- a/tests/providers/chatgpt/cassette/codex_sessions.rs
+++ b/tests/providers/chatgpt/cassette/codex_sessions.rs
@@ -1,0 +1,522 @@
+//! ChatGPT/Codex Responses backend long-session regression tests.
+//!
+//! These tests lock down multi-turn, multi-tool agent sessions against the
+//! Responses API: sequential tool roundtrips, parallel tool calls in a single
+//! model turn, long chat-history replay, reasoning-enabled tool sessions, and
+//! usage accounting across turns.
+//!
+//! Run cassette tests in replay mode by default, or set
+//! `RIG_PROVIDER_TEST_MODE=record` to record against the real provider.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use futures::StreamExt;
+use rig::agent::MultiTurnStreamItem;
+use rig::client::CompletionClient;
+use rig::completion::{Chat, CompletionModel, Message};
+use rig::message::{AssistantContent, UserContent};
+use rig::providers::chatgpt;
+use rig::streaming::{StreamingChat, StreamingPrompt};
+use rig::tool::Tool;
+
+use super::super::support::with_chatgpt_cassette;
+use crate::reasoning::{self, WeatherTool};
+use crate::support::{
+    ALPHA_SIGNAL_OUTPUT, Adder, AlphaSignal, BETA_SIGNAL_OUTPUT, BetaSignal,
+    ORDERED_TOOL_STREAM_PREAMBLE, ORDERED_TOOL_STREAM_PROMPT, Subtract, TWO_TOOL_STREAM_PREAMBLE,
+    TWO_TOOL_STREAM_PROMPT, assert_mentions_expected_number, assert_two_tool_roundtrip_contract,
+    collect_stream_observation,
+};
+
+const SEQUENTIAL_TOOLS_PREAMBLE: &str = "\
+You are a calculator. Use the provided tools instead of doing arithmetic yourself. \
+Call exactly one tool at a time and wait for its result before deciding the next step.";
+
+const SEQUENTIAL_TOOLS_PROMPT: &str = "\
+First use the add tool to compute 3 + 4. After you receive that result, use the \
+subtract tool to subtract 5 from it. Then state the final number in one short sentence.";
+
+/// A recorded tool event from a caller-owned chat history: the message index
+/// it appeared at plus the identifiers needed to pair calls with results.
+struct ToolEvent {
+    message_index: usize,
+    name_or_id: String,
+    call_id: Option<String>,
+}
+
+fn history_tool_calls(history: &[Message]) -> Vec<ToolEvent> {
+    let mut calls = Vec::new();
+    for (message_index, message) in history.iter().enumerate() {
+        if let Message::Assistant { content, .. } = message {
+            for item in content.iter() {
+                if let AssistantContent::ToolCall(tool_call) = item {
+                    calls.push(ToolEvent {
+                        message_index,
+                        name_or_id: tool_call.function.name.clone(),
+                        call_id: tool_call.call_id.clone().or(Some(tool_call.id.clone())),
+                    });
+                }
+            }
+        }
+    }
+    calls
+}
+
+fn history_tool_results(history: &[Message]) -> Vec<ToolEvent> {
+    let mut results = Vec::new();
+    for (message_index, message) in history.iter().enumerate() {
+        if let Message::User { content } = message {
+            for item in content.iter() {
+                if let UserContent::ToolResult(tool_result) = item {
+                    results.push(ToolEvent {
+                        message_index,
+                        name_or_id: tool_result.id.clone(),
+                        call_id: tool_result.call_id.clone().or(Some(tool_result.id.clone())),
+                    });
+                }
+            }
+        }
+    }
+    results
+}
+
+fn result_index_for_call(results: &[ToolEvent], call: &ToolEvent) -> usize {
+    results
+        .iter()
+        .find(|result| result.call_id == call.call_id)
+        .unwrap_or_else(|| {
+            panic!(
+                "chat history is missing the tool result answering call {:?} (call_id {:?})",
+                call.name_or_id, call.call_id
+            )
+        })
+        .message_index
+}
+
+#[tokio::test]
+async fn sequential_tool_calls_nonstreaming() {
+    with_chatgpt_cassette(
+        "codex_sessions/sequential_tool_calls_nonstreaming",
+        |client| async move {
+            let agent = client
+                .agent(chatgpt::GPT_5_4)
+                .preamble(SEQUENTIAL_TOOLS_PREAMBLE)
+                .tool(Adder)
+                .tool(Subtract)
+                .default_max_turns(6)
+                .build();
+            let mut history = Vec::<Message>::new();
+
+            let result = agent
+                .chat(SEQUENTIAL_TOOLS_PROMPT, &mut history)
+                .await
+                .expect("sequential tool chat should succeed");
+
+            assert_mentions_expected_number(&result, 2);
+
+            let calls = history_tool_calls(&history);
+            let results = history_tool_results(&history);
+            let add_call = calls
+                .iter()
+                .find(|call| call.name_or_id == Adder::NAME)
+                .expect("history should contain an add tool call");
+            let subtract_call = calls
+                .iter()
+                .find(|call| call.name_or_id == Subtract::NAME)
+                .expect("history should contain a subtract tool call");
+            let add_result_index = result_index_for_call(&results, add_call);
+            let subtract_result_index = result_index_for_call(&results, subtract_call);
+
+            assert!(
+                add_call.message_index < add_result_index,
+                "add result should follow the add call"
+            );
+            assert!(
+                add_result_index < subtract_call.message_index,
+                "subtract call should only happen after the add result (sequential turns)"
+            );
+            assert!(
+                subtract_call.message_index < subtract_result_index,
+                "subtract result should follow the subtract call"
+            );
+
+            let final_assistant_text = history
+                .iter()
+                .skip(subtract_result_index + 1)
+                .filter_map(|message| match message {
+                    Message::Assistant { content, .. } => Some(
+                        content
+                            .iter()
+                            .filter_map(|item| match item {
+                                AssistantContent::Text(text) => Some(text.text.clone()),
+                                _ => None,
+                            })
+                            .collect::<String>(),
+                    ),
+                    _ => None,
+                })
+                .collect::<String>();
+            assert!(
+                !final_assistant_text.trim().is_empty(),
+                "history should record a final assistant answer after the last tool result"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn sequential_tool_calls_streaming() {
+    with_chatgpt_cassette(
+        "codex_sessions/sequential_tool_calls_streaming",
+        |client| async move {
+            let agent = client
+                .agent(chatgpt::GPT_5_4)
+                .preamble(SEQUENTIAL_TOOLS_PREAMBLE)
+                .tool(Adder)
+                .tool(Subtract)
+                .build();
+
+            let mut stream = agent
+                .stream_chat(SEQUENTIAL_TOOLS_PROMPT, Vec::<Message>::new())
+                .multi_turn(6)
+                .await;
+            let observation = collect_stream_observation(&mut stream).await;
+
+            assert!(
+                observation.errors.is_empty(),
+                "stream should not emit errors: {:?}",
+                observation.errors
+            );
+            assert_eq!(
+                observation.tool_calls,
+                vec![Adder::NAME.to_string(), Subtract::NAME.to_string()],
+                "expected exactly one add call followed by one subtract call"
+            );
+            assert_eq!(
+                observation.tool_results, 2,
+                "expected one tool result per tool call"
+            );
+            assert!(
+                observation.got_final_response,
+                "stream should emit a final response"
+            );
+            let response = observation
+                .final_response_text
+                .as_deref()
+                .expect("stream should produce final response text");
+            assert_mentions_expected_number(response, 2);
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn parallel_tool_calls_single_turn_nonstreaming() {
+    with_chatgpt_cassette(
+        "codex_sessions/parallel_tool_calls_single_turn_nonstreaming",
+        |client| async move {
+            let agent = client
+                .agent(chatgpt::GPT_5_4)
+                .preamble(TWO_TOOL_STREAM_PREAMBLE)
+                .tool(AlphaSignal)
+                .tool(BetaSignal)
+                .default_max_turns(5)
+                .build();
+            let mut history = Vec::<Message>::new();
+
+            let result = agent
+                .chat(TWO_TOOL_STREAM_PROMPT, &mut history)
+                .await
+                .expect("parallel tool chat should succeed");
+
+            let lowered = result.to_ascii_lowercase();
+            assert!(
+                lowered.contains(ALPHA_SIGNAL_OUTPUT) && lowered.contains(BETA_SIGNAL_OUTPUT),
+                "final response should include both tool outputs, got {result:?}"
+            );
+
+            let calls = history_tool_calls(&history);
+            let results = history_tool_results(&history);
+            assert_eq!(
+                calls.len(),
+                2,
+                "expected exactly two tool calls in history, got {:?}",
+                calls
+                    .iter()
+                    .map(|call| call.name_or_id.as_str())
+                    .collect::<Vec<_>>()
+            );
+            assert_eq!(results.len(), 2, "expected exactly two tool results");
+
+            for call in &calls {
+                let result_index = result_index_for_call(&results, call);
+                assert!(
+                    call.message_index < result_index,
+                    "each tool result should follow its call"
+                );
+            }
+
+            // Results must come back in the same order as the calls they answer.
+            let call_order: Vec<_> = calls.iter().map(|call| call.call_id.clone()).collect();
+            let result_order: Vec<_> = results
+                .iter()
+                .map(|result| result.call_id.clone())
+                .collect();
+            assert_eq!(
+                call_order, result_order,
+                "tool results should be recorded in tool-call order"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn parallel_tool_calls_single_turn_streaming() {
+    with_chatgpt_cassette(
+        "codex_sessions/parallel_tool_calls_single_turn_streaming",
+        |client| async move {
+            let agent = client
+                .agent(chatgpt::GPT_5_4)
+                .preamble(TWO_TOOL_STREAM_PREAMBLE)
+                .tool(AlphaSignal)
+                .tool(BetaSignal)
+                .build();
+
+            let mut stream = agent
+                .stream_prompt(TWO_TOOL_STREAM_PROMPT)
+                .multi_turn(5)
+                .await;
+            let observation = collect_stream_observation(&mut stream).await;
+
+            assert_two_tool_roundtrip_contract(
+                &observation,
+                &[AlphaSignal::NAME, BetaSignal::NAME],
+                &[ALPHA_SIGNAL_OUTPUT, BETA_SIGNAL_OUTPUT],
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn long_history_replay_nonstreaming() {
+    with_chatgpt_cassette(
+        "codex_sessions/long_history_replay_nonstreaming",
+        |client| async move {
+            let model = client.completion_model(chatgpt::GPT_5_4);
+            let preamble = "You are a concise assistant with perfect recall of this conversation.";
+
+            // First turn: obtain a real tool call so the follow-up can echo
+            // its call_id back, the way a caller-owned history would.
+            let first_request = model
+                .completion_request("Look up the harbor label with the tool.")
+                .preamble(preamble.to_string())
+                .tool(AlphaSignal.definition(String::new()).await)
+                .build();
+            let first_response = model
+                .completion(first_request)
+                .await
+                .expect("first turn should succeed");
+            let tool_call = first_response
+                .choice
+                .iter()
+                .find_map(|content| match content {
+                    AssistantContent::ToolCall(tool_call) => Some(tool_call.clone()),
+                    _ => None,
+                })
+                .expect("first turn should call lookup_harbor_label");
+            let call_id = tool_call
+                .call_id
+                .clone()
+                .unwrap_or_else(|| tool_call.id.clone());
+
+            // Follow-up: replay a long client-owned history around that tool
+            // roundtrip. The tool call is re-tagged with a local item ID (not
+            // the provider's `fc_...` ID) — the request must still be accepted
+            // because non-native IDs are omitted and calls pair by call_id.
+            let request = model
+                .completion_request(
+                    "In one short sentence: what is my favorite color, and what was the \
+                     harbor label you looked up earlier?",
+                )
+                .preamble(preamble.to_string())
+                .message(Message::user(
+                    "My favorite color is teal. Please remember it.",
+                ))
+                .message(Message::assistant("Noted - your favorite color is teal."))
+                .message(Message::user("Now look up the harbor label with the tool."))
+                .message(Message::Assistant {
+                    id: None,
+                    content: rig::OneOrMany::one(AssistantContent::tool_call_with_call_id(
+                        "history_tool_1",
+                        call_id.clone(),
+                        AlphaSignal::NAME,
+                        serde_json::json!({}),
+                    )),
+                })
+                .message(Message::tool_result_with_call_id(
+                    "history_tool_1",
+                    Some(call_id),
+                    ALPHA_SIGNAL_OUTPUT,
+                ))
+                .message(Message::assistant("The harbor label is crimson-harbor."))
+                .tool(AlphaSignal.definition(String::new()).await)
+                .build();
+
+            let response = model
+                .completion(request)
+                .await
+                .expect("long history replay should be accepted by the Responses API");
+
+            let text: String = response
+                .choice
+                .iter()
+                .filter_map(|content| match content {
+                    AssistantContent::Text(text) => Some(text.text.as_str()),
+                    _ => None,
+                })
+                .collect();
+            let lowered = text.to_ascii_lowercase();
+            assert!(
+                lowered.contains("teal"),
+                "answer should recall the user fact from early history, got {text:?}"
+            );
+            assert!(
+                lowered.contains(ALPHA_SIGNAL_OUTPUT),
+                "answer should recall the replayed tool result, got {text:?}"
+            );
+            assert!(
+                response.usage.input_tokens > 0 && response.usage.output_tokens > 0,
+                "usage should be populated, got {:?}",
+                response.usage
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn reasoning_session_two_tool_calls_streaming() {
+    with_chatgpt_cassette(
+        "codex_sessions/reasoning_session_two_tool_calls_streaming",
+        |client| async move {
+            let call_count = Arc::new(AtomicUsize::new(0));
+            let agent = client
+                .agent(chatgpt::GPT_5_4)
+                .preamble(reasoning::TOOL_SYSTEM_PROMPT)
+                .max_tokens(6000)
+                .tool(WeatherTool::new(call_count.clone()))
+                .additional_params(serde_json::json!({
+                    "reasoning": { "effort": "low" }
+                }))
+                .build();
+
+            let stream = agent
+                .stream_chat(
+                    "I need the current weather in Tokyo and in Paris. Use the get_weather \
+                     tool once per city, then compare the two cities in one short paragraph \
+                     that mentions both city names.",
+                    Vec::<Message>::new(),
+                )
+                .multi_turn(5)
+                .await;
+
+            let stats = reasoning::collect_stream_stats(stream, "chatgpt").await;
+
+            assert!(
+                stats.errors.is_empty(),
+                "stream had errors: {:?}",
+                stats.errors
+            );
+            let invocations = call_count.load(Ordering::SeqCst);
+            assert!(
+                invocations >= 2,
+                "expected get_weather to run once per city, got {invocations}"
+            );
+            assert!(
+                stats
+                    .tool_calls_in_stream
+                    .iter()
+                    .filter(|name| name.as_str() == WeatherTool::NAME)
+                    .count()
+                    >= 2,
+                "expected at least two get_weather calls in the stream, saw {:?}",
+                stats.tool_calls_in_stream
+            );
+            assert!(
+                stats.tool_results_in_stream >= 2,
+                "expected a tool result per call, got {}",
+                stats.tool_results_in_stream
+            );
+            assert!(
+                stats.reasoning_block_count >= 1,
+                "expected reasoning output from a reasoning-enabled session"
+            );
+            assert!(
+                stats.got_final_response,
+                "stream should emit a final response"
+            );
+            let final_text = stats.final_turn_text.to_ascii_lowercase();
+            assert!(
+                final_text.contains("tokyo") && final_text.contains("paris"),
+                "final answer should mention both cities, got {:?}",
+                stats.final_turn_text
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn usage_accumulates_across_streaming_multi_turn() {
+    with_chatgpt_cassette(
+        "codex_sessions/usage_accumulates_across_streaming_multi_turn",
+        |client| async move {
+            let agent = client
+                .agent(chatgpt::GPT_5_4)
+                .preamble(ORDERED_TOOL_STREAM_PREAMBLE)
+                .tool(AlphaSignal)
+                .build();
+
+            let mut stream = agent
+                .stream_prompt(ORDERED_TOOL_STREAM_PROMPT)
+                .multi_turn(5)
+                .await;
+
+            let mut saw_tool_result = false;
+            let mut final_usage = None;
+
+            while let Some(item) = stream.next().await {
+                match item.expect("stream item should be ok") {
+                    MultiTurnStreamItem::StreamUserItem(_) => saw_tool_result = true,
+                    MultiTurnStreamItem::FinalResponse(response) => {
+                        final_usage = Some(response.usage());
+                    }
+                    _ => {}
+                }
+            }
+
+            assert!(
+                saw_tool_result,
+                "session should include a tool roundtrip so usage spans two model turns"
+            );
+            let usage = final_usage.expect("stream should emit a final response with usage");
+            assert!(
+                usage.input_tokens > 0,
+                "aggregated input tokens should be nonzero: {usage:?}"
+            );
+            assert!(
+                usage.output_tokens > 0,
+                "aggregated output tokens should be nonzero: {usage:?}"
+            );
+            assert!(
+                usage.total_tokens >= usage.output_tokens,
+                "total tokens should cover output tokens: {usage:?}"
+            );
+        },
+    )
+    .await;
+}

--- a/tests/providers/chatgpt/cassette/codex_tool_args.rs
+++ b/tests/providers/chatgpt/cassette/codex_tool_args.rs
@@ -1,0 +1,354 @@
+//! ChatGPT/Codex Responses backend tool-argument shape regression tests.
+//!
+//! Locks down how tool-call arguments survive the Responses API wire format:
+//! empty `{}` arguments, deeply nested objects, and non-ASCII/escaped strings,
+//! in both streaming (fragmented `function_call_arguments.delta` reassembly)
+//! and non-streaming form.
+//!
+//! Run cassette tests in replay mode by default, or set
+//! `RIG_PROVIDER_TEST_MODE=record` to record against the real provider.
+
+use rig::client::CompletionClient;
+use rig::completion::{Chat, CompletionModel, Message, ToolDefinition};
+use rig::message::AssistantContent;
+use rig::providers::chatgpt;
+use rig::tool::Tool;
+use serde::Deserialize;
+use serde_json::json;
+
+use super::super::support::with_chatgpt_cassette;
+use crate::support::{
+    REQUIRED_ZERO_ARG_TOOL_PROMPT, assert_stream_contains_zero_arg_tool_call_named,
+    collect_raw_stream_observation, zero_arg_tool_definition,
+};
+
+const NESTED_ARGS_PREAMBLE: &str = "\
+You are a travel booking assistant. Use the plan_trip tool for every booking request \
+and copy the requested values into the tool arguments exactly as given.";
+
+const NESTED_ARGS_PROMPT: &str = "\
+Book this trip by calling the plan_trip tool exactly once with these exact values: \
+itinerary.city = \"Kyoto\", itinerary.days = 3, \
+itinerary.activities = [\"temples\", \"tea ceremony\"], \
+itinerary.lodging.name = \"Sakura Inn\", itinerary.lodging.rooms = 2. \
+After the tool returns, repeat its confirmation code in one short sentence.";
+
+#[derive(Debug, thiserror::Error)]
+#[error("Trip planning failed")]
+struct PlanTripError;
+
+#[derive(Deserialize)]
+struct Lodging {
+    name: String,
+    rooms: u32,
+}
+
+#[derive(Deserialize)]
+struct Itinerary {
+    city: String,
+    days: u32,
+    activities: Vec<String>,
+    lodging: Lodging,
+}
+
+#[derive(Deserialize)]
+struct PlanTripArgs {
+    itinerary: Itinerary,
+}
+
+struct PlanTrip;
+
+impl Tool for PlanTrip {
+    const NAME: &'static str = "plan_trip";
+    type Error = PlanTripError;
+    type Args = PlanTripArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "Book a trip from a nested itinerary object.".to_string(),
+            parameters: plan_trip_parameters(),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        Ok(format!(
+            "Booked {} for {} day(s), {} room(s) at {}, with {} planned activities. \
+             Confirmation code SAKURA-77.",
+            args.itinerary.city,
+            args.itinerary.days,
+            args.itinerary.lodging.rooms,
+            args.itinerary.lodging.name,
+            args.itinerary.activities.len(),
+        ))
+    }
+}
+
+fn plan_trip_parameters() -> serde_json::Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "itinerary": {
+                "type": "object",
+                "description": "The trip to book.",
+                "properties": {
+                    "city": { "type": "string" },
+                    "days": { "type": "integer" },
+                    "activities": {
+                        "type": "array",
+                        "items": { "type": "string" }
+                    },
+                    "lodging": {
+                        "type": "object",
+                        "properties": {
+                            "name": { "type": "string" },
+                            "rooms": { "type": "integer" }
+                        },
+                        "required": ["name", "rooms"]
+                    }
+                },
+                "required": ["city", "days", "activities", "lodging"]
+            }
+        },
+        "required": ["itinerary"]
+    })
+}
+
+fn assert_expected_plan_trip_arguments(arguments: &serde_json::Value) {
+    let itinerary = arguments
+        .get("itinerary")
+        .expect("arguments should contain the nested itinerary object");
+    assert_eq!(
+        itinerary.get("city").and_then(|value| value.as_str()),
+        Some("Kyoto"),
+        "nested city should survive the wire format: {arguments:?}"
+    );
+    assert_eq!(
+        itinerary.get("days").and_then(|value| value.as_u64()),
+        Some(3),
+        "nested integer should survive the wire format: {arguments:?}"
+    );
+    assert_eq!(
+        itinerary.get("activities"),
+        Some(&json!(["temples", "tea ceremony"])),
+        "nested string array should survive the wire format: {arguments:?}"
+    );
+    let lodging = itinerary
+        .get("lodging")
+        .expect("arguments should contain the doubly nested lodging object");
+    assert_eq!(
+        lodging.get("name").and_then(|value| value.as_str()),
+        Some("Sakura Inn"),
+        "doubly nested string should survive the wire format: {arguments:?}"
+    );
+    assert_eq!(
+        lodging.get("rooms").and_then(|value| value.as_u64()),
+        Some(2),
+        "doubly nested integer should survive the wire format: {arguments:?}"
+    );
+}
+
+#[tokio::test]
+async fn zero_argument_tool_call_streaming() {
+    with_chatgpt_cassette(
+        "codex_tool_args/zero_argument_tool_call_streaming",
+        |client| async move {
+            let model = client.completion_model(chatgpt::GPT_5_4);
+            let request = model
+                .completion_request(REQUIRED_ZERO_ARG_TOOL_PROMPT)
+                .preamble("Follow the tool-calling instructions exactly.".to_string())
+                .tool(zero_arg_tool_definition("ping"))
+                .build();
+
+            let stream = model
+                .stream(request)
+                .await
+                .expect("zero-arg streaming request should start");
+
+            assert_stream_contains_zero_arg_tool_call_named(stream, "ping", true).await;
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn zero_argument_tool_call_nonstreaming() {
+    with_chatgpt_cassette(
+        "codex_tool_args/zero_argument_tool_call_nonstreaming",
+        |client| async move {
+            let model = client.completion_model(chatgpt::GPT_5_4);
+            let request = model
+                .completion_request(REQUIRED_ZERO_ARG_TOOL_PROMPT)
+                .preamble("Follow the tool-calling instructions exactly.".to_string())
+                .tool(zero_arg_tool_definition("ping"))
+                .build();
+
+            let response = model
+                .completion(request)
+                .await
+                .expect("zero-arg completion should succeed");
+
+            let tool_call = response
+                .choice
+                .iter()
+                .find_map(|content| match content {
+                    AssistantContent::ToolCall(tool_call) => Some(tool_call.clone()),
+                    _ => None,
+                })
+                .expect("response should contain the ping tool call");
+            assert_eq!(tool_call.function.name, "ping");
+            assert_eq!(
+                tool_call.function.arguments,
+                json!({}),
+                "zero-argument tool calls should surface empty-object arguments"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn nested_arguments_roundtrip_nonstreaming() {
+    with_chatgpt_cassette(
+        "codex_tool_args/nested_arguments_roundtrip_nonstreaming",
+        |client| async move {
+            let agent = client
+                .agent(chatgpt::GPT_5_4)
+                .preamble(NESTED_ARGS_PREAMBLE)
+                .tool(PlanTrip)
+                .default_max_turns(4)
+                .build();
+            let mut history = Vec::<Message>::new();
+
+            let result = agent
+                .chat(NESTED_ARGS_PROMPT, &mut history)
+                .await
+                .expect("nested-args tool chat should succeed");
+
+            assert!(
+                result.contains("SAKURA-77"),
+                "final answer should repeat the tool's confirmation code, got {result:?}"
+            );
+
+            let arguments = history
+                .iter()
+                .find_map(|message| match message {
+                    Message::Assistant { content, .. } => {
+                        content.iter().find_map(|item| match item {
+                            AssistantContent::ToolCall(tool_call)
+                                if tool_call.function.name == PlanTrip::NAME =>
+                            {
+                                Some(tool_call.function.arguments.clone())
+                            }
+                            _ => None,
+                        })
+                    }
+                    _ => None,
+                })
+                .expect("chat history should record the plan_trip tool call");
+            assert_expected_plan_trip_arguments(&arguments);
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn nested_arguments_streaming() {
+    with_chatgpt_cassette(
+        "codex_tool_args/nested_arguments_streaming",
+        |client| async move {
+            let model = client.completion_model(chatgpt::GPT_5_4);
+            let request = model
+                .completion_request(NESTED_ARGS_PROMPT)
+                .preamble(NESTED_ARGS_PREAMBLE.to_string())
+                .tool(PlanTrip.definition(String::new()).await)
+                .build();
+
+            let observation = collect_raw_stream_observation(
+                model
+                    .stream(request)
+                    .await
+                    .expect("nested-args streaming request should start"),
+            )
+            .await;
+
+            assert!(
+                observation.errors.is_empty(),
+                "stream should not emit errors: {:?}",
+                observation.errors
+            );
+            let tool_call = observation
+                .tool_calls
+                .iter()
+                .find(|tool_call| tool_call.function.name == PlanTrip::NAME)
+                .expect("stream should emit the plan_trip tool call");
+            assert_expected_plan_trip_arguments(&tool_call.function.arguments);
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn unicode_arguments_streaming() {
+    with_chatgpt_cassette(
+        "codex_tool_args/unicode_arguments_streaming",
+        |client| async move {
+            let model = client.completion_model(chatgpt::GPT_5_4);
+            let request = model
+                .completion_request(
+                    "Call the echo tool exactly once with the message argument set to \
+                     exactly this text: Grüße aus 東京, from the \"naïve café\"!",
+                )
+                .preamble(
+                    "You must call the echo tool with the exact text the user provides. \
+                     Do not translate, reword, or drop any characters."
+                        .to_string(),
+                )
+                .tool(ToolDefinition {
+                    name: "echo".to_string(),
+                    description: "Echo a message back to the user.".to_string(),
+                    parameters: json!({
+                        "type": "object",
+                        "properties": {
+                            "message": { "type": "string" }
+                        },
+                        "required": ["message"]
+                    }),
+                })
+                .build();
+
+            let observation = collect_raw_stream_observation(
+                model
+                    .stream(request)
+                    .await
+                    .expect("unicode-args streaming request should start"),
+            )
+            .await;
+
+            assert!(
+                observation.errors.is_empty(),
+                "stream should not emit errors: {:?}",
+                observation.errors
+            );
+            let tool_call = observation
+                .tool_calls
+                .iter()
+                .find(|tool_call| tool_call.function.name == "echo")
+                .expect("stream should emit the echo tool call");
+            let message = tool_call
+                .function
+                .arguments
+                .get("message")
+                .and_then(|value| value.as_str())
+                .expect("echo arguments should contain a message string");
+            for expected in ["Grüße", "東京", "naïve café"] {
+                assert!(
+                    message.contains(expected),
+                    "streamed unicode arguments should preserve {expected:?}, got {message:?}"
+                );
+            }
+        },
+    )
+    .await;
+}

--- a/tests/providers/chatgpt/cassette/codex_tool_choice.rs
+++ b/tests/providers/chatgpt/cassette/codex_tool_choice.rs
@@ -1,0 +1,203 @@
+//! ChatGPT/Codex Responses backend `tool_choice` regression tests.
+//!
+//! Locks down every `tool_choice` shape the Responses API accepts from Rig:
+//! `required` (forced tool use), `none` (suppressed tool use), a single
+//! specific function (`{"type": "function", "name": ...}`), and multiple
+//! specific functions (`{"type": "allowed_tools", ...}`).
+//!
+//! Run cassette tests in replay mode by default, or set
+//! `RIG_PROVIDER_TEST_MODE=record` to record against the real provider.
+
+use rig::client::CompletionClient;
+use rig::completion::CompletionModel;
+use rig::message::{AssistantContent, ToolChoice};
+use rig::providers::chatgpt;
+use rig::tool::Tool;
+
+use super::super::support::with_chatgpt_cassette;
+use crate::support::{Adder, AlphaSignal, Subtract, TOOLS_PREAMBLE};
+
+fn tool_call_names(choice: &rig::OneOrMany<AssistantContent>) -> Vec<String> {
+    choice
+        .iter()
+        .filter_map(|content| match content {
+            AssistantContent::ToolCall(tool_call) => Some(tool_call.function.name.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn required_forces_a_tool_call() {
+    with_chatgpt_cassette(
+        "codex_tool_choice/required_forces_a_tool_call",
+        |client| async move {
+            let model = client.completion_model(chatgpt::GPT_5_4);
+            let request = model
+                .completion_request("Please greet me.")
+                .preamble(TOOLS_PREAMBLE.to_string())
+                .tool(Adder.definition(String::new()).await)
+                .tool_choice(ToolChoice::Required)
+                .build();
+
+            let response = model
+                .completion(request)
+                .await
+                .expect("required tool choice completion should succeed");
+
+            let names = tool_call_names(&response.choice);
+            assert!(
+                !names.is_empty(),
+                "tool_choice=required must force a tool call even for a chat prompt, got {:?}",
+                response.choice
+            );
+            assert!(
+                names.iter().all(|name| name == Adder::NAME),
+                "only the provided tool can be called, saw {names:?}"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn none_suppresses_tool_calls() {
+    with_chatgpt_cassette(
+        "codex_tool_choice/none_suppresses_tool_calls",
+        |client| async move {
+            let model = client.completion_model(chatgpt::GPT_5_4);
+            let request = model
+                .completion_request("What is 2 plus 3? Reply with just the number.")
+                .preamble(TOOLS_PREAMBLE.to_string())
+                .tool(Adder.definition(String::new()).await)
+                .tool_choice(ToolChoice::None)
+                .build();
+
+            let response = model
+                .completion(request)
+                .await
+                .expect("none tool choice completion should succeed");
+
+            let names = tool_call_names(&response.choice);
+            assert!(
+                names.is_empty(),
+                "tool_choice=none must suppress tool calls, saw {names:?}"
+            );
+            let text: String = response
+                .choice
+                .iter()
+                .filter_map(|content| match content {
+                    AssistantContent::Text(text) => Some(text.text.as_str()),
+                    _ => None,
+                })
+                .collect();
+            assert!(
+                text.contains('5'),
+                "model should answer directly without tools, got {text:?}"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn specific_single_function_targets_named_tool() {
+    with_chatgpt_cassette(
+        "codex_tool_choice/specific_single_function_targets_named_tool",
+        |client| async move {
+            let model = client.completion_model(chatgpt::GPT_5_4);
+            let request = model
+                .completion_request("Compute 9 minus 4 using a tool.")
+                .preamble(TOOLS_PREAMBLE.to_string())
+                .tool(Adder.definition(String::new()).await)
+                .tool(Subtract.definition(String::new()).await)
+                .tool_choice(ToolChoice::Specific {
+                    function_names: vec![Subtract::NAME.to_string()],
+                })
+                .build();
+
+            let response = model
+                .completion(request)
+                .await
+                .expect("specific tool choice completion should succeed");
+
+            let tool_call = response
+                .choice
+                .iter()
+                .find_map(|content| match content {
+                    AssistantContent::ToolCall(tool_call) => Some(tool_call.clone()),
+                    _ => None,
+                })
+                .expect("a specific tool choice must produce a tool call");
+            assert_eq!(
+                tool_call.function.name,
+                Subtract::NAME,
+                "the named tool must be the one called"
+            );
+            assert_eq!(
+                tool_call
+                    .function
+                    .arguments
+                    .get("x")
+                    .and_then(|value| value.as_f64()),
+                Some(9.0),
+                "arguments should reflect the prompt: {:?}",
+                tool_call.function.arguments
+            );
+            assert_eq!(
+                tool_call
+                    .function
+                    .arguments
+                    .get("y")
+                    .and_then(|value| value.as_f64()),
+                Some(4.0),
+                "arguments should reflect the prompt: {:?}",
+                tool_call.function.arguments
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn specific_multiple_functions_use_allowed_tools() {
+    with_chatgpt_cassette(
+        "codex_tool_choice/specific_multiple_functions_use_allowed_tools",
+        |client| async move {
+            let model = client.completion_model(chatgpt::GPT_5_4);
+            let request = model
+                .completion_request("What is 2 plus 3? Use exactly one tool.")
+                .preamble(TOOLS_PREAMBLE.to_string())
+                .tool(Adder.definition(String::new()).await)
+                .tool(Subtract.definition(String::new()).await)
+                .tool(AlphaSignal.definition(String::new()).await)
+                .tool_choice(ToolChoice::Specific {
+                    function_names: vec![Adder::NAME.to_string(), Subtract::NAME.to_string()],
+                })
+                .build();
+
+            let response = model
+                .completion(request)
+                .await
+                .expect("allowed-tools tool choice completion should succeed");
+
+            let names = tool_call_names(&response.choice);
+            assert!(
+                !names.is_empty(),
+                "allowed_tools in required mode must force a tool call, got {:?}",
+                response.choice
+            );
+            assert!(
+                names
+                    .iter()
+                    .all(|name| name == Adder::NAME || name == Subtract::NAME),
+                "only allowed tools may be called, saw {names:?}"
+            );
+            assert!(
+                names.iter().any(|name| name == Adder::NAME),
+                "an addition prompt restricted to add/subtract should call add, saw {names:?}"
+            );
+        },
+    )
+    .await;
+}

--- a/tests/providers/chatgpt/mod.rs
+++ b/tests/providers/chatgpt/mod.rs
@@ -1,6 +1,10 @@
 mod support;
 
 mod cassette {
+    mod codex_behaviors;
+    mod codex_sessions;
+    mod codex_tool_args;
+    mod codex_tool_choice;
     mod streaming_tools;
 }
 

--- a/tests/providers/chatgpt/support.rs
+++ b/tests/providers/chatgpt/support.rs
@@ -5,7 +5,10 @@ use std::panic::AssertUnwindSafe;
 use crate::cassettes::{CassetteSpec, ProviderCassette};
 use futures::FutureExt;
 
-async fn chatgpt_cassette(spec: impl Into<CassetteSpec>) -> (ProviderCassette, chatgpt::Client) {
+async fn chatgpt_cassette_with_default_instructions(
+    spec: impl Into<CassetteSpec>,
+    default_instructions: impl Into<String>,
+) -> (ProviderCassette, chatgpt::Client) {
     let cassette =
         ProviderCassette::start("chatgpt", spec, "https://chatgpt.com/backend-api/codex").await;
     let client = chatgpt::Client::builder()
@@ -14,11 +17,15 @@ async fn chatgpt_cassette(spec: impl Into<CassetteSpec>) -> (ProviderCassette, c
             account_id: Some(cassette.api_key("CHATGPT_ACCOUNT_ID")),
         })
         .base_url(cassette.base_url())
-        .default_instructions("")
+        .default_instructions(default_instructions)
         .build()
         .expect("client should build");
 
     (cassette, client)
+}
+
+async fn chatgpt_cassette(spec: impl Into<CassetteSpec>) -> (ProviderCassette, chatgpt::Client) {
+    chatgpt_cassette_with_default_instructions(spec, "").await
 }
 
 pub(super) async fn with_chatgpt_cassette<F, Fut>(spec: impl Into<CassetteSpec>, test_body: F)
@@ -27,6 +34,20 @@ where
     Fut: Future<Output = ()>,
 {
     let (cassette, client) = chatgpt_cassette(spec).await;
+    let result = AssertUnwindSafe(test_body(client)).catch_unwind().await;
+    cassette.finish_after_test(result).await;
+}
+
+pub(super) async fn with_chatgpt_cassette_default_instructions<F, Fut>(
+    spec: impl Into<CassetteSpec>,
+    default_instructions: impl Into<String>,
+    test_body: F,
+) where
+    F: FnOnce(chatgpt::Client) -> Fut,
+    Fut: Future<Output = ()>,
+{
+    let (cassette, client) =
+        chatgpt_cassette_with_default_instructions(spec, default_instructions).await;
     let result = AssertUnwindSafe(test_body(client)).catch_unwind().await;
     cassette.finish_after_test(result).await;
 }


### PR DESCRIPTION
## Summary

Adds a broad ChatGPT/Codex backend cassette regression suite covering production-style long-running sessions and provider quirks:

- Multi-turn sequential tool loops, parallel tool calls, long chat-history replay, and streaming usage aggregation.
- Tool argument shapes: empty objects, nested JSON objects/arrays, and escaped/unicode strings, in streaming and non-streaming paths.
- Streaming SSE reconstruction for `response.function_call_arguments.delta`, `response.function_call_arguments.done`, and `response.output_item.done`, including terminal `response.completed` payloads with `output: []`.
- Tool result continuation after assistant tool calls and parity-oriented streaming/non-streaming scenarios.
- ChatGPT-specific behavior: `store:false`, prompt cache fields, scrubbed safety identifiers, encrypted reasoning include/roundtrip, default instruction merging, and lifted system instructions.
- Tool-choice coverage for required, none, named function, and allowed-tools shapes.

Also documents ChatGPT cassette replay/record commands and updates cassette safety registration for the new default-instructions helper.

## Inspiration references used

Read and adapted coverage ideas from:

- `tests/providers/openai/cassette/responses_sessions.rs`
- `tests/providers/openai/cassette/responses_tool_args.rs`
- `tests/providers/openai/cassette/responses_tool_choice.rs`
- `tests/providers/openai/cassette/responses_behaviors.rs`
- `/Users/kisaczka/Desktop/code/many_rigs/inspirations/vercel-ai-sdk/packages/openai/src/responses/openai-responses-language-model.test.ts`
- `/Users/kisaczka/Desktop/code/many_rigs/inspirations/vercel-ai-sdk/packages/openai/src/responses/convert-to-openai-responses-input.test.ts`
- `/Users/kisaczka/Desktop/code/many_rigs/inspirations/pydantic-ai/tests/models/test_openai.py`
- `/Users/kisaczka/Desktop/code/many_rigs/inspirations/semantic-kernel/python/tests/unit/agents/open_ai/test_openai_responses_agent_reasoning.py`
- `/Users/kisaczka/Desktop/code/many_rigs/inspirations/semantic-kernel/python/tests/unit/agents/openai_responses/test_openai_responses_agent.py`
- `/Users/kisaczka/Desktop/code/many_rigs/inspirations/langchain/libs/partners/openai/tests/unit_tests/chat_models/test_base.py`

## Bugs found and fixed

No Rig provider bug was found while recording these cassettes, so this PR is test coverage only plus cassette helper/docs wiring.

Recording notes:

- `gpt-5.3-codex` was rejected by the live ChatGPT account as unsupported for this account, so the suite records against `gpt-5.4` on the ChatGPT Codex backend endpoint.
- One live recording attempt hit a transient `server_is_overloaded` SSE error; the targeted cassette was re-recorded successfully.

## Recording/replay commands run

Credential inspection:

```bash
python3 - <<'PY'
import json, pathlib
p=pathlib.Path.home()/'.config/chatgpt/auth.json'
print('exists', p.exists())
if p.exists():
    data=json.loads(p.read_text())
    required=['access_token','refresh_token','id_token','account_id','expires_at']
    print('required_keys_present', all(k in data and bool(data[k]) for k in required))
    print('keys_checked', ','.join(required))
PY
```

Successful recording:

```bash
CHATGPT_ACCESS_TOKEN="$(python3 - <<'PY'
import json, pathlib
print(json.loads((pathlib.Path.home()/'.config/chatgpt/auth.json').read_text())['access_token'])
PY
)" \
CHATGPT_ACCOUNT_ID="$(python3 - <<'PY'
import json, pathlib
print(json.loads((pathlib.Path.home()/'.config/chatgpt/auth.json').read_text())['account_id'])
PY
)" \
RIG_PROVIDER_TEST_MODE=record \
cargo test -p rig --all-features --test chatgpt codex -- --nocapture --test-threads=1
```

Targeted retry after transient overload:

```bash
CHATGPT_ACCESS_TOKEN="$(python3 - <<'PY'
import json, pathlib
print(json.loads((pathlib.Path.home()/'.config/chatgpt/auth.json').read_text())['access_token'])
PY
)" \
CHATGPT_ACCOUNT_ID="$(python3 - <<'PY'
import json, pathlib
print(json.loads((pathlib.Path.home()/'.config/chatgpt/auth.json').read_text())['account_id'])
PY
)" \
RIG_PROVIDER_TEST_MODE=record \
cargo test -p rig --all-features --test chatgpt reasoning_session_two_tool_calls_streaming -- --nocapture --test-threads=1
```

Replay without credentials:

```bash
env -u CHATGPT_ACCESS_TOKEN -u CHATGPT_ACCOUNT_ID \
cargo test -p rig --all-features --test chatgpt chatgpt::cassette -- --nocapture --test-threads=1
```

## Validation

Passed:

```bash
cargo fmt
cargo test -p rig --all-features --test chatgpt chatgpt::cassette -- --nocapture --test-threads=1
cargo test -p rig --all-features --test chatgpt cassette_safety -- --nocapture
cargo test -p rig --all-features --test chatgpt -- --nocapture --test-threads=1
cargo test -p rig-core providers::chatgpt -- --nocapture
cargo clippy --all-targets --all-features
cargo test -p rig --all-features --no-run
```

Broad default-feature check attempted:

```bash
cargo test -p rig
```

This failed to compile unrelated Gemini image-generation cassette tests because the default-feature build does not enable the `image` feature, while `tests/providers/gemini/cassette/image_generation.rs` references image-gated APIs. The all-features test build (`cargo test -p rig --all-features --no-run`) passed.

## OAuth credential safety and cassette inspection

- Confirmed `~/.config/chatgpt/auth.json` exists and contains `access_token`, `refresh_token`, `id_token`, `account_id`, and `expires_at` without printing token values.
- Used `access_token` and `account_id` only through environment variables for recording commands.
- Manually inspected representative cassette YAMLs for request/response shape, including tool arguments, tool continuations, reasoning encrypted content, `store:false`, prompt cache fields, safety identifiers, and terminal `output: []` SSE reconstruction.
- Ran cassette safety tests and an additional local scan confirming no access token, refresh token, id token, account id, bearer token, cookies, or ChatGPT account-id header values were present in committed ChatGPT cassettes.

## Remaining known gaps / non-goals

- The suite records against `gpt-5.4` because the available ChatGPT account rejected `gpt-5.3-codex`; coverage still targets the ChatGPT Codex backend path.
- No public provider behavior changes are included.
- The suite avoids exact prose assertions where possible and focuses on structural behavior, tool ordering, argument shape, usage, and wire payloads.
