### PR TITLE
feat(openai): GPT-5.6 model constants and request-side reasoning controls

### DIFF
--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -38,6 +38,18 @@ where
     content.serialize(serializer)
 }
 
+/// `gpt-5.6` completion model (alias that routes to GPT-5.6 Sol)
+pub const GPT_5_6: &str = "gpt-5.6";
+
+/// `gpt-5.6-sol` completion model
+pub const GPT_5_6_SOL: &str = "gpt-5.6-sol";
+
+/// `gpt-5.6-terra` completion model
+pub const GPT_5_6_TERRA: &str = "gpt-5.6-terra";
+
+/// `gpt-5.6-luna` completion model
+pub const GPT_5_6_LUNA: &str = "gpt-5.6-luna";
+
 /// `gpt-5.5` completion model
 pub const GPT_5_5: &str = "gpt-5.5";
 

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -1531,22 +1531,41 @@ pub struct StructuredOutputsInput {
 }
 
 /// Add reasoning to a [`CompletionRequest`].
+///
+/// # Example
+/// ```
+/// use rig_core::providers::openai::responses_api::{
+///     Reasoning, ReasoningContext, ReasoningEffort, ReasoningMode,
+/// };
+///
+/// // GPT-5.6 reasoning controls: effort, pro mode, and persisted-reasoning context.
+/// let reasoning = Reasoning::new()
+///     .with_effort(ReasoningEffort::Max)
+///     .with_mode(ReasoningMode::Pro)
+///     .with_context(ReasoningContext::AllTurns);
+/// ```
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct Reasoning {
     /// How much effort you want the model to put into thinking/reasoning.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub effort: Option<ReasoningEffort>,
     /// How much effort you want the model to put into writing the reasoning summary.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub summary: Option<ReasoningSummaryLevel>,
+    /// The reasoning mode. Independent from `effort`; the standard mode is
+    /// represented by omitting the field. Supported by the GPT-5.6 model family.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode: Option<ReasoningMode>,
+    /// How persisted reasoning is carried across turns. Supported by the
+    /// GPT-5.6 model family.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context: Option<ReasoningContext>,
 }
 
 impl Reasoning {
     /// Creates a new Reasoning instantiation (with empty values).
     pub fn new() -> Self {
-        Self {
-            effort: None,
-            summary: None,
-        }
+        Self::default()
     }
 
     /// Adds reasoning effort.
@@ -1559,6 +1578,20 @@ impl Reasoning {
     /// Adds summary level (how detailed the reasoning summary will be).
     pub fn with_summary_level(mut self, reasoning_summary_level: ReasoningSummaryLevel) -> Self {
         self.summary = Some(reasoning_summary_level);
+
+        self
+    }
+
+    /// Sets the reasoning mode (e.g. pro mode on GPT-5.6 models).
+    pub fn with_mode(mut self, reasoning_mode: ReasoningMode) -> Self {
+        self.mode = Some(reasoning_mode);
+
+        self
+    }
+
+    /// Sets how persisted reasoning is carried across turns (GPT-5.6 models).
+    pub fn with_context(mut self, reasoning_context: ReasoningContext) -> Self {
+        self.context = Some(reasoning_context);
 
         self
     }
@@ -1626,6 +1659,33 @@ pub enum ReasoningEffort {
     Medium,
     High,
     Xhigh,
+    /// The highest reasoning effort. Supported by the GPT-5.6 model family.
+    Max,
+}
+
+/// The reasoning mode used by a given model. Independent from
+/// [`ReasoningEffort`]; the standard mode is represented by omitting the field
+/// (`None` on [`Reasoning::mode`]), so this enum only carries the documented
+/// non-default modes.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReasoningMode {
+    /// Pro mode. Supported by the GPT-5.6 model family.
+    Pro,
+}
+
+/// How persisted reasoning is carried across turns. Supported by the GPT-5.6
+/// model family.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReasoningContext {
+    /// Let the model decide how much persisted reasoning to reuse.
+    #[default]
+    Auto,
+    /// Reuse persisted reasoning from all previous turns.
+    AllTurns,
+    /// Only use reasoning from the current turn.
+    CurrentTurn,
 }
 
 /// The amount of effort that will go into a reasoning summary by a given model.
@@ -3360,6 +3420,70 @@ mod tests {
         let items = completion.choice.iter().collect::<Vec<_>>();
         assert_eq!(items.len(), 1);
         assert!(matches!(items[0], completion::AssistantContent::Text(_)));
+    }
+
+    fn request_with_reasoning_params(reasoning: Value) -> CompletionRequest {
+        let mut request = request_with_preamble("You are concise.");
+        request.additional_params = Some(json!({ "reasoning": reasoning }));
+
+        CompletionRequest::try_from(("gpt-5.6".to_string(), request))
+            .expect("request with reasoning params should convert")
+    }
+
+    #[test]
+    fn reasoning_effort_max_survives_request_conversion() {
+        let request = request_with_reasoning_params(json!({ "effort": "max" }));
+        let serialized = serde_json::to_value(&request).expect("request should serialize");
+
+        assert_eq!(serialized["reasoning"], json!({ "effort": "max" }));
+    }
+
+    #[test]
+    fn reasoning_mode_pro_composes_with_independent_effort() {
+        let request = request_with_reasoning_params(json!({ "effort": "high", "mode": "pro" }));
+        let serialized = serde_json::to_value(&request).expect("request should serialize");
+
+        assert_eq!(
+            serialized["reasoning"],
+            json!({ "effort": "high", "mode": "pro" })
+        );
+    }
+
+    #[test]
+    fn reasoning_context_values_survive_request_conversion() {
+        for context in ["auto", "all_turns", "current_turn"] {
+            let request = request_with_reasoning_params(json!({ "context": context }));
+            let serialized = serde_json::to_value(&request).expect("request should serialize");
+
+            assert_eq!(serialized["reasoning"], json!({ "context": context }));
+        }
+    }
+
+    #[test]
+    fn reasoning_omits_unset_optional_fields() {
+        let reasoning = serde_json::to_value(Reasoning::new().with_mode(ReasoningMode::Pro))
+            .expect("reasoning should serialize");
+
+        assert_eq!(reasoning, json!({ "mode": "pro" }));
+
+        let reasoning = serde_json::to_value(
+            Reasoning::new()
+                .with_effort(ReasoningEffort::Max)
+                .with_mode(ReasoningMode::Pro)
+                .with_context(ReasoningContext::CurrentTurn)
+                .with_summary_level(ReasoningSummaryLevel::Detailed),
+        )
+        .expect("reasoning should serialize");
+
+        assert_eq!(
+            reasoning,
+            json!({
+                "effort": "max",
+                "mode": "pro",
+                "context": "current_turn",
+                "summary": "detailed"
+            })
+        );
     }
 
     #[test]

--- a/tests/cassettes/openai/gpt_5_6_reasoning/context_all_turns.yaml
+++ b/tests/cassettes/openai/gpt_5_6_reasoning/context_all_turns.yaml
@@ -1,0 +1,16 @@
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Reply with exactly: OK","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-5.6-luna","reasoning":{"context":"all_turns","effort":"low"}}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"background":false,"billing":{"payer":"developer"},"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.6-luna","moderation":null,"object":"response","output":[{"content":[{"annotations":[],"logprobs":[],"text":"OK","type":"output_text"}],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"completed","type":"message"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"all_turns","effort":"low","mode":"standard","summary":null},"safety_identifier":null,"service_tier":"default","status":"completed","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":11,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":5,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":16},"user":null}'

--- a/tests/cassettes/openai/gpt_5_6_reasoning/context_auto.yaml
+++ b/tests/cassettes/openai/gpt_5_6_reasoning/context_auto.yaml
@@ -1,0 +1,16 @@
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Reply with exactly: OK","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-5.6-terra","reasoning":{"context":"auto","effort":"low"}}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"background":false,"billing":{"payer":"developer"},"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.6-terra","moderation":null,"object":"response","output":[{"content":[{"annotations":[],"logprobs":[],"text":"OK","type":"output_text"}],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"completed","type":"message"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"all_turns","effort":"low","mode":"standard","summary":null},"safety_identifier":null,"service_tier":"default","status":"completed","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":11,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":5,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":16},"user":null}'

--- a/tests/cassettes/openai/gpt_5_6_reasoning/context_current_turn.yaml
+++ b/tests/cassettes/openai/gpt_5_6_reasoning/context_current_turn.yaml
@@ -1,0 +1,16 @@
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Reply with exactly: OK","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-5.6-sol","reasoning":{"context":"current_turn","effort":"low"}}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"background":false,"billing":{"payer":"developer"},"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.6-sol","moderation":null,"object":"response","output":[{"content":[{"annotations":[],"logprobs":[],"text":"OK","type":"output_text"}],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"completed","type":"message"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"low","mode":"standard","summary":null},"safety_identifier":null,"service_tier":"default","status":"completed","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":11,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":5,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":16},"user":null}'

--- a/tests/cassettes/openai/gpt_5_6_reasoning/effort_max.yaml
+++ b/tests/cassettes/openai/gpt_5_6_reasoning/effort_max.yaml
@@ -1,0 +1,16 @@
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Reply with exactly: OK","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-5.6","reasoning":{"effort":"max"}}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"background":false,"billing":{"payer":"developer"},"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.6-sol","moderation":null,"object":"response","output":[{"content":[{"annotations":[],"logprobs":[],"text":"OK","type":"output_text"}],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"completed","type":"message"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"all_turns","effort":"max","mode":"standard","summary":null},"safety_identifier":null,"service_tier":"default","status":"completed","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":11,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":5,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":16},"user":null}'

--- a/tests/cassettes/openai/gpt_5_6_reasoning/mode_pro_with_independent_effort.yaml
+++ b/tests/cassettes/openai/gpt_5_6_reasoning/mode_pro_with_independent_effort.yaml
@@ -1,0 +1,16 @@
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Reply with exactly: OK","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-5.6-sol","reasoning":{"effort":"high","mode":"pro"}}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"background":false,"billing":{"payer":"developer"},"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.6-sol","moderation":null,"object":"response","output":[{"content":[{"annotations":[],"logprobs":[],"text":"OK","type":"output_text"}],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"completed","type":"message"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"all_turns","effort":"high","mode":"pro","summary":null},"safety_identifier":null,"service_tier":"default","status":"completed","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":1522,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":1283},"output_tokens":30,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":1552},"user":null}'

--- a/tests/providers/openai/cassette/gpt_5_6_reasoning.rs
+++ b/tests/providers/openai/cassette/gpt_5_6_reasoning.rs
@@ -1,0 +1,121 @@
+//! GPT-5.6 reasoning-control regression tests.
+//!
+//! Locks down the GPT-5.6 model constants and the reasoning controls added for
+//! the family: `reasoning.effort = "max"`, `reasoning.mode = "pro"`, and
+//! `reasoning.context`. The recorded request bodies pin the wire shape each
+//! typed control serializes to, and the fixtures prove the real API accepts
+//! them.
+//!
+//! Run cassette tests in replay mode by default, or set
+//! `RIG_PROVIDER_TEST_MODE=record` to record against the real provider.
+
+use rig::client::CompletionClient;
+use rig::completion::{CompletionModel, CompletionResponse};
+use rig::message::AssistantContent;
+use rig::providers::openai;
+use serde_json::json;
+
+use super::super::support::with_openai_cassette;
+
+const PROMPT: &str = "Reply with exactly: OK";
+
+async fn prompt_with_reasoning<M>(
+    model: &M,
+    reasoning: serde_json::Value,
+) -> CompletionResponse<M::Response>
+where
+    M: CompletionModel,
+{
+    let request = model
+        .completion_request(PROMPT)
+        .additional_params(json!({ "reasoning": reasoning }))
+        .build();
+
+    model
+        .completion(request)
+        .await
+        .expect("completion with GPT-5.6 reasoning controls should succeed")
+}
+
+fn assert_has_text(response: &CompletionResponse<openai::responses_api::CompletionResponse>) {
+    let text: String = response
+        .choice
+        .iter()
+        .filter_map(|content| match content {
+            AssistantContent::Text(text) => Some(text.text.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        !text.trim().is_empty(),
+        "response should surface output text"
+    );
+}
+
+#[tokio::test]
+async fn effort_max() {
+    with_openai_cassette("gpt_5_6_reasoning/effort_max", |client| async move {
+        let model = client.completion_model(openai::GPT_5_6);
+        let response = prompt_with_reasoning(&model, json!({ "effort": "max" })).await;
+
+        assert_has_text(&response);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn mode_pro_with_independent_effort() {
+    with_openai_cassette(
+        "gpt_5_6_reasoning/mode_pro_with_independent_effort",
+        |client| async move {
+            let model = client.completion_model(openai::GPT_5_6_SOL);
+            let response =
+                prompt_with_reasoning(&model, json!({ "effort": "high", "mode": "pro" })).await;
+
+            assert_has_text(&response);
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn context_auto() {
+    with_openai_cassette("gpt_5_6_reasoning/context_auto", |client| async move {
+        let model = client.completion_model(openai::GPT_5_6_TERRA);
+        let response =
+            prompt_with_reasoning(&model, json!({ "effort": "low", "context": "auto" })).await;
+
+        assert_has_text(&response);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn context_all_turns() {
+    with_openai_cassette("gpt_5_6_reasoning/context_all_turns", |client| async move {
+        let model = client.completion_model(openai::GPT_5_6_LUNA);
+        let response =
+            prompt_with_reasoning(&model, json!({ "effort": "low", "context": "all_turns" })).await;
+
+        assert_has_text(&response);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn context_current_turn() {
+    with_openai_cassette(
+        "gpt_5_6_reasoning/context_current_turn",
+        |client| async move {
+            let model = client.completion_model(openai::GPT_5_6_SOL);
+            let response = prompt_with_reasoning(
+                &model,
+                json!({ "effort": "low", "context": "current_turn" }),
+            )
+            .await;
+
+            assert_has_text(&response);
+        },
+    )
+    .await;
+}

--- a/tests/providers/openai/mod.rs
+++ b/tests/providers/openai/mod.rs
@@ -7,6 +7,7 @@ mod cassette {
     mod document_ordering;
     mod extractor;
     mod extractor_usage;
+    mod gpt_5_6_reasoning;
     mod models;
     mod multi_extract;
     mod openai_compatible_reasoning_content;


### PR DESCRIPTION
Part of #2102 (request-side slice; see the split note below).

## Summary

The minimal fix for every broken behavior in #2102's motivation section — GPT-5.6 requests that currently fail or silently lose reasoning controls during typed request conversion:

- **Model constants**: `GPT_5_6` (alias routing to GPT-5.6 Sol), `GPT_5_6_SOL`, `GPT_5_6_TERRA`, `GPT_5_6_LUNA`, following the existing constant naming conventions.
- **`ReasoningEffort::Max`**: serialized as `"max"`, so `{"reasoning":{"effort":"max"}}` no longer fails typed request conversion.
- **`Reasoning.mode`**: new optional typed field with `ReasoningMode::Pro` plus a `with_mode` builder. Standard mode is represented by omitting the field, per the issue's proposal.
- **`Reasoning.context`**: new optional typed field with `ReasoningContext::{Auto, AllTurns, CurrentTurn}` plus a `with_context` builder, serialized as `"auto"` / `"all_turns"` / `"current_turn"`. Both fields were previously accepted via `additional_params` but silently discarded during typed conversion.
- **Field omission**: unset optional reasoning fields are omitted. `effort` previously serialized as `"effort": null` when unset; it now gets `skip_serializing_if` too, so mode-/context-only payloads stay clean. (No cassette or test relied on the explicit null.)
- Rustdoc example on `Reasoning` showing the GPT-5.6 controls.

No response-path changes and no changes to existing public field types. The only API-surface changes are the ones the issue's proposal itself requires (a new enum variant, new optional struct fields).

## Tests

**Live-recorded cassettes** (`tests/providers/openai/cassette/gpt_5_6_reasoning.rs`, fixtures under `tests/cassettes/openai/gpt_5_6_reasoning/`) pin the exact request wire shape for every control and prove the real API accepts them, replaying without credentials:

- `effort_max` — `gpt-5.6` alias + `effort=max` (the recorded response shows the alias routing to `gpt-5.6-sol`)
- `mode_pro_with_independent_effort` — `gpt-5.6-sol` with `effort=high, mode=pro`
- `context_auto` / `context_all_turns` / `context_current_turn` — on `gpt-5.6-terra` / `gpt-5.6-luna` / `gpt-5.6-sol`

**Unit tests** cover the same at the serde layer: `effort = "max"` through request conversion, `mode = "pro"` with an independently selected effort, all three `context` values, and omission of unset optional fields.

## Split note

#2102 also proposes preserving the effective reasoning configuration (including the resolved `reasoning.context`) that the API echoes back on responses. That requires changing the type of `CompletionResponse.provider_reasoning` (the response's `reasoning` key carries either a config object or, on some OpenAI-compatible providers, raw reasoning text), plus a `ReasoningMode::Standard` variant since live responses always echo the effective mode explicitly. Per the issue's invitation to split into focused PRs, that breaking response-side change is kept separate — #2106 contains it (and will be rebased onto this once merged) so the request-side fix isn't held up by the response-model design discussion.

## Verification

- `cargo test -p rig-core --lib` — 1173 passed
- `cargo test -p rig --all-features --test openai openai::cassette -- --test-threads=1` — 84 passed (recorded fixtures replay byte-identically against this implementation)
- `cargo test -p rig --all-features --test openai cassette_safety -- --test-threads=1` — cassettes pass the secret-scrub checks (also inspected manually: no auth headers, IDs redacted)
- `cargo test -p rig-core --doc providers::openai::responses_api`
- `cargo clippy -p rig -p rig-core --all-targets --all-features` — clean
- `cargo check --workspace --all-features`, `cargo fmt`