### PR TITLE
fix(chatgpt): preserve non-success response errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,9 @@ expectations:
   streaming normalization patterns.
 - Provider error responses preserve status/body details through the relevant Rig
   error helpers, so callers can inspect provider response details.
+- Non-2xx completion responses surface through the capability error's
+  `from_http_response(status, body)` helper so retry/status logic can inspect
+  `provider_response_status()` and the raw provider body.
 - `ProviderResponseExt`, telemetry spans, and GenAI fields are populated
   consistently with nearby providers where applicable.
 - Tests cover the smallest reliable scope: unit tests, cassette-backed provider

--- a/crates/rig-core/src/providers/chatgpt/mod.rs
+++ b/crates/rig-core/src/providers/chatgpt/mod.rs
@@ -458,7 +458,12 @@ where
             .map_err(|err| CompletionError::HttpError(err.into()))?;
 
         let response = self.client.send(req).await?;
+        let status = response.status();
         let text = http_client::text(response).await?;
+        if !status.is_success() {
+            return Err(CompletionError::from_http_response(status, text));
+        }
+
         let raw_response = responses_api::streaming::parse_sse_completion_body(&text, "ChatGPT")?;
 
         match raw_response.clone().try_into() {
@@ -812,5 +817,52 @@ data: [DONE]"#;
 
         assert_eq!(text, "hi");
         assert_eq!(response.usage.total_tokens, 2);
+    }
+
+    #[tokio::test]
+    async fn completion_http_non_success_preserves_status_and_body() {
+        use crate::client::CompletionClient;
+        use crate::completion::CompletionModel;
+        use crate::test_utils::RecordingHttpClient;
+
+        let cases = [
+            (
+                http::StatusCode::UNAUTHORIZED,
+                r#"{"error":{"message":"expired access token","type":"invalid_request_error"}}"#,
+                "expired access token",
+            ),
+            (
+                http::StatusCode::TOO_MANY_REQUESTS,
+                r#"{"error":{"message":"rate limited","type":"rate_limit_error"}}"#,
+                "rate limited",
+            ),
+        ];
+
+        for (status, body, message) in cases {
+            let http_client = RecordingHttpClient::with_error_response(status, body);
+            let client = crate::providers::chatgpt::Client::builder()
+                .api_key(ChatGPTAuth::AccessToken {
+                    access_token: "test-token".to_string(),
+                    account_id: Some("account-id".to_string()),
+                })
+                .http_client(http_client)
+                .build()
+                .expect("client should build");
+            let model = client.completion_model(GPT_5_4);
+            let request = model.completion_request("hello").build();
+
+            let error = model
+                .completion(request)
+                .await
+                .expect_err("completion should fail with non-success status");
+
+            assert!(matches!(&error, CompletionError::HttpError(_)));
+            assert_eq!(error.provider_response_status(), Some(status));
+            assert_eq!(error.provider_response_body(), Some(body));
+            assert!(
+                error.to_string().contains(message),
+                "error should include provider body: {error}"
+            );
+        }
     }
 }

--- a/tests/cassettes/chatgpt/http_errors/nonstreaming_unauthorized_preserves_status_and_body.yaml
+++ b/tests/cassettes/chatgpt/http_errors/nonstreaming_unauthorized_preserves_status_and_body.yaml
@@ -1,0 +1,16 @@
+when:
+  path: /backend-api/codex/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"hello","type":"input_text"}],"role":"user","type":"message"}],"instructions":"","model":"gpt-5.4","store":false,"stream":true}'
+then:
+  status: 401
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"detail":"Could not parse your authentication token. Please try signing in again."}'

--- a/tests/providers/chatgpt/cassette/http_errors.rs
+++ b/tests/providers/chatgpt/cassette/http_errors.rs
@@ -1,0 +1,48 @@
+//! ChatGPT cassette coverage for non-success Responses API status handling.
+
+use axum::http;
+use rig::client::CompletionClient;
+use rig::completion::{CompletionError, CompletionModel};
+use rig::providers::chatgpt;
+
+use super::super::support::with_chatgpt_cassette;
+
+#[tokio::test]
+async fn nonstreaming_unauthorized_preserves_status_and_body() {
+    with_chatgpt_cassette(
+        "http_errors/nonstreaming_unauthorized_preserves_status_and_body",
+        |client| async move {
+            assert_nonstreaming_http_error(
+                client,
+                http::StatusCode::UNAUTHORIZED,
+                "authentication token",
+            )
+            .await;
+        },
+    )
+    .await;
+}
+
+async fn assert_nonstreaming_http_error(
+    client: chatgpt::Client,
+    expected_status: http::StatusCode,
+    expected_message: &str,
+) {
+    let model = client.completion_model(chatgpt::GPT_5_4);
+    let request = model.completion_request("hello").build();
+
+    let error = model
+        .completion(request)
+        .await
+        .expect_err("non-success response should fail");
+
+    assert!(matches!(&error, CompletionError::HttpError(_)));
+    assert_eq!(error.provider_response_status(), Some(expected_status));
+    let body = error
+        .provider_response_body()
+        .expect("provider response body should be preserved");
+    assert!(
+        body.contains(expected_message),
+        "provider response body should include {expected_message:?}: {body}"
+    );
+}

--- a/tests/providers/chatgpt/mod.rs
+++ b/tests/providers/chatgpt/mod.rs
@@ -5,6 +5,7 @@ mod cassette {
     mod codex_sessions;
     mod codex_tool_args;
     mod codex_tool_choice;
+    mod http_errors;
     mod noninteractive_oauth;
     mod streaming_tools;
 }


### PR DESCRIPTION
## Summary
- check ChatGPT Responses non-streaming HTTP status before parsing the SSE body
- return `CompletionError::from_http_response(status, body)` for non-2xx responses so status/body helpers work
- add unit coverage for 401 and 429 status/body propagation
- add live-recorded ChatGPT cassette coverage for the 401 Responses API error path
- document the provider checklist requirement for non-2xx completion errors

Fixes #2037

## Tests
- `cargo fmt`
- `RIG_PROVIDER_TEST_MODE=record CHATGPT_ACCESS_TOKEN=invalid-token-for-recording CHATGPT_ACCOUNT_ID=invalid-account cargo test -p rig --all-features --test chatgpt chatgpt::cassette::http_errors::nonstreaming_unauthorized_preserves_status_and_body -- --nocapture --test-threads=1`
- `cargo test -p rig-core providers::chatgpt::tests::completion_http_non_success_preserves_status_and_body -- --nocapture`
- `cargo test -p rig --all-features --test chatgpt chatgpt::cassette::http_errors -- --nocapture --test-threads=1`
- `cargo clippy --all-targets --all-features`
- `cargo test -- --test-threads=1`

Cassette notes: the committed ChatGPT cassette was recorded live against `https://chatgpt.com/backend-api/codex` using an intentionally invalid access token to produce a deterministic 401. I did not live-record a 429 fixture because reliably forcing ChatGPT rate limiting would require intentionally exhausting a real account/rate limit; the 429 path is covered by the unit test instead.
