### PR TITLE
feat(vertexai): round-trip Gemini thoughtSignature in tool-calling loop

### DIFF
--- a/crates/rig-vertexai/Cargo.toml
+++ b/crates/rig-vertexai/Cargo.toml
@@ -10,6 +10,7 @@ description = "VertexAI model provider for Rig integration."
 workspace = true
 
 [dependencies]
+base64 = { workspace = true }
 google-cloud-aiplatform-v1 = { workspace = true }
 google-cloud-auth = { workspace = true }
 rig-core = { path = "../rig-core", version = "0.39.0", default-features = false }

--- a/crates/rig-vertexai/src/types/completion_response.rs
+++ b/crates/rig-vertexai/src/types/completion_response.rs
@@ -1,3 +1,5 @@
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64;
 use google_cloud_aiplatform_v1 as vertexai;
 use rig_core::OneOrMany;
 use rig_core::completion::{CompletionError, CompletionResponse, Usage};
@@ -27,6 +29,13 @@ impl TryFrom<VertexGenerateContentOutput> for CompletionResponse<VertexGenerateC
         // vertexai internally uses a wkt::Struct (serde_json::Map<String, serde_json::Value>) in
         // function calling args. We need to convert that to serde_json::Value for rig_core::completion type matching
         for part in content.parts.iter() {
+            // Gemini "thinking" models attach an opaque `thoughtSignature` to (usually) the
+            // functionCall part. It must be echoed back verbatim on subsequent turns or Vertex
+            // rejects the request with INVALID_ARGUMENT ("missing a thought_signature"). We carry
+            // it through rig-core's `ToolCall.signature` (base64, since it is raw bytes).
+            let signature = (!part.thought_signature.is_empty())
+                .then(|| BASE64.encode(&part.thought_signature));
+
             if let Some(function_call) = part.function_call() {
                 let args_json = function_call
                     .args
@@ -34,12 +43,23 @@ impl TryFrom<VertexGenerateContentOutput> for CompletionResponse<VertexGenerateC
                     .map(|s| serde_json::Value::Object(s.clone()))
                     .unwrap_or_else(|| serde_json::json!({}));
 
-                assistant_contents.push(AssistantContent::ToolCall(ToolCall::new(
-                    function_call.name.clone(),
-                    ToolFunction::new(function_call.name.clone(), args_json),
-                )));
+                assistant_contents.push(AssistantContent::ToolCall(
+                    ToolCall::new(
+                        function_call.name.clone(),
+                        ToolFunction::new(function_call.name.clone(), args_json),
+                    )
+                    .with_signature(signature),
+                ));
             } else if let Some(text) = part.text() {
                 assistant_contents.push(AssistantContent::Text(Text::new(text.clone())));
+            } else if signature.is_some() {
+                // A signature-bearing part that is neither a function call nor text (e.g. a
+                // standalone "thinking" part). rig-core has no carrier for it, so it is dropped —
+                // log it so a later INVALID_ARGUMENT can be traced back here rather than being silent.
+                tracing::warn!(
+                    "Vertex response part carries a thought_signature but is neither a function \
+                     call nor text; signature dropped (no rig-core carrier)."
+                );
             }
         }
 
@@ -115,6 +135,49 @@ mod tests {
             .set_finish_reason(vertexai::model::candidate::FinishReason::Stop);
         let response = vertexai::model::GenerateContentResponse::new().set_candidates([candidate]);
         VertexGenerateContentOutput(response)
+    }
+
+    fn create_signed_tool_call_response(
+        function_name: &str,
+        signature: &[u8],
+    ) -> VertexGenerateContentOutput {
+        let function_call = vertexai::model::FunctionCall::new()
+            .set_name(function_name.to_string())
+            .set_args(serde_json::Map::new());
+        let part = vertexai::model::Part::new()
+            .set_function_call(function_call)
+            .set_thought_signature(signature.to_vec());
+        let content = vertexai::model::Content::new()
+            .set_role("model")
+            .set_parts([part]);
+        let candidate = vertexai::model::Candidate::new().set_content(content);
+        let response = vertexai::model::GenerateContentResponse::new().set_candidates([candidate]);
+        VertexGenerateContentOutput(response)
+    }
+
+    #[test]
+    fn test_tool_call_response_captures_thought_signature() {
+        let raw = b"\x00\x01\x02thinking-sig\xff";
+        let response: CompletionResponse<VertexGenerateContentOutput> =
+            create_signed_tool_call_response("add", raw)
+                .try_into()
+                .unwrap();
+        match response.choice.first() {
+            AssistantContent::ToolCall(tc) => assert_eq!(tc.signature, Some(BASE64.encode(raw))),
+            _ => panic!("Expected ToolCall"),
+        }
+    }
+
+    #[test]
+    fn test_tool_call_response_without_signature_is_none() {
+        let response: CompletionResponse<VertexGenerateContentOutput> =
+            create_tool_call_response("add", serde_json::json!({"x": 1}))
+                .try_into()
+                .unwrap();
+        match response.choice.first() {
+            AssistantContent::ToolCall(tc) => assert_eq!(tc.signature, None),
+            _ => panic!("Expected ToolCall"),
+        }
     }
 
     #[test]

--- a/crates/rig-vertexai/src/types/message.rs
+++ b/crates/rig-vertexai/src/types/message.rs
@@ -1,3 +1,5 @@
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64;
 use google_cloud_aiplatform_v1 as vertexai;
 use rig_core::completion::CompletionError;
 use rig_core::message::{AssistantContent, Message, Text, ToolResultContent, UserContent};
@@ -86,7 +88,26 @@ impl TryFrom<RigMessage> for vertexai::model::Content {
                                 .set_name(tool_call.function.name.clone())
                                 .set_args(struct_val);
 
-                            Ok(vertexai::model::Part::new().set_function_call(function_call))
+                            let mut part =
+                                vertexai::model::Part::new().set_function_call(function_call);
+
+                            // Echo back the Gemini `thoughtSignature` captured on the read side
+                            // (base64 → bytes). Required by thinking models on every follow-up turn.
+                            // A malformed signature is dropped (with a warning) rather than failing
+                            // the whole turn — one bad byte must not kill every other tool call.
+                            if let Some(signature) = &tool_call.signature {
+                                match BASE64.decode(signature.as_bytes()) {
+                                    Ok(bytes) => part = part.set_thought_signature(bytes),
+                                    Err(err) => tracing::warn!(
+                                        %err,
+                                        tool = %tool_call.function.name,
+                                        "Failed to base64-decode tool call thought_signature; \
+                                         dropping it for this turn"
+                                    ),
+                                }
+                            }
+
+                            Ok(part)
                         }
                         _ => Err(CompletionError::ProviderError(format!(
                             "Unsupported assistant content type: {:?}",
@@ -177,6 +198,44 @@ mod tests {
         assert!(function_call.is_some());
         let function_call = function_call.unwrap();
         assert_eq!(function_call.name.as_str(), "add");
+    }
+
+    #[test]
+    fn test_assistant_tool_call_echoes_thought_signature() {
+        use rig_core::message::{ToolCall, ToolFunction};
+        let raw = b"\x00\x01\x02thinking-sig\xff";
+        let tool_call = ToolCall::new(
+            "add".to_string(),
+            ToolFunction::new("add".to_string(), serde_json::json!({"x": 5})),
+        )
+        .with_signature(Some(BASE64.encode(raw)));
+        let content: vertexai::model::Content = RigMessage(Message::Assistant {
+            id: None,
+            content: OneOrMany::one(AssistantContent::ToolCall(tool_call)),
+        })
+        .try_into()
+        .unwrap();
+        assert_eq!(content.parts[0].thought_signature.as_ref(), raw.as_slice());
+    }
+
+    #[test]
+    fn test_assistant_tool_call_malformed_signature_is_dropped_not_fatal() {
+        // A malformed signature must not abort the whole turn — it is dropped with a warning.
+        use rig_core::message::{ToolCall, ToolFunction};
+        let tool_call = ToolCall::new(
+            "add".to_string(),
+            ToolFunction::new("add".to_string(), serde_json::json!({"x": 5})),
+        )
+        .with_signature(Some("!!! not base64 !!!".to_string()));
+        let content: vertexai::model::Content = RigMessage(Message::Assistant {
+            id: None,
+            content: OneOrMany::one(AssistantContent::ToolCall(tool_call)),
+        })
+        .try_into()
+        .expect("malformed signature should not fail the conversion");
+        assert_eq!(content.parts.len(), 1);
+        assert!(content.parts[0].thought_signature.is_empty());
+        assert!(content.parts[0].function_call().is_some());
     }
 
     #[test]


### PR DESCRIPTION
Closes #2026.

## Problem

Gemini 2.5/3.x "thinking" models attach an opaque **`thoughtSignature`** to `functionCall` parts, which must be echoed back verbatim on every subsequent turn of a multi-tool conversation. `rig-vertexai` drops it on **both** sides of the tool loop, so turn 2+ of any multi-tool request is rejected by Vertex with:

```
INVALID_ARGUMENT — Function call is missing a thought_signature in functionCall parts.
```

- Read side (`completion_response.rs`) never read `part.thought_signature`.
- Write side (`message.rs`) never called `Part::set_thought_signature(...)`.

## Fix

Mirrors the pattern already present in the direct Gemini provider (`rig-core/src/providers/gemini/completion.rs`, from #1396), scoped to the two Vertex files. The carrier fields already exist end-to-end (`ToolCall.signature: Option<String>` and `Part.thought_signature: Bytes`), so this is only wiring:

- **`completion_response.rs`** — carry `part.thought_signature` into `ToolCall.signature` (base64, since it is raw bytes).
- **`message.rs`** — base64-decode `ToolCall.signature` back into `set_thought_signature(...)`.
- **`Cargo.toml`** — add `base64` (workspace dependency).

### Robustness

- A malformed signature is dropped **with a warning** rather than failing the whole `Content` conversion — one bad byte must not kill every other tool call in the same turn.
- A signature-bearing part that is neither a function call nor text (a standalone "thinking" part with no rig-core carrier) is logged before being dropped, so a later `INVALID_ARGUMENT` can be traced back rather than being silent.

## Tests

Added 4 unit tests (all green):
- read side captures `thought_signature` into `ToolCall.signature` (base64)
- read side leaves `signature` `None` when absent
- write side echoes the signature back into the `Part`
- write side drops a malformed signature without failing the conversion

`cargo test -p rig-vertexai` and `cargo clippy -p rig-vertexai --all-targets` pass.
