### PR TITLE
Refactor tool identity around registered keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- *(tool)* [**breaking**] flatten `Tool` / `ToolDyn` metadata: tool authors now implement `description()` and `parameters()` directly, and `Tool::definition(prompt)` / `ToolDyn::definition(prompt)` are removed. `ToolDefinition` remains a provider/request artifact generated from registered tools, with `Tool::NAME` / `Tool::name()` / `ToolDyn::name()` as the single source of truth for advertised and dispatched tool names.
+- *(tool)* [**breaking**] make tool identity single-source: `Tool::name()`, the object-safe `ToolDyn` trait, and runtime `ToolType::name()` are removed. Typed tools use `Tool::NAME`; dynamic tools are complete `ToolDyn` values built with `ToolDyn::builder()`/`ToolDyn::from_tool()`, and once registered the `ToolSet` `IndexMap` key is the only source for provider definitions, schemas, and dispatch. `ToolDefinition` remains a provider/request artifact generated from registered tools.
 
 ## [0.39.0](https://github.com/0xPlaygrounds/rig/compare/v0.38.2...v0.39.0) - 2026-06-19
 

--- a/crates/rig-core/CHANGELOG.md
+++ b/crates/rig-core/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- *(tool)* [**breaking**] flatten `Tool` and `ToolDyn`: tool implementations now provide `description()` and `parameters()` directly, while provider-facing `ToolDefinition`s are generated at registration/request boundaries. `Tool::definition(prompt)` and `ToolDyn::definition(prompt)` are removed, and the registered `Tool::NAME` / `Tool::name()` / `ToolDyn::name()` is the only advertised dispatch identity.
+- *(tool)* [**breaking**] make tool identity single-source: `Tool::name()`, the object-safe `ToolDyn` trait, and runtime `ToolType::name()` are removed. Typed tools use `Tool::NAME`; dynamic tools are complete `ToolDyn` values built with `ToolDyn::builder()`/`ToolDyn::from_tool()`, and once registered the `ToolSet` `IndexMap` key is the only source for provider definitions, schemas, and dispatch. `ToolDefinition` remains a provider/request artifact generated from registered tools.
 
 ### Added
 

--- a/crates/rig-core/src/agent/builder.rs
+++ b/crates/rig-core/src/agent/builder.rs
@@ -8,7 +8,7 @@ use crate::{
     memory::ConversationMemory,
     message::ToolChoice,
     tool::{
-        Tool, ToolDyn, ToolSet,
+        IntoToolDyn, ToolDyn, ToolSet,
         server::{ToolServer, ToolServerHandle},
     },
     vector_store::VectorStoreIndexDyn,
@@ -21,20 +21,19 @@ use crate::tool::rmcp::McpTool as RmcpTool;
 use super::{Agent, OutputMode};
 
 /// Build [`RmcpTool`]s from MCP tool definitions, applying the given per-call
-/// timeout to each (`None` disables it; see issue #1914). Returns
-/// `(tool_name, tool)` pairs.
+/// timeout to each (`None` disables it; see issue #1914).
 #[cfg(feature = "rmcp")]
 fn build_rmcp_tools(
     tools: Vec<rmcp::model::Tool>,
     client: rmcp::service::ServerSink,
     timeout: Option<std::time::Duration>,
-) -> Vec<(String, RmcpTool)> {
+) -> Vec<ToolDyn> {
     tools
         .into_iter()
         .map(|tool| {
-            let name = tool.name.to_string();
-            let rmcp_tool = RmcpTool::from_mcp_server(tool, client.clone()).with_timeout(timeout);
-            (name, rmcp_tool)
+            crate::tool::IntoToolDyn::into_tool_dyn(
+                RmcpTool::from_mcp_server(tool, client.clone()).with_timeout(timeout),
+            )
         })
         .collect()
 }
@@ -350,8 +349,9 @@ where
     ///
     /// This transitions the builder to the `WithBuilderTools` state, where
     /// additional tools can be added but `tool_server_handle()` is no longer available.
-    pub fn tool(self, tool: impl Tool + 'static) -> AgentBuilder<M, WithBuilderTools> {
-        let toolname = tool.name();
+    pub fn tool(self, tool: impl IntoToolDyn) -> AgentBuilder<M, WithBuilderTools> {
+        let mut tools = ToolSet::default();
+        let toolname = tools.add_tool(tool);
         AgentBuilder {
             name: self.name,
             description: self.description,
@@ -366,7 +366,7 @@ where
             default_max_turns: self.default_max_turns,
             tool_state: WithBuilderTools {
                 static_tools: vec![toolname],
-                tools: ToolSet::from_tools(vec![tool]),
+                tools,
                 dynamic_tools: vec![],
             },
             hooks: self.hooks,
@@ -377,13 +377,13 @@ where
         }
     }
 
-    /// Add a vector of boxed static tools to the agent.
+    /// Add a vector of dynamic static tools to the agent.
     ///
-    /// This is useful when you need to dynamically add static tools to the agent.
+    /// This is useful when you need to dynamically assemble static tools for the agent.
     /// Transitions the builder to the `WithBuilderTools` state.
-    pub fn tools(self, tools: Vec<Box<dyn ToolDyn>>) -> AgentBuilder<M, WithBuilderTools> {
-        let static_tools = tools.iter().map(|tool| tool.name()).collect();
-        let tools = ToolSet::from_tools_boxed(tools);
+    pub fn tools(self, tools: Vec<ToolDyn>) -> AgentBuilder<M, WithBuilderTools> {
+        let tools = ToolSet::from_tools_dyn(tools);
+        let static_tools = tools.ordered_names().cloned().collect();
 
         AgentBuilder {
             name: self.name,
@@ -480,11 +480,9 @@ where
     /// Transition into the `WithBuilderTools` state carrying the given built
     /// MCP tools.
     #[cfg(feature = "rmcp")]
-    fn with_rmcp_toolset(
-        self,
-        built: Vec<(String, RmcpTool)>,
-    ) -> AgentBuilder<M, WithBuilderTools> {
-        let (static_tools, toolset): (Vec<String>, Vec<RmcpTool>) = built.into_iter().unzip();
+    fn with_rmcp_toolset(self, built: Vec<ToolDyn>) -> AgentBuilder<M, WithBuilderTools> {
+        let toolset = ToolSet::from_tools_dyn(built);
+        let static_tools = toolset.ordered_names().cloned().collect();
 
         AgentBuilder {
             name: self.name,
@@ -505,7 +503,7 @@ where
             default_conversation_id: self.default_conversation_id,
             tool_state: WithBuilderTools {
                 static_tools,
-                tools: ToolSet::from_tools(toolset),
+                tools: toolset,
                 dynamic_tools: vec![],
             },
         }
@@ -607,17 +605,16 @@ where
     M: CompletionModel,
 {
     /// Add another static tool to the agent.
-    pub fn tool(mut self, tool: impl Tool + 'static) -> Self {
-        let toolname = tool.name();
-        self.tool_state.tools.add_tool(tool);
+    pub fn tool(mut self, tool: impl IntoToolDyn) -> Self {
+        let toolname = self.tool_state.tools.add_tool(tool);
         self.tool_state.static_tools.push(toolname);
         self
     }
 
-    /// Add a vector of boxed static tools to the agent.
-    pub fn tools(mut self, tools: Vec<Box<dyn ToolDyn>>) -> Self {
-        let toolnames: Vec<String> = tools.iter().map(|tool| tool.name()).collect();
-        let tools = ToolSet::from_tools_boxed(tools);
+    /// Add a vector of dynamic static tools to the agent.
+    pub fn tools(mut self, tools: Vec<ToolDyn>) -> Self {
+        let tools = ToolSet::from_tools_dyn(tools);
+        let toolnames: Vec<String> = tools.ordered_names().cloned().collect();
         self.tool_state.tools.add_tools(tools);
         self.tool_state.static_tools.extend(toolnames);
         self
@@ -655,10 +652,10 @@ where
     }
 
     #[cfg(feature = "rmcp")]
-    fn add_rmcp_tools(mut self, built: Vec<(String, RmcpTool)>) -> Self {
-        for (name, tool) in built {
+    fn add_rmcp_tools(mut self, built: Vec<ToolDyn>) -> Self {
+        for tool in built {
+            let name = self.tool_state.tools.add_tool(tool);
             self.tool_state.static_tools.push(name);
-            self.tool_state.tools.add_tool(tool);
         }
 
         self
@@ -737,8 +734,6 @@ mod tests {
     #[cfg(feature = "rmcp")]
     #[tokio::test]
     async fn build_rmcp_tools_threads_timeout_into_built_tools() {
-        use crate::tool::ToolDyn;
-        use crate::tool::rmcp::DEFAULT_MCP_TOOL_TIMEOUT;
         use rmcp::model::{
             CallToolRequestParams, CallToolResult, ClientInfo, ErrorData, Implementation,
             ProtocolVersion, ServerCapabilities, ServerInfo, Tool,
@@ -785,27 +780,15 @@ mod tests {
             .expect("client connect");
         let peer = client.peer().clone();
 
-        // The configured timeout (default, explicit, or disabled) is threaded
-        // onto each built tool.
-        let built_default = build_rmcp_tools(
-            vec![tool("a")],
-            peer.clone(),
-            Some(DEFAULT_MCP_TOOL_TIMEOUT),
-        );
-        assert_eq!(built_default[0].1.timeout(), Some(DEFAULT_MCP_TOOL_TIMEOUT));
-        let built_none = build_rmcp_tools(vec![tool("b")], peer.clone(), None);
-        assert_eq!(built_none[0].1.timeout(), None);
-
-        // ...and the threaded timeout actually bounds a hanging call.
+        // The configured timeout is threaded onto the built tool and bounds a hanging call.
         let built = build_rmcp_tools(
             vec![tool("hang_forever")],
-            peer,
+            peer.clone(),
             Some(Duration::from_millis(200)),
         );
         assert_eq!(built.len(), 1);
-        assert_eq!(built[0].0, "hang_forever");
         let timed =
-            tokio::time::timeout(Duration::from_secs(5), built[0].1.call("{}".to_string())).await;
+            tokio::time::timeout(Duration::from_secs(5), built[0].call("{}".to_string())).await;
         let err = timed
             .expect("built tool hung past the safety timeout")
             .expect_err("call should time out");

--- a/crates/rig-core/src/agent/tool.rs
+++ b/crates/rig-core/src/agent/tool.rs
@@ -1,7 +1,7 @@
 use crate::{
     agent::Agent,
-    completion::{CompletionModel, Prompt, PromptError},
-    tool::{Tool, ToolCallExtensions},
+    completion::{CompletionModel, Prompt},
+    tool::{IntoToolDyn, ToolCallExtensions, ToolDyn, ToolError, ToolRuntime},
 };
 use schemars::{JsonSchema, schema_for};
 use serde::{Deserialize, Serialize};
@@ -13,14 +13,14 @@ pub struct AgentToolArgs {
     prompt: String,
 }
 
-impl<M: CompletionModel + 'static> Tool for Agent<M> {
-    const NAME: &'static str = "agent_tool";
+impl<M: CompletionModel + 'static> Agent<M> {
+    fn agent_tool_name(&self) -> String {
+        self.name
+            .clone()
+            .unwrap_or_else(|| "agent_tool".to_string())
+    }
 
-    type Error = PromptError;
-    type Args = AgentToolArgs;
-    type Output = String;
-
-    fn description(&self) -> String {
+    fn agent_tool_description(&self) -> String {
         format!(
             "
             Prompt a sub-agent to do a task for you.
@@ -35,30 +35,51 @@ impl<M: CompletionModel + 'static> Tool for Agent<M> {
         )
     }
 
-    fn parameters(&self) -> serde_json::Value {
+    fn agent_tool_parameters(&self) -> serde_json::Value {
         json!(schema_for!(AgentToolArgs))
     }
+}
 
-    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
-        self.prompt(args.prompt).await
+impl<M: CompletionModel + 'static> ToolRuntime for Agent<M> {
+    fn description(&self) -> String {
+        self.agent_tool_description()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        self.agent_tool_parameters()
+    }
+
+    fn call<'a>(
+        &'a self,
+        args: String,
+    ) -> crate::wasm_compat::WasmBoxedFuture<'a, Result<String, ToolError>> {
+        self.call_with_extensions(args, &ToolCallExtensions::EMPTY)
     }
 
     /// Propagate the caller's [`ToolCallExtensions`] into the sub-agent run, so the
     /// inner agent's own tools observe them too (sub-agent delegation / A2A
     /// chains). Without this, a sub-agent invoked as a tool would start with
     /// empty extensions.
-    async fn call_with_extensions(
-        &self,
-        args: Self::Args,
-        extensions: &ToolCallExtensions,
-    ) -> Result<Self::Output, Self::Error> {
-        self.prompt(args.prompt)
-            .tool_extensions(extensions.clone())
-            .await
+    fn call_with_extensions<'a>(
+        &'a self,
+        args: String,
+        extensions: &'a ToolCallExtensions,
+    ) -> crate::wasm_compat::WasmBoxedFuture<'a, Result<String, ToolError>> {
+        Box::pin(async move {
+            let args =
+                serde_json::from_str::<AgentToolArgs>(&args).map_err(ToolError::JsonError)?;
+            self.prompt(args.prompt)
+                .tool_extensions(extensions.clone())
+                .await
+                .map_err(|err| ToolError::ToolCallError(Box::new(err)))
+        })
     }
+}
 
-    fn name(&self) -> String {
-        self.name.clone().unwrap_or_else(|| Self::NAME.to_string())
+impl<M: CompletionModel + 'static> IntoToolDyn for Agent<M> {
+    fn into_tool_dyn(self) -> ToolDyn {
+        let name = self.agent_tool_name();
+        ToolDyn::from_runtime(name, self)
     }
 }
 
@@ -83,8 +104,7 @@ mod tests {
             .tool(probe.clone())
             .build();
 
-        // Outer agent: delegates to the inner agent (registered as the
-        // "researcher" tool), then answers.
+        // Outer agent invokes the inner agent as the named "researcher" tool), then answers.
         let outer_model = MockCompletionModel::new([
             MockTurn::tool_call("c2", "researcher", json!({"prompt": "do research"})),
             MockTurn::text("outer done"),
@@ -92,16 +112,14 @@ mod tests {
         let outer = AgentBuilder::new(outer_model).tool(inner).build();
 
         let mut extensions = ToolCallExtensions::new();
-        extensions.insert(SessionId("abc-123".to_string()));
-
-        let out = outer
+        extensions.insert(SessionId("abc".to_string()));
+        let response = outer
             .prompt("start")
             .tool_extensions(extensions)
-            .max_turns(5)
             .await
             .expect("run succeeds");
 
-        assert_eq!(out, "outer done");
-        assert_eq!(probe.observed().as_deref(), Some("session:abc-123"));
+        assert_eq!(response, "outer done");
+        assert_eq!(probe.observations(), vec!["session:abc".to_string()]);
     }
 }

--- a/crates/rig-core/src/embeddings/tool.rs
+++ b/crates/rig-core/src/embeddings/tool.rs
@@ -78,20 +78,15 @@ impl ToolSchema {
     ///     fn context(&self) -> Self::Context {}
     /// }
     ///
-    /// let tool = ToolSchema::try_from(&Nothing).unwrap();
+    /// let tool = ToolSchema::from_tool("nothing", &Nothing).unwrap();
     ///
     /// assert_eq!(tool.name, "nothing".to_string());
     /// assert_eq!(tool.embedding_docs, vec!["Do nothing.".to_string()]);
     /// ```
-    pub fn try_from(tool: &dyn ToolEmbeddingDyn) -> Result<Self, EmbedError> {
-        Self::from_tool(tool.name(), tool)
-    }
-
     /// Convert a tool to a schema using an explicit registered name.
     ///
     /// Registry paths should pass the key under which the tool was registered so
-    /// vector-store IDs resolve back to the same entry even if `tool.name()` is
-    /// computed dynamically.
+    /// vector-store IDs resolve back to the same entry.
     pub fn from_tool(
         name: impl Into<String>,
         tool: &dyn ToolEmbeddingDyn,

--- a/crates/rig-core/src/tool/mod.rs
+++ b/crates/rig-core/src/tool/mod.rs
@@ -141,11 +141,6 @@ pub trait Tool: Sized + WasmCompatSend + WasmCompatSync {
     /// The output type of the tool.
     type Output: Serialize;
 
-    /// A method returning the name of the tool.
-    fn name(&self) -> String {
-        Self::NAME.to_string()
-    }
-
     /// Model-facing description of what the tool does.
     fn description(&self) -> String;
 
@@ -227,7 +222,7 @@ pub trait Tool: Sized + WasmCompatSend + WasmCompatSync {
     ///
     /// **Override contract:** this is the single entry point under *structured
     /// dynamic dispatch* — the agent loop routes every tool call here via the
-    /// blanket [`ToolDyn`] impl. If you override it, the `call` /
+    /// blanket erased-tool runtime impl. If you override it, the `call` /
     /// `call_with_extensions` bodies are unreachable on that structured path (a
     /// direct call still runs them), so put your logic here. A returned
     /// `Err(Self::Error)` is still classified via
@@ -273,14 +268,13 @@ pub trait ToolEmbedding: Tool {
     fn init(state: Self::State, context: Self::Context) -> Result<Self, Self::InitError>;
 }
 
-/// Wrapper trait to allow for dynamic dispatch of simple tools.
+/// Runtime behavior for an erased tool.
 ///
-/// This is the object-safe erased form of [`Tool`]: it exposes the same flat
-/// metadata and string-based execution methods for runtime dispatch.
-pub trait ToolDyn: WasmCompatSend + WasmCompatSync {
-    /// Returns the tool name used for dispatch and provider advertisement.
-    fn name(&self) -> String;
-
+/// This trait is intentionally nameless. A tool name is captured exactly once
+/// before registration (`Tool::NAME` for typed tools, or `ToolDyn`'s builder
+/// name for dynamic tools), then the [`ToolSet`] map key is the only runtime
+/// source of tool identity.
+pub(crate) trait ToolRuntime: WasmCompatSend + WasmCompatSync {
     /// Model-facing description of what the tool does.
     fn description(&self) -> String;
 
@@ -291,10 +285,6 @@ pub trait ToolDyn: WasmCompatSend + WasmCompatSync {
     fn call<'a>(&'a self, args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>>;
 
     /// Dynamic dispatch variant of tool execution with per-call runtime extensions.
-    ///
-    /// The default ignores the extensions and delegates to [`ToolDyn::call`].
-    /// The blanket impl for [`Tool`] types overrides this to thread the
-    /// extensions through to [`Tool::call_with_extensions`].
     fn call_with_extensions<'a>(
         &'a self,
         args: String,
@@ -306,21 +296,6 @@ pub trait ToolDyn: WasmCompatSend + WasmCompatSync {
     /// Execute the tool with per-call extensions, returning a structured
     /// [`ToolExecutionResult`] (model output + [`ToolOutcome`] + result
     /// extensions).
-    ///
-    /// This is the structured dynamic boundary the agent loop drives: the result
-    /// flows through to the
-    /// [`StepEvent::ToolResult`](crate::agent::StepEvent::ToolResult) hook event.
-    /// Unlike [`call`](Self::call) it never returns a bare error — a failure is
-    /// carried as [`ToolOutcome::Error`] inside the result, with the
-    /// model-visible message on [`ToolExecutionResult::model_output`].
-    ///
-    /// The default wraps [`call_with_extensions`](Self::call_with_extensions): an
-    /// `Ok` output becomes a [`ToolOutcome::Success`]; a [`ToolError`] is
-    /// classified ([`ToolError::JsonError`] as
-    /// [`ToolFailureKind::InvalidArgs`], otherwise [`ToolFailureKind::Other`]).
-    /// The blanket impl for [`Tool`] types overrides this to route through
-    /// [`Tool::call_structured`] and [`Tool::classify_error`]; a manual `ToolDyn`
-    /// impl should override it to emit precise outcomes (e.g. a real timeout).
     fn call_structured<'a>(
         &'a self,
         args: String,
@@ -361,10 +336,9 @@ where
     }
 }
 
-/// Map a [`ToolError`] surfaced by a string-returning [`ToolDyn`] path into a
+/// Map a [`ToolError`] surfaced by a string-returning dynamic tool path into a
 /// structured [`ToolExecutionResult`], classifying a JSON error as invalid
-/// arguments. Used by the default [`ToolDyn::call_structured`] for manual
-/// implementations that only provide the string [`ToolDyn::call`].
+/// arguments.
 fn tool_error_to_execution_result(err: ToolError) -> ToolExecutionResult {
     let message = err.to_string();
     let failure = match err {
@@ -374,19 +348,7 @@ fn tool_error_to_execution_result(err: ToolError) -> ToolExecutionResult {
     ToolExecutionResult::failed(message, failure)
 }
 
-/// Generate a provider-facing [`ToolDefinition`] from a registered tool's
-/// flat metadata.
-///
-/// The tool name is always taken from [`ToolDyn::name`], making that registered
-/// name the single source of truth for provider advertisement and dispatch.
-pub fn tool_definition(tool: &dyn ToolDyn) -> ToolDefinition {
-    tool_definition_with_name(tool.name(), tool)
-}
-
-pub(crate) fn tool_definition_with_name(
-    name: impl Into<String>,
-    tool: &dyn ToolDyn,
-) -> ToolDefinition {
+fn tool_definition_from_runtime(name: impl Into<String>, tool: &dyn ToolRuntime) -> ToolDefinition {
     ToolDefinition {
         name: name.into(),
         description: tool.description(),
@@ -394,11 +356,19 @@ pub(crate) fn tool_definition_with_name(
     }
 }
 
-impl<T: Tool> ToolDyn for T {
-    fn name(&self) -> String {
-        <Self as Tool>::name(self)
+/// Generate a provider-facing [`ToolDefinition`] from a typed tool.
+///
+/// The name comes from [`Tool::NAME`]. Registered tools use the [`ToolSet`] map
+/// key instead; this helper is for direct request/test construction.
+pub fn tool_definition<T: Tool>(tool: &T) -> ToolDefinition {
+    ToolDefinition {
+        name: T::NAME.to_string(),
+        description: tool.description(),
+        parameters: tool.parameters(),
     }
+}
 
+impl<T: Tool> ToolRuntime for T {
     fn description(&self) -> String {
         <Self as Tool>::description(self)
     }
@@ -408,7 +378,7 @@ impl<T: Tool> ToolDyn for T {
     }
 
     fn call<'a>(&'a self, args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
-        ToolDyn::call_with_extensions(self, args, &ToolCallExtensions::EMPTY)
+        ToolRuntime::call_with_extensions(self, args, &ToolCallExtensions::EMPTY)
     }
 
     fn call_with_extensions<'a>(
@@ -427,12 +397,6 @@ impl<T: Tool> ToolDyn for T {
         })
     }
 
-    /// Routes through [`Tool::call_structured`] so rich returns
-    /// ([`ToolReturn`]) and [`Tool::classify_error`] are honored: a JSON
-    /// argument parse failure becomes an
-    /// [`InvalidArgs`](ToolFailureKind::InvalidArgs) outcome, a returned
-    /// `Err(Self::Error)` is classified, and a successful [`ToolReturn`] is
-    /// serialized while preserving its outcome and extensions.
     fn call_structured<'a>(
         &'a self,
         args: String,
@@ -459,12 +423,274 @@ impl<T: Tool> ToolDyn for T {
     }
 }
 
+/// A complete dynamically-dispatched tool value.
+///
+/// A `ToolDyn` carries its name only until registration. When inserted into a
+/// [`ToolSet`], the name is moved into the set's `IndexMap` key; all provider
+/// definitions, documents, schemas, and dispatch then use that key.
+#[derive(Clone)]
+pub struct ToolDyn {
+    name: String,
+    runtime: Arc<dyn ToolRuntime>,
+}
+
+impl ToolDyn {
+    /// Start building a dynamic tool.
+    pub fn builder() -> ToolDynBuilder {
+        ToolDynBuilder::default()
+    }
+
+    /// Erase a typed [`Tool`] into a dynamic tool value.
+    pub fn from_tool<T>(tool: T) -> Self
+    where
+        T: Tool + 'static,
+    {
+        Self::from_runtime(T::NAME, tool)
+    }
+
+    pub(crate) fn from_runtime(
+        name: impl Into<String>,
+        runtime: impl ToolRuntime + 'static,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            runtime: Arc::new(runtime),
+        }
+    }
+
+    fn into_parts(self) -> (String, Arc<dyn ToolRuntime>) {
+        (self.name, self.runtime)
+    }
+
+    /// Model-facing description of what the tool does.
+    pub fn description(&self) -> String {
+        self.runtime.description()
+    }
+
+    /// JSON Schema for the tool arguments.
+    pub fn parameters(&self) -> serde_json::Value {
+        self.runtime.parameters()
+    }
+
+    /// Calls the tool with JSON-encoded arguments and returns model-facing text.
+    pub fn call<'a>(&'a self, args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
+        self.runtime.call(args)
+    }
+
+    /// Dynamic dispatch variant of tool execution with per-call runtime extensions.
+    pub fn call_with_extensions<'a>(
+        &'a self,
+        args: String,
+        extensions: &'a ToolCallExtensions,
+    ) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
+        self.runtime.call_with_extensions(args, extensions)
+    }
+
+    /// Execute the tool with per-call extensions, returning a structured result.
+    pub fn call_structured<'a>(
+        &'a self,
+        args: String,
+        extensions: &'a ToolCallExtensions,
+    ) -> WasmBoxedFuture<'a, ToolExecutionResult> {
+        self.runtime.call_structured(args, extensions)
+    }
+}
+
+impl<T> From<T> for ToolDyn
+where
+    T: Tool + 'static,
+{
+    fn from(tool: T) -> Self {
+        Self::from_tool(tool)
+    }
+}
+
+/// Convert values into complete dynamic tools for registration.
+pub trait IntoToolDyn {
+    /// Convert into a named dynamic tool value.
+    fn into_tool_dyn(self) -> ToolDyn;
+}
+
+impl<T> IntoToolDyn for T
+where
+    T: Tool + 'static,
+{
+    fn into_tool_dyn(self) -> ToolDyn {
+        ToolDyn::from_tool(self)
+    }
+}
+
+impl IntoToolDyn for ToolDyn {
+    fn into_tool_dyn(self) -> ToolDyn {
+        self
+    }
+}
+
+/// Error returned when building a dynamic tool is incomplete.
+#[derive(Debug, thiserror::Error)]
+pub enum ToolDynBuildError {
+    /// The dynamic tool name was not provided.
+    #[error("dynamic tool name is required")]
+    MissingName,
+    /// The dynamic tool description was not provided.
+    #[error("dynamic tool description is required")]
+    MissingDescription,
+    /// The dynamic tool parameters schema was not provided.
+    #[error("dynamic tool parameters schema is required")]
+    MissingParameters,
+    /// The dynamic tool call handler was not provided.
+    #[error("dynamic tool call handler is required")]
+    MissingCall,
+}
+
+#[cfg(not(target_family = "wasm"))]
+type DynCallFn = dyn for<'a> Fn(String, &'a ToolCallExtensions) -> WasmBoxedFuture<'a, Result<String, ToolError>>
+    + Send
+    + Sync;
+
+#[cfg(target_family = "wasm")]
+type DynCallFn = dyn for<'a> Fn(
+    String,
+    &'a ToolCallExtensions,
+) -> WasmBoxedFuture<'a, Result<String, ToolError>>;
+
+struct ClosureToolRuntime {
+    description: String,
+    parameters: serde_json::Value,
+    call: Arc<DynCallFn>,
+}
+
+impl ToolRuntime for ClosureToolRuntime {
+    fn description(&self) -> String {
+        self.description.clone()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        self.parameters.clone()
+    }
+
+    fn call<'a>(&'a self, args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
+        (self.call)(args, &ToolCallExtensions::EMPTY)
+    }
+
+    fn call_with_extensions<'a>(
+        &'a self,
+        args: String,
+        extensions: &'a ToolCallExtensions,
+    ) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
+        (self.call)(args, extensions)
+    }
+}
+
+/// Builder for [`ToolDyn`] values.
+#[derive(Default)]
+pub struct ToolDynBuilder {
+    name: Option<String>,
+    description: Option<String>,
+    parameters: Option<serde_json::Value>,
+    call: Option<Arc<DynCallFn>>,
+}
+
+impl ToolDynBuilder {
+    /// Set the dynamic tool name.
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    /// Set the model-facing tool description.
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Set the JSON Schema for the tool arguments.
+    pub fn parameters(mut self, parameters: serde_json::Value) -> Self {
+        self.parameters = Some(parameters);
+        self
+    }
+
+    /// Set a call handler that does not inspect per-call extensions.
+    pub fn call<F, Fut>(mut self, call: F) -> Self
+    where
+        F: Fn(String) -> Fut + WasmCompatSend + WasmCompatSync + 'static,
+        Fut: Future<Output = Result<String, ToolError>> + WasmCompatSend + 'static,
+    {
+        self.call = Some(Arc::new(move |args, _extensions| Box::pin(call(args))));
+        self
+    }
+
+    /// Set a call handler that can inspect per-call extensions.
+    pub fn call_with_extensions<F>(mut self, call: F) -> Self
+    where
+        F: Fn(String, &ToolCallExtensions) -> WasmBoxedFuture<'_, Result<String, ToolError>>
+            + WasmCompatSend
+            + WasmCompatSync
+            + 'static,
+    {
+        self.call = Some(Arc::new(call));
+        self
+    }
+
+    /// Build the complete dynamic tool value.
+    pub fn build(self) -> Result<ToolDyn, ToolDynBuildError> {
+        let name = self.name.ok_or(ToolDynBuildError::MissingName)?;
+        let description = self
+            .description
+            .ok_or(ToolDynBuildError::MissingDescription)?;
+        let parameters = self
+            .parameters
+            .ok_or(ToolDynBuildError::MissingParameters)?;
+        let call = self.call.ok_or(ToolDynBuildError::MissingCall)?;
+        Ok(ToolDyn::from_runtime(
+            name,
+            ClosureToolRuntime {
+                description,
+                parameters,
+                call,
+            },
+        ))
+    }
+}
+
 #[cfg(feature = "rmcp")]
 #[cfg_attr(docsrs, doc(cfg(feature = "rmcp")))]
 pub mod rmcp;
 
-/// Wrapper trait to allow for dynamic dispatch of raggable tools
-pub trait ToolEmbeddingDyn: ToolDyn {
+/// Wrapper trait to allow for dynamic dispatch of raggable tools.
+pub trait ToolEmbeddingDyn: WasmCompatSend + WasmCompatSync {
+    /// Model-facing description of what the tool does.
+    fn description(&self) -> String;
+
+    /// JSON Schema for the tool arguments.
+    fn parameters(&self) -> serde_json::Value;
+
+    /// Calls the tool with JSON-encoded arguments and returns model-facing text.
+    fn call<'a>(&'a self, args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>>;
+
+    /// Dynamic dispatch variant of tool execution with per-call runtime extensions.
+    fn call_with_extensions<'a>(
+        &'a self,
+        args: String,
+        _extensions: &'a ToolCallExtensions,
+    ) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
+        self.call(args)
+    }
+
+    /// Execute the tool with per-call extensions, returning a structured result.
+    fn call_structured<'a>(
+        &'a self,
+        args: String,
+        extensions: &'a ToolCallExtensions,
+    ) -> WasmBoxedFuture<'a, ToolExecutionResult> {
+        Box::pin(async move {
+            match self.call_with_extensions(args, extensions).await {
+                Ok(model_output) => ToolExecutionResult::success(model_output),
+                Err(err) => tool_error_to_execution_result(err),
+            }
+        })
+    }
+
     /// Serializes context needed to reconstruct this dynamic tool.
     fn context(&self) -> serde_json::Result<serde_json::Value>;
 
@@ -476,6 +702,59 @@ impl<T> ToolEmbeddingDyn for T
 where
     T: ToolEmbedding + 'static,
 {
+    fn description(&self) -> String {
+        <Self as Tool>::description(self)
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        <Self as Tool>::parameters(self)
+    }
+
+    fn call<'a>(&'a self, args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
+        ToolEmbeddingDyn::call_with_extensions(self, args, &ToolCallExtensions::EMPTY)
+    }
+
+    fn call_with_extensions<'a>(
+        &'a self,
+        args: String,
+        extensions: &'a ToolCallExtensions,
+    ) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
+        Box::pin(async move {
+            match parse_tool_args::<T::Args>(&args) {
+                Ok(args) => <Self as Tool>::call_with_extensions(self, args, extensions)
+                    .await
+                    .map_err(|e| ToolError::ToolCallError(Box::new(e)))
+                    .and_then(|output| serialize_tool_output(output).map_err(ToolError::JsonError)),
+                Err(e) => Err(ToolError::JsonError(e)),
+            }
+        })
+    }
+
+    fn call_structured<'a>(
+        &'a self,
+        args: String,
+        extensions: &'a ToolCallExtensions,
+    ) -> WasmBoxedFuture<'a, ToolExecutionResult> {
+        Box::pin(async move {
+            let parsed = match parse_tool_args::<T::Args>(&args) {
+                Ok(parsed) => parsed,
+                Err(err) => {
+                    return ToolExecutionResult::failed(
+                        format!("failed to parse tool arguments: {err}"),
+                        ToolFailure::invalid_args(err.to_string()),
+                    );
+                }
+            };
+            match <Self as Tool>::call_structured(self, parsed, extensions).await {
+                Ok(tool_return) => tool_return.into_execution_result(),
+                Err(err) => {
+                    let failure = self.classify_error(&err);
+                    ToolExecutionResult::failed(err.to_string(), failure)
+                }
+            }
+        })
+    }
+
     fn context(&self) -> serde_json::Result<serde_json::Value> {
         serde_json::to_value(self.context())
     }
@@ -487,22 +766,19 @@ where
 
 #[derive(Clone)]
 pub(crate) enum ToolType {
-    Simple(Arc<dyn ToolDyn>),
+    Simple(Arc<dyn ToolRuntime>),
     Embedding(Arc<dyn ToolEmbeddingDyn>),
 }
 
 impl ToolType {
-    pub fn name(&self) -> String {
-        match self {
-            ToolType::Simple(tool) => tool.name(),
-            ToolType::Embedding(tool) => tool.name(),
-        }
-    }
-
     pub fn definition_with_name(&self, name: impl Into<String>) -> ToolDefinition {
         match self {
-            ToolType::Simple(tool) => tool_definition_with_name(name, &**tool),
-            ToolType::Embedding(tool) => tool_definition_with_name(name, &**tool),
+            ToolType::Simple(tool) => tool_definition_from_runtime(name, &**tool),
+            ToolType::Embedding(tool) => ToolDefinition {
+                name: name.into(),
+                description: tool.description(),
+                parameters: tool.parameters(),
+            },
         }
     }
 
@@ -561,8 +837,11 @@ pub struct ToolSet {
 }
 
 impl ToolSet {
-    /// Create a new ToolSet from a list of tools
-    pub fn from_tools(tools: Vec<impl ToolDyn + 'static>) -> Self {
+    /// Create a new ToolSet from a list of tools.
+    pub fn from_tools<T>(tools: Vec<T>) -> Self
+    where
+        T: IntoToolDyn,
+    {
         let mut toolset = Self::default();
         tools.into_iter().for_each(|tool| {
             toolset.add_tool(tool);
@@ -570,11 +849,11 @@ impl ToolSet {
         toolset
     }
 
-    /// Create a new `ToolSet` from boxed dynamically-dispatched tools.
-    pub fn from_tools_boxed(tools: Vec<Box<dyn ToolDyn + 'static>>) -> Self {
+    /// Create a new `ToolSet` from dynamically-dispatched tools.
+    pub fn from_tools_dyn(tools: Vec<ToolDyn>) -> Self {
         let mut toolset = Self::default();
         tools.into_iter().for_each(|tool| {
-            toolset.add_tool_boxed(tool);
+            toolset.add_tool(tool);
         });
         toolset
     }
@@ -590,19 +869,17 @@ impl ToolSet {
     }
 
     /// Add a tool to the toolset, returning the registered key used for it.
-    pub fn add_tool(&mut self, tool: impl ToolDyn + 'static) -> String {
-        self.insert(ToolType::Simple(Arc::new(tool)))
+    pub fn add_tool(&mut self, tool: impl IntoToolDyn) -> String {
+        let (name, runtime) = tool.into_tool_dyn().into_parts();
+        self.insert_with_name(name, ToolType::Simple(runtime))
     }
 
-    /// Adds a boxed tool to the toolset. Useful for situations when dynamic dispatch is required.
-    /// Returns the registered key used for the tool.
-    pub fn add_tool_boxed(&mut self, tool: Box<dyn ToolDyn>) -> String {
-        self.insert(ToolType::Simple(Arc::from(tool)))
-    }
-
-    pub(crate) fn insert(&mut self, tool: ToolType) -> String {
-        let name = tool.name();
-        self.insert_with_name(name, tool)
+    /// Add a raggable tool to the toolset, returning the registered key used for it.
+    pub fn add_dynamic_tool<T>(&mut self, tool: T) -> String
+    where
+        T: ToolEmbedding + 'static,
+    {
+        self.insert_with_name(T::NAME.to_string(), ToolType::Embedding(Arc::new(tool)))
     }
 
     fn insert_with_name(&mut self, name: String, tool: ToolType) -> String {
@@ -750,27 +1027,32 @@ impl ToolSet {
 #[derive(Default)]
 /// Builder for constructing a [`ToolSet`] with static and dynamic tools.
 pub struct ToolSetBuilder {
-    tools: Vec<ToolType>,
+    tools: Vec<(String, ToolType)>,
 }
 
 impl ToolSetBuilder {
     /// Add a regular tool that is always available when the set is used.
-    pub fn static_tool(mut self, tool: impl ToolDyn + 'static) -> Self {
-        self.tools.push(ToolType::Simple(Arc::new(tool)));
+    pub fn static_tool(mut self, tool: impl IntoToolDyn) -> Self {
+        let (name, runtime) = tool.into_tool_dyn().into_parts();
+        self.tools.push((name, ToolType::Simple(runtime)));
         self
     }
 
     /// Add a tool that can be represented as embeddings for dynamic retrieval.
-    pub fn dynamic_tool(mut self, tool: impl ToolEmbeddingDyn + 'static) -> Self {
-        self.tools.push(ToolType::Embedding(Arc::new(tool)));
+    pub fn dynamic_tool<T>(mut self, tool: T) -> Self
+    where
+        T: ToolEmbedding + 'static,
+    {
+        self.tools
+            .push((T::NAME.to_string(), ToolType::Embedding(Arc::new(tool))));
         self
     }
 
     /// Build the tool set, keyed by each tool's name.
     pub fn build(self) -> ToolSet {
         let mut toolset = ToolSet::default();
-        for tool in self.tools {
-            toolset.insert(tool);
+        for (name, tool) in self.tools {
+            toolset.insert_with_name(name, tool);
         }
         toolset
     }
@@ -845,47 +1127,20 @@ mod tests {
         );
     }
 
-    /// A tool whose name and definition are chosen at runtime, for ordering
-    /// and duplicate-registration tests.
-    struct NamedTool {
-        name: String,
-        description: String,
-    }
-
-    impl ToolDyn for NamedTool {
-        fn name(&self) -> String {
-            self.name.clone()
-        }
-
-        fn description(&self) -> String {
-            self.description.clone()
-        }
-
-        fn parameters(&self) -> serde_json::Value {
-            json!({ "type": "object", "properties": {} })
-        }
-
-        fn call(&self, _args: String) -> WasmBoxedFuture<'_, Result<String, ToolError>> {
-            let output = format!("called {}", self.description);
-            Box::pin(async move { Ok(output) })
-        }
-    }
-
-    fn named_tool(name: &str, description: &str) -> NamedTool {
-        NamedTool {
-            name: name.to_string(),
-            description: description.to_string(),
-        }
-    }
-
-    #[test]
-    fn tool_definition_uses_flattened_dyn_metadata() {
-        let tool = named_tool("alpha", "runtime description");
-        let definition = tool_definition(&tool);
-
-        assert_eq!(definition.name, "alpha");
-        assert_eq!(definition.description, "runtime description");
-        assert_eq!(definition.parameters["type"], "object");
+    /// A dynamic tool whose name and metadata are chosen at runtime, for
+    /// ordering and duplicate-registration tests.
+    fn named_tool(name: &str, description: &str) -> ToolDyn {
+        let description = description.to_string();
+        ToolDyn::builder()
+            .name(name)
+            .description(description.clone())
+            .parameters(json!({ "type": "object", "properties": {} }))
+            .call(move |_args| {
+                let output = format!("called {description}");
+                async move { Ok(output) }
+            })
+            .build()
+            .unwrap()
     }
 
     #[tokio::test]
@@ -910,37 +1165,8 @@ mod tests {
 
     #[tokio::test]
     async fn registered_name_is_definition_source_of_truth() {
-        use std::sync::atomic::{AtomicUsize, Ordering};
-
-        struct ChangingNameTool {
-            calls: AtomicUsize,
-        }
-
-        impl ToolDyn for ChangingNameTool {
-            fn name(&self) -> String {
-                match self.calls.fetch_add(1, Ordering::SeqCst) {
-                    0 => "registered".to_string(),
-                    _ => "changed".to_string(),
-                }
-            }
-
-            fn description(&self) -> String {
-                "changes name after registration".to_string()
-            }
-
-            fn parameters(&self) -> serde_json::Value {
-                json!({ "type": "object", "properties": {} })
-            }
-
-            fn call(&self, _args: String) -> WasmBoxedFuture<'_, Result<String, ToolError>> {
-                Box::pin(async { Ok("ok".to_string()) })
-            }
-        }
-
         let mut toolset = ToolSet::default();
-        toolset.add_tool(ChangingNameTool {
-            calls: AtomicUsize::new(0),
-        });
+        toolset.add_tool(named_tool("registered", "registered dynamic tool"));
 
         let defs = toolset.get_tool_definitions().unwrap();
         assert_eq!(defs[0].name, "registered");
@@ -948,33 +1174,21 @@ mod tests {
         let docs = toolset.documents().await.unwrap();
         assert_eq!(docs[0].id, "registered");
         assert!(docs[0].text.contains("registered"));
-        assert!(!docs[0].text.contains("changed"));
     }
 
     #[test]
     fn dynamic_tool_schemas_use_registered_name() {
-        use std::sync::atomic::{AtomicUsize, Ordering};
-
         #[derive(Debug, thiserror::Error)]
         #[error("init error")]
         struct InitError;
 
-        struct ChangingDynamicTool {
-            calls: AtomicUsize,
-        }
+        struct DynamicTool;
 
-        impl Tool for ChangingDynamicTool {
-            const NAME: &'static str = "unused";
+        impl Tool for DynamicTool {
+            const NAME: &'static str = "registered_dynamic";
             type Error = MockToolError;
             type Args = serde_json::Value;
             type Output = String;
-
-            fn name(&self) -> String {
-                match self.calls.fetch_add(1, Ordering::SeqCst) {
-                    0 => "registered_dynamic".to_string(),
-                    _ => "changed_dynamic".to_string(),
-                }
-            }
 
             fn description(&self) -> String {
                 "dynamic tool".to_string()
@@ -989,7 +1203,7 @@ mod tests {
             }
         }
 
-        impl ToolEmbedding for ChangingDynamicTool {
+        impl ToolEmbedding for DynamicTool {
             type InitError = InitError;
             type Context = ();
             type State = ();
@@ -1001,17 +1215,11 @@ mod tests {
             fn context(&self) -> Self::Context {}
 
             fn init(_state: Self::State, _context: Self::Context) -> Result<Self, Self::InitError> {
-                Ok(Self {
-                    calls: AtomicUsize::new(0),
-                })
+                Ok(Self)
             }
         }
 
-        let toolset = ToolSet::builder()
-            .dynamic_tool(ChangingDynamicTool {
-                calls: AtomicUsize::new(0),
-            })
-            .build();
+        let toolset = ToolSet::builder().dynamic_tool(DynamicTool).build();
 
         let schemas = toolset.schemas().unwrap();
         assert_eq!(schemas.len(), 1);

--- a/crates/rig-core/src/tool/rmcp.rs
+++ b/crates/rig-core/src/tool/rmcp.rs
@@ -58,7 +58,8 @@ use tokio::sync::RwLock;
 use crate::completion::ToolDefinition;
 use crate::tool::server::{ToolServerError, ToolServerHandle};
 use crate::tool::{
-    ToolCallExtensions, ToolDyn, ToolError, ToolExecutionResult, ToolFailure, ToolFailureKind,
+    IntoToolDyn, ToolCallExtensions, ToolDyn, ToolError, ToolExecutionResult, ToolFailure,
+    ToolFailureKind, ToolRuntime,
 };
 use crate::wasm_compat::WasmBoxedFuture;
 
@@ -78,7 +79,7 @@ pub const DEFAULT_MCP_TOOL_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// A Rig tool adapter wrapping an `rmcp` MCP tool.
 ///
-/// Bridges between the MCP tool protocol and Rig's [`ToolDyn`] trait,
+/// Bridges between the MCP tool protocol and Rig's [`ToolDyn`] runtime tool,
 /// allowing MCP tools to be used seamlessly in Rig agents.
 #[derive(Clone)]
 pub struct McpTool {
@@ -129,6 +130,29 @@ impl McpTool {
     pub fn timeout(&self) -> Option<Duration> {
         self.timeout
     }
+
+    /// Calls the MCP tool with JSON-encoded arguments.
+    pub fn call<'a>(&'a self, args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
+        ToolRuntime::call(self, args)
+    }
+
+    /// Calls the MCP tool with JSON-encoded arguments and per-call extensions.
+    pub fn call_with_extensions<'a>(
+        &'a self,
+        args: String,
+        extensions: &'a ToolCallExtensions,
+    ) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
+        ToolRuntime::call_with_extensions(self, args, extensions)
+    }
+
+    /// Calls the MCP tool with JSON-encoded arguments and returns a structured result.
+    pub fn call_structured<'a>(
+        &'a self,
+        args: String,
+        extensions: &'a ToolCallExtensions,
+    ) -> WasmBoxedFuture<'a, ToolExecutionResult> {
+        ToolRuntime::call_structured(self, args, extensions)
+    }
 }
 
 impl From<&rmcp::model::Tool> for ToolDefinition {
@@ -148,6 +172,13 @@ impl From<rmcp::model::Tool> for ToolDefinition {
             description: val.description.clone().unwrap_or(Cow::from("")).to_string(),
             parameters: val.schema_as_json_value(),
         }
+    }
+}
+
+impl IntoToolDyn for McpTool {
+    fn into_tool_dyn(self) -> ToolDyn {
+        let name = self.definition.name.to_string();
+        ToolDyn::from_runtime(name, self)
     }
 }
 
@@ -344,11 +375,7 @@ impl McpTool {
     }
 }
 
-impl ToolDyn for McpTool {
-    fn name(&self) -> String {
-        self.definition.name.to_string()
-    }
-
+impl ToolRuntime for McpTool {
     fn description(&self) -> String {
         self.definition
             .description
@@ -801,7 +828,7 @@ mod tests {
     #[tokio::test]
     async fn mcp_tool_exposes_flattened_metadata() {
         use super::McpTool;
-        use crate::tool::{ToolDyn, tool_definition};
+        use crate::completion::ToolDefinition;
 
         let mut schema = serde_json::Map::new();
         schema.insert("type".to_string(), json!("object"));
@@ -830,10 +857,9 @@ mod tests {
             .serve((client_from_server, client_to_server))
             .await
             .expect("client connect failed");
-        let mcp_tool = McpTool::from_mcp_server(server_tool, client.peer().clone());
-        let definition = tool_definition(&mcp_tool);
+        let definition = ToolDefinition::from(&server_tool);
+        let _mcp_tool = McpTool::from_mcp_server(server_tool, client.peer().clone());
 
-        assert_eq!(mcp_tool.name(), "search_docs");
         assert_eq!(definition.name, "search_docs");
         assert_eq!(definition.description, "Search the docs");
         assert_eq!(
@@ -862,7 +888,6 @@ mod tests {
     #[tokio::test]
     async fn mcp_tool_call_without_timeout_is_unbounded() {
         use super::McpTool;
-        use crate::tool::ToolDyn;
 
         let (client_to_server, server_from_client) = tokio::io::duplex(8192);
         let (server_to_client, client_from_server) = tokio::io::duplex(8192);
@@ -918,7 +943,6 @@ mod tests {
     #[tokio::test]
     async fn mcp_tool_call_with_timeout_errors_instead_of_hanging() {
         use super::McpTool;
-        use crate::tool::ToolDyn;
 
         let (client_to_server, server_from_client) = tokio::io::duplex(8192);
         let (server_to_client, client_from_server) = tokio::io::duplex(8192);
@@ -972,7 +996,6 @@ mod tests {
     #[tokio::test]
     async fn mcp_tool_call_returns_promptly_for_responsive_server() {
         use super::McpTool;
-        use crate::tool::ToolDyn;
 
         let server = DynamicToolServer::new(vec![make_tool("ping", "responds immediately")]);
 
@@ -1143,7 +1166,7 @@ mod tests {
     #[tokio::test]
     async fn mcp_tool_forwards_meta_from_context() {
         use super::McpTool;
-        use crate::tool::{ToolCallExtensions, ToolDyn};
+        use crate::tool::ToolCallExtensions;
 
         let seen_meta = Arc::new(RwLock::new(None));
         let server = MetaCapturingServer {
@@ -1256,7 +1279,7 @@ mod tests {
     #[tokio::test]
     async fn mcp_tool_invalid_json_args_short_circuit_as_invalid_args() {
         use super::McpTool;
-        use crate::tool::{ToolCallExtensions, ToolDyn, ToolFailureKind, ToolOutcome};
+        use crate::tool::{ToolCallExtensions, ToolFailureKind, ToolOutcome};
 
         let (client_to_server, server_from_client) = tokio::io::duplex(8192);
         let (server_to_client, client_from_server) = tokio::io::duplex(8192);

--- a/crates/rig-core/src/tool/server.rs
+++ b/crates/rig-core/src/tool/server.rs
@@ -5,7 +5,7 @@ use tokio::sync::RwLock;
 use crate::{
     completion::{CompletionError, ToolDefinition},
     tool::{
-        Tool, ToolCallExtensions, ToolDyn, ToolExecutionResult, ToolFailure, ToolSet, ToolSetError,
+        IntoToolDyn, ToolCallExtensions, ToolExecutionResult, ToolFailure, ToolSet, ToolSetError,
     },
     vector_store::{VectorSearchRequest, VectorStoreError, VectorStoreIndexDyn, request::Filter},
 };
@@ -82,7 +82,7 @@ impl ToolServer {
 
     /// Add a static tool to the agent. Re-registering an existing name
     /// replaces the implementation (last wins) and keeps its position.
-    pub fn tool(mut self, tool: impl Tool + 'static) -> Self {
+    pub fn tool(mut self, tool: impl IntoToolDyn) -> Self {
         let toolname = self.toolset.add_tool(tool);
         push_unique_name(&mut self.static_tool_names, toolname);
         self
@@ -152,9 +152,9 @@ pub struct ToolServerHandle(Arc<RwLock<ToolServerState>>);
 impl ToolServerHandle {
     /// Register a new static tool. Re-registering an existing name replaces
     /// the implementation (last wins) and keeps its position.
-    pub async fn add_tool(&self, tool: impl ToolDyn + 'static) -> Result<(), ToolServerError> {
+    pub async fn add_tool(&self, tool: impl IntoToolDyn) -> Result<(), ToolServerError> {
         let mut state = self.0.write().await;
-        let toolname = state.toolset.add_tool_boxed(Box::new(tool));
+        let toolname = state.toolset.add_tool(tool);
         push_unique_name(&mut state.static_tool_names, toolname);
         Ok(())
     }
@@ -376,13 +376,7 @@ pub enum ToolServerError {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        sync::{
-            Arc,
-            atomic::{AtomicUsize, Ordering},
-        },
-        time::Duration,
-    };
+    use std::{sync::Arc, time::Duration};
 
     use crate::{
         test_utils::{
@@ -392,30 +386,19 @@ mod tests {
         tool::{Tool, ToolEmbedding, ToolSet, server::ToolServer},
     };
 
-    struct ChangingNameTool {
-        calls: AtomicUsize,
-    }
+    struct RegisteredNameTool;
 
-    impl ChangingNameTool {
+    impl RegisteredNameTool {
         fn new() -> Self {
-            Self {
-                calls: AtomicUsize::new(0),
-            }
+            Self
         }
     }
 
-    impl Tool for ChangingNameTool {
-        const NAME: &'static str = "unused";
+    impl Tool for RegisteredNameTool {
+        const NAME: &'static str = "registered_changing";
         type Error = MockToolError;
         type Args = serde_json::Value;
         type Output = String;
-
-        fn name(&self) -> String {
-            match self.calls.fetch_add(1, Ordering::SeqCst) {
-                0 => "registered_changing".to_string(),
-                _ => "changed_after_registration".to_string(),
-            }
-        }
 
         fn description(&self) -> String {
             "changes name after registration".to_string()
@@ -434,7 +417,7 @@ mod tests {
     #[error("init error")]
     struct InitError;
 
-    impl ToolEmbedding for ChangingNameTool {
+    impl ToolEmbedding for RegisteredNameTool {
         type InitError = InitError;
         type Context = ();
         type State = ();
@@ -504,7 +487,7 @@ mod tests {
 
     #[tokio::test]
     pub async fn builder_tool_uses_registered_key_for_static_names() {
-        let handle = ToolServer::new().tool(ChangingNameTool::new()).run();
+        let handle = ToolServer::new().tool(RegisteredNameTool::new()).run();
 
         let defs = handle.get_tool_defs(None).await.unwrap();
         assert_eq!(defs.len(), 1);
@@ -514,7 +497,7 @@ mod tests {
     #[tokio::test]
     pub async fn handle_add_tool_uses_registered_key_for_static_names() {
         let handle = ToolServer::new().run();
-        handle.add_tool(ChangingNameTool::new()).await.unwrap();
+        handle.add_tool(RegisteredNameTool::new()).await.unwrap();
 
         let defs = handle.get_tool_defs(None).await.unwrap();
         assert_eq!(defs.len(), 1);
@@ -524,7 +507,7 @@ mod tests {
     #[tokio::test]
     pub async fn dynamic_retrieval_resolves_registered_key() {
         let toolset = ToolSet::builder()
-            .dynamic_tool(ChangingNameTool::new())
+            .dynamic_tool(RegisteredNameTool::new())
             .build();
         let handle = ToolServer::new()
             .dynamic_tools(1, MockToolIndex::new(["registered_changing"]), toolset)

--- a/crates/rig-derive/src/lib.rs
+++ b/crates/rig-derive/src/lib.rs
@@ -539,10 +539,6 @@ pub fn rig_tool(args: TokenStream, input: TokenStream) -> TokenStream {
             type Output = #output_type;
             type Error = #error_type;
 
-            fn name(&self) -> String {
-                #tool_name.to_string()
-            }
-
             fn description(&self) -> String {
                 #tool_description.to_string()
             }

--- a/crates/rig-derive/tests/calculator.rs
+++ b/crates/rig-derive/tests/calculator.rs
@@ -70,7 +70,7 @@ async fn test_calculator_tool() {
     let calculator = Calculator;
 
     let definition = rig_core::tool::tool_definition(&calculator);
-    assert_eq!(calculator.name(), "calculator");
+    assert_eq!(Calculator::NAME, "calculator");
     assert_eq!(
         definition.description,
         "Perform basic arithmetic operations"

--- a/crates/rig-derive/tests/custom_name.rs
+++ b/crates/rig-derive/tests/custom_name.rs
@@ -25,7 +25,6 @@ async fn test_custom_tool_name_overrides_function_name() {
     let definition = rig_core::tool::tool_definition(&tool);
 
     assert_eq!(SearchDocsImpl::NAME, "search-docs");
-    assert_eq!(tool.name(), "search-docs");
     assert_eq!(definition.name, "search-docs");
 }
 
@@ -35,7 +34,6 @@ async fn test_tool_name_falls_back_to_function_name() {
     let definition = rig_core::tool::tool_definition(&tool);
 
     assert_eq!(FallbackNameTool::NAME, "fallback_name_tool");
-    assert_eq!(tool.name(), "fallback_name_tool");
     assert_eq!(definition.name, "fallback_name_tool");
 }
 

--- a/examples/agent_with_tools/src/main.rs
+++ b/examples/agent_with_tools/src/main.rs
@@ -1,4 +1,4 @@
-//! Demonstrates registering boxed tools on an agent.
+//! Demonstrates registering dynamic tools on an agent.
 //! Requires `OPENAI_API_KEY`.
 //! Run it to see the model use arithmetic tools instead of answering from scratch.
 
@@ -79,8 +79,8 @@ impl Tool for Subtract {
     }
 }
 
-fn boxed_tools() -> Vec<Box<dyn ToolDyn>> {
-    vec![Box::new(Add), Box::new(Subtract)]
+fn dynamic_tools() -> Vec<ToolDyn> {
+    vec![ToolDyn::from_tool(Add), ToolDyn::from_tool(Subtract)]
 }
 
 #[tokio::main]
@@ -91,7 +91,7 @@ async fn main() -> Result<()> {
             "You are a calculator here to help the user perform arithmetic operations. \
              You must use the provided tools before answering.",
         )
-        .tools(boxed_tools())
+        .tools(dynamic_tools())
         .max_tokens(1024)
         .build();
 

--- a/examples/multi_agent/src/main.rs
+++ b/examples/multi_agent/src/main.rs
@@ -84,7 +84,7 @@ async fn main() -> Result<(), anyhow::Error> {
             When you receive input that is not in English, or contains grammatical errors \
             use the {} tool first to ensure proper English, then provide your response. \
             Always show both the translated text and your final response.",
-            translator_tool.name()
+            "translator"
         ))
         .tool(translator_tool)
         .build();

--- a/tests/providers/chatgpt/permission_control.rs
+++ b/tests/providers/chatgpt/permission_control.rs
@@ -11,12 +11,14 @@ use serde_json::json;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use tokio::sync::Mutex as AsyncMutex;
 
 use crate::chatgpt::{LIVE_MODEL, live_client};
 use crate::support::assert_nonempty_response;
 
 const TEST_FILE: &str = "test.txt";
 const TEST_CONTENT: &str = "hello world\n";
+static PERMISSION_CONTROL_TEST_LOCK: AsyncMutex<()> = AsyncMutex::const_new(());
 
 struct FileCleanup;
 
@@ -142,6 +144,7 @@ impl<M: CompletionModel> AgentHook<M> for PermissionHook {
 #[tokio::test]
 #[ignore = "requires ChatGPT credentials or existing OAuth cache"]
 async fn permission_control_prompt_example() -> Result<()> {
+    let _guard = PERMISSION_CONTROL_TEST_LOCK.lock().await;
     let _cleanup = FileCleanup::new()?;
 
     let agent = live_client()
@@ -176,6 +179,7 @@ async fn permission_control_prompt_example() -> Result<()> {
 #[tokio::test]
 #[ignore = "requires ChatGPT credentials or existing OAuth cache"]
 async fn permission_control_streaming_example() -> Result<()> {
+    let _guard = PERMISSION_CONTROL_TEST_LOCK.lock().await;
     let _cleanup = FileCleanup::new()?;
 
     let agent = live_client()

--- a/tests/providers/copilot/permission_control.rs
+++ b/tests/providers/copilot/permission_control.rs
@@ -11,12 +11,14 @@ use serde_json::json;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use tokio::sync::Mutex as AsyncMutex;
 
 use crate::copilot::{LIVE_LIGHT_MODEL, live_client, with_copilot_cassette_result};
 use crate::support::assert_nonempty_response;
 
 const TEST_FILE: &str = "test.txt";
 const TEST_CONTENT: &str = "hello world\n";
+static PERMISSION_CONTROL_TEST_LOCK: AsyncMutex<()> = AsyncMutex::const_new(());
 
 struct FileCleanup;
 
@@ -143,6 +145,7 @@ impl<M: CompletionModel> AgentHook<M> for PermissionHook {
 
 #[tokio::test]
 async fn permission_control_prompt_example() -> Result<()> {
+    let _guard = PERMISSION_CONTROL_TEST_LOCK.lock().await;
     with_copilot_cassette_result(
         "permission_control/permission_control_prompt_example",
         |client| async move {
@@ -188,6 +191,7 @@ async fn permission_control_prompt_example() -> Result<()> {
 #[tokio::test]
 #[ignore = "requires Copilot credentials or existing OAuth cache"]
 async fn permission_control_streaming_example() -> Result<()> {
+    let _guard = PERMISSION_CONTROL_TEST_LOCK.lock().await;
     let _cleanup = FileCleanup::new()?;
 
     let agent = live_client()

--- a/tests/providers/deepseek/permission_control.rs
+++ b/tests/providers/deepseek/permission_control.rs
@@ -12,11 +12,13 @@ use serde_json::json;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use tokio::sync::Mutex as AsyncMutex;
 
 use super::support::with_deepseek_cassette_result;
 use crate::support::assert_nonempty_response;
 
 const TEST_CONTENT: &str = "hello world\n";
+static PERMISSION_CONTROL_TEST_LOCK: AsyncMutex<()> = AsyncMutex::const_new(());
 
 /// A per-test fixture file. The two tests in this module run in parallel
 /// within one target, so a shared path would let one test's cleanup race the
@@ -157,6 +159,7 @@ impl<M: CompletionModel> AgentHook<M> for PermissionHook {
 
 #[tokio::test]
 async fn permission_control_prompt_example() -> Result<()> {
+    let _guard = PERMISSION_CONTROL_TEST_LOCK.lock().await;
     with_deepseek_cassette_result(
         "permission_control/permission_control_prompt_example",
         |client| async move {
@@ -207,6 +210,7 @@ async fn permission_control_prompt_example() -> Result<()> {
 
 #[tokio::test]
 async fn permission_control_streaming_example() -> Result<()> {
+    let _guard = PERMISSION_CONTROL_TEST_LOCK.lock().await;
     with_deepseek_cassette_result(
         "permission_control/permission_control_streaming_example",
         |client| async move {

--- a/tests/providers/groq/permission_control.rs
+++ b/tests/providers/groq/permission_control.rs
@@ -12,6 +12,7 @@ use serde_json::json;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use tokio::sync::Mutex as AsyncMutex;
 
 use crate::support::assert_nonempty_response;
 
@@ -19,6 +20,7 @@ use super::{PERMISSION_CONTROL_PROMPT_MODEL, PERMISSION_CONTROL_STREAMING_MODEL}
 
 const TEST_FILE: &str = "test.txt";
 const TEST_CONTENT: &str = "hello world\n";
+static PERMISSION_CONTROL_TEST_LOCK: AsyncMutex<()> = AsyncMutex::const_new(());
 
 struct FileCleanup;
 
@@ -146,6 +148,7 @@ impl<M: CompletionModel> AgentHook<M> for PermissionHook {
 #[tokio::test]
 #[ignore = "requires GROQ_API_KEY"]
 async fn permission_control_prompt_example() -> Result<()> {
+    let _guard = PERMISSION_CONTROL_TEST_LOCK.lock().await;
     let _cleanup = FileCleanup::new()?;
 
     let agent = groq::Client::from_env()
@@ -185,6 +188,7 @@ async fn permission_control_prompt_example() -> Result<()> {
 #[tokio::test]
 #[ignore = "requires GROQ_API_KEY"]
 async fn permission_control_streaming_example() -> Result<()> {
+    let _guard = PERMISSION_CONTROL_TEST_LOCK.lock().await;
     let _cleanup = FileCleanup::new()?;
 
     let agent = groq::Client::from_env()

--- a/tests/providers/llamacpp/permission_control.rs
+++ b/tests/providers/llamacpp/permission_control.rs
@@ -9,6 +9,7 @@ use serde_json::json;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use tokio::sync::Mutex as AsyncMutex;
 
 use crate::support::{assert_nonempty_response, collect_stream_observation};
 
@@ -16,6 +17,7 @@ use super::support;
 
 const TEST_FILE: &str = "test.txt";
 const TEST_CONTENT: &str = "hello world\n";
+static PERMISSION_CONTROL_TEST_LOCK: AsyncMutex<()> = AsyncMutex::const_new(());
 
 struct FileCleanup;
 
@@ -141,6 +143,7 @@ impl<M: CompletionModel> AgentHook<M> for PermissionHook {
 #[tokio::test]
 #[ignore = "requires a local llama.cpp OpenAI-compatible server"]
 async fn permission_control_prompt_example() -> Result<()> {
+    let _guard = PERMISSION_CONTROL_TEST_LOCK.lock().await;
     let _cleanup = FileCleanup::new()?;
 
     let agent = support::completions_client()
@@ -178,6 +181,7 @@ async fn permission_control_prompt_example() -> Result<()> {
 #[tokio::test]
 #[ignore = "requires a local llama.cpp OpenAI-compatible server"]
 async fn permission_control_streaming_example() -> Result<()> {
+    let _guard = PERMISSION_CONTROL_TEST_LOCK.lock().await;
     let _cleanup = FileCleanup::new()?;
 
     let agent = support::completions_client()

--- a/tests/providers/llamafile/permission_control.rs
+++ b/tests/providers/llamafile/permission_control.rs
@@ -11,6 +11,7 @@ use serde_json::json;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use tokio::sync::Mutex as AsyncMutex;
 
 use crate::support::assert_nonempty_response;
 
@@ -18,6 +19,7 @@ use super::support;
 
 const TEST_FILE: &str = "test.txt";
 const TEST_CONTENT: &str = "hello world\n";
+static PERMISSION_CONTROL_TEST_LOCK: AsyncMutex<()> = AsyncMutex::const_new(());
 
 struct FileCleanup;
 
@@ -161,6 +163,7 @@ impl<M: CompletionModel> AgentHook<M> for PermissionHook {
 #[tokio::test]
 #[ignore = "requires a local llamafile server at http://localhost:8080"]
 async fn permission_control_prompt_example() -> Result<()> {
+    let _guard = PERMISSION_CONTROL_TEST_LOCK.lock().await;
     if support::skip_if_server_unavailable() {
         return Ok(());
     }
@@ -235,6 +238,7 @@ async fn permission_control_prompt_example() -> Result<()> {
 #[tokio::test]
 #[ignore = "requires a local llamafile server at http://localhost:8080"]
 async fn permission_control_streaming_example() -> Result<()> {
+    let _guard = PERMISSION_CONTROL_TEST_LOCK.lock().await;
     if support::skip_if_server_unavailable() {
         return Ok(());
     }

--- a/tests/providers/mistral/permission_control.rs
+++ b/tests/providers/mistral/permission_control.rs
@@ -12,6 +12,7 @@ use serde_json::json;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use tokio::sync::Mutex as AsyncMutex;
 
 use crate::support::assert_nonempty_response;
 
@@ -19,6 +20,7 @@ use super::TOOL_MODEL;
 
 const TEST_FILE: &str = "test.txt";
 const TEST_CONTENT: &str = "hello world\n";
+static PERMISSION_CONTROL_TEST_LOCK: AsyncMutex<()> = AsyncMutex::const_new(());
 
 struct FileCleanup;
 
@@ -144,6 +146,7 @@ impl<M: CompletionModel> AgentHook<M> for PermissionHook {
 #[tokio::test]
 #[ignore = "requires MISTRAL_API_KEY"]
 async fn permission_control_prompt_example() -> Result<()> {
+    let _guard = PERMISSION_CONTROL_TEST_LOCK.lock().await;
     let _cleanup = FileCleanup::new()?;
 
     let agent = mistral::Client::from_env()
@@ -180,6 +183,7 @@ async fn permission_control_prompt_example() -> Result<()> {
 #[tokio::test]
 #[ignore = "requires MISTRAL_API_KEY"]
 async fn permission_control_streaming_example() -> Result<()> {
+    let _guard = PERMISSION_CONTROL_TEST_LOCK.lock().await;
     let _cleanup = FileCleanup::new()?;
 
     let agent = mistral::Client::from_env()

--- a/tests/providers/openai/cassette/permission_control.rs
+++ b/tests/providers/openai/cassette/permission_control.rs
@@ -10,12 +10,14 @@ use serde_json::json;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use tokio::sync::Mutex as AsyncMutex;
 
 use super::super::support::with_openai_cassette_result;
 use crate::support::assert_nonempty_response;
 
 const TEST_FILE: &str = "test.txt";
 const TEST_CONTENT: &str = "hello world\n";
+static PERMISSION_CONTROL_TEST_LOCK: AsyncMutex<()> = AsyncMutex::const_new(());
 
 struct FileCleanup;
 
@@ -140,6 +142,7 @@ impl<M: CompletionModel> AgentHook<M> for PermissionHook {
 
 #[tokio::test]
 async fn permission_control_prompt_example() -> Result<()> {
+    let _guard = PERMISSION_CONTROL_TEST_LOCK.lock().await;
     with_openai_cassette_result(
         "permission_control/permission_control_prompt_example",
         |client| async move {
@@ -181,6 +184,7 @@ async fn permission_control_prompt_example() -> Result<()> {
 
 #[tokio::test]
 async fn permission_control_streaming_example() -> Result<()> {
+    let _guard = PERMISSION_CONTROL_TEST_LOCK.lock().await;
     with_openai_cassette_result(
         "permission_control/permission_control_streaming_example",
         |client| async move {

--- a/tests/providers/openrouter/cassette/permission_control.rs
+++ b/tests/providers/openrouter/cassette/permission_control.rs
@@ -11,6 +11,7 @@ use serde_json::json;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use tokio::sync::Mutex as AsyncMutex;
 
 use crate::support::assert_nonempty_response;
 
@@ -18,6 +19,7 @@ use super::super::{TOOL_MODEL, support::with_openrouter_cassette_result};
 
 const TEST_FILE: &str = "test.txt";
 const TEST_CONTENT: &str = "hello world\n";
+static PERMISSION_CONTROL_TEST_LOCK: AsyncMutex<()> = AsyncMutex::const_new(());
 
 struct FileCleanup;
 
@@ -142,6 +144,7 @@ impl<M: CompletionModel> AgentHook<M> for PermissionHook {
 
 #[tokio::test]
 async fn permission_control_prompt_example() -> Result<()> {
+    let _guard = PERMISSION_CONTROL_TEST_LOCK.lock().await;
     with_openrouter_cassette_result(
         "permission_control/permission_control_prompt_example",
         |client| async move {
@@ -182,6 +185,7 @@ async fn permission_control_prompt_example() -> Result<()> {
 
 #[tokio::test]
 async fn permission_control_streaming_example() -> Result<()> {
+    let _guard = PERMISSION_CONTROL_TEST_LOCK.lock().await;
     with_openrouter_cassette_result(
         "permission_control/permission_control_streaming_example",
         |client| async move {

--- a/tests/providers/xai/permission_control.rs
+++ b/tests/providers/xai/permission_control.rs
@@ -13,12 +13,14 @@ use std::sync::Arc;
 use std::sync::LazyLock;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use tokio::sync::Mutex as AsyncMutex;
 
 use super::support::with_xai_cassette_result;
 use crate::support::assert_nonempty_response;
 
 const TEST_FILE: &str = "test.txt";
 const TEST_CONTENT: &str = "hello world\n";
+static PERMISSION_CONTROL_TEST_LOCK: AsyncMutex<()> = AsyncMutex::const_new(());
 static PERMISSION_CONTROL_LOCK: LazyLock<tokio::sync::Mutex<()>> =
     LazyLock::new(|| tokio::sync::Mutex::new(()));
 
@@ -145,6 +147,7 @@ impl<M: CompletionModel> AgentHook<M> for PermissionHook {
 
 #[tokio::test]
 async fn permission_control_prompt_example() -> Result<()> {
+    let _guard = PERMISSION_CONTROL_TEST_LOCK.lock().await;
     with_xai_cassette_result(
         "permission_control/permission_control_prompt_example",
         |client| async move {
@@ -186,6 +189,7 @@ async fn permission_control_prompt_example() -> Result<()> {
 
 #[tokio::test]
 async fn permission_control_streaming_example() -> Result<()> {
+    let _guard = PERMISSION_CONTROL_TEST_LOCK.lock().await;
     with_xai_cassette_result(
         "permission_control/permission_control_streaming_example",
         |client| async move {


### PR DESCRIPTION
## Summary
- remove runtime tool-name getters by replacing the object-safe ToolDyn trait with a concrete named ToolDyn value and nameless erased runtime
- make ToolSet registration keys the source of truth for definitions, schemas, documents, dispatch, ToolServer static names, and dynamic retrieval
- keep sub-agent tools using their agent name through IntoToolDyn and serialize provider permission-control tests that share test.txt

Closes #2031.

## Testing
- cargo fmt --check
- cargo check -p rig-core --all-targets --all-features
- cargo check --workspace --all-targets --all-features
- cargo test -p rig-core --lib
- cargo test -p rig-derive
- cargo test --doc --workspace --all-features
- cargo clippy --all-targets --all-features
- cargo test