### PR TITLE
test(gemini): live cassette hook-system stress suite

### DIFF
--- a/tests/cassettes/gemini/hook_stress/chained_arg_rewrite_then_result_redaction_blocking.yaml
+++ b/tests/cassettes/gemini/hook_stress/chained_arg_rewrite_then_result_redaction_blocking.yaml
@@ -1,0 +1,37 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the add tool to add 2 and 2, then report the exact tool result.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the add tool for the addition. After the tool result is available, report the exact tool result text verbatim as your final answer.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":2,"y":2},"name":"add"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":18,"promptTokenCount":106,"promptTokensDetails":[{"modality":"TEXT","tokenCount":106}],"serviceTier":"standard","thoughtsTokenCount":50,"totalTokenCount":174}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the add tool to add 2 and 2, then report the exact tool result.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":2,"y":2},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":"REDACTED-SUM-ZK7"}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the add tool for the addition. After the tool result is available, report the exact tool result text verbatim as your final answer.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"{\"add_response\": {\"result\": \"REDACTED-SUM-ZK7\"}}"}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_2","usageMetadata":{"candidatesTokenCount":18,"promptTokenCount":144,"promptTokensDetails":[{"modality":"TEXT","tokenCount":144}],"serviceTier":"standard","totalTokenCount":162}}'

--- a/tests/cassettes/gemini/hook_stress/lifecycle_and_scratchpad_thread_across_multi_turn_blocking.yaml
+++ b/tests/cassettes/gemini/hook_stress/lifecycle_and_scratchpad_thread_across_multi_turn_blocking.yaml
@@ -1,0 +1,56 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"First add 10 and 5 with the add tool. Then subtract 3 from that sum with the subtract tool. Report the final number.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Perform the steps in order, using the result of each step as an input to the next. Once you have the final tool result, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":10,"y":5},"name":"add"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":19,"promptTokenCount":199,"promptTokensDetails":[{"modality":"TEXT","tokenCount":199}],"serviceTier":"standard","thoughtsTokenCount":91,"totalTokenCount":309}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"First add 10 and 5 with the add tool. Then subtract 3 from that sum with the subtract tool. Report the final number.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":10,"y":5},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":15}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Perform the steps in order, using the result of each step as an input to the next. Once you have the final tool result, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":15,"y":3},"name":"subtract"},"thoughtSignature":"signature_REDACTED_2"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_2","usageMetadata":{"candidatesTokenCount":19,"promptTokenCount":232,"promptTokensDetails":[{"modality":"TEXT","tokenCount":232}],"serviceTier":"standard","thoughtsTokenCount":41,"totalTokenCount":292}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"First add 10 and 5 with the add tool. Then subtract 3 from that sum with the subtract tool. Report the final number.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":10,"y":5},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":15}},"thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":15,"y":3},"name":"subtract"},"thought":false,"thoughtSignature":"signature_REDACTED_2"}],"role":"model"},{"parts":[{"functionResponse":{"name":"subtract","response":{"result":12}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Perform the steps in order, using the result of each step as an input to the next. Once you have the final tool result, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"12","thoughtSignature":"signature_REDACTED_3"}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_3","usageMetadata":{"candidatesTokenCount":2,"promptTokenCount":265,"promptTokensDetails":[{"modality":"TEXT","tokenCount":265}],"serviceTier":"standard","thoughtsTokenCount":43,"totalTokenCount":310}}'

--- a/tests/cassettes/gemini/hook_stress/multi_tool_workflow_pairs_calls_and_results_per_turn_blocking.yaml
+++ b/tests/cassettes/gemini/hook_stress/multi_tool_workflow_pairs_calls_and_results_per_turn_blocking.yaml
@@ -1,0 +1,37 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Independently compute 12 + 8 using the add tool and 30 - 7 using the subtract tool, then report both results.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation. These two computations are independent — you may request them together. Once you have both results, report both numbers.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":12,"y":8},"name":"add"},"thoughtSignature":"signature_REDACTED_1"},{"functionCall":{"args":{"x":30,"y":7},"name":"subtract"}}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":38,"promptTokenCount":180,"promptTokensDetails":[{"modality":"TEXT","tokenCount":180}],"serviceTier":"standard","thoughtsTokenCount":62,"totalTokenCount":280}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Independently compute 12 + 8 using the add tool and 30 - 7 using the subtract tool, then report both results.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":12,"y":8},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"},{"functionCall":{"args":{"x":30,"y":7},"name":"subtract"},"thought":false}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":20}},"thought":false},{"functionResponse":{"name":"subtract","response":{"result":23}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation. These two computations are independent — you may request them together. Once you have both results, report both numbers.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"The sum of 12 and 8 is 20, and the difference of 30 and 7 is 23."}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_2","usageMetadata":{"candidatesTokenCount":29,"promptTokenCount":244,"promptTokensDetails":[{"modality":"TEXT","tokenCount":244}],"serviceTier":"standard","totalTokenCount":273}}'

--- a/tests/cassettes/gemini/hook_stress/request_patch_injects_context_and_narrows_active_tools_blocking.yaml
+++ b/tests/cassettes/gemini/hook_stress/request_patch_injects_context_and_narrows_active_tools_blocking.yaml
@@ -1,0 +1,37 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"<file id: vault-note>\nOperational note: the vault access code is CINNABAR-42.\n</file>\n","thought":false}],"role":"user"},{"parts":[{"text":"Two things: (1) tell me the vault access code, and (2) use a tool to compute 41 + 1.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a helpful assistant. Use a tool for any arithmetic. Consult the provided context for any facts you are asked about.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":41,"y":1},"name":"add"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":19,"promptTokenCount":137,"promptTokensDetails":[{"modality":"TEXT","tokenCount":137}],"serviceTier":"standard","thoughtsTokenCount":121,"totalTokenCount":277}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"<file id: vault-note>\nOperational note: the vault access code is CINNABAR-42.\n</file>\n","thought":false}],"role":"user"},{"parts":[{"text":"Two things: (1) tell me the vault access code, and (2) use a tool to compute 41 + 1.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":41,"y":1},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":42}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a helpful assistant. Use a tool for any arithmetic. Consult the provided context for any facts you are asked about.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"The vault access code is CINNABAR-42. 41 + 1 = 42."}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_2","usageMetadata":{"candidatesTokenCount":24,"promptTokenCount":170,"promptTokensDetails":[{"modality":"TEXT","tokenCount":170}],"serviceTier":"standard","totalTokenCount":194}}'

--- a/tests/cassettes/gemini/hook_stress/skip_in_multi_tool_workflow_leaves_tool_unexecuted_blocking.yaml
+++ b/tests/cassettes/gemini/hook_stress/skip_in_multi_tool_workflow_leaves_tool_unexecuted_blocking.yaml
@@ -1,0 +1,37 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the add tool to compute 14 + 6, and use the subtract tool to compute 40 - 9. Report what you can.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation. If a tool reports it is unavailable, acknowledge that in your answer and still report any results you do have.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":14,"y":6},"name":"add"},"thoughtSignature":"signature_REDACTED_1"},{"functionCall":{"args":{"x":40,"y":9},"name":"subtract"}}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":38,"promptTokenCount":181,"promptTokensDetails":[{"modality":"TEXT","tokenCount":181}],"serviceTier":"standard","thoughtsTokenCount":51,"totalTokenCount":270}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the add tool to compute 14 + 6, and use the subtract tool to compute 40 - 9. Report what you can.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":14,"y":6},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"},{"functionCall":{"args":{"x":40,"y":9},"name":"subtract"},"thought":false}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":20}},"thought":false},{"functionResponse":{"name":"subtract","response":{"result":"the subtract tool is offline; treat its result as unavailable and continue"}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation. If a tool reports it is unavailable, acknowledge that in your answer and still report any results you do have.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"14 + 6 = 20. The subtract tool is unavailable, so I cannot compute 40 - 9.","thoughtSignature":"signature_REDACTED_2"}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_2","usageMetadata":{"candidatesTokenCount":27,"promptTokenCount":256,"promptTokensDetails":[{"modality":"TEXT","tokenCount":256}],"serviceTier":"standard","thoughtsTokenCount":85,"totalTokenCount":368}}'

--- a/tests/cassettes/gemini/hook_stress/streaming_lifecycle_ordering_and_context_streaming_flag.yaml
+++ b/tests/cassettes/gemini/hook_stress/streaming_lifecycle_ordering_and_context_streaming_flag.yaml
@@ -1,0 +1,62 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"First add 20 and 5 with the add tool. Then subtract 4 from that sum with the subtract tool. Report the final number.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Perform the steps in order, using the result of each step as an input to the next. Once you have the final tool result, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"args\":{\"x\":20,\"y\":5},\"name\":\"add\"},\"thoughtSignature\":\"signature_REDACTED_1\"}],\"role\":\"model\"},\"finishMessage\":\"Model generated function call(s).\",\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_1\",\"usageMetadata\":{\"candidatesTokenCount\":19,\"promptTokenCount\":199,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":199}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":74,\"totalTokenCount\":292}}\r\n\r\n"
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"First add 20 and 5 with the add tool. Then subtract 4 from that sum with the subtract tool. Report the final number.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":20,"y":5},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":25}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Perform the steps in order, using the result of each step as an input to the next. Once you have the final tool result, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"args\":{\"x\":25,\"y\":4},\"name\":\"subtract\"},\"thoughtSignature\":\"signature_REDACTED_2\"}],\"role\":\"model\"},\"finishMessage\":\"Model generated function call(s).\",\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_2\",\"usageMetadata\":{\"candidatesTokenCount\":19,\"promptTokenCount\":306,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":306}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":52,\"totalTokenCount\":377}}\r\n\r\n"
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"First add 20 and 5 with the add tool. Then subtract 4 from that sum with the subtract tool. Report the final number.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":20,"y":5},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":25}},"thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":25,"y":4},"name":"subtract"},"thought":false,"thoughtSignature":"signature_REDACTED_2"}],"role":"model"},{"parts":[{"functionResponse":{"name":"subtract","response":{"result":21}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Perform the steps in order, using the result of each step as an input to the next. Once you have the final tool result, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"21\",\"thoughtSignature\":\"signature_REDACTED_3\"}],\"role\":\"model\"},\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_3\",\"usageMetadata\":{\"candidatesTokenCount\":2,\"promptTokenCount\":391,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":391}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":14,\"totalTokenCount\":407}}\r\n\r\n"

--- a/tests/cassettes/gemini/hook_stress_context/add_hook_appends_across_builder_and_request_blocking.yaml
+++ b/tests/cassettes/gemini/hook_stress_context/add_hook_appends_across_builder_and_request_blocking.yaml
@@ -1,0 +1,37 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the add tool to add 5 and 6, then report the result.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Perform the steps in order, using the result of each step as an input to the next. Once you have the final tool result, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":5,"y":6},"name":"add"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":18,"promptTokenCount":128,"promptTokensDetails":[{"modality":"TEXT","tokenCount":128}],"serviceTier":"standard","thoughtsTokenCount":43,"totalTokenCount":189}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the add tool to add 5 and 6, then report the result.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":5,"y":6},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":11}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Perform the steps in order, using the result of each step as an input to the next. Once you have the final tool result, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"11"}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_2","usageMetadata":{"candidatesTokenCount":2,"promptTokenCount":160,"promptTokensDetails":[{"modality":"TEXT","tokenCount":160}],"serviceTier":"standard","totalTokenCount":162}}'

--- a/tests/cassettes/gemini/hook_stress_context/agent_name_absent_when_unconfigured_blocking.yaml
+++ b/tests/cassettes/gemini/hook_stress_context/agent_name_absent_when_unconfigured_blocking.yaml
@@ -1,0 +1,37 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the add tool to add 3 and 4, then report the result.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Perform the steps in order, using the result of each step as an input to the next. Once you have the final tool result, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":3,"y":4},"name":"add"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":18,"promptTokenCount":128,"promptTokensDetails":[{"modality":"TEXT","tokenCount":128}],"serviceTier":"standard","thoughtsTokenCount":63,"totalTokenCount":209}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the add tool to add 3 and 4, then report the result.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":3,"y":4},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":7}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Perform the steps in order, using the result of each step as an input to the next. Once you have the final tool result, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"7"}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_2","usageMetadata":{"candidatesTokenCount":1,"promptTokenCount":159,"promptTokensDetails":[{"modality":"TEXT","tokenCount":159}],"serviceTier":"standard","totalTokenCount":160}}'

--- a/tests/cassettes/gemini/hook_stress_context/completion_call_patches_accumulate_from_two_hooks_blocking.yaml
+++ b/tests/cassettes/gemini/hook_stress_context/completion_call_patches_accumulate_from_two_hooks_blocking.yaml
@@ -1,0 +1,18 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"<file id: harbor>\nThe harbor code is ALPHA-11.\n</file>\n","thought":false},{"text":"<file id: orchard>\nThe orchard code is BETA-22.\n</file>\n","thought":false}],"role":"user"},{"parts":[{"text":"Tell me both the harbor code and the orchard code.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a helpful assistant. Consult the provided context for any facts you are asked about; use a tool for arithmetic.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"The harbor code is ALPHA-11 and the orchard code is BETA-22.","thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":18,"promptTokenCount":130,"promptTokensDetails":[{"modality":"TEXT","tokenCount":130}],"serviceTier":"standard","thoughtsTokenCount":99,"totalTokenCount":247}}'

--- a/tests/cassettes/gemini/hook_stress_context/hook_context_identity_stable_and_turn_advances_blocking.yaml
+++ b/tests/cassettes/gemini/hook_stress_context/hook_context_identity_stable_and_turn_advances_blocking.yaml
@@ -1,0 +1,56 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"First add 9 and 6 with the add tool. Then subtract 4 from that sum with the subtract tool. Report the final number.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Perform the steps in order, using the result of each step as an input to the next. Once you have the final tool result, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":9,"y":6},"name":"add"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":18,"promptTokenCount":198,"promptTokensDetails":[{"modality":"TEXT","tokenCount":198}],"serviceTier":"standard","thoughtsTokenCount":90,"totalTokenCount":306}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"First add 9 and 6 with the add tool. Then subtract 4 from that sum with the subtract tool. Report the final number.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":9,"y":6},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":15}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Perform the steps in order, using the result of each step as an input to the next. Once you have the final tool result, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":15,"y":4},"name":"subtract"},"thoughtSignature":"signature_REDACTED_2"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_2","usageMetadata":{"candidatesTokenCount":19,"promptTokenCount":230,"promptTokensDetails":[{"modality":"TEXT","tokenCount":230}],"serviceTier":"standard","thoughtsTokenCount":55,"totalTokenCount":304}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"First add 9 and 6 with the add tool. Then subtract 4 from that sum with the subtract tool. Report the final number.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":9,"y":6},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":15}},"thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":15,"y":4},"name":"subtract"},"thought":false,"thoughtSignature":"signature_REDACTED_2"}],"role":"model"},{"parts":[{"functionResponse":{"name":"subtract","response":{"result":11}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Perform the steps in order, using the result of each step as an input to the next. Once you have the final tool result, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"11","thoughtSignature":"signature_REDACTED_3"}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_3","usageMetadata":{"candidatesTokenCount":2,"promptTokenCount":263,"promptTokensDetails":[{"modality":"TEXT","tokenCount":263}],"serviceTier":"standard","thoughtsTokenCount":42,"totalTokenCount":307}}'

--- a/tests/cassettes/gemini/hook_stress_context/internal_call_id_correlates_tool_call_and_result_blocking.yaml
+++ b/tests/cassettes/gemini/hook_stress_context/internal_call_id_correlates_tool_call_and_result_blocking.yaml
@@ -1,0 +1,56 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"First add 7 and 7 with the add tool. Then subtract 2 from that sum with the subtract tool. Report the final number.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Perform the steps in order, using the result of each step as an input to the next. Once you have the final tool result, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":7,"y":7},"name":"add"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":18,"promptTokenCount":198,"promptTokensDetails":[{"modality":"TEXT","tokenCount":198}],"serviceTier":"standard","thoughtsTokenCount":76,"totalTokenCount":292}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"First add 7 and 7 with the add tool. Then subtract 2 from that sum with the subtract tool. Report the final number.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":7,"y":7},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":14}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Perform the steps in order, using the result of each step as an input to the next. Once you have the final tool result, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":14,"y":2},"name":"subtract"},"thoughtSignature":"signature_REDACTED_2"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_2","usageMetadata":{"candidatesTokenCount":19,"promptTokenCount":230,"promptTokensDetails":[{"modality":"TEXT","tokenCount":230}],"serviceTier":"standard","thoughtsTokenCount":52,"totalTokenCount":301}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"First add 7 and 7 with the add tool. Then subtract 2 from that sum with the subtract tool. Report the final number.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":7,"y":7},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":14}},"thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":14,"y":2},"name":"subtract"},"thought":false,"thoughtSignature":"signature_REDACTED_2"}],"role":"model"},{"parts":[{"functionResponse":{"name":"subtract","response":{"result":12}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Perform the steps in order, using the result of each step as an input to the next. Once you have the final tool result, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"12","thoughtSignature":"signature_REDACTED_3"}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_3","usageMetadata":{"candidatesTokenCount":2,"promptTokenCount":263,"promptTokensDetails":[{"modality":"TEXT","tokenCount":263}],"serviceTier":"standard","thoughtsTokenCount":57,"totalTokenCount":322}}'

--- a/tests/cassettes/gemini/hook_stress_context/scratchpad_tally_grows_across_turns_and_is_read_by_second_hook_blocking.yaml
+++ b/tests/cassettes/gemini/hook_stress_context/scratchpad_tally_grows_across_turns_and_is_read_by_second_hook_blocking.yaml
@@ -1,0 +1,56 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"First add 30 and 12 with the add tool. Then subtract 5 from that sum with the subtract tool. Report the final number.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Perform the steps in order, using the result of each step as an input to the next. Once you have the final tool result, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":30,"y":12},"name":"add"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":20,"promptTokenCount":200,"promptTokensDetails":[{"modality":"TEXT","tokenCount":200}],"serviceTier":"standard","thoughtsTokenCount":66,"totalTokenCount":286}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"First add 30 and 12 with the add tool. Then subtract 5 from that sum with the subtract tool. Report the final number.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":30,"y":12},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":42}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Perform the steps in order, using the result of each step as an input to the next. Once you have the final tool result, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":42,"y":5},"name":"subtract"},"thoughtSignature":"signature_REDACTED_2"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_2","usageMetadata":{"candidatesTokenCount":19,"promptTokenCount":234,"promptTokensDetails":[{"modality":"TEXT","tokenCount":234}],"serviceTier":"standard","thoughtsTokenCount":56,"totalTokenCount":309}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"First add 30 and 12 with the add tool. Then subtract 5 from that sum with the subtract tool. Report the final number.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":30,"y":12},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":42}},"thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":42,"y":5},"name":"subtract"},"thought":false,"thoughtSignature":"signature_REDACTED_2"}],"role":"model"},{"parts":[{"functionResponse":{"name":"subtract","response":{"result":37}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Perform the steps in order, using the result of each step as an input to the next. Once you have the final tool result, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"37","thoughtSignature":"signature_REDACTED_3"}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_3","usageMetadata":{"candidatesTokenCount":2,"promptTokenCount":267,"promptTokensDetails":[{"modality":"TEXT","tokenCount":267}],"serviceTier":"standard","thoughtsTokenCount":29,"totalTokenCount":298}}'

--- a/tests/cassettes/gemini/hook_stress_context/two_hooks_narrow_active_tools_to_intersection_blocking.yaml
+++ b/tests/cassettes/gemini/hook_stress_context/two_hooks_narrow_active_tools_to_intersection_blocking.yaml
@@ -1,0 +1,37 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Compute 6 + 2, then 10 - 3, then 4 * 5. Report whichever results you can obtain.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. Use a provided tool for any arithmetic you can. If a needed tool is unavailable, say so and move on.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":6,"y":2},"name":"add"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":18,"promptTokenCount":110,"promptTokensDetails":[{"modality":"TEXT","tokenCount":110}],"serviceTier":"standard","thoughtsTokenCount":79,"totalTokenCount":207}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Compute 6 + 2, then 10 - 3, then 4 * 5. Report whichever results you can obtain.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":6,"y":2},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":8}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. Use a provided tool for any arithmetic you can. If a needed tool is unavailable, say so and move on.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"I can compute 6 + 2 = 8. I cannot compute 10 - 3 or 4 * 5, as I do not have the capability to subtract or multiply."}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_2","usageMetadata":{"candidatesTokenCount":40,"promptTokenCount":141,"promptTokensDetails":[{"modality":"TEXT","tokenCount":141}],"serviceTier":"standard","totalTokenCount":181}}'

--- a/tests/cassettes/gemini/hook_stress_context/two_observe_only_hooks_both_observe_the_run_blocking.yaml
+++ b/tests/cassettes/gemini/hook_stress_context/two_observe_only_hooks_both_observe_the_run_blocking.yaml
@@ -1,0 +1,37 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the add tool to add 8 and 8, then report the result.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Perform the steps in order, using the result of each step as an input to the next. Once you have the final tool result, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":8,"y":8},"name":"add"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":18,"promptTokenCount":128,"promptTokensDetails":[{"modality":"TEXT","tokenCount":128}],"serviceTier":"standard","thoughtsTokenCount":44,"totalTokenCount":190}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the add tool to add 8 and 8, then report the result.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":8,"y":8},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":16}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Perform the steps in order, using the result of each step as an input to the next. Once you have the final tool result, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"16"}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_2","usageMetadata":{"candidatesTokenCount":2,"promptTokenCount":160,"promptTokensDetails":[{"modality":"TEXT","tokenCount":160}],"serviceTier":"standard","totalTokenCount":162}}'

--- a/tests/cassettes/gemini/hook_stress_patch/history_replacement_injects_prior_fact_blocking.yaml
+++ b/tests/cassettes/gemini/hook_stress_patch/history_replacement_injects_prior_fact_blocking.yaml
@@ -1,0 +1,18 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"For this session, the passphrase is OMEGA-7. Acknowledge and remember it.","thought":false}],"role":"user"},{"parts":[{"text":"What is the passphrase?","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a helpful assistant. Use the conversation so far to answer.","thought":false}],"role":"model"},"toolConfig":null}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"The passphrase is OMEGA-7. I have acknowledged and remembered it."}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":15,"promptTokenCount":41,"promptTokensDetails":[{"modality":"TEXT","tokenCount":41}],"serviceTier":"standard","thoughtsTokenCount":36,"totalTokenCount":92}}'

--- a/tests/cassettes/gemini/hook_stress_patch/multi_field_patch_applies_preamble_and_context_blocking.yaml
+++ b/tests/cassettes/gemini/hook_stress_patch/multi_field_patch_applies_preamble_and_context_blocking.yaml
@@ -1,0 +1,18 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"<file id: depot>\nThe depot code is GAMMA-33.\n</file>\n","thought":false}],"role":"user"},{"parts":[{"text":"What is the depot code? Keep it short.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a terse assistant. End every reply with the exact token ZULU-99.","thought":false}],"role":"model"},"toolConfig":null}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"GAMMA-33 ZULU-99"}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":9,"promptTokenCount":53,"promptTokensDetails":[{"modality":"TEXT","tokenCount":53}],"serviceTier":"standard","thoughtsTokenCount":47,"totalTokenCount":109}}'

--- a/tests/cassettes/gemini/hook_stress_patch/preamble_override_forces_codeword_blocking.yaml
+++ b/tests/cassettes/gemini/hook_stress_patch/preamble_override_forces_codeword_blocking.yaml
@@ -1,0 +1,18 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Greet me in one short sentence.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a terse assistant. End every reply with the exact token ZULU-99 on its own, verbatim.","thought":false}],"role":"model"},"toolConfig":null}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"Hello.\nZULU-99"}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":8,"promptTokenCount":33,"promptTokensDetails":[{"modality":"TEXT","tokenCount":33}],"serviceTier":"standard","thoughtsTokenCount":31,"totalTokenCount":72}}'

--- a/tests/cassettes/gemini/hook_stress_patch/tool_choice_required_forces_a_tool_call_blocking.yaml
+++ b/tests/cassettes/gemini/hook_stress_patch/tool_choice_required_forces_a_tool_call_blocking.yaml
@@ -1,0 +1,37 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the add tool to compute 12 plus 30, then report the number.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant.","thought":false}],"role":"model"},"toolConfig":{"functionCallingConfig":{"mode":"ANY"}},"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":12,"y":30},"name":"add"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":20,"promptTokenCount":77,"promptTokensDetails":[{"modality":"TEXT","tokenCount":77}],"serviceTier":"standard","thoughtsTokenCount":66,"totalTokenCount":163}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the add tool to compute 12 plus 30, then report the number.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":12,"y":30},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":42}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"The sum is 42."}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_2","usageMetadata":{"candidatesTokenCount":7,"promptTokenCount":111,"promptTokensDetails":[{"modality":"TEXT","tokenCount":111}],"serviceTier":"standard","totalTokenCount":118}}'

--- a/tests/cassettes/gemini/hook_stress_streaming/parity_blocking.yaml
+++ b/tests/cassettes/gemini/hook_stress_streaming/parity_blocking.yaml
@@ -1,0 +1,56 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"First add 10 and 5 with the add tool. Then subtract 3 from that sum with the subtract tool. Report the final number.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Perform the steps in order, using the result of each step as an input to the next. Once you have the final tool result, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":10,"y":5},"name":"add"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":19,"promptTokenCount":199,"promptTokensDetails":[{"modality":"TEXT","tokenCount":199}],"serviceTier":"standard","thoughtsTokenCount":99,"totalTokenCount":317}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"First add 10 and 5 with the add tool. Then subtract 3 from that sum with the subtract tool. Report the final number.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":10,"y":5},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":15}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Perform the steps in order, using the result of each step as an input to the next. Once you have the final tool result, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":15,"y":3},"name":"subtract"},"thoughtSignature":"signature_REDACTED_2"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_2","usageMetadata":{"candidatesTokenCount":19,"promptTokenCount":232,"promptTokensDetails":[{"modality":"TEXT","tokenCount":232}],"serviceTier":"standard","thoughtsTokenCount":54,"totalTokenCount":305}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"First add 10 and 5 with the add tool. Then subtract 3 from that sum with the subtract tool. Report the final number.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":10,"y":5},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":15}},"thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":15,"y":3},"name":"subtract"},"thought":false,"thoughtSignature":"signature_REDACTED_2"}],"role":"model"},{"parts":[{"functionResponse":{"name":"subtract","response":{"result":12}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Perform the steps in order, using the result of each step as an input to the next. Once you have the final tool result, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"12","thoughtSignature":"signature_REDACTED_3"}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_3","usageMetadata":{"candidatesTokenCount":2,"promptTokenCount":265,"promptTokensDetails":[{"modality":"TEXT","tokenCount":265}],"serviceTier":"standard","thoughtsTokenCount":39,"totalTokenCount":306}}'

--- a/tests/cassettes/gemini/hook_stress_streaming/parity_streaming.yaml
+++ b/tests/cassettes/gemini/hook_stress_streaming/parity_streaming.yaml
@@ -1,0 +1,62 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"First add 10 and 5 with the add tool. Then subtract 3 from that sum with the subtract tool. Report the final number.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Perform the steps in order, using the result of each step as an input to the next. Once you have the final tool result, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"args\":{\"x\":10,\"y\":5},\"name\":\"add\"},\"thoughtSignature\":\"signature_REDACTED_1\"}],\"role\":\"model\"},\"finishMessage\":\"Model generated function call(s).\",\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_1\",\"usageMetadata\":{\"candidatesTokenCount\":19,\"promptTokenCount\":199,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":199}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":82,\"totalTokenCount\":300}}\r\n\r\n"
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"First add 10 and 5 with the add tool. Then subtract 3 from that sum with the subtract tool. Report the final number.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":10,"y":5},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":15}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Perform the steps in order, using the result of each step as an input to the next. Once you have the final tool result, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"args\":{\"x\":15,\"y\":3},\"name\":\"subtract\"},\"thoughtSignature\":\"signature_REDACTED_2\"}],\"role\":\"model\"},\"finishMessage\":\"Model generated function call(s).\",\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_2\",\"usageMetadata\":{\"candidatesTokenCount\":19,\"promptTokenCount\":314,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":314}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":41,\"totalTokenCount\":374}}\r\n\r\n"
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"First add 10 and 5 with the add tool. Then subtract 3 from that sum with the subtract tool. Report the final number.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":10,"y":5},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":15}},"thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":15,"y":3},"name":"subtract"},"thought":false,"thoughtSignature":"signature_REDACTED_2"}],"role":"model"},{"parts":[{"functionResponse":{"name":"subtract","response":{"result":12}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Perform the steps in order, using the result of each step as an input to the next. Once you have the final tool result, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"12\",\"thoughtSignature\":\"signature_REDACTED_3\"}],\"role\":\"model\"},\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_3\",\"usageMetadata\":{\"candidatesTokenCount\":2,\"promptTokenCount\":388,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":388}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":36,\"totalTokenCount\":426}}\r\n\r\n"

--- a/tests/cassettes/gemini/hook_stress_streaming/streaming_active_tools_narrowing_filters_a_tool.yaml
+++ b/tests/cassettes/gemini/hook_stress_streaming/streaming_active_tools_narrowing_filters_a_tool.yaml
@@ -1,0 +1,41 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Compute 12 + 8, then compute 30 - 7. Report whichever you can.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. Use a provided tool for any arithmetic you can; if a tool is unavailable, say so and continue.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"args\":{\"x\":12,\"y\":8},\"name\":\"add\"},\"thoughtSignature\":\"signature_REDACTED_1\"}],\"role\":\"model\"},\"finishMessage\":\"Model generated function call(s).\",\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_1\",\"usageMetadata\":{\"candidatesTokenCount\":19,\"promptTokenCount\":101,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":101}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":67,\"totalTokenCount\":187}}\r\n\r\n"
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Compute 12 + 8, then compute 30 - 7. Report whichever you can.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":12,"y":8},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":20}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. Use a provided tool for any arithmetic you can; if a tool is unavailable, say so and continue.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"I\"}],\"role\":\"model\"},\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_2\",\"usageMetadata\":{\"candidatesTokenCount\":1,\"promptTokenCount\":201,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":201}],\"serviceTier\":\"standard\",\"totalTokenCount\":202}}\r\n\r\ndata: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\" can compute 12 + 8 = 20. I cannot help\"}],\"role\":\"model\"},\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_2\",\"usageMetadata\":{\"candidatesTokenCount\":17,\"promptTokenCount\":201,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":201}],\"serviceTier\":\"standard\",\"totalTokenCount\":218}}\r\n\r\ndata: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\" with subtraction.\"}],\"role\":\"model\"},\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_2\",\"usageMetadata\":{\"candidatesTokenCount\":20,\"promptTokenCount\":201,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":201}],\"serviceTier\":\"standard\",\"totalTokenCount\":221}}\r\n\r\n"

--- a/tests/cassettes/gemini/hook_stress_streaming/streaming_result_redaction_reaches_final_response.yaml
+++ b/tests/cassettes/gemini/hook_stress_streaming/streaming_result_redaction_reaches_final_response.yaml
@@ -1,0 +1,41 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the add tool to add 5 and 5, then report the exact tool result.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. Use the add tool, then report the exact tool result text verbatim.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"args\":{\"x\":5,\"y\":5},\"name\":\"add\"},\"thoughtSignature\":\"signature_REDACTED_1\"}],\"role\":\"model\"},\"finishMessage\":\"Model generated function call(s).\",\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_1\",\"usageMetadata\":{\"candidatesTokenCount\":18,\"promptTokenCount\":91,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":91}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":49,\"totalTokenCount\":158}}\r\n\r\n"
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the add tool to add 5 and 5, then report the exact tool result.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":5,"y":5},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":"STREAM-REDACTED-Q3"}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. Use the add tool, then report the exact tool result text verbatim.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"{\\\"\"}],\"role\":\"model\"},\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_2\",\"usageMetadata\":{\"candidatesTokenCount\":1,\"promptTokenCount\":178,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":178}],\"serviceTier\":\"standard\",\"totalTokenCount\":179}}\r\n\r\ndata: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"add_response\\\": {\\\"result\\\": \\\"STREAM-REDACTED-Q3\"}],\"role\":\"model\"},\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_2\",\"usageMetadata\":{\"candidatesTokenCount\":17,\"promptTokenCount\":178,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":178}],\"serviceTier\":\"standard\",\"totalTokenCount\":195}}\r\n\r\ndata: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"\\\"}}\"}],\"role\":\"model\"},\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_2\",\"usageMetadata\":{\"candidatesTokenCount\":18,\"promptTokenCount\":178,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":178}],\"serviceTier\":\"standard\",\"totalTokenCount\":196}}\r\n\r\n"

--- a/tests/cassettes/gemini/hook_stress_streaming/streaming_skip_leaves_tool_unexecuted.yaml
+++ b/tests/cassettes/gemini/hook_stress_streaming/streaming_skip_leaves_tool_unexecuted.yaml
@@ -1,0 +1,41 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Add 14 and 6, and subtract 9 from 40. Report what you can.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools. If a tool reports it is unavailable, acknowledge that and report any results you have.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"args\":{\"x\":14,\"y\":6},\"name\":\"add\"},\"thoughtSignature\":\"signature_REDACTED_1\"},{\"functionCall\":{\"args\":{\"x\":40,\"y\":9},\"name\":\"subtract\"}}],\"role\":\"model\"},\"finishMessage\":\"Model generated function call(s).\",\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_1\",\"usageMetadata\":{\"candidatesTokenCount\":38,\"promptTokenCount\":162,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":162}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":48,\"totalTokenCount\":248}}\r\n\r\n"
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Add 14 and 6, and subtract 9 from 40. Report what you can.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":14,"y":6},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"},{"functionCall":{"args":{"x":40,"y":9},"name":"subtract"},"thought":false}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":20}},"thought":false},{"functionResponse":{"name":"subtract","response":{"result":"the subtract tool is offline; continue without it"}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools. If a tool reports it is unavailable, acknowledge that and report any results you have.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"I added\"}],\"role\":\"model\"},\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_2\",\"usageMetadata\":{\"candidatesTokenCount\":2,\"promptTokenCount\":281,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":281}],\"serviceTier\":\"standard\",\"totalTokenCount\":283}}\r\n\r\ndata: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\" 14 and 6, which resulted in 20. The subtract tool is offline\"}],\"role\":\"model\"},\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_2\",\"usageMetadata\":{\"candidatesTokenCount\":20,\"promptTokenCount\":281,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":281}],\"serviceTier\":\"standard\",\"totalTokenCount\":301}}\r\n\r\ndata: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\", so I am unable to subtract 9 from 40.\"}],\"role\":\"model\"},\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_2\",\"usageMetadata\":{\"candidatesTokenCount\":34,\"promptTokenCount\":281,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":281}],\"serviceTier\":\"standard\",\"totalTokenCount\":315}}\r\n\r\n"

--- a/tests/cassettes/gemini/hook_stress_streaming/streaming_text_only_emits_text_deltas_and_stream_finish.yaml
+++ b/tests/cassettes/gemini/hook_stress_streaming/streaming_text_only_emits_text_deltas_and_stream_finish.yaml
@@ -1,0 +1,20 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"In one short sentence, describe the color of a clear daytime sky.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a concise assistant. Answer directly in plain text.","thought":false}],"role":"model"},"toolConfig":null}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"The color of a clear daytime sky is blue.\"}],\"role\":\"model\"},\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_1\",\"usageMetadata\":{\"candidatesTokenCount\":10,\"promptTokenCount\":28,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":28}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":38,\"totalTokenCount\":76}}\r\n\r\n"

--- a/tests/cassettes/gemini/hook_stress_streaming/streaming_tool_turns_fire_model_turn_finished.yaml
+++ b/tests/cassettes/gemini/hook_stress_streaming/streaming_tool_turns_fire_model_turn_finished.yaml
@@ -1,0 +1,62 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"First add 40 and 2 with the add tool. Then subtract 10 from that sum with the subtract tool. Report the final number.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Perform the steps in order, using the result of each step as an input to the next. Once you have the final tool result, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"args\":{\"x\":40,\"y\":2},\"name\":\"add\"},\"thoughtSignature\":\"signature_REDACTED_1\"}],\"role\":\"model\"},\"finishMessage\":\"Model generated function call(s).\",\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_1\",\"usageMetadata\":{\"candidatesTokenCount\":19,\"promptTokenCount\":200,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":200}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":52,\"totalTokenCount\":271}}\r\n\r\n"
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"First add 40 and 2 with the add tool. Then subtract 10 from that sum with the subtract tool. Report the final number.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":40,"y":2},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":42}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Perform the steps in order, using the result of each step as an input to the next. Once you have the final tool result, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"args\":{\"x\":42,\"y\":10},\"name\":\"subtract\"},\"thoughtSignature\":\"signature_REDACTED_2\"}],\"role\":\"model\"},\"finishMessage\":\"Model generated function call(s).\",\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_2\",\"usageMetadata\":{\"candidatesTokenCount\":20,\"promptTokenCount\":285,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":285}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":32,\"totalTokenCount\":337}}\r\n\r\n"
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:streamGenerateContent
+  method: POST
+  query_param:
+  - name: alt
+    value: sse
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"First add 40 and 2 with the add tool. Then subtract 10 from that sum with the subtract tool. Report the final number.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":40,"y":2},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":42}},"thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":42,"y":10},"name":"subtract"},"thought":false,"thoughtSignature":"signature_REDACTED_2"}],"role":"model"},{"parts":[{"functionResponse":{"name":"subtract","response":{"result":32}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. You MUST use the provided tools for every arithmetic operation instead of computing results yourself. Perform the steps in order, using the result of each step as an input to the next. Once you have the final tool result, reply with the final numeric answer in plain text.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}},{"description":"Subtract y from x (i.e. x - y)","name":"subtract","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"32\",\"thoughtSignature\":\"signature_REDACTED_3\"}],\"role\":\"model\"},\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-2.5-flash\",\"responseId\":\"id_REDACTED_3\",\"usageMetadata\":{\"candidatesTokenCount\":2,\"promptTokenCount\":351,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":351}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":19,\"totalTokenCount\":372}}\r\n\r\n"

--- a/tests/cassettes/gemini/hook_stress_tools/arg_rewrite_sets_one_key_preserving_rest_blocking.yaml
+++ b/tests/cassettes/gemini/hook_stress_tools/arg_rewrite_sets_one_key_preserving_rest_blocking.yaml
@@ -1,0 +1,37 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the add tool to add 3 and 4, then report the tool''s result.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. Use the add tool for the addition.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":3,"y":4},"name":"add"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":18,"promptTokenCount":86,"promptTokensDetails":[{"modality":"TEXT","tokenCount":86}],"serviceTier":"standard","thoughtsTokenCount":43,"totalTokenCount":147}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the add tool to add 3 and 4, then report the tool''s result.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":3,"y":4},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":104}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. Use the add tool for the addition.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"The result of adding 3 and 4 is 104."}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_2","usageMetadata":{"candidatesTokenCount":15,"promptTokenCount":119,"promptTokensDetails":[{"modality":"TEXT","tokenCount":119}],"serviceTier":"standard","totalTokenCount":134}}'

--- a/tests/cassettes/gemini/hook_stress_tools/result_truncation_reaches_model_blocking.yaml
+++ b/tests/cassettes/gemini/hook_stress_tools/result_truncation_reaches_model_blocking.yaml
@@ -1,0 +1,37 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Call fetch_motto and report exactly what it returns.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"Call the fetch_motto tool, then report the exact tool result text verbatim.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Fetch the two-line workshop motto.","name":"fetch_motto","parameters":{"properties":{},"required":[],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{},"name":"fetch_motto"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":11,"promptTokenCount":61,"promptTokensDetails":[{"modality":"TEXT","tokenCount":61}],"serviceTier":"standard","thoughtsTokenCount":31,"totalTokenCount":103}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Call fetch_motto and report exactly what it returns.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{},"name":"fetch_motto"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"fetch_motto","response":{"result":"steady"}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"Call the fetch_motto tool, then report the exact tool result text verbatim.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Fetch the two-line workshop motto.","name":"fetch_motto","parameters":{"properties":{},"required":[],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"The exact tool result text is: `{\"fetch_motto_response\": {\"result\": \"steady\"}}`"}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_2","usageMetadata":{"candidatesTokenCount":23,"promptTokenCount":88,"promptTokensDetails":[{"modality":"TEXT","tokenCount":88}],"serviceTier":"standard","totalTokenCount":111}}'

--- a/tests/cassettes/gemini/hook_stress_tools/terminate_from_tool_result_cancels_after_execution_blocking.yaml
+++ b/tests/cassettes/gemini/hook_stress_tools/terminate_from_tool_result_cancels_after_execution_blocking.yaml
@@ -1,0 +1,18 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the add tool to add 21 and 21, then report the result.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. Use the add tool for the addition.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":21,"y":21},"name":"add"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":20,"promptTokenCount":85,"promptTokensDetails":[{"modality":"TEXT","tokenCount":85}],"serviceTier":"standard","thoughtsTokenCount":58,"totalTokenCount":163}}'

--- a/tests/cassettes/gemini/hook_stress_tools/tool_error_guidance_drives_model_retry_blocking.yaml
+++ b/tests/cassettes/gemini/hook_stress_tools/tool_error_guidance_drives_model_retry_blocking.yaml
@@ -1,0 +1,56 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Look up the codeword for the red team.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You look up team codewords with the lookup_codeword tool. If the tool returns an error with guidance, follow that guidance and try again, then report the codeword you obtain.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Look up the secret codeword for a team.","name":"lookup_codeword","parameters":{"properties":{"team":{"description":"The team name, lowercase","type":"string"}},"required":["team"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"team":"red"},"name":"lookup_codeword"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":16,"promptTokenCount":93,"promptTokensDetails":[{"modality":"TEXT","tokenCount":93}],"serviceTier":"standard","thoughtsTokenCount":56,"totalTokenCount":165}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Look up the codeword for the red team.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"team":"red"},"name":"lookup_codeword"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"lookup_codeword","response":{"result":"Toolset error: ToolCallError: ToolCallError: the red team was disbanded; look up the codeword for the \"blue\" team instead"}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You look up team codewords with the lookup_codeword tool. If the tool returns an error with guidance, follow that guidance and try again, then report the codeword you obtain.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Look up the secret codeword for a team.","name":"lookup_codeword","parameters":{"properties":{"team":{"description":"The team name, lowercase","type":"string"}},"required":["team"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"team":"blue"},"name":"lookup_codeword"},"thoughtSignature":"signature_REDACTED_2"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_2","usageMetadata":{"candidatesTokenCount":16,"promptTokenCount":152,"promptTokensDetails":[{"modality":"TEXT","tokenCount":152}],"serviceTier":"standard","thoughtsTokenCount":74,"totalTokenCount":242}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Look up the codeword for the red team.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"team":"red"},"name":"lookup_codeword"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"lookup_codeword","response":{"result":"Toolset error: ToolCallError: ToolCallError: the red team was disbanded; look up the codeword for the \"blue\" team instead"}},"thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"team":"blue"},"name":"lookup_codeword"},"thought":false,"thoughtSignature":"signature_REDACTED_2"}],"role":"model"},{"parts":[{"functionResponse":{"name":"lookup_codeword","response":{"result":"azure-falcon"}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You look up team codewords with the lookup_codeword tool. If the tool returns an error with guidance, follow that guidance and try again, then report the codeword you obtain.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Look up the secret codeword for a team.","name":"lookup_codeword","parameters":{"properties":{"team":{"description":"The team name, lowercase","type":"string"}},"required":["team"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"The codeword for the blue team is azure-falcon.","thoughtSignature":"signature_REDACTED_3"}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_3","usageMetadata":{"candidatesTokenCount":11,"promptTokenCount":186,"promptTokensDetails":[{"modality":"TEXT","tokenCount":186}],"serviceTier":"standard","thoughtsTokenCount":31,"totalTokenCount":228}}'

--- a/tests/cassettes/gemini/hook_stress_tools/two_arg_rewrites_chain_blocking.yaml
+++ b/tests/cassettes/gemini/hook_stress_tools/two_arg_rewrites_chain_blocking.yaml
@@ -1,0 +1,37 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the add tool to add 1 and 1, then report the tool''s result.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. Use the add tool for the addition.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":1,"y":1},"name":"add"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":18,"promptTokenCount":86,"promptTokensDetails":[{"modality":"TEXT","tokenCount":86}],"serviceTier":"standard","thoughtsTokenCount":49,"totalTokenCount":153}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the add tool to add 1 and 1, then report the tool''s result.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":1,"y":1},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":15}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. Use the add tool for the addition.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"The result of adding 1 and 1 is 15."}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_2","usageMetadata":{"candidatesTokenCount":14,"promptTokenCount":118,"promptTokensDetails":[{"modality":"TEXT","tokenCount":118}],"serviceTier":"standard","totalTokenCount":132}}'

--- a/tests/cassettes/gemini/hook_stress_tools/two_result_rewrites_chain_redact_then_wrap_blocking.yaml
+++ b/tests/cassettes/gemini/hook_stress_tools/two_result_rewrites_chain_redact_then_wrap_blocking.yaml
@@ -1,0 +1,37 @@
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the add tool to add 2 and 2, then report the exact tool result.","thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. Use the add tool, then report the exact tool result text verbatim.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"functionCall":{"args":{"x":2,"y":2},"name":"add"},"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},"finishMessage":"Model generated function call(s).","finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_1","usageMetadata":{"candidatesTokenCount":18,"promptTokenCount":91,"promptTokensDetails":[{"modality":"TEXT","tokenCount":91}],"serviceTier":"standard","thoughtsTokenCount":51,"totalTokenCount":160}}'
+---
+when:
+  path: /v1beta/models/gemini-2.5-flash:generateContent
+  method: POST
+  query_param:
+  - name: key
+    value: '[REDACTED]'
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"contents":[{"parts":[{"text":"Use the add tool to add 2 and 2, then report the exact tool result.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{"x":2,"y":2},"name":"add"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"add","response":{"result":"[SECRET]"}},"thought":false}],"role":"user"}],"generationConfig":null,"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a calculator assistant. Use the add tool, then report the exact tool result text verbatim.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Add x and y together","name":"add","parameters":{"properties":{"x":{"description":"The first operand","type":"number"},"y":{"description":"The second operand","type":"number"}},"required":["x","y"],"type":"object"}}]}]}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json; charset=UTF-8
+  body: '{"candidates":[{"content":{"parts":[{"text":"The exact tool result is `{\"add_response\": {\"result\": \"[SECRET]\"}}`."}],"role":"model"},"finishReason":"STOP","index":0}],"modelVersion":"gemini-2.5-flash","responseId":"id_REDACTED_2","usageMetadata":{"candidatesTokenCount":19,"promptTokenCount":123,"promptTokensDetails":[{"modality":"TEXT","tokenCount":123}],"serviceTier":"standard","totalTokenCount":142}}'

--- a/tests/providers/gemini/cassette/hook_stress.rs
+++ b/tests/providers/gemini/cassette/hook_stress.rs
@@ -1,0 +1,753 @@
+//! Long, multi-turn hook-system stress workflows recorded against real Gemini.
+//!
+//! Where the small `tool_hooks` suite pins one hook decision each, these tests
+//! drive rich multi-turn workflows and assert *structural invariants* of the
+//! merged hook system: `HookContext` identity/turn/streaming, a shared
+//! `Scratchpad` threaded across hooks and turns, `RequestPatch` context
+//! injection + `active_tools` narrowing, chained `RewriteArgs` -> observe ->
+//! `RewriteResult` redaction, and streaming lifecycle ordering / blocking-vs-
+//! streaming parity.
+//!
+//! ## On loose assertions
+//!
+//! Following `tools_support`'s convention: only values Rig synthesizes with **no
+//! model input** (a hook-rewritten arg, a verbatim redaction marker, a
+//! `HookContext` field, a scratchpad tally, an event *shape*) are pinned to exact
+//! equality. Everything shaped by Gemini's generated text or its chosen call
+//! count/ordering uses loose assertions (`contains`, `>=`, "mentions"), so these
+//! cassettes survive re-recording. Deterministic hooks (no clocks/RNG) keep the
+//! outbound requests byte-identical for replay.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use futures::StreamExt;
+use rig::agent::{
+    AgentHook, Flow, HookContext, MultiTurnStreamItem, RequestPatch, StepEvent, StreamingError,
+};
+use rig::client::CompletionClient;
+use rig::completion::{Document, Prompt};
+use rig::providers::gemini;
+use rig::streaming::{StreamedAssistantContent, StreamedUserContent, StreamingPrompt};
+use rig::tool::Tool;
+
+use super::super::support::with_gemini_cassette;
+use super::super::tools_support::{CountingAdd, CountingSubtract, SkipToolHook, ToolEventRecorder};
+use crate::support::assert_nonempty_response;
+
+type GeminiModel = gemini::completion::CompletionModel;
+
+/// Preamble that forces tool use and a dependent two-step chain so the model
+/// takes at least two turns (compute A, then use A to compute B).
+const CHAIN_PREAMBLE: &str = "You are a calculator assistant. You MUST use the provided tools for \
+     every arithmetic operation instead of computing results yourself. Perform the steps in order, \
+     using the result of each step as an input to the next. Once you have the final tool result, \
+     reply with the final numeric answer in plain text.";
+
+// ---------------------------------------------------------------------------
+// Fixtures: hooks that observe HookContext identity, thread the Scratchpad, and
+// steer requests/tools. All deterministic.
+// ---------------------------------------------------------------------------
+
+/// One observed hook event: its variant tag and the one-based turn it fired on.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Breadcrumb {
+    tag: &'static str,
+    turn: usize,
+}
+
+/// Cross-hook, cross-turn scratchpad value: how many `ToolCall`s the writer hook
+/// has seen so far this run.
+#[derive(Clone, Default)]
+struct ToolCallTally(usize);
+
+/// Records, for the whole run: the ordered lifecycle breadcrumb, the set of
+/// `run_id`s seen, the `is_streaming` flag, and the `agent_name` — proving
+/// `HookContext` identity is stable and correct. Also bumps a shared
+/// `Scratchpad` tally on each `ToolCall`.
+#[derive(Clone, Default)]
+struct LifecycleRecorder {
+    breadcrumbs: Arc<Mutex<Vec<Breadcrumb>>>,
+    run_ids: Arc<Mutex<BTreeSet<String>>>,
+    streaming: Arc<Mutex<Option<bool>>>,
+    agent_name: Arc<Mutex<Option<String>>>,
+}
+
+impl LifecycleRecorder {
+    fn breadcrumbs(&self) -> Vec<Breadcrumb> {
+        self.breadcrumbs.lock().expect("breadcrumbs").clone()
+    }
+    fn distinct_run_ids(&self) -> usize {
+        self.run_ids.lock().expect("run_ids").len()
+    }
+    fn is_streaming(&self) -> Option<bool> {
+        *self.streaming.lock().expect("streaming")
+    }
+    fn agent_name(&self) -> Option<String> {
+        self.agent_name.lock().expect("agent_name").clone()
+    }
+    fn count(&self, tag: &str) -> usize {
+        self.breadcrumbs()
+            .iter()
+            .filter(|crumb| crumb.tag == tag)
+            .count()
+    }
+}
+
+impl AgentHook<GeminiModel> for LifecycleRecorder {
+    async fn on_event(&self, ctx: &HookContext, event: StepEvent<'_, GeminiModel>) -> Flow {
+        let tag = match event {
+            StepEvent::CompletionCall { .. } => Some("CompletionCall"),
+            StepEvent::CompletionResponse { .. } => Some("CompletionResponse"),
+            StepEvent::ModelTurnFinished { .. } => Some("ModelTurnFinished"),
+            StepEvent::ToolCall { .. } => Some("ToolCall"),
+            StepEvent::ToolResult { .. } => Some("ToolResult"),
+            _ => None,
+        };
+        // Record identity on every event so it is proven stable across the run.
+        self.run_ids
+            .lock()
+            .expect("run_ids")
+            .insert(ctx.run_id().as_str().to_string());
+        *self.streaming.lock().expect("streaming") = Some(ctx.is_streaming());
+        *self.agent_name.lock().expect("agent_name") = ctx.agent_name().map(str::to_string);
+
+        if matches!(event, StepEvent::ToolCall { .. }) {
+            ctx.scratchpad()
+                .update(|tally: &mut ToolCallTally| tally.0 += 1);
+        }
+
+        if let Some(tag) = tag {
+            self.breadcrumbs
+                .lock()
+                .expect("breadcrumbs")
+                .push(Breadcrumb {
+                    tag,
+                    turn: ctx.turn(),
+                });
+        }
+        Flow::cont()
+    }
+}
+
+/// Registered *after* [`LifecycleRecorder`]: on each `ModelTurnFinished` it reads
+/// the shared `Scratchpad` tally the recorder wrote and appends it to an external
+/// log — proving the two hooks share run-scoped state that accumulates across
+/// turns.
+#[derive(Clone, Default)]
+struct ScratchpadReader {
+    tallies: Arc<Mutex<Vec<usize>>>,
+}
+
+impl ScratchpadReader {
+    fn tallies(&self) -> Vec<usize> {
+        self.tallies.lock().expect("tallies").clone()
+    }
+}
+
+impl AgentHook<GeminiModel> for ScratchpadReader {
+    async fn on_event(&self, ctx: &HookContext, event: StepEvent<'_, GeminiModel>) -> Flow {
+        if matches!(event, StepEvent::ModelTurnFinished { .. }) {
+            let tally = ctx
+                .scratchpad()
+                .get::<ToolCallTally>()
+                .map(|t| t.0)
+                .unwrap_or(0);
+            self.tallies.lock().expect("tallies").push(tally);
+        }
+        Flow::cont()
+    }
+}
+
+/// `CompletionCall` hook that injects a run-state fact via `extra_context`,
+/// narrows `active_tools`, and pins temperature — one merged `RequestPatch`.
+#[derive(Clone)]
+struct InjectContextAndNarrowTools {
+    fact_id: &'static str,
+    fact_text: &'static str,
+    allow: &'static [&'static str],
+}
+
+impl AgentHook<GeminiModel> for InjectContextAndNarrowTools {
+    async fn on_event(&self, _ctx: &HookContext, event: StepEvent<'_, GeminiModel>) -> Flow {
+        if matches!(event, StepEvent::CompletionCall { .. }) {
+            let doc = Document {
+                id: self.fact_id.to_string(),
+                text: self.fact_text.to_string(),
+                additional_props: Default::default(),
+            };
+            Flow::patch_request(
+                RequestPatch::new()
+                    .context(doc)
+                    .active_tools(self.allow.iter().copied())
+                    .temperature(0.0),
+            )
+        } else {
+            Flow::cont()
+        }
+    }
+}
+
+/// `ToolCall` hook that rewrites a named tool's arguments to a fixed object,
+/// regardless of what the model emitted (execution-args rewrite).
+#[derive(Clone)]
+struct ForceArgs {
+    tool_name: &'static str,
+    args: serde_json::Value,
+}
+
+impl AgentHook<GeminiModel> for ForceArgs {
+    async fn on_event(&self, _ctx: &HookContext, event: StepEvent<'_, GeminiModel>) -> Flow {
+        match event {
+            StepEvent::ToolCall { tool_name, .. } if tool_name == self.tool_name => {
+                Flow::rewrite_args(self.args.clone())
+            }
+            _ => Flow::cont(),
+        }
+    }
+}
+
+/// `ToolResult` hook that redacts a named tool's output with a fixed marker.
+#[derive(Clone)]
+struct RedactResult {
+    tool_name: &'static str,
+    marker: &'static str,
+}
+
+impl AgentHook<GeminiModel> for RedactResult {
+    async fn on_event(&self, _ctx: &HookContext, event: StepEvent<'_, GeminiModel>) -> Flow {
+        match event {
+            StepEvent::ToolResult { tool_name, .. } if tool_name == self.tool_name => {
+                Flow::rewrite_result(self.marker)
+            }
+            _ => Flow::cont(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. HookContext identity + Scratchpad threaded across a long multi-turn run.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn lifecycle_and_scratchpad_thread_across_multi_turn_blocking() {
+    let add = CountingAdd::default();
+    let subtract = CountingSubtract::default();
+    let add_calls = add.counter.clone();
+    let subtract_calls = subtract.counter.clone();
+    let recorder = LifecycleRecorder::default();
+    let reader = ScratchpadReader::default();
+    let recorder_probe = recorder.clone();
+    let reader_probe = reader.clone();
+
+    with_gemini_cassette(
+        "hook_stress/lifecycle_and_scratchpad_thread_across_multi_turn_blocking",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .name("stress-agent")
+                .preamble(CHAIN_PREAMBLE)
+                .temperature(0.0)
+                .tool(add)
+                .tool(subtract)
+                .build();
+
+            let response = agent
+                .prompt(
+                    "First add 10 and 5 with the add tool. Then subtract 3 from that sum with the \
+                     subtract tool. Report the final number.",
+                )
+                .max_turns(6)
+                .add_hook(recorder)
+                .add_hook(reader)
+                .await
+                .expect("dependent multi-turn tool run should succeed");
+
+            assert_nonempty_response(&response);
+
+            // --- HookContext identity is stable and correct across the run ---
+            assert_eq!(
+                recorder_probe.distinct_run_ids(),
+                1,
+                "run_id must be stable across every event of one run"
+            );
+            assert_eq!(
+                recorder_probe.is_streaming(),
+                Some(false),
+                "blocking surface must report is_streaming() == false"
+            );
+            assert_eq!(
+                recorder_probe.agent_name().as_deref(),
+                Some("stress-agent"),
+                "the configured agent name must reach the hook"
+            );
+
+            // --- turn() advances; the workflow really is multi-turn ---
+            let crumbs = recorder_probe.breadcrumbs();
+            let max_turn = crumbs.iter().map(|c| c.turn).max().unwrap_or(0);
+            assert!(
+                max_turn >= 2,
+                "a dependent add-then-subtract chain must span >= 2 model turns, saw {crumbs:?}"
+            );
+            let turns: Vec<usize> = crumbs.iter().map(|c| c.turn).collect();
+            assert!(
+                turns.windows(2).all(|w| w[0] <= w[1]),
+                "turn() must be non-decreasing across the run, saw {turns:?}"
+            );
+
+            // --- each tool call is paired with a result, and the shared
+            //     Scratchpad tally tracks them across hooks and turns ---
+            let tool_calls = recorder_probe.count("ToolCall");
+            let tool_results = recorder_probe.count("ToolResult");
+            assert_eq!(
+                tool_calls, tool_results,
+                "every observed ToolCall must have a paired ToolResult"
+            );
+            assert_eq!(
+                add_calls.count() + subtract_calls.count(),
+                tool_calls,
+                "observed ToolCall events must equal real tool executions"
+            );
+            assert!(
+                add_calls.count() >= 1 && subtract_calls.count() >= 1,
+                "the chain must exercise both add and subtract"
+            );
+
+            // ScratchpadReader (a *different* hook) saw the writer's tally grow to
+            // the final ToolCall count — cross-hook, cross-turn shared state.
+            let tallies = reader_probe.tallies();
+            assert!(
+                !tallies.is_empty(),
+                "ModelTurnFinished should fire, so the reader should see tallies"
+            );
+            assert!(
+                tallies.windows(2).all(|w| w[0] <= w[1]),
+                "the shared scratchpad tally must be non-decreasing, saw {tallies:?}"
+            );
+            assert_eq!(
+                *tallies.last().expect("at least one tally"),
+                tool_calls,
+                "the final scratchpad tally must equal the total ToolCall count"
+            );
+        },
+    )
+    .await;
+}
+
+// ---------------------------------------------------------------------------
+// 2. RequestPatch: extra_context injection + active_tools narrowing.
+// ---------------------------------------------------------------------------
+
+const VAULT_FACT_ID: &str = "vault-note";
+const VAULT_FACT: &str = "Operational note: the vault access code is CINNABAR-42.";
+const VAULT_CODE: &str = "CINNABAR-42";
+
+#[tokio::test]
+async fn request_patch_injects_context_and_narrows_active_tools_blocking() {
+    let add = CountingAdd::default();
+    let subtract = CountingSubtract::default();
+    let add_calls = add.counter.clone();
+    let subtract_calls = subtract.counter.clone();
+
+    with_gemini_cassette(
+        "hook_stress/request_patch_injects_context_and_narrows_active_tools_blocking",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .name("stress-agent")
+                .preamble(
+                    "You are a helpful assistant. Use a tool for any arithmetic. Consult the \
+                     provided context for any facts you are asked about.",
+                )
+                .tool(add)
+                .tool(subtract)
+                .build();
+
+            let response = agent
+                .prompt(
+                    "Two things: (1) tell me the vault access code, and (2) use a tool to compute \
+                     41 + 1.",
+                )
+                .max_turns(5)
+                // Inject the secret via extra_context and narrow the advertised
+                // tools to `add` only (subtract is filtered out this run).
+                .add_hook(InjectContextAndNarrowTools {
+                    fact_id: VAULT_FACT_ID,
+                    fact_text: VAULT_FACT,
+                    allow: &["add"],
+                })
+                .await
+                .expect("context-injecting, tool-narrowing run should succeed");
+
+            // extra_context injection reached the model: the answer uses the fact
+            // that appears only in the injected document (no model input).
+            assert!(
+                response.contains(VAULT_CODE),
+                "the extra_context fact must reach the model; answer: {response:?}"
+            );
+            // active_tools narrowing is proven by the downstream negative: the
+            // filtered-out tool never executes, while the advertised one does.
+            assert_eq!(
+                subtract_calls.count(),
+                0,
+                "subtract was filtered out of active_tools and must never execute"
+            );
+            assert!(
+                add_calls.count() >= 1,
+                "the advertised add tool should still run for 41 + 1"
+            );
+        },
+    )
+    .await;
+}
+
+// ---------------------------------------------------------------------------
+// 3. Chained tool lifecycle: RewriteArgs -> observe -> RewriteResult redaction.
+// ---------------------------------------------------------------------------
+
+const REDACTION_MARKER: &str = "REDACTED-SUM-ZK7";
+
+#[tokio::test]
+async fn chained_arg_rewrite_then_result_redaction_blocking() {
+    let add = CountingAdd::default();
+    let recorder = ToolEventRecorder::default();
+    let recorder_probe = recorder.clone();
+
+    with_gemini_cassette(
+        "hook_stress/chained_arg_rewrite_then_result_redaction_blocking",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .name("stress-agent")
+                .preamble(
+                    "You are a calculator assistant. You MUST use the add tool for the addition. \
+                     After the tool result is available, report the exact tool result text \
+                     verbatim as your final answer.",
+                )
+                .temperature(0.0)
+                .tool(add)
+                .build();
+
+            let response = agent
+                .prompt("Use the add tool to add 2 and 2, then report the exact tool result.")
+                .max_turns(4)
+                // Hook order matters: rewrite args -> observe -> redact result.
+                .add_hook(ForceArgs {
+                    tool_name: CountingAdd::NAME,
+                    args: serde_json::json!({ "x": 7, "y": 8 }),
+                })
+                .add_hook(recorder)
+                .add_hook(RedactResult {
+                    tool_name: CountingAdd::NAME,
+                    marker: REDACTION_MARKER,
+                })
+                .await
+                .expect("chained rewrite + redaction run should succeed");
+
+            // The observer (registered after the rewriter) saw the *rewritten*
+            // args — the tool executed against them, not the model's `2 + 2`.
+            let calls = recorder_probe.recorded_calls();
+            assert_eq!(calls.len(), 1, "exactly one add call, saw {calls:?}");
+            let observed_args: serde_json::Value =
+                serde_json::from_str(&calls[0].1).expect("observed args are JSON");
+            assert_eq!(
+                observed_args,
+                serde_json::json!({ "x": 7, "y": 8 }),
+                "the observer must see the hook-rewritten args"
+            );
+
+            // The observer saw the raw tool output (7 + 8 = 15), *before* the
+            // downstream redaction hook replaced it.
+            let results = recorder_probe.recorded_results();
+            assert_eq!(results.len(), 1, "exactly one add result");
+            assert_eq!(
+                results[0].2, "15",
+                "the observer must see the raw tool output before redaction"
+            );
+
+            // Paired positive + negative: the redacted marker reached the model,
+            // and the raw executed result (15) did not.
+            assert!(
+                response.contains(REDACTION_MARKER),
+                "the redaction marker must reach the model; answer: {response:?}"
+            );
+            assert!(
+                !response.contains("15"),
+                "the raw tool result must not reach the model; answer: {response:?}"
+            );
+        },
+    )
+    .await;
+}
+
+// ---------------------------------------------------------------------------
+// 4. Streaming lifecycle ordering + is_streaming parity vs the blocking surface.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn streaming_lifecycle_ordering_and_context_streaming_flag() {
+    let add = CountingAdd::default();
+    let subtract = CountingSubtract::default();
+    let add_calls = add.counter.clone();
+    let subtract_calls = subtract.counter.clone();
+    let recorder = LifecycleRecorder::default();
+    let recorder_probe = recorder.clone();
+
+    with_gemini_cassette(
+        "hook_stress/streaming_lifecycle_ordering_and_context_streaming_flag",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .name("stress-agent")
+                .preamble(CHAIN_PREAMBLE)
+                .temperature(0.0)
+                .tool(add)
+                .tool(subtract)
+                .build();
+
+            let mut stream = agent
+                .stream_prompt(
+                    "First add 20 and 5 with the add tool. Then subtract 4 from that sum with the \
+                     subtract tool. Report the final number.",
+                )
+                .add_hook(recorder)
+                .multi_turn(6)
+                .await;
+
+            // Ordered stream-item taxonomy tags, so we can assert lifecycle order.
+            let mut events: Vec<&'static str> = Vec::new();
+            let mut saw_final = false;
+            let mut final_text = String::new();
+            while let Some(item) = stream.next().await {
+                match item {
+                    Ok(MultiTurnStreamItem::StreamAssistantItem(content)) => match content {
+                        StreamedAssistantContent::Text(_) => events.push("text"),
+                        StreamedAssistantContent::ToolCall { .. } => events.push("tool_call"),
+                        StreamedAssistantContent::ToolCallDelta { .. } => {
+                            events.push("tool_call_delta")
+                        }
+                        _ => {}
+                    },
+                    Ok(MultiTurnStreamItem::ToolExecutionStart { .. }) => {
+                        events.push("tool_execution_start")
+                    }
+                    Ok(MultiTurnStreamItem::StreamUserItem(StreamedUserContent::ToolResult {
+                        ..
+                    })) => events.push("tool_result"),
+                    Ok(MultiTurnStreamItem::FinalResponse(response)) => {
+                        saw_final = true;
+                        final_text = response.response().to_owned();
+                        events.push("final_response");
+                    }
+                    Ok(_) => {}
+                    Err(StreamingError::Prompt(error)) => panic!("stream errored: {error:?}"),
+                    Err(other) => panic!("stream errored: {other:?}"),
+                }
+            }
+
+            assert!(saw_final, "the stream must yield a FinalResponse");
+            assert_nonempty_response(&final_text);
+
+            // Lifecycle ordering: a tool call precedes its execution start, which
+            // precedes its result, which precedes the final response.
+            let first = |tag: &str| events.iter().position(|e| *e == tag);
+            let tool_call_at = first("tool_call").expect("a complete tool call is surfaced");
+            let exec_start_at = first("tool_execution_start").expect("execution start is surfaced");
+            let tool_result_at = first("tool_result").expect("a tool result is surfaced");
+            let final_at = first("final_response").expect("a final response is surfaced");
+            assert!(
+                tool_call_at < exec_start_at,
+                "the model-emitted tool call must precede its execution start: {events:?}"
+            );
+            assert!(
+                exec_start_at <= tool_result_at,
+                "execution start must precede its tool result: {events:?}"
+            );
+            assert!(
+                tool_result_at < final_at,
+                "tool results must precede the final response: {events:?}"
+            );
+
+            // Same medium-independent lifecycle as the blocking run, plus the
+            // streaming flag flips.
+            assert_eq!(
+                recorder_probe.is_streaming(),
+                Some(true),
+                "the streaming surface must report is_streaming() == true"
+            );
+            assert_eq!(
+                recorder_probe.distinct_run_ids(),
+                1,
+                "run_id must be stable across the streamed run too"
+            );
+            assert_eq!(recorder_probe.agent_name().as_deref(), Some("stress-agent"));
+            assert!(
+                recorder_probe.count("ModelTurnFinished") >= 2,
+                "ModelTurnFinished must fire per accepted turn on the streaming surface"
+            );
+            assert!(
+                add_calls.count() >= 1 && subtract_calls.count() >= 1,
+                "the streamed chain must exercise both tools"
+            );
+        },
+    )
+    .await;
+}
+
+// ---------------------------------------------------------------------------
+// 5. Multi-tool workflow: per-turn atomic call/result pairing (batch surfacing).
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn multi_tool_workflow_pairs_calls_and_results_per_turn_blocking() {
+    let add = CountingAdd::default();
+    let subtract = CountingSubtract::default();
+    let add_calls = add.counter.clone();
+    let subtract_calls = subtract.counter.clone();
+    let recorder = LifecycleRecorder::default();
+    let recorder_probe = recorder.clone();
+
+    with_gemini_cassette(
+        "hook_stress/multi_tool_workflow_pairs_calls_and_results_per_turn_blocking",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .name("stress-agent")
+                .preamble(
+                    "You are a calculator assistant. You MUST use the provided tools for every \
+                     arithmetic operation. These two computations are independent — you may request \
+                     them together. Once you have both results, report both numbers.",
+                )
+                .temperature(0.0)
+                .tool(add)
+                .tool(subtract)
+                .build();
+
+            let response = agent
+                .prompt(
+                    "Independently compute 12 + 8 using the add tool and 30 - 7 using the subtract \
+                     tool, then report both results.",
+                )
+                .max_turns(5)
+                .add_hook(recorder)
+                .await
+                .expect("independent multi-tool run should succeed");
+
+            assert_nonempty_response(&response);
+            assert!(
+                add_calls.count() >= 1 && subtract_calls.count() >= 1,
+                "both independent tools should run"
+            );
+
+            // Whether Gemini batches the two calls into one turn or splits them,
+            // the atomic tool batch must pair every ToolCall with a ToolResult
+            // *within the same turn* — no orphan call, no orphan result.
+            let mut per_turn: BTreeMap<usize, (usize, usize)> = BTreeMap::new();
+            for crumb in recorder_probe.breadcrumbs() {
+                let entry = per_turn.entry(crumb.turn).or_default();
+                match crumb.tag {
+                    "ToolCall" => entry.0 += 1,
+                    "ToolResult" => entry.1 += 1,
+                    _ => {}
+                }
+            }
+            for (turn, (calls, results)) in &per_turn {
+                assert_eq!(
+                    calls, results,
+                    "turn {turn} must pair every ToolCall with a ToolResult (atomic batch)"
+                );
+            }
+            assert_eq!(
+                recorder_probe.count("ToolCall"),
+                add_calls.count() + subtract_calls.count(),
+                "observed ToolCall events must equal real tool executions"
+            );
+        },
+    )
+    .await;
+}
+
+// ---------------------------------------------------------------------------
+// 6. Hook Skip in a multi-tool workflow: the skipped tool never executes, yet
+//    the run continues to a real answer (skip's zero-execution invariant).
+// ---------------------------------------------------------------------------
+
+const SUBTRACT_SKIP_REASON: &str =
+    "the subtract tool is offline; treat its result as unavailable and continue";
+
+#[tokio::test]
+async fn skip_in_multi_tool_workflow_leaves_tool_unexecuted_blocking() {
+    let add = CountingAdd::default();
+    let subtract = CountingSubtract::default();
+    let add_calls = add.counter.clone();
+    let subtract_calls = subtract.counter.clone();
+
+    with_gemini_cassette(
+        "hook_stress/skip_in_multi_tool_workflow_leaves_tool_unexecuted_blocking",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .name("stress-agent")
+                .preamble(
+                    "You are a calculator assistant. You MUST use the provided tools for every \
+                     arithmetic operation. If a tool reports it is unavailable, acknowledge that in \
+                     your answer and still report any results you do have.",
+                )
+                .temperature(0.0)
+                .tool(add)
+                .tool(subtract)
+                .build();
+
+            let response = agent
+                .prompt(
+                    "Use the add tool to compute 14 + 6, and use the subtract tool to compute \
+                     40 - 9. Report what you can.",
+                )
+                .max_turns(5)
+                // Skip every `subtract` call: its body must never run, but the run
+                // continues with the skip reason surfaced as that tool's result.
+                .add_hook(SkipToolHook {
+                    tool_name: CountingSubtract::NAME,
+                    reason: SUBTRACT_SKIP_REASON,
+                })
+                .await
+                .expect("a skipped tool must not fail the run");
+
+            assert_nonempty_response(&response);
+            // Zero-execution invariant: the skipped tool's body never ran.
+            assert_eq!(
+                subtract_calls.count(),
+                0,
+                "the skipped subtract tool must never execute"
+            );
+            // The other tool still ran, so the run made real progress.
+            assert!(
+                add_calls.count() >= 1,
+                "the non-skipped add tool should still execute"
+            );
+        },
+    )
+    .await;
+}
+
+// Compile-time proof the fixtures implement the hook trait for the Gemini model.
+#[allow(unused)]
+fn assert_hook_impls() {
+    fn requires_hook<H: AgentHook<GeminiModel>>(_hook: H) {}
+    requires_hook(LifecycleRecorder::default());
+    requires_hook(ScratchpadReader::default());
+    requires_hook(InjectContextAndNarrowTools {
+        fact_id: "",
+        fact_text: "",
+        allow: &[],
+    });
+    requires_hook(ForceArgs {
+        tool_name: "add",
+        args: serde_json::Value::Null,
+    });
+    requires_hook(RedactResult {
+        tool_name: "add",
+        marker: "",
+    });
+}

--- a/tests/providers/gemini/cassette/hook_stress_context.rs
+++ b/tests/providers/gemini/cassette/hook_stress_context.rs
@@ -1,0 +1,438 @@
+//! Hook-system stress suite: `HookContext` identity, the shared `Scratchpad`
+//! threaded across hooks and turns, and `HookStack` composition (multiple hooks,
+//! observe-only both-fire, `add_hook` append, `CompletionCall` patch
+//! accumulation, `active_tools` intersection). Recorded against real Gemini.
+//!
+//! Assertions are loose for model-shaped values and exact only for
+//! rig-synthesized values (see `tools_support`'s note).
+
+use rig::client::CompletionClient;
+use rig::completion::Prompt;
+use rig::providers::gemini;
+
+use super::super::hook_stress_support::{
+    ApplyPatch, CHAIN_PREAMBLE, CountingMultiply, EventTap, ScratchpadReader, fact_doc,
+};
+use super::super::support::with_gemini_cassette;
+use super::super::tools_support::{CountingAdd, CountingSubtract};
+use crate::support::assert_nonempty_response;
+
+use rig::agent::RequestPatch;
+
+// ---------------------------------------------------------------------------
+// HookContext identity + turn advancement.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn hook_context_identity_stable_and_turn_advances_blocking() {
+    let add = CountingAdd::default();
+    let subtract = CountingSubtract::default();
+    let tap = EventTap::default();
+    let probe = tap.clone();
+
+    with_gemini_cassette(
+        "hook_stress_context/hook_context_identity_stable_and_turn_advances_blocking",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .name("stress-agent")
+                .preamble(CHAIN_PREAMBLE)
+                .temperature(0.0)
+                .tool(add)
+                .tool(subtract)
+                .build();
+
+            let response = agent
+                .prompt(
+                    "First add 9 and 6 with the add tool. Then subtract 4 from that sum with the \
+                     subtract tool. Report the final number.",
+                )
+                .max_turns(6)
+                .add_hook(tap)
+                .await
+                .expect("dependent chain should succeed");
+
+            assert_nonempty_response(&response);
+            assert_eq!(probe.distinct_run_ids(), 1, "run_id must be stable");
+            assert_eq!(probe.is_streaming(), Some(false));
+            assert_eq!(probe.agent_name().as_deref(), Some("stress-agent"));
+
+            let turns = probe.distinct_turns();
+            assert_eq!(
+                turns.first().copied(),
+                Some(1),
+                "the first observed turn must be turn 1, saw {turns:?}"
+            );
+            assert!(
+                turns.len() >= 2 && *turns.last().expect("turn") >= 2,
+                "a dependent chain must reach >= 2 turns, saw {turns:?}"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn agent_name_absent_when_unconfigured_blocking() {
+    let add = CountingAdd::default();
+    let tap = EventTap::default();
+    let probe = tap.clone();
+
+    with_gemini_cassette(
+        "hook_stress_context/agent_name_absent_when_unconfigured_blocking",
+        |client| async move {
+            // No `.name(..)` on the builder.
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .preamble(CHAIN_PREAMBLE)
+                .temperature(0.0)
+                .tool(add)
+                .build();
+
+            let response = agent
+                .prompt("Use the add tool to add 3 and 4, then report the result.")
+                .max_turns(4)
+                .add_hook(tap)
+                .await
+                .expect("run should succeed");
+
+            assert_nonempty_response(&response);
+            assert_eq!(
+                probe.agent_name(),
+                None,
+                "agent_name() must be None when the agent has no configured name"
+            );
+        },
+    )
+    .await;
+}
+
+// ---------------------------------------------------------------------------
+// Scratchpad: shared across two hooks and growing across turns.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn scratchpad_tally_grows_across_turns_and_is_read_by_second_hook_blocking() {
+    let add = CountingAdd::default();
+    let subtract = CountingSubtract::default();
+    let add_calls = add.counter.clone();
+    let subtract_calls = subtract.counter.clone();
+    let tap = EventTap::default();
+    let reader = ScratchpadReader::default();
+    let tap_probe = tap.clone();
+    let reader_probe = reader.clone();
+
+    with_gemini_cassette(
+        "hook_stress_context/scratchpad_tally_grows_across_turns_and_is_read_by_second_hook_blocking",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .name("stress-agent")
+                .preamble(CHAIN_PREAMBLE)
+                .temperature(0.0)
+                .tool(add)
+                .tool(subtract)
+                .build();
+
+            let response = agent
+                .prompt(
+                    "First add 30 and 12 with the add tool. Then subtract 5 from that sum with the \
+                     subtract tool. Report the final number.",
+                )
+                .max_turns(6)
+                // Writer (tap) bumps the scratchpad tally on each ToolCall; the
+                // reader (a *different* hook) reads it on each ModelTurnFinished.
+                .add_hook(tap)
+                .add_hook(reader)
+                .await
+                .expect("dependent chain should succeed");
+
+            assert_nonempty_response(&response);
+            let total_calls = add_calls.count() + subtract_calls.count();
+            let tallies = reader_probe.tallies();
+            assert!(
+                tallies.len() >= 2,
+                "a multi-turn run should fire ModelTurnFinished at least twice, saw {tallies:?}"
+            );
+            assert!(
+                tallies.windows(2).all(|w| w[0] <= w[1]),
+                "the shared scratchpad tally must be non-decreasing, saw {tallies:?}"
+            );
+            assert!(
+                tallies.first() < tallies.last(),
+                "the tally must grow across turns (cross-turn shared state), saw {tallies:?}"
+            );
+            assert_eq!(
+                *tallies.last().expect("a tally"),
+                total_calls,
+                "the final tally must equal the total ToolCall count"
+            );
+            assert_eq!(
+                tap_probe.count("ToolCall"),
+                total_calls,
+                "observed ToolCall events must equal real executions"
+            );
+        },
+    )
+    .await;
+}
+
+// ---------------------------------------------------------------------------
+// Tool-call correlation: internal_call_id pairs ToolCall with ToolResult.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn internal_call_id_correlates_tool_call_and_result_blocking() {
+    let add = CountingAdd::default();
+    let subtract = CountingSubtract::default();
+    let tap = EventTap::default();
+    let probe = tap.clone();
+
+    with_gemini_cassette(
+        "hook_stress_context/internal_call_id_correlates_tool_call_and_result_blocking",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .name("stress-agent")
+                .preamble(CHAIN_PREAMBLE)
+                .temperature(0.0)
+                .tool(add)
+                .tool(subtract)
+                .build();
+
+            let response = agent
+                .prompt(
+                    "First add 7 and 7 with the add tool. Then subtract 2 from that sum with the \
+                     subtract tool. Report the final number.",
+                )
+                .max_turns(6)
+                .add_hook(tap)
+                .await
+                .expect("dependent chain should succeed");
+
+            assert_nonempty_response(&response);
+            let call_ids = probe.call_ids();
+            let result_ids = probe.result_ids();
+            assert!(!call_ids.is_empty(), "the run should make tool calls");
+            assert_eq!(
+                call_ids, result_ids,
+                "each ToolResult must carry the same internal_call_id as its ToolCall, in order"
+            );
+            assert!(
+                call_ids.iter().all(|id| !id.is_empty()),
+                "internal_call_ids must be non-empty"
+            );
+        },
+    )
+    .await;
+}
+
+// ---------------------------------------------------------------------------
+// HookStack composition: multiple observe-only hooks, add_hook append.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn two_observe_only_hooks_both_observe_the_run_blocking() {
+    let add = CountingAdd::default();
+    let first = EventTap::default();
+    let second = EventTap::default();
+    let first_probe = first.clone();
+    let second_probe = second.clone();
+
+    with_gemini_cassette(
+        "hook_stress_context/two_observe_only_hooks_both_observe_the_run_blocking",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .name("stress-agent")
+                .preamble(CHAIN_PREAMBLE)
+                .temperature(0.0)
+                .tool(add)
+                .build();
+
+            let response = agent
+                .prompt("Use the add tool to add 8 and 8, then report the result.")
+                .max_turns(4)
+                .add_hook(first)
+                .add_hook(second)
+                .await
+                .expect("run should succeed");
+
+            assert_nonempty_response(&response);
+            // Both observe-only hooks see the same run — neither short-circuits.
+            for tag in [
+                "CompletionCall",
+                "ToolCall",
+                "ToolResult",
+                "ModelTurnFinished",
+            ] {
+                assert_eq!(
+                    first_probe.count(tag),
+                    second_probe.count(tag),
+                    "both hooks must observe the same number of {tag} events"
+                );
+            }
+            assert!(first_probe.count("ToolCall") >= 1);
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn add_hook_appends_across_builder_and_request_blocking() {
+    let add = CountingAdd::default();
+    let builder_hook = EventTap::default();
+    let request_hook = EventTap::default();
+    let builder_probe = builder_hook.clone();
+    let request_probe = request_hook.clone();
+
+    with_gemini_cassette(
+        "hook_stress_context/add_hook_appends_across_builder_and_request_blocking",
+        |client| async move {
+            // One hook on the agent builder, one on the request: both must fire
+            // (the request-level add_hook appends to the agent-default stack).
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .name("stress-agent")
+                .preamble(CHAIN_PREAMBLE)
+                .temperature(0.0)
+                .tool(add)
+                .add_hook(builder_hook)
+                .build();
+
+            let response = agent
+                .prompt("Use the add tool to add 5 and 6, then report the result.")
+                .max_turns(4)
+                .add_hook(request_hook)
+                .await
+                .expect("run should succeed");
+
+            assert_nonempty_response(&response);
+            assert!(
+                builder_probe.count("CompletionCall") >= 1,
+                "the agent-default (builder) hook must still fire"
+            );
+            assert!(
+                request_probe.count("CompletionCall") >= 1,
+                "the request-level hook must fire too"
+            );
+            assert_eq!(
+                builder_probe.count("ToolCall"),
+                request_probe.count("ToolCall"),
+                "both stacked hooks observe the same tool calls"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn completion_call_patches_accumulate_from_two_hooks_blocking() {
+    let add = CountingAdd::default();
+
+    with_gemini_cassette(
+        "hook_stress_context/completion_call_patches_accumulate_from_two_hooks_blocking",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .name("stress-agent")
+                .preamble(
+                    "You are a helpful assistant. Consult the provided context for any facts you \
+                     are asked about; use a tool for arithmetic.",
+                )
+                .tool(add)
+                .build();
+
+            // Two independent hooks each inject a different fact via extra_context.
+            // Patches must accumulate (append), so BOTH facts reach the model.
+            let response = agent
+                .prompt("Tell me both the harbor code and the orchard code.")
+                .max_turns(4)
+                .add_hook(ApplyPatch(
+                    RequestPatch::new()
+                        .context(fact_doc("harbor", "The harbor code is ALPHA-11."))
+                        .temperature(0.0),
+                ))
+                .add_hook(ApplyPatch(
+                    RequestPatch::new()
+                        .context(fact_doc("orchard", "The orchard code is BETA-22.")),
+                ))
+                .await
+                .expect("accumulated context run should succeed");
+
+            assert!(
+                response.contains("ALPHA-11"),
+                "the first hook's injected fact must reach the model: {response:?}"
+            );
+            assert!(
+                response.contains("BETA-22"),
+                "the second hook's injected fact must reach the model too (patches accumulate): \
+                 {response:?}"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn two_hooks_narrow_active_tools_to_intersection_blocking() {
+    let add = CountingAdd::default();
+    let subtract = CountingSubtract::default();
+    let multiply = CountingMultiply::default();
+    let add_calls = add.counter.clone();
+    let subtract_calls = subtract.counter.clone();
+    let multiply_calls = multiply.counter.clone();
+
+    with_gemini_cassette(
+        "hook_stress_context/two_hooks_narrow_active_tools_to_intersection_blocking",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .name("stress-agent")
+                .preamble(
+                    "You are a calculator assistant. Use a provided tool for any arithmetic you \
+                     can. If a needed tool is unavailable, say so and move on.",
+                )
+                .tool(add)
+                .tool(subtract)
+                .tool(multiply)
+                .build();
+
+            // Two narrowing hooks: {add, subtract} ∩ {add, multiply} == {add}.
+            let response = agent
+                .prompt(
+                    "Compute 6 + 2, then 10 - 3, then 4 * 5. Report whichever results you can \
+                     obtain.",
+                )
+                .max_turns(5)
+                .add_hook(ApplyPatch(
+                    RequestPatch::new()
+                        .active_tools(["add", "subtract"])
+                        .temperature(0.0),
+                ))
+                .add_hook(ApplyPatch(
+                    RequestPatch::new().active_tools(["add", "multiply"]),
+                ))
+                .await
+                .expect("intersected-tools run should succeed");
+
+            assert_nonempty_response(&response);
+            // Only `add` is in the intersection, so only it can execute.
+            assert!(
+                add_calls.count() >= 1,
+                "add is in the intersection and should run"
+            );
+            assert_eq!(
+                subtract_calls.count(),
+                0,
+                "subtract is outside the intersection and must never execute"
+            );
+            assert_eq!(
+                multiply_calls.count(),
+                0,
+                "multiply is outside the intersection and must never execute"
+            );
+        },
+    )
+    .await;
+}

--- a/tests/providers/gemini/cassette/hook_stress_patch.rs
+++ b/tests/providers/gemini/cassette/hook_stress_patch.rs
@@ -1,0 +1,170 @@
+//! Hook-system stress suite: `RequestPatch` steering on `CompletionCall` —
+//! preamble override, `tool_choice`, per-turn `history` replacement, and
+//! multi-field patches. Recorded against real Gemini; each patch effect is
+//! proven by a downstream-observable change (the model can't echo settings).
+
+use rig::agent::RequestPatch;
+use rig::client::CompletionClient;
+use rig::completion::Prompt;
+use rig::message::{Message, ToolChoice};
+use rig::providers::gemini;
+
+use super::super::hook_stress_support::{ApplyPatch, FirstTurnPatch, fact_doc};
+use super::super::support::with_gemini_cassette;
+use super::super::tools_support::CountingAdd;
+use crate::support::assert_nonempty_response;
+
+const CODEWORD: &str = "ZULU-99";
+
+#[tokio::test]
+async fn preamble_override_forces_codeword_blocking() {
+    with_gemini_cassette(
+        "hook_stress_patch/preamble_override_forces_codeword_blocking",
+        |client| async move {
+            // The agent's own preamble says nothing about a codeword.
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .name("stress-agent")
+                .preamble("You are a terse assistant.")
+                .build();
+
+            // A hook overrides the preamble for this turn to require a codeword
+            // suffix — a behavior change only the injected preamble can cause.
+            let response = agent
+                .prompt("Greet me in one short sentence.")
+                .max_turns(2)
+                .add_hook(ApplyPatch(
+                    RequestPatch::new()
+                        .preamble(format!(
+                            "You are a terse assistant. End every reply with the exact token \
+                             {CODEWORD} on its own, verbatim."
+                        ))
+                        .temperature(0.0),
+                ))
+                .await
+                .expect("preamble-override run should succeed");
+
+            assert!(
+                response.contains(CODEWORD),
+                "the overridden preamble must change behavior; answer: {response:?}"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn tool_choice_required_forces_a_tool_call_blocking() {
+    let add = CountingAdd::default();
+    let add_calls = add.counter.clone();
+
+    with_gemini_cassette(
+        "hook_stress_patch/tool_choice_required_forces_a_tool_call_blocking",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .name("stress-agent")
+                .preamble("You are a calculator assistant.")
+                .tool(add)
+                .build();
+
+            // Force tool_choice = Required on the FIRST turn only, so the model
+            // must call the tool up front. (Forcing it every turn would force a
+            // tool call on every turn and loop until max_turns — a real footgun
+            // this stress test surfaced.)
+            let response = agent
+                .prompt("Use the add tool to compute 12 plus 30, then report the number.")
+                .max_turns(4)
+                .add_hook(FirstTurnPatch(
+                    RequestPatch::new()
+                        .tool_choice(ToolChoice::Required)
+                        .temperature(0.0),
+                ))
+                .await
+                .expect("tool_choice=Required run should succeed");
+
+            assert_nonempty_response(&response);
+            assert!(
+                add_calls.count() >= 1,
+                "tool_choice=Required (via RequestPatch) must force a tool call"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn history_replacement_injects_prior_fact_blocking() {
+    with_gemini_cassette(
+        "hook_stress_patch/history_replacement_injects_prior_fact_blocking",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .name("stress-agent")
+                .preamble("You are a helpful assistant. Use the conversation so far to answer.")
+                .build();
+
+            // A hook replaces the messages sent this turn with a synthetic prior
+            // exchange that establishes a fact — the model answers from it.
+            let response = agent
+                .prompt("What is the passphrase?")
+                .max_turns(2)
+                .add_hook(ApplyPatch(
+                    RequestPatch::new()
+                        .history([Message::user(
+                            "For this session, the passphrase is OMEGA-7. Acknowledge and remember it.",
+                        )])
+                        .temperature(0.0),
+                ))
+                .await
+                .expect("history-replacement run should succeed");
+
+            assert!(
+                response.contains("OMEGA-7"),
+                "the per-turn history view must reach the model; answer: {response:?}"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn multi_field_patch_applies_preamble_and_context_blocking() {
+    with_gemini_cassette(
+        "hook_stress_patch/multi_field_patch_applies_preamble_and_context_blocking",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .name("stress-agent")
+                .preamble("You are a terse assistant.")
+                .build();
+
+            // One patch sets BOTH the preamble and an extra_context document; both
+            // fields must take effect.
+            let response = agent
+                .prompt("What is the depot code? Keep it short.")
+                .max_turns(2)
+                .add_hook(ApplyPatch(
+                    RequestPatch::new()
+                        .preamble(format!(
+                            "You are a terse assistant. End every reply with the exact token \
+                             {CODEWORD}."
+                        ))
+                        .context(fact_doc("depot", "The depot code is GAMMA-33."))
+                        .temperature(0.0),
+                ))
+                .await
+                .expect("multi-field patch run should succeed");
+
+            assert!(
+                response.contains("GAMMA-33"),
+                "the patch's extra_context must reach the model; answer: {response:?}"
+            );
+            assert!(
+                response.contains(CODEWORD),
+                "the patch's preamble override must also take effect; answer: {response:?}"
+            );
+        },
+    )
+    .await;
+}

--- a/tests/providers/gemini/cassette/hook_stress_streaming.rs
+++ b/tests/providers/gemini/cassette/hook_stress_streaming.rs
@@ -1,0 +1,303 @@
+//! Hook-system stress suite: streaming lifecycle and blocking-vs-streaming
+//! parity — `TextDelta` / `StreamResponseFinish` / `ModelTurnFinished` on the
+//! streaming surface, `RewriteResult` redaction reaching the `FinalResponse`,
+//! `active_tools` narrowing and `Skip` on the streaming driver, and the same
+//! workflow producing the same answer on both surfaces. Recorded against real
+//! Gemini.
+
+use rig::agent::RequestPatch;
+use rig::client::CompletionClient;
+use rig::completion::Prompt;
+use rig::providers::gemini;
+use rig::streaming::StreamingPrompt;
+
+use super::super::hook_stress_support::{
+    ApplyPatch, CHAIN_PREAMBLE, EventTap, ResultRewrite, RewriteToolResult,
+};
+use super::super::support::with_gemini_cassette;
+use super::super::tools_support::{CountingAdd, CountingSubtract, SkipToolHook};
+use crate::support::{
+    assert_mentions_expected_number, assert_nonempty_response, collect_stream_final_response,
+};
+
+#[tokio::test]
+async fn streaming_text_only_emits_text_deltas_and_stream_finish() {
+    let tap = EventTap::default();
+    let probe = tap.clone();
+
+    with_gemini_cassette(
+        "hook_stress_streaming/streaming_text_only_emits_text_deltas_and_stream_finish",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .name("stress-agent")
+                .preamble("You are a concise assistant. Answer directly in plain text.")
+                .temperature(0.0)
+                .build();
+
+            let mut stream = agent
+                .stream_prompt("In one short sentence, describe the color of a clear daytime sky.")
+                .add_hook(tap)
+                .multi_turn(2)
+                .await;
+
+            let final_text = collect_stream_final_response(&mut stream)
+                .await
+                .expect("a final response");
+            assert_nonempty_response(&final_text);
+
+            assert_eq!(probe.is_streaming(), Some(true));
+            assert!(
+                probe.count("TextDelta") >= 1,
+                "a streamed text turn must emit TextDelta events"
+            );
+            assert!(
+                probe.count("StreamResponseFinish") >= 1,
+                "a streamed text turn must emit StreamResponseFinish"
+            );
+            assert!(
+                probe.count("ModelTurnFinished") >= 1,
+                "ModelTurnFinished must fire on the streaming surface"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn streaming_tool_turns_fire_model_turn_finished() {
+    let add = CountingAdd::default();
+    let subtract = CountingSubtract::default();
+    let tap = EventTap::default();
+    let probe = tap.clone();
+
+    with_gemini_cassette(
+        "hook_stress_streaming/streaming_tool_turns_fire_model_turn_finished",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .name("stress-agent")
+                .preamble(CHAIN_PREAMBLE)
+                .temperature(0.0)
+                .tool(add)
+                .tool(subtract)
+                .build();
+
+            let mut stream = agent
+                .stream_prompt(
+                    "First add 40 and 2 with the add tool. Then subtract 10 from that sum with the \
+                     subtract tool. Report the final number.",
+                )
+                .add_hook(tap)
+                .multi_turn(6)
+                .await;
+
+            let final_text = collect_stream_final_response(&mut stream)
+                .await
+                .expect("a final response");
+            assert_nonempty_response(&final_text);
+
+            assert_eq!(probe.is_streaming(), Some(true));
+            assert!(
+                probe.count("ToolCall") >= 1,
+                "the streamed run should call tools"
+            );
+            assert!(
+                probe.count("ModelTurnFinished") >= 2,
+                "ModelTurnFinished must fire once per accepted turn on the streaming surface, \
+                 including tool turns"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn streaming_result_redaction_reaches_final_response() {
+    let add = CountingAdd::default();
+
+    with_gemini_cassette(
+        "hook_stress_streaming/streaming_result_redaction_reaches_final_response",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .name("stress-agent")
+                .preamble(
+                    "You are a calculator assistant. Use the add tool, then report the exact tool \
+                     result text verbatim.",
+                )
+                .temperature(0.0)
+                .tool(add)
+                .build();
+
+            let mut stream = agent
+                .stream_prompt(
+                    "Use the add tool to add 5 and 5, then report the exact tool result.",
+                )
+                .add_hook(RewriteToolResult {
+                    tool: "add",
+                    rewrite: ResultRewrite::Replace("STREAM-REDACTED-Q3"),
+                })
+                .multi_turn(4)
+                .await;
+
+            let final_text = collect_stream_final_response(&mut stream)
+                .await
+                .expect("a final response");
+            assert!(
+                final_text.contains("STREAM-REDACTED-Q3"),
+                "the redacted result must reach the streamed final response: {final_text:?}"
+            );
+            assert!(
+                !final_text.contains("10"),
+                "the raw tool result must not reach the model: {final_text:?}"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn streaming_active_tools_narrowing_filters_a_tool() {
+    let add = CountingAdd::default();
+    let subtract = CountingSubtract::default();
+    let add_calls = add.counter.clone();
+    let subtract_calls = subtract.counter.clone();
+
+    with_gemini_cassette(
+        "hook_stress_streaming/streaming_active_tools_narrowing_filters_a_tool",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .name("stress-agent")
+                .preamble(
+                    "You are a calculator assistant. Use a provided tool for any arithmetic you \
+                     can; if a tool is unavailable, say so and continue.",
+                )
+                .tool(add)
+                .tool(subtract)
+                .build();
+
+            let mut stream = agent
+                .stream_prompt("Compute 12 + 8, then compute 30 - 7. Report whichever you can.")
+                .add_hook(ApplyPatch(
+                    RequestPatch::new().active_tools(["add"]).temperature(0.0),
+                ))
+                .multi_turn(5)
+                .await;
+
+            let final_text = collect_stream_final_response(&mut stream)
+                .await
+                .expect("a final response");
+            assert_nonempty_response(&final_text);
+            assert!(
+                add_calls.count() >= 1,
+                "add stays advertised and should run"
+            );
+            assert_eq!(
+                subtract_calls.count(),
+                0,
+                "subtract is filtered out of active_tools on the streaming surface too"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn streaming_skip_leaves_tool_unexecuted() {
+    let add = CountingAdd::default();
+    let subtract = CountingSubtract::default();
+    let subtract_calls = subtract.counter.clone();
+
+    with_gemini_cassette(
+        "hook_stress_streaming/streaming_skip_leaves_tool_unexecuted",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .name("stress-agent")
+                .preamble(
+                    "You are a calculator assistant. You MUST use the provided tools. If a tool \
+                     reports it is unavailable, acknowledge that and report any results you have.",
+                )
+                .temperature(0.0)
+                .tool(add)
+                .tool(subtract)
+                .build();
+
+            let mut stream = agent
+                .stream_prompt("Add 14 and 6, and subtract 9 from 40. Report what you can.")
+                .add_hook(SkipToolHook {
+                    tool_name: "subtract",
+                    reason: "the subtract tool is offline; continue without it",
+                })
+                .multi_turn(5)
+                .await;
+
+            let final_text = collect_stream_final_response(&mut stream)
+                .await
+                .expect("a final response");
+            assert_nonempty_response(&final_text);
+            assert_eq!(
+                subtract_calls.count(),
+                0,
+                "a skipped tool must never execute on the streaming surface"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn blocking_and_streaming_produce_same_final_answer() {
+    const PROMPT: &str = "First add 10 and 5 with the add tool. Then subtract 3 from that sum with \
+         the subtract tool. Report the final number.";
+    const EXPECTED: i32 = 12;
+
+    // Blocking surface.
+    let add_b = CountingAdd::default();
+    let sub_b = CountingSubtract::default();
+    with_gemini_cassette(
+        "hook_stress_streaming/parity_blocking",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .name("stress-agent")
+                .preamble(CHAIN_PREAMBLE)
+                .temperature(0.0)
+                .tool(add_b)
+                .tool(sub_b)
+                .build();
+            let response = agent
+                .prompt(PROMPT)
+                .max_turns(6)
+                .await
+                .expect("blocking parity run should succeed");
+            assert_mentions_expected_number(&response, EXPECTED);
+        },
+    )
+    .await;
+
+    // Streaming surface — same workflow, same expected answer.
+    let add_s = CountingAdd::default();
+    let sub_s = CountingSubtract::default();
+    with_gemini_cassette(
+        "hook_stress_streaming/parity_streaming",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .name("stress-agent")
+                .preamble(CHAIN_PREAMBLE)
+                .temperature(0.0)
+                .tool(add_s)
+                .tool(sub_s)
+                .build();
+            let mut stream = agent.stream_prompt(PROMPT).multi_turn(6).await;
+            let final_text = collect_stream_final_response(&mut stream)
+                .await
+                .expect("a final response");
+            assert_mentions_expected_number(&final_text, EXPECTED);
+        },
+    )
+    .await;
+}

--- a/tests/providers/gemini/cassette/hook_stress_tools.rs
+++ b/tests/providers/gemini/cassette/hook_stress_tools.rs
@@ -1,0 +1,311 @@
+//! Hook-system stress suite: the tool-execution lifecycle — chained
+//! `RewriteArgs`, chained `RewriteResult` (redact / wrap / truncate),
+//! `Terminate` from a `ToolResult` (post-execution), and model-driven recovery
+//! from a tool error. Recorded against real Gemini.
+
+use rig::client::CompletionClient;
+use rig::completion::{Prompt, PromptError};
+use rig::providers::gemini;
+use serde_json::json;
+
+use super::super::hook_stress_support::{
+    ResultRewrite, RewriteToolResult, SetArg, TerminateOnResult,
+};
+use super::super::support::with_gemini_cassette;
+use super::super::tools_support::{CodewordLookup, CountingAdd, MottoTool, ToolEventRecorder};
+use crate::support::assert_nonempty_response;
+
+// ---------------------------------------------------------------------------
+// Argument rewriting.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn arg_rewrite_sets_one_key_preserving_rest_blocking() {
+    let add = CountingAdd::default();
+    let add_calls = add.counter.clone();
+    let recorder = ToolEventRecorder::default();
+    let recorder_probe = recorder.clone();
+
+    with_gemini_cassette(
+        "hook_stress_tools/arg_rewrite_sets_one_key_preserving_rest_blocking",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .name("stress-agent")
+                .preamble("You are a calculator assistant. Use the add tool for the addition.")
+                .temperature(0.0)
+                .tool(add)
+                .build();
+
+            let response = agent
+                .prompt("Use the add tool to add 3 and 4, then report the tool's result.")
+                .max_turns(4)
+                // Force x = 100 but leave y untouched, then observe.
+                .add_hook(SetArg {
+                    tool: "add",
+                    key: "x",
+                    value: json!(100),
+                })
+                .add_hook(recorder)
+                .await
+                .expect("single-key arg rewrite run should succeed");
+
+            assert_nonempty_response(&response);
+            assert!(add_calls.count() >= 1, "the tool should execute");
+            let calls = recorder_probe.recorded_calls();
+            assert_eq!(calls.len(), 1, "one add call, saw {calls:?}");
+            let observed: serde_json::Value =
+                serde_json::from_str(&calls[0].1).expect("observed args are JSON");
+            assert_eq!(observed["x"], json!(100), "x must be the rewritten value");
+            assert!(
+                observed.get("y").is_some(),
+                "the model's y argument must be preserved: {observed}"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn two_arg_rewrites_chain_blocking() {
+    let add = CountingAdd::default();
+    let recorder = ToolEventRecorder::default();
+    let recorder_probe = recorder.clone();
+
+    with_gemini_cassette(
+        "hook_stress_tools/two_arg_rewrites_chain_blocking",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .name("stress-agent")
+                .preamble("You are a calculator assistant. Use the add tool for the addition.")
+                .temperature(0.0)
+                .tool(add)
+                .build();
+
+            let response = agent
+                .prompt("Use the add tool to add 1 and 1, then report the tool's result.")
+                .max_turns(4)
+                // Two rewriters chain: the second sees the first's output and adds
+                // its own key, so the tool executes against {x:7, y:8}.
+                .add_hook(SetArg {
+                    tool: "add",
+                    key: "x",
+                    value: json!(7),
+                })
+                .add_hook(SetArg {
+                    tool: "add",
+                    key: "y",
+                    value: json!(8),
+                })
+                .add_hook(recorder)
+                .await
+                .expect("chained arg rewrite run should succeed");
+
+            assert_nonempty_response(&response);
+            let calls = recorder_probe.recorded_calls();
+            assert_eq!(calls.len(), 1);
+            let observed: serde_json::Value =
+                serde_json::from_str(&calls[0].1).expect("observed args are JSON");
+            assert_eq!(
+                observed,
+                json!({ "x": 7, "y": 8 }),
+                "both chained rewrites must compose"
+            );
+            let results = recorder_probe.recorded_results();
+            assert_eq!(
+                results[0].2, "15",
+                "the tool executed against the composed args"
+            );
+        },
+    )
+    .await;
+}
+
+// ---------------------------------------------------------------------------
+// Result rewriting.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn two_result_rewrites_chain_redact_then_wrap_blocking() {
+    let add = CountingAdd::default();
+
+    with_gemini_cassette(
+        "hook_stress_tools/two_result_rewrites_chain_redact_then_wrap_blocking",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .name("stress-agent")
+                .preamble(
+                    "You are a calculator assistant. Use the add tool, then report the exact tool \
+                     result text verbatim.",
+                )
+                .temperature(0.0)
+                .tool(add)
+                .build();
+
+            let response = agent
+                .prompt("Use the add tool to add 2 and 2, then report the exact tool result.")
+                .max_turns(4)
+                // Redact -> wrap: the model sees "[SECRET]".
+                .add_hook(RewriteToolResult {
+                    tool: "add",
+                    rewrite: ResultRewrite::Replace("SECRET"),
+                })
+                .add_hook(RewriteToolResult {
+                    tool: "add",
+                    rewrite: ResultRewrite::Wrap {
+                        prefix: "[",
+                        suffix: "]",
+                    },
+                })
+                .await
+                .expect("chained result rewrite run should succeed");
+
+            assert!(
+                response.contains("[SECRET]"),
+                "both chained result rewrites must compose (redact then wrap): {response:?}"
+            );
+            assert!(
+                !response.contains('4'),
+                "the raw tool result must not reach the model: {response:?}"
+            );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn result_truncation_reaches_model_blocking() {
+    with_gemini_cassette(
+        "hook_stress_tools/result_truncation_reaches_model_blocking",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .name("stress-agent")
+                .preamble(
+                    "Call the fetch_motto tool, then report the exact tool result text verbatim.",
+                )
+                .temperature(0.0)
+                .tool(MottoTool)
+                .build();
+
+            // The motto is "steady hands\ncalm waters"; truncate to its first 6
+            // chars ("steady") before the model sees it.
+            let response = agent
+                .prompt("Call fetch_motto and report exactly what it returns.")
+                .max_turns(4)
+                .add_hook(RewriteToolResult {
+                    tool: "fetch_motto",
+                    rewrite: ResultRewrite::Truncate(6),
+                })
+                .await
+                .expect("result truncation run should succeed");
+
+            assert!(
+                response.contains("steady"),
+                "the truncated result prefix must reach the model: {response:?}"
+            );
+            assert!(
+                !response.contains("waters"),
+                "the truncated-off suffix must not reach the model: {response:?}"
+            );
+        },
+    )
+    .await;
+}
+
+// ---------------------------------------------------------------------------
+// Terminate from a ToolResult (post-execution).
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn terminate_from_tool_result_cancels_after_execution_blocking() {
+    let add = CountingAdd::default();
+    let add_calls = add.counter.clone();
+
+    with_gemini_cassette(
+        "hook_stress_tools/terminate_from_tool_result_cancels_after_execution_blocking",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .name("stress-agent")
+                .preamble("You are a calculator assistant. Use the add tool for the addition.")
+                .temperature(0.0)
+                .tool(add)
+                .build();
+
+            let error = agent
+                .prompt("Use the add tool to add 21 and 21, then report the result.")
+                .max_turns(4)
+                // Unlike a ToolCall terminate, the tool body DOES run first; the
+                // hook then vetoes the run when it sees the result.
+                .add_hook(TerminateOnResult {
+                    tool: "add",
+                    reason: "result vetoed by policy hook",
+                })
+                .await
+                .expect_err("a ToolResult terminate should cancel the run");
+
+            // The tool executed before the terminate fired.
+            assert!(
+                add_calls.count() >= 1,
+                "the tool body must have run before the ToolResult terminate"
+            );
+            match &error {
+                PromptError::PromptCancelled { reason, .. } => assert_eq!(
+                    reason, "result vetoed by policy hook",
+                    "the cancellation must carry the hook reason verbatim"
+                ),
+                other => panic!("expected PromptCancelled, got {other:?}"),
+            }
+        },
+    )
+    .await;
+}
+
+// ---------------------------------------------------------------------------
+// Model-driven recovery from a tool error.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn tool_error_guidance_drives_model_retry_blocking() {
+    let lookup = CodewordLookup::default();
+    let lookup_calls = lookup.counter.clone();
+
+    with_gemini_cassette(
+        "hook_stress_tools/tool_error_guidance_drives_model_retry_blocking",
+        |client| async move {
+            let agent = client
+                .agent(gemini::completion::GEMINI_2_5_FLASH)
+                .name("stress-agent")
+                .preamble(
+                    "You look up team codewords with the lookup_codeword tool. If the tool returns \
+                     an error with guidance, follow that guidance and try again, then report the \
+                     codeword you obtain.",
+                )
+                .temperature(0.0)
+                .tool(lookup)
+                .build();
+
+            // The first (red) lookup errors with corrective guidance pointing at
+            // the blue team; the model should retry and obtain the blue codeword.
+            let response = agent
+                .prompt("Look up the codeword for the red team.")
+                .max_turns(5)
+                .await
+                .expect("tool-error recovery run should succeed");
+
+            assert!(
+                lookup_calls.count() >= 2,
+                "the model should retry the lookup after the error guidance, saw {} call(s)",
+                lookup_calls.count()
+            );
+            assert!(
+                response.to_ascii_lowercase().contains("azure-falcon"),
+                "the model should report the recovered codeword: {response:?}"
+            );
+        },
+    )
+    .await;
+}

--- a/tests/providers/gemini/hook_stress_support.rs
+++ b/tests/providers/gemini/hook_stress_support.rs
@@ -1,0 +1,373 @@
+//! Shared fixtures for the hook-system stress cassette suites
+//! (`cassette::hook_stress*`): a comprehensive event-tap observer, flexible
+//! request-patch / arg-rewrite / result-rewrite / terminate hooks, scratchpad
+//! probes, and a third counting arithmetic tool.
+//!
+//! Every hook here is **deterministic** (no clocks/RNG), so the outbound
+//! requests it produces stay byte-identical across replay. See
+//! `tools_support`'s note on loose assertions: only rig-synthesized values are
+//! pinned to exact equality.
+#![allow(dead_code)]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::{Arc, Mutex};
+
+use rig::agent::{AgentHook, Flow, HookContext, RequestPatch, StepEvent};
+use rig::completion::{CompletionModel, Document, ToolDefinition};
+use rig::tool::Tool;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+/// Forces tool use and a dependent chain so the model takes >= 2 turns.
+pub(crate) const CHAIN_PREAMBLE: &str = "You are a calculator assistant. You MUST use the provided \
+     tools for every arithmetic operation instead of computing results yourself. Perform the steps \
+     in order, using the result of each step as an input to the next. Once you have the final tool \
+     result, reply with the final numeric answer in plain text.";
+
+/// Forces independent tool use (no dependency) so the model may batch calls.
+pub(crate) const INDEPENDENT_TOOLS_PREAMBLE: &str = "You are a calculator assistant. You MUST use \
+     the provided tools for every arithmetic operation instead of computing results yourself. Once \
+     you have the tool results you need, reply with the requested numbers in plain text.";
+
+// ---------------------------------------------------------------------------
+// A third counting tool (add/subtract live in tools_support).
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize, Serialize)]
+pub(crate) struct OperationArgs {
+    pub(crate) x: i64,
+    pub(crate) y: i64,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("math error")]
+pub(crate) struct MathError;
+
+#[derive(Clone, Default)]
+pub(crate) struct CallCounter(Arc<std::sync::atomic::AtomicUsize>);
+
+impl CallCounter {
+    pub(crate) fn count(&self) -> usize {
+        self.0.load(std::sync::atomic::Ordering::SeqCst)
+    }
+    fn bump(&self) {
+        self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    }
+}
+
+/// `multiply` tool that counts its real executions.
+#[derive(Clone, Default)]
+pub(crate) struct CountingMultiply {
+    pub(crate) counter: CallCounter,
+}
+
+impl Tool for CountingMultiply {
+    const NAME: &'static str = "multiply";
+    type Error = MathError;
+    type Args = OperationArgs;
+    type Output = i64;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "Multiply x and y together".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "x": { "type": "number", "description": "The first operand" },
+                    "y": { "type": "number", "description": "The second operand" }
+                },
+                "required": ["x", "y"]
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        self.counter.bump();
+        Ok(args.x * args.y)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Observation: one comprehensive event tap.
+// ---------------------------------------------------------------------------
+
+/// One observed hook event: its variant tag and the one-based turn it fired on.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct Breadcrumb {
+    pub(crate) tag: &'static str,
+    pub(crate) turn: usize,
+}
+
+/// Cross-hook, cross-turn scratchpad value: how many `ToolCall`s have been seen.
+#[derive(Clone, Default)]
+pub(crate) struct ToolCallTally(pub(crate) usize);
+
+/// A comprehensive observe-only hook: counts every event kind, records the
+/// `HookContext` identity (run id / streaming flag / agent name), captures each
+/// tool call's and result's `internal_call_id` for correlation, records an
+/// ordered `(tag, turn)` breadcrumb, and bumps a shared `Scratchpad` tally on
+/// every `ToolCall`.
+#[derive(Clone, Default)]
+pub(crate) struct EventTap {
+    breadcrumbs: Arc<Mutex<Vec<Breadcrumb>>>,
+    run_ids: Arc<Mutex<BTreeSet<String>>>,
+    streaming: Arc<Mutex<Option<bool>>>,
+    agent_name: Arc<Mutex<Option<String>>>,
+    call_ids: Arc<Mutex<Vec<String>>>,
+    result_ids: Arc<Mutex<Vec<String>>>,
+}
+
+impl EventTap {
+    pub(crate) fn breadcrumbs(&self) -> Vec<Breadcrumb> {
+        self.breadcrumbs.lock().expect("breadcrumbs").clone()
+    }
+    pub(crate) fn distinct_run_ids(&self) -> usize {
+        self.run_ids.lock().expect("run_ids").len()
+    }
+    pub(crate) fn is_streaming(&self) -> Option<bool> {
+        *self.streaming.lock().expect("streaming")
+    }
+    pub(crate) fn agent_name(&self) -> Option<String> {
+        self.agent_name.lock().expect("agent_name").clone()
+    }
+    pub(crate) fn count(&self, tag: &str) -> usize {
+        self.breadcrumbs()
+            .iter()
+            .filter(|crumb| crumb.tag == tag)
+            .count()
+    }
+    pub(crate) fn call_ids(&self) -> Vec<String> {
+        self.call_ids.lock().expect("call_ids").clone()
+    }
+    pub(crate) fn result_ids(&self) -> Vec<String> {
+        self.result_ids.lock().expect("result_ids").clone()
+    }
+    /// Distinct turn indices observed, in ascending order.
+    pub(crate) fn distinct_turns(&self) -> Vec<usize> {
+        let set: BTreeSet<usize> = self.breadcrumbs().iter().map(|c| c.turn).collect();
+        set.into_iter().collect()
+    }
+    /// Per-turn `(ToolCall count, ToolResult count)`.
+    pub(crate) fn per_turn_tool_pairs(&self) -> BTreeMap<usize, (usize, usize)> {
+        let mut map: BTreeMap<usize, (usize, usize)> = BTreeMap::new();
+        for crumb in self.breadcrumbs() {
+            let entry = map.entry(crumb.turn).or_default();
+            match crumb.tag {
+                "ToolCall" => entry.0 += 1,
+                "ToolResult" => entry.1 += 1,
+                _ => {}
+            }
+        }
+        map
+    }
+}
+
+impl<M: CompletionModel> AgentHook<M> for EventTap {
+    async fn on_event(&self, ctx: &HookContext, event: StepEvent<'_, M>) -> Flow {
+        self.run_ids
+            .lock()
+            .expect("run_ids")
+            .insert(ctx.run_id().as_str().to_string());
+        *self.streaming.lock().expect("streaming") = Some(ctx.is_streaming());
+        *self.agent_name.lock().expect("agent_name") = ctx.agent_name().map(str::to_string);
+
+        let tag = match event {
+            StepEvent::CompletionCall { .. } => Some("CompletionCall"),
+            StepEvent::CompletionResponse { .. } => Some("CompletionResponse"),
+            StepEvent::ModelTurnFinished { .. } => Some("ModelTurnFinished"),
+            StepEvent::InvalidToolCall(_) => Some("InvalidToolCall"),
+            StepEvent::ToolCall {
+                internal_call_id, ..
+            } => {
+                self.call_ids
+                    .lock()
+                    .expect("call_ids")
+                    .push(internal_call_id.to_string());
+                ctx.scratchpad()
+                    .update(|tally: &mut ToolCallTally| tally.0 += 1);
+                Some("ToolCall")
+            }
+            StepEvent::ToolResult {
+                internal_call_id, ..
+            } => {
+                self.result_ids
+                    .lock()
+                    .expect("result_ids")
+                    .push(internal_call_id.to_string());
+                Some("ToolResult")
+            }
+            StepEvent::TextDelta { .. } => Some("TextDelta"),
+            StepEvent::ToolCallDelta { .. } => Some("ToolCallDelta"),
+            StepEvent::StreamResponseFinish { .. } => Some("StreamResponseFinish"),
+            _ => None,
+        };
+
+        if let Some(tag) = tag {
+            self.breadcrumbs
+                .lock()
+                .expect("breadcrumbs")
+                .push(Breadcrumb {
+                    tag,
+                    turn: ctx.turn(),
+                });
+        }
+        Flow::cont()
+    }
+}
+
+/// Registered *after* an [`EventTap`]: reads the shared `Scratchpad` tally on each
+/// `ModelTurnFinished` and appends it — proving cross-hook, cross-turn shared
+/// state.
+#[derive(Clone, Default)]
+pub(crate) struct ScratchpadReader {
+    tallies: Arc<Mutex<Vec<usize>>>,
+}
+
+impl ScratchpadReader {
+    pub(crate) fn tallies(&self) -> Vec<usize> {
+        self.tallies.lock().expect("tallies").clone()
+    }
+}
+
+impl<M: CompletionModel> AgentHook<M> for ScratchpadReader {
+    async fn on_event(&self, ctx: &HookContext, event: StepEvent<'_, M>) -> Flow {
+        if matches!(event, StepEvent::ModelTurnFinished { .. }) {
+            let tally = ctx
+                .scratchpad()
+                .get::<ToolCallTally>()
+                .map(|t| t.0)
+                .unwrap_or(0);
+            self.tallies.lock().expect("tallies").push(tally);
+        }
+        Flow::cont()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Steering: flexible request-patch / arg-rewrite / result-rewrite / terminate.
+// ---------------------------------------------------------------------------
+
+/// Applies a fixed [`RequestPatch`] on every `CompletionCall` — the workhorse for
+/// the `RequestPatch` suite (preamble / temperature / max_tokens / tool_choice /
+/// active_tools / additional_params / extra_context / history).
+#[derive(Clone)]
+pub(crate) struct ApplyPatch(pub(crate) RequestPatch);
+
+impl<M: CompletionModel> AgentHook<M> for ApplyPatch {
+    async fn on_event(&self, _ctx: &HookContext, event: StepEvent<'_, M>) -> Flow {
+        if matches!(event, StepEvent::CompletionCall { .. }) {
+            Flow::patch_request(self.0.clone())
+        } else {
+            Flow::cont()
+        }
+    }
+}
+
+/// Applies a fixed [`RequestPatch`] only on the **first** turn. Use this for
+/// per-turn steering that must not repeat forever — e.g. a forced
+/// `tool_choice = Required`, which, if re-applied every turn, would force a tool
+/// call on every turn and loop until `max_turns`.
+#[derive(Clone)]
+pub(crate) struct FirstTurnPatch(pub(crate) RequestPatch);
+
+impl<M: CompletionModel> AgentHook<M> for FirstTurnPatch {
+    async fn on_event(&self, ctx: &HookContext, event: StepEvent<'_, M>) -> Flow {
+        if matches!(event, StepEvent::CompletionCall { .. }) && ctx.turn() == 1 {
+            Flow::patch_request(self.0.clone())
+        } else {
+            Flow::cont()
+        }
+    }
+}
+
+/// Convenience: a `Document` for `RequestPatch::context`.
+pub(crate) fn fact_doc(id: &str, text: &str) -> Document {
+    Document {
+        id: id.to_string(),
+        text: text.to_string(),
+        additional_props: Default::default(),
+    }
+}
+
+/// Sets one key of a named tool's arguments, preserving the rest — chains with
+/// other `SetArg`s so several hooks compose.
+#[derive(Clone)]
+pub(crate) struct SetArg {
+    pub(crate) tool: &'static str,
+    pub(crate) key: &'static str,
+    pub(crate) value: serde_json::Value,
+}
+
+impl<M: CompletionModel> AgentHook<M> for SetArg {
+    async fn on_event(&self, _ctx: &HookContext, event: StepEvent<'_, M>) -> Flow {
+        if let StepEvent::ToolCall {
+            tool_name, args, ..
+        } = event
+            && tool_name == self.tool
+        {
+            let mut parsed: serde_json::Value =
+                serde_json::from_str(args).unwrap_or_else(|_| json!({}));
+            parsed[self.key] = self.value.clone();
+            return Flow::rewrite_args(parsed);
+        }
+        Flow::cont()
+    }
+}
+
+/// How a [`RewriteToolResult`] transforms a named tool's output.
+#[derive(Clone)]
+pub(crate) enum ResultRewrite {
+    /// Replace the whole result with a fixed marker.
+    Replace(&'static str),
+    /// Wrap the (possibly already-rewritten) result — chains with a prior rewrite.
+    Wrap {
+        prefix: &'static str,
+        suffix: &'static str,
+    },
+    /// Keep only the first `n` characters.
+    Truncate(usize),
+}
+
+/// Rewrites a named tool's result. Chains with other `RewriteToolResult`s.
+#[derive(Clone)]
+pub(crate) struct RewriteToolResult {
+    pub(crate) tool: &'static str,
+    pub(crate) rewrite: ResultRewrite,
+}
+
+impl<M: CompletionModel> AgentHook<M> for RewriteToolResult {
+    async fn on_event(&self, _ctx: &HookContext, event: StepEvent<'_, M>) -> Flow {
+        if let StepEvent::ToolResult {
+            tool_name, result, ..
+        } = event
+            && tool_name == self.tool
+        {
+            let new = match &self.rewrite {
+                ResultRewrite::Replace(marker) => (*marker).to_string(),
+                ResultRewrite::Wrap { prefix, suffix } => format!("{prefix}{result}{suffix}"),
+                ResultRewrite::Truncate(n) => result.chars().take(*n).collect(),
+            };
+            return Flow::rewrite_result(new);
+        }
+        Flow::cont()
+    }
+}
+
+/// Terminates the run when a named tool *produces a result* (post-execution).
+#[derive(Clone)]
+pub(crate) struct TerminateOnResult {
+    pub(crate) tool: &'static str,
+    pub(crate) reason: &'static str,
+}
+
+impl<M: CompletionModel> AgentHook<M> for TerminateOnResult {
+    async fn on_event(&self, _ctx: &HookContext, event: StepEvent<'_, M>) -> Flow {
+        if let StepEvent::ToolResult { tool_name, .. } = event
+            && tool_name == self.tool
+        {
+            return Flow::terminate(self.reason);
+        }
+        Flow::cont()
+    }
+}

--- a/tests/providers/gemini/mod.rs
+++ b/tests/providers/gemini/mod.rs
@@ -1,4 +1,5 @@
 mod agent_run_support;
+mod hook_stress_support;
 mod support;
 mod tools_support;
 
@@ -19,6 +20,10 @@ mod cassette {
     mod generate_tool_args;
     mod generate_tool_modes;
     mod hook_stress;
+    mod hook_stress_context;
+    mod hook_stress_patch;
+    mod hook_stress_streaming;
+    mod hook_stress_tools;
     #[cfg(feature = "image")]
     mod image_generation;
     mod interactions_api;

--- a/tests/providers/gemini/mod.rs
+++ b/tests/providers/gemini/mod.rs
@@ -18,6 +18,7 @@ mod cassette {
     mod generate_sessions;
     mod generate_tool_args;
     mod generate_tool_modes;
+    mod hook_stress;
     #[cfg(feature = "image")]
     mod image_generation;
     mod interactions_api;


### PR DESCRIPTION
## Summary

A **Gemini cassette-backed stress-test suite for the merged hook system (v2, #2012)**: **30 long, realistic multi-turn workflows** recorded against a real Gemini model and replayed deterministically (no API key needed for replay). Five cassette files under `tests/providers/gemini/cassette/` (`hook_stress`, `hook_stress_context`, `hook_stress_patch`, `hook_stress_tools`, `hook_stress_streaming`) + 31 cassette fixtures, driven by a shared deterministic-fixtures module (`hook_stress_support.rs`). No production code changes.

## Inspiration-library test patterns studied

I studied how six libraries test their hook/middleware/callback/guardrail systems and adopted the transferable *assertion strategies* (a recorded real Gemini is the deterministic script the fake-model scripting can't be):

| Library | What their hook tests stress | Strategy adopted |
|---|---|---|
| **LangChain** (v1 agent middleware) | onion order, override immutability, tool arg-rewrite/skip, PII redaction | **Paired positive+negative redaction**; ordered call-log |
| **LangGraph** (prebuilt/pregel) | pre/post-model hooks, tool interceptor Flow matrix | **Prove mutations via downstream observable effect** (Gemini won't echo settings) |
| **OpenAI Agents** (lifecycle/guardrail) | callback counts+order, guardrail short-circuit | **Zero-downstream invariant** for skip/terminate; per-event scratchpad counters |
| **pydantic-ai** (capabilities/TestModel) | log-spy hook, capture-what-reached-the-model | **The cassette *is* the deterministic multi-turn script** |
| **Semantic Kernel** (filters) | registration-order breadcrumb, skip zero-downstream | **Execution-order breadcrumb** `(event, turn)`; paired counters |
| **Vercel AI SDK** (generate/stream-text) | multi-step loop, per-step callbacks, override precedence | **Ordered lifecycle event list**; matrix the RequestPatch merge/precedence |

## What the new Gemini hook stress tests cover

`hook_stress.rs` (6) — the original core: HookContext + Scratchpad across a long chain; RequestPatch extra_context + active_tools narrowing; chained RewriteArgs→observe→RewriteResult redaction; streaming lifecycle ordering + is_streaming parity; per-turn atomic call/result pairing; Skip zero-execution.

`hook_stress_context.rs` (8) — HookContext identity (stable `run_id`, advancing `turn`, `is_streaming`, `agent_name` incl. the **unset** case); a shared `Scratchpad` **written by one hook and read by a second**, growing across turns; **`internal_call_id` correlation** of `ToolCall`↔`ToolResult`; two observe-only hooks **both** firing; `add_hook` **appending across builder + request**; `CompletionCall` **patch accumulation**; `active_tools` **set-intersection** across two narrowing hooks.

`hook_stress_patch.rs` (4) — **preamble override**; **`tool_choice=Required`** (first turn only); per-turn **`history` replacement** injecting a prior fact; a **multi-field patch** (preamble + extra_context).

`hook_stress_tools.rs` (6) — single-key and **chained `RewriteArgs`**; **chained `RewriteResult`** (redact→wrap) and **truncation**; **`Terminate` from a `ToolResult`** (post-execution — the tool body ran first); and **model-driven recovery from a tool error** (the tool errors with guidance → the model retries → succeeds).

`hook_stress_streaming.rs` (6) — `TextDelta` / `StreamResponseFinish` / `ModelTurnFinished` on the streaming surface; **`ModelTurnFinished` on tool turns**; **`RewriteResult` redaction reaching the `FinalResponse`**; `active_tools` narrowing and `Skip` on the **streaming** driver; and **blocking-vs-streaming answer parity** (two cassettes).

Aspects covered: HookContext (all accessors + unset name), Scratchpad (cross-hook, cross-turn, keyed correlation), HookStack composition (multi-hook order, both-fire, add_hook append, chained rewrites, patch accumulation, active_tools intersection), RequestPatch (preamble / temperature / tool_choice / active_tools / extra_context / history), tool lifecycle (arg rewrite / result redact-wrap-truncate / skip / terminate-on-result / tool-error recovery / execution start), streaming lifecycle + blocking-vs-streaming parity.

## Bugs found and fixed

**No hook-system bugs.** Every scenario passed on live recording, confirming the merged system behaves as documented. One **footgun** surfaced: forcing `tool_choice=Required` on *every* turn loops until `max_turns` (each turn re-forces a tool call). It's expected per the per-turn/re-fire semantics, so rather than change production code I captured the intended pattern with a `FirstTurnPatch` fixture and a comment. No production code changed.

## Cassette safety

- Recorded with `RIG_PROVIDER_TEST_MODE=record` + `GEMINI_API_KEY`, then **auto-scrubbed and safety-checked by the recorder before writing** (the run fails if unsafe artifacts remain).
- Manually reviewed: `key` query param → `[REDACTED]`; `thoughtSignature`/`responseId` → placeholders; grep across all fixtures for `x-goog-api-key`/`gemini_api_key`/`AIza`/`authorization`/`bearer`/`set-cookie` and the raw key value all return empty.
- Descriptive names, deterministic prompts (low temperature, simple arithmetic tools), targeted record commands only.

## Commands run

- Record (targeted, live): `RIG_PROVIDER_TEST_MODE=record cargo test -p rig --all-features --test gemini hook_stress_<mod> -- --test-threads=1` → all passed.
- Replay (no key): `cargo test -p rig --all-features --test gemini hook_stress -- --test-threads=1` → **30 passed** (0.18s, deterministic).
- Full provider suite: `cargo test -p rig --all-features --test gemini gemini::cassette -- --test-threads=1` → **115 passed, 0 failed**.
- `cargo fmt` (clean) · `cargo clippy -p rig --all-features --test gemini` (clean).

## Remaining risks / flakiness considerations

- Replay is byte-identical/deterministic (hooks use no clocks/RNG). Variability exists only at **re-record** time, which is why model-shaped values use loose assertions — a re-recording with a different call count/ordering still passes.
- Deferred as hard-to-force-live or already covered: invalid-tool-call recovery (`Retry`/`Repair`/`Skip`/`Fail` via unregistered/disallowed calls — Gemini won't emit those on purpose; covered by `agent_run_recovery.rs` + rig-core `agent::runner` unit tests) and structured-output Tool-mode finalization (`structured_output.rs` + rig-core unit tests for `ModelTurnFinished` content and the output-tool stream item). Per the guidance to prefer a few rich workflows over many flaky tiny live tests.
