### PR TITLE
Gate Gemini image cassette tests on image feature

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,6 +112,13 @@ jobs:
       - name: Install Protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
 
+      # `nextest` below runs with `--all-features`, which does not compile the
+      # default-feature test graph. Build the root integration tests with the
+      # default feature set so feature-gated test modules cannot accidentally
+      # depend on APIs that only exist under optional features.
+      - name: Compile default-feature root test targets
+        run: cargo test -p rig --tests --no-run
+
       - name: Test with latest nextest release
         uses: actions-rs/cargo@v1
         with:

--- a/tests/providers/gemini/mod.rs
+++ b/tests/providers/gemini/mod.rs
@@ -18,6 +18,7 @@ mod cassette {
     mod generate_sessions;
     mod generate_tool_args;
     mod generate_tool_modes;
+    #[cfg(feature = "image")]
     mod image_generation;
     mod interactions_api;
     mod models;


### PR DESCRIPTION
## Summary
- Gates the Gemini image-generation cassette module behind `#[cfg(feature = "image")]`.
- Adds a CI default-feature test-target compile step: `cargo test -p rig --tests --no-run`.
- This prevents CI from only validating the `--all-features` graph and missing root integration-test compile failures when optional features are disabled.

## Why CI passed before
- The CI test job ran `cargo nextest run --all-features --retries 2`.
- The Gemini image-generation test module compiled under `--all-features` because the `image` feature was enabled, so `rig::image_generation`, `ImageGenerationClient`, and `GEMINI_2_5_FLASH_IMAGE` existed.
- A plain `cargo test` uses the default feature set, where `image` is disabled; the ungated Gemini image-generation test module still compiled and referenced image-only APIs, causing the failure.
- The new CI no-run step compiles the root integration-test targets with default features before the all-features nextest run.

## Validation
- `cargo fmt --check`
- `cargo test -p rig --tests --no-run`
- `cargo test -p rig --test gemini -- --nocapture --test-threads=1`
- `cargo test -p rig --all-features --test gemini image_generation -- --nocapture --test-threads=1`
- `cargo clippy --all-targets --all-features`
- `cargo test` was also run. The prior Gemini image-generation compile failure is fixed; the run later fails on an unrelated existing OpenAI cassette replay mismatch in `openai::cassette::permission_control::permission_control_streaming_example`.

## Notes
- No cassette fixtures changed.
- The Gemini test gating mirrors existing image-feature gating used by OpenAI, xAI, HuggingFace, and other image-generation provider tests.
