### PR TITLE
Remove unused generation wrapper traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- *(core)* [**breaking**] remove the unused public `AudioGeneration<M>`, `ImageGeneration<M>`, and `Transcription<M>` wrapper traits; use the corresponding `AudioGenerationModel`, `ImageGenerationModel`, and `TranscriptionModel` APIs and request builders directly.
 - *(core)* [**breaking**] remove the unused `evals` module (`Eval` trait, judge metrics, and builders) along with the `experimental` feature flag that gated it
 - *(anthropic)* [**breaking**] remove the unused public `providers::anthropic::decoders` module; Anthropic streaming uses the shared SSE machinery.
 - *(providers)* [**breaking**] remove the Galadriel provider integration (`providers::galadriel`), including its client, model constants, environment-variable support, and ignored live tests.

--- a/crates/rig-core/CHANGELOG.md
+++ b/crates/rig-core/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- *(core)* [**breaking**] remove the unused public `AudioGeneration<M>`, `ImageGeneration<M>`, and `Transcription<M>` wrapper traits; use the corresponding `AudioGenerationModel`, `ImageGenerationModel`, and `TranscriptionModel` APIs and request builders directly.
 - *(anthropic)* [**breaking**] remove the unused public `providers::anthropic::decoders` module; Anthropic streaming uses the shared SSE machinery.
 
 ### Added

--- a/crates/rig-core/src/audio_generation.rs
+++ b/crates/rig-core/src/audio_generation.rs
@@ -47,30 +47,6 @@ pub enum AudioGenerationError {
 
 crate::provider_response::impl_provider_response_helpers!(AudioGenerationError);
 
-pub trait AudioGeneration<M>
-where
-    M: AudioGenerationModel,
-{
-    /// Generates an audio generation request builder for the given `text` and `voice`.
-    /// This function is meant to be called by the user to further customize the
-    /// request at generation time before sending it.
-    ///
-    /// ❗IMPORTANT: The type that implements this trait might have already
-    /// populated fields in the builder (the exact fields depend on the type).
-    /// For fields that have already been set by the model, calling the corresponding
-    /// method on the builder will overwrite the value set by the model.
-    fn audio_generation(
-        &self,
-        text: &str,
-        voice: &str,
-    ) -> impl std::future::Future<
-        Output = Result<
-            AudioGenerationRequestBuilder<M, Provided<String>, Provided<String>>,
-            AudioGenerationError,
-        >,
-    > + Send;
-}
-
 pub struct AudioGenerationResponse<T> {
     pub audio: Vec<u8>,
     pub response: T,

--- a/crates/rig-core/src/image_generation.rs
+++ b/crates/rig-core/src/image_generation.rs
@@ -39,27 +39,6 @@ pub enum ImageGenerationError {
 
 crate::provider_response::impl_provider_response_helpers!(ImageGenerationError);
 
-pub trait ImageGeneration<M>
-where
-    M: ImageGenerationModel,
-{
-    /// Generates an image generation request builder for the given prompt and size.
-    /// This function is meant to be called by the user to further customize the
-    /// request at image generation time before sending it.
-    ///
-    /// ❗IMPORTANT: The type that implements this trait might have already
-    /// populated fields in the builder (the exact fields depend on the type).
-    /// For fields that have already been set by the model, calling the corresponding
-    /// method on the builder will overwrite the value set by the model.
-    fn image_generation(
-        &self,
-        prompt: &str,
-        size: &(u32, u32),
-    ) -> impl std::future::Future<
-        Output = Result<ImageGenerationRequestBuilder<M, Provided<String>>, ImageGenerationError>,
-    > + Send;
-}
-
 /// A unified response for a model image generation, returning both the image and the raw response.
 #[derive(Debug)]
 pub struct ImageGenerationResponse<T> {

--- a/crates/rig-core/src/transcription.rs
+++ b/crates/rig-core/src/transcription.rs
@@ -49,28 +49,6 @@ pub enum TranscriptionError {
 
 crate::provider_response::impl_provider_response_helpers!(TranscriptionError);
 
-/// Trait defining a low-level LLM transcription interface
-pub trait Transcription<M>
-where
-    M: TranscriptionModel,
-{
-    /// Generates a transcription request builder for the given `file`.
-    /// This function is meant to be called by the user to further customize the
-    /// request at transcription time before sending it.
-    ///
-    /// ❗IMPORTANT: The type that implements this trait might have already
-    /// populated fields in the builder (the exact fields depend on the type).
-    /// For fields that have already been set by the model, calling the corresponding
-    /// method on the builder will overwrite the value set by the model.
-    fn transcription(
-        &self,
-        filename: &str,
-        data: &[u8],
-    ) -> impl std::future::Future<
-        Output = Result<TranscriptionRequestBuilder<M, Provided<Vec<u8>>>, TranscriptionError>,
-    > + WasmCompatSend;
-}
-
 /// General transcription response struct that contains the transcription text
 /// and the raw response.
 pub struct TranscriptionResponse<T> {


### PR DESCRIPTION
## Summary
- Remove unused public wrapper traits `AudioGeneration<M>`, `ImageGeneration<M>`, and `Transcription<M>`.
- Keep the live `AudioGenerationModel`, `ImageGenerationModel`, and `TranscriptionModel` APIs, request builders, clients, providers, examples, and tests intact.
- Document the public API removal as breaking in the root and `rig-core` changelogs.

Closes #2072.

## Validation
- `cargo fmt`
- `cargo fmt --check`
- `cargo check -p rig-core --all-features`
- `cargo check -p rig-core --features image,audio`
- `cargo test -p rig-core --features image,audio provider_response_tests`
- `cargo test -p rig-core --all-features provider_response_tests`
- `git diff --check`
- exact `rg` / `git grep` checks confirmed the removed wrapper traits are gone and the live model traits plus Gemini Nano Banana support remain.

## Not run
- Full workspace `cargo test`
- Full `cargo clippy --all-targets --all-features`
- `cargo doc`
- Live provider tests requiring credentials/network
