### PR TITLE
feat(anthropic): support ANTHROPIC_BASE_URL in from_env()

### DIFF
--- a/crates/rig-core/src/providers/anthropic/client.rs
+++ b/crates/rig-core/src/providers/anthropic/client.rs
@@ -112,9 +112,16 @@ impl ProviderClient for Client {
     where
         Self: Sized,
     {
+        let base_url = crate::client::optional_env_var("ANTHROPIC_BASE_URL")?;
         let key = crate::client::required_env_var("ANTHROPIC_API_KEY")?;
 
-        Self::builder().api_key(key).build().map_err(Into::into)
+        let mut builder = Self::builder().api_key(key);
+
+        if let Some(base) = base_url {
+            builder = builder.base_url(&base);
+        }
+
+        builder.build().map_err(Into::into)
     }
 
     fn from_val(input: Self::Input) -> Result<Self, Self::Error>


### PR DESCRIPTION
## Summary
Closes #2024 
- Read `ANTHROPIC_BASE_URL` in `anthropic::Client::from_env()` and pass it to the builder when set
- Matches the existing `OPENAI_BASE_URL` behavior for OpenAI clients
- No breaking changes — when the env var is unset, the default Anthropic API URL is used

Fixes #2024

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy -p rig-core --all-targets --all-features`
- [x] `cargo test -p rig-core anthropic::client::tests`


