### PR TITLE
chore: Upgrade rusqlite dependency from 0.32 to 0.40.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ testcontainers = "0.27"
 textwrap = "0.16.2"
 thiserror = "2.0.12"
 tokio = "1.52.3"
-tokio-rusqlite = { version = "0.6.0", default-features = false }
+tokio-rusqlite = { version = "0.7.0", default-features = false }
 tokio-test = "0.4.4"
 tokio-stream = "0.1.17"
 tokio-tungstenite = { version = "0.28.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ testcontainers = "0.27"
 textwrap = "0.16.2"
 thiserror = "2.0.12"
 tokio = "1.52.3"
-tokio-rusqlite = { version = "0.7.0", default-features = false }
+tokio-rusqlite = { git = "https://github.com/kkuehl/tokio-rusqlite.git", default-features = false }
 tokio-test = "0.4.4"
 tokio-stream = "0.1.17"
 tokio-tungstenite = { version = "0.28.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ reqwest-middleware = { version = "0.5.2", default-features = false }
 reqwest-retry = "0.9"
 rmcp = "1.7.0"
 url = "2.5"
-rusqlite = "0.32"
+rusqlite = "0.40.1"
 scylla = "1.2.0"
 schemars = "1.0.4"
 serde = "1.0.219"


### PR DESCRIPTION
## Summary

Upgrades `rusqlite` from 0.32 to 0.40.1, bringing 8 minor versions of improvements including bug fixes, performance enhancements, and updated SQLite bundled version.

## Changes

1. **rusqlite**: `0.32` → `0.40.1`
2. **tokio-rusqlite**: Now uses fork `kkuehl/tokio-rusqlite` with rusqlite 0.40.1 support

## tokio-rusqlite Fork Rationale

The `tokio-rusqlite` crate is a dependency of `rig-sqlite`. Unfortunately, the upstream maintainer has not merged rusqlite upgrade PRs:

- [PR #52](https://github.com/programatik29/tokio-rusqlite/pull/52) (upgrade to 0.39) has been open since March 2026 with no maintainer response
- Multiple community members have requested the merge in comments

Until upstream merges a rusqlite 0.40+ compatible version, this PR uses a fork with the necessary 2-line change to unblock rig users who need modern rusqlite features.

## Alternative Approach

If using a git dependency for `tokio-rusqlite` is not acceptable, consider:
1. Waiting for upstream to merge rusqlite upgrades
2. Switching to an alternative async SQLite wrapper
3. Maintaining the fork as `rig-tokio-rusqlite`

## Testing

- [ ] All existing tests pass
- [ ] `rig-sqlite` builds successfully with the changes
