### PR TITLE
fix(release): avoid contributor mention notifications

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -35,11 +35,11 @@ body = """
 {%- if remote.contributors %}
 ### Contributors
 {% for contributor in remote.contributors %}
-    * @{{ contributor.username }}
+    * [{{ contributor.username }}](https://github.com/{{ contributor.username }})
 {%- endfor %}
 {% endif -%}
 {%- macro username(commit) -%}
-    {% if commit.remote.username %} (by @{{ commit.remote.username }}){% endif -%}
+    {% if commit.remote.username %} (by [{{ commit.remote.username }}](https://github.com/{{ commit.remote.username }})){% endif -%}
 {% endmacro -%}
 {%- macro pr(commit) -%}
     {% if commit.remote.pr_number %} - #{{ commit.remote.pr_number }}{% endif -%}


### PR DESCRIPTION
## Summary

`release-plz` updates its release PR after every merge to `main`. The generated changelog currently uses `@username` for every commit author and contributor, so each update can trigger another GitHub mention notification.

This replaces those mentions with ordinary GitHub profile links. Contributors remain visibly credited and linked, but release PR refreshes no longer repeatedly mention them.

## Validation

- parsed `release-plz.toml` with Python's `tomllib`
- asserted the changelog template contains no generated `@{{ ... }}` mentions
- asserted both commit authors and contributor-list entries use profile links
- `git diff --check`

The existing release PR will pick up the non-mention format the next time `release-plz` refreshes it after this change lands.
