### PR TITLE
feat(anthropic): support ANTHROPIC_BASE_URL in from_env()

### DIFF
--- a/crates/rig-core/src/providers/anthropic/client.rs
+++ b/crates/rig-core/src/providers/anthropic/client.rs
@@ -112,9 +112,16 @@ impl ProviderClient for Client {
     where
         Self: Sized,
     {
-        let key = crate::client::required_env_var("ANTHROPIC_API_KEY")?;
+        let base_url = crate::client::optional_env_var("ANTHROPIC_BASE_URL")?;
+        let api_key = crate::client::required_env_var("ANTHROPIC_API_KEY")?;
 
-        Self::builder().api_key(key).build().map_err(Into::into)
+        let mut builder = Self::builder().api_key(api_key);
+
+        if let Some(base) = base_url {
+            builder = builder.base_url(&base);
+        }
+
+        builder.build().map_err(Into::into)
     }
 
     fn from_val(input: Self::Input) -> Result<Self, Self::Error>


### PR DESCRIPTION
## Summary

Support `ANTHROPIC_BASE_URL` environment variable in `Client::from_env()`, matching the existing `OPENAI_BASE_URL` behavior in the OpenAI provider. This allows users to use third-party Anthropic-compatible APIs without manually building the client.

## Related Issue

Closes #2024

## Type of Change

- [x] New feature (non-breaking change)

## Checklist

- [x] My code follows the existing style.
- [x] CI is green (passing all checks).