### PR TITLE
fix(core): make Extractor usage accounting match its docs, drop per-attempt clones, fix retry log

### DIFF
--- a/crates/rig-core/src/extractor.rs
+++ b/crates/rig-core/src/extractor.rs
@@ -93,7 +93,7 @@ where
         &self,
         text: impl Into<Message> + WasmCompatSend,
     ) -> Result<T, ExtractionError> {
-        let (data, _usage) = self.retry_extract(text, vec![]).await?;
+        let (data, _usage) = self.retry_extract(text.into(), vec![]).await?;
         Ok(data)
     }
 
@@ -108,7 +108,7 @@ where
         text: impl Into<Message> + WasmCompatSend,
         chat_history: Vec<Message>,
     ) -> Result<T, ExtractionError> {
-        let (data, _usage) = self.retry_extract(text, chat_history).await?;
+        let (data, _usage) = self.retry_extract(text.into(), chat_history).await?;
         Ok(data)
     }
 
@@ -129,7 +129,7 @@ where
         &self,
         text: impl Into<Message> + WasmCompatSend,
     ) -> Result<ExtractionResponse<T>, ExtractionError> {
-        let (data, usage) = self.retry_extract(text, vec![]).await?;
+        let (data, usage) = self.retry_extract(text.into(), vec![]).await?;
         Ok(ExtractionResponse { data, usage })
     }
 
@@ -152,7 +152,7 @@ where
         text: impl Into<Message> + WasmCompatSend,
         chat_history: Vec<Message>,
     ) -> Result<ExtractionResponse<T>, ExtractionError> {
-        let (data, usage) = self.retry_extract(text, chat_history).await?;
+        let (data, usage) = self.retry_extract(text.into(), chat_history).await?;
         Ok(ExtractionResponse { data, usage })
     }
 
@@ -163,11 +163,10 @@ where
     /// returned error cannot carry it.
     async fn retry_extract(
         &self,
-        text: impl Into<Message> + WasmCompatSend,
+        text: Message,
         chat_history: Vec<Message>,
     ) -> Result<(T, Usage), ExtractionError> {
         let mut last_error = None;
-        let text_message = text.into();
         let mut usage = Usage::new();
 
         for i in 0..=self.retries {
@@ -175,18 +174,13 @@ where
                 "Attempting to extract JSON. Retries left: {retries}",
                 retries = self.retries - i
             );
-            let (result, attempt_usage) = self
-                .extract_json_with_usage(&text_message, &chat_history)
-                .await;
+            let (result, attempt_usage) = self.extract_json_with_usage(&text, &chat_history).await;
             usage += attempt_usage;
             match result {
                 Ok(data) => return Ok((data, usage)),
                 Err(e) => {
-                    if i < self.retries {
-                        tracing::warn!("Attempt {i} to extract JSON failed: {e:?}. Retrying...");
-                    } else {
-                        tracing::warn!("Attempt {i} to extract JSON failed: {e:?}.");
-                    }
+                    let suffix = if i < self.retries { " Retrying..." } else { "" };
+                    tracing::warn!("Attempt {i} to extract JSON failed: {e:?}.{suffix}");
                     last_error = Some(e);
                 }
             }
@@ -207,11 +201,9 @@ where
         text: &Message,
         messages: &[Message],
     ) -> (Result<T, ExtractionError>, Usage) {
-        let response = match self.agent.completion(text, messages).await {
-            Ok(builder) => match builder.send().await {
-                Ok(response) => response,
-                Err(e) => return (Err(e.into()), Usage::new()),
-            },
+        let completion = async { self.agent.completion(text, messages).await?.send().await };
+        let response = match completion.await {
+            Ok(response) => response,
             Err(e) => return (Err(e.into()), Usage::new()),
         };
         let usage = response.usage;
@@ -255,7 +247,7 @@ where
 
         if arguments.len() > 1 {
             tracing::warn!(
-                "Multiple submit calls detected, using the last one. Providers / agents should only ensure one submit call."
+                "Multiple submit calls detected, using the first one. Providers / agents should only ensure one submit call."
             );
         }
 
@@ -488,5 +480,21 @@ mod tests {
             .expect_err("extraction should fail");
 
         assert!(matches!(err, ExtractionError::NoData));
+    }
+
+    #[tokio::test]
+    async fn exhausted_retries_return_error_from_final_attempt() {
+        let model = MockCompletionModel::new([MockTurn::error("first"), MockTurn::error("second")]);
+
+        let err = extractor(model, 1)
+            .extract("John")
+            .await
+            .expect_err("extraction should fail");
+
+        assert!(matches!(
+            err,
+            ExtractionError::CompletionError(CompletionError::ProviderError(message))
+                if message == "second"
+        ));
     }
 }

--- a/crates/rig-core/src/extractor.rs
+++ b/crates/rig-core/src/extractor.rs
@@ -121,7 +121,8 @@ where
     /// The number of retries is determined by the `retries` field on the Extractor struct.
     ///
     /// Usage accumulates across all retry attempts, providing the complete cost picture
-    /// including failed attempts.
+    /// including failed attempts. Attempts that fail before the provider returns a
+    /// response (e.g. network errors) contribute no usage.
     pub async fn extract_with_usage(
         &self,
         text: impl Into<Message> + WasmCompatSend,
@@ -140,7 +141,8 @@ where
     /// The number of retries is determined by the `retries` field on the Extractor struct.
     ///
     /// Usage accumulates across all retry attempts, providing the complete cost picture
-    /// including failed attempts.
+    /// including failed attempts. Attempts that fail before the provider returns a
+    /// response (e.g. network errors) contribute no usage.
     pub async fn extract_with_chat_history_with_usage(
         &self,
         text: impl Into<Message> + WasmCompatSend,
@@ -151,7 +153,8 @@ where
     }
 
     /// Runs the extraction with the retry semantics shared by all public
-    /// `extract*` methods, returning the extracted data and accumulated usage.
+    /// `extract*` methods, returning the extracted data and the token usage
+    /// accumulated across all attempts, including failed ones.
     async fn retry_extract(
         &self,
         text: impl Into<Message> + WasmCompatSend,
@@ -166,17 +169,18 @@ where
                 "Attempting to extract JSON. Retries left: {retries}",
                 retries = self.retries - i
             );
-            let attempt_text = text_message.clone();
-            match self
-                .extract_json_with_usage(attempt_text, chat_history.clone())
-                .await
-            {
-                Ok((data, u)) => {
-                    usage += u;
-                    return Ok((data, usage));
-                }
+            let (result, attempt_usage) = self
+                .extract_json_with_usage(&text_message, &chat_history)
+                .await;
+            usage += attempt_usage;
+            match result {
+                Ok(data) => return Ok((data, usage)),
                 Err(e) => {
-                    tracing::warn!("Attempt {i} to extract JSON failed: {e:?}. Retrying...");
+                    if i < self.retries {
+                        tracing::warn!("Attempt {i} to extract JSON failed: {e:?}. Retrying...");
+                    } else {
+                        tracing::warn!("Attempt {i} to extract JSON failed: {e:?}.");
+                    }
                     last_error = Some(e);
                 }
             }
@@ -186,12 +190,22 @@ where
         Err(last_error.unwrap_or(ExtractionError::NoData))
     }
 
+    /// Performs a single extraction attempt, returning its outcome alongside
+    /// the token usage it consumed. Usage is reported even when the attempt
+    /// fails after a billed completion (e.g. the model never called `submit`);
+    /// it is zero only when the completion request itself failed.
     async fn extract_json_with_usage(
         &self,
-        text: impl Into<Message> + WasmCompatSend,
-        messages: Vec<Message>,
-    ) -> Result<(T, Usage), ExtractionError> {
-        let response = self.agent.completion(text, &messages).await?.send().await?;
+        text: &Message,
+        messages: &[Message],
+    ) -> (Result<T, ExtractionError>, Usage) {
+        let response = match self.agent.completion(text, messages).await {
+            Ok(builder) => match builder.send().await {
+                Ok(response) => response,
+                Err(e) => return (Err(e.into()), Usage::new()),
+            },
+            Err(e) => return (Err(e.into()), Usage::new()),
+        };
         let usage = response.usage;
 
         if !response.choice.iter().any(|x| {
@@ -237,14 +251,14 @@ where
             );
         }
 
-        let raw_data = if let Some(arg) = arguments.into_iter().next() {
-            arg
-        } else {
-            return Err(ExtractionError::NoData);
+        let Some(raw_data) = arguments.into_iter().next() else {
+            return (Err(ExtractionError::NoData), usage);
         };
 
-        let data = serde_json::from_value(raw_data)?;
-        Ok((data, usage))
+        (
+            serde_json::from_value(raw_data).map_err(ExtractionError::from),
+            usage,
+        )
     }
 }
 
@@ -374,5 +388,97 @@ where
 
     async fn call(&self, data: Self::Args) -> Result<Self::Output, Self::Error> {
         Ok(data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::test_utils::{MockCompletionModel, MockTurn};
+
+    #[derive(Debug, PartialEq, Deserialize, Serialize, JsonSchema)]
+    struct Person {
+        name: String,
+    }
+
+    fn usage(total_tokens: u64) -> Usage {
+        Usage {
+            total_tokens,
+            ..Usage::new()
+        }
+    }
+
+    fn extractor(
+        model: MockCompletionModel,
+        retries: u64,
+    ) -> Extractor<MockCompletionModel, Person> {
+        ExtractorBuilder::new(model).retries(retries).build()
+    }
+
+    fn submit_turn(name: &str) -> MockTurn {
+        MockTurn::tool_call("id1", SUBMIT_TOOL_NAME, json!({ "name": name }))
+    }
+
+    #[tokio::test]
+    async fn usage_accumulates_across_failed_attempts() {
+        let model = MockCompletionModel::new([
+            MockTurn::text("no submit call").with_usage(usage(10)),
+            submit_turn("John").with_usage(usage(5)),
+        ]);
+
+        let response = extractor(model, 1)
+            .extract_with_usage("John")
+            .await
+            .expect("second attempt should succeed");
+
+        assert_eq!(
+            response.data,
+            Person {
+                name: "John".to_string()
+            }
+        );
+        assert_eq!(response.usage.total_tokens, 15);
+    }
+
+    #[tokio::test]
+    async fn transport_errors_contribute_no_usage() {
+        let model = MockCompletionModel::new([
+            MockTurn::error("boom"),
+            submit_turn("John").with_usage(usage(5)),
+        ]);
+
+        let response = extractor(model, 1)
+            .extract_with_usage("John")
+            .await
+            .expect("second attempt should succeed");
+
+        assert_eq!(response.usage.total_tokens, 5);
+    }
+
+    #[tokio::test]
+    async fn single_successful_attempt_reports_its_own_usage() {
+        let model = MockCompletionModel::new([submit_turn("John").with_usage(usage(7))]);
+
+        let response = extractor(model, 0)
+            .extract_with_usage("John")
+            .await
+            .expect("extraction should succeed");
+
+        assert_eq!(response.usage.total_tokens, 7);
+    }
+
+    #[tokio::test]
+    async fn exhausted_retries_return_last_error() {
+        let model =
+            MockCompletionModel::new([MockTurn::text("no submit call").with_usage(usage(10))]);
+
+        let err = extractor(model, 0)
+            .extract("John")
+            .await
+            .expect_err("extraction should fail");
+
+        assert!(matches!(err, ExtractionError::NoData));
     }
 }

--- a/crates/rig-core/src/extractor.rs
+++ b/crates/rig-core/src/extractor.rs
@@ -120,9 +120,11 @@ where
     ///
     /// The number of retries is determined by the `retries` field on the Extractor struct.
     ///
-    /// Usage accumulates across all retry attempts, providing the complete cost picture
-    /// including failed attempts. Attempts that fail before the provider returns a
-    /// response (e.g. network errors) contribute no usage.
+    /// Usage accumulates across all retry attempts, including attempts that received
+    /// a billed response but failed extraction (e.g. the model never called `submit`).
+    /// Attempts whose completion call itself returned an error (e.g. network failures
+    /// or unparseable provider responses) contribute no usage, and when every attempt
+    /// fails the returned error carries no usage information at all.
     pub async fn extract_with_usage(
         &self,
         text: impl Into<Message> + WasmCompatSend,
@@ -140,9 +142,11 @@ where
     ///
     /// The number of retries is determined by the `retries` field on the Extractor struct.
     ///
-    /// Usage accumulates across all retry attempts, providing the complete cost picture
-    /// including failed attempts. Attempts that fail before the provider returns a
-    /// response (e.g. network errors) contribute no usage.
+    /// Usage accumulates across all retry attempts, including attempts that received
+    /// a billed response but failed extraction (e.g. the model never called `submit`).
+    /// Attempts whose completion call itself returned an error (e.g. network failures
+    /// or unparseable provider responses) contribute no usage, and when every attempt
+    /// fails the returned error carries no usage information at all.
     pub async fn extract_with_chat_history_with_usage(
         &self,
         text: impl Into<Message> + WasmCompatSend,
@@ -154,7 +158,9 @@ where
 
     /// Runs the extraction with the retry semantics shared by all public
     /// `extract*` methods, returning the extracted data and the token usage
-    /// accumulated across all attempts, including failed ones.
+    /// accumulated across all attempts, including failed ones. The accumulated
+    /// usage is only observable on success: when every attempt fails, the
+    /// returned error cannot carry it.
     async fn retry_extract(
         &self,
         text: impl Into<Message> + WasmCompatSend,
@@ -193,7 +199,9 @@ where
     /// Performs a single extraction attempt, returning its outcome alongside
     /// the token usage it consumed. Usage is reported even when the attempt
     /// fails after a billed completion (e.g. the model never called `submit`);
-    /// it is zero only when the completion request itself failed.
+    /// it is zero whenever the completion call itself returns an error, since
+    /// `CompletionError` carries no usage — even if the provider billed the
+    /// request (e.g. an unparseable response body).
     async fn extract_json_with_usage(
         &self,
         text: &Message,


### PR DESCRIPTION
Follow-up to #2107, addressing findings from review of the `Extractor` retry path that the consolidation into `retry_extract` made visible and fixable in one place. Three commits: the core fixes, a doc-precision pass, and a review-driven cleanup pass.

## 1. Usage accounting now matches the documented contract

The docs on `extract_with_usage` / `extract_with_chat_history_with_usage` (and `ExtractionResponse.usage`) promise usage accumulates across retry attempts — but no `ExtractionError` variant carries usage, so a completion that billed tokens and then failed extraction (model never called `submit`, or the arguments failed to deserialize) silently dropped its usage. With `retries(3)` and two failed attempts before success, callers metering spend undercounted by two full completions.

`extract_json_with_usage` now returns `(Result<T, ExtractionError>, Usage)` so the attempt's usage survives extraction failure, and `retry_extract` accumulates it on every attempt. Attempts whose completion call itself errors (transport failures, unparseable responses) contribute zero, and when every attempt fails the returned error carries no usage — the docs now state both caveats explicitly. (Per-attempt usage is still observable via the GenAI telemetry spans in all cases.)

This is a behavior change for retried extractions — toward the already-documented contract. Single-attempt extractions (the common case) report identical usage.

## 2. No more extractor-level per-attempt clones

The retry loop cloned `text_message` and the entire `chat_history` `Vec<Message>` on every attempt (including the last), even though the private helpers only ever borrow them — `Agent::completion` accepts `&Message` / `&[Message]` via its existing bounds and materializes its own copy internally. The private helpers now take `&Message` / `&[Message]` (and `retry_extract` a concrete `Message`); with a large multimodal history this removes a full redundant deep copy per attempt. Public signatures unchanged.

## 3. Honest retry logs

- The warn log said `"... Retrying..."` unconditionally, including on the final attempt — with the builder default `retries = 0`, every failure logged "Retrying..." and then immediately returned the error. The suffix is now gated on a retry actually remaining.
- **Log string change:** `"Multiple submit calls detected, using the last one"` → `"using the first one"` — the code has always deserialized the *first* submit call (`arguments.into_iter().next()`); the message was wrong. Anyone matching the old string in log tooling should update.

## 4. Internal cleanup (review findings)

- Collapsed the completion+send error handling into a single error arm via an inner async block, so the zero-usage-on-error policy lives in one place.
- Single `warn!` call site with a suffix variable (byte-identical output).
- `retry_extract` takes a concrete `Message`; wrappers pass `text.into()`.

## Testing

Five unit tests in `extractor.rs` using the existing `MockCompletionModel` scripted-turn harness:
- `usage_accumulates_across_failed_attempts` — failed attempt (10 tokens) + success (5) → reports 15
- `transport_errors_contribute_no_usage` — provider error + success (5) → reports 5
- `single_successful_attempt_reports_its_own_usage`
- `exhausted_retries_return_last_error` — retries=0, no submit call → `NoData`
- `exhausted_retries_return_error_from_final_attempt` — retries=1, two scripted provider errors → returns the second, pinning last-error selection

`cargo test -p rig-core --lib` (1174 passed), gemini + openrouter extractor cassette suites under `tests/providers/` (8 passed, unchanged — confirming single-attempt usage values didn't move), `cargo clippy -p rig-core --all-targets` clean, and `cargo check -p rig-core --features wasm --target wasm32-unknown-unknown` (the wasm CI target) clean.