### PR TITLE
fix(openrouter): record gen_ai input/output messages on completion span

### DIFF
--- a/crates/rig-core/src/providers/openrouter/completion.rs
+++ b/crates/rig-core/src/providers/openrouter/completion.rs
@@ -1981,10 +1981,17 @@ where
                 gen_ai.usage.output_tokens = tracing::field::Empty,
                 gen_ai.usage.input_tokens = tracing::field::Empty,
                 gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
+                gen_ai.input.messages = tracing::field::Empty,
+                gen_ai.output.messages = tracing::field::Empty,
             )
         } else {
             tracing::Span::current()
         };
+
+        // Record the request messages as GenAI input on the span so observability
+        // backends (e.g. Langfuse) can render the conversation. The provider only
+        // recorded token usage before, leaving `gen_ai.input.messages` empty.
+        span.record_model_input(&request.messages);
 
         let body = serde_json::to_vec(&body)?;
 
@@ -2014,6 +2021,13 @@ where
                         span.record_token_usage(&response.usage);
                         span.record("gen_ai.response.id", &response.id);
                         span.record("gen_ai.response.model", &response.model);
+                        span.record_model_output(
+                            &response
+                                .choices
+                                .iter()
+                                .map(|choice| &choice.message)
+                                .collect::<Vec<_>>(),
+                        );
 
                         tracing::debug!(target: "rig::completions",
                             "OpenRouter response: {response:?}");


### PR DESCRIPTION
Fixes #2059

## Problem

The OpenRouter completion provider records token usage and response metadata on its `chat` span but never records the messages, so `gen_ai.input.messages` and `gen_ai.output.messages` stay empty. Observability backends (Langfuse, Phoenix, …) show the span with token counts but no conversation content.

## Implementation

Mirror the existing pattern from the Cohere/galadriel/openai providers:

- Declare `gen_ai.input.messages` and `gen_ai.output.messages` on the locally-created span.
- Record the request messages as model input via the existing `SpanCombinator::record_model_input` helper before sending the request.
- Record the response choice messages as model output via `record_model_output` after a successful response.

No new abstractions — this reuses the `record_model_input`/`record_model_output` helpers already defined in `telemetry/mod.rs` and already used by Cohere. The helpers no-op on disabled spans, so there's no cost when tracing is off.

## Scope / out of scope

This brings the OpenRouter provider to parity with the other providers that already record message content. It intentionally follows the **existing, ungated** recording pattern — message content is recorded whenever the span is enabled, same as Cohere/galadriel/openai today.

The broader privacy/cardinality concern raised in #1788 (an opt-in toggle, empty by default, gating message-content recording across **all** providers at the `telemetry/mod.rs` chokepoint) is a separate, cross-cutting change and is deliberately out of scope here. Happy to follow up on that once there's a decision on the desired config surface.

## Testing

`record_model_input`/`record_model_output` are already covered by tests in `telemetry/mod.rs`. This change is a provider call-site into those helpers, consistent with the untested-at-provider-level pattern used by the sibling providers.

## AI assistance

AI-assisted; I reviewed every line, confirmed it matches the existing provider pattern, and verified the helper semantics (disabled-span no-op, field declaration required for `record` to take effect).
