### PR TITLE
Make ToolDyn a concrete named tool

### DIFF
--- a/crates/rig-core/src/agent/builder.rs
+++ b/crates/rig-core/src/agent/builder.rs
@@ -351,7 +351,8 @@ where
     /// This transitions the builder to the `WithBuilderTools` state, where
     /// additional tools can be added but `tool_server_handle()` is no longer available.
     pub fn tool(self, tool: impl Tool + 'static) -> AgentBuilder<M, WithBuilderTools> {
-        let toolname = tool.name();
+        let mut tools = ToolSet::default();
+        let toolname = tools.add_tool(tool);
         AgentBuilder {
             name: self.name,
             description: self.description,
@@ -366,7 +367,7 @@ where
             default_max_turns: self.default_max_turns,
             tool_state: WithBuilderTools {
                 static_tools: vec![toolname],
-                tools: ToolSet::from_tools(vec![tool]),
+                tools,
                 dynamic_tools: vec![],
             },
             hooks: self.hooks,
@@ -377,13 +378,13 @@ where
         }
     }
 
-    /// Add a vector of boxed static tools to the agent.
+    /// Add a vector of complete dynamic static tools to the agent.
     ///
     /// This is useful when you need to dynamically add static tools to the agent.
     /// Transitions the builder to the `WithBuilderTools` state.
-    pub fn tools(self, tools: Vec<Box<dyn ToolDyn>>) -> AgentBuilder<M, WithBuilderTools> {
-        let static_tools = tools.iter().map(|tool| tool.name()).collect();
-        let tools = ToolSet::from_tools_boxed(tools);
+    pub fn tools(self, tools: Vec<ToolDyn>) -> AgentBuilder<M, WithBuilderTools> {
+        let static_tools = tools.iter().map(|tool| tool.name().to_string()).collect();
+        let tools = ToolSet::from_tools_dyn(tools);
 
         AgentBuilder {
             name: self.name,
@@ -608,16 +609,15 @@ where
 {
     /// Add another static tool to the agent.
     pub fn tool(mut self, tool: impl Tool + 'static) -> Self {
-        let toolname = tool.name();
-        self.tool_state.tools.add_tool(tool);
+        let toolname = self.tool_state.tools.add_tool(tool);
         self.tool_state.static_tools.push(toolname);
         self
     }
 
-    /// Add a vector of boxed static tools to the agent.
-    pub fn tools(mut self, tools: Vec<Box<dyn ToolDyn>>) -> Self {
-        let toolnames: Vec<String> = tools.iter().map(|tool| tool.name()).collect();
-        let tools = ToolSet::from_tools_boxed(tools);
+    /// Add a vector of complete dynamic static tools to the agent.
+    pub fn tools(mut self, tools: Vec<ToolDyn>) -> Self {
+        let toolnames: Vec<String> = tools.iter().map(|tool| tool.name().to_string()).collect();
+        let tools = ToolSet::from_tools_dyn(tools);
         self.tool_state.tools.add_tools(tools);
         self.tool_state.static_tools.extend(toolnames);
         self
@@ -656,9 +656,9 @@ where
 
     #[cfg(feature = "rmcp")]
     fn add_rmcp_tools(mut self, built: Vec<(String, RmcpTool)>) -> Self {
-        for (name, tool) in built {
+        for (_name, tool) in built {
+            let name = self.tool_state.tools.add_tool(tool);
             self.tool_state.static_tools.push(name);
-            self.tool_state.tools.add_tool(tool);
         }
 
         self
@@ -737,7 +737,7 @@ mod tests {
     #[cfg(feature = "rmcp")]
     #[tokio::test]
     async fn build_rmcp_tools_threads_timeout_into_built_tools() {
-        use crate::tool::ToolDyn;
+        use crate::tool::ToolRuntime;
         use crate::tool::rmcp::DEFAULT_MCP_TOOL_TIMEOUT;
         use rmcp::model::{
             CallToolRequestParams, CallToolResult, ClientInfo, ErrorData, Implementation,

--- a/crates/rig-core/src/agent/tool.rs
+++ b/crates/rig-core/src/agent/tool.rs
@@ -29,7 +29,7 @@ impl<M: CompletionModel + 'static> Tool for Agent<M> {
             Agent description: {description}
             Agent system prompt: {sysprompt}
             ",
-            name = self.name(),
+            name = self.name.as_deref().unwrap_or(Self::NAME),
             description = self.description.clone().unwrap_or_default(),
             sysprompt = self.preamble.clone().unwrap_or_default()
         )
@@ -55,10 +55,6 @@ impl<M: CompletionModel + 'static> Tool for Agent<M> {
         self.prompt(args.prompt)
             .tool_extensions(extensions.clone())
             .await
-    }
-
-    fn name(&self) -> String {
-        self.name.clone().unwrap_or_else(|| Self::NAME.to_string())
     }
 }
 
@@ -86,7 +82,7 @@ mod tests {
         // Outer agent: delegates to the inner agent (registered as the
         // "researcher" tool), then answers.
         let outer_model = MockCompletionModel::new([
-            MockTurn::tool_call("c2", "researcher", json!({"prompt": "do research"})),
+            MockTurn::tool_call("c2", "agent_tool", json!({"prompt": "do research"})),
             MockTurn::text("outer done"),
         ]);
         let outer = AgentBuilder::new(outer_model).tool(inner).build();

--- a/crates/rig-core/src/embeddings/tool.rs
+++ b/crates/rig-core/src/embeddings/tool.rs
@@ -1,6 +1,6 @@
 //! The module defines the [ToolSchema] struct, which is used to embed an object that implements [crate::tool::ToolEmbedding]
 
-use crate::{Embed, tool::ToolEmbeddingDyn};
+use crate::{Embed, tool::ToolDyn};
 use serde::Serialize;
 
 use super::embed::EmbedError;
@@ -23,14 +23,18 @@ impl Embed for ToolSchema {
     }
 }
 
+#[derive(Debug, thiserror::Error)]
+#[error("tool `{0}` does not expose embedding metadata")]
+struct MissingEmbeddingMetadata(String);
+
 impl ToolSchema {
-    /// Convert item that implements [ToolEmbeddingDyn] to an [ToolSchema].
+    /// Convert a dynamic tool to a schema using the tool's stored name.
     ///
     /// # Example
     /// ```rust
     /// use rig_core::{
     ///     embeddings::ToolSchema,
-    ///     tool::{Tool, ToolEmbedding, ToolEmbeddingDyn},
+    ///     tool::{Tool, ToolDyn, ToolEmbedding},
     /// };
     ///
     /// #[derive(Debug, thiserror::Error)]
@@ -78,28 +82,31 @@ impl ToolSchema {
     ///     fn context(&self) -> Self::Context {}
     /// }
     ///
-    /// let tool = ToolSchema::try_from(&Nothing).unwrap();
+    /// let tool_dyn = ToolDyn::from_embedding(Nothing);
+    /// let tool = ToolSchema::try_from(&tool_dyn).unwrap();
     ///
     /// assert_eq!(tool.name, "nothing".to_string());
     /// assert_eq!(tool.embedding_docs, vec!["Do nothing.".to_string()]);
     /// ```
-    pub fn try_from(tool: &dyn ToolEmbeddingDyn) -> Result<Self, EmbedError> {
+    pub fn try_from(tool: &ToolDyn) -> Result<Self, EmbedError> {
         Self::from_tool(tool.name(), tool)
     }
 
     /// Convert a tool to a schema using an explicit registered name.
     ///
     /// Registry paths should pass the key under which the tool was registered so
-    /// vector-store IDs resolve back to the same entry even if `tool.name()` is
-    /// computed dynamically.
-    pub fn from_tool(
-        name: impl Into<String>,
-        tool: &dyn ToolEmbeddingDyn,
-    ) -> Result<Self, EmbedError> {
+    /// vector-store IDs resolve back to the same entry.
+    pub fn from_tool(name: impl Into<String>, tool: &ToolDyn) -> Result<Self, EmbedError> {
+        let name = name.into();
         Ok(ToolSchema {
-            name: name.into(),
-            context: tool.context().map_err(EmbedError::new)?,
-            embedding_docs: tool.embedding_docs(),
+            name: name.clone(),
+            context: tool
+                .embedding_context()
+                .ok_or_else(|| EmbedError::new(MissingEmbeddingMetadata(name.clone())))?
+                .map_err(EmbedError::new)?,
+            embedding_docs: tool
+                .embedding_docs()
+                .ok_or_else(|| EmbedError::new(MissingEmbeddingMetadata(name)))?,
         })
     }
 }

--- a/crates/rig-core/src/tool/mod.rs
+++ b/crates/rig-core/src/tool/mod.rs
@@ -141,11 +141,6 @@ pub trait Tool: Sized + WasmCompatSend + WasmCompatSync {
     /// The output type of the tool.
     type Output: Serialize;
 
-    /// A method returning the name of the tool.
-    fn name(&self) -> String {
-        Self::NAME.to_string()
-    }
-
     /// Model-facing description of what the tool does.
     fn description(&self) -> String;
 
@@ -273,28 +268,311 @@ pub trait ToolEmbedding: Tool {
     fn init(state: Self::State, context: Self::Context) -> Result<Self, Self::InitError>;
 }
 
-/// Wrapper trait to allow for dynamic dispatch of simple tools.
+fn serialize_tool_output(output: impl Serialize) -> serde_json::Result<String> {
+    match serde_json::to_value(output)? {
+        serde_json::Value::String(text) => Ok(text),
+        value => Ok(value.to_string()),
+    }
+}
+
+/// Deserialize JSON tool arguments, normalizing a bare `null` (which LLMs
+/// frequently send for tools whose arguments are all optional) to `{}`.
+fn parse_tool_args<A>(args: &str) -> serde_json::Result<A>
+where
+    A: for<'de> Deserialize<'de>,
+{
+    match serde_json::from_str(args) {
+        Ok(parsed) => Ok(parsed),
+        Err(err) if args.trim() == "null" => serde_json::from_str("{}").map_err(|_| err),
+        Err(err) => Err(err),
+    }
+}
+
+/// Map a [`ToolError`] surfaced by a string-returning [`ToolDyn`] path into a
+/// structured [`ToolExecutionResult`], classifying a JSON error as invalid
+/// arguments.
+fn tool_error_to_execution_result(err: ToolError) -> ToolExecutionResult {
+    let message = err.to_string();
+    let failure = match err {
+        ToolError::JsonError(_) => ToolFailure::invalid_args(message.clone()),
+        ToolError::ToolCallError(_) => ToolFailure::other(message.clone()),
+    };
+    ToolExecutionResult::failed(message, failure)
+}
+
+/// Source for constructing a provider-facing [`ToolDefinition`].
+pub trait ToolDefinitionSource {
+    /// Construct the provider-facing tool definition.
+    fn to_tool_definition(&self) -> ToolDefinition;
+}
+
+impl ToolDefinitionSource for ToolDyn {
+    fn to_tool_definition(&self) -> ToolDefinition {
+        tool_definition_with_name(self.name(), self)
+    }
+}
+
+impl<T> ToolDefinitionSource for T
+where
+    T: Tool,
+{
+    fn to_tool_definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            name: T::NAME.to_string(),
+            description: self.description(),
+            parameters: self.parameters(),
+        }
+    }
+}
+
+/// Generate a provider-facing [`ToolDefinition`] from a tool's structural name source.
+pub fn tool_definition<T>(tool: &T) -> ToolDefinition
+where
+    T: ToolDefinitionSource + ?Sized,
+{
+    tool.to_tool_definition()
+}
+
+pub(crate) fn tool_definition_with_name(name: impl Into<String>, tool: &ToolDyn) -> ToolDefinition {
+    ToolDefinition {
+        name: name.into(),
+        description: tool.description(),
+        parameters: tool.parameters(),
+    }
+}
+
+/// Concrete dynamically-dispatched tool value.
 ///
-/// This is the object-safe erased form of [`Tool`]: it exposes the same flat
-/// metadata and string-based execution methods for runtime dispatch.
-pub trait ToolDyn: WasmCompatSend + WasmCompatSync {
-    /// Returns the tool name used for dispatch and provider advertisement.
-    fn name(&self) -> String;
+/// `ToolDyn` stores the tool name once, at construction time. The erased runtime
+/// below is intentionally nameless so provider advertisement and dispatch cannot
+/// recompute or diverge from this stored identity.
+#[derive(Clone)]
+pub struct ToolDyn {
+    name: String,
+    runtime: Arc<dyn ToolRuntime>,
+    embedding: Option<Arc<dyn ToolEmbeddingRuntime>>,
+}
+
+impl ToolDyn {
+    /// Erase a typed [`Tool`] into a concrete dynamic tool, capturing
+    /// [`Tool::NAME`] as the canonical name.
+    pub fn from_tool<T>(tool: T) -> Self
+    where
+        T: Tool + 'static,
+    {
+        let runtime = Arc::new(TypedToolRuntime(tool));
+        Self {
+            name: T::NAME.to_string(),
+            runtime,
+            embedding: None,
+        }
+    }
+
+    /// Erase an embeddable typed [`ToolEmbedding`] into a concrete dynamic tool,
+    /// capturing [`Tool::NAME`] as the canonical name.
+    pub fn from_embedding<T>(tool: T) -> Self
+    where
+        T: ToolEmbedding + 'static,
+    {
+        let runtime = Arc::new(TypedToolRuntime(tool));
+        Self {
+            name: T::NAME.to_string(),
+            runtime: runtime.clone(),
+            embedding: Some(runtime),
+        }
+    }
+
+    /// Construct a dynamic tool from a custom runtime.
+    pub(crate) fn from_runtime(name: impl Into<String>, runtime: Arc<dyn ToolRuntime>) -> Self {
+        Self {
+            name: name.into(),
+            runtime,
+            embedding: None,
+        }
+    }
+
+    /// Start building a custom dynamic tool.
+    pub fn builder() -> ToolDynBuilder {
+        ToolDynBuilder::default()
+    }
+
+    /// The canonical tool name captured at construction/registration time.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
 
     /// Model-facing description of what the tool does.
-    fn description(&self) -> String;
+    pub fn description(&self) -> String {
+        self.runtime.description()
+    }
 
     /// JSON Schema for the tool arguments.
-    fn parameters(&self) -> serde_json::Value;
+    pub fn parameters(&self) -> serde_json::Value {
+        self.runtime.parameters()
+    }
 
     /// Calls the tool with JSON-encoded arguments and returns model-facing text.
-    fn call<'a>(&'a self, args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>>;
+    pub fn call<'a>(&'a self, args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
+        self.runtime.call(args)
+    }
 
     /// Dynamic dispatch variant of tool execution with per-call runtime extensions.
-    ///
-    /// The default ignores the extensions and delegates to [`ToolDyn::call`].
-    /// The blanket impl for [`Tool`] types overrides this to thread the
-    /// extensions through to [`Tool::call_with_extensions`].
+    pub fn call_with_extensions<'a>(
+        &'a self,
+        args: String,
+        extensions: &'a ToolCallExtensions,
+    ) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
+        self.runtime.call_with_extensions(args, extensions)
+    }
+
+    /// Execute the tool with per-call extensions, returning a structured
+    /// [`ToolExecutionResult`].
+    pub fn call_structured<'a>(
+        &'a self,
+        args: String,
+        extensions: &'a ToolCallExtensions,
+    ) -> WasmBoxedFuture<'a, ToolExecutionResult> {
+        self.runtime.call_structured(args, extensions)
+    }
+
+    fn embedding(&self) -> Option<&dyn ToolEmbeddingRuntime> {
+        self.embedding.as_deref()
+    }
+
+    pub(crate) fn embedding_context(&self) -> Option<serde_json::Result<serde_json::Value>> {
+        self.embedding().map(ToolEmbeddingRuntime::context)
+    }
+
+    pub(crate) fn embedding_docs(&self) -> Option<Vec<String>> {
+        self.embedding().map(ToolEmbeddingRuntime::embedding_docs)
+    }
+}
+
+impl<T> From<T> for ToolDyn
+where
+    T: Tool + 'static,
+{
+    fn from(tool: T) -> Self {
+        Self::from_tool(tool)
+    }
+}
+
+/// Builder for a custom concrete [`ToolDyn`].
+#[derive(Default)]
+pub struct ToolDynBuilder {
+    name: Option<String>,
+    description: Option<String>,
+    parameters: Option<serde_json::Value>,
+    call: Option<Arc<DynamicCallFn>>,
+}
+
+trait DynamicCall: WasmCompatSend + WasmCompatSync {
+    fn call(
+        &self,
+        args: String,
+        extensions: ToolCallExtensions,
+    ) -> WasmBoxedFuture<'static, Result<String, ToolError>>;
+}
+
+struct BoxedDynamicCall<F>(F);
+
+impl<F, Fut> DynamicCall for BoxedDynamicCall<F>
+where
+    F: Fn(String, ToolCallExtensions) -> Fut + WasmCompatSend + WasmCompatSync,
+    Fut: Future<Output = Result<String, ToolError>> + WasmCompatSend + 'static,
+{
+    fn call(
+        &self,
+        args: String,
+        extensions: ToolCallExtensions,
+    ) -> WasmBoxedFuture<'static, Result<String, ToolError>> {
+        Box::pin((self.0)(args, extensions))
+    }
+}
+
+type DynamicCallFn = dyn DynamicCall;
+
+impl ToolDynBuilder {
+    /// Set the canonical tool name.
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    /// Set the model-facing tool description.
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Set the JSON Schema for tool arguments.
+    pub fn parameters(mut self, parameters: serde_json::Value) -> Self {
+        self.parameters = Some(parameters);
+        self
+    }
+
+    /// Set the dynamic call implementation.
+    pub fn call<F, Fut>(mut self, call: F) -> Self
+    where
+        F: Fn(String, ToolCallExtensions) -> Fut + WasmCompatSend + WasmCompatSync + 'static,
+        Fut: Future<Output = Result<String, ToolError>> + WasmCompatSend + 'static,
+    {
+        self.call = Some(Arc::new(BoxedDynamicCall(call)));
+        self
+    }
+
+    /// Build the dynamic tool.
+    pub fn build(self) -> Result<ToolDyn, ToolDynBuilderError> {
+        let name = self.name.ok_or(ToolDynBuilderError::MissingName)?;
+        if name.trim().is_empty() {
+            return Err(ToolDynBuilderError::EmptyName);
+        }
+        let description = self
+            .description
+            .ok_or(ToolDynBuilderError::MissingDescription)?;
+        let parameters = self
+            .parameters
+            .ok_or(ToolDynBuilderError::MissingParameters)?;
+        let call = self.call.ok_or(ToolDynBuilderError::MissingCall)?;
+        Ok(ToolDyn::from_runtime(
+            name,
+            Arc::new(DynamicToolRuntime {
+                description,
+                parameters,
+                call,
+            }),
+        ))
+    }
+}
+
+/// Error returned by [`ToolDynBuilder::build`].
+#[derive(Debug, thiserror::Error)]
+pub enum ToolDynBuilderError {
+    /// Tool name was not provided.
+    #[error("tool name is required")]
+    MissingName,
+    /// Tool name was empty or whitespace-only.
+    #[error("tool name must not be empty")]
+    EmptyName,
+    /// Tool description was not provided.
+    #[error("tool description is required")]
+    MissingDescription,
+    /// Tool parameters schema was not provided.
+    #[error("tool parameters are required")]
+    MissingParameters,
+    /// Tool call implementation was not provided.
+    #[error("tool call implementation is required")]
+    MissingCall,
+}
+
+/// Private nameless runtime for dynamically-dispatched tools.
+pub(crate) trait ToolRuntime: WasmCompatSend + WasmCompatSync {
+    fn description(&self) -> String;
+
+    fn parameters(&self) -> serde_json::Value;
+
+    fn call<'a>(&'a self, args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>>;
+
     fn call_with_extensions<'a>(
         &'a self,
         args: String,
@@ -303,24 +581,6 @@ pub trait ToolDyn: WasmCompatSend + WasmCompatSync {
         self.call(args)
     }
 
-    /// Execute the tool with per-call extensions, returning a structured
-    /// [`ToolExecutionResult`] (model output + [`ToolOutcome`] + result
-    /// extensions).
-    ///
-    /// This is the structured dynamic boundary the agent loop drives: the result
-    /// flows through to the
-    /// [`StepEvent::ToolResult`](crate::agent::StepEvent::ToolResult) hook event.
-    /// Unlike [`call`](Self::call) it never returns a bare error — a failure is
-    /// carried as [`ToolOutcome::Error`] inside the result, with the
-    /// model-visible message on [`ToolExecutionResult::model_output`].
-    ///
-    /// The default wraps [`call_with_extensions`](Self::call_with_extensions): an
-    /// `Ok` output becomes a [`ToolOutcome::Success`]; a [`ToolError`] is
-    /// classified ([`ToolError::JsonError`] as
-    /// [`ToolFailureKind::InvalidArgs`], otherwise [`ToolFailureKind::Other`]).
-    /// The blanket impl for [`Tool`] types overrides this to route through
-    /// [`Tool::call_structured`] and [`Tool::classify_error`]; a manual `ToolDyn`
-    /// impl should override it to emit precise outcomes (e.g. a real timeout).
     fn call_structured<'a>(
         &'a self,
         args: String,
@@ -335,80 +595,56 @@ pub trait ToolDyn: WasmCompatSend + WasmCompatSync {
     }
 }
 
-fn serialize_tool_output(output: impl Serialize) -> serde_json::Result<String> {
-    match serde_json::to_value(output)? {
-        serde_json::Value::String(text) => Ok(text),
-        value => Ok(value.to_string()),
-    }
+pub(crate) trait ToolEmbeddingRuntime: WasmCompatSend + WasmCompatSync {
+    fn context(&self) -> serde_json::Result<serde_json::Value>;
+
+    fn embedding_docs(&self) -> Vec<String>;
 }
 
-/// Deserialize JSON tool arguments, normalizing a bare `null` (which LLMs
-/// frequently send for tools whose arguments are all optional) to `{}`.
-///
-/// `serde_json::from_str::<T>("null")` fails for struct types even when every
-/// field is `Option<_>`, because JSON null does not deserialize to an empty
-/// object. Any args type that already accepts `null` (such as `()` or
-/// `Option<T>`) is preserved; the fallback to `{}` only applies after the
-/// original parse fails.
-fn parse_tool_args<A>(args: &str) -> serde_json::Result<A>
-where
-    A: for<'de> Deserialize<'de>,
-{
-    match serde_json::from_str(args) {
-        Ok(parsed) => Ok(parsed),
-        Err(err) if args.trim() == "null" => serde_json::from_str("{}").map_err(|_| err),
-        Err(err) => Err(err),
-    }
+struct DynamicToolRuntime {
+    description: String,
+    parameters: serde_json::Value,
+    call: Arc<DynamicCallFn>,
 }
 
-/// Map a [`ToolError`] surfaced by a string-returning [`ToolDyn`] path into a
-/// structured [`ToolExecutionResult`], classifying a JSON error as invalid
-/// arguments. Used by the default [`ToolDyn::call_structured`] for manual
-/// implementations that only provide the string [`ToolDyn::call`].
-fn tool_error_to_execution_result(err: ToolError) -> ToolExecutionResult {
-    let message = err.to_string();
-    let failure = match err {
-        ToolError::JsonError(_) => ToolFailure::invalid_args(message.clone()),
-        ToolError::ToolCallError(_) => ToolFailure::other(message.clone()),
-    };
-    ToolExecutionResult::failed(message, failure)
-}
-
-/// Generate a provider-facing [`ToolDefinition`] from a registered tool's
-/// flat metadata.
-///
-/// The tool name is always taken from [`ToolDyn::name`], making that registered
-/// name the single source of truth for provider advertisement and dispatch.
-pub fn tool_definition(tool: &dyn ToolDyn) -> ToolDefinition {
-    tool_definition_with_name(tool.name(), tool)
-}
-
-pub(crate) fn tool_definition_with_name(
-    name: impl Into<String>,
-    tool: &dyn ToolDyn,
-) -> ToolDefinition {
-    ToolDefinition {
-        name: name.into(),
-        description: tool.description(),
-        parameters: tool.parameters(),
-    }
-}
-
-impl<T: Tool> ToolDyn for T {
-    fn name(&self) -> String {
-        <Self as Tool>::name(self)
-    }
-
+impl ToolRuntime for DynamicToolRuntime {
     fn description(&self) -> String {
-        <Self as Tool>::description(self)
+        self.description.clone()
     }
 
     fn parameters(&self) -> serde_json::Value {
-        <Self as Tool>::parameters(self)
+        self.parameters.clone()
     }
 
     fn call<'a>(&'a self, args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
-        ToolDyn::call_with_extensions(self, args, &ToolCallExtensions::EMPTY)
+        self.call_with_extensions(args, &ToolCallExtensions::EMPTY)
+    }
+
+    fn call_with_extensions<'a>(
+        &'a self,
+        args: String,
+        extensions: &'a ToolCallExtensions,
+    ) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
+        self.call.call(args, extensions.clone())
+    }
+}
+
+struct TypedToolRuntime<T>(T);
+
+impl<T> ToolRuntime for TypedToolRuntime<T>
+where
+    T: Tool,
+{
+    fn description(&self) -> String {
+        self.0.description()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        self.0.parameters()
+    }
+
+    fn call<'a>(&'a self, args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
+        self.call_with_extensions(args, &ToolCallExtensions::EMPTY)
     }
 
     fn call_with_extensions<'a>(
@@ -418,7 +654,9 @@ impl<T: Tool> ToolDyn for T {
     ) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
         Box::pin(async move {
             match parse_tool_args::<T::Args>(&args) {
-                Ok(args) => <Self as Tool>::call_with_extensions(self, args, extensions)
+                Ok(args) => self
+                    .0
+                    .call_with_extensions(args, extensions)
                     .await
                     .map_err(|e| ToolError::ToolCallError(Box::new(e)))
                     .and_then(|output| serialize_tool_output(output).map_err(ToolError::JsonError)),
@@ -428,11 +666,7 @@ impl<T: Tool> ToolDyn for T {
     }
 
     /// Routes through [`Tool::call_structured`] so rich returns
-    /// ([`ToolReturn`]) and [`Tool::classify_error`] are honored: a JSON
-    /// argument parse failure becomes an
-    /// [`InvalidArgs`](ToolFailureKind::InvalidArgs) outcome, a returned
-    /// `Err(Self::Error)` is classified, and a successful [`ToolReturn`] is
-    /// serialized while preserving its outcome and extensions.
+    /// ([`ToolReturn`]) and [`Tool::classify_error`] are honored.
     fn call_structured<'a>(
         &'a self,
         args: String,
@@ -448,10 +682,10 @@ impl<T: Tool> ToolDyn for T {
                     );
                 }
             };
-            match <Self as Tool>::call_structured(self, parsed, extensions).await {
+            match self.0.call_structured(parsed, extensions).await {
                 Ok(tool_return) => tool_return.into_execution_result(),
                 Err(err) => {
-                    let failure = self.classify_error(&err);
+                    let failure = self.0.classify_error(&err);
                     ToolExecutionResult::failed(err.to_string(), failure)
                 }
             }
@@ -459,50 +693,35 @@ impl<T: Tool> ToolDyn for T {
     }
 }
 
+impl<T> ToolEmbeddingRuntime for TypedToolRuntime<T>
+where
+    T: ToolEmbedding,
+{
+    fn context(&self) -> serde_json::Result<serde_json::Value> {
+        serde_json::to_value(self.0.context())
+    }
+
+    fn embedding_docs(&self) -> Vec<String> {
+        self.0.embedding_docs()
+    }
+}
+
 #[cfg(feature = "rmcp")]
 #[cfg_attr(docsrs, doc(cfg(feature = "rmcp")))]
 pub mod rmcp;
 
-/// Wrapper trait to allow for dynamic dispatch of raggable tools
-pub trait ToolEmbeddingDyn: ToolDyn {
-    /// Serializes context needed to reconstruct this dynamic tool.
-    fn context(&self) -> serde_json::Result<serde_json::Value>;
-
-    /// Returns text fragments used to retrieve this tool from a vector store.
-    fn embedding_docs(&self) -> Vec<String>;
-}
-
-impl<T> ToolEmbeddingDyn for T
-where
-    T: ToolEmbedding + 'static,
-{
-    fn context(&self) -> serde_json::Result<serde_json::Value> {
-        serde_json::to_value(self.context())
-    }
-
-    fn embedding_docs(&self) -> Vec<String> {
-        self.embedding_docs()
-    }
-}
-
 #[derive(Clone)]
 pub(crate) enum ToolType {
-    Simple(Arc<dyn ToolDyn>),
-    Embedding(Arc<dyn ToolEmbeddingDyn>),
+    Simple(Arc<ToolDyn>),
+    Embedding(Arc<ToolDyn>),
 }
 
 impl ToolType {
-    pub fn name(&self) -> String {
-        match self {
-            ToolType::Simple(tool) => tool.name(),
-            ToolType::Embedding(tool) => tool.name(),
-        }
-    }
-
     pub fn definition_with_name(&self, name: impl Into<String>) -> ToolDefinition {
         match self {
-            ToolType::Simple(tool) => tool_definition_with_name(name, &**tool),
-            ToolType::Embedding(tool) => tool_definition_with_name(name, &**tool),
+            ToolType::Simple(tool) | ToolType::Embedding(tool) => {
+                tool_definition_with_name(name, tool)
+            }
         }
     }
 
@@ -512,8 +731,9 @@ impl ToolType {
         extensions: &ToolCallExtensions,
     ) -> Result<String, ToolError> {
         match self {
-            ToolType::Simple(tool) => tool.call_with_extensions(args, extensions).await,
-            ToolType::Embedding(tool) => tool.call_with_extensions(args, extensions).await,
+            ToolType::Simple(tool) | ToolType::Embedding(tool) => {
+                tool.call_with_extensions(args, extensions).await
+            }
         }
     }
 
@@ -524,8 +744,9 @@ impl ToolType {
         extensions: &ToolCallExtensions,
     ) -> ToolExecutionResult {
         match self {
-            ToolType::Simple(tool) => tool.call_structured(args, extensions).await,
-            ToolType::Embedding(tool) => tool.call_structured(args, extensions).await,
+            ToolType::Simple(tool) | ToolType::Embedding(tool) => {
+                tool.call_structured(args, extensions).await
+            }
         }
     }
 }
@@ -562,7 +783,7 @@ pub struct ToolSet {
 
 impl ToolSet {
     /// Create a new ToolSet from a list of tools
-    pub fn from_tools(tools: Vec<impl ToolDyn + 'static>) -> Self {
+    pub fn from_tools(tools: Vec<impl Into<ToolDyn>>) -> Self {
         let mut toolset = Self::default();
         tools.into_iter().for_each(|tool| {
             toolset.add_tool(tool);
@@ -570,13 +791,18 @@ impl ToolSet {
         toolset
     }
 
-    /// Create a new `ToolSet` from boxed dynamically-dispatched tools.
-    pub fn from_tools_boxed(tools: Vec<Box<dyn ToolDyn + 'static>>) -> Self {
+    /// Create a new `ToolSet` from complete dynamically-dispatched tools.
+    pub fn from_tools_dyn(tools: Vec<ToolDyn>) -> Self {
         let mut toolset = Self::default();
         tools.into_iter().for_each(|tool| {
-            toolset.add_tool_boxed(tool);
+            toolset.add_tool(tool);
         });
         toolset
+    }
+
+    /// Create a new `ToolSet` from complete dynamically-dispatched tools.
+    pub fn from_tools_boxed(tools: Vec<ToolDyn>) -> Self {
+        Self::from_tools_dyn(tools)
     }
 
     /// Create a toolset builder
@@ -590,18 +816,26 @@ impl ToolSet {
     }
 
     /// Add a tool to the toolset, returning the registered key used for it.
-    pub fn add_tool(&mut self, tool: impl ToolDyn + 'static) -> String {
-        self.insert(ToolType::Simple(Arc::new(tool)))
+    pub fn add_tool(&mut self, tool: impl Into<ToolDyn>) -> String {
+        let tool = tool.into();
+        let kind = if tool.embedding().is_some() {
+            ToolType::Embedding(Arc::new(tool))
+        } else {
+            ToolType::Simple(Arc::new(tool))
+        };
+        self.insert(kind)
     }
 
-    /// Adds a boxed tool to the toolset. Useful for situations when dynamic dispatch is required.
+    /// Adds a dynamic tool to the toolset. Useful for situations when dynamic dispatch is required.
     /// Returns the registered key used for the tool.
-    pub fn add_tool_boxed(&mut self, tool: Box<dyn ToolDyn>) -> String {
-        self.insert(ToolType::Simple(Arc::from(tool)))
+    pub fn add_tool_boxed(&mut self, tool: ToolDyn) -> String {
+        self.add_tool(tool)
     }
 
     pub(crate) fn insert(&mut self, tool: ToolType) -> String {
-        let name = tool.name();
+        let name = match &tool {
+            ToolType::Simple(tool) | ToolType::Embedding(tool) => tool.name().to_string(),
+        };
         self.insert_with_name(name, tool)
     }
 
@@ -738,7 +972,7 @@ impl ToolSet {
         self.ordered_entries()
             .filter_map(|(name, tool_type)| {
                 if let ToolType::Embedding(tool) = tool_type {
-                    Some(ToolSchema::from_tool(name.clone(), &**tool))
+                    Some(ToolSchema::from_tool(name.clone(), tool))
                 } else {
                     None
                 }
@@ -755,14 +989,18 @@ pub struct ToolSetBuilder {
 
 impl ToolSetBuilder {
     /// Add a regular tool that is always available when the set is used.
-    pub fn static_tool(mut self, tool: impl ToolDyn + 'static) -> Self {
-        self.tools.push(ToolType::Simple(Arc::new(tool)));
+    pub fn static_tool(mut self, tool: impl Into<ToolDyn>) -> Self {
+        self.tools.push(ToolType::Simple(Arc::new(tool.into())));
         self
     }
 
     /// Add a tool that can be represented as embeddings for dynamic retrieval.
-    pub fn dynamic_tool(mut self, tool: impl ToolEmbeddingDyn + 'static) -> Self {
-        self.tools.push(ToolType::Embedding(Arc::new(tool)));
+    pub fn dynamic_tool<T>(mut self, tool: T) -> Self
+    where
+        T: ToolEmbedding + 'static,
+    {
+        self.tools
+            .push(ToolType::Embedding(Arc::new(ToolDyn::from_embedding(tool))));
         self
     }
 
@@ -845,37 +1083,20 @@ mod tests {
         );
     }
 
-    /// A tool whose name and definition are chosen at runtime, for ordering
-    /// and duplicate-registration tests.
-    struct NamedTool {
-        name: String,
-        description: String,
-    }
-
-    impl ToolDyn for NamedTool {
-        fn name(&self) -> String {
-            self.name.clone()
-        }
-
-        fn description(&self) -> String {
-            self.description.clone()
-        }
-
-        fn parameters(&self) -> serde_json::Value {
-            json!({ "type": "object", "properties": {} })
-        }
-
-        fn call(&self, _args: String) -> WasmBoxedFuture<'_, Result<String, ToolError>> {
-            let output = format!("called {}", self.description);
-            Box::pin(async move { Ok(output) })
-        }
-    }
-
-    fn named_tool(name: &str, description: &str) -> NamedTool {
-        NamedTool {
-            name: name.to_string(),
-            description: description.to_string(),
-        }
+    /// A dynamic tool whose name and definition are chosen at construction time,
+    /// for ordering and duplicate-registration tests.
+    fn named_tool(name: &str, description: &str) -> ToolDyn {
+        let description = description.to_string();
+        ToolDyn::builder()
+            .name(name)
+            .description(description.clone())
+            .parameters(json!({ "type": "object", "properties": {} }))
+            .call(move |_args, _extensions| {
+                let output = format!("called {description}");
+                async move { Ok(output) }
+            })
+            .build()
+            .expect("test dynamic tool should build")
     }
 
     #[test]
@@ -910,37 +1131,8 @@ mod tests {
 
     #[tokio::test]
     async fn registered_name_is_definition_source_of_truth() {
-        use std::sync::atomic::{AtomicUsize, Ordering};
-
-        struct ChangingNameTool {
-            calls: AtomicUsize,
-        }
-
-        impl ToolDyn for ChangingNameTool {
-            fn name(&self) -> String {
-                match self.calls.fetch_add(1, Ordering::SeqCst) {
-                    0 => "registered".to_string(),
-                    _ => "changed".to_string(),
-                }
-            }
-
-            fn description(&self) -> String {
-                "changes name after registration".to_string()
-            }
-
-            fn parameters(&self) -> serde_json::Value {
-                json!({ "type": "object", "properties": {} })
-            }
-
-            fn call(&self, _args: String) -> WasmBoxedFuture<'_, Result<String, ToolError>> {
-                Box::pin(async { Ok("ok".to_string()) })
-            }
-        }
-
         let mut toolset = ToolSet::default();
-        toolset.add_tool(ChangingNameTool {
-            calls: AtomicUsize::new(0),
-        });
+        toolset.add_tool(named_tool("registered", "stable dynamic tool"));
 
         let defs = toolset.get_tool_definitions().unwrap();
         assert_eq!(defs[0].name, "registered");
@@ -948,33 +1140,21 @@ mod tests {
         let docs = toolset.documents().await.unwrap();
         assert_eq!(docs[0].id, "registered");
         assert!(docs[0].text.contains("registered"));
-        assert!(!docs[0].text.contains("changed"));
     }
 
     #[test]
     fn dynamic_tool_schemas_use_registered_name() {
-        use std::sync::atomic::{AtomicUsize, Ordering};
-
         #[derive(Debug, thiserror::Error)]
         #[error("init error")]
         struct InitError;
 
-        struct ChangingDynamicTool {
-            calls: AtomicUsize,
-        }
+        struct ChangingDynamicTool;
 
         impl Tool for ChangingDynamicTool {
-            const NAME: &'static str = "unused";
+            const NAME: &'static str = "registered_dynamic";
             type Error = MockToolError;
             type Args = serde_json::Value;
             type Output = String;
-
-            fn name(&self) -> String {
-                match self.calls.fetch_add(1, Ordering::SeqCst) {
-                    0 => "registered_dynamic".to_string(),
-                    _ => "changed_dynamic".to_string(),
-                }
-            }
 
             fn description(&self) -> String {
                 "dynamic tool".to_string()
@@ -1001,17 +1181,11 @@ mod tests {
             fn context(&self) -> Self::Context {}
 
             fn init(_state: Self::State, _context: Self::Context) -> Result<Self, Self::InitError> {
-                Ok(Self {
-                    calls: AtomicUsize::new(0),
-                })
+                Ok(Self)
             }
         }
 
-        let toolset = ToolSet::builder()
-            .dynamic_tool(ChangingDynamicTool {
-                calls: AtomicUsize::new(0),
-            })
-            .build();
+        let toolset = ToolSet::builder().dynamic_tool(ChangingDynamicTool).build();
 
         let schemas = toolset.schemas().unwrap();
         assert_eq!(schemas.len(), 1);

--- a/crates/rig-core/src/tool/rmcp.rs
+++ b/crates/rig-core/src/tool/rmcp.rs
@@ -59,6 +59,7 @@ use crate::completion::ToolDefinition;
 use crate::tool::server::{ToolServerError, ToolServerHandle};
 use crate::tool::{
     ToolCallExtensions, ToolDyn, ToolError, ToolExecutionResult, ToolFailure, ToolFailureKind,
+    ToolRuntime,
 };
 use crate::wasm_compat::WasmBoxedFuture;
 
@@ -344,11 +345,14 @@ impl McpTool {
     }
 }
 
-impl ToolDyn for McpTool {
-    fn name(&self) -> String {
-        self.definition.name.to_string()
+impl From<McpTool> for ToolDyn {
+    fn from(tool: McpTool) -> Self {
+        let name = tool.definition.name.to_string();
+        ToolDyn::from_runtime(name, Arc::new(tool))
     }
+}
 
+impl ToolRuntime for McpTool {
     fn description(&self) -> String {
         self.definition
             .description
@@ -369,7 +373,7 @@ impl ToolDyn for McpTool {
     /// as the MCP request's `_meta`. This lets callers attach per-call metadata
     /// (auth, session, A2A `context_id`/`task_id`) to MCP tool invocations
     /// without exposing it to the model. Absent a `Meta`, behaves like
-    /// [`call`](ToolDyn::call).
+    /// [`ToolDyn::call`].
     fn call_with_extensions<'a>(
         &'a self,
         args: String,
@@ -581,7 +585,7 @@ mod tests {
     use tokio::sync::RwLock;
 
     use super::McpClientHandler;
-    use crate::tool::server::ToolServer;
+    use crate::tool::{ToolDyn, ToolRuntime, server::ToolServer};
 
     /// An MCP server whose tool list can be swapped at runtime.
     #[derive(Clone)]
@@ -801,7 +805,7 @@ mod tests {
     #[tokio::test]
     async fn mcp_tool_exposes_flattened_metadata() {
         use super::McpTool;
-        use crate::tool::{ToolDyn, tool_definition};
+        use crate::tool::tool_definition;
 
         let mut schema = serde_json::Map::new();
         schema.insert("type".to_string(), json!("object"));
@@ -830,7 +834,7 @@ mod tests {
             .serve((client_from_server, client_to_server))
             .await
             .expect("client connect failed");
-        let mcp_tool = McpTool::from_mcp_server(server_tool, client.peer().clone());
+        let mcp_tool: ToolDyn = McpTool::from_mcp_server(server_tool, client.peer().clone()).into();
         let definition = tool_definition(&mcp_tool);
 
         assert_eq!(mcp_tool.name(), "search_docs");
@@ -862,7 +866,6 @@ mod tests {
     #[tokio::test]
     async fn mcp_tool_call_without_timeout_is_unbounded() {
         use super::McpTool;
-        use crate::tool::ToolDyn;
 
         let (client_to_server, server_from_client) = tokio::io::duplex(8192);
         let (server_to_client, client_from_server) = tokio::io::duplex(8192);
@@ -918,7 +921,6 @@ mod tests {
     #[tokio::test]
     async fn mcp_tool_call_with_timeout_errors_instead_of_hanging() {
         use super::McpTool;
-        use crate::tool::ToolDyn;
 
         let (client_to_server, server_from_client) = tokio::io::duplex(8192);
         let (server_to_client, client_from_server) = tokio::io::duplex(8192);
@@ -972,7 +974,6 @@ mod tests {
     #[tokio::test]
     async fn mcp_tool_call_returns_promptly_for_responsive_server() {
         use super::McpTool;
-        use crate::tool::ToolDyn;
 
         let server = DynamicToolServer::new(vec![make_tool("ping", "responds immediately")]);
 
@@ -1143,7 +1144,7 @@ mod tests {
     #[tokio::test]
     async fn mcp_tool_forwards_meta_from_context() {
         use super::McpTool;
-        use crate::tool::{ToolCallExtensions, ToolDyn};
+        use crate::tool::ToolCallExtensions;
 
         let seen_meta = Arc::new(RwLock::new(None));
         let server = MetaCapturingServer {
@@ -1256,7 +1257,7 @@ mod tests {
     #[tokio::test]
     async fn mcp_tool_invalid_json_args_short_circuit_as_invalid_args() {
         use super::McpTool;
-        use crate::tool::{ToolCallExtensions, ToolDyn, ToolFailureKind, ToolOutcome};
+        use crate::tool::{ToolCallExtensions, ToolFailureKind, ToolOutcome};
 
         let (client_to_server, server_from_client) = tokio::io::duplex(8192);
         let (server_to_client, client_from_server) = tokio::io::duplex(8192);

--- a/crates/rig-core/src/tool/server.rs
+++ b/crates/rig-core/src/tool/server.rs
@@ -152,9 +152,9 @@ pub struct ToolServerHandle(Arc<RwLock<ToolServerState>>);
 impl ToolServerHandle {
     /// Register a new static tool. Re-registering an existing name replaces
     /// the implementation (last wins) and keeps its position.
-    pub async fn add_tool(&self, tool: impl ToolDyn + 'static) -> Result<(), ToolServerError> {
+    pub async fn add_tool(&self, tool: impl Into<ToolDyn>) -> Result<(), ToolServerError> {
         let mut state = self.0.write().await;
-        let toolname = state.toolset.add_tool_boxed(Box::new(tool));
+        let toolname = state.toolset.add_tool_boxed(tool.into());
         push_unique_name(&mut state.static_tool_names, toolname);
         Ok(())
     }
@@ -376,13 +376,7 @@ pub enum ToolServerError {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        sync::{
-            Arc,
-            atomic::{AtomicUsize, Ordering},
-        },
-        time::Duration,
-    };
+    use std::{sync::Arc, time::Duration};
 
     use crate::{
         test_utils::{
@@ -392,30 +386,19 @@ mod tests {
         tool::{Tool, ToolEmbedding, ToolSet, server::ToolServer},
     };
 
-    struct ChangingNameTool {
-        calls: AtomicUsize,
-    }
+    struct ChangingNameTool;
 
     impl ChangingNameTool {
         fn new() -> Self {
-            Self {
-                calls: AtomicUsize::new(0),
-            }
+            Self
         }
     }
 
     impl Tool for ChangingNameTool {
-        const NAME: &'static str = "unused";
+        const NAME: &'static str = "registered_changing";
         type Error = MockToolError;
         type Args = serde_json::Value;
         type Output = String;
-
-        fn name(&self) -> String {
-            match self.calls.fetch_add(1, Ordering::SeqCst) {
-                0 => "registered_changing".to_string(),
-                _ => "changed_after_registration".to_string(),
-            }
-        }
 
         fn description(&self) -> String {
             "changes name after registration".to_string()

--- a/crates/rig-core/src/tools/think.rs
+++ b/crates/rig-core/src/tools/think.rs
@@ -64,11 +64,11 @@ impl Tool for ThinkTool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tool::tool_definition;
+    use crate::tool::{ToolDyn, tool_definition};
 
     #[test]
     fn test_think_tool_definition() {
-        let tool = ThinkTool;
+        let tool = ToolDyn::from(ThinkTool);
         let definition = tool_definition(&tool);
 
         assert_eq!(definition.name, "think");

--- a/crates/rig-derive/src/lib.rs
+++ b/crates/rig-derive/src/lib.rs
@@ -539,10 +539,6 @@ pub fn rig_tool(args: TokenStream, input: TokenStream) -> TokenStream {
             type Output = #output_type;
             type Error = #error_type;
 
-            fn name(&self) -> String {
-                #tool_name.to_string()
-            }
-
             fn description(&self) -> String {
                 #tool_description.to_string()
             }

--- a/crates/rig-derive/tests/calculator.rs
+++ b/crates/rig-derive/tests/calculator.rs
@@ -69,8 +69,9 @@ fn sync_calculator(x: i32, y: i32, operation: String) -> Result<i32, rig_core::t
 async fn test_calculator_tool() {
     let calculator = Calculator;
 
-    let definition = rig_core::tool::tool_definition(&calculator);
-    assert_eq!(calculator.name(), "calculator");
+    let dynamic_calculator = rig_core::tool::ToolDyn::from(Calculator);
+    let definition = rig_core::tool::tool_definition(&dynamic_calculator);
+    assert_eq!(dynamic_calculator.name(), "calculator");
     assert_eq!(
         definition.description,
         "Perform basic arithmetic operations"

--- a/crates/rig-derive/tests/custom_name.rs
+++ b/crates/rig-derive/tests/custom_name.rs
@@ -6,7 +6,7 @@
     clippy::unreachable
 )]
 
-use rig_core::tool::Tool;
+use rig_core::tool::{Tool, ToolDyn};
 use rig_derive::rig_tool;
 
 #[rig_tool(name = "search-docs")]
@@ -21,7 +21,7 @@ fn fallback_name_tool() -> Result<String, rig_core::tool::ToolError> {
 
 #[tokio::test]
 async fn test_custom_tool_name_overrides_function_name() {
-    let tool = SearchDocsImpl;
+    let tool = ToolDyn::from(SearchDocsImpl);
     let definition = rig_core::tool::tool_definition(&tool);
 
     assert_eq!(SearchDocsImpl::NAME, "search-docs");
@@ -31,7 +31,7 @@ async fn test_custom_tool_name_overrides_function_name() {
 
 #[tokio::test]
 async fn test_tool_name_falls_back_to_function_name() {
-    let tool = FallbackNameTool;
+    let tool = ToolDyn::from(FallbackNameTool);
     let definition = rig_core::tool::tool_definition(&tool);
 
     assert_eq!(FallbackNameTool::NAME, "fallback_name_tool");

--- a/examples/README.md
+++ b/examples/README.md
@@ -30,7 +30,7 @@ Most examples expect provider API keys in the environment (e.g. `OPENAI_API_KEY`
 | `agent_with_memory_streaming` | Demonstrates Rig-managed conversation memory with streaming. |
 | `agent_with_memory` | Demonstrates Rig-managed conversation memory with an in-memory backend. |
 | `agent_with_tools_otel` | Agent multi-turn with tools, but with a tracing subscriber that sends all logs/traces to an OTel collector. |
-| `agent_with_tools` | Demonstrates registering boxed tools on an agent. |
+| `agent_with_tools` | Demonstrates registering dynamic tools on an agent. |
 | `agent` | Demonstrates the smallest useful agent setup with OpenAI. |
 | `calculator_chatbot` | See source. |
 | `chain` | Demonstrates a retrieval-augmented pipeline with `parallel!` and `lookup`. |

--- a/examples/agent_with_tools/src/main.rs
+++ b/examples/agent_with_tools/src/main.rs
@@ -1,4 +1,4 @@
-//! Demonstrates registering boxed tools on an agent.
+//! Demonstrates registering dynamic tools on an agent.
 //! Requires `OPENAI_API_KEY`.
 //! Run it to see the model use arithmetic tools instead of answering from scratch.
 
@@ -79,8 +79,8 @@ impl Tool for Subtract {
     }
 }
 
-fn boxed_tools() -> Vec<Box<dyn ToolDyn>> {
-    vec![Box::new(Add), Box::new(Subtract)]
+fn dynamic_tools() -> Vec<ToolDyn> {
+    vec![ToolDyn::from(Add), ToolDyn::from(Subtract)]
 }
 
 #[tokio::main]
@@ -91,7 +91,7 @@ async fn main() -> Result<()> {
             "You are a calculator here to help the user perform arithmetic operations. \
              You must use the provided tools before answering.",
         )
-        .tools(boxed_tools())
+        .tools(dynamic_tools())
         .max_tokens(1024)
         .build();
 

--- a/examples/multi_agent/src/main.rs
+++ b/examples/multi_agent/src/main.rs
@@ -84,7 +84,7 @@ async fn main() -> Result<(), anyhow::Error> {
             When you receive input that is not in English, or contains grammatical errors \
             use the {} tool first to ensure proper English, then provide your response. \
             Always show both the translated text and your final response.",
-            translator_tool.name()
+            "translator"
         ))
         .tool(translator_tool)
         .build();


### PR DESCRIPTION
## Summary
- make `Tool` identity structural by keeping typed tools on `Tool::NAME` and replacing the public object-safe `ToolDyn` trait with a concrete named dynamic tool value
- move execution behind nameless runtime internals, preserving structured/extension-aware calls and embedding metadata
- update tool registration, MCP tools, derive output, examples, and regressions to use stored/registered tool names

Closes #2031.

## Verification
- `cargo fmt`
- `cargo check -p rig-core --all-targets --all-features`
- `cargo check --workspace --all-targets --all-features`
- `cargo clippy --all-targets --all-features`
- `cargo test -p rig-derive`
- `cargo test --doc --workspace --all-features`
- `cargo test -p rig-core --lib agent::tool::tests::context_propagates_into_sub_agent --all-features`

Note: `cargo test -p rig-core --lib --all-features` was run; all tool-related tests passed, but it currently fails on unrelated `providers::gemini::image_generation::tests::image_generation_2xx_error_envelope_preserves_status_and_body` with `expected ProviderResponse, got ResponseError("Gemini image generation response did not include image data")`.
