### PR TITLE
fix(vertexai): map generation config and preserve image history

### DIFF
--- a/crates/rig-vertexai/src/completion.rs
+++ b/crates/rig-vertexai/src/completion.rs
@@ -90,7 +90,7 @@ impl CompletionModelTrait for CompletionModel {
         let vertex_request = VertexCompletionRequest(request);
 
         let contents = vertex_request.contents()?;
-        let generation_config = vertex_request.generation_config();
+        let generation_config = vertex_request.generation_config()?;
         let system_instruction = vertex_request.system_instruction();
         let tools = vertex_request.tools();
         let tool_config = vertex_request.tool_config();

--- a/crates/rig-vertexai/src/types/completion_request.rs
+++ b/crates/rig-vertexai/src/types/completion_request.rs
@@ -117,13 +117,25 @@ impl VertexCompletionRequest {
         } = serde_json::from_value(additional_params)?;
 
         let mut config = generation_config
-            .map(vertex_generation_config)
+            .map(|mut config| {
+                // Typed max_tokens is authoritative, so an overridden provider value must not be
+                // converted or range-validated before the typed value is applied below.
+                if self.0.max_tokens.is_some() {
+                    config.max_output_tokens = None;
+                }
+                // Typed temperature is likewise authoritative, so it must bypass provider
+                // conversion and range validation before being applied below.
+                if self.0.temperature.is_some() {
+                    config.temperature = None;
+                }
+                vertex_generation_config(config)
+            })
             .transpose()?
             .unwrap_or_else(vertexai::model::GenerationConfig::new);
 
         // The typed request surface is authoritative over provider-specific extras.
         if let Some(temperature) = self.0.temperature {
-            config = config.set_temperature(temperature as f32);
+            config = config.set_temperature(vertex_f32(temperature, "temperature")?);
         }
 
         if let Some(max_tokens) = self.0.max_tokens {
@@ -144,9 +156,33 @@ fn vertex_max_output_tokens(max_output_tokens: u64) -> Result<i32, CompletionErr
     })
 }
 
+fn vertex_f32(value: f64, field: &str) -> Result<f32, CompletionError> {
+    if !value.is_finite() || value < f64::from(f32::MIN) || value > f64::from(f32::MAX) {
+        return Err(CompletionError::RequestError(
+            format!("{field} must be finite and within Vertex AI's f32 range").into(),
+        ));
+    }
+
+    Ok(value as f32)
+}
+
 fn vertex_generation_config(
     config: GeminiGenerationConfig,
 ) -> Result<vertexai::model::GenerationConfig, CompletionError> {
+    if config.response_schema.is_some()
+        && (config.response_json_schema.is_some() || config._response_json_schema.is_some())
+    {
+        return Err(CompletionError::RequestError(
+            "responseSchema cannot be combined with responseJsonSchema or _responseJsonSchema"
+                .into(),
+        ));
+    }
+    if config.response_json_schema.is_some() && config._response_json_schema.is_some() {
+        return Err(CompletionError::RequestError(
+            "responseJsonSchema cannot be combined with _responseJsonSchema".into(),
+        ));
+    }
+
     let mut vertex_config = vertexai::model::GenerationConfig::new();
 
     if let Some(stop_sequences) = config.stop_sequences {
@@ -169,19 +205,21 @@ fn vertex_generation_config(
             vertex_config.set_max_output_tokens(vertex_max_output_tokens(max_output_tokens)?);
     }
     if let Some(temperature) = config.temperature {
-        vertex_config = vertex_config.set_temperature(temperature as f32);
+        vertex_config = vertex_config.set_temperature(vertex_f32(temperature, "temperature")?);
     }
     if let Some(top_p) = config.top_p {
-        vertex_config = vertex_config.set_top_p(top_p as f32);
+        vertex_config = vertex_config.set_top_p(vertex_f32(top_p, "top_p")?);
     }
     if let Some(top_k) = config.top_k {
-        vertex_config = vertex_config.set_top_k(top_k as f32);
+        vertex_config = vertex_config.set_top_k(vertex_f32(f64::from(top_k), "top_k")?);
     }
     if let Some(presence_penalty) = config.presence_penalty {
-        vertex_config = vertex_config.set_presence_penalty(presence_penalty as f32);
+        vertex_config =
+            vertex_config.set_presence_penalty(vertex_f32(presence_penalty, "presence_penalty")?);
     }
     if let Some(frequency_penalty) = config.frequency_penalty {
-        vertex_config = vertex_config.set_frequency_penalty(frequency_penalty as f32);
+        vertex_config = vertex_config
+            .set_frequency_penalty(vertex_f32(frequency_penalty, "frequency_penalty")?);
     }
     if let Some(response_logprobs) = config.response_logprobs {
         vertex_config = vertex_config.set_response_logprobs(response_logprobs);
@@ -193,12 +231,11 @@ fn vertex_generation_config(
         vertex_config = vertex_config.set_thinking_config(vertex_thinking_config(thinking_config)?);
     }
     if let Some(response_modalities) = config.response_modalities {
-        vertex_config = vertex_config.set_response_modalities(
-            response_modalities
-                .into_iter()
-                .map(vertex_response_modality)
-                .collect::<Vec<_>>(),
-        );
+        let response_modalities = response_modalities
+            .into_iter()
+            .map(vertex_response_modality)
+            .collect::<Result<Vec<_>, _>>()?;
+        vertex_config = vertex_config.set_response_modalities(response_modalities);
     }
     if let Some(image_config) = config.image_config {
         vertex_config = vertex_config.set_image_config(vertex_image_config(image_config));
@@ -248,11 +285,14 @@ fn vertex_thinking_config(
 
 fn vertex_response_modality(
     modality: ResponseModality,
-) -> vertexai::model::generation_config::Modality {
+) -> Result<vertexai::model::generation_config::Modality, CompletionError> {
     match modality {
-        ResponseModality::Text => vertexai::model::generation_config::Modality::Text,
-        ResponseModality::Image => vertexai::model::generation_config::Modality::Image,
-        ResponseModality::Audio => vertexai::model::generation_config::Modality::Audio,
+        ResponseModality::Text => Ok(vertexai::model::generation_config::Modality::Text),
+        ResponseModality::Image => Ok(vertexai::model::generation_config::Modality::Image),
+        ResponseModality::Audio => Err(CompletionError::RequestError(
+            "responseModalities AUDIO is unsupported because Rig cannot represent assistant audio responses"
+                .into(),
+        )),
     }
 }
 
@@ -760,6 +800,57 @@ mod tests {
     }
 
     #[test]
+    fn generation_config_rejects_audio_response_modality() {
+        let request = CompletionRequest {
+            additional_params: Some(serde_json::json!({
+                "generationConfig": { "responseModalities": ["AUDIO"] }
+            })),
+            ..minimal_request()
+        };
+
+        let error = VertexCompletionRequest(request)
+            .generation_config()
+            .expect_err("audio output must fail before the API call");
+        assert!(matches!(error, CompletionError::RequestError(_)));
+        assert!(error.to_string().contains("responseModalities AUDIO"));
+    }
+
+    #[test]
+    fn generation_config_rejects_out_of_f32_range_typed_and_provider_values() {
+        let typed_request = CompletionRequest {
+            temperature: Some(f64::MAX),
+            ..minimal_request()
+        };
+        let typed_error = VertexCompletionRequest(typed_request)
+            .generation_config()
+            .expect_err("typed temperature beyond f32 must fail");
+        assert!(matches!(typed_error, CompletionError::RequestError(_)));
+        assert!(typed_error.to_string().contains("temperature"));
+
+        let provider_error = vertex_generation_config(GeminiGenerationConfig {
+            top_p: Some(f64::MAX),
+            ..Default::default()
+        })
+        .expect_err("provider top_p beyond f32 must fail");
+        assert!(matches!(provider_error, CompletionError::RequestError(_)));
+        assert!(provider_error.to_string().contains("top_p"));
+    }
+
+    #[test]
+    fn generation_config_rejects_non_finite_typed_values() {
+        let request = CompletionRequest {
+            temperature: Some(f64::NAN),
+            ..minimal_request()
+        };
+
+        let error = VertexCompletionRequest(request)
+            .generation_config()
+            .expect_err("non-finite typed temperature must fail");
+        assert!(matches!(error, CompletionError::RequestError(_)));
+        assert!(error.to_string().contains("temperature"));
+    }
+
+    #[test]
     fn generation_config_maps_response_schema() {
         let request = CompletionRequest {
             additional_params: Some(serde_json::json!({
@@ -794,7 +885,41 @@ mod tests {
     }
 
     #[test]
-    fn generation_config_rejects_out_of_range_max_output_tokens() {
+    fn generation_config_typed_max_overrides_out_of_range_provider_max() {
+        let request = CompletionRequest {
+            max_tokens: Some(100),
+            additional_params: Some(serde_json::json!({
+                "generationConfig": { "maxOutputTokens": 2_147_483_648_u64 }
+            })),
+            ..minimal_request()
+        };
+
+        let config = VertexCompletionRequest(request)
+            .generation_config()
+            .expect("typed max should override an unrepresentable provider max")
+            .expect("generation config should exist");
+        assert_eq!(config.max_output_tokens, Some(100));
+    }
+
+    #[test]
+    fn generation_config_typed_temperature_overrides_out_of_range_provider_temperature() {
+        let request = CompletionRequest {
+            temperature: Some(0.7),
+            additional_params: Some(serde_json::json!({
+                "generationConfig": { "temperature": f64::MAX }
+            })),
+            ..minimal_request()
+        };
+
+        let config = VertexCompletionRequest(request)
+            .generation_config()
+            .expect("typed temperature should override an unrepresentable provider temperature")
+            .expect("generation config should exist");
+        assert_eq!(config.temperature, Some(0.7));
+    }
+
+    #[test]
+    fn generation_config_rejects_out_of_range_max_output_tokens_without_typed_override() {
         let provider_request = CompletionRequest {
             additional_params: Some(serde_json::json!({
                 "generationConfig": { "maxOutputTokens": 2_147_483_648_u64 }
@@ -821,6 +946,54 @@ mod tests {
             typed_error
                 .to_string()
                 .contains("max_output_tokens exceeds Vertex AI's i32 range")
+        );
+    }
+
+    #[test]
+    fn generation_config_rejects_conflicting_response_schema_forms() {
+        for json_schema_key in ["responseJsonSchema", "_responseJsonSchema"] {
+            let request = CompletionRequest {
+                additional_params: Some(serde_json::json!({
+                    "generationConfig": {
+                        "responseSchema": { "type": "OBJECT" },
+                        (json_schema_key): { "type": "object" }
+                    }
+                })),
+                ..minimal_request()
+            };
+
+            let error = VertexCompletionRequest(request)
+                .generation_config()
+                .expect_err("response schema forms cannot be combined");
+            assert!(matches!(error, CompletionError::RequestError(_)));
+            assert!(
+                error
+                    .to_string()
+                    .contains("responseSchema cannot be combined")
+            );
+        }
+    }
+
+    #[test]
+    fn generation_config_rejects_both_response_json_schema_aliases() {
+        let request = CompletionRequest {
+            additional_params: Some(serde_json::json!({
+                "generationConfig": {
+                    "responseJsonSchema": { "type": "object" },
+                    "_responseJsonSchema": { "type": "object" }
+                }
+            })),
+            ..minimal_request()
+        };
+
+        let error = VertexCompletionRequest(request)
+            .generation_config()
+            .expect_err("JSON schema aliases cannot be combined");
+        assert!(matches!(error, CompletionError::RequestError(_)));
+        assert!(
+            error
+                .to_string()
+                .contains("responseJsonSchema cannot be combined with _responseJsonSchema")
         );
     }
 

--- a/crates/rig-vertexai/src/types/completion_request.rs
+++ b/crates/rig-vertexai/src/types/completion_request.rs
@@ -1,6 +1,12 @@
 use crate::types::message::RigMessage;
 use google_cloud_aiplatform_v1 as vertexai;
 use rig_core::completion::CompletionError;
+use rig_core::providers::gemini::completion::gemini_api_types::{
+    AdditionalParameters, GenerationConfig as GeminiGenerationConfig,
+    ImageConfig as GeminiImageConfig, ResponseModality, ThinkingConfig as GeminiThinkingConfig,
+    ThinkingLevel,
+};
+use serde_json::{Map, Value};
 
 pub struct VertexCompletionRequest(pub rig_core::completion::CompletionRequest);
 
@@ -98,21 +104,167 @@ impl VertexCompletionRequest {
         )
     }
 
-    pub fn generation_config(&self) -> Option<vertexai::model::GenerationConfig> {
-        let mut config = vertexai::model::GenerationConfig::new();
+    pub fn generation_config(
+        &self,
+    ) -> Result<Option<vertexai::model::GenerationConfig>, CompletionError> {
+        let additional_params = self
+            .0
+            .additional_params
+            .clone()
+            .unwrap_or_else(|| Value::Object(Map::new()));
+        let AdditionalParameters {
+            generation_config, ..
+        } = serde_json::from_value(additional_params)?;
 
+        let mut config = generation_config
+            .map(vertex_generation_config)
+            .transpose()?
+            .unwrap_or_else(vertexai::model::GenerationConfig::new);
+
+        // The typed request surface is authoritative over provider-specific extras.
         if let Some(temperature) = self.0.temperature {
             config = config.set_temperature(temperature as f32);
         }
 
         if let Some(max_tokens) = self.0.max_tokens {
-            config = config.set_max_output_tokens(max_tokens as i32);
+            config = config.set_max_output_tokens(vertex_max_output_tokens(max_tokens)?);
         }
 
+        // Rig's normalized response retains one candidate, so the request must not
+        // ask Vertex to generate candidates that would be silently discarded.
         config = config.set_candidate_count(1);
 
-        Some(config)
+        Ok(Some(config))
     }
+}
+
+fn vertex_max_output_tokens(max_output_tokens: u64) -> Result<i32, CompletionError> {
+    i32::try_from(max_output_tokens).map_err(|_| {
+        CompletionError::RequestError("max_output_tokens exceeds Vertex AI's i32 range".into())
+    })
+}
+
+fn vertex_generation_config(
+    config: GeminiGenerationConfig,
+) -> Result<vertexai::model::GenerationConfig, CompletionError> {
+    let mut vertex_config = vertexai::model::GenerationConfig::new();
+
+    if let Some(stop_sequences) = config.stop_sequences {
+        vertex_config = vertex_config.set_stop_sequences(stop_sequences);
+    }
+    if let Some(response_mime_type) = config.response_mime_type {
+        vertex_config = vertex_config.set_response_mime_type(response_mime_type);
+    }
+    if let Some(response_schema) = config.response_schema {
+        vertex_config.response_schema = Some(serde_json::from_value(serde_json::to_value(
+            response_schema,
+        )?)?);
+    }
+    if let Some(response_json_schema) = config.response_json_schema.or(config._response_json_schema)
+    {
+        vertex_config.response_json_schema = Some(serde_json::from_value(response_json_schema)?);
+    }
+    if let Some(max_output_tokens) = config.max_output_tokens {
+        vertex_config =
+            vertex_config.set_max_output_tokens(vertex_max_output_tokens(max_output_tokens)?);
+    }
+    if let Some(temperature) = config.temperature {
+        vertex_config = vertex_config.set_temperature(temperature as f32);
+    }
+    if let Some(top_p) = config.top_p {
+        vertex_config = vertex_config.set_top_p(top_p as f32);
+    }
+    if let Some(top_k) = config.top_k {
+        vertex_config = vertex_config.set_top_k(top_k as f32);
+    }
+    if let Some(presence_penalty) = config.presence_penalty {
+        vertex_config = vertex_config.set_presence_penalty(presence_penalty as f32);
+    }
+    if let Some(frequency_penalty) = config.frequency_penalty {
+        vertex_config = vertex_config.set_frequency_penalty(frequency_penalty as f32);
+    }
+    if let Some(response_logprobs) = config.response_logprobs {
+        vertex_config = vertex_config.set_response_logprobs(response_logprobs);
+    }
+    if let Some(logprobs) = config.logprobs {
+        vertex_config = vertex_config.set_logprobs(logprobs);
+    }
+    if let Some(thinking_config) = config.thinking_config {
+        vertex_config = vertex_config.set_thinking_config(vertex_thinking_config(thinking_config)?);
+    }
+    if let Some(response_modalities) = config.response_modalities {
+        vertex_config = vertex_config.set_response_modalities(
+            response_modalities
+                .into_iter()
+                .map(vertex_response_modality)
+                .collect::<Vec<_>>(),
+        );
+    }
+    if let Some(image_config) = config.image_config {
+        vertex_config = vertex_config.set_image_config(vertex_image_config(image_config));
+    }
+
+    Ok(vertex_config)
+}
+
+fn vertex_thinking_config(
+    config: GeminiThinkingConfig,
+) -> Result<vertexai::model::generation_config::ThinkingConfig, CompletionError> {
+    if config.thinking_budget.is_some() && config.thinking_level.is_some() {
+        return Err(CompletionError::RequestError(
+            "thinking_budget and thinking_level cannot both be set".into(),
+        ));
+    }
+
+    let mut vertex_config = vertexai::model::generation_config::ThinkingConfig::new();
+    if let Some(include_thoughts) = config.include_thoughts {
+        vertex_config = vertex_config.set_include_thoughts(include_thoughts);
+    }
+    if let Some(thinking_budget) = config.thinking_budget {
+        let thinking_budget = i32::try_from(thinking_budget).map_err(|_| {
+            CompletionError::RequestError("thinking_budget exceeds Vertex AI's i32 range".into())
+        })?;
+        vertex_config = vertex_config.set_thinking_budget(thinking_budget);
+    }
+    if let Some(thinking_level) = config.thinking_level {
+        vertex_config = vertex_config.set_thinking_level(match thinking_level {
+            ThinkingLevel::Minimal => {
+                vertexai::model::generation_config::thinking_config::ThinkingLevel::Minimal
+            }
+            ThinkingLevel::Low => {
+                vertexai::model::generation_config::thinking_config::ThinkingLevel::Low
+            }
+            ThinkingLevel::Medium => {
+                vertexai::model::generation_config::thinking_config::ThinkingLevel::Medium
+            }
+            ThinkingLevel::High => {
+                vertexai::model::generation_config::thinking_config::ThinkingLevel::High
+            }
+        });
+    }
+
+    Ok(vertex_config)
+}
+
+fn vertex_response_modality(
+    modality: ResponseModality,
+) -> vertexai::model::generation_config::Modality {
+    match modality {
+        ResponseModality::Text => vertexai::model::generation_config::Modality::Text,
+        ResponseModality::Image => vertexai::model::generation_config::Modality::Image,
+        ResponseModality::Audio => vertexai::model::generation_config::Modality::Audio,
+    }
+}
+
+fn vertex_image_config(image_config: GeminiImageConfig) -> vertexai::model::ImageConfig {
+    let mut vertex_config = vertexai::model::ImageConfig::new();
+    if let Some(aspect_ratio) = image_config.aspect_ratio {
+        vertex_config = vertex_config.set_aspect_ratio(aspect_ratio);
+    }
+    if let Some(image_size) = image_config.image_size {
+        vertex_config = vertex_config.set_image_size(image_size);
+    }
+    vertex_config
 }
 
 #[cfg(test)]
@@ -472,12 +624,238 @@ mod tests {
         };
 
         let vertex_request = VertexCompletionRequest(request);
-        let generation_config = vertex_request.generation_config();
+        let generation_config = vertex_request
+            .generation_config()
+            .expect("generation config should parse");
 
         assert!(generation_config.is_some());
         let config = generation_config.unwrap();
         assert_eq!(config.temperature, Some(0.7));
         assert_eq!(config.max_output_tokens, Some(100));
         assert_eq!(config.candidate_count, Some(1));
+    }
+
+    #[test]
+    fn generation_config_maps_thinking_budget_and_include_thoughts() {
+        let request = CompletionRequest {
+            additional_params: Some(serde_json::json!({
+                "generationConfig": {
+                    "thinkingConfig": {
+                        "thinkingBudget": 1024,
+                        "includeThoughts": true
+                    }
+                }
+            })),
+            ..minimal_request()
+        };
+
+        let config = VertexCompletionRequest(request)
+            .generation_config()
+            .expect("generation config should parse")
+            .expect("generation config should exist");
+        let thinking = config
+            .thinking_config
+            .expect("thinking config should be mapped");
+
+        assert_eq!(thinking.thinking_budget, Some(1024));
+        assert_eq!(thinking.include_thoughts, Some(true));
+        assert_eq!(thinking.thinking_level, None);
+    }
+
+    #[test]
+    fn generation_config_maps_thinking_levels() {
+        use vertexai::model::generation_config::thinking_config::ThinkingLevel as VertexThinkingLevel;
+
+        for (level, expected) in [
+            ("minimal", VertexThinkingLevel::Minimal),
+            ("low", VertexThinkingLevel::Low),
+            ("medium", VertexThinkingLevel::Medium),
+            ("high", VertexThinkingLevel::High),
+        ] {
+            let request = CompletionRequest {
+                additional_params: Some(serde_json::json!({
+                    "generationConfig": {
+                        "thinkingConfig": { "thinkingLevel": level }
+                    }
+                })),
+                ..minimal_request()
+            };
+
+            let config = VertexCompletionRequest(request)
+                .generation_config()
+                .expect("generation config should parse")
+                .expect("generation config should exist");
+            let thinking = config
+                .thinking_config
+                .expect("thinking config should be mapped");
+
+            assert_eq!(thinking.thinking_level, Some(expected));
+        }
+    }
+
+    #[test]
+    fn generation_config_maps_supported_fields_and_typed_fields_take_precedence() {
+        let request = CompletionRequest {
+            temperature: Some(0.7),
+            max_tokens: Some(100),
+            additional_params: Some(serde_json::json!({
+                "generationConfig": {
+                    "temperature": 0.2,
+                    "maxOutputTokens": 20,
+                    "candidateCount": 2,
+                    "stopSequences": ["END"],
+                    "responseMimeType": "application/json",
+                    "responseJsonSchema": { "type": "object" },
+                    "topP": 0.8,
+                    "topK": 40,
+                    "presencePenalty": 0.1,
+                    "frequencyPenalty": 0.2,
+                    "responseLogprobs": true,
+                    "logprobs": 3,
+                    "responseModalities": ["TEXT", "IMAGE"],
+                    "imageConfig": {
+                        "aspectRatio": "16:9",
+                        "imageSize": "1K"
+                    }
+                }
+            })),
+            ..minimal_request()
+        };
+
+        let config = VertexCompletionRequest(request)
+            .generation_config()
+            .expect("generation config should parse")
+            .expect("generation config should exist");
+
+        assert_eq!(config.temperature, Some(0.7));
+        assert_eq!(config.max_output_tokens, Some(100));
+        assert_eq!(config.candidate_count, Some(1));
+        assert_eq!(config.stop_sequences, ["END"]);
+        assert_eq!(config.response_mime_type, "application/json");
+        assert_eq!(
+            serde_json::to_value(
+                config
+                    .response_json_schema
+                    .expect("JSON schema should be mapped")
+            )
+            .expect("Vertex JSON schema should serialize"),
+            serde_json::json!({ "type": "object" })
+        );
+        assert_eq!(config.top_p, Some(0.8));
+        assert_eq!(config.top_k, Some(40.0));
+        assert_eq!(config.presence_penalty, Some(0.1));
+        assert_eq!(config.frequency_penalty, Some(0.2));
+        assert_eq!(config.response_logprobs, Some(true));
+        assert_eq!(config.logprobs, Some(3));
+        assert_eq!(
+            config.response_modalities,
+            [
+                vertexai::model::generation_config::Modality::Text,
+                vertexai::model::generation_config::Modality::Image,
+            ]
+        );
+        let image = config.image_config.expect("image config should be mapped");
+        assert_eq!(image.aspect_ratio.as_deref(), Some("16:9"));
+        assert_eq!(image.image_size.as_deref(), Some("1K"));
+    }
+
+    #[test]
+    fn generation_config_maps_response_schema() {
+        let request = CompletionRequest {
+            additional_params: Some(serde_json::json!({
+                "generationConfig": {
+                    "responseSchema": {
+                        "type": "OBJECT",
+                        "properties": {
+                            "name": { "type": "STRING" }
+                        }
+                    }
+                }
+            })),
+            ..minimal_request()
+        };
+
+        let config = VertexCompletionRequest(request)
+            .generation_config()
+            .expect("generation config should parse")
+            .expect("generation config should exist");
+
+        let schema = config
+            .response_schema
+            .expect("response schema should be mapped");
+        assert_eq!(schema.r#type, vertexai::model::Type::Object);
+        assert_eq!(
+            schema
+                .properties
+                .get("name")
+                .map(|property| &property.r#type),
+            Some(&vertexai::model::Type::String)
+        );
+    }
+
+    #[test]
+    fn generation_config_rejects_out_of_range_max_output_tokens() {
+        let provider_request = CompletionRequest {
+            additional_params: Some(serde_json::json!({
+                "generationConfig": { "maxOutputTokens": 2_147_483_648_u64 }
+            })),
+            ..minimal_request()
+        };
+        let provider_error = VertexCompletionRequest(provider_request)
+            .generation_config()
+            .expect_err("provider max output tokens beyond i32 must fail");
+        assert!(
+            provider_error
+                .to_string()
+                .contains("max_output_tokens exceeds Vertex AI's i32 range")
+        );
+
+        let typed_request = CompletionRequest {
+            max_tokens: Some(2_147_483_648),
+            ..minimal_request()
+        };
+        let typed_error = VertexCompletionRequest(typed_request)
+            .generation_config()
+            .expect_err("typed max output tokens beyond i32 must fail");
+        assert!(
+            typed_error
+                .to_string()
+                .contains("max_output_tokens exceeds Vertex AI's i32 range")
+        );
+    }
+
+    #[test]
+    fn generation_config_rejects_invalid_thinking_config() {
+        let malformed_request = CompletionRequest {
+            additional_params: Some(serde_json::json!({
+                "generationConfig": { "thinkingConfig": { "thinkingBudget": "invalid" } }
+            })),
+            ..minimal_request()
+        };
+        assert!(
+            VertexCompletionRequest(malformed_request)
+                .generation_config()
+                .is_err()
+        );
+
+        let conflicting_request = CompletionRequest {
+            additional_params: Some(serde_json::json!({
+                "generationConfig": {
+                    "thinkingConfig": {
+                        "thinkingBudget": 1024,
+                        "thinkingLevel": "high"
+                    }
+                }
+            })),
+            ..minimal_request()
+        };
+        let error = VertexCompletionRequest(conflicting_request)
+            .generation_config()
+            .expect_err("mutually exclusive thinking values must fail");
+        assert!(
+            error
+                .to_string()
+                .contains("thinking_budget and thinking_level cannot both be set")
+        );
     }
 }

--- a/crates/rig-vertexai/src/types/completion_response.rs
+++ b/crates/rig-vertexai/src/types/completion_response.rs
@@ -3,7 +3,10 @@ use base64::engine::general_purpose::STANDARD as BASE64;
 use google_cloud_aiplatform_v1 as vertexai;
 use rig_core::OneOrMany;
 use rig_core::completion::{CompletionError, CompletionResponse, Usage};
-use rig_core::message::{AssistantContent, Reasoning, Text, ToolCall, ToolFunction};
+use rig_core::message::{
+    AssistantContent, ImageDetail, ImageMediaType, MediaType, MimeType, Reasoning, Text, ToolCall,
+    ToolFunction,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -58,6 +61,47 @@ impl TryFrom<VertexGenerateContentOutput> for CompletionResponse<VertexGenerateC
                 } else {
                     assistant_contents.push(AssistantContent::Text(Text::new(text.clone())));
                 }
+            } else if let Some(inline_data) = part.inline_data() {
+                if signature.is_some() {
+                    return Err(CompletionError::ResponseError(
+                        "Vertex inline images with thought_signature cannot be replayed through assistant history"
+                            .to_string(),
+                    ));
+                }
+
+                // Assistant history cannot represent the `thought` flag on image parts, so
+                // avoid replaying an internal thought image as visible assistant content.
+                if part.thought {
+                    continue;
+                }
+
+                let media_type = MediaType::from_mime_type(&inline_data.mime_type);
+                match media_type {
+                    Some(MediaType::Image(
+                        media_type @ (ImageMediaType::JPEG
+                        | ImageMediaType::PNG
+                        | ImageMediaType::WEBP
+                        | ImageMediaType::HEIC
+                        | ImageMediaType::HEIF),
+                    )) => {
+                        assistant_contents.push(AssistantContent::image_base64(
+                            BASE64.encode(&inline_data.data),
+                            Some(media_type),
+                            Some(ImageDetail::default()),
+                        ));
+                    }
+                    Some(MediaType::Image(media_type)) => {
+                        return Err(CompletionError::ResponseError(format!(
+                            "Unsupported Vertex inline image media type {media_type:?}; it cannot be replayed through assistant history"
+                        )));
+                    }
+                    _ => {
+                        return Err(CompletionError::ResponseError(format!(
+                            "Unsupported Vertex inline media type {:?}",
+                            inline_data.mime_type
+                        )));
+                    }
+                }
             } else if signature.is_some() {
                 // A signature-bearing part that is neither a function call nor text (e.g. a
                 // standalone "thinking" part). rig-core has no carrier for it, so it is dropped —
@@ -107,7 +151,9 @@ mod tests {
     use super::*;
     use google_cloud_aiplatform_v1 as vertexai;
     use rig_core::OneOrMany;
-    use rig_core::message::{AssistantContent, Text, ToolCall};
+    use rig_core::message::{
+        AssistantContent, DocumentSourceKind, ImageDetail, ImageMediaType, Text, ToolCall,
+    };
 
     fn create_text_response(text: &str) -> VertexGenerateContentOutput {
         let part = vertexai::model::Part::new().set_text(text.to_string());
@@ -119,6 +165,25 @@ mod tests {
             .set_finish_reason(vertexai::model::candidate::FinishReason::Stop);
         let response = vertexai::model::GenerateContentResponse::new().set_candidates([candidate]);
         VertexGenerateContentOutput(response)
+    }
+
+    fn create_parts_response(
+        parts: impl IntoIterator<Item = vertexai::model::Part>,
+    ) -> VertexGenerateContentOutput {
+        let content = vertexai::model::Content::new()
+            .set_role("model")
+            .set_parts(parts);
+        let candidate = vertexai::model::Candidate::new().set_content(content);
+        let response = vertexai::model::GenerateContentResponse::new().set_candidates([candidate]);
+        VertexGenerateContentOutput(response)
+    }
+
+    fn inline_data_part(mime_type: &str, data: Vec<u8>) -> vertexai::model::Part {
+        vertexai::model::Part::new().set_inline_data(
+            vertexai::model::Blob::new()
+                .set_mime_type(mime_type)
+                .set_data(data),
+        )
     }
 
     fn create_tool_call_response(
@@ -251,6 +316,131 @@ mod tests {
             }
             _ => panic!("Expected ToolCall"),
         }
+    }
+
+    #[test]
+    fn inline_image_response_converts_raw_bytes_to_base64_with_mime_type() {
+        let raw = vec![0, 1, 2, 255];
+        let response: CompletionResponse<VertexGenerateContentOutput> =
+            create_parts_response([inline_data_part("image/png", raw.clone())])
+                .try_into()
+                .expect("image response should convert");
+
+        match response.choice.first() {
+            AssistantContent::Image(image) => {
+                assert_eq!(image.data, DocumentSourceKind::Base64(BASE64.encode(raw)));
+                assert_eq!(image.media_type, Some(ImageMediaType::PNG));
+                assert_eq!(image.detail, Some(ImageDetail::default()));
+            }
+            _ => panic!("Expected Image"),
+        }
+    }
+
+    #[test]
+    fn mixed_text_and_image_response_preserves_part_order() {
+        let raw = vec![1, 2, 3];
+        let response: CompletionResponse<VertexGenerateContentOutput> = create_parts_response([
+            vertexai::model::Part::new().set_text("before"),
+            inline_data_part("image/jpeg", raw.clone()),
+            vertexai::model::Part::new().set_text("after"),
+        ])
+        .try_into()
+        .expect("mixed response should convert");
+
+        let contents: Vec<_> = response.choice.iter().collect();
+        assert!(matches!(contents[0], AssistantContent::Text(text) if text.text == "before"));
+        match contents[1] {
+            AssistantContent::Image(image) => {
+                assert_eq!(image.data, DocumentSourceKind::Base64(BASE64.encode(raw)));
+                assert_eq!(image.media_type, Some(ImageMediaType::JPEG));
+            }
+            _ => panic!("Expected Image"),
+        }
+        assert!(matches!(contents[2], AssistantContent::Text(text) if text.text == "after"));
+    }
+
+    #[test]
+    fn mixed_text_and_thought_image_response_keeps_only_visible_text_in_order() {
+        let response: CompletionResponse<VertexGenerateContentOutput> = create_parts_response([
+            vertexai::model::Part::new().set_text("before"),
+            inline_data_part("image/png", vec![1, 2, 3]).set_thought(true),
+            vertexai::model::Part::new().set_text("after"),
+        ])
+        .try_into()
+        .expect("thought image should be skipped");
+
+        let contents: Vec<_> = response.choice.iter().collect();
+        assert_eq!(contents.len(), 2);
+        assert!(matches!(contents[0], AssistantContent::Text(text) if text.text == "before"));
+        assert!(matches!(contents[1], AssistantContent::Text(text) if text.text == "after"));
+    }
+
+    #[test]
+    fn thought_image_only_response_fails_without_visible_assistant_content() {
+        let result =
+            CompletionResponse::<VertexGenerateContentOutput>::try_from(create_parts_response([
+                inline_data_part("image/png", vec![1, 2, 3]).set_thought(true),
+            ]));
+
+        let error = match result {
+            Err(error) => error,
+            Ok(_) => panic!("thought-image-only response must fail"),
+        };
+        assert!(matches!(error, CompletionError::ProviderError(_)));
+        assert!(
+            error
+                .to_string()
+                .contains("No text or tool call content found in response")
+        );
+    }
+
+    #[test]
+    fn inline_audio_and_non_image_media_are_rejected() {
+        for mime_type in ["audio/wav", "application/pdf", "application/octet-stream"] {
+            let result = CompletionResponse::<VertexGenerateContentOutput>::try_from(
+                create_parts_response([inline_data_part(mime_type, vec![0])]),
+            );
+            let error = match result {
+                Err(error) => error,
+                Ok(_) => panic!("unsupported inline media must fail"),
+            };
+            assert!(matches!(error, CompletionError::ResponseError(_)));
+            assert!(error.to_string().contains(mime_type));
+        }
+    }
+
+    #[test]
+    fn inline_gif_and_svg_images_are_rejected() {
+        for mime_type in ["image/gif", "image/svg+xml"] {
+            let result = CompletionResponse::<VertexGenerateContentOutput>::try_from(
+                create_parts_response([inline_data_part(mime_type, vec![0])]),
+            );
+            let error = match result {
+                Err(error) => error,
+                Ok(_) => panic!("non-replayable inline image must fail"),
+            };
+            assert!(matches!(error, CompletionError::ResponseError(_)));
+            assert!(
+                error
+                    .to_string()
+                    .contains("Unsupported Vertex inline image media type")
+            );
+        }
+    }
+
+    #[test]
+    fn signed_inline_image_is_rejected() {
+        let part = inline_data_part("image/png", vec![0]).set_thought_signature(vec![1, 2, 3]);
+        let result =
+            CompletionResponse::<VertexGenerateContentOutput>::try_from(create_parts_response([
+                part,
+            ]));
+        let error = match result {
+            Err(error) => error,
+            Ok(_) => panic!("signed inline image must fail"),
+        };
+        assert!(matches!(error, CompletionError::ResponseError(_)));
+        assert!(error.to_string().contains("thought_signature"));
     }
 
     #[test]

--- a/crates/rig-vertexai/src/types/message.rs
+++ b/crates/rig-vertexai/src/types/message.rs
@@ -2,7 +2,10 @@ use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use google_cloud_aiplatform_v1 as vertexai;
 use rig_core::completion::CompletionError;
-use rig_core::message::{AssistantContent, Message, Text, ToolResultContent, UserContent};
+use rig_core::message::{
+    AssistantContent, DocumentSourceKind, Image, ImageMediaType, Message, MimeType, Text,
+    ToolResultContent, UserContent,
+};
 
 pub struct RigMessage(pub Message);
 
@@ -74,6 +77,7 @@ impl TryFrom<RigMessage> for vertexai::model::Content {
                         AssistantContent::Text(Text { text, .. }) => {
                             Ok(vertexai::model::Part::new().set_text(text))
                         }
+                        AssistantContent::Image(image) => vertex_assistant_image_part(image),
                         AssistantContent::ToolCall(tool_call) => {
                             let struct_val = match tool_call.function.arguments {
                                 serde_json::Value::Object(map) => map,
@@ -127,10 +131,6 @@ impl TryFrom<RigMessage> for vertexai::model::Content {
 
                             Ok(part)
                         }
-                        _ => Err(CompletionError::ProviderError(format!(
-                            "Unsupported assistant content type: {:?}",
-                            assistant_content
-                        ))),
                     })
                     .collect();
 
@@ -143,11 +143,50 @@ impl TryFrom<RigMessage> for vertexai::model::Content {
     }
 }
 
+fn vertex_assistant_image_part(image: Image) -> Result<vertexai::model::Part, CompletionError> {
+    let media_type = image.media_type.ok_or_else(|| {
+        CompletionError::RequestError(
+            "Media type for assistant image is required for Vertex AI".into(),
+        )
+    })?;
+
+    match media_type {
+        ImageMediaType::JPEG
+        | ImageMediaType::PNG
+        | ImageMediaType::WEBP
+        | ImageMediaType::HEIC
+        | ImageMediaType::HEIF => {}
+        unsupported => {
+            return Err(CompletionError::RequestError(
+                format!("Unsupported Vertex AI assistant image media type {unsupported:?}").into(),
+            ));
+        }
+    }
+
+    let DocumentSourceKind::Base64(data) = image.data else {
+        return Err(CompletionError::RequestError(
+            "Vertex AI assistant images must use base64 data".into(),
+        ));
+    };
+
+    let data = BASE64.decode(data.as_bytes()).map_err(|err| {
+        CompletionError::RequestError(format!("Invalid base64 assistant image data: {err}").into())
+    })?;
+
+    Ok(vertexai::model::Part::new().set_inline_data(
+        vertexai::model::Blob::new()
+            .set_mime_type(media_type.to_mime_type())
+            .set_data(data),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::completion_response::VertexGenerateContentOutput;
     use google_cloud_aiplatform_v1 as vertexai;
     use rig_core::OneOrMany;
+    use rig_core::completion::CompletionResponse;
     use rig_core::message::{Message, Text, ToolResult, ToolResultContent};
 
     #[test]
@@ -183,6 +222,79 @@ mod tests {
         assert_eq!(content.role.as_str(), "model");
         assert_eq!(content.parts.len(), 1);
         assert_eq!(content.parts[0].text(), Some(&"Hi there".to_string()));
+    }
+
+    #[test]
+    fn test_assistant_image_response_round_trips_through_history_in_order() {
+        let raw_image = vec![0, 1, 2, 255];
+        let response = vertexai::model::GenerateContentResponse::new().set_candidates([
+            vertexai::model::Candidate::new().set_content(
+                vertexai::model::Content::new()
+                    .set_role("model")
+                    .set_parts([
+                        vertexai::model::Part::new().set_text("before"),
+                        vertexai::model::Part::new().set_inline_data(
+                            vertexai::model::Blob::new()
+                                .set_mime_type("image/png")
+                                .set_data(raw_image.clone()),
+                        ),
+                        vertexai::model::Part::new().set_text("after"),
+                    ]),
+            ),
+        ]);
+        let response: CompletionResponse<VertexGenerateContentOutput> =
+            VertexGenerateContentOutput(response)
+                .try_into()
+                .expect("image response should convert");
+
+        let content: vertexai::model::Content = RigMessage(Message::Assistant {
+            id: None,
+            content: response.choice,
+        })
+        .try_into()
+        .expect("assistant history image should convert");
+
+        assert_eq!(content.parts.len(), 3);
+        assert_eq!(content.parts[0].text().map(String::as_str), Some("before"));
+        let image = content.parts[1]
+            .inline_data()
+            .expect("middle part should be an inline image");
+        assert_eq!(image.mime_type, "image/png");
+        assert_eq!(image.data.as_ref(), raw_image.as_slice());
+        assert_eq!(content.parts[2].text().map(String::as_str), Some("after"));
+    }
+
+    #[test]
+    fn test_assistant_image_history_rejects_invalid_or_unsupported_input() {
+        let cases = [
+            (
+                AssistantContent::image_base64(BASE64.encode([1]), None, None),
+                "Media type",
+            ),
+            (
+                AssistantContent::image_base64(BASE64.encode([1]), Some(ImageMediaType::GIF), None),
+                "Unsupported",
+            ),
+            (
+                AssistantContent::image_base64("not valid base64", Some(ImageMediaType::PNG), None),
+                "Invalid base64",
+            ),
+        ];
+
+        for (image, expected_message) in cases {
+            let result: Result<vertexai::model::Content, CompletionError> =
+                RigMessage(Message::Assistant {
+                    id: None,
+                    content: OneOrMany::one(image),
+                })
+                .try_into();
+            let error = match result {
+                Err(error) => error,
+                Ok(_) => panic!("invalid assistant image must fail"),
+            };
+            assert!(matches!(error, CompletionError::RequestError(_)));
+            assert!(error.to_string().contains(expected_message));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- map Gemini-compatible `additional_params.generationConfig` into Vertex AI request configuration, with typed-field precedence and request-side validation
- support replayable Vertex image output end-to-end: inline image bytes normalize to Rig assistant content and can be returned in subsequent Vertex history
- fail closed for ambiguous schemas, unsafe numeric values, unsupported audio/media, non-replayable image formats, and image parts carrying unreplayable thought metadata
- preserve the one-candidate response invariant

Fixes #2067

## Validation
- `cargo fmt --check`
- `cargo test -p rig-vertexai` — 49 unit tests and 1 doctest
- `cargo clippy -p rig-vertexai --all-targets --all-features -- -D warnings`
- `cargo check -p rig --features vertexai`
- `git diff --check`

No live Vertex AI request was run because it requires configured Google Cloud credentials, project, and model access.

## AI assistance
AI assistance was used for implementation and review; the final diff and validation results were independently reviewed.