### PR TITLE
fix(auth): allow non-interactive OAuth

### DIFF
--- a/crates/rig-core/src/providers/chatgpt/auth/mod.rs
+++ b/crates/rig-core/src/providers/chatgpt/auth/mod.rs
@@ -100,10 +100,15 @@ impl Authenticator {
         source: AuthSource,
         auth_file: Option<PathBuf>,
         device_code_handler: DeviceCodeHandler,
+        allow_device_flow: bool,
     ) -> Self {
         Self {
             source,
-            platform: platform::PlatformAuthenticator::new(auth_file, device_code_handler),
+            platform: platform::PlatformAuthenticator::new(
+                auth_file,
+                device_code_handler,
+                allow_device_flow,
+            ),
             state_lock: Arc::new(Mutex::new(())),
         }
     }

--- a/crates/rig-core/src/providers/chatgpt/auth/native.rs
+++ b/crates/rig-core/src/providers/chatgpt/auth/native.rs
@@ -20,6 +20,7 @@ const DEVICE_CODE_POLL_SLEEP_SECONDS: u64 = 5;
 pub(super) struct PlatformAuthenticator {
     auth_file: Option<PathBuf>,
     device_code_handler: DeviceCodeHandler,
+    allow_device_flow: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
@@ -65,10 +66,15 @@ enum RefreshTokensError {
 }
 
 impl PlatformAuthenticator {
-    pub(super) fn new(auth_file: Option<PathBuf>, device_code_handler: DeviceCodeHandler) -> Self {
+    pub(super) fn new(
+        auth_file: Option<PathBuf>,
+        device_code_handler: DeviceCodeHandler,
+        allow_device_flow: bool,
+    ) -> Self {
         Self {
             auth_file,
             device_code_handler,
+            allow_device_flow,
         }
     }
 
@@ -105,6 +111,13 @@ impl PlatformAuthenticator {
                 Err(RefreshTokensError::Reauthenticate) => {}
                 Err(RefreshTokensError::Auth(err)) => return Err(err),
             }
+        }
+
+        if !self.allow_device_flow {
+            return Err(AuthError::Message(
+                "ChatGPT sign-in required. Reconnect ChatGPT in Settings before using this provider."
+                    .into(),
+            ));
         }
 
         let fresh = self.login_device_flow().await?;
@@ -418,8 +431,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        DeviceCodeResponse, OAuthErrorResponse, OAuthTokenResponse, build_auth_record,
-        format_refresh_error, should_reauthenticate_after_refresh,
+        DeviceCodeHandler, DeviceCodeResponse, OAuthErrorResponse, OAuthTokenResponse,
+        PlatformAuthenticator, build_auth_record, format_refresh_error,
+        should_reauthenticate_after_refresh,
     };
     use reqwest::StatusCode;
 
@@ -473,6 +487,18 @@ mod tests {
             StatusCode::UNAUTHORIZED,
             None
         ));
+    }
+
+    #[tokio::test]
+    async fn noninteractive_oauth_requires_sign_in_instead_of_device_flow() {
+        let auth = PlatformAuthenticator::new(None, DeviceCodeHandler::default(), false);
+        let err = auth
+            .auth_context_oauth()
+            .await
+            .expect_err("missing cached auth should not start device flow")
+            .to_string();
+
+        assert!(err.contains("ChatGPT sign-in required"), "{err}");
     }
 
     #[test]

--- a/crates/rig-core/src/providers/chatgpt/auth/wasm.rs
+++ b/crates/rig-core/src/providers/chatgpt/auth/wasm.rs
@@ -10,6 +10,7 @@ impl PlatformAuthenticator {
     pub(super) fn new(
         _auth_file: Option<PathBuf>,
         _device_code_handler: DeviceCodeHandler,
+        _allow_device_flow: bool,
     ) -> Self {
         Self
     }

--- a/crates/rig-core/src/providers/chatgpt/mod.rs
+++ b/crates/rig-core/src/providers/chatgpt/mod.rs
@@ -87,6 +87,7 @@ pub struct ChatGPTBuilder {
     auth_file: Option<PathBuf>,
     default_instructions: Option<String>,
     device_code_handler: auth::DeviceCodeHandler,
+    allow_device_flow: bool,
     originator: String,
     user_agent: Option<String>,
 }
@@ -125,6 +126,7 @@ impl Default for ChatGPTBuilder {
                     .unwrap_or_else(|| DEFAULT_INSTRUCTIONS.to_string()),
             ),
             device_code_handler: auth::DeviceCodeHandler::default(),
+            allow_device_flow: true,
             originator: std::env::var("CHATGPT_ORIGINATOR")
                 .ok()
                 .filter(|value| !value.is_empty())
@@ -213,6 +215,7 @@ impl ProviderBuilder for ChatGPTBuilder {
                 auth,
                 ext.auth_file.clone(),
                 ext.device_code_handler.clone(),
+                ext.allow_device_flow,
             ),
             default_instructions: ext.default_instructions.clone(),
             originator: ext.originator.clone(),
@@ -266,6 +269,19 @@ impl<H> ClientBuilder<H> {
     {
         self.over_ext(|mut ext| {
             ext.device_code_handler = auth::DeviceCodeHandler::new(handler);
+            ext
+        })
+    }
+
+    /// Control whether OAuth may fall back to an interactive device-code login
+    /// when the cached token is missing or cannot be refreshed.
+    ///
+    /// Default is `true` for CLI-style interactive use. Long-running services
+    /// should set this to `false` so a stale refresh token returns an actionable
+    /// auth error instead of printing a device code and waiting unattended.
+    pub fn allow_device_flow(self, allow: bool) -> Self {
+        self.over_ext(|mut ext| {
+            ext.allow_device_flow = allow;
             ext
         })
     }

--- a/crates/rig-core/src/providers/copilot/auth/mod.rs
+++ b/crates/rig-core/src/providers/copilot/auth/mod.rs
@@ -98,6 +98,7 @@ impl Authenticator {
         access_token_file: Option<PathBuf>,
         api_key_file: Option<PathBuf>,
         device_code_handler: DeviceCodeHandler,
+        allow_device_flow: bool,
     ) -> Self {
         Self {
             source,
@@ -105,6 +106,7 @@ impl Authenticator {
                 access_token_file,
                 api_key_file,
                 device_code_handler,
+                allow_device_flow,
             ),
             state_lock: Arc::new(Mutex::new(())),
         }

--- a/crates/rig-core/src/providers/copilot/auth/native.rs
+++ b/crates/rig-core/src/providers/copilot/auth/native.rs
@@ -16,6 +16,7 @@ pub(super) struct PlatformAuthenticator {
     access_token_file: Option<PathBuf>,
     api_key_file: Option<PathBuf>,
     device_code_handler: DeviceCodeHandler,
+    allow_device_flow: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
@@ -58,11 +59,13 @@ impl PlatformAuthenticator {
         access_token_file: Option<PathBuf>,
         api_key_file: Option<PathBuf>,
         device_code_handler: DeviceCodeHandler,
+        allow_device_flow: bool,
     ) -> Self {
         Self {
             access_token_file,
             api_key_file,
             device_code_handler,
+            allow_device_flow,
         }
     }
 
@@ -291,6 +294,12 @@ impl PlatformAuthenticator {
     }
 
     async fn reauthenticate_access_token(&self) -> Result<String, AuthError> {
+        if !self.allow_device_flow {
+            return Err(AuthError::Message(
+                "GitHub Copilot sign-in required. Reconnect Copilot in Settings before using this provider."
+                    .into(),
+            ));
+        }
         let token = self.login_device_flow().await?;
         self.write_access_token(&token)?;
         Ok(token)
@@ -452,8 +461,9 @@ fn should_retry_with_fresh_access_token_status(status: Option<reqwest::StatusCod
 #[cfg(test)]
 mod tests {
     use super::{
-        ApiKeyRecord, bootstrap_token_fingerprint, next_poll_interval_seconds,
-        normalize_poll_interval_seconds, should_retry_with_fresh_access_token_status,
+        ApiKeyRecord, DeviceCodeHandler, PlatformAuthenticator, bootstrap_token_fingerprint,
+        next_poll_interval_seconds, normalize_poll_interval_seconds,
+        should_retry_with_fresh_access_token_status,
     };
     use reqwest::StatusCode;
 
@@ -474,6 +484,18 @@ mod tests {
             record.api_base().as_deref(),
             Some("https://api.individual.githubcopilot.com")
         );
+    }
+
+    #[tokio::test]
+    async fn noninteractive_oauth_requires_sign_in_instead_of_device_flow() {
+        let auth = PlatformAuthenticator::new(None, None, DeviceCodeHandler::default(), false);
+        let err = auth
+            .auth_context_oauth()
+            .await
+            .expect_err("missing cached auth should not start device flow")
+            .to_string();
+
+        assert!(err.contains("GitHub Copilot sign-in required"), "{err}");
     }
 
     #[test]

--- a/crates/rig-core/src/providers/copilot/auth/wasm.rs
+++ b/crates/rig-core/src/providers/copilot/auth/wasm.rs
@@ -23,6 +23,7 @@ impl PlatformAuthenticator {
         _access_token_file: Option<PathBuf>,
         _api_key_file: Option<PathBuf>,
         _device_code_handler: DeviceCodeHandler,
+        _allow_device_flow: bool,
     ) -> Self {
         Self
     }

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -155,6 +155,7 @@ pub struct CopilotBuilder {
     access_token_file: Option<PathBuf>,
     api_key_file: Option<PathBuf>,
     device_code_handler: auth::DeviceCodeHandler,
+    allow_device_flow: bool,
 }
 
 #[derive(Clone)]
@@ -181,6 +182,7 @@ impl Default for CopilotBuilder {
             access_token_file: token_dir.as_ref().map(|dir| dir.join("access-token")),
             api_key_file: token_dir.map(|dir| dir.join("api-key.json")),
             device_code_handler: auth::DeviceCodeHandler::default(),
+            allow_device_flow: true,
         }
     }
 }
@@ -235,6 +237,7 @@ impl ProviderBuilder for CopilotBuilder {
                 ext.access_token_file.clone(),
                 ext.api_key_file.clone(),
                 ext.device_code_handler.clone(),
+                ext.allow_device_flow,
             ),
         })
     }
@@ -291,6 +294,19 @@ impl<H> ClientBuilder<H> {
     {
         self.over_ext(|mut ext| {
             ext.device_code_handler = auth::DeviceCodeHandler::new(handler);
+            ext
+        })
+    }
+
+    /// Control whether OAuth may fall back to an interactive device-code login
+    /// when the cached token is missing or cannot refresh.
+    ///
+    /// Default is `true` for CLI-style interactive use. Services should set it
+    /// to `false` so unattended background work returns a clear auth error
+    /// instead of printing a device code and waiting.
+    pub fn allow_device_flow(self, allow: bool) -> Self {
+        self.over_ext(|mut ext| {
+            ext.allow_device_flow = allow;
             ext
         })
     }


### PR DESCRIPTION
## Summary
- add an opt-out for OAuth device-code fallback on ChatGPT and Copilot clients
- keep the default interactive behavior unchanged
- return a clear sign-in-required error when non-interactive clients have no usable cached auth

## Why
Library users running Rig inside services or background workers need to reuse and refresh cached OAuth credentials without accidentally printing a device code and waiting unattended when re-authentication is required.

## Tests
- `cargo fmt --all`
- `cargo test -p rig-core noninteractive_oauth_requires_sign_in_instead_of_device_flow`
- `git diff --check`