### PR TITLE
fix(examples): align tool result turn budget

### DIFF
--- a/examples/tool_result_outcomes/src/main.rs
+++ b/examples/tool_result_outcomes/src/main.rs
@@ -350,7 +350,9 @@ async fn main() -> Result<()> {
 
     let response = agent
         .prompt(prompt)
-        .max_turns(3)
+        // The recoverable path needs exactly two model calls: one tool call,
+        // then one final answer. The fatal path terminates after the first.
+        .max_turns(2)
         // This steering hook only guarantees the initial probe; the next two
         // hooks remain the example's recorder/policy pipeline.
         .add_hook(ForceSystemProbeOnFirstTurn)


### PR DESCRIPTION
## Summary

- update `tool_result_outcomes` for the exact total-model-call semantics introduced by #2093
- use the minimum two-call budget for the recoverable path: one tool call followed by one final answer
- document that the fatal path terminates after its first model call

This is a focused follow-up to #2092, which merged before this adjustment was pushed.

## Validation

- `cargo test -p tool_result_outcomes`
- `cargo clippy -p tool_result_outcomes --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
