### PR TITLE
feat(tool): flatten tool metadata APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+
+- *(tool)* [**breaking**] flatten tool metadata: `Tool::definition(prompt)` and `ToolDyn::definition(...)` were removed. Tool authors now implement `const NAME`, `description()`, and `parameters()` directly; Rig generates `ToolDefinition` request artifacts from registered tools, using `Tool::name()` / `ToolDyn::name()` as the single source of truth.
+
 ## [0.39.0](https://github.com/0xPlaygrounds/rig/compare/v0.38.2...v0.39.0) - 2026-06-19
 
 ### Added

--- a/crates/rig-bedrock/examples/common/mod.rs
+++ b/crates/rig-bedrock/examples/common/mod.rs
@@ -3,7 +3,7 @@ use std::{
     fmt::{Display, Formatter},
 };
 
-use rig_core::{completion::ToolDefinition, tool::Tool};
+use rig_core::tool::Tool;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
@@ -33,24 +33,24 @@ impl Tool for Adder {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "add".to_string(),
-            description: "Add x and y together".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The first number to add"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The second number to add"
-                    }
+    fn description(&self) -> String {
+        "Add x and y together".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "number",
+                    "description": "The first number to add"
+                },
+                "y": {
+                    "type": "number",
+                    "description": "The second number to add"
                 }
-            }),
-        }
+            }
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/crates/rig-core/CHANGELOG.md
+++ b/crates/rig-core/CHANGELOG.md
@@ -37,6 +37,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- *(tool)* [**breaking**] flattened the tool authoring/runtime metadata APIs. `Tool::definition(prompt)` and `ToolDyn::definition(...)` are removed; implement `description(&self) -> String` and `parameters(&self) -> serde_json::Value` alongside `const NAME` instead. `ToolDefinition` remains a provider/request artifact generated at registry/request boundaries from `ToolDyn::name()`, `description()`, and `parameters()`, so a registered tool cannot advertise a provider name different from its dispatch name. Migration:
+  ```rust
+  // before
+  async fn definition(&self, _prompt: String) -> ToolDefinition {
+      ToolDefinition {
+          name: "search".into(),
+          description: "Search docs".into(),
+          parameters: serde_json::json!({ "type": "object" }),
+      }
+  }
+
+  // after
+  const NAME: &'static str = "search";
+
+  fn description(&self) -> String {
+      "Search docs".into()
+  }
+
+  fn parameters(&self) -> serde_json::Value {
+      serde_json::json!({ "type": "object" })
+  }
+  ```
+
 - *(openai)* [**breaking**] the Responses API conversion now sends Rig system instructions (the preamble and any leading system messages) through the official top-level `instructions` field instead of as `system` messages in `input`. Mid-conversation system messages keep their position in `input`; ChatGPT (whose backend rejects the `system` role entirely) lifts all of them. **Behavioral note for OpenAI-compatible endpoints:** a backend that ignores or rejects top-level `instructions` (some vLLM / mistral.rs / LM Studio setups) will silently lose the system prompt under the new default — call `with_system_instructions_as_messages()` on the `openai::Client` (applies to every model, agent, and extractor created from it) or on a `ResponsesCompletionModel` to restore the previous request shape. Placement is expressed by the new public `responses_api::SystemInstructionsPlacement` enum — selectable via `with_system_instructions_placement(..)` on the `openai::Client` and on `ResponsesCompletionModel` (including `AllInstructions` for backends that reject the `system` role), with `with_system_instructions_as_messages()` kept as a shorthand for the compatibility fallback — and a client-level default flows through the new `responses_api::ResponsesProviderExt` trait implemented by the client's `Ext` type (`system_instructions_placement` is a required method, so implementors must state their placement explicitly). A configured placement survives `completions_api()`/`responses_api()` round trips. Direct request conversion with a non-default placement uses the public `responses_api::ResponsesRequestParams` (a `TryFrom` source for the Responses `CompletionRequest`, mirroring the Chat Completions `OpenAIRequestParams` pattern). Also [**breaking**]: `OpenAIResponsesExt` and `OpenAICompletionsExt` are no longer unit structs — construct them with `::default()` instead of the struct literal. ([#1995](https://github.com/0xPlaygrounds/rig/pull/1995), closes [#1599](https://github.com/0xPlaygrounds/rig/issues/1599))
 - *(anthropic)* the streaming completion path now honors the request's `tool_choice` instead of hardcoding `auto`, so a caller's tool choice (including one set per-turn via `Flow::PatchRequest`) takes effect under `stream_prompt`/streaming as it already did on the blocking path. A `tool_choice` Anthropic cannot represent (a multi-name `ToolChoice::Specific`) now surfaces as a request error on both the streaming and blocking paths instead of being silently downgraded to `auto`. ([#1966](https://github.com/0xPlaygrounds/rig/pull/1966))
 - *(agent)* [**breaking**] `Flow` no longer implements `Eq` (it remains `PartialEq`), because `Flow::PatchRequest` carries a `RequestPatch` with an `f64` `temperature`. Code that relied on `Flow: Eq` (e.g. an `Eq` derive on a type embedding `Flow`, or an `Eq`/`Hash` bound) must drop that requirement. ([#1966](https://github.com/0xPlaygrounds/rig/pull/1966))

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -646,7 +646,7 @@ mod tests {
         },
         completion::{
             AssistantContent, CompletionError, CompletionRequest, Message, Prompt, PromptError,
-            StructuredOutputError, ToolDefinition, TypedPrompt, Usage,
+            StructuredOutputError, TypedPrompt, Usage,
         },
         message::{Text, ToolCall, ToolChoice, ToolFunction, UserContent},
         test_utils::{
@@ -880,8 +880,12 @@ mod tests {
         type Args = MockOperationArgs;
         type Output = i32;
 
-        async fn definition(&self, _prompt: String) -> ToolDefinition {
-            MockAddTool.definition(String::new()).await
+        fn description(&self) -> String {
+            MockAddTool.description()
+        }
+
+        fn parameters(&self) -> serde_json::Value {
+            MockAddTool.parameters()
         }
 
         async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -1598,7 +1598,7 @@ mod tests {
     use crate::agent::run::streamed::merge_reasoning_blocks;
     use crate::client::ProviderClient;
     use crate::client::completion::CompletionClient;
-    use crate::completion::{CompletionRequest, PromptError, ToolDefinition, Usage};
+    use crate::completion::{CompletionRequest, PromptError, Usage};
     use crate::message::{
         AssistantContent, DocumentSourceKind, ImageMediaType, Message, ReasoningContent,
         ToolChoice, ToolResultContent, UserContent,
@@ -2025,25 +2025,21 @@ mod tests {
         y: i32,
     }
 
-    fn arithmetic_tool_definition(name: &str, description: &str) -> ToolDefinition {
-        ToolDefinition {
-            name: name.to_string(),
-            description: description.to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The first operand"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The second operand"
-                    }
+    fn arithmetic_tool_parameters() -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "number",
+                    "description": "The first operand"
                 },
-                "required": ["x", "y"],
-            }),
-        }
+                "y": {
+                    "type": "number",
+                    "description": "The second operand"
+                }
+            },
+            "required": ["x", "y"],
+        })
     }
 
     impl Tool for CountingAddTool {
@@ -2052,8 +2048,12 @@ mod tests {
         type Args = CountingOperationArgs;
         type Output = i32;
 
-        async fn definition(&self, _prompt: String) -> ToolDefinition {
-            arithmetic_tool_definition(Self::NAME, "Add x and y together")
+        fn description(&self) -> String {
+            "Add x and y together".to_string()
+        }
+
+        fn parameters(&self) -> serde_json::Value {
+            arithmetic_tool_parameters()
         }
 
         async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -2068,8 +2068,12 @@ mod tests {
         type Args = CountingOperationArgs;
         type Output = i32;
 
-        async fn definition(&self, _prompt: String) -> ToolDefinition {
-            arithmetic_tool_definition(Self::NAME, "Subtract y from x")
+        fn description(&self) -> String {
+            "Subtract y from x".to_string()
+        }
+
+        fn parameters(&self) -> serde_json::Value {
+            arithmetic_tool_parameters()
         }
 
         async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/crates/rig-core/src/agent/runner.rs
+++ b/crates/rig-core/src/agent/runner.rs
@@ -1094,7 +1094,7 @@ mod tests {
     };
     use crate::agent::prompt_request::streaming::{MultiTurnStreamItem, StreamingError};
     use crate::agent::run::OutputMode;
-    use crate::completion::{CompletionModel, Message, PromptError, ToolDefinition};
+    use crate::completion::{CompletionModel, Message, PromptError};
     use crate::message::{AssistantContent, ToolCall, ToolChoice, ToolFunction, UserContent};
     use crate::streaming::{StreamedAssistantContent, StreamedUserContent};
     use crate::test_utils::{
@@ -2248,12 +2248,12 @@ mod tests {
             type Error = crate::test_utils::MockToolError;
             type Args = serde_json::Value;
             type Output = String;
-            async fn definition(&self, _prompt: String) -> crate::completion::ToolDefinition {
-                crate::completion::ToolDefinition {
-                    name: Self::NAME.to_string(),
-                    description: "returns a secret".to_string(),
-                    parameters: serde_json::json!({ "type": "object", "properties": {} }),
-                }
+            fn description(&self) -> String {
+                "returns a secret".to_string()
+            }
+
+            fn parameters(&self) -> serde_json::Value {
+                serde_json::json!({ "type": "object", "properties": {} })
             }
             async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
                 Ok("SUPER_SECRET_TOKEN_42".to_string())
@@ -2465,8 +2465,12 @@ mod tests {
         type Args = MockOperationArgs;
         type Output = i32;
 
-        async fn definition(&self, _prompt: String) -> ToolDefinition {
-            MockAddTool.definition(String::new()).await
+        fn description(&self) -> String {
+            MockAddTool.description()
+        }
+
+        fn parameters(&self) -> serde_json::Value {
+            MockAddTool.parameters()
         }
 
         async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -2857,8 +2861,12 @@ mod tests {
         type Args = serde_json::Value;
         type Output = i32;
 
-        async fn definition(&self, _prompt: String) -> ToolDefinition {
-            MockAddTool.definition(String::new()).await
+        fn description(&self) -> String {
+            MockAddTool.description()
+        }
+
+        fn parameters(&self) -> serde_json::Value {
+            MockAddTool.parameters()
         }
 
         async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -3168,8 +3176,12 @@ mod tests {
         type Args = serde_json::Value;
         type Output = i32;
 
-        async fn definition(&self, _prompt: String) -> ToolDefinition {
-            MockAddTool.definition(String::new()).await
+        fn description(&self) -> String {
+            MockAddTool.description()
+        }
+
+        fn parameters(&self) -> serde_json::Value {
+            MockAddTool.parameters()
         }
 
         async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -3306,8 +3318,12 @@ mod tests {
         type Error = MockToolError;
         type Args = serde_json::Value;
         type Output = i32;
-        async fn definition(&self, _prompt: String) -> ToolDefinition {
-            MockAddTool.definition(String::new()).await
+        fn description(&self) -> String {
+            MockAddTool.description()
+        }
+
+        fn parameters(&self) -> serde_json::Value {
+            MockAddTool.parameters()
         }
         async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
             if args.get("x").and_then(serde_json::Value::as_i64) == Some(1) {
@@ -3663,8 +3679,12 @@ mod tests {
         type Args = MockOperationArgs;
         type Output = i32;
 
-        async fn definition(&self, _prompt: String) -> ToolDefinition {
-            MockAddTool.definition(String::new()).await
+        fn description(&self) -> String {
+            MockAddTool.description()
+        }
+
+        fn parameters(&self) -> serde_json::Value {
+            MockAddTool.parameters()
         }
 
         async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -5515,12 +5535,12 @@ mod tests {
         type Args = serde_json::Value;
         type Output = String;
 
-        async fn definition(&self, _prompt: String) -> ToolDefinition {
-            ToolDefinition {
-                name: Self::NAME.to_string(),
-                description: "A real tool sharing the default output-tool name".to_string(),
-                parameters: json!({ "type": "object", "properties": {} }),
-            }
+        fn description(&self) -> String {
+            "A real tool sharing the default output-tool name".to_string()
+        }
+
+        fn parameters(&self) -> serde_json::Value {
+            json!({ "type": "object", "properties": {} })
         }
 
         async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/crates/rig-core/src/agent/tool.rs
+++ b/crates/rig-core/src/agent/tool.rs
@@ -1,6 +1,6 @@
 use crate::{
     agent::Agent,
-    completion::{CompletionModel, Prompt, PromptError, ToolDefinition},
+    completion::{CompletionModel, Prompt, PromptError},
     tool::{Tool, ToolCallExtensions},
 };
 use schemars::{JsonSchema, schema_for};
@@ -20,8 +20,8 @@ impl<M: CompletionModel + 'static> Tool for Agent<M> {
     type Args = AgentToolArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        let description = format!(
+    fn description(&self) -> String {
+        format!(
             "
             Prompt a sub-agent to do a task for you.
 
@@ -32,12 +32,11 @@ impl<M: CompletionModel + 'static> Tool for Agent<M> {
             name = self.name(),
             description = self.description.clone().unwrap_or_default(),
             sysprompt = self.preamble.clone().unwrap_or_default()
-        );
-        ToolDefinition {
-            name: <Self as Tool>::name(self),
-            description,
-            parameters: json!(schema_for!(AgentToolArgs)),
-        }
+        )
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!(schema_for!(AgentToolArgs))
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/crates/rig-core/src/embeddings/tool.rs
+++ b/crates/rig-core/src/embeddings/tool.rs
@@ -29,7 +29,6 @@ impl ToolSchema {
     /// # Example
     /// ```rust
     /// use rig_core::{
-    ///     completion::ToolDefinition,
     ///     embeddings::ToolSchema,
     ///     tool::{Tool, ToolEmbedding, ToolEmbeddingDyn},
     /// };
@@ -51,13 +50,12 @@ impl ToolSchema {
     ///     type Args = ();
     ///     type Output = ();
     ///
-    ///     async fn definition(&self, _prompt: String) -> ToolDefinition {
-    ///         serde_json::from_value(json!({
-    ///             "name": "nothing",
-    ///             "description": "nothing",
-    ///             "parameters": {}
-    ///         }))
-    ///         .expect("Tool Definition")
+    ///     fn description(&self) -> String {
+    ///         "nothing".to_string()
+    ///     }
+    ///
+    ///     fn parameters(&self) -> serde_json::Value {
+    ///         json!({})
     ///     }
     ///
     ///     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/crates/rig-core/src/extractor.rs
+++ b/crates/rig-core/src/extractor.rs
@@ -37,7 +37,7 @@ use serde_json::json;
 
 use crate::{
     agent::{Agent, AgentBuilder, WithBuilderTools},
-    completion::{Completion, CompletionError, CompletionModel, ToolDefinition, Usage},
+    completion::{Completion, CompletionError, CompletionModel, Usage},
     message::{AssistantContent, Message, ToolCall, ToolChoice, ToolFunction},
     tool::Tool,
     vector_store::VectorStoreIndexDyn,
@@ -422,13 +422,12 @@ where
     type Args = T;
     type Output = T;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Submit the structured data you extracted from the provided text."
-                .to_string(),
-            parameters: json!(schema_for!(T)),
-        }
+    fn description(&self) -> String {
+        "Submit the structured data you extracted from the provided text.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!(schema_for!(T))
     }
 
     async fn call(&self, data: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/crates/rig-core/src/test_utils/tools.rs
+++ b/crates/rig-core/src/test_utils/tools.rs
@@ -6,7 +6,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::{
-    completion::ToolDefinition,
     tool::{Tool, ToolCallExtensions, ToolFailure, ToolFailureKind, ToolReturn, ToolSet},
     vector_store::{VectorSearchRequest, VectorStoreError, VectorStoreIndex, request::Filter},
     wasm_compat::WasmCompatSend,
@@ -34,25 +33,25 @@ impl Tool for MockAddTool {
     type Args = MockOperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Add x and y together".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The first number to add"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The second number to add"
-                    }
+    fn description(&self) -> String {
+        "Add x and y together".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "number",
+                    "description": "The first number to add"
                 },
-                "required": ["x", "y"],
-            }),
-        }
+                "y": {
+                    "type": "number",
+                    "description": "The second number to add"
+                }
+            },
+            "required": ["x", "y"],
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -105,12 +104,12 @@ impl Tool for MockExtensionsProbeTool {
     type Args = serde_json::Value;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Records the SessionId observed in its call context".to_string(),
-            parameters: json!({"type": "object", "properties": {}}),
-        }
+    fn description(&self) -> String {
+        "Records the SessionId observed in its call context".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({"type": "object", "properties": {}})
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -148,25 +147,25 @@ impl Tool for MockSubtractTool {
     type Args = MockOperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Subtract y from x".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The number to subtract from"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The number to subtract"
-                    }
+    fn description(&self) -> String {
+        "Subtract y from x".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "number",
+                    "description": "The number to subtract from"
                 },
-                "required": ["x", "y"],
-            }),
-        }
+                "y": {
+                    "type": "number",
+                    "description": "The number to subtract"
+                }
+            },
+            "required": ["x", "y"],
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -192,15 +191,15 @@ impl Tool for MockStringOutputTool {
     type Args = serde_json::Value;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Returns a multiline string".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {}
-            }),
-        }
+    fn description(&self) -> String {
+        "Returns a multiline string".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {}
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -218,15 +217,15 @@ impl Tool for MockImageOutputTool {
     type Args = serde_json::Value;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Returns image JSON".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {}
-            }),
-        }
+    fn description(&self) -> String {
+        "Returns image JSON".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {}
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -249,16 +248,16 @@ impl Tool for MockImageGeneratorTool {
     type Args = serde_json::Value;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Generates a small test image (a 1x1 red pixel). Call this tool when asked to generate or show an image.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {},
-                "required": []
-            }),
-        }
+    fn description(&self) -> String {
+        "Generates a small test image (a 1x1 red pixel). Call this tool when asked to generate or show an image.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "required": []
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -281,15 +280,15 @@ impl Tool for MockObjectOutputTool {
     type Args = serde_json::Value;
     type Output = serde_json::Value;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Returns an object".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {}
-            }),
-        }
+    fn description(&self) -> String {
+        "Returns an object".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {}
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -309,16 +308,16 @@ impl Tool for MockExampleTool {
     type Args = ();
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "A tool that returns some example text.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {},
-                "required": []
-            }),
-        }
+    fn description(&self) -> String {
+        "A tool that returns some example text.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "required": []
+        })
     }
 
     async fn call(&self, _input: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -346,12 +345,12 @@ impl Tool for MockBarrierTool {
     type Args = serde_json::Value;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Waits at a barrier to test concurrency".to_string(),
-            parameters: json!({"type": "object", "properties": {}}),
-        }
+    fn description(&self) -> String {
+        "Waits at a barrier to test concurrency".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({"type": "object", "properties": {}})
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -385,12 +384,12 @@ impl Tool for MockControlledTool {
     type Args = serde_json::Value;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Test tool".to_string(),
-            parameters: json!({"type": "object", "properties": {}}),
-        }
+    fn description(&self) -> String {
+        "Test tool".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({"type": "object", "properties": {}})
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -499,12 +498,12 @@ impl Tool for MockFailingTool {
     type Args = serde_json::Value;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "A tool that always fails".to_string(),
-            parameters: json!({ "type": "object", "properties": {} }),
-        }
+    fn description(&self) -> String {
+        "A tool that always fails".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({ "type": "object", "properties": {} })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -536,12 +535,12 @@ impl Tool for MockHandledFailureTool {
     type Args = serde_json::Value;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Looks up a record".to_string(),
-            parameters: json!({ "type": "object", "properties": {} }),
-        }
+    fn description(&self) -> String {
+        "Looks up a record".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({ "type": "object", "properties": {} })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -575,12 +574,12 @@ impl Tool for MockDeniedTool {
     type Args = serde_json::Value;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "A tool with an internal authorization check".to_string(),
-            parameters: json!({ "type": "object", "properties": {} }),
-        }
+    fn description(&self) -> String {
+        "A tool with an internal authorization check".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({ "type": "object", "properties": {} })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -614,12 +613,12 @@ impl Tool for MockMetadataTool {
     type Args = serde_json::Value;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Succeeds and attaches request metadata".to_string(),
-            parameters: json!({ "type": "object", "properties": {} }),
-        }
+    fn description(&self) -> String {
+        "Succeeds and attaches request metadata".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({ "type": "object", "properties": {} })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/crates/rig-core/src/tool/mod.rs
+++ b/crates/rig-core/src/tool/mod.rs
@@ -77,10 +77,7 @@ impl fmt::Display for ToolError {
 ///
 /// # Example
 /// ```
-/// use rig_core::{
-///     completion::ToolDefinition,
-///     tool::{ToolSet, Tool},
-/// };
+/// use rig_core::tool::{ToolSet, Tool};
 ///
 /// #[derive(serde::Deserialize)]
 /// struct AddArgs {
@@ -102,24 +99,24 @@ impl fmt::Display for ToolError {
 ///     type Args = AddArgs;
 ///     type Output = i32;
 ///
-///     async fn definition(&self, _prompt: String) -> ToolDefinition {
-///         ToolDefinition {
-///             name: "add".to_string(),
-///             description: "Add x and y together".to_string(),
-///             parameters: serde_json::json!({
-///                 "type": "object",
-///                 "properties": {
-///                     "x": {
-///                         "type": "number",
-///                         "description": "The first number to add"
-///                     },
-///                     "y": {
-///                         "type": "number",
-///                         "description": "The second number to add"
-///                     }
+///     fn description(&self) -> String {
+///         "Add x and y together".to_string()
+///     }
+///
+///     fn parameters(&self) -> serde_json::Value {
+///         serde_json::json!({
+///             "type": "object",
+///             "properties": {
+///                 "x": {
+///                     "type": "number",
+///                     "description": "The first number to add"
+///                 },
+///                 "y": {
+///                     "type": "number",
+///                     "description": "The second number to add"
 ///                 }
-///             })
-///         }
+///             }
+///         })
 ///     }
 ///
 ///     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -145,12 +142,11 @@ pub trait Tool: Sized + WasmCompatSend + WasmCompatSync {
         Self::NAME.to_string()
     }
 
-    /// A method returning the tool definition. The user prompt can be used to
-    /// tailor the definition to the specific use case.
-    fn definition(
-        &self,
-        _prompt: String,
-    ) -> impl Future<Output = ToolDefinition> + WasmCompatSend + WasmCompatSync;
+    /// A provider-facing description of what the tool does.
+    fn description(&self) -> String;
+
+    /// The JSON Schema describing this tool's arguments.
+    fn parameters(&self) -> serde_json::Value;
 
     /// The tool execution method.
     /// Both the arguments and return value are a String since these values are meant to
@@ -278,8 +274,11 @@ pub trait ToolDyn: WasmCompatSend + WasmCompatSync {
     /// Returns the tool name used for dispatch.
     fn name(&self) -> String;
 
-    /// Returns the provider-facing tool schema.
-    fn definition<'a>(&'a self, prompt: String) -> WasmBoxedFuture<'a, ToolDefinition>;
+    /// A provider-facing description of what the tool does.
+    fn description(&self) -> String;
+
+    /// The JSON Schema describing this tool's arguments.
+    fn parameters(&self) -> serde_json::Value;
 
     /// Calls the tool with JSON-encoded arguments and returns model-facing text.
     fn call<'a>(&'a self, args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>>;
@@ -368,13 +367,30 @@ fn tool_error_to_execution_result(err: ToolError) -> ToolExecutionResult {
     ToolExecutionResult::failed(message, failure)
 }
 
+/// Build the provider-facing request artifact for a registered tool.
+///
+/// The definition is generated from the flattened tool metadata, using
+/// [`ToolDyn::name`] as the single source of truth for the advertised and
+/// dispatchable tool identity.
+pub fn tool_definition(tool: &dyn ToolDyn) -> ToolDefinition {
+    ToolDefinition {
+        name: tool.name(),
+        description: tool.description(),
+        parameters: tool.parameters(),
+    }
+}
+
 impl<T: Tool> ToolDyn for T {
     fn name(&self) -> String {
-        self.name()
+        <Self as Tool>::name(self)
     }
 
-    fn definition<'a>(&'a self, prompt: String) -> WasmBoxedFuture<'a, ToolDefinition> {
-        Box::pin(<Self as Tool>::definition(self, prompt))
+    fn description(&self) -> String {
+        <Self as Tool>::description(self)
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        <Self as Tool>::parameters(self)
     }
 
     fn call<'a>(&'a self, args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
@@ -469,10 +485,25 @@ impl ToolType {
         }
     }
 
-    pub async fn definition(&self, prompt: String) -> ToolDefinition {
+    pub fn description(&self) -> String {
         match self {
-            ToolType::Simple(tool) => tool.definition(prompt).await,
-            ToolType::Embedding(tool) => tool.definition(prompt).await,
+            ToolType::Simple(tool) => tool.description(),
+            ToolType::Embedding(tool) => tool.description(),
+        }
+    }
+
+    pub fn parameters(&self) -> serde_json::Value {
+        match self {
+            ToolType::Simple(tool) => tool.parameters(),
+            ToolType::Embedding(tool) => tool.parameters(),
+        }
+    }
+
+    pub fn to_definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            name: self.name(),
+            description: self.description(),
+            parameters: self.parameters(),
         }
     }
 
@@ -616,8 +647,7 @@ impl ToolSet {
     pub async fn get_tool_definitions(&self) -> Result<Vec<ToolDefinition>, ToolSetError> {
         let mut defs = Vec::new();
         for tool in self.ordered_tools() {
-            let def = tool.definition(String::new()).await;
-            defs.push(def);
+            defs.push(tool.to_definition());
         }
         Ok(defs)
     }
@@ -679,38 +709,20 @@ impl ToolSet {
     pub async fn documents(&self) -> Result<Vec<completion::Document>, ToolSetError> {
         let mut docs = Vec::new();
         for tool in self.ordered_tools() {
-            match tool {
-                ToolType::Simple(tool) => {
-                    docs.push(completion::Document {
-                        id: tool.name(),
-                        text: format!(
-                            "\
-                            Tool: {}\n\
-                            Definition: \n\
-                            {}\
-                        ",
-                            tool.name(),
-                            serde_json::to_string_pretty(&tool.definition("".to_string()).await)?
-                        ),
-                        additional_props: HashMap::new(),
-                    });
-                }
-                ToolType::Embedding(tool) => {
-                    docs.push(completion::Document {
-                        id: tool.name(),
-                        text: format!(
-                            "\
-                            Tool: {}\n\
-                            Definition: \n\
-                            {}\
-                        ",
-                            tool.name(),
-                            serde_json::to_string_pretty(&tool.definition("".to_string()).await)?
-                        ),
-                        additional_props: HashMap::new(),
-                    });
-                }
-            }
+            let definition = tool.to_definition();
+            docs.push(completion::Document {
+                id: definition.name.clone(),
+                text: format!(
+                    "\
+                    Tool: {}\n\
+                    Definition: \n\
+                    {}\
+                ",
+                    definition.name,
+                    serde_json::to_string_pretty(&definition)?
+                ),
+                additional_props: HashMap::new(),
+            });
         }
         Ok(docs)
     }
@@ -780,6 +792,16 @@ mod tests {
         let toolset = get_test_toolset();
         let tools = toolset.get_tool_definitions().await.unwrap();
         assert_eq!(tools.len(), 2);
+        assert_eq!(
+            tools
+                .iter()
+                .map(|tool| tool.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["add", "subtract"],
+            "provider definitions must use registered tool names in order"
+        );
+        assert!(tools.iter().all(|tool| !tool.description.is_empty()));
+        assert!(tools.iter().all(|tool| tool.parameters.is_object()));
     }
 
     #[test]
@@ -831,14 +853,12 @@ mod tests {
             self.name.clone()
         }
 
-        fn definition(&self, _prompt: String) -> WasmBoxedFuture<'_, ToolDefinition> {
-            Box::pin(async move {
-                ToolDefinition {
-                    name: self.name.clone(),
-                    description: self.description.clone(),
-                    parameters: json!({ "type": "object", "properties": {} }),
-                }
-            })
+        fn description(&self) -> String {
+            self.description.clone()
+        }
+
+        fn parameters(&self) -> serde_json::Value {
+            json!({ "type": "object", "properties": {} })
         }
 
         fn call(&self, _args: String) -> WasmBoxedFuture<'_, Result<String, ToolError>> {
@@ -852,6 +872,19 @@ mod tests {
             name: name.to_string(),
             description: description.to_string(),
         }
+    }
+
+    #[tokio::test]
+    async fn tool_definition_uses_flattened_tooldyn_metadata() {
+        let tool = named_tool("provider_name", "advertised description");
+        let definition = tool_definition(&tool);
+
+        assert_eq!(definition.name, "provider_name");
+        assert_eq!(definition.description, "advertised description");
+        assert_eq!(
+            definition.parameters,
+            json!({ "type": "object", "properties": {} })
+        );
     }
 
     #[tokio::test]
@@ -1005,12 +1038,12 @@ mod tests {
             type Args = NoRequiredArgs;
             type Output = String;
 
-            async fn definition(&self, _prompt: String) -> ToolDefinition {
-                ToolDefinition {
-                    name: Self::NAME.to_string(),
-                    description: "Tool with no required arguments".to_string(),
-                    parameters: json!({"type": "object", "properties": {}}),
-                }
+            fn description(&self) -> String {
+                "Tool with no required arguments".to_string()
+            }
+
+            fn parameters(&self) -> serde_json::Value {
+                json!({"type": "object", "properties": {}})
             }
 
             async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/crates/rig-core/src/tool/rmcp.rs
+++ b/crates/rig-core/src/tool/rmcp.rs
@@ -349,19 +349,16 @@ impl ToolDyn for McpTool {
         self.definition.name.to_string()
     }
 
-    fn definition(&self, _prompt: String) -> WasmBoxedFuture<'_, ToolDefinition> {
-        Box::pin(async move {
-            ToolDefinition {
-                name: self.definition.name.to_string(),
-                description: self
-                    .definition
-                    .description
-                    .clone()
-                    .unwrap_or(Cow::from(""))
-                    .to_string(),
-                parameters: serde_json::to_value(&self.definition.input_schema).unwrap_or_default(),
-            }
-        })
+    fn description(&self) -> String {
+        self.definition
+            .description
+            .clone()
+            .unwrap_or(Cow::from(""))
+            .to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        self.definition.schema_as_json_value()
     }
 
     fn call(&self, args: String) -> WasmBoxedFuture<'_, Result<String, ToolError>> {

--- a/crates/rig-core/src/tool/server.rs
+++ b/crates/rig-core/src/tool/server.rs
@@ -322,11 +322,10 @@ impl ToolServerHandle {
                     .collect()
             };
 
-            let mut tools = Vec::new();
-            for tool in dynamic_tool_handles {
-                tools.push(tool.definition(text.clone()).await);
-            }
-            tools
+            dynamic_tool_handles
+                .into_iter()
+                .map(|tool| tool.to_definition())
+                .collect()
         } else {
             Vec::new()
         };
@@ -346,7 +345,7 @@ impl ToolServerHandle {
         };
 
         for tool in static_tool_handles {
-            tools.push(tool.definition(String::new()).await);
+            tools.push(tool.to_definition());
         }
 
         // One shared toolset backs both lists, so a name appearing in the
@@ -438,6 +437,20 @@ mod tests {
                 .zip(via_append_toolset.iter())
                 .all(|(a, b)| a.name == b.name),
             "append_toolset must surface the same LLM-visible tools as add_tool",
+        );
+    }
+
+    #[tokio::test]
+    pub async fn get_tool_defs_preserves_static_registration_order() {
+        let handle = ToolServer::new()
+            .tool(MockAddTool)
+            .tool(MockSubtractTool)
+            .run();
+
+        let defs = handle.get_tool_defs(None).await.unwrap();
+        assert_eq!(
+            defs.iter().map(|def| def.name.as_str()).collect::<Vec<_>>(),
+            vec!["add", "subtract"]
         );
     }
 
@@ -664,12 +677,12 @@ mod tests {
         type Args = serde_json::Value;
         type Output = String;
 
-        async fn definition(&self, _prompt: String) -> crate::completion::ToolDefinition {
-            crate::completion::ToolDefinition {
-                name: "context_reader".to_string(),
-                description: "Reads SessionId from context".to_string(),
-                parameters: serde_json::json!({"type": "object", "properties": {}}),
-            }
+        fn description(&self) -> String {
+            "Reads SessionId from context".to_string()
+        }
+
+        fn parameters(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object", "properties": {}})
         }
 
         async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/crates/rig-core/src/tools/think.rs
+++ b/crates/rig-core/src/tools/think.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-use crate::completion::ToolDefinition;
 use crate::tool::Tool;
 
 /// Arguments for the Think tool
@@ -35,24 +34,24 @@ impl Tool for ThinkTool {
     type Args = ThinkArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "think".to_string(),
-            description: "Use the tool to think about something. It will not obtain new information
+    fn description(&self) -> String {
+        "Use the tool to think about something. It will not obtain new information
             or change the database, but just append the thought to the log. Use it when complex
             reasoning or some cache memory is needed."
-                .to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "thought": {
-                        "type": "string",
-                        "description": "A thought to think about."
-                    }
-                },
-                "required": ["thought"]
-            }),
-        }
+            .to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "thought": {
+                    "type": "string",
+                    "description": "A thought to think about."
+                }
+            },
+            "required": ["thought"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -69,7 +68,7 @@ mod tests {
     #[tokio::test]
     async fn test_think_tool_definition() {
         let tool = ThinkTool;
-        let definition = tool.definition("".to_string()).await;
+        let definition = crate::tool::tool_definition(&tool);
 
         assert_eq!(definition.name, "think");
         assert!(

--- a/crates/rig-core/src/vector_store/mod.rs
+++ b/crates/rig-core/src/vector_store/mod.rs
@@ -17,7 +17,6 @@ use serde_json::{Value, json};
 
 use crate::{
     Embed, OneOrMany,
-    completion::ToolDefinition,
     embeddings::{Embedding, EmbeddingError},
     tool::Tool,
     vector_store::request::{Filter, FilterError, SearchFilter},
@@ -202,33 +201,31 @@ where
     type Args = VectorSearchRequest<F>;
     type Output = Vec<VectorStoreOutput>;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description:
-                "Retrieves the most relevant documents from a vector store based on a query."
-                    .to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "query": {
-                        "type": "string",
-                        "description": "The query string to search for relevant documents in the vector store."
-                    },
-                    "samples": {
-                        "type": "integer",
-                        "description": "The maximum number of samples / documents to retrieve.",
-                        "default": 5,
-                        "minimum": 1
-                    },
-                    "threshold": {
-                        "type": "number",
-                        "description": "Similarity search threshold. If present, any result with a distance less than this may be omitted from the final result."
-                    }
+    fn description(&self) -> String {
+        "Retrieves the most relevant documents from a vector store based on a query.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "The query string to search for relevant documents in the vector store."
                 },
-                "required": ["query", "samples"]
-            }),
-        }
+                "samples": {
+                    "type": "integer",
+                    "description": "The maximum number of samples / documents to retrieve.",
+                    "default": 5,
+                    "minimum": 1
+                },
+                "threshold": {
+                    "type": "number",
+                    "description": "Similarity search threshold. If present, any result with a distance less than this may be omitted from the final result."
+                }
+            },
+            "required": ["query", "samples"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/crates/rig-derive/CHANGELOG.md
+++ b/crates/rig-derive/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+
+- *(rig-derive)* [**breaking**] `#[rig_tool]` now generates flattened `Tool` metadata methods (`description()` and `parameters()`) instead of the removed `definition(...)` method. Generated `NAME` / `name()` remains the source of the provider-advertised tool name.
+
 ## [0.38.2](https://github.com/0xPlaygrounds/rig/compare/rig-derive-v0.38.1...rig-derive-v0.38.2) - 2026-06-09
 
 ### Other

--- a/crates/rig-derive/examples/rig_tool/async_tool.rs
+++ b/crates/rig-derive/examples/rig_tool/async_tool.rs
@@ -1,7 +1,7 @@
 use rig_core::client::{CompletionClient, ProviderClient};
 use rig_core::completion::Prompt;
 use rig_core::providers;
-use rig_core::tool::{Tool, ToolError};
+use rig_core::tool::ToolError;
 use rig_derive::rig_tool;
 use std::time::Duration;
 
@@ -36,7 +36,7 @@ async fn main() -> Result<(), anyhow::Error> {
     println!("Tool definition:");
     println!(
         "ASYNCOPERATION: {}",
-        serde_json::to_string_pretty(&AsyncOperation.definition(String::default()).await)?
+        serde_json::to_string_pretty(&rig_core::tool::tool_definition(&AsyncOperation))?
     );
 
     for prompt in [

--- a/crates/rig-derive/examples/rig_tool/complex_types.rs
+++ b/crates/rig-derive/examples/rig_tool/complex_types.rs
@@ -1,4 +1,3 @@
-use rig_core::tool::Tool;
 use rig_derive::rig_tool;
 
 #[derive(serde::Deserialize, schemars::JsonSchema)]
@@ -32,7 +31,7 @@ fn list_items(
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    let def = ListItems.definition(String::default()).await;
+    let def = rig_core::tool::tool_definition(&ListItems);
     println!("Tool definition:\n{}", serde_json::to_string_pretty(&def)?);
 
     Ok(())

--- a/crates/rig-derive/examples/rig_tool/full.rs
+++ b/crates/rig-derive/examples/rig_tool/full.rs
@@ -1,7 +1,6 @@
 use rig_core::client::{CompletionClient, ProviderClient};
 use rig_core::completion::Prompt;
 use rig_core::providers;
-use rig_core::tool::Tool;
 use rig_derive::rig_tool;
 
 /// A tool that performs string operations
@@ -40,7 +39,7 @@ async fn main() -> Result<(), anyhow::Error> {
     println!("Tool definition:");
     println!(
         "STRINGPROCESSOR: {}",
-        serde_json::to_string_pretty(&StringProcessor.definition(String::default()).await)?
+        serde_json::to_string_pretty(&rig_core::tool::tool_definition(&StringProcessor))?
     );
 
     for prompt in [

--- a/crates/rig-derive/examples/rig_tool/with_description.rs
+++ b/crates/rig-derive/examples/rig_tool/with_description.rs
@@ -1,7 +1,6 @@
 use rig_core::client::{CompletionClient, ProviderClient};
 use rig_core::completion::Prompt;
 use rig_core::providers;
-use rig_core::tool::Tool;
 use rig_derive::rig_tool;
 
 // Demonstrates explicit attribute override.
@@ -51,7 +50,7 @@ async fn main() -> Result<(), anyhow::Error> {
     println!("Tool definition:");
     println!(
         "CALCULATOR: {}",
-        serde_json::to_string_pretty(&CALCULATOR.definition(String::default()).await)?
+        serde_json::to_string_pretty(&rig_core::tool::tool_definition(&CALCULATOR))?
     );
 
     for prompt in [

--- a/crates/rig-derive/src/lib.rs
+++ b/crates/rig-derive/src/lib.rs
@@ -543,17 +543,16 @@ pub fn rig_tool(args: TokenStream, input: TokenStream) -> TokenStream {
                 #tool_name.to_string()
             }
 
-            async fn definition(&self, _prompt: String) -> #rig_core::completion::ToolDefinition {
+            fn description(&self) -> String {
+                #tool_description.to_string()
+            }
+
+            fn parameters(&self) -> serde_json::Value {
                 let mut schema = serde_json::to_value(
                     #rig_core::schemars::schema_for!(#params_struct_name)
                 ).expect("schema serialization");
                 schema["required"] = serde_json::json!([#(#required_args),*]);
-
-                #rig_core::completion::ToolDefinition {
-                    name: #tool_name.to_string(),
-                    description: #tool_description.to_string(),
-                    parameters: schema,
-                }
+                schema
             }
 
             #call_impl

--- a/crates/rig-derive/tests/calculator.rs
+++ b/crates/rig-derive/tests/calculator.rs
@@ -69,7 +69,7 @@ fn sync_calculator(x: i32, y: i32, operation: String) -> Result<i32, rig_core::t
 async fn test_calculator_tool() {
     let calculator = Calculator;
 
-    let definition = calculator.definition(String::default()).await;
+    let definition = rig_core::tool::tool_definition(&calculator);
     assert_eq!(calculator.name(), "calculator");
     assert_eq!(
         definition.description,

--- a/crates/rig-derive/tests/custom_name.rs
+++ b/crates/rig-derive/tests/custom_name.rs
@@ -22,7 +22,7 @@ fn fallback_name_tool() -> Result<String, rig_core::tool::ToolError> {
 #[tokio::test]
 async fn test_custom_tool_name_overrides_function_name() {
     let tool = SearchDocsImpl;
-    let definition = tool.definition(String::default()).await;
+    let definition = rig_core::tool::tool_definition(&tool);
 
     assert_eq!(SearchDocsImpl::NAME, "search-docs");
     assert_eq!(tool.name(), "search-docs");
@@ -32,7 +32,7 @@ async fn test_custom_tool_name_overrides_function_name() {
 #[tokio::test]
 async fn test_tool_name_falls_back_to_function_name() {
     let tool = FallbackNameTool;
-    let definition = tool.definition(String::default()).await;
+    let definition = rig_core::tool::tool_definition(&tool);
 
     assert_eq!(FallbackNameTool::NAME, "fallback_name_tool");
     assert_eq!(tool.name(), "fallback_name_tool");

--- a/crates/rig-derive/tests/required_defaults.rs
+++ b/crates/rig-derive/tests/required_defaults.rs
@@ -9,7 +9,6 @@
     clippy::unreachable
 )]
 
-use rig_core::tool::Tool;
 use rig_derive::rig_tool;
 
 // No `required(...)` — should default to all params required
@@ -45,7 +44,7 @@ fn constant() -> Result<i32, rig_core::tool::ToolError> {
 
 #[tokio::test]
 async fn test_required_defaults_to_all_params() {
-    let def = AddImplicit.definition(String::default()).await;
+    let def = rig_core::tool::tool_definition(&AddImplicit);
     let required = def.parameters["required"].as_array().unwrap();
     let names: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
 
@@ -62,7 +61,7 @@ async fn test_required_defaults_to_all_params() {
 
 #[tokio::test]
 async fn test_explicit_required_overrides_default() {
-    let def = AddExplicit.definition(String::default()).await;
+    let def = rig_core::tool::tool_definition(&AddExplicit);
     let required = def.parameters["required"].as_array().unwrap();
     let names: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
 
@@ -75,7 +74,7 @@ async fn test_explicit_required_overrides_default() {
 
 #[tokio::test]
 async fn test_explicit_empty_required_overrides_default() {
-    let def = SearchOptional.definition(String::default()).await;
+    let def = rig_core::tool::tool_definition(&SearchOptional);
     let required = def.parameters["required"].as_array().unwrap();
 
     assert!(
@@ -86,7 +85,7 @@ async fn test_explicit_empty_required_overrides_default() {
 
 #[tokio::test]
 async fn test_no_params_means_empty_required() {
-    let def = Constant.definition(String::default()).await;
+    let def = rig_core::tool::tool_definition(&Constant);
     let required = def.parameters["required"].as_array().unwrap();
 
     assert!(

--- a/crates/rig-derive/tests/schemars_schema.rs
+++ b/crates/rig-derive/tests/schemars_schema.rs
@@ -28,13 +28,13 @@ fn add_doc(
 
 #[tokio::test]
 async fn test_doc_comment_description() {
-    let def = AddDoc.definition(String::default()).await;
+    let def = rig_core::tool::tool_definition(&AddDoc);
     assert_eq!(def.description, "Add two numbers");
 }
 
 #[tokio::test]
 async fn test_param_doc_comments() {
-    let def = AddDoc.definition(String::default()).await;
+    let def = rig_core::tool::tool_definition(&AddDoc);
     let props = def.parameters["properties"].as_object().unwrap();
     assert_eq!(props["a"]["description"], "First number");
     assert_eq!(props["b"]["description"], "Second number");
@@ -56,7 +56,7 @@ fn search_override(
 
 #[tokio::test]
 async fn test_explicit_overrides_doc() {
-    let def = SearchOverride.definition(String::default()).await;
+    let def = rig_core::tool::tool_definition(&SearchOverride);
     assert_eq!(def.description, "Override description");
     let props = def.parameters["properties"].as_object().unwrap();
     assert_eq!(props["query"]["description"], "Override param doc");
@@ -77,7 +77,7 @@ fn search_optional(
 
 #[tokio::test]
 async fn test_option_nullable() {
-    let def = SearchOptional.definition(String::default()).await;
+    let def = rig_core::tool::tool_definition(&SearchOptional);
     let props = def.parameters["properties"].as_object().unwrap();
 
     // query is a plain string
@@ -127,7 +127,7 @@ fn numeric_types(
 
 #[tokio::test]
 async fn test_integer_vs_number() {
-    let def = NumericTypes.definition(String::default()).await;
+    let def = rig_core::tool::tool_definition(&NumericTypes);
     let props = def.parameters["properties"].as_object().unwrap();
     assert_eq!(props["int_val"]["type"], "integer");
     assert_eq!(props["float_val"]["type"], "number");
@@ -146,7 +146,7 @@ fn sum_vec(
 
 #[tokio::test]
 async fn test_vec_param() {
-    let def = SumVec.definition(String::default()).await;
+    let def = rig_core::tool::tool_definition(&SumVec);
     let props = def.parameters["properties"].as_object().unwrap();
     assert_eq!(props["numbers"]["type"], "array");
     assert_eq!(props["numbers"]["items"]["type"], "integer");
@@ -162,7 +162,7 @@ fn no_params() -> Result<i32, rig_core::tool::ToolError> {
 
 #[tokio::test]
 async fn test_no_params() {
-    let def = NoParams.definition(String::default()).await;
+    let def = rig_core::tool::tool_definition(&NoParams);
     let required = def.parameters["required"].as_array().unwrap();
     assert!(required.is_empty());
 
@@ -185,7 +185,7 @@ fn toggle(
 
 #[tokio::test]
 async fn test_bool_param() {
-    let def = Toggle.definition(String::default()).await;
+    let def = rig_core::tool::tool_definition(&Toggle);
     let props = def.parameters["properties"].as_object().unwrap();
     assert_eq!(props["enabled"]["type"], "boolean");
 }
@@ -199,7 +199,7 @@ fn no_docs(x: i32) -> Result<i32, rig_core::tool::ToolError> {
 
 #[tokio::test]
 async fn test_default_description_fallback() {
-    let def = NoDocs.definition(String::default()).await;
+    let def = rig_core::tool::tool_definition(&NoDocs);
     assert_eq!(def.description, "Function to no_docs");
 
     let props = def.parameters["properties"].as_object().unwrap();
@@ -210,7 +210,7 @@ async fn test_default_description_fallback() {
 
 #[tokio::test]
 async fn test_schema_type_object() {
-    let def = AddDoc.definition(String::default()).await;
+    let def = rig_core::tool::tool_definition(&AddDoc);
     assert_eq!(def.parameters["type"], "object");
 }
 
@@ -218,7 +218,7 @@ async fn test_schema_type_object() {
 
 #[tokio::test]
 async fn test_required_all_by_default() {
-    let def = AddDoc.definition(String::default()).await;
+    let def = rig_core::tool::tool_definition(&AddDoc);
     let required = def.parameters["required"].as_array().unwrap();
     let names: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
     assert_eq!(names.len(), 2);
@@ -247,7 +247,7 @@ fn sort_items(
 
 #[tokio::test]
 async fn test_enum_param() {
-    let def = SortItems.definition(String::default()).await;
+    let def = rig_core::tool::tool_definition(&SortItems);
     let schema_str = serde_json::to_string(&def.parameters).unwrap();
 
     // schemars may use $defs/$ref or inline the enum — verify the renamed
@@ -269,7 +269,7 @@ fn store_metadata(
 
 #[tokio::test]
 async fn test_hashmap_param() {
-    let def = StoreMetadata.definition(String::default()).await;
+    let def = rig_core::tool::tool_definition(&StoreMetadata);
     let props = def.parameters["properties"].as_object().unwrap();
     let meta = &props["metadata"];
     assert_eq!(meta["type"], "object");
@@ -303,7 +303,7 @@ fn find_nearby(
 
 #[tokio::test]
 async fn test_nested_struct_param() {
-    let def = FindNearby.definition(String::default()).await;
+    let def = rig_core::tool::tool_definition(&FindNearby);
     let props = def.parameters["properties"].as_object().unwrap();
 
     // The location field should reference a nested struct definition
@@ -341,7 +341,7 @@ async fn fetch_url(
 
 #[tokio::test]
 async fn test_async_tool_with_docs() {
-    let def = FetchUrl.definition(String::default()).await;
+    let def = rig_core::tool::tool_definition(&FetchUrl);
     assert_eq!(def.description, "Fetch a URL asynchronously");
     assert_eq!(def.name, "fetch_url");
 

--- a/crates/rig-derive/tests/visibility.rs
+++ b/crates/rig-derive/tests/visibility.rs
@@ -45,7 +45,7 @@ async fn test_pub_tool_accessible_from_outside_module() {
 
     // PublicAdder and its parameters struct are accessible outside the `tools` module.
     let tool = tools::PublicAdder;
-    let def = tool.definition(String::default()).await;
+    let def = rig_core::tool::tool_definition(&tool);
     assert_eq!(def.name, "public_adder");
     assert_eq!(def.description, "A public tool for testing visibility");
 

--- a/crates/rig-vertexai/examples/tool_vertexai.rs
+++ b/crates/rig-vertexai/examples/tool_vertexai.rs
@@ -1,9 +1,6 @@
 use anyhow::Result;
 use rig_core::prelude::*;
-use rig_core::{
-    completion::{Prompt, ToolDefinition},
-    tool::Tool,
-};
+use rig_core::{completion::Prompt, tool::Tool};
 use rig_vertexai::{Client, completion::GEMINI_2_5_FLASH_LITE};
 use schemars::{JsonSchema, schema_for};
 use serde::{Deserialize, Serialize};
@@ -28,12 +25,12 @@ impl Tool for Adder {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "add".to_string(),
-            description: "Add x and y together".to_string(),
-            parameters: json!(schema_for!(OperationArgs)),
-        }
+    fn description(&self) -> String {
+        "Add x and y together".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!(schema_for!(OperationArgs))
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/examples/agent_run_stepping/src/main.rs
+++ b/examples/agent_run_stepping/src/main.rs
@@ -23,7 +23,7 @@ use anyhow::Result;
 use rig::agent::run::{AgentRun, AgentRunStep, ModelTurn, ModelTurnOutcome};
 use rig::agent::{AgentHook, Flow, HookContext, InvalidToolCallHookAction, StepEvent};
 use rig::client::{CompletionClient, ProviderClient};
-use rig::completion::{Completion, CompletionModel, ToolDefinition};
+use rig::completion::{Completion, CompletionModel};
 use rig::message::{ToolResultContent, UserContent};
 use rig::providers::openai;
 use rig::tool::Tool;
@@ -48,19 +48,19 @@ impl Tool for Add {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "add".to_string(),
-            description: "Add x and y together".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": { "type": "number", "description": "The first number to add" },
-                    "y": { "type": "number", "description": "The second number to add" }
-                },
-                "required": ["x", "y"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Add x and y together".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": { "type": "number", "description": "The first number to add" },
+                "y": { "type": "number", "description": "The second number to add" }
+            },
+            "required": ["x", "y"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/examples/agent_with_agent_tool/src/main.rs
+++ b/examples/agent_with_agent_tool/src/main.rs
@@ -1,10 +1,6 @@
 use anyhow::Result;
 use rig::prelude::*;
-use rig::{
-    completion::{Prompt, ToolDefinition},
-    providers,
-    tool::Tool,
-};
+use rig::{completion::Prompt, providers, tool::Tool};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
@@ -26,25 +22,25 @@ impl Tool for Adder {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "add".to_string(),
-            description: "Add x and y together".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The first number to add"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The second number to add"
-                    }
+    fn description(&self) -> String {
+        "Add x and y together".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "number",
+                    "description": "The first number to add"
                 },
-                "required": ["x", "y"],
-            }),
-        }
+                "y": {
+                    "type": "number",
+                    "description": "The second number to add"
+                }
+            },
+            "required": ["x", "y"],
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -63,25 +59,25 @@ impl Tool for Subtract {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "subtract".to_string(),
-            description: "Subtract y from x (i.e.: x - y)".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The number to subtract from"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The number to subtract"
-                    }
+    fn description(&self) -> String {
+        "Subtract y from x (i.e.: x - y)".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "number",
+                    "description": "The number to subtract from"
                 },
-                "required": ["x", "y"],
-            }),
-        }
+                "y": {
+                    "type": "number",
+                    "description": "The number to subtract"
+                }
+            },
+            "required": ["x", "y"],
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/examples/agent_with_approval_policy/src/main.rs
+++ b/examples/agent_with_approval_policy/src/main.rs
@@ -22,7 +22,7 @@ use std::collections::HashSet;
 use anyhow::Result;
 use rig::agent::{AgentHook, Flow, HookContext, StepEvent};
 use rig::client::{CompletionClient, ProviderClient};
-use rig::completion::{CompletionModel, Prompt, ToolDefinition};
+use rig::completion::{CompletionModel, Prompt};
 use rig::providers::openai;
 use rig::tool::Tool;
 use serde::Deserialize;
@@ -45,16 +45,16 @@ impl Tool for SearchWeb {
     type Args = SearchArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Search the web for a query (read-only).".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": { "query": { "type": "string", "description": "Search query" } },
-                "required": ["query"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Search the web for a query (read-only).".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": { "query": { "type": "string", "description": "Search query" } },
+            "required": ["query"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -77,19 +77,19 @@ impl Tool for TransferFunds {
     type Args = TransferArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Transfer funds to an account.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "to": { "type": "string", "description": "Destination account id" },
-                    "amount": { "type": "integer", "description": "Amount in whole dollars" }
-                },
-                "required": ["to", "amount"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Transfer funds to an account.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "to": { "type": "string", "description": "Destination account id" },
+                "amount": { "type": "integer", "description": "Amount in whole dollars" }
+            },
+            "required": ["to", "amount"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/examples/agent_with_default_max_turns/src/main.rs
+++ b/examples/agent_with_default_max_turns/src/main.rs
@@ -4,7 +4,7 @@
 
 use anyhow::Result;
 use rig::client::{CompletionClient, ProviderClient};
-use rig::completion::{Prompt, ToolDefinition};
+use rig::completion::Prompt;
 use rig::providers::anthropic;
 use rig::tool::Tool;
 use serde::{Deserialize, Serialize};
@@ -31,16 +31,16 @@ impl Tool for Add {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "add".to_string(),
-            description: "Add x and y together".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": { "x": { "type": "number" }, "y": { "type": "number" } },
-                "required": ["x", "y"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Add x and y together".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": { "x": { "type": "number" }, "y": { "type": "number" } },
+            "required": ["x", "y"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -57,16 +57,16 @@ impl Tool for Divide {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "divide".to_string(),
-            description: "Compute the quotient of x and y.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": { "x": { "type": "number" }, "y": { "type": "number" } },
-                "required": ["x", "y"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Compute the quotient of x and y.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": { "x": { "type": "number" }, "y": { "type": "number" } },
+            "required": ["x", "y"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/examples/agent_with_durable_approval/src/main.rs
+++ b/examples/agent_with_durable_approval/src/main.rs
@@ -31,7 +31,7 @@ use anyhow::Result;
 use rig::agent::InvalidToolCallHookAction;
 use rig::agent::run::{AgentRun, AgentRunStep, ModelTurn, ModelTurnOutcome};
 use rig::client::{CompletionClient, ProviderClient};
-use rig::completion::{Completion, ToolDefinition};
+use rig::completion::Completion;
 use rig::message::{ToolResultContent, UserContent};
 use rig::providers::openai;
 use rig::tool::Tool;
@@ -60,16 +60,16 @@ impl Tool for GetBalance {
     type Args = BalanceArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Get the balance of an account.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": { "account": { "type": "string", "description": "Account id" } },
-                "required": ["account"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Get the balance of an account.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": { "account": { "type": "string", "description": "Account id" } },
+            "required": ["account"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -92,19 +92,19 @@ impl Tool for TransferFunds {
     type Args = TransferArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Transfer funds to an account.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "to": { "type": "string", "description": "Destination account id" },
-                    "amount": { "type": "integer", "description": "Amount in whole dollars" }
-                },
-                "required": ["to", "amount"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Transfer funds to an account.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "to": { "type": "string", "description": "Destination account id" },
+                "amount": { "type": "integer", "description": "Amount in whole dollars" }
+            },
+            "required": ["to", "amount"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/examples/agent_with_echochambers/src/main.rs
+++ b/examples/agent_with_echochambers/src/main.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use reqwest::header::{CONTENT_TYPE, HeaderMap, HeaderValue};
 use rig::prelude::*;
 use rig::{
-    completion::ToolDefinition,
     integrations::cli_chatbot::ChatBotBuilder,
     providers::openai::{self, Client},
     tool::Tool,
@@ -52,37 +51,37 @@ impl Tool for SendMessage {
     type Error = EchoChamberError;
     type Args = SendMessageArgs;
     type Output = serde_json::Value;
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "send_message".to_string(),
-            description: "Send a message to a specified EchoChambers room".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "content": {
-                        "type": "string",
-                        "description": "The message content to send"
-                    },
-                    "room_id": {
-                        "type": "string",
-                        "description": "The ID of the room to send the message to"
-                    },
-                    "sender": {
-                        "type": "object",
-                        "properties": {
-                            "username": {
-                                "type": "string",
-                                "description": "Username of the sender"
-                            },
-                            "model": {
-                                "type": "string",
-                                "description": "Model identifier of the sender"
-                            }
+    fn description(&self) -> String {
+        "Send a message to a specified EchoChambers room".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string",
+                    "description": "The message content to send"
+                },
+                "room_id": {
+                    "type": "string",
+                    "description": "The ID of the room to send the message to"
+                },
+                "sender": {
+                    "type": "object",
+                    "properties": {
+                        "username": {
+                            "type": "string",
+                            "description": "Username of the sender"
+                        },
+                        "model": {
+                            "type": "string",
+                            "description": "Model identifier of the sender"
                         }
                     }
                 }
-            }),
-        }
+            }
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -138,24 +137,24 @@ impl Tool for GetHistory {
     type Error = EchoChamberError;
     type Args = GetHistoryArgs;
     type Output = serde_json::Value;
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "get_history".to_string(),
-            description: "Retrieve message history from a specified room".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "room_id": {
-                        "type": "string",
-                        "description": "The ID of the room to get history from"
-                    },
-                    "limit": {
-                        "type": "number",
-                        "description": "Optional limit on number of messages to retrieve"
-                    }
+    fn description(&self) -> String {
+        "Retrieve message history from a specified room".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "room_id": {
+                    "type": "string",
+                    "description": "The ID of the room to get history from"
+                },
+                "limit": {
+                    "type": "number",
+                    "description": "Optional limit on number of messages to retrieve"
                 }
-            }),
-        }
+            }
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -187,20 +186,20 @@ impl Tool for GetRoomMetrics {
     type Args = GetMetricsArgs;
     type Output = serde_json::Value;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "get_room_metrics".to_string(),
-            description: "Retrieve overall metrics for a room".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "room_id": {
-                        "type": "string",
-                        "description": "The ID of the room to get metrics for"
-                    }
+    fn description(&self) -> String {
+        "Retrieve overall metrics for a room".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "room_id": {
+                    "type": "string",
+                    "description": "The ID of the room to get metrics for"
                 }
-            }),
-        }
+            }
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -228,20 +227,20 @@ impl Tool for GetAgentMetrics {
     type Error = EchoChamberError;
     type Args = GetMetricsArgs;
     type Output = serde_json::Value;
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "get_agent_metrics".to_string(),
-            description: "Retrieve metrics for agents in a room".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "room_id": {
-                        "type": "string",
-                        "description": "The ID of the room to get agent metrics for"
-                    }
+    fn description(&self) -> String {
+        "Retrieve metrics for agents in a room".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "room_id": {
+                    "type": "string",
+                    "description": "The ID of the room to get agent metrics for"
                 }
-            }),
-        }
+            }
+        })
     }
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
         let client = reqwest::Client::new();
@@ -268,20 +267,20 @@ impl Tool for GetMetricsHistory {
     type Error = EchoChamberError;
     type Args = GetMetricsArgs;
     type Output = serde_json::Value;
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "get_metrics_history".to_string(),
-            description: "Retrieve historical metrics for a room".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "room_id": {
-                        "type": "string",
-                        "description": "The ID of the room to get metrics history for"
-                    }
+    fn description(&self) -> String {
+        "Retrieve historical metrics for a room".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "room_id": {
+                    "type": "string",
+                    "description": "The ID of the room to get metrics history for"
                 }
-            }),
-        }
+            }
+        })
     }
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
         let client = reqwest::Client::new();

--- a/examples/agent_with_human_in_the_loop/src/main.rs
+++ b/examples/agent_with_human_in_the_loop/src/main.rs
@@ -23,7 +23,7 @@
 use anyhow::Result;
 use rig::agent::{AgentHook, Flow, HookContext, StepEvent};
 use rig::client::{CompletionClient, ProviderClient};
-use rig::completion::{CompletionModel, Prompt, ToolDefinition};
+use rig::completion::{CompletionModel, Prompt};
 use rig::providers::openai;
 use rig::tool::Tool;
 use serde::Deserialize;
@@ -52,20 +52,20 @@ impl Tool for SendEmail {
     type Args = SendEmailArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Send an email to a recipient.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "to": { "type": "string", "description": "Recipient email address" },
-                    "subject": { "type": "string", "description": "Email subject line" },
-                    "body": { "type": "string", "description": "Email body" }
-                },
-                "required": ["to", "subject", "body"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Send an email to a recipient.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "to": { "type": "string", "description": "Recipient email address" },
+                "subject": { "type": "string", "description": "Email subject line" },
+                "body": { "type": "string", "description": "Email body" }
+            },
+            "required": ["to", "subject", "body"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -93,18 +93,18 @@ impl Tool for DeleteFile {
     type Args = DeleteFileArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Permanently delete a file at the given path.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "path": { "type": "string", "description": "Absolute path of the file to delete" }
-                },
-                "required": ["path"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Permanently delete a file at the given path.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string", "description": "Absolute path of the file to delete" }
+            },
+            "required": ["path"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/examples/agent_with_tools/src/main.rs
+++ b/examples/agent_with_tools/src/main.rs
@@ -4,7 +4,7 @@
 
 use anyhow::Result;
 use rig::client::{CompletionClient, ProviderClient};
-use rig::completion::{Prompt, ToolDefinition};
+use rig::completion::Prompt;
 use rig::providers::openai;
 use rig::tool::{Tool, ToolDyn};
 use serde::Deserialize;
@@ -30,19 +30,19 @@ impl Tool for Add {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "add".to_string(),
-            description: "Add x and y together".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": { "type": "number", "description": "The first number to add" },
-                    "y": { "type": "number", "description": "The second number to add" }
-                },
-                "required": ["x", "y"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Add x and y together".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": { "type": "number", "description": "The first number to add" },
+                "y": { "type": "number", "description": "The second number to add" }
+            },
+            "required": ["x", "y"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -59,19 +59,19 @@ impl Tool for Subtract {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "subtract".to_string(),
-            description: "Subtract y from x (i.e.: x - y)".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": { "type": "number", "description": "The number to subtract from" },
-                    "y": { "type": "number", "description": "The number to subtract" }
-                },
-                "required": ["x", "y"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Subtract y from x (i.e.: x - y)".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": { "type": "number", "description": "The number to subtract from" },
+                "y": { "type": "number", "description": "The number to subtract" }
+            },
+            "required": ["x", "y"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/examples/agent_with_tools_otel/src/main.rs
+++ b/examples/agent_with_tools_otel/src/main.rs
@@ -12,11 +12,7 @@ use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::trace::SdkTracerProvider;
 use rig::prelude::*;
-use rig::{
-    completion::{Prompt, ToolDefinition},
-    providers,
-    tool::Tool,
-};
+use rig::{completion::Prompt, providers, tool::Tool};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tracing::Level;
@@ -41,25 +37,25 @@ impl Tool for Adder {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "add".to_string(),
-            description: "Add x and y together".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The first number to add"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The second number to add"
-                    }
+    fn description(&self) -> String {
+        "Add x and y together".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "number",
+                    "description": "The first number to add"
                 },
-                "required": ["x", "y"],
-            }),
-        }
+                "y": {
+                    "type": "number",
+                    "description": "The second number to add"
+                }
+            },
+            "required": ["x", "y"],
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -78,25 +74,25 @@ impl Tool for Subtract {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "subtract".to_string(),
-            description: "Subtract y from x (i.e.: x - y)".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The number to subtract from"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The number to subtract"
-                    }
+    fn description(&self) -> String {
+        "Subtract y from x (i.e.: x - y)".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "number",
+                    "description": "The number to subtract from"
                 },
-                "required": ["x", "y"],
-            }),
-        }
+                "y": {
+                    "type": "number",
+                    "description": "The number to subtract"
+                }
+            },
+            "required": ["x", "y"],
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/examples/calculator_chatbot/src/main.rs
+++ b/examples/calculator_chatbot/src/main.rs
@@ -3,7 +3,6 @@ use rig::integrations::cli_chatbot::ChatBotBuilder;
 use rig::prelude::*;
 use rig::providers::openai;
 use rig::{
-    completion::ToolDefinition,
     embeddings::EmbeddingsBuilder,
     providers::openai::Client,
     tool::{Tool, ToolEmbedding, ToolSet},
@@ -36,25 +35,25 @@ impl Tool for Add {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "add".to_string(),
-            description: "Add x and y together".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The first number to add"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The second number to add"
-                    }
+    fn description(&self) -> String {
+        "Add x and y together".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "number",
+                    "description": "The first number to add"
                 },
-                "required": [ "x", "y" ]
-            }),
-        }
+                "y": {
+                    "type": "number",
+                    "description": "The second number to add"
+                }
+            },
+            "required": [ "x", "y" ]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -88,25 +87,25 @@ impl Tool for Subtract {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "subtract".to_string(),
-            description: "Subtract y from x (i.e.: x - y)".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The number to subtract from"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The number to subtract"
-                    }
+    fn description(&self) -> String {
+        "Subtract y from x (i.e.: x - y)".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "number",
+                    "description": "The number to subtract from"
                 },
-                "required": [ "x", "y" ]
-            }),
-        }
+                "y": {
+                    "type": "number",
+                    "description": "The number to subtract"
+                }
+            },
+            "required": [ "x", "y" ]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -139,25 +138,25 @@ impl Tool for Multiply {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "multiply".to_string(),
-            description: "Compute the product of x and y (i.e.: x * y)".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The first factor in the product"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The second factor in the product"
-                    }
+    fn description(&self) -> String {
+        "Compute the product of x and y (i.e.: x * y)".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "number",
+                    "description": "The first factor in the product"
                 },
-                "required": [ "x", "y" ]
-            }),
-        }
+                "y": {
+                    "type": "number",
+                    "description": "The second factor in the product"
+                }
+            },
+            "required": [ "x", "y" ]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -186,26 +185,25 @@ impl Tool for Divide {
     type Error = MathError;
     type Args = OperationArgs;
     type Output = i32;
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "divide".to_string(),
-            description: "Compute the Quotient of x and y (i.e.: x / y). Useful for ratios."
-                .to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The Dividend of the division. The number being divided"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The Divisor of the division. The number by which the dividend is being divided"
-                    }
+    fn description(&self) -> String {
+        "Compute the Quotient of x and y (i.e.: x / y). Useful for ratios.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "number",
+                    "description": "The Dividend of the division. The number being divided"
                 },
-                "required": [ "x", "y" ]
-            }),
-        }
+                "y": {
+                    "type": "number",
+                    "description": "The Divisor of the division. The number by which the dividend is being divided"
+                }
+            },
+            "required": [ "x", "y" ]
+        })
     }
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
         let result = args.x / args.y;

--- a/examples/gemini_default_api_recovery/src/main.rs
+++ b/examples/gemini_default_api_recovery/src/main.rs
@@ -10,7 +10,7 @@ use rig::agent::{
     StepEvent, StreamingResult,
 };
 use rig::client::{CompletionClient, ProviderClient};
-use rig::completion::{CompletionModel, ToolDefinition};
+use rig::completion::CompletionModel;
 use rig::message::ToolResultContent;
 use rig::providers::gemini::{
     self,
@@ -107,12 +107,12 @@ impl Tool for JavaScript {
     type Args = JavaScriptProgram;
     type Output = ExecutorResponse;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.into(),
-            description: "JavaScript runtime with an array of tools for completing the tasks assigned by the user. Legacy workspace agents may refer to this runtime as default_api.".into(),
-            parameters: schema_for!(JavaScriptProgram).to_value(),
-        }
+    fn description(&self) -> String {
+        "JavaScript runtime with an array of tools for completing the tasks assigned by the user. Legacy workspace agents may refer to this runtime as default_api.".into()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        schema_for!(JavaScriptProgram).to_value()
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/examples/manual_tool_calls/src/main.rs
+++ b/examples/manual_tool_calls/src/main.rs
@@ -12,7 +12,7 @@
 use anyhow::{Result, bail};
 use rig::OneOrMany;
 use rig::client::{CompletionClient, ProviderClient};
-use rig::completion::{Completion, ToolDefinition};
+use rig::completion::Completion;
 use rig::message::{AssistantContent, Message, ToolCall, ToolChoice};
 use rig::providers::openai;
 use rig::tool::{Tool, ToolSet};
@@ -38,19 +38,19 @@ impl Tool for Add {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "add".to_string(),
-            description: "Add x and y together".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": { "type": "number", "description": "The first number to add" },
-                    "y": { "type": "number", "description": "The second number to add" }
-                },
-                "required": ["x", "y"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Add x and y together".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": { "type": "number", "description": "The first number to add" },
+                "y": { "type": "number", "description": "The second number to add" }
+            },
+            "required": ["x", "y"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -67,19 +67,19 @@ impl Tool for Subtract {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "subtract".to_string(),
-            description: "Subtract y from x (x - y)".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": { "type": "number", "description": "The number to subtract from" },
-                    "y": { "type": "number", "description": "The number to subtract" }
-                },
-                "required": ["x", "y"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Subtract y from x (x - y)".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": { "type": "number", "description": "The number to subtract from" },
+                "y": { "type": "number", "description": "The number to subtract" }
+            },
+            "required": ["x", "y"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/examples/multi_agent/src/main.rs
+++ b/examples/multi_agent/src/main.rs
@@ -4,7 +4,7 @@ use rig::prelude::*;
 use rig::providers::openai;
 use rig::{
     agent::{Agent, AgentBuilder},
-    completion::{Chat, CompletionModel, Message, PromptError, ToolDefinition},
+    completion::{Chat, CompletionModel, Message, PromptError},
     providers::openai::Client as OpenAIClient,
     tool::Tool,
 };
@@ -28,23 +28,22 @@ impl<M: CompletionModel + 'static> Tool for TranslatorTool<M> {
     type Error = PromptError;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description:
-                "Translate any text to English. If already in English, fix grammar and syntax issues."
-                    .to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "prompt": {
-                        "type": "string",
-                        "description": "The text to translate to English"
-                    }
-                },
-                "required": ["prompt"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Translate any text to English. If already in English, fix grammar and syntax issues."
+            .to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "prompt": {
+                    "type": "string",
+                    "description": "The text to translate to English"
+                }
+            },
+            "required": ["prompt"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/examples/multi_turn_agent/src/main.rs
+++ b/examples/multi_turn_agent/src/main.rs
@@ -1,9 +1,5 @@
 use rig::prelude::*;
-use rig::{
-    completion::{Prompt, ToolDefinition},
-    providers::anthropic,
-    tool::Tool,
-};
+use rig::{completion::Prompt, providers::anthropic, tool::Tool};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
@@ -72,24 +68,24 @@ impl Tool for Add {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "add".to_string(),
-            description: "Add x and y together".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The first number to add"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The second number to add"
-                    }
+    fn description(&self) -> String {
+        "Add x and y together".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "number",
+                    "description": "The first number to add"
+                },
+                "y": {
+                    "type": "number",
+                    "description": "The second number to add"
                 }
-            }),
-        }
+            }
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -107,24 +103,24 @@ impl Tool for Subtract {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "subtract".to_string(),
-            description: "Subtract y from x (i.e.: x - y)".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The number to subtract from"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The number to subtract"
-                    }
+    fn description(&self) -> String {
+        "Subtract y from x (i.e.: x - y)".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "number",
+                    "description": "The number to subtract from"
+                },
+                "y": {
+                    "type": "number",
+                    "description": "The number to subtract"
                 }
-            }),
-        }
+            }
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -142,24 +138,24 @@ impl Tool for Multiply {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "multiply".to_string(),
-            description: "Compute the product of x and y (i.e.: x * y)".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The first factor in the product"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The second factor in the product"
-                    }
+    fn description(&self) -> String {
+        "Compute the product of x and y (i.e.: x * y)".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "number",
+                    "description": "The first factor in the product"
+                },
+                "y": {
+                    "type": "number",
+                    "description": "The second factor in the product"
                 }
-            }),
-        }
+            }
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -177,25 +173,24 @@ impl Tool for Divide {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "divide".to_string(),
-            description: "Compute the Quotient of x and y (i.e.: x / y). Useful for ratios."
-                .to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The Dividend of the division. The number being divided"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The Divisor of the division. The number by which the dividend is being divided"
-                    }
+    fn description(&self) -> String {
+        "Compute the Quotient of x and y (i.e.: x / y). Useful for ratios.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "number",
+                    "description": "The Dividend of the division. The number being divided"
+                },
+                "y": {
+                    "type": "number",
+                    "description": "The Divisor of the division. The number by which the dividend is being divided"
                 }
-            }),
-        }
+            }
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/examples/multi_turn_agent_extended/src/main.rs
+++ b/examples/multi_turn_agent_extended/src/main.rs
@@ -1,9 +1,5 @@
 use rig::prelude::*;
-use rig::{
-    completion::{Prompt, ToolDefinition},
-    providers::anthropic,
-    tool::Tool,
-};
+use rig::{completion::Prompt, providers::anthropic, tool::Tool};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
@@ -74,24 +70,24 @@ impl Tool for Add {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "add".to_string(),
-            description: "Add x and y together".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The first number to add"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The second number to add"
-                    }
+    fn description(&self) -> String {
+        "Add x and y together".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "number",
+                    "description": "The first number to add"
+                },
+                "y": {
+                    "type": "number",
+                    "description": "The second number to add"
                 }
-            }),
-        }
+            }
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -109,24 +105,24 @@ impl Tool for Subtract {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "subtract".to_string(),
-            description: "Subtract y from x (i.e.: x - y)".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The number to subtract from"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The number to subtract"
-                    }
+    fn description(&self) -> String {
+        "Subtract y from x (i.e.: x - y)".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "number",
+                    "description": "The number to subtract from"
+                },
+                "y": {
+                    "type": "number",
+                    "description": "The number to subtract"
                 }
-            }),
-        }
+            }
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -144,24 +140,24 @@ impl Tool for Multiply {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "multiply".to_string(),
-            description: "Compute the product of x and y (i.e.: x * y)".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The first factor in the product"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The second factor in the product"
-                    }
+    fn description(&self) -> String {
+        "Compute the product of x and y (i.e.: x * y)".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "number",
+                    "description": "The first factor in the product"
+                },
+                "y": {
+                    "type": "number",
+                    "description": "The second factor in the product"
                 }
-            }),
-        }
+            }
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -179,25 +175,24 @@ impl Tool for Divide {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "divide".to_string(),
-            description: "Compute the Quotient of x and y (i.e.: x / y). Useful for ratios."
-                .to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The Dividend of the division. The number being divided"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The Divisor of the division. The number by which the dividend is being divided"
-                    }
+    fn description(&self) -> String {
+        "Compute the Quotient of x and y (i.e.: x / y). Useful for ratios.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "number",
+                    "description": "The Dividend of the division. The number being divided"
+                },
+                "y": {
+                    "type": "number",
+                    "description": "The Divisor of the division. The number by which the dividend is being divided"
                 }
-            }),
-        }
+            }
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/examples/openai_streaming_per_call_usage/src/main.rs
+++ b/examples/openai_streaming_per_call_usage/src/main.rs
@@ -23,7 +23,7 @@ use anyhow::{Result, anyhow};
 use futures::StreamExt;
 use rig::agent::MultiTurnStreamItem;
 use rig::client::{CompletionClient, ProviderClient};
-use rig::completion::{ToolDefinition, Usage};
+use rig::completion::Usage;
 use rig::providers::openai;
 use rig::streaming::{StreamedAssistantContent, StreamingPrompt};
 use rig::tool::Tool;
@@ -50,21 +50,21 @@ impl Tool for ProjectStatusTool {
     type Args = ProjectStatusArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Look up the current status for an internal project ticket.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "ticket": {
-                        "type": "string",
-                        "description": "The internal project ticket to look up"
-                    }
-                },
-                "required": ["ticket"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Look up the current status for an internal project ticket.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "ticket": {
+                    "type": "string",
+                    "description": "The internal project ticket to look up"
+                }
+            },
+            "required": ["ticket"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/examples/openai_streaming_with_tools_otel/src/main.rs
+++ b/examples/openai_streaming_with_tools_otel/src/main.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use rig::agent::stream_to_stdout;
 use rig::prelude::*;
 
-use rig::{completion::ToolDefinition, providers, streaming::StreamingPrompt, tool::Tool};
+use rig::{providers, streaming::StreamingPrompt, tool::Tool};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
@@ -33,25 +33,25 @@ impl Tool for Adder {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "add".to_string(),
-            description: "Add x and y together".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The first number to add"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The second number to add"
-                    }
+    fn description(&self) -> String {
+        "Add x and y together".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "number",
+                    "description": "The first number to add"
                 },
-                "required": ["x", "y"],
-            }),
-        }
+                "y": {
+                    "type": "number",
+                    "description": "The second number to add"
+                }
+            },
+            "required": ["x", "y"],
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -69,25 +69,25 @@ impl Tool for Subtract {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "subtract".to_string(),
-            description: "Subtract y from x (i.e.: x - y)".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The number to subtract from"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The number to subtract"
-                    }
+    fn description(&self) -> String {
+        "Subtract y from x (i.e.: x - y)".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "number",
+                    "description": "The number to subtract from"
                 },
-                "required": ["x", "y"],
-            }),
-        }
+                "y": {
+                    "type": "number",
+                    "description": "The number to subtract"
+                }
+            },
+            "required": ["x", "y"],
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/examples/rag_dynamic_tools/src/main.rs
+++ b/examples/rag_dynamic_tools/src/main.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use rig::prelude::*;
 use rig::providers::openai;
 use rig::{
-    completion::{Prompt, ToolDefinition},
+    completion::Prompt,
     embeddings::EmbeddingsBuilder,
     providers::openai::Client,
     tool::{Tool, ToolEmbedding, ToolSet},
@@ -34,24 +34,24 @@ impl Tool for Add {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "add".to_string(),
-            description: "Add x and y together".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The first number to add"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The second number to add"
-                    }
+    fn description(&self) -> String {
+        "Add x and y together".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "number",
+                    "description": "The first number to add"
+                },
+                "y": {
+                    "type": "number",
+                    "description": "The second number to add"
                 }
-            }),
-        }
+            }
+        })
     }
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
         let result = args.x + args.y;
@@ -77,24 +77,24 @@ impl Tool for Subtract {
     type Error = MathError;
     type Args = OperationArgs;
     type Output = i32;
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "subtract".to_string(),
-            description: "Subtract y from x (i.e.: x - y)".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The number to subtract from"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The number to subtract"
-                    }
+    fn description(&self) -> String {
+        "Subtract y from x (i.e.: x - y)".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "number",
+                    "description": "The number to subtract from"
+                },
+                "y": {
+                    "type": "number",
+                    "description": "The number to subtract"
                 }
-            }),
-        }
+            }
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/examples/rag_dynamic_tools_multi_turn/src/main.rs
+++ b/examples/rag_dynamic_tools_multi_turn/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use rig::{
-    completion::{Prompt, ToolDefinition},
+    completion::Prompt,
     embeddings::EmbeddingsBuilder,
     prelude::*,
     providers::openai::{self, Client},
@@ -34,24 +34,24 @@ impl Tool for Add {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "add".to_string(),
-            description: "Add x and y together".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The first number to add"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The second number to add"
-                    }
+    fn description(&self) -> String {
+        "Add x and y together".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "number",
+                    "description": "The first number to add"
+                },
+                "y": {
+                    "type": "number",
+                    "description": "The second number to add"
                 }
-            }),
-        }
+            }
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -86,24 +86,24 @@ impl Tool for Subtract {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "subtract".to_string(),
-            description: "Subtract y from x (i.e.: x - y)".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The number to subtract from"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The number to subtract"
-                    }
+    fn description(&self) -> String {
+        "Subtract y from x (i.e.: x - y)".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "number",
+                    "description": "The number to subtract from"
+                },
+                "y": {
+                    "type": "number",
+                    "description": "The number to subtract"
                 }
-            }),
-        }
+            }
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/examples/reasoning_loop/src/main.rs
+++ b/examples/reasoning_loop/src/main.rs
@@ -1,7 +1,7 @@
 use rig::prelude::*;
 use rig::{
     agent::Agent,
-    completion::{CompletionError, CompletionModel, Prompt, PromptError, ToolDefinition},
+    completion::{CompletionError, CompletionModel, Prompt, PromptError},
     extractor::Extractor,
     message::Message,
     providers::anthropic,
@@ -127,24 +127,24 @@ impl Tool for Add {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "add".to_string(),
-            description: "Add x and y together".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The first number to add"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The second number to add"
-                    }
+    fn description(&self) -> String {
+        "Add x and y together".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "number",
+                    "description": "The first number to add"
+                },
+                "y": {
+                    "type": "number",
+                    "description": "The second number to add"
                 }
-            }),
-        }
+            }
+        })
     }
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
         let result = args.x + args.y;
@@ -158,24 +158,24 @@ impl Tool for Subtract {
     type Error = MathError;
     type Args = OperationArgs;
     type Output = i32;
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "subtract".to_string(),
-            description: "Subtract y from x (i.e.: x - y)".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The number to subtract from"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The number to subtract"
-                    }
+    fn description(&self) -> String {
+        "Subtract y from x (i.e.: x - y)".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "number",
+                    "description": "The number to subtract from"
+                },
+                "y": {
+                    "type": "number",
+                    "description": "The number to subtract"
                 }
-            }),
-        }
+            }
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -192,24 +192,24 @@ impl Tool for Multiply {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "multiply".to_string(),
-            description: "Compute the product of x and y (i.e.: x * y)".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The first factor in the product"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The second factor in the product"
-                    }
+    fn description(&self) -> String {
+        "Compute the product of x and y (i.e.: x * y)".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "number",
+                    "description": "The first factor in the product"
+                },
+                "y": {
+                    "type": "number",
+                    "description": "The second factor in the product"
                 }
-            }),
-        }
+            }
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -226,25 +226,24 @@ impl Tool for Divide {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "divide".to_string(),
-            description: "Compute the Quotient of x and y (i.e.: x / y). Useful for ratios."
-                .to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": {
-                        "type": "number",
-                        "description": "The Dividend of the division. The number being divided"
-                    },
-                    "y": {
-                        "type": "number",
-                        "description": "The Divisor of the division. The number by which the dividend is being divided"
-                    }
+    fn description(&self) -> String {
+        "Compute the Quotient of x and y (i.e.: x / y). Useful for ratios.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": {
+                    "type": "number",
+                    "description": "The Dividend of the division. The number being divided"
+                },
+                "y": {
+                    "type": "number",
+                    "description": "The Divisor of the division. The number by which the dividend is being divided"
                 }
-            }),
-        }
+            }
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/examples/tool_result_outcomes/src/main.rs
+++ b/examples/tool_result_outcomes/src/main.rs
@@ -29,7 +29,7 @@
 use anyhow::Result;
 use rig::agent::{AgentHook, Flow, HookContext, StepEvent};
 use rig::client::{CompletionClient, ProviderClient};
-use rig::completion::{CompletionModel, Prompt, ToolDefinition};
+use rig::completion::{CompletionModel, Prompt};
 use rig::providers::openai;
 use rig::tool::{Tool, ToolFailure, ToolFailureKind, ToolOutcome};
 
@@ -58,20 +58,20 @@ impl Tool for HttpFetch {
     type Args = FetchArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Fetch a URL and return its body. URLs containing 'slow' time out; \
-                          URLs containing 'missing' return HTTP 404."
-                .to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "url": { "type": "string", "description": "The URL to fetch" }
-                },
-                "required": ["url"],
-            }),
-        }
+    fn description(&self) -> String {
+        "Fetch a URL and return its body. URLs containing 'slow' time out; \
+                                  URLs containing 'missing' return HTTP 404."
+            .to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "url": { "type": "string", "description": "The URL to fetch" }
+            },
+            "required": ["url"],
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/tests/common/reasoning.rs
+++ b/tests/common/reasoning.rs
@@ -11,7 +11,6 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use futures::StreamExt;
 use rig::OneOrMany;
 use rig::agent::{MultiTurnStreamItem, StreamingError};
-use rig::completion::request::ToolDefinition;
 use rig::completion::{self, CompletionModel};
 use rig::message::{
     AssistantContent, Message, Reasoning, ReasoningContent, ToolResultContent, UserContent,
@@ -285,23 +284,21 @@ impl Tool for WeatherTool {
     type Args = WeatherArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "get_weather".to_string(),
-            description:
-                "Get the current weather for a city. Must be called for weather questions."
-                    .to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "city": {
-                        "type": "string",
-                        "description": "City name to get weather for"
-                    }
-                },
-                "required": ["city"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Get the current weather for a city. Must be called for weather questions.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "city": {
+                    "type": "string",
+                    "description": "City name to get weather for"
+                }
+            },
+            "required": ["city"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/tests/common/support.rs
+++ b/tests/common/support.rs
@@ -131,15 +131,15 @@ impl Tool for Adder {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "add".to_string(),
-            description: "Add x and y together".to_string(),
-            parameters: serde_json::from_str(
-                r#"{"type":"object","properties":{"x":{"type":"number","description":"The first number to add"},"y":{"type":"number","description":"The second number to add"}},"required":["x","y"]}"#,
-            )
-            .expect("adder schema should deserialize"),
-        }
+    fn description(&self) -> String {
+        "Add x and y together".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::from_str(
+                        r#"{"type":"object","properties":{"x":{"type":"number","description":"The first number to add"},"y":{"type":"number","description":"The second number to add"}},"required":["x","y"]}"#,
+                    )
+                    .expect("adder schema should deserialize")
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -156,15 +156,15 @@ impl Tool for Subtract {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "subtract".to_string(),
-            description: "Subtract y from x (i.e.: x - y)".to_string(),
-            parameters: serde_json::from_str(
-                r#"{"type":"object","properties":{"x":{"type":"number","description":"The number to subtract from"},"y":{"type":"number","description":"The number to subtract"}},"required":["x","y"]}"#,
-            )
-            .expect("subtract schema should deserialize"),
-        }
+    fn description(&self) -> String {
+        "Subtract y from x (i.e.: x - y)".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::from_str(
+                        r#"{"type":"object","properties":{"x":{"type":"number","description":"The number to subtract from"},"y":{"type":"number","description":"The number to subtract"}},"required":["x","y"]}"#,
+                    )
+                    .expect("subtract schema should deserialize")
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -181,16 +181,16 @@ impl Tool for AlphaSignal {
     type Args = EmptyArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Return the alpha signal marker.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {},
-                "required": [],
-            }),
-        }
+    fn description(&self) -> String {
+        "Return the alpha signal marker.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "required": [],
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -207,16 +207,16 @@ impl Tool for BetaSignal {
     type Args = EmptyArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Return the beta signal marker.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {},
-                "required": [],
-            }),
-        }
+    fn description(&self) -> String {
+        "Return the beta signal marker.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "required": [],
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/tests/core/tool_macro.rs
+++ b/tests/core/tool_macro.rs
@@ -17,9 +17,7 @@ fn facade_find_nearby(
 
 #[tokio::test]
 async fn test_tool_macro_accepts_facade_schemars_reexport() {
-    use rig::tool::Tool;
-
-    let definition = FacadeFindNearby.definition(String::default()).await;
+    let definition = rig::tool::tool_definition(&FacadeFindNearby);
     let schema = serde_json::to_string(&definition.parameters).unwrap();
 
     assert!(schema.contains("lat"), "expected lat in schema: {schema}");

--- a/tests/integrations/bedrock/streaming.rs
+++ b/tests/integrations/bedrock/streaming.rs
@@ -59,7 +59,7 @@ async fn raw_streaming_tool_call_smoke() {
     let request = model
         .completion_request(ORDERED_TOOL_STREAM_PROMPT)
         .preamble(ORDERED_TOOL_STREAM_PREAMBLE.to_string())
-        .tool(AlphaSignal.definition(String::new()).await)
+        .tool(rig::tool::tool_definition(&AlphaSignal))
         .tool_choice(ToolChoice::Specific {
             function_names: vec![AlphaSignal::NAME.to_string()],
         })

--- a/tests/providers/anthropic/cassette/default_max_turns.rs
+++ b/tests/providers/anthropic/cassette/default_max_turns.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 use rig::client::CompletionClient;
-use rig::completion::{Prompt, ToolDefinition};
+use rig::completion::Prompt;
 use rig::providers::anthropic;
 use rig::tool::Tool;
 use serde::{Deserialize, Serialize};
@@ -31,16 +31,16 @@ impl Tool for Add {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "add".to_string(),
-            description: "Add x and y together".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": { "x": { "type": "number" }, "y": { "type": "number" } },
-                "required": ["x", "y"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Add x and y together".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": { "x": { "type": "number" }, "y": { "type": "number" } },
+            "required": ["x", "y"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -57,16 +57,16 @@ impl Tool for Divide {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "divide".to_string(),
-            description: "Compute the quotient of x and y.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": { "x": { "type": "number" }, "y": { "type": "number" } },
-                "required": ["x", "y"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Compute the quotient of x and y.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": { "x": { "type": "number" }, "y": { "type": "number" } },
+            "required": ["x", "y"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/tests/providers/anthropic/cassette/empty_end_turn.rs
+++ b/tests/providers/anthropic/cassette/empty_end_turn.rs
@@ -39,20 +39,24 @@ struct NotifyArgs {
 #[error("notify error")]
 struct NotifyError;
 
+fn notify_tool_parameters() -> serde_json::Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "msg": {
+                "type": "string",
+                "description": "The short notification to send."
+            }
+        },
+        "required": ["msg"]
+    })
+}
+
 fn notify_tool_definition() -> ToolDefinition {
     ToolDefinition {
         name: Notify::NAME.to_string(),
         description: "Send a short notification for a user status update.".to_string(),
-        parameters: json!({
-            "type": "object",
-            "properties": {
-                "msg": {
-                    "type": "string",
-                    "description": "The short notification to send."
-                }
-            },
-            "required": ["msg"]
-        }),
+        parameters: notify_tool_parameters(),
     }
 }
 
@@ -72,8 +76,12 @@ impl Tool for Notify {
     type Args = NotifyArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        notify_tool_definition()
+    fn description(&self) -> String {
+        "Send a short notification for a user status update.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        notify_tool_parameters()
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/tests/providers/anthropic/cassette/messages_sessions.rs
+++ b/tests/providers/anthropic/cassette/messages_sessions.rs
@@ -273,7 +273,7 @@ async fn long_history_replay_nonstreaming() {
                 .completion_request("Look up the harbor label with the tool.")
                 .preamble(preamble.to_string())
                 .max_tokens(1024)
-                .tool(AlphaSignal.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&AlphaSignal))
                 .build();
             let first_response = model
                 .completion(first_request)
@@ -322,7 +322,7 @@ async fn long_history_replay_nonstreaming() {
                     ALPHA_SIGNAL_OUTPUT,
                 ))
                 .message(Message::assistant("The harbor label is crimson-harbor."))
-                .tool(AlphaSignal.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&AlphaSignal))
                 .build();
 
             let response = model

--- a/tests/providers/anthropic/cassette/messages_tool_args.rs
+++ b/tests/providers/anthropic/cassette/messages_tool_args.rs
@@ -64,12 +64,12 @@ impl Tool for PlanTrip {
     type Args = PlanTripArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Book a trip from a nested itinerary object.".to_string(),
-            parameters: plan_trip_parameters(),
-        }
+    fn description(&self) -> String {
+        "Book a trip from a nested itinerary object.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        plan_trip_parameters()
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -266,7 +266,7 @@ async fn nested_arguments_streaming() {
                 .completion_request(NESTED_ARGS_PROMPT)
                 .preamble(NESTED_ARGS_PREAMBLE.to_string())
                 .max_tokens(2048)
-                .tool(PlanTrip.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&PlanTrip))
                 .build();
 
             let observation = collect_raw_stream_observation(

--- a/tests/providers/anthropic/cassette/messages_tool_choice.rs
+++ b/tests/providers/anthropic/cassette/messages_tool_choice.rs
@@ -36,7 +36,7 @@ async fn required_maps_to_any_and_forces_tool_use() {
                 .completion_request("Please greet me.")
                 .preamble(TOOLS_PREAMBLE.to_string())
                 .max_tokens(1024)
-                .tool(Adder.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&Adder))
                 .tool_choice(ToolChoice::Required)
                 .build();
 
@@ -79,7 +79,7 @@ async fn none_suppresses_tool_use() {
                 .completion_request("Name the capital of France in one word.")
                 .preamble("You are a concise assistant. Answer directly.".to_string())
                 .max_tokens(1024)
-                .tool(Adder.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&Adder))
                 .tool_choice(ToolChoice::None)
                 .build();
 
@@ -125,8 +125,8 @@ async fn specific_tool_targets_named_tool() {
                 .completion_request("Compute 9 minus 4 using a tool.")
                 .preamble(TOOLS_PREAMBLE.to_string())
                 .max_tokens(1024)
-                .tool(Adder.definition(String::new()).await)
-                .tool(Subtract.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&Adder))
+                .tool(rig::tool::tool_definition(&Subtract))
                 .tool_choice(ToolChoice::Specific {
                     function_names: vec![Subtract::NAME.to_string()],
                 })

--- a/tests/providers/anthropic/cassette/multi_turn_streaming.rs
+++ b/tests/providers/anthropic/cassette/multi_turn_streaming.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rig::client::CompletionClient;
-use rig::completion::ToolDefinition;
 use rig::providers::anthropic;
 use rig::streaming::StreamingPrompt;
 use rig::tool::Tool;
@@ -42,13 +41,12 @@ impl Tool for Add {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "add".to_string(),
-            description: "Add x and y together".to_string(),
-            parameters: serde_json::to_value(schema_for!(OperationArgs))
-                .expect("schema should serialize"),
-        }
+    fn description(&self) -> String {
+        "Add x and y together".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::to_value(schema_for!(OperationArgs)).expect("schema should serialize")
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -73,13 +71,12 @@ impl Tool for Subtract {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "subtract".to_string(),
-            description: "Subtract y from x (i.e.: x - y)".to_string(),
-            parameters: serde_json::to_value(schema_for!(OperationArgs))
-                .expect("schema should serialize"),
-        }
+    fn description(&self) -> String {
+        "Subtract y from x (i.e.: x - y)".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::to_value(schema_for!(OperationArgs)).expect("schema should serialize")
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -104,13 +101,12 @@ impl Tool for Multiply {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "multiply".to_string(),
-            description: "Compute the product of x and y (i.e.: x * y).".to_string(),
-            parameters: serde_json::to_value(schema_for!(OperationArgs))
-                .expect("schema should serialize"),
-        }
+    fn description(&self) -> String {
+        "Compute the product of x and y (i.e.: x * y).".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::to_value(schema_for!(OperationArgs)).expect("schema should serialize")
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -135,13 +131,12 @@ impl Tool for Divide {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "divide".to_string(),
-            description: "Compute the quotient of x and y.".to_string(),
-            parameters: serde_json::to_value(schema_for!(OperationArgs))
-                .expect("schema should serialize"),
-        }
+    fn description(&self) -> String {
+        "Compute the quotient of x and y.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::to_value(schema_for!(OperationArgs)).expect("schema should serialize")
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/tests/providers/anthropic/cassette/request_override.rs
+++ b/tests/providers/anthropic/cassette/request_override.rs
@@ -14,7 +14,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rig::agent::{AgentHook, Flow, RequestPatch, StepEvent};
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, Prompt, ToolDefinition};
+use rig::completion::{CompletionModel, Prompt};
 use rig::message::ToolChoice;
 use rig::providers::anthropic;
 use rig::streaming::StreamingPrompt;
@@ -56,16 +56,16 @@ impl Tool for GetWeather {
     type Args = WeatherArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Get the current weather for a location.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": { "location": { "type": "string", "description": "City name" } },
-                "required": ["location"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Get the current weather for a location.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": { "location": { "type": "string", "description": "City name" } },
+            "required": ["location"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -88,16 +88,16 @@ impl Tool for GetTime {
     type Args = TimeArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Get the current time in a timezone.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": { "timezone": { "type": "string", "description": "IANA timezone" } },
-                "required": ["timezone"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Get the current time in a timezone.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": { "timezone": { "type": "string", "description": "IANA timezone" } },
+            "required": ["timezone"]
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/tests/providers/anthropic/cassette/streaming_tools.rs
+++ b/tests/providers/anthropic/cassette/streaming_tools.rs
@@ -3,7 +3,6 @@
 use futures::StreamExt;
 use rig::agent::{MultiTurnStreamItem, StreamingError, StreamingResult};
 use rig::client::CompletionClient;
-use rig::completion::ToolDefinition;
 use rig::message::{Message, UserContent};
 use rig::providers::anthropic;
 use rig::streaming::{StreamedAssistantContent, StreamedUserContent, StreamingPrompt};
@@ -205,8 +204,12 @@ impl Tool for OutOfOrderAlphaSignal {
     type Args = EmptyArgs;
     type Output = String;
 
-    async fn definition(&self, prompt: String) -> ToolDefinition {
-        AlphaSignal.definition(prompt).await
+    fn description(&self) -> String {
+        AlphaSignal.description()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        AlphaSignal.parameters()
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -224,8 +227,12 @@ impl Tool for OutOfOrderBetaSignal {
     type Args = EmptyArgs;
     type Output = String;
 
-    async fn definition(&self, prompt: String) -> ToolDefinition {
-        BetaSignal.definition(prompt).await
+    fn description(&self) -> String {
+        BetaSignal.description()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        BetaSignal.parameters()
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/tests/providers/anthropic/cassette/think_tool_with_other_tools.rs
+++ b/tests/providers/anthropic/cassette/think_tool_with_other_tools.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use anyhow::Result;
 use rig::client::CompletionClient;
-use rig::completion::{Prompt, ToolDefinition};
+use rig::completion::Prompt;
 use rig::message::{AssistantContent, Message};
 use rig::providers::anthropic;
 use rig::tool::Tool;
@@ -41,22 +41,21 @@ impl Tool for Calculator {
     type Args = CalculatorArgs;
     type Output = f64;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "calculator".to_string(),
-            description: "Evaluate arithmetic expressions with +, -, *, /, and parentheses."
-                .to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "expression": {
-                        "type": "string",
-                        "description": "An arithmetic expression such as '25 + (2 * 40)'"
-                    }
-                },
-                "required": ["expression"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Evaluate arithmetic expressions with +, -, *, /, and parentheses.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "expression": {
+                    "type": "string",
+                    "description": "An arithmetic expression such as '25 + (2 * 40)'"
+                }
+            },
+            "required": ["expression"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -210,22 +209,21 @@ impl Tool for DatabaseLookup {
     type Args = DatabaseLookupArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "database_lookup".to_string(),
-            description: "Look up customer_policy, shipping_rates, or product_inventory."
-                .to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "query": {
-                        "type": "string",
-                        "description": "One of customer_policy, shipping_rates, or product_inventory"
-                    }
-                },
-                "required": ["query"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Look up customer_policy, shipping_rates, or product_inventory.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "One of customer_policy, shipping_rates, or product_inventory"
+                }
+            },
+            "required": ["query"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/tests/providers/anthropic/cassette/tool_call_rewrite_args.rs
+++ b/tests/providers/anthropic/cassette/tool_call_rewrite_args.rs
@@ -12,7 +12,7 @@ use std::sync::{Arc, Mutex};
 
 use rig::agent::{AgentHook, Flow, StepEvent};
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, Prompt, ToolDefinition};
+use rig::completion::{CompletionModel, Prompt};
 use rig::providers::anthropic;
 use rig::streaming::StreamingPrompt;
 use rig::tool::Tool;
@@ -64,21 +64,21 @@ impl Tool for GetWeather {
     type Args = WeatherArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Get the current weather for a location.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "location": {
-                        "type": "string",
-                        "description": "City to get the weather for, e.g. 'Tokyo'"
-                    }
-                },
-                "required": ["location"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Get the current weather for a location.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "location": {
+                    "type": "string",
+                    "description": "City to get the weather for, e.g. 'Tokyo'"
+                }
+            },
+            "required": ["location"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/tests/providers/anthropic/cassette/tool_result_rewrite.rs
+++ b/tests/providers/anthropic/cassette/tool_result_rewrite.rs
@@ -12,7 +12,7 @@ use std::sync::{Arc, Mutex};
 
 use rig::agent::{AgentHook, Flow, StepEvent};
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, Prompt, ToolDefinition};
+use rig::completion::{CompletionModel, Prompt};
 use rig::providers::anthropic;
 use rig::streaming::StreamingPrompt;
 use rig::tool::Tool;
@@ -63,18 +63,18 @@ impl Tool for GetUserRecord {
     type Args = LookupArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Look up a user record by id.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "user_id": { "type": "string", "description": "The user id, e.g. 'u-42'" }
-                },
-                "required": ["user_id"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Look up a user record by id.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "user_id": { "type": "string", "description": "The user id, e.g. 'u-42'" }
+            },
+            "required": ["user_id"]
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/tests/providers/chatgpt/cassette/codex_behaviors.rs
+++ b/tests/providers/chatgpt/cassette/codex_behaviors.rs
@@ -29,7 +29,7 @@ async fn strict_tools_opt_in_roundtrip() {
             let request = model
                 .completion_request("Use the add tool to add 7 and 5.")
                 .preamble(TOOLS_PREAMBLE.to_string())
-                .tool(Adder.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&Adder))
                 .build();
 
             let response = model

--- a/tests/providers/chatgpt/cassette/codex_sessions.rs
+++ b/tests/providers/chatgpt/cassette/codex_sessions.rs
@@ -314,7 +314,7 @@ async fn long_history_replay_nonstreaming() {
             let first_request = model
                 .completion_request("Look up the harbor label with the tool.")
                 .preamble(preamble.to_string())
-                .tool(AlphaSignal.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&AlphaSignal))
                 .build();
             let first_response = model
                 .completion(first_request)
@@ -363,7 +363,7 @@ async fn long_history_replay_nonstreaming() {
                     ALPHA_SIGNAL_OUTPUT,
                 ))
                 .message(Message::assistant("The harbor label is crimson-harbor."))
-                .tool(AlphaSignal.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&AlphaSignal))
                 .build();
 
             let response = model

--- a/tests/providers/chatgpt/cassette/codex_tool_args.rs
+++ b/tests/providers/chatgpt/cassette/codex_tool_args.rs
@@ -64,12 +64,12 @@ impl Tool for PlanTrip {
     type Args = PlanTripArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Book a trip from a nested itinerary object.".to_string(),
-            parameters: plan_trip_parameters(),
-        }
+    fn description(&self) -> String {
+        "Book a trip from a nested itinerary object.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        plan_trip_parameters()
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -262,7 +262,7 @@ async fn nested_arguments_streaming() {
             let request = model
                 .completion_request(NESTED_ARGS_PROMPT)
                 .preamble(NESTED_ARGS_PREAMBLE.to_string())
-                .tool(PlanTrip.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&PlanTrip))
                 .build();
 
             let observation = collect_raw_stream_observation(

--- a/tests/providers/chatgpt/cassette/codex_tool_choice.rs
+++ b/tests/providers/chatgpt/cassette/codex_tool_choice.rs
@@ -36,7 +36,7 @@ async fn required_forces_a_tool_call() {
             let request = model
                 .completion_request("Please greet me.")
                 .preamble(TOOLS_PREAMBLE.to_string())
-                .tool(Adder.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&Adder))
                 .tool_choice(ToolChoice::Required)
                 .build();
 
@@ -69,7 +69,7 @@ async fn none_suppresses_tool_calls() {
             let request = model
                 .completion_request("What is 2 plus 3? Reply with just the number.")
                 .preamble(TOOLS_PREAMBLE.to_string())
-                .tool(Adder.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&Adder))
                 .tool_choice(ToolChoice::None)
                 .build();
 
@@ -109,8 +109,8 @@ async fn specific_single_function_targets_named_tool() {
             let request = model
                 .completion_request("Compute 9 minus 4 using a tool.")
                 .preamble(TOOLS_PREAMBLE.to_string())
-                .tool(Adder.definition(String::new()).await)
-                .tool(Subtract.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&Adder))
+                .tool(rig::tool::tool_definition(&Subtract))
                 .tool_choice(ToolChoice::Specific {
                     function_names: vec![Subtract::NAME.to_string()],
                 })
@@ -168,9 +168,9 @@ async fn specific_multiple_functions_use_allowed_tools() {
             let request = model
                 .completion_request("What is 2 plus 3? Use exactly one tool.")
                 .preamble(TOOLS_PREAMBLE.to_string())
-                .tool(Adder.definition(String::new()).await)
-                .tool(Subtract.definition(String::new()).await)
-                .tool(AlphaSignal.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&Adder))
+                .tool(rig::tool::tool_definition(&Subtract))
+                .tool(rig::tool::tool_definition(&AlphaSignal))
                 .tool_choice(ToolChoice::Specific {
                     function_names: vec![Adder::NAME.to_string(), Subtract::NAME.to_string()],
                 })

--- a/tests/providers/chatgpt/permission_control.rs
+++ b/tests/providers/chatgpt/permission_control.rs
@@ -3,7 +3,7 @@
 use anyhow::Result;
 use rig::agent::{AgentHook, Flow, StepEvent, stream_to_stdout};
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, Prompt, ToolDefinition};
+use rig::completion::{CompletionModel, Prompt};
 use rig::streaming::StreamingPrompt;
 use rig::tool::Tool;
 use serde::{Deserialize, Serialize};
@@ -49,15 +49,15 @@ impl Tool for ReadFileHead {
     type Args = ReadFileArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "read_file_head".to_string(),
-            description: "Read the first line of test.txt using the head command".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {},
-            }),
-        }
+    fn description(&self) -> String {
+        "Read the first line of test.txt using the head command".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -80,15 +80,15 @@ impl Tool for ReadFileTail {
     type Args = ReadFileArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "read_file_tail".to_string(),
-            description: "Read the last line of test.txt using the tail command".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {},
-            }),
-        }
+    fn description(&self) -> String {
+        "Read the last line of test.txt using the tail command".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/tests/providers/copilot/permission_control.rs
+++ b/tests/providers/copilot/permission_control.rs
@@ -3,7 +3,7 @@
 use anyhow::Result;
 use rig::agent::{AgentHook, Flow, StepEvent, stream_to_stdout};
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, Prompt, ToolDefinition};
+use rig::completion::{CompletionModel, Prompt};
 use rig::streaming::StreamingPrompt;
 use rig::tool::Tool;
 use serde::{Deserialize, Serialize};
@@ -49,15 +49,15 @@ impl Tool for ReadFileHead {
     type Args = ReadFileArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "read_file_head".to_string(),
-            description: "Read the first line of test.txt using the head command".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {},
-            }),
-        }
+    fn description(&self) -> String {
+        "Read the first line of test.txt using the head command".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -80,15 +80,15 @@ impl Tool for ReadFileTail {
     type Args = ReadFileArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "read_file_tail".to_string(),
-            description: "Read the last line of test.txt using the tail command".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {},
-            }),
-        }
+    fn description(&self) -> String {
+        "Read the last line of test.txt using the tail command".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/tests/providers/copilot/streaming_tools.rs
+++ b/tests/providers/copilot/streaming_tools.rs
@@ -5,7 +5,6 @@ use rig::client::CompletionClient;
 use rig::completion::CompletionModel;
 use rig::message::{AssistantContent, Message, ToolChoice};
 use rig::streaming::StreamingPrompt;
-use rig::tool::Tool;
 
 use crate::copilot::{LIVE_MODEL, with_copilot_cassette};
 use crate::support::{
@@ -94,8 +93,8 @@ async fn raw_stream_surfaces_two_distinct_tool_calls_before_text() {
             let request = model
                 .completion_request(TWO_TOOL_STREAM_PROMPT)
                 .preamble(TWO_TOOL_STREAM_PREAMBLE.to_string())
-                .tool(AlphaSignal.definition(String::new()).await)
-                .tool(BetaSignal.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&AlphaSignal))
+                .tool(rig::tool::tool_definition(&BetaSignal))
                 .build();
 
             let observation = collect_raw_stream_observation(
@@ -150,7 +149,7 @@ async fn raw_followup_uses_tool_result_without_new_tool_calls() {
         let request = model
             .completion_request(ORDERED_TOOL_STREAM_PROMPT)
             .preamble(ORDERED_TOOL_STREAM_PREAMBLE.to_string())
-            .tool(AlphaSignal.definition(String::new()).await)
+            .tool(rig::tool::tool_definition(&AlphaSignal))
             .build();
 
         let first_turn = collect_raw_stream_observation(

--- a/tests/providers/copilot/typed_prompt_tools.rs
+++ b/tests/providers/copilot/typed_prompt_tools.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rig::client::CompletionClient;
-use rig::completion::{ToolDefinition, TypedPrompt};
+use rig::completion::TypedPrompt;
 use rig::tool::Tool;
 
 use crate::copilot::{live_responses_model, with_copilot_cassette_result};
@@ -42,18 +42,18 @@ impl Tool for WeatherTool {
     type Args = WeatherArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Get the current weather for a city.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "city": { "type": "string" }
-                },
-                "required": ["city"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Get the current weather for a city.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "city": { "type": "string" }
+            },
+            "required": ["city"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/tests/providers/deepseek/agent_tool_sessions.rs
+++ b/tests/providers/deepseek/agent_tool_sessions.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex};
 use anyhow::Result;
 use rig::OneOrMany;
 use rig::client::CompletionClient;
-use rig::completion::{Chat, CompletionModel, Message, ToolDefinition};
+use rig::completion::{Chat, CompletionModel, Message};
 use rig::message::{AssistantContent, ToolChoice, UserContent};
 use rig::providers::deepseek;
 use rig::streaming::{StreamingChat, StreamingPrompt};
@@ -137,16 +137,16 @@ impl Tool for PingEmpty {
     type Args = EmptyArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Return EMPTY-OK. This tool takes no arguments.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {},
-                "required": []
-            }),
-        }
+    fn description(&self) -> String {
+        "Return EMPTY-OK. This tool takes no arguments.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "required": []
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -161,38 +161,38 @@ impl Tool for InspectManifest {
     type Args = ManifestArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Validate a nested deployment manifest.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "project": { "type": "string" },
-                    "flags": {
+    fn description(&self) -> String {
+        "Validate a nested deployment manifest.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "project": { "type": "string" },
+                "flags": {
+                    "type": "object",
+                    "properties": {
+                        "critical": { "type": "boolean" },
+                        "retries": { "type": "integer" }
+                    },
+                    "required": ["critical", "retries"]
+                },
+                "steps": {
+                    "type": "array",
+                    "items": {
                         "type": "object",
                         "properties": {
-                            "critical": { "type": "boolean" },
-                            "retries": { "type": "integer" }
+                            "name": { "type": "string" },
+                            "weight": { "type": "integer" }
                         },
-                        "required": ["critical", "retries"]
-                    },
-                    "steps": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "name": { "type": "string" },
-                                "weight": { "type": "integer" }
-                            },
-                            "required": ["name", "weight"]
-                        }
-                    },
-                    "note": { "type": "string" }
+                        "required": ["name", "weight"]
+                    }
                 },
-                "required": ["project", "flags", "steps", "note"]
-            }),
-        }
+                "note": { "type": "string" }
+            },
+            "required": ["project", "flags", "steps", "note"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -212,22 +212,22 @@ impl Tool for JoinLabels {
     type Args = JoinArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Join label strings with the requested separator.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "labels": {
-                        "type": "array",
-                        "items": { "type": "string" }
-                    },
-                    "separator": { "type": "string" }
+    fn description(&self) -> String {
+        "Join label strings with the requested separator.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "labels": {
+                    "type": "array",
+                    "items": { "type": "string" }
                 },
-                "required": ["labels", "separator"]
-            }),
-        }
+                "separator": { "type": "string" }
+            },
+            "required": ["labels", "separator"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -242,18 +242,18 @@ impl Tool for EscapeEcho {
     type Args = EchoArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Echo a string containing escaping-sensitive characters.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "text": { "type": "string" }
-                },
-                "required": ["text"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Echo a string containing escaping-sensitive characters.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "text": { "type": "string" }
+            },
+            "required": ["text"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -627,7 +627,7 @@ async fn raw_stream_complex_tool_call_deltas_have_object_arguments() -> Result<(
                      Do not write normal text before the tool call.",
                 )
                 .preamble("Use the requested tool call and no prose before it.".to_string())
-                .tool(tool.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&tool))
                 .tool_choice(ToolChoice::Required)
                 .additional_params(non_thinking_params())
                 .build();
@@ -682,7 +682,7 @@ async fn long_history_replay_with_tool_result_continuation() -> Result<()> {
                 })
                 .message(Message::tool_result("call_REDACTED_1", ALPHA_SIGNAL_OUTPUT))
                 .message(Message::assistant("The harbor label is crimson-harbor."))
-                .tool(AlphaSignal.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&AlphaSignal))
                 .tool_choice(ToolChoice::None)
                 .additional_params(non_thinking_params())
                 .build();
@@ -713,7 +713,7 @@ async fn tool_choice_required_specific_and_none() -> Result<()> {
                         .completion_request(
                             "Call lookup_harbor_label exactly once with an empty object and do not answer in prose.",
                         )
-                        .tool(AlphaSignal.definition(String::new()).await)
+                        .tool(rig::tool::tool_definition(&AlphaSignal))
                         .tool_choice(ToolChoice::Required)
                         .additional_params(non_thinking_params())
                         .build(),
@@ -735,8 +735,8 @@ async fn tool_choice_required_specific_and_none() -> Result<()> {
                         .completion_request(
                             "Call the orchard-label tool exactly once with an empty object and do not call any other tool.",
                         )
-                        .tool(AlphaSignal.definition(String::new()).await)
-                        .tool(BetaSignal.definition(String::new()).await)
+                        .tool(rig::tool::tool_definition(&AlphaSignal))
+                        .tool(rig::tool::tool_definition(&BetaSignal))
                         .tool_choice(ToolChoice::Specific {
                             function_names: vec![BetaSignal::NAME.to_string()],
                         })
@@ -764,7 +764,7 @@ async fn tool_choice_required_specific_and_none() -> Result<()> {
                         .completion_request(
                             "Do not call tools. Reply with exactly this phrase: no-tool-answer",
                         )
-                        .tool(AlphaSignal.definition(String::new()).await)
+                        .tool(rig::tool::tool_definition(&AlphaSignal))
                         .tool_choice(ToolChoice::None)
                         .additional_params(non_thinking_params())
                         .build(),

--- a/tests/providers/deepseek/permission_control.rs
+++ b/tests/providers/deepseek/permission_control.rs
@@ -3,7 +3,7 @@
 use anyhow::Result;
 use rig::agent::{AgentHook, Flow, StepEvent, stream_to_stdout};
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, Prompt, ToolDefinition};
+use rig::completion::{CompletionModel, Prompt};
 use rig::providers::deepseek;
 use rig::streaming::StreamingPrompt;
 use rig::tool::Tool;
@@ -62,15 +62,15 @@ impl Tool for ReadFileHead {
     type Args = ReadFileArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "read_file_head".to_string(),
-            description: "Read the first line of test.txt using the head command".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {},
-            }),
-        }
+    fn description(&self) -> String {
+        "Read the first line of test.txt using the head command".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -96,15 +96,15 @@ impl Tool for ReadFileTail {
     type Args = ReadFileArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "read_file_tail".to_string(),
-            description: "Read the last line of test.txt using the tail command".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {},
-            }),
-        }
+    fn description(&self) -> String {
+        "Read the last line of test.txt using the tail command".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/tests/providers/deepseek/streaming_tools.rs
+++ b/tests/providers/deepseek/streaming_tools.rs
@@ -6,7 +6,6 @@ use rig::completion::CompletionModel;
 use rig::message::{AssistantContent, Message, ToolChoice};
 use rig::providers::deepseek::DEEPSEEK_V4_FLASH;
 use rig::streaming::StreamingChat;
-use rig::tool::Tool;
 
 use super::support::with_deepseek_cassette;
 use crate::support::{
@@ -83,8 +82,8 @@ async fn raw_stream_surfaces_two_distinct_tool_calls_before_text() {
             let request = model
                 .completion_request(TWO_TOOL_STREAM_PROMPT)
                 .preamble(TWO_TOOL_STREAM_PREAMBLE.to_string())
-                .tool(AlphaSignal.definition(String::new()).await)
-                .tool(BetaSignal.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&AlphaSignal))
+                .tool(rig::tool::tool_definition(&BetaSignal))
                 .additional_params(non_thinking_params())
                 .build();
 
@@ -121,8 +120,8 @@ async fn raw_stream_tool_call_arguments_are_objects() {
             let request = model
                 .completion_request(TWO_TOOL_STREAM_PROMPT)
                 .preamble(TWO_TOOL_STREAM_PREAMBLE.to_string())
-                .tool(AlphaSignal.definition(String::new()).await)
-                .tool(BetaSignal.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&AlphaSignal))
+                .tool(rig::tool::tool_definition(&BetaSignal))
                 .additional_params(non_thinking_params())
                 .build();
 
@@ -211,7 +210,7 @@ async fn raw_followup_uses_tool_result_without_new_tool_calls() {
             let request = model
                 .completion_request(ORDERED_TOOL_STREAM_PROMPT)
                 .preamble(ORDERED_TOOL_STREAM_PREAMBLE.to_string())
-                .tool(AlphaSignal.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&AlphaSignal))
                 .additional_params(non_thinking_params())
                 .build();
 

--- a/tests/providers/gemini/agent_run_support.rs
+++ b/tests/providers/gemini/agent_run_support.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeSet;
 
 use rig::agent::CompletionCall;
 use rig::agent::run::{ModelTurn, PendingToolCall};
-use rig::completion::{Completion, ToolDefinition, Usage};
+use rig::completion::{Completion, Usage};
 use rig::message::{AssistantContent, Message, ToolResultContent, UserContent};
 use rig::providers::gemini;
 use rig::tool::Tool;
@@ -28,19 +28,15 @@ pub(crate) struct OperationArgs {
 #[error("math error")]
 pub(crate) struct MathError;
 
-fn operation_definition(name: &str, description: &str) -> ToolDefinition {
-    ToolDefinition {
-        name: name.to_string(),
-        description: description.to_string(),
-        parameters: json!({
-            "type": "object",
-            "properties": {
-                "x": { "type": "number", "description": "The first operand" },
-                "y": { "type": "number", "description": "The second operand" }
-            },
-            "required": ["x", "y"]
-        }),
-    }
+fn operation_parameters() -> serde_json::Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "x": { "type": "number", "description": "The first operand" },
+            "y": { "type": "number", "description": "The second operand" }
+        },
+        "required": ["x", "y"]
+    })
 }
 
 pub(crate) struct Add;
@@ -51,8 +47,12 @@ impl Tool for Add {
     type Args = OperationArgs;
     type Output = i64;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        operation_definition(Self::NAME, "Add x and y together")
+    fn description(&self) -> String {
+        "Add x and y together".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        operation_parameters()
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -68,8 +68,12 @@ impl Tool for Subtract {
     type Args = OperationArgs;
     type Output = i64;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        operation_definition(Self::NAME, "Subtract y from x (i.e. x - y)")
+    fn description(&self) -> String {
+        "Subtract y from x (i.e. x - y)".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        operation_parameters()
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -87,8 +91,12 @@ impl Tool for Sum {
     type Args = OperationArgs;
     type Output = i64;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        operation_definition(Self::NAME, "Add x and y together (alias of add)")
+    fn description(&self) -> String {
+        "Add x and y together (alias of add)".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        operation_parameters()
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/tests/providers/gemini/cassette/chat_history.rs
+++ b/tests/providers/gemini/cassette/chat_history.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rig::client::CompletionClient;
-use rig::completion::{Chat, Message, ToolDefinition};
+use rig::completion::{Chat, Message};
 use rig::message::{AssistantContent, UserContent};
 use rig::providers::gemini;
 use rig::tool::Tool;
@@ -44,20 +44,19 @@ impl Tool for StressAdd {
     type Args = StressMathArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Add x and y. This tool must be used for stress-test addition turns."
-                .to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": { "type": "number", "description": "Left operand" },
-                    "y": { "type": "number", "description": "Right operand" }
-                },
-                "required": ["x", "y"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Add x and y. This tool must be used for stress-test addition turns.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": { "type": "number", "description": "Left operand" },
+                "y": { "type": "number", "description": "Right operand" }
+            },
+            "required": ["x", "y"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -82,21 +81,19 @@ impl Tool for StressSubtract {
     type Args = StressMathArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description:
-                "Subtract y from x. This tool must be used for stress-test subtraction turns."
-                    .to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": { "type": "number", "description": "Value to subtract from" },
-                    "y": { "type": "number", "description": "Value to subtract" }
-                },
-                "required": ["x", "y"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Subtract y from x. This tool must be used for stress-test subtraction turns.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": { "type": "number", "description": "Value to subtract from" },
+                "y": { "type": "number", "description": "Value to subtract" }
+            },
+            "required": ["x", "y"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/tests/providers/gemini/cassette/generate_sessions.rs
+++ b/tests/providers/gemini/cassette/generate_sessions.rs
@@ -225,7 +225,7 @@ async fn long_history_replay_nonstreaming() {
                 })
                 .message(Message::tool_result(AlphaSignal::NAME, ALPHA_SIGNAL_OUTPUT))
                 .message(Message::assistant("The harbor label is crimson-harbor."))
-                .tool(AlphaSignal.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&AlphaSignal))
                 .build();
 
             let response = model

--- a/tests/providers/gemini/cassette/generate_tool_args.rs
+++ b/tests/providers/gemini/cassette/generate_tool_args.rs
@@ -61,12 +61,12 @@ impl Tool for PlanTrip {
     type Args = PlanTripArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Book a trip from a nested itinerary object.".to_string(),
-            parameters: plan_trip_parameters(),
-        }
+    fn description(&self) -> String {
+        "Book a trip from a nested itinerary object.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        plan_trip_parameters()
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -202,7 +202,7 @@ async fn nested_arguments_streaming() {
                 .completion_request(NESTED_ARGS_PROMPT)
                 .preamble(NESTED_ARGS_PREAMBLE.to_string())
                 .temperature(0.0)
-                .tool(PlanTrip.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&PlanTrip))
                 .build();
 
             let observation = collect_raw_stream_observation(

--- a/tests/providers/gemini/cassette/generate_tool_modes.rs
+++ b/tests/providers/gemini/cassette/generate_tool_modes.rs
@@ -26,7 +26,7 @@ async fn required_maps_to_any_and_forces_function_call() {
                 .completion_request("Please greet me.")
                 .preamble(TOOLS_PREAMBLE.to_string())
                 .temperature(0.0)
-                .tool(Adder.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&Adder))
                 .tool_choice(ToolChoice::Required)
                 .build();
 

--- a/tests/providers/gemini/cassette/multi_turn_streaming.rs
+++ b/tests/providers/gemini/cassette/multi_turn_streaming.rs
@@ -8,7 +8,7 @@ use futures::{Stream, StreamExt};
 use rig::OneOrMany;
 use rig::agent::Agent;
 use rig::client::CompletionClient;
-use rig::completion::{self, CompletionError, CompletionModel, PromptError, ToolDefinition};
+use rig::completion::{self, CompletionError, CompletionModel, PromptError};
 use rig::message::{AssistantContent, Message, Text, ToolResultContent, UserContent};
 use rig::providers::gemini;
 use rig::streaming::{StreamedAssistantContent, StreamingCompletion};
@@ -217,13 +217,12 @@ impl Tool for Add {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "add".to_string(),
-            description: "Add x and y together".to_string(),
-            parameters: serde_json::to_value(schema_for!(OperationArgs))
-                .expect("schema should serialize"),
-        }
+    fn description(&self) -> String {
+        "Add x and y together".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::to_value(schema_for!(OperationArgs)).expect("schema should serialize")
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -248,13 +247,12 @@ impl Tool for Subtract {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "subtract".to_string(),
-            description: "Subtract y from x (i.e.: x - y)".to_string(),
-            parameters: serde_json::to_value(schema_for!(OperationArgs))
-                .expect("schema should serialize"),
-        }
+    fn description(&self) -> String {
+        "Subtract y from x (i.e.: x - y)".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::to_value(schema_for!(OperationArgs)).expect("schema should serialize")
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -279,13 +277,12 @@ impl Tool for Multiply {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "multiply".to_string(),
-            description: "Compute the product of x and y (i.e.: x * y)".to_string(),
-            parameters: serde_json::to_value(schema_for!(OperationArgs))
-                .expect("schema should serialize"),
-        }
+    fn description(&self) -> String {
+        "Compute the product of x and y (i.e.: x * y)".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::to_value(schema_for!(OperationArgs)).expect("schema should serialize")
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -310,13 +307,12 @@ impl Tool for Divide {
     type Args = OperationArgs;
     type Output = i32;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "divide".to_string(),
-            description: "Compute the quotient of x and y.".to_string(),
-            parameters: serde_json::to_value(schema_for!(OperationArgs))
-                .expect("schema should serialize"),
-        }
+    fn description(&self) -> String {
+        "Compute the quotient of x and y.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::to_value(schema_for!(OperationArgs)).expect("schema should serialize")
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/tests/providers/gemini/cassette/streaming_multimodal_tool_results.rs
+++ b/tests/providers/gemini/cassette/streaming_multimodal_tool_results.rs
@@ -3,7 +3,6 @@
 use futures::StreamExt;
 use rig::agent::MultiTurnStreamItem;
 use rig::client::CompletionClient;
-use rig::completion::ToolDefinition;
 use rig::message::{
     AssistantContent, DocumentSourceKind, ImageMediaType, Message, ToolResultContent, UserContent,
 };
@@ -38,17 +37,16 @@ impl Tool for HybridImageTool {
     type Args = serde_json::Value;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Return a reference image the assistant must inspect before answering."
-                .to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {},
-                "required": [],
-            }),
-        }
+    fn description(&self) -> String {
+        "Return a reference image the assistant must inspect before answering.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "required": [],
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/tests/providers/gemini/cassette/tool_choice.rs
+++ b/tests/providers/gemini/cassette/tool_choice.rs
@@ -58,8 +58,8 @@ async fn specific_add_raw_streaming_allows_only_add() {
                     "Use the add tool to calculate 20 + 22. Do not use subtraction.",
                 )
                 .temperature(0.0)
-                .tool(Adder.definition(String::new()).await)
-                .tool(Subtract.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&Adder))
+                .tool(rig::tool::tool_definition(&Subtract))
                 .tool_choice(specific_add_choice())
                 .build();
             let stream = model.stream(request).await.expect("stream should start");
@@ -111,8 +111,8 @@ async fn specific_add_raw_nonstreaming_allows_only_add() {
                     "Use the add tool to calculate 20 + 22. Do not use subtraction.",
                 )
                 .temperature(0.0)
-                .tool(Adder.definition(String::new()).await)
-                .tool(Subtract.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&Adder))
+                .tool(rig::tool::tool_definition(&Subtract))
                 .tool_choice(specific_add_choice())
                 .send()
                 .await

--- a/tests/providers/gemini/cassette/tool_definitions.rs
+++ b/tests/providers/gemini/cassette/tool_definitions.rs
@@ -6,7 +6,7 @@
 //! replay fails with a body mismatch.
 
 use rig::client::CompletionClient;
-use rig::completion::{Chat, Message, ToolDefinition};
+use rig::completion::{Chat, Message};
 use rig::providers::gemini;
 use rig::tool::Tool;
 use serde::{Deserialize, Serialize};
@@ -37,39 +37,39 @@ impl Tool for PlanTrip {
     type Args = TripArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Plan a trip itinerary.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "destination": {
-                        "type": "string",
-                        "description": "Destination city"
-                    },
-                    "travellers": {
-                        "type": "integer",
-                        "description": "Number of travellers"
-                    },
-                    "transport": {
-                        "type": "string",
-                        "enum": ["train", "car", "plane"],
-                        "description": "Mode of transport"
-                    },
-                    "waypoints": {
-                        "type": "array",
-                        "items": { "type": "string" },
-                        "description": "Cities to pass through, in order"
-                    },
-                    "notes": {
-                        "type": "string",
-                        "description": "Optional free-form notes"
-                    }
+    fn description(&self) -> String {
+        "Plan a trip itinerary.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "destination": {
+                    "type": "string",
+                    "description": "Destination city"
                 },
-                "required": ["destination", "travellers", "transport", "waypoints"]
-            }),
-        }
+                "travellers": {
+                    "type": "integer",
+                    "description": "Number of travellers"
+                },
+                "transport": {
+                    "type": "string",
+                    "enum": ["train", "car", "plane"],
+                    "description": "Mode of transport"
+                },
+                "waypoints": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Cities to pass through, in order"
+                },
+                "notes": {
+                    "type": "string",
+                    "description": "Optional free-form notes"
+                }
+            },
+            "required": ["destination", "travellers", "transport", "waypoints"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -99,18 +99,18 @@ impl Tool for LegacyEcho {
     type Args = EchoArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "LEGACY echo implementation.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "text": { "type": "string", "description": "Text to echo" }
-                },
-                "required": ["text"]
-            }),
-        }
+    fn description(&self) -> String {
+        "LEGACY echo implementation.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "text": { "type": "string", "description": "Text to echo" }
+            },
+            "required": ["text"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -127,18 +127,18 @@ impl Tool for ModernEcho {
     type Args = EchoArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Echo the provided text back to the caller.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "text": { "type": "string", "description": "Text to echo" }
-                },
-                "required": ["text"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Echo the provided text back to the caller.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "text": { "type": "string", "description": "Text to echo" }
+            },
+            "required": ["text"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/tests/providers/gemini/hook_stress_support.rs
+++ b/tests/providers/gemini/hook_stress_support.rs
@@ -13,7 +13,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, Mutex};
 
 use rig::agent::{AgentHook, Flow, HookContext, RequestPatch, StepEvent};
-use rig::completion::{CompletionModel, Document, ToolDefinition};
+use rig::completion::{CompletionModel, Document};
 use rig::tool::Tool;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -67,19 +67,19 @@ impl Tool for CountingMultiply {
     type Args = OperationArgs;
     type Output = i64;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Multiply x and y together".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "x": { "type": "number", "description": "The first operand" },
-                    "y": { "type": "number", "description": "The second operand" }
-                },
-                "required": ["x", "y"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Multiply x and y together".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "x": { "type": "number", "description": "The first operand" },
+                "y": { "type": "number", "description": "The second operand" }
+            },
+            "required": ["x", "y"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/tests/providers/gemini/tools_support.rs
+++ b/tests/providers/gemini/tools_support.rs
@@ -24,7 +24,7 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rig::agent::{AgentHook, Flow, StepEvent};
-use rig::completion::{CompletionModel, ToolDefinition};
+use rig::completion::CompletionModel;
 use rig::tool::server::ToolServerHandle;
 use rig::tool::{Tool, ToolEmbedding};
 use serde::{Deserialize, Serialize};
@@ -63,19 +63,15 @@ pub(crate) struct OperationArgs {
 #[error("math error")]
 pub(crate) struct MathError;
 
-fn operation_definition(name: &str, description: &str) -> ToolDefinition {
-    ToolDefinition {
-        name: name.to_string(),
-        description: description.to_string(),
-        parameters: json!({
-            "type": "object",
-            "properties": {
-                "x": { "type": "number", "description": "The first operand" },
-                "y": { "type": "number", "description": "The second operand" }
-            },
-            "required": ["x", "y"]
-        }),
-    }
+fn operation_parameters() -> serde_json::Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "x": { "type": "number", "description": "The first operand" },
+            "y": { "type": "number", "description": "The second operand" }
+        },
+        "required": ["x", "y"]
+    })
 }
 
 /// `add` tool that counts its real executions.
@@ -90,8 +86,12 @@ impl Tool for CountingAdd {
     type Args = OperationArgs;
     type Output = i64;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        operation_definition(Self::NAME, "Add x and y together")
+    fn description(&self) -> String {
+        "Add x and y together".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        operation_parameters()
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -112,8 +112,12 @@ impl Tool for CountingSubtract {
     type Args = OperationArgs;
     type Output = i64;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        operation_definition(Self::NAME, "Subtract y from x (i.e. x - y)")
+    fn description(&self) -> String {
+        "Subtract y from x (i.e. x - y)".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        operation_parameters()
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -140,16 +144,16 @@ impl Tool for CountingPing {
     type Args = EmptyArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Return the current ping marker. Takes no arguments.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {},
-                "required": [],
-            }),
-        }
+    fn description(&self) -> String {
+        "Return the current ping marker. Takes no arguments.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "required": [],
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -184,18 +188,18 @@ impl Tool for CodewordLookup {
     type Args = CodewordArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Look up the secret codeword for a team.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "team": { "type": "string", "description": "The team name, lowercase" }
-                },
-                "required": ["team"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Look up the secret codeword for a team.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "team": { "type": "string", "description": "The team name, lowercase" }
+            },
+            "required": ["team"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -227,21 +231,21 @@ impl Tool for StrictRegister {
     type Args = StrictRegisterArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Register guests for the event.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "seats": {
-                        "type": "string",
-                        "description": "Number of seats, spelled out as a lowercase English word (e.g. \"four\")"
-                    }
-                },
-                "required": ["seats"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Register guests for the event.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "seats": {
+                    "type": "string",
+                    "description": "Number of seats, spelled out as a lowercase English word (e.g. \"four\")"
+                }
+            },
+            "required": ["seats"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -263,12 +267,12 @@ impl Tool for MottoTool {
     type Args = EmptyArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Fetch the two-line workshop motto.".to_string(),
-            parameters: json!({ "type": "object", "properties": {}, "required": [] }),
-        }
+    fn description(&self) -> String {
+        "Fetch the two-line workshop motto.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({ "type": "object", "properties": {}, "required": [] })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -303,12 +307,12 @@ impl Tool for ConfigTool {
     type Args = EmptyArgs;
     type Output = ConfigOutput;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Fetch the service configuration object.".to_string(),
-            parameters: json!({ "type": "object", "properties": {}, "required": [] }),
-        }
+    fn description(&self) -> String {
+        "Fetch the service configuration object.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({ "type": "object", "properties": {}, "required": [] })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -330,13 +334,12 @@ impl Tool for BadgeImageTool {
     type Args = EmptyArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Fetch the attendee badge as an image the assistant must inspect."
-                .to_string(),
-            parameters: json!({ "type": "object", "properties": {}, "required": [] }),
-        }
+    fn description(&self) -> String {
+        "Fetch the attendee badge as an image the assistant must inspect.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({ "type": "object", "properties": {}, "required": [] })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -500,8 +503,12 @@ macro_rules! embeddable_operation {
             type Args = OperationArgs;
             type Output = i64;
 
-            async fn definition(&self, _prompt: String) -> ToolDefinition {
-                operation_definition(Self::NAME, $description)
+            fn description(&self) -> String {
+                $description.to_string()
+            }
+
+            fn parameters(&self) -> serde_json::Value {
+                operation_parameters()
             }
 
             async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/tests/providers/groq/agent_tool_sessions.rs
+++ b/tests/providers/groq/agent_tool_sessions.rs
@@ -11,7 +11,7 @@ use anyhow::Result;
 use futures::StreamExt;
 use rig::OneOrMany;
 use rig::client::CompletionClient;
-use rig::completion::{Chat, CompletionModel, GetTokenUsage, Message, ToolDefinition};
+use rig::completion::{Chat, CompletionModel, GetTokenUsage, Message};
 use rig::message::{AssistantContent, ToolChoice};
 use rig::providers::openai;
 use rig::streaming::{StreamedAssistantContent, StreamingChat, StreamingPrompt};
@@ -142,16 +142,16 @@ impl Tool for PingEmpty {
     type Args = EmptyArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Return EMPTY-OK. This tool takes no arguments.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {},
-                "required": []
-            }),
-        }
+    fn description(&self) -> String {
+        "Return EMPTY-OK. This tool takes no arguments.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "required": []
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -166,38 +166,38 @@ impl Tool for InspectManifest {
     type Args = ManifestArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Validate a nested deployment manifest.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "project": { "type": "string" },
-                    "flags": {
+    fn description(&self) -> String {
+        "Validate a nested deployment manifest.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "project": { "type": "string" },
+                "flags": {
+                    "type": "object",
+                    "properties": {
+                        "critical": { "type": "boolean" },
+                        "retries": { "type": "integer" }
+                    },
+                    "required": ["critical", "retries"]
+                },
+                "steps": {
+                    "type": "array",
+                    "items": {
                         "type": "object",
                         "properties": {
-                            "critical": { "type": "boolean" },
-                            "retries": { "type": "integer" }
+                            "name": { "type": "string" },
+                            "weight": { "type": "integer" }
                         },
-                        "required": ["critical", "retries"]
-                    },
-                    "steps": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "name": { "type": "string" },
-                                "weight": { "type": "integer" }
-                            },
-                            "required": ["name", "weight"]
-                        }
-                    },
-                    "note": { "type": "string" }
+                        "required": ["name", "weight"]
+                    }
                 },
-                "required": ["project", "flags", "steps", "note"]
-            }),
-        }
+                "note": { "type": "string" }
+            },
+            "required": ["project", "flags", "steps", "note"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -217,19 +217,19 @@ impl Tool for JoinLabels {
     type Args = JoinArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Join label strings with the requested separator.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "labels": { "type": "array", "items": { "type": "string" } },
-                    "separator": { "type": "string" }
-                },
-                "required": ["labels", "separator"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Join label strings with the requested separator.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "labels": { "type": "array", "items": { "type": "string" } },
+                "separator": { "type": "string" }
+            },
+            "required": ["labels", "separator"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -244,20 +244,20 @@ impl Tool for OptionalNullableProbe {
     type Args = OptionalNullableArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Validate optional and nullable argument serialization.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "name": { "type": "string" },
-                    "note": { "type": ["string", "null"] },
-                    "nullable_code": { "type": ["string", "null"] }
-                },
-                "required": ["name", "nullable_code"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Validate optional and nullable argument serialization.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" },
+                "note": { "type": ["string", "null"] },
+                "nullable_code": { "type": ["string", "null"] }
+            },
+            "required": ["name", "nullable_code"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -277,16 +277,16 @@ impl Tool for EscapeEcho {
     type Args = EchoArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Echo a string containing escaping-sensitive characters.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": { "text": { "type": "string" } },
-                "required": ["text"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Echo a string containing escaping-sensitive characters.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": { "text": { "type": "string" } },
+            "required": ["text"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -677,7 +677,7 @@ async fn raw_stream_complex_tool_call_deltas_have_object_arguments() -> Result<(
                      Do not write normal text before the tool call.",
                 )
                 .preamble("Use the requested tool call and no prose before it.".to_string())
-                .tool(tool.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&tool))
                 .tool_choice(ToolChoice::Required)
                 .build();
 
@@ -740,7 +740,7 @@ async fn long_history_replay_with_tool_result_continuation() -> Result<()> {
                     ALPHA_SIGNAL_OUTPUT,
                 ))
                 .message(Message::assistant("The harbor label is crimson-harbor."))
-                .tool(AlphaSignal.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&AlphaSignal))
                 .tool_choice(ToolChoice::None)
                 .build();
 
@@ -768,7 +768,7 @@ async fn tool_choice_auto_required_specific_and_none() -> Result<()> {
                 .completion(
                     model
                         .completion_request("Call lookup_harbor_label exactly once with an empty object.")
-                        .tool(AlphaSignal.definition(String::new()).await)
+                        .tool(rig::tool::tool_definition(&AlphaSignal))
                         .tool_choice(ToolChoice::Auto)
                         .build(),
                 )
@@ -787,7 +787,7 @@ async fn tool_choice_auto_required_specific_and_none() -> Result<()> {
                 .completion(
                     model
                         .completion_request("Call lookup_harbor_label exactly once with an empty object and do not answer in prose.")
-                        .tool(AlphaSignal.definition(String::new()).await)
+                        .tool(rig::tool::tool_definition(&AlphaSignal))
                         .tool_choice(ToolChoice::Required)
                         .build(),
                 )
@@ -806,8 +806,8 @@ async fn tool_choice_auto_required_specific_and_none() -> Result<()> {
                 .completion(
                     model
                         .completion_request("Call the orchard-label tool exactly once with an empty object and do not call any other tool.")
-                        .tool(AlphaSignal.definition(String::new()).await)
-                        .tool(BetaSignal.definition(String::new()).await)
+                        .tool(rig::tool::tool_definition(&AlphaSignal))
+                        .tool(rig::tool::tool_definition(&BetaSignal))
                         .tool_choice(ToolChoice::Specific {
                             function_names: vec![BetaSignal::NAME.to_string()],
                         })
@@ -832,7 +832,7 @@ async fn tool_choice_auto_required_specific_and_none() -> Result<()> {
                 .completion(
                     model
                         .completion_request("Do not call tools. Reply with exactly this phrase: no-tool-answer")
-                        .tool(AlphaSignal.definition(String::new()).await)
+                        .tool(rig::tool::tool_definition(&AlphaSignal))
                         .tool_choice(ToolChoice::None)
                         .build(),
                 )

--- a/tests/providers/groq/permission_control.rs
+++ b/tests/providers/groq/permission_control.rs
@@ -3,7 +3,7 @@
 use anyhow::Result;
 use rig::agent::{AgentHook, Flow, StepEvent, stream_to_stdout};
 use rig::client::{CompletionClient, ProviderClient};
-use rig::completion::{CompletionModel, Prompt, ToolDefinition};
+use rig::completion::{CompletionModel, Prompt};
 use rig::providers::groq;
 use rig::streaming::StreamingPrompt;
 use rig::tool::Tool;
@@ -51,16 +51,16 @@ impl Tool for ReadFileHead {
     type Args = ReadFileArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "read_file_head".to_string(),
-            description: "Read the first line of test.txt using the head command".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {},
-                "required": [],
-            }),
-        }
+    fn description(&self) -> String {
+        "Read the first line of test.txt using the head command".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "required": [],
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -83,16 +83,16 @@ impl Tool for ReadFileTail {
     type Args = ReadFileArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "read_file_tail".to_string(),
-            description: "Read the last line of test.txt using the tail command".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {},
-                "required": [],
-            }),
-        }
+    fn description(&self) -> String {
+        "Read the last line of test.txt using the tail command".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "required": [],
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/tests/providers/groq/streaming_tools.rs
+++ b/tests/providers/groq/streaming_tools.rs
@@ -6,7 +6,6 @@ use rig::completion::CompletionModel;
 use rig::message::{AssistantContent, Message, ToolChoice};
 use rig::providers::groq;
 use rig::streaming::StreamingPrompt;
-use rig::tool::Tool;
 
 use crate::support::{
     ALPHA_SIGNAL_OUTPUT, AlphaSignal, BETA_SIGNAL_OUTPUT, BetaSignal, ORDERED_TOOL_STREAM_PREAMBLE,
@@ -45,8 +44,8 @@ async fn raw_stream_surfaces_two_distinct_tool_calls_before_text() {
     let request = model
         .completion_request(TWO_TOOL_STREAM_PROMPT)
         .preamble(TWO_TOOL_STREAM_PREAMBLE.to_string())
-        .tool(AlphaSignal.definition(String::new()).await)
-        .tool(BetaSignal.definition(String::new()).await)
+        .tool(rig::tool::tool_definition(&AlphaSignal))
+        .tool(rig::tool::tool_definition(&BetaSignal))
         .build();
 
     let observation = collect_raw_stream_observation(
@@ -118,7 +117,7 @@ async fn raw_followup_uses_tool_result_without_new_tool_calls() {
     let request = model
         .completion_request(ORDERED_TOOL_STREAM_PROMPT)
         .preamble(ORDERED_TOOL_STREAM_PREAMBLE.to_string())
-        .tool(AlphaSignal.definition(String::new()).await)
+        .tool(rig::tool::tool_definition(&AlphaSignal))
         .build();
 
     let first_turn = collect_raw_stream_observation(

--- a/tests/providers/groq/typed_prompt_tools.rs
+++ b/tests/providers/groq/typed_prompt_tools.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rig::client::{CompletionClient, ProviderClient};
-use rig::completion::{ToolDefinition, TypedPrompt};
+use rig::completion::TypedPrompt;
 use rig::providers::groq;
 use rig::tool::Tool;
 
@@ -44,20 +44,17 @@ impl Tool for WeatherTool {
     type Args = WeatherArgs;
     type Output = String;
 
-    fn definition(
-        &self,
-        _prompt: String,
-    ) -> impl std::future::Future<Output = ToolDefinition> + Send + Sync {
-        std::future::ready(ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Get the current weather for a city.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "city": { "type": "string" }
-                },
-                "required": ["city"]
-            }),
+    fn description(&self) -> String {
+        "Get the current weather for a city.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "city": { "type": "string" }
+            },
+            "required": ["city"]
         })
     }
 

--- a/tests/providers/llamacpp/permission_control.rs
+++ b/tests/providers/llamacpp/permission_control.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use rig::agent::{AgentHook, Flow, StepEvent};
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, Prompt, ToolDefinition};
+use rig::completion::{CompletionModel, Prompt};
 use rig::streaming::StreamingPrompt;
 use rig::tool::Tool;
 use serde::{Deserialize, Serialize};
@@ -48,15 +48,15 @@ impl Tool for ReadFileHead {
     type Args = ReadFileArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "read_file_head".to_string(),
-            description: "Read the first line of test.txt using the head command".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {},
-            }),
-        }
+    fn description(&self) -> String {
+        "Read the first line of test.txt using the head command".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -79,15 +79,15 @@ impl Tool for ReadFileTail {
     type Args = ReadFileArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "read_file_tail".to_string(),
-            description: "Read the last line of test.txt using the tail command".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {},
-            }),
-        }
+    fn description(&self) -> String {
+        "Read the last line of test.txt using the tail command".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/tests/providers/llamacpp/typed_prompt_tools.rs
+++ b/tests/providers/llamacpp/typed_prompt_tools.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rig::agent::{AgentHook, Flow, StepEvent};
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, ToolDefinition, TypedPrompt};
+use rig::completion::{CompletionModel, TypedPrompt};
 use rig::tool::Tool;
 
 use super::support;
@@ -136,20 +136,17 @@ impl Tool for WeatherTool {
     type Args = WeatherArgs;
     type Output = String;
 
-    fn definition(
-        &self,
-        _prompt: String,
-    ) -> impl std::future::Future<Output = ToolDefinition> + Send + Sync {
-        std::future::ready(ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Get the current weather for a city".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "city": { "type": "string" }
-                },
-                "required": ["city"]
-            }),
+    fn description(&self) -> String {
+        "Get the current weather for a city".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "city": { "type": "string" }
+            },
+            "required": ["city"]
         })
     }
 

--- a/tests/providers/llamafile/permission_control.rs
+++ b/tests/providers/llamafile/permission_control.rs
@@ -3,7 +3,7 @@
 use anyhow::Result;
 use rig::agent::{AgentHook, Flow, StepEvent, stream_to_stdout};
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, Prompt, PromptError, ToolDefinition};
+use rig::completion::{CompletionModel, Prompt, PromptError};
 use rig::streaming::StreamingPrompt;
 use rig::tool::Tool;
 use serde::{Deserialize, Serialize};
@@ -50,16 +50,16 @@ impl Tool for ReadFileHead {
     type Args = ReadFileArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "read_file_head".to_string(),
-            description: "Read the first line of test.txt using the head command".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {},
-                "required": [],
-            }),
-        }
+    fn description(&self) -> String {
+        "Read the first line of test.txt using the head command".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "required": [],
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -82,16 +82,16 @@ impl Tool for ReadFileTail {
     type Args = ReadFileArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "read_file_tail".to_string(),
-            description: "Read the last line of test.txt using the tail command".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {},
-                "required": [],
-            }),
-        }
+    fn description(&self) -> String {
+        "Read the last line of test.txt using the tail command".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "required": [],
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/tests/providers/llamafile/streaming_tools.rs
+++ b/tests/providers/llamafile/streaming_tools.rs
@@ -5,7 +5,6 @@ use rig::client::CompletionClient;
 use rig::completion::CompletionModel;
 use rig::message::{AssistantContent, Message, ToolChoice};
 use rig::streaming::StreamingPrompt;
-use rig::tool::Tool;
 
 use crate::support::{
     ALPHA_SIGNAL_OUTPUT, Adder, AlphaSignal, BETA_SIGNAL_OUTPUT, BetaSignal,
@@ -102,8 +101,8 @@ async fn raw_stream_surfaces_two_distinct_tool_calls_before_text() {
     let request = model
         .completion_request(TWO_TOOL_STREAM_PROMPT)
         .preamble(TWO_TOOL_STREAM_PREAMBLE.to_string())
-        .tool(AlphaSignal.definition(String::new()).await)
-        .tool(BetaSignal.definition(String::new()).await)
+        .tool(rig::tool::tool_definition(&AlphaSignal))
+        .tool(rig::tool::tool_definition(&BetaSignal))
         .build();
 
     let observation = collect_raw_stream_observation(
@@ -187,7 +186,7 @@ async fn raw_followup_uses_tool_result_without_new_tool_calls() {
     let request = model
         .completion_request(ORDERED_TOOL_STREAM_PROMPT)
         .preamble(ORDERED_TOOL_STREAM_PREAMBLE.to_string())
-        .tool(AlphaSignal.definition(String::new()).await)
+        .tool(rig::tool::tool_definition(&AlphaSignal))
         .build();
 
     let first_turn = collect_raw_stream_observation(

--- a/tests/providers/llamafile/typed_prompt_tools.rs
+++ b/tests/providers/llamafile/typed_prompt_tools.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rig::client::CompletionClient;
-use rig::completion::{ToolDefinition, TypedPrompt};
+use rig::completion::TypedPrompt;
 use rig::tool::Tool;
 
 use crate::support::assert_weather_tool_roundtrip_response;
@@ -43,18 +43,18 @@ impl Tool for WeatherTool {
     type Args = WeatherArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Get the current weather for a city.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "city": { "type": "string" }
-                },
-                "required": ["city"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Get the current weather for a city.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "city": { "type": "string" }
+            },
+            "required": ["city"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/tests/providers/mistral/agent_tool_sessions.rs
+++ b/tests/providers/mistral/agent_tool_sessions.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex};
 use anyhow::Result;
 use rig::OneOrMany;
 use rig::client::CompletionClient;
-use rig::completion::{Chat, CompletionModel, Message, ToolDefinition};
+use rig::completion::{Chat, CompletionModel, Message};
 use rig::message::{AssistantContent, ToolChoice};
 use rig::providers::mistral;
 use rig::streaming::{StreamingChat, StreamingPrompt};
@@ -140,16 +140,16 @@ impl Tool for PingEmpty {
     type Args = EmptyArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Return EMPTY-OK. This tool takes no arguments.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {},
-                "required": []
-            }),
-        }
+    fn description(&self) -> String {
+        "Return EMPTY-OK. This tool takes no arguments.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "required": []
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -164,38 +164,38 @@ impl Tool for InspectManifest {
     type Args = ManifestArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Validate a nested deployment manifest.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "project": { "type": "string" },
-                    "flags": {
+    fn description(&self) -> String {
+        "Validate a nested deployment manifest.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "project": { "type": "string" },
+                "flags": {
+                    "type": "object",
+                    "properties": {
+                        "critical": { "type": "boolean" },
+                        "retries": { "type": "integer" }
+                    },
+                    "required": ["critical", "retries"]
+                },
+                "steps": {
+                    "type": "array",
+                    "items": {
                         "type": "object",
                         "properties": {
-                            "critical": { "type": "boolean" },
-                            "retries": { "type": "integer" }
+                            "name": { "type": "string" },
+                            "weight": { "type": "integer" }
                         },
-                        "required": ["critical", "retries"]
-                    },
-                    "steps": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "name": { "type": "string" },
-                                "weight": { "type": "integer" }
-                            },
-                            "required": ["name", "weight"]
-                        }
-                    },
-                    "note": { "type": "string" }
+                        "required": ["name", "weight"]
+                    }
                 },
-                "required": ["project", "flags", "steps", "note"]
-            }),
-        }
+                "note": { "type": "string" }
+            },
+            "required": ["project", "flags", "steps", "note"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -215,19 +215,19 @@ impl Tool for JoinLabels {
     type Args = JoinArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Join label strings with the requested separator.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "labels": { "type": "array", "items": { "type": "string" } },
-                    "separator": { "type": "string" }
-                },
-                "required": ["labels", "separator"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Join label strings with the requested separator.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "labels": { "type": "array", "items": { "type": "string" } },
+                "separator": { "type": "string" }
+            },
+            "required": ["labels", "separator"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -242,20 +242,20 @@ impl Tool for OptionalNullableProbe {
     type Args = OptionalNullableArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Validate optional and nullable argument serialization.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "name": { "type": "string" },
-                    "note": { "type": "string" },
-                    "nullable_code": { "type": ["string", "null"] }
-                },
-                "required": ["name", "nullable_code"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Validate optional and nullable argument serialization.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" },
+                "note": { "type": "string" },
+                "nullable_code": { "type": ["string", "null"] }
+            },
+            "required": ["name", "nullable_code"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -275,16 +275,16 @@ impl Tool for EscapeEcho {
     type Args = EchoArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Echo a string containing escaping-sensitive characters.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": { "text": { "type": "string" } },
-                "required": ["text"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Echo a string containing escaping-sensitive characters.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": { "text": { "type": "string" } },
+            "required": ["text"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -671,7 +671,7 @@ async fn raw_stream_complex_tool_call_deltas_have_object_arguments() -> Result<(
                      Do not write normal text before the tool call.",
                 )
                 .preamble("Use the requested tool call and no prose before it.".to_string())
-                .tool(tool.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&tool))
                 .tool_choice(ToolChoice::Required)
                 .build();
 
@@ -725,7 +725,7 @@ async fn long_history_replay_with_tool_result_continuation() -> Result<()> {
                     ALPHA_SIGNAL_OUTPUT,
                 ))
                 .message(Message::assistant("The harbor label is crimson-harbor."))
-                .tool(AlphaSignal.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&AlphaSignal))
                 .tool_choice(ToolChoice::None)
                 .build();
 
@@ -753,7 +753,7 @@ async fn tool_choice_auto_any_specific_and_none() -> Result<()> {
                 .completion(
                     model
                         .completion_request("Call lookup_harbor_label exactly once with an empty object.")
-                        .tool(AlphaSignal.definition(String::new()).await)
+                        .tool(rig::tool::tool_definition(&AlphaSignal))
                         .tool_choice(ToolChoice::Auto)
                         .build(),
                 )
@@ -772,7 +772,7 @@ async fn tool_choice_auto_any_specific_and_none() -> Result<()> {
                 .completion(
                     model
                         .completion_request("Call lookup_harbor_label exactly once with an empty object and do not answer in prose.")
-                        .tool(AlphaSignal.definition(String::new()).await)
+                        .tool(rig::tool::tool_definition(&AlphaSignal))
                         .tool_choice(ToolChoice::Required)
                         .build(),
                 )
@@ -791,8 +791,8 @@ async fn tool_choice_auto_any_specific_and_none() -> Result<()> {
                 .completion(
                     model
                         .completion_request("Call the orchard-label tool exactly once with an empty object and do not call any other tool.")
-                        .tool(AlphaSignal.definition(String::new()).await)
-                        .tool(BetaSignal.definition(String::new()).await)
+                        .tool(rig::tool::tool_definition(&AlphaSignal))
+                        .tool(rig::tool::tool_definition(&BetaSignal))
                         .tool_choice(ToolChoice::Specific {
                             function_names: vec![BetaSignal::NAME.to_string()],
                         })
@@ -817,7 +817,7 @@ async fn tool_choice_auto_any_specific_and_none() -> Result<()> {
                 .completion(
                     model
                         .completion_request("Do not call tools. Reply with exactly this phrase: no-tool-answer")
-                        .tool(AlphaSignal.definition(String::new()).await)
+                        .tool(rig::tool::tool_definition(&AlphaSignal))
                         .tool_choice(ToolChoice::None)
                         .build(),
                 )

--- a/tests/providers/mistral/permission_control.rs
+++ b/tests/providers/mistral/permission_control.rs
@@ -3,7 +3,7 @@
 use anyhow::Result;
 use rig::agent::{AgentHook, Flow, StepEvent, stream_to_stdout};
 use rig::client::{CompletionClient, ProviderClient};
-use rig::completion::{CompletionModel, Prompt, ToolDefinition};
+use rig::completion::{CompletionModel, Prompt};
 use rig::providers::mistral;
 use rig::streaming::StreamingPrompt;
 use rig::tool::Tool;
@@ -51,15 +51,15 @@ impl Tool for ReadFileHead {
     type Args = ReadFileArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "read_file_head".to_string(),
-            description: "Read the first line of test.txt using the head command".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {},
-            }),
-        }
+    fn description(&self) -> String {
+        "Read the first line of test.txt using the head command".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -82,15 +82,15 @@ impl Tool for ReadFileTail {
     type Args = ReadFileArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "read_file_tail".to_string(),
-            description: "Read the last line of test.txt using the tail command".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {},
-            }),
-        }
+    fn description(&self) -> String {
+        "Read the last line of test.txt using the tail command".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/tests/providers/mistral/typed_prompt_tools.rs
+++ b/tests/providers/mistral/typed_prompt_tools.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rig::client::{CompletionClient, ProviderClient};
-use rig::completion::{ToolDefinition, TypedPrompt};
+use rig::completion::TypedPrompt;
 use rig::providers::mistral;
 use rig::tool::Tool;
 
@@ -44,20 +44,17 @@ impl Tool for WeatherTool {
     type Args = WeatherArgs;
     type Output = String;
 
-    fn definition(
-        &self,
-        _prompt: String,
-    ) -> impl std::future::Future<Output = ToolDefinition> + Send + Sync {
-        std::future::ready(ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Get the current weather for a city.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "city": { "type": "string" }
-                },
-                "required": ["city"]
-            }),
+    fn description(&self) -> String {
+        "Get the current weather for a city.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "city": { "type": "string" }
+            },
+            "required": ["city"]
         })
     }
 

--- a/tests/providers/ollama/cassette/tools.rs
+++ b/tests/providers/ollama/cassette/tools.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rig::client::CompletionClient;
-use rig::completion::{Chat, Message, ToolDefinition};
+use rig::completion::{Chat, Message};
 use rig::tool::Tool;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -44,13 +44,13 @@ impl Tool for RepeatTool {
     type Args = RepeatArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "repeat_text".to_string(),
-            description: "Repeat `text`. `times` is optional and defaults to 2.".to_string(),
-            // schemars schema, exactly as repo-tagger builds its tool parameters.
-            parameters: serde_json::to_value(schemars::schema_for!(RepeatArgs)).unwrap_or_default(),
-        }
+    fn description(&self) -> String {
+        "Repeat `text`. `times` is optional and defaults to 2.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        // schemars schema, exactly as repo-tagger builds its tool parameters.
+        serde_json::to_value(schemars::schema_for!(RepeatArgs)).unwrap_or_default()
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -114,12 +114,12 @@ impl Tool for AddTool {
     type Args = BinOpArgs;
     type Output = i64;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "add".to_string(),
-            description: "Add two integers a and b.".to_string(),
-            parameters: serde_json::to_value(schemars::schema_for!(BinOpArgs)).unwrap_or_default(),
-        }
+    fn description(&self) -> String {
+        "Add two integers a and b.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::to_value(schemars::schema_for!(BinOpArgs)).unwrap_or_default()
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -139,12 +139,12 @@ impl Tool for MultiplyTool {
     type Args = BinOpArgs;
     type Output = i64;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "multiply".to_string(),
-            description: "Multiply two integers a and b.".to_string(),
-            parameters: serde_json::to_value(schemars::schema_for!(BinOpArgs)).unwrap_or_default(),
-        }
+    fn description(&self) -> String {
+        "Multiply two integers a and b.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::to_value(schemars::schema_for!(BinOpArgs)).unwrap_or_default()
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/tests/providers/openai/cassette/completions_api.rs
+++ b/tests/providers/openai/cassette/completions_api.rs
@@ -8,7 +8,6 @@ use rig::message::{AssistantContent, Message, ToolChoice};
 use rig::providers::openai;
 use rig::streaming::StreamingPrompt;
 use rig::telemetry::ProviderResponseExt;
-use rig::tool::Tool;
 
 use super::super::support::with_openai_completions_cassette;
 use crate::support::{
@@ -159,8 +158,8 @@ async fn completions_api_raw_stream_surfaces_two_distinct_tool_calls_before_text
             let request = model
                 .completion_request(TWO_TOOL_STREAM_PROMPT)
                 .preamble(TWO_TOOL_STREAM_PREAMBLE.to_string())
-                .tool(AlphaSignal.definition(String::new()).await)
-                .tool(BetaSignal.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&AlphaSignal))
+                .tool(rig::tool::tool_definition(&BetaSignal))
                 .build();
 
             let observation = collect_raw_stream_observation(
@@ -216,7 +215,7 @@ async fn completions_api_raw_followup_uses_tool_result_without_new_tool_calls() 
             let request = model
                 .completion_request(ORDERED_TOOL_STREAM_PROMPT)
                 .preamble(ORDERED_TOOL_STREAM_PREAMBLE.to_string())
-                .tool(AlphaSignal.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&AlphaSignal))
                 .build();
 
             let first_turn = collect_raw_stream_observation(

--- a/tests/providers/openai/cassette/permission_control.rs
+++ b/tests/providers/openai/cassette/permission_control.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use rig::agent::{AgentHook, Flow, StepEvent, stream_to_stdout};
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, Prompt, ToolDefinition};
+use rig::completion::{CompletionModel, Prompt};
 use rig::providers;
 use rig::streaming::StreamingPrompt;
 use rig::tool::Tool;
@@ -48,15 +48,15 @@ impl Tool for ReadFileHead {
     type Args = ReadFileArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "read_file_head".to_string(),
-            description: "Read the first line of test.txt using the head command".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {},
-            }),
-        }
+    fn description(&self) -> String {
+        "Read the first line of test.txt using the head command".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -79,15 +79,15 @@ impl Tool for ReadFileTail {
     type Args = ReadFileArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "read_file_tail".to_string(),
-            description: "Read the last line of test.txt using the tail command".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {},
-            }),
-        }
+    fn description(&self) -> String {
+        "Read the last line of test.txt using the tail command".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/tests/providers/openai/cassette/responses_behaviors.rs
+++ b/tests/providers/openai/cassette/responses_behaviors.rs
@@ -28,7 +28,7 @@ async fn strict_tools_opt_in_roundtrip() {
             let request = model
                 .completion_request("Use the add tool to add 7 and 5.")
                 .preamble(TOOLS_PREAMBLE.to_string())
-                .tool(Adder.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&Adder))
                 .build();
 
             let response = model

--- a/tests/providers/openai/cassette/responses_sessions.rs
+++ b/tests/providers/openai/cassette/responses_sessions.rs
@@ -314,7 +314,7 @@ async fn long_history_replay_nonstreaming() {
             let first_request = model
                 .completion_request("Look up the harbor label with the tool.")
                 .preamble(preamble.to_string())
-                .tool(AlphaSignal.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&AlphaSignal))
                 .build();
             let first_response = model
                 .completion(first_request)
@@ -363,7 +363,7 @@ async fn long_history_replay_nonstreaming() {
                     ALPHA_SIGNAL_OUTPUT,
                 ))
                 .message(Message::assistant("The harbor label is crimson-harbor."))
-                .tool(AlphaSignal.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&AlphaSignal))
                 .build();
 
             let response = model

--- a/tests/providers/openai/cassette/responses_tool_args.rs
+++ b/tests/providers/openai/cassette/responses_tool_args.rs
@@ -64,12 +64,12 @@ impl Tool for PlanTrip {
     type Args = PlanTripArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Book a trip from a nested itinerary object.".to_string(),
-            parameters: plan_trip_parameters(),
-        }
+    fn description(&self) -> String {
+        "Book a trip from a nested itinerary object.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        plan_trip_parameters()
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -262,7 +262,7 @@ async fn nested_arguments_streaming() {
             let request = model
                 .completion_request(NESTED_ARGS_PROMPT)
                 .preamble(NESTED_ARGS_PREAMBLE.to_string())
-                .tool(PlanTrip.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&PlanTrip))
                 .build();
 
             let observation = collect_raw_stream_observation(

--- a/tests/providers/openai/cassette/responses_tool_choice.rs
+++ b/tests/providers/openai/cassette/responses_tool_choice.rs
@@ -36,7 +36,7 @@ async fn required_forces_a_tool_call() {
             let request = model
                 .completion_request("Please greet me.")
                 .preamble(TOOLS_PREAMBLE.to_string())
-                .tool(Adder.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&Adder))
                 .tool_choice(ToolChoice::Required)
                 .build();
 
@@ -69,7 +69,7 @@ async fn none_suppresses_tool_calls() {
             let request = model
                 .completion_request("What is 2 plus 3? Reply with just the number.")
                 .preamble(TOOLS_PREAMBLE.to_string())
-                .tool(Adder.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&Adder))
                 .tool_choice(ToolChoice::None)
                 .build();
 
@@ -109,8 +109,8 @@ async fn specific_single_function_targets_named_tool() {
             let request = model
                 .completion_request("Compute 9 minus 4 using a tool.")
                 .preamble(TOOLS_PREAMBLE.to_string())
-                .tool(Adder.definition(String::new()).await)
-                .tool(Subtract.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&Adder))
+                .tool(rig::tool::tool_definition(&Subtract))
                 .tool_choice(ToolChoice::Specific {
                     function_names: vec![Subtract::NAME.to_string()],
                 })
@@ -168,9 +168,9 @@ async fn specific_multiple_functions_use_allowed_tools() {
             let request = model
                 .completion_request("What is 2 plus 3? Use exactly one tool.")
                 .preamble(TOOLS_PREAMBLE.to_string())
-                .tool(Adder.definition(String::new()).await)
-                .tool(Subtract.definition(String::new()).await)
-                .tool(AlphaSignal.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&Adder))
+                .tool(rig::tool::tool_definition(&Subtract))
+                .tool(rig::tool::tool_definition(&AlphaSignal))
                 .tool_choice(ToolChoice::Specific {
                     function_names: vec![Adder::NAME.to_string(), Subtract::NAME.to_string()],
                 })

--- a/tests/providers/openai/cassette/streaming_tools.rs
+++ b/tests/providers/openai/cassette/streaming_tools.rs
@@ -7,7 +7,6 @@ use rig::message::{AssistantContent, Message};
 use rig::providers::openai;
 use rig::providers::openai::responses_api::streaming::StreamingCompletionChunk;
 use rig::streaming::StreamingPrompt;
-use rig::tool::Tool;
 
 use serde::Deserialize;
 
@@ -168,7 +167,7 @@ async fn raw_responses_stream_preserves_tool_then_followup_text_ordering() {
             let request = model
                 .completion_request(ORDERED_TOOL_STREAM_PROMPT)
                 .preamble(ORDERED_TOOL_STREAM_PREAMBLE.to_string())
-                .tool(AlphaSignal.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&AlphaSignal))
                 .build();
 
             let first_turn = collect_raw_stream_observation(

--- a/tests/providers/openai/cassette/typed_prompt_tools.rs
+++ b/tests/providers/openai/cassette/typed_prompt_tools.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rig::client::CompletionClient;
-use rig::completion::{ToolDefinition, TypedPrompt};
+use rig::completion::TypedPrompt;
 use rig::tool::Tool;
 
 use super::super::support::with_openai_completions_cassette_result;
@@ -42,20 +42,17 @@ impl Tool for WeatherTool {
     type Args = WeatherArgs;
     type Output = String;
 
-    fn definition(
-        &self,
-        _prompt: String,
-    ) -> impl std::future::Future<Output = ToolDefinition> + Send + Sync {
-        std::future::ready(ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Get the current weather for a city.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "city": { "type": "string" }
-                },
-                "required": ["city"]
-            }),
+    fn description(&self) -> String {
+        "Get the current weather for a city.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "city": { "type": "string" }
+            },
+            "required": ["city"]
         })
     }
 

--- a/tests/providers/openrouter/cassette/agent_tool_sessions.rs
+++ b/tests/providers/openrouter/cassette/agent_tool_sessions.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex};
 use anyhow::Result;
 use rig::OneOrMany;
 use rig::client::CompletionClient;
-use rig::completion::{Chat, CompletionModel, Message, ToolDefinition, TypedPrompt};
+use rig::completion::{Chat, CompletionModel, Message, TypedPrompt};
 use rig::message::{AssistantContent, ToolChoice, UserContent};
 use rig::streaming::{StreamingChat, StreamingPrompt};
 use rig::tool::Tool;
@@ -124,16 +124,16 @@ impl Tool for PingEmpty {
     type Args = EmptyArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Return EMPTY-OK. This tool takes no arguments.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {},
-                "required": []
-            }),
-        }
+    fn description(&self) -> String {
+        "Return EMPTY-OK. This tool takes no arguments.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "required": []
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -148,38 +148,38 @@ impl Tool for InspectManifest {
     type Args = ManifestArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Validate a nested deployment manifest.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "project": { "type": "string" },
-                    "flags": {
+    fn description(&self) -> String {
+        "Validate a nested deployment manifest.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "project": { "type": "string" },
+                "flags": {
+                    "type": "object",
+                    "properties": {
+                        "critical": { "type": "boolean" },
+                        "retries": { "type": "integer" }
+                    },
+                    "required": ["critical", "retries"]
+                },
+                "steps": {
+                    "type": "array",
+                    "items": {
                         "type": "object",
                         "properties": {
-                            "critical": { "type": "boolean" },
-                            "retries": { "type": "integer" }
+                            "name": { "type": "string" },
+                            "weight": { "type": "integer" }
                         },
-                        "required": ["critical", "retries"]
-                    },
-                    "steps": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "name": { "type": "string" },
-                                "weight": { "type": "integer" }
-                            },
-                            "required": ["name", "weight"]
-                        }
-                    },
-                    "note": { "type": "string" }
+                        "required": ["name", "weight"]
+                    }
                 },
-                "required": ["project", "flags", "steps", "note"]
-            }),
-        }
+                "note": { "type": "string" }
+            },
+            "required": ["project", "flags", "steps", "note"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -199,22 +199,22 @@ impl Tool for JoinLabels {
     type Args = JoinArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Join label strings with the requested separator.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "labels": {
-                        "type": "array",
-                        "items": { "type": "string" }
-                    },
-                    "separator": { "type": "string" }
+    fn description(&self) -> String {
+        "Join label strings with the requested separator.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "labels": {
+                    "type": "array",
+                    "items": { "type": "string" }
                 },
-                "required": ["labels", "separator"]
-            }),
-        }
+                "separator": { "type": "string" }
+            },
+            "required": ["labels", "separator"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -229,18 +229,18 @@ impl Tool for EscapeEcho {
     type Args = EchoArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Echo a string containing escaping-sensitive characters.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "text": { "type": "string" }
-                },
-                "required": ["text"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Echo a string containing escaping-sensitive characters.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "text": { "type": "string" }
+            },
+            "required": ["text"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -573,7 +573,7 @@ async fn raw_stream_complex_tool_call_deltas_have_object_arguments() -> Result<(
                      Do not write normal text before the tool call.",
                 )
                 .preamble("Use the requested tool call and no prose before it.".to_string())
-                .tool(tool.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&tool))
                 .tool_choice(ToolChoice::Required)
                 .build();
 
@@ -627,7 +627,7 @@ async fn long_history_replay_with_tool_result_continuation() -> Result<()> {
                 })
                 .message(Message::tool_result("call_REDACTED_1", ALPHA_SIGNAL_OUTPUT))
                 .message(Message::assistant("The harbor label is crimson-harbor."))
-                .tool(AlphaSignal.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&AlphaSignal))
                 .tool_choice(ToolChoice::None)
                 .build();
 

--- a/tests/providers/openrouter/cassette/permission_control.rs
+++ b/tests/providers/openrouter/cassette/permission_control.rs
@@ -3,7 +3,7 @@
 use anyhow::Result;
 use rig::agent::{AgentHook, Flow, StepEvent, stream_to_stdout};
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, Prompt, ToolDefinition};
+use rig::completion::{CompletionModel, Prompt};
 use rig::streaming::StreamingPrompt;
 use rig::tool::Tool;
 use serde::{Deserialize, Serialize};
@@ -50,15 +50,15 @@ impl Tool for ReadFileHead {
     type Args = ReadFileArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "read_file_head".to_string(),
-            description: "Read the first line of test.txt using the head command".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {},
-            }),
-        }
+    fn description(&self) -> String {
+        "Read the first line of test.txt using the head command".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -81,15 +81,15 @@ impl Tool for ReadFileTail {
     type Args = ReadFileArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "read_file_tail".to_string(),
-            description: "Read the last line of test.txt using the tail command".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {},
-            }),
-        }
+    fn description(&self) -> String {
+        "Read the last line of test.txt using the tail command".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/tests/providers/openrouter/cassette/streaming_tools.rs
+++ b/tests/providers/openrouter/cassette/streaming_tools.rs
@@ -5,7 +5,6 @@ use rig::client::CompletionClient;
 use rig::completion::CompletionModel;
 use rig::message::{AssistantContent, Message};
 use rig::streaming::StreamingPrompt;
-use rig::tool::Tool;
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 
@@ -50,9 +49,9 @@ async fn raw_stream_decorates_reasoning_tool_call_metadata() {
         "streaming_tools/raw_stream_decorates_reasoning_tool_call_metadata",
         |client| async move {
             let model = client.completion_model("openai/o4-mini");
-            let tool_definition = WeatherTool::new(Arc::new(AtomicUsize::new(0)))
-                .definition(String::new())
-                .await;
+            let tool_definition = rig::tool::tool_definition(&WeatherTool::new(Arc::new(
+                AtomicUsize::new(0),
+            )));
             let request = model
                 .completion_request(crate::reasoning::TOOL_USER_PROMPT)
                 .preamble(crate::reasoning::TOOL_SYSTEM_PROMPT.to_string())
@@ -105,8 +104,8 @@ async fn raw_stream_surfaces_two_distinct_tool_calls_before_text() {
             let request = model
                 .completion_request(TWO_TOOL_STREAM_PROMPT)
                 .preamble(TWO_TOOL_STREAM_PREAMBLE.to_string())
-                .tool(AlphaSignal.definition(String::new()).await)
-                .tool(BetaSignal.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&AlphaSignal))
+                .tool(rig::tool::tool_definition(&BetaSignal))
                 .build();
 
             let observation = collect_raw_stream_observation(
@@ -135,7 +134,7 @@ async fn raw_followup_uses_tool_result_without_new_tool_calls() {
             let request = model
                 .completion_request(ORDERED_TOOL_STREAM_PROMPT)
                 .preamble(ORDERED_TOOL_STREAM_PREAMBLE.to_string())
-                .tool(AlphaSignal.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&AlphaSignal))
                 .build();
 
             let first_turn = collect_raw_stream_observation(

--- a/tests/providers/openrouter/cassette/typed_prompt_tools.rs
+++ b/tests/providers/openrouter/cassette/typed_prompt_tools.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rig::client::CompletionClient;
-use rig::completion::{ToolDefinition, TypedPrompt};
+use rig::completion::TypedPrompt;
 use rig::tool::Tool;
 
 use crate::support::assert_weather_tool_roundtrip_response;
@@ -43,20 +43,17 @@ impl Tool for WeatherTool {
     type Args = WeatherArgs;
     type Output = String;
 
-    fn definition(
-        &self,
-        _prompt: String,
-    ) -> impl std::future::Future<Output = ToolDefinition> + Send + Sync {
-        std::future::ready(ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Get the current weather for a city.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "city": { "type": "string" }
-                },
-                "required": ["city"]
-            }),
+    fn description(&self) -> String {
+        "Get the current weather for a city.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "city": { "type": "string" }
+            },
+            "required": ["city"]
         })
     }
 

--- a/tests/providers/xai/agent_tool_sessions.rs
+++ b/tests/providers/xai/agent_tool_sessions.rs
@@ -11,7 +11,7 @@ use anyhow::Result;
 use base64::{Engine, prelude::BASE64_STANDARD};
 use rig::OneOrMany;
 use rig::client::CompletionClient;
-use rig::completion::{Chat, CompletionModel, Message, Prompt, ToolDefinition};
+use rig::completion::{Chat, CompletionModel, Message, Prompt};
 use rig::message::{AssistantContent, ImageMediaType, ToolChoice, UserContent};
 use rig::providers::openai::responses_api::Output;
 use rig::providers::xai;
@@ -128,16 +128,16 @@ impl Tool for PingEmpty {
     type Args = EmptyArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Return EMPTY-OK. This tool takes no arguments.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {},
-                "required": []
-            }),
-        }
+    fn description(&self) -> String {
+        "Return EMPTY-OK. This tool takes no arguments.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "required": []
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -152,38 +152,38 @@ impl Tool for InspectManifest {
     type Args = ManifestArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Validate a nested deployment manifest.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "project": { "type": "string" },
-                    "flags": {
+    fn description(&self) -> String {
+        "Validate a nested deployment manifest.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "project": { "type": "string" },
+                "flags": {
+                    "type": "object",
+                    "properties": {
+                        "critical": { "type": "boolean" },
+                        "retries": { "type": "integer" }
+                    },
+                    "required": ["critical", "retries"]
+                },
+                "steps": {
+                    "type": "array",
+                    "items": {
                         "type": "object",
                         "properties": {
-                            "critical": { "type": "boolean" },
-                            "retries": { "type": "integer" }
+                            "name": { "type": "string" },
+                            "weight": { "type": "integer" }
                         },
-                        "required": ["critical", "retries"]
-                    },
-                    "steps": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "name": { "type": "string" },
-                                "weight": { "type": "integer" }
-                            },
-                            "required": ["name", "weight"]
-                        }
-                    },
-                    "note": { "type": "string" }
+                        "required": ["name", "weight"]
+                    }
                 },
-                "required": ["project", "flags", "steps", "note"]
-            }),
-        }
+                "note": { "type": "string" }
+            },
+            "required": ["project", "flags", "steps", "note"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -203,22 +203,22 @@ impl Tool for JoinLabels {
     type Args = JoinArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Join label strings with the requested separator.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "labels": {
-                        "type": "array",
-                        "items": { "type": "string" }
-                    },
-                    "separator": { "type": "string" }
+    fn description(&self) -> String {
+        "Join label strings with the requested separator.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "labels": {
+                    "type": "array",
+                    "items": { "type": "string" }
                 },
-                "required": ["labels", "separator"]
-            }),
-        }
+                "separator": { "type": "string" }
+            },
+            "required": ["labels", "separator"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -233,18 +233,18 @@ impl Tool for EscapeEcho {
     type Args = EchoArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Echo a string containing escaping-sensitive characters.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {
-                    "text": { "type": "string" }
-                },
-                "required": ["text"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Echo a string containing escaping-sensitive characters.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "text": { "type": "string" }
+            },
+            "required": ["text"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -603,7 +603,7 @@ async fn raw_stream_complex_tool_call_deltas_have_object_arguments() -> Result<(
                      Do not write normal text before the tool call.",
                 )
                 .preamble("Use the requested tool call and no prose before it.".to_string())
-                .tool(tool.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&tool))
                 .tool_choice(ToolChoice::Required)
                 .build();
 
@@ -662,7 +662,7 @@ async fn long_history_replay_with_tool_result_continuation() -> Result<()> {
                     ALPHA_SIGNAL_OUTPUT,
                 ))
                 .message(Message::assistant("The harbor label is crimson-harbor."))
-                .tool(AlphaSignal.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&AlphaSignal))
                 .tool_choice(ToolChoice::None)
                 .build();
 
@@ -697,7 +697,7 @@ async fn tool_choice_required_specific_and_none() -> Result<()> {
                         .completion_request(
                             "Call lookup_harbor_label exactly once with an empty object and do not answer in prose.",
                         )
-                        .tool(AlphaSignal.definition(String::new()).await)
+                        .tool(rig::tool::tool_definition(&AlphaSignal))
                         .tool_choice(ToolChoice::Required)
                         .build(),
                 )
@@ -718,8 +718,8 @@ async fn tool_choice_required_specific_and_none() -> Result<()> {
                         .completion_request(
                             "Call the orchard-label tool exactly once with an empty object and do not call any other tool.",
                         )
-                        .tool(AlphaSignal.definition(String::new()).await)
-                        .tool(BetaSignal.definition(String::new()).await)
+                        .tool(rig::tool::tool_definition(&AlphaSignal))
+                        .tool(rig::tool::tool_definition(&BetaSignal))
                         .tool_choice(ToolChoice::Specific {
                             function_names: vec![BetaSignal::NAME.to_string()],
                         })
@@ -746,7 +746,7 @@ async fn tool_choice_required_specific_and_none() -> Result<()> {
                         .completion_request(
                             "Do not call tools. Reply with exactly this phrase: no-tool-answer",
                         )
-                        .tool(AlphaSignal.definition(String::new()).await)
+                        .tool(rig::tool::tool_definition(&AlphaSignal))
                         .tool_choice(ToolChoice::None)
                         .build(),
                 )

--- a/tests/providers/xai/permission_control.rs
+++ b/tests/providers/xai/permission_control.rs
@@ -3,7 +3,7 @@
 use anyhow::Result;
 use rig::agent::{AgentHook, Flow, StepEvent, stream_to_stdout};
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, Prompt, ToolDefinition};
+use rig::completion::{CompletionModel, Prompt};
 use rig::providers::xai;
 use rig::streaming::StreamingPrompt;
 use rig::tool::Tool;
@@ -53,15 +53,15 @@ impl Tool for ReadFileHead {
     type Args = ReadFileArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "read_file_head".to_string(),
-            description: "Read the first line of test.txt using the head command".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {},
-            }),
-        }
+    fn description(&self) -> String {
+        "Read the first line of test.txt using the head command".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -84,15 +84,15 @@ impl Tool for ReadFileTail {
     type Args = ReadFileArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: "read_file_tail".to_string(),
-            description: "Read the last line of test.txt using the tail command".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {},
-            }),
-        }
+    fn description(&self) -> String {
+        "Read the last line of test.txt using the tail command".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/tests/providers/xai/streaming_tools.rs
+++ b/tests/providers/xai/streaming_tools.rs
@@ -2,7 +2,7 @@
 
 use rig::OneOrMany;
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, ToolDefinition};
+use rig::completion::CompletionModel;
 use rig::message::ToolChoice;
 use rig::message::{AssistantContent, Message};
 use rig::providers::xai;
@@ -42,16 +42,16 @@ impl Tool for StatusWordTool {
     type Args = NoArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Return a harmless status word.".to_string(),
-            parameters: json!({
-                "type": "object",
-                "properties": {},
-                "required": [],
-            }),
-        }
+    fn description(&self) -> String {
+        "Return a harmless status word.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "required": [],
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -114,7 +114,7 @@ async fn raw_responses_stream_preserves_tool_then_followup_text_ordering() {
             let request = model
                 .completion_request(XAI_STATUS_TOOL_PROMPT)
                 .preamble(XAI_STATUS_TOOL_PREAMBLE.to_string())
-                .tool(StatusWordTool.definition(String::new()).await)
+                .tool(rig::tool::tool_definition(&StatusWordTool))
                 .build();
 
             let first_turn = collect_raw_stream_observation(

--- a/tests/providers/xai/tools.rs
+++ b/tests/providers/xai/tools.rs
@@ -1,7 +1,7 @@
 //! xAI tools smoke test.
 
 use rig::client::CompletionClient;
-use rig::completion::{Prompt, ToolDefinition};
+use rig::completion::Prompt;
 use rig::providers::xai;
 use rig::tool::Tool;
 use serde::{Deserialize, Serialize};
@@ -28,19 +28,19 @@ impl Tool for Adder {
     type Args = OperationArgs;
     type Output = f64;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Add x and y together".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "x": { "type": "number", "description": "The first number to add" },
-                    "y": { "type": "number", "description": "The second number to add" }
-                },
-                "required": ["x", "y"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Add x and y together".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "x": { "type": "number", "description": "The first number to add" },
+                "y": { "type": "number", "description": "The second number to add" }
+            },
+            "required": ["x", "y"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -57,19 +57,19 @@ impl Tool for Subtract {
     type Args = OperationArgs;
     type Output = f64;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Subtract y from x (that is, x - y)".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "x": { "type": "number", "description": "The number to subtract from" },
-                    "y": { "type": "number", "description": "The number to subtract" }
-                },
-                "required": ["x", "y"]
-            }),
-        }
+    fn description(&self) -> String {
+        "Subtract y from x (that is, x - y)".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "x": { "type": "number", "description": "The number to subtract from" },
+                "y": { "type": "number", "description": "The number to subtract" }
+            },
+            "required": ["x", "y"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/tests/providers/xai/typed_prompt_tools.rs
+++ b/tests/providers/xai/typed_prompt_tools.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rig::client::CompletionClient;
-use rig::completion::{ToolDefinition, TypedPrompt};
+use rig::completion::TypedPrompt;
 use rig::providers::xai;
 use rig::tool::Tool;
 
@@ -43,20 +43,17 @@ impl Tool for WeatherTool {
     type Args = WeatherArgs;
     type Output = String;
 
-    fn definition(
-        &self,
-        _prompt: String,
-    ) -> impl std::future::Future<Output = ToolDefinition> + Send + Sync {
-        std::future::ready(ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Get the current weather for a city.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "city": { "type": "string" }
-                },
-                "required": ["city"]
-            }),
+    fn description(&self) -> String {
+        "Get the current weather for a city.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "city": { "type": "string" }
+            },
+            "required": ["city"]
         })
     }
 


### PR DESCRIPTION
## Summary
- flatten Tool and ToolDyn metadata to name/description/parameters and remove author-facing definition methods
- generate provider ToolDefinition artifacts from registered ToolDyn metadata so dispatch name is the single source of truth
- migrate derive output, vector-store/MCP/agent tools, examples, and provider test helpers to the flat API

## Testing
- cargo fmt
- cargo check -p rig-core --all-targets --all-features
- cargo check --workspace --all-targets --all-features
- cargo test -p rig-core --lib
- cargo test -p rig-derive
- cargo test --doc --workspace --all-features
- cargo clippy --all-targets --all-features