### PR TITLE
feat(openai): expose complete Responses reasoning metadata

### DIFF
--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -1068,6 +1068,7 @@ where
         let stream = tracing_futures::Instrument::instrument(
             stream! {
                 let mut final_usage = responses_api::ResponsesUsage::new();
+                let mut reasoning_metadata = None;
                 let mut reasoning_context = None;
                 let mut tool_calls: Vec<streaming::RawStreamingChoice<CopilotStreamingResponse>> = Vec::new();
                 let mut tool_call_internal_ids: HashMap<String, String> = HashMap::new();
@@ -1180,6 +1181,9 @@ where
                                         if let Some(usage) = response.usage {
                                             final_usage = usage;
                                         }
+                                        if response.reasoning_metadata.is_some() {
+                                            reasoning_metadata = response.reasoning_metadata;
+                                        }
                                         if response.reasoning_context.is_some() {
                                             reasoning_context = response.reasoning_context;
                                         }
@@ -1247,6 +1251,7 @@ where
                     CopilotStreamingResponse::Responses(
                         responses_api::streaming::StreamingCompletionResponse {
                             usage: final_usage,
+                            reasoning_metadata,
                             reasoning_context,
                         }
                     )
@@ -2185,6 +2190,59 @@ mod tests {
             stream.next().await.is_none(),
             "responses stream should terminate immediately after a terminal error"
         );
+    }
+
+    #[tokio::test]
+    async fn responses_stream_preserves_reasoning_metadata_on_final_response() {
+        let metadata = serde_json::json!({
+            "context": "all_turns",
+            "effort": "ultra",
+            "summary": null,
+            "future_control": true
+        });
+        let completed = serde_json::json!({
+            "type": "response.completed",
+            "sequence_number": 1,
+            "response": {
+                "id": "resp_123",
+                "object": "response",
+                "created_at": 1700000000,
+                "status": "completed",
+                "error": null,
+                "incomplete_details": null,
+                "instructions": null,
+                "max_output_tokens": null,
+                "model": "gpt-5.3-codex",
+                "reasoning": metadata.clone(),
+                "usage": null,
+                "output": [],
+                "tools": []
+            }
+        });
+        let http_client = MockStreamingClient {
+            sse_bytes: sse_bytes_from_json_events(&[completed]),
+        };
+        let client = Client::builder()
+            .api_key("copilot-token")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model("gpt-5.3-codex");
+        let request = model.completion_request("hello").build();
+        let mut stream = model.stream(request).await.expect("stream should start");
+
+        while let Some(item) = stream.next().await {
+            if let StreamedAssistantContent::Final(super::CopilotStreamingResponse::Responses(
+                response,
+            )) = item.expect("completed stream should not error")
+            {
+                assert_eq!(response.reasoning_context.as_deref(), Some("all_turns"));
+                assert_eq!(response.reasoning_metadata.as_ref(), metadata.as_object());
+                return;
+            }
+        }
+
+        panic!("responses stream should yield a final response");
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -1373,11 +1373,20 @@ pub struct CompletionResponse {
     /// Provider-specific top-level reasoning content returned by some
     /// OpenAI-compatible Responses implementations.
     pub provider_reasoning: Option<String>,
+    /// The complete object-shaped top-level reasoning metadata returned by the provider.
+    ///
+    /// Unknown fields, unknown values, and null-valued members inside the object
+    /// are preserved value-equivalently. A top-level null, missing field, or
+    /// unsupported non-object shape is normalized to no reasoning metadata.
+    /// When serializing manually constructed responses, [`Self::provider_reasoning`]
+    /// takes precedence over this field, and this field takes precedence over
+    /// [`Self::reasoning_context`].
+    pub reasoning_metadata: Option<Map<String, Value>>,
     /// The effective reasoning context returned by OpenAI.
     ///
-    /// This is populated from an object-shaped top-level `reasoning` response.
-    /// String-shaped reasoning returned by compatible providers remains available
-    /// through [`Self::provider_reasoning`].
+    /// This is populated as a convenience projection of
+    /// [`Self::reasoning_metadata`]. String-shaped reasoning returned by compatible
+    /// providers remains available through [`Self::provider_reasoning`].
     pub reasoning_context: Option<String>,
     /// Token usage
     pub usage: Option<ResponsesUsage>,
@@ -1393,6 +1402,7 @@ pub struct CompletionResponse {
 #[serde(untagged)]
 enum CompletionResponseReasoningRef<'a> {
     Text(&'a str),
+    Metadata(&'a Map<String, Value>),
     Context { context: &'a str },
 }
 
@@ -1443,10 +1453,22 @@ impl Serialize for CompletionResponse {
     where
         S: Serializer,
     {
+        // `AdditionalParameters::reasoning` models request configuration. A
+        // response's top-level `reasoning` field is represented by the three
+        // response surfaces above, so omit the request field here to avoid
+        // serializing duplicate `reasoning` keys.
+        let mut additional_parameters = self.additional_parameters.clone();
+        additional_parameters.reasoning = None;
+
         let reasoning = self
             .provider_reasoning
             .as_deref()
             .map(CompletionResponseReasoningRef::Text)
+            .or_else(|| {
+                self.reasoning_metadata
+                    .as_ref()
+                    .map(CompletionResponseReasoningRef::Metadata)
+            })
             .or_else(|| {
                 self.reasoning_context
                     .as_deref()
@@ -1467,7 +1489,7 @@ impl Serialize for CompletionResponse {
             usage: &self.usage,
             output: &self.output,
             tools: &self.tools,
-            additional_parameters: &self.additional_parameters,
+            additional_parameters: &additional_parameters,
         }
         .serialize(serializer)
     }
@@ -1479,15 +1501,16 @@ impl<'de> Deserialize<'de> for CompletionResponse {
         D: Deserializer<'de>,
     {
         let response = CompletionResponseWire::deserialize(deserializer)?;
-        let provider_reasoning = response
-            .reasoning
+        let (provider_reasoning, reasoning_metadata) = match response.reasoning {
+            Some(Value::String(reasoning)) => (Some(reasoning), None),
+            Some(Value::Object(metadata)) => (None, Some(metadata)),
+            // Null, arrays, numbers, and booleans are not documented top-level
+            // reasoning response shapes. Ignore them to preserve the lenient
+            // behavior that predates object-shaped metadata support.
+            _ => (None, None),
+        };
+        let reasoning_context = reasoning_metadata
             .as_ref()
-            .and_then(Value::as_str)
-            .map(ToOwned::to_owned);
-        let reasoning_context = response
-            .reasoning
-            .as_ref()
-            .and_then(Value::as_object)
             .and_then(|reasoning| reasoning.get("context"))
             .and_then(Value::as_str)
             .map(ToOwned::to_owned);
@@ -1503,6 +1526,7 @@ impl<'de> Deserialize<'de> for CompletionResponse {
             max_output_tokens: response.max_output_tokens,
             model: response.model,
             provider_reasoning,
+            reasoning_metadata,
             reasoning_context,
             usage: response.usage,
             output: response.output,
@@ -3404,6 +3428,7 @@ mod tests {
             response.provider_reasoning.as_deref(),
             Some("thinking through the answer")
         );
+        assert_eq!(response.reasoning_metadata, None);
         assert_eq!(response.reasoning_context, None);
         assert_eq!(
             serde_json::to_value(&response).expect("response should serialize")["reasoning"],
@@ -3509,8 +3534,10 @@ mod tests {
             "status": "completed",
             "model": "Qwen/Qwen3-4B",
             "reasoning": {
+                "context": "all_turns",
                 "effort": "high",
-                "context": "all_turns"
+                "mode": "standard",
+                "summary": null
             },
             "output": [{
                 "type": "message",
@@ -3530,8 +3557,23 @@ mod tests {
         assert!(response.provider_reasoning.is_none());
         assert_eq!(response.reasoning_context.as_deref(), Some("all_turns"));
         assert_eq!(
+            response.reasoning_metadata.as_ref(),
+            json!({
+                "context": "all_turns",
+                "effort": "high",
+                "mode": "standard",
+                "summary": null
+            })
+            .as_object()
+        );
+        assert_eq!(
             serde_json::to_value(&response).expect("response should serialize")["reasoning"],
-            json!({ "context": "all_turns" })
+            json!({
+                "context": "all_turns",
+                "effort": "high",
+                "mode": "standard",
+                "summary": null
+            })
         );
 
         let completion: completion::CompletionResponse<CompletionResponse> =
@@ -3539,6 +3581,103 @@ mod tests {
         let items = completion.choice.iter().collect::<Vec<_>>();
         assert_eq!(items.len(), 1);
         assert!(matches!(items[0], completion::AssistantContent::Text(_)));
+    }
+
+    #[test]
+    fn completion_response_preserves_unknown_reasoning_metadata_and_nulls() {
+        let metadata = json!({
+            "context": "future_context",
+            "effort": "ultra",
+            "summary": null,
+            "future_control": { "depth": 3 }
+        });
+        let response: CompletionResponse = serde_json::from_value(json!({
+            "id": "resp_123",
+            "object": "response",
+            "created_at": 0,
+            "status": "completed",
+            "model": "gpt-future",
+            "reasoning": metadata.clone(),
+            "output": [],
+            "tools": []
+        }))
+        .expect("unknown reasoning metadata should deserialize");
+
+        assert_eq!(
+            response.reasoning_context.as_deref(),
+            Some("future_context")
+        );
+        assert_eq!(response.reasoning_metadata.as_ref(), metadata.as_object());
+        assert_eq!(
+            serde_json::to_value(&response).expect("response should serialize")["reasoning"],
+            metadata
+        );
+    }
+
+    #[test]
+    fn completion_response_ignores_unsupported_reasoning_shapes() {
+        for reasoning in [Value::Null, json!(["unexpected"]), json!(42), json!(true)] {
+            let response: CompletionResponse = serde_json::from_value(json!({
+                "id": "resp_123",
+                "object": "response",
+                "created_at": 0,
+                "status": "completed",
+                "model": "openai-compatible-model",
+                "reasoning": reasoning,
+                "output": [],
+                "tools": []
+            }))
+            .expect("unsupported reasoning shapes should remain non-fatal");
+
+            assert_eq!(response.provider_reasoning, None);
+            assert_eq!(response.reasoning_metadata, None);
+            assert_eq!(response.reasoning_context, None);
+            let serialized = serde_json::to_value(&response).expect("response should serialize");
+            assert!(
+                !serialized
+                    .as_object()
+                    .expect("response should serialize as an object")
+                    .contains_key("reasoning")
+            );
+        }
+    }
+
+    #[test]
+    fn completion_response_reasoning_serialization_precedence_is_stable() {
+        let mut response: CompletionResponse = serde_json::from_value(json!({
+            "id": "resp_123",
+            "object": "response",
+            "created_at": 0,
+            "status": "completed",
+            "model": "gpt-5.6",
+            "reasoning": { "context": "all_turns", "effort": "max" },
+            "output": [],
+            "tools": []
+        }))
+        .expect("reasoning metadata should deserialize");
+
+        response.reasoning_context = Some("current_turn".to_owned());
+        response.additional_parameters.reasoning =
+            Some(Reasoning::new().with_effort(ReasoningEffort::Low));
+        let serialized = serde_json::to_string(&response).expect("response should serialize");
+        assert_eq!(serialized.matches("\"reasoning\":").count(), 1);
+        assert_eq!(
+            serde_json::to_value(&response).expect("response should serialize")["reasoning"],
+            json!({ "context": "all_turns", "effort": "max" })
+        );
+
+        let metadata = response.reasoning_metadata.take();
+        assert_eq!(
+            serde_json::to_value(&response).expect("response should serialize")["reasoning"],
+            json!({ "context": "current_turn" })
+        );
+
+        response.reasoning_metadata = metadata;
+        response.provider_reasoning = Some("compatible-provider text".to_owned());
+        assert_eq!(
+            serde_json::to_value(&response).expect("response should serialize")["reasoning"],
+            json!("compatible-provider text")
+        );
     }
 
     fn request_with_reasoning_params(reasoning: Value) -> CompletionRequest {

--- a/crates/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -38,6 +38,9 @@ pub enum StreamingCompletionChunk {
 pub struct StreamingCompletionResponse {
     /// Token usage
     pub usage: ResponsesUsage,
+    /// The complete object-shaped reasoning metadata from the terminal response event.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_metadata: Option<serde_json::Map<String, serde_json::Value>>,
     /// The effective reasoning context from the terminal response event.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning_context: Option<String>,
@@ -215,6 +218,7 @@ pub(crate) fn parse_sse_completion_body(
 
 struct RawChoiceAccumulator {
     final_usage: ResponsesUsage,
+    reasoning_metadata: Option<serde_json::Map<String, serde_json::Value>>,
     reasoning_context: Option<String>,
     tool_calls: Vec<StreamingRawChoice>,
     tool_call_internal_ids: std::collections::HashMap<String, String>,
@@ -224,6 +228,7 @@ impl RawChoiceAccumulator {
     fn new(initial_usage: ResponsesUsage) -> Self {
         Self {
             final_usage: initial_usage,
+            reasoning_metadata: None,
             reasoning_context: None,
             tool_calls: Vec::new(),
             tool_call_internal_ids: std::collections::HashMap::new(),
@@ -315,6 +320,9 @@ impl RawChoiceAccumulator {
                 if let Some(usage) = response.usage {
                     self.final_usage = usage;
                 }
+                if response.reasoning_metadata.is_some() {
+                    self.reasoning_metadata = response.reasoning_metadata;
+                }
                 if response.reasoning_context.is_some() {
                     self.reasoning_context = response.reasoning_context;
                 }
@@ -385,6 +393,7 @@ impl RawChoiceAccumulator {
         choices.push(RawStreamingChoice::FinalResponse(
             StreamingCompletionResponse {
                 usage: self.final_usage,
+                reasoning_metadata: self.reasoning_metadata,
                 reasoning_context: self.reasoning_context,
             },
         ));
@@ -930,6 +939,7 @@ mod tests {
             max_output_tokens: None,
             model: "gpt-5.4".to_string(),
             provider_reasoning: None,
+            reasoning_metadata: None,
             reasoning_context: None,
             usage: None,
             output: Vec::new(),
@@ -1566,17 +1576,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn response_completed_chunk_populates_reasoning_context() {
+    async fn response_completed_chunk_populates_reasoning_metadata_and_context() {
         let response = sample_response(ResponseStatus::Completed);
         let mut event = json!({
             "type": "response.completed",
             "sequence_number": 1,
             "response": response,
         });
-        event["response"]["reasoning"] = json!({ "context": "all_turns" });
+        let metadata = json!({
+            "context": "all_turns",
+            "effort": "ultra",
+            "summary": null,
+            "future_control": true
+        });
+        event["response"]["reasoning"] = metadata.clone();
 
         let response = final_response_from_event(event).await;
         assert_eq!(response.reasoning_context.as_deref(), Some("all_turns"));
+        assert_eq!(response.reasoning_metadata.as_ref(), metadata.as_object());
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/providers/openai/responses_api/websocket.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/websocket.rs
@@ -898,6 +898,7 @@ mod tests {
             tools: Vec::new(),
             additional_parameters: Default::default(),
             provider_reasoning: None,
+            reasoning_metadata: None,
             reasoning_context: None,
         }
     }
@@ -2020,7 +2021,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unknown_event_is_skipped_during_session() {
+    async fn unknown_event_is_skipped_and_reasoning_metadata_is_preserved() {
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
             .expect("listener should bind");
@@ -2050,12 +2051,23 @@ mod tests {
                 .await
                 .expect("unknown event should send");
 
-            // Then send the real completed response
-            let response = serde_json::to_value(CompletionResponse {
-                id: "resp_after_unknown".to_string(),
-                ..sample_response(ResponseStatus::Completed)
-            })
-            .expect("response should serialize");
+            // Then send the real completed response, including reasoning
+            // metadata to verify that the WebSocket path preserves it.
+            let mut response = sample_response(ResponseStatus::Completed);
+            response.id = "resp_after_unknown".to_string();
+            response.reasoning_metadata = Some(
+                json!({
+                    "context": "all_turns",
+                    "effort": "ultra",
+                    "summary": null,
+                    "future_control": true
+                })
+                .as_object()
+                .expect("reasoning metadata should be an object")
+                .clone(),
+            );
+            response.reasoning_context = Some("all_turns".to_string());
+            let response = serde_json::to_value(response).expect("response should serialize");
 
             socket
                 .send(Message::text(
@@ -2091,6 +2103,17 @@ mod tests {
             .await
             .expect("response should complete despite unknown event");
         assert_eq!(response.id, "resp_after_unknown");
+        assert_eq!(response.reasoning_context.as_deref(), Some("all_turns"));
+        assert_eq!(
+            response.reasoning_metadata.as_ref(),
+            json!({
+                "context": "all_turns",
+                "effort": "ultra",
+                "summary": null,
+                "future_control": true
+            })
+            .as_object()
+        );
 
         server.await.expect("server task should finish");
     }

--- a/tests/cassettes/openai/gpt_5_6_reasoning/five_turn_metadata_roundtrip.yaml
+++ b/tests/cassettes/openai/gpt_5_6_reasoning/five_turn_metadata_roundtrip.yaml
@@ -1,0 +1,84 @@
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Remember the codeword ALPHA-17. Reply exactly: ACK-1","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-5.6-sol","reasoning":{"context":"all_turns","effort":"low","mode":"pro"}}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"background":false,"billing":{"payer":"developer"},"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.6-sol","moderation":null,"object":"response","output":[{"content":[{"annotations":[],"logprobs":[],"text":"ACK-1","type":"output_text"}],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"completed","type":"message"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"all_turns","effort":"low","mode":"pro","summary":null},"safety_identifier":null,"service_tier":"default","status":"completed","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":1568,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":36,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":1604},"user":null}'
+---
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Remember the codeword ALPHA-17. Reply exactly: ACK-1","type":"input_text"}],"role":"user","type":"message"},{"content":[{"text":"ACK-1","type":"output_text"}],"id":"msg_REDACTED_1","role":"assistant","status":"completed","type":"message"},{"content":[{"text":"Remember that the shape is octagon. Reply exactly: ACK-2","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-5.6-sol","reasoning":{"context":"all_turns","effort":"low","mode":"pro"}}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"background":false,"billing":{"payer":"developer"},"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.6-sol","moderation":null,"object":"response","output":[{"content":[{"annotations":[],"logprobs":[],"text":"ACK-2","type":"output_text"}],"id":"msg_REDACTED_2","phase":"final_answer","role":"assistant","status":"completed","type":"message"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"all_turns","effort":"low","mode":"pro","summary":null},"safety_identifier":null,"service_tier":"default","status":"completed","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":1690,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":36,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":1726},"user":null}'
+---
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Remember the codeword ALPHA-17. Reply exactly: ACK-1","type":"input_text"}],"role":"user","type":"message"},{"content":[{"text":"ACK-1","type":"output_text"}],"id":"msg_REDACTED_1","role":"assistant","status":"completed","type":"message"},{"content":[{"text":"Remember that the shape is octagon. Reply exactly: ACK-2","type":"input_text"}],"role":"user","type":"message"},{"content":[{"text":"ACK-2","type":"output_text"}],"id":"msg_REDACTED_2","role":"assistant","status":"completed","type":"message"},{"content":[{"text":"Remember that the city is Kyoto. Reply exactly: ACK-3","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-5.6-sol","reasoning":{"context":"all_turns","effort":"low","mode":"pro"}}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"background":false,"billing":{"payer":"developer"},"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_3","incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.6-sol","moderation":null,"object":"response","output":[{"content":[{"annotations":[],"logprobs":[],"text":"ACK-3","type":"output_text"}],"id":"msg_REDACTED_3","phase":"final_answer","role":"assistant","status":"completed","type":"message"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"all_turns","effort":"low","mode":"pro","summary":null},"safety_identifier":null,"service_tier":"default","status":"completed","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":1808,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":36,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":1844},"user":null}'
+---
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Remember the codeword ALPHA-17. Reply exactly: ACK-1","type":"input_text"}],"role":"user","type":"message"},{"content":[{"text":"ACK-1","type":"output_text"}],"id":"msg_REDACTED_1","role":"assistant","status":"completed","type":"message"},{"content":[{"text":"Remember that the shape is octagon. Reply exactly: ACK-2","type":"input_text"}],"role":"user","type":"message"},{"content":[{"text":"ACK-2","type":"output_text"}],"id":"msg_REDACTED_2","role":"assistant","status":"completed","type":"message"},{"content":[{"text":"Remember that the city is Kyoto. Reply exactly: ACK-3","type":"input_text"}],"role":"user","type":"message"},{"content":[{"text":"ACK-3","type":"output_text"}],"id":"msg_REDACTED_3","role":"assistant","status":"completed","type":"message"},{"content":[{"text":"Remember that the number is 8642. Reply exactly: ACK-4","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-5.6-sol","reasoning":{"context":"all_turns","effort":"low","mode":"pro"}}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"background":false,"billing":{"payer":"developer"},"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_4","incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.6-sol","moderation":null,"object":"response","output":[{"content":[{"annotations":[],"logprobs":[],"text":"ACK-4","type":"output_text"}],"id":"msg_REDACTED_4","phase":"final_answer","role":"assistant","status":"completed","type":"message"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"all_turns","effort":"low","mode":"pro","summary":null},"safety_identifier":null,"service_tier":"default","status":"completed","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":1934,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":36,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":1970},"user":null}'
+---
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Remember the codeword ALPHA-17. Reply exactly: ACK-1","type":"input_text"}],"role":"user","type":"message"},{"content":[{"text":"ACK-1","type":"output_text"}],"id":"msg_REDACTED_1","role":"assistant","status":"completed","type":"message"},{"content":[{"text":"Remember that the shape is octagon. Reply exactly: ACK-2","type":"input_text"}],"role":"user","type":"message"},{"content":[{"text":"ACK-2","type":"output_text"}],"id":"msg_REDACTED_2","role":"assistant","status":"completed","type":"message"},{"content":[{"text":"Remember that the city is Kyoto. Reply exactly: ACK-3","type":"input_text"}],"role":"user","type":"message"},{"content":[{"text":"ACK-3","type":"output_text"}],"id":"msg_REDACTED_3","role":"assistant","status":"completed","type":"message"},{"content":[{"text":"Remember that the number is 8642. Reply exactly: ACK-4","type":"input_text"}],"role":"user","type":"message"},{"content":[{"text":"ACK-4","type":"output_text"}],"id":"msg_REDACTED_4","role":"assistant","status":"completed","type":"message"},{"content":[{"text":"Reply with exactly these remembered values, including capitalization and separators: ALPHA-17 | octagon | Kyoto | 8642","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-5.6-sol","reasoning":{"context":"all_turns","effort":"low","mode":"pro"}}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"background":false,"billing":{"payer":"developer"},"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_5","incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.6-sol","moderation":null,"object":"response","output":[{"content":[{"annotations":[],"logprobs":[],"text":"ALPHA-17 | octagon | Kyoto | 8642","type":"output_text"}],"id":"msg_REDACTED_5","phase":"final_answer","role":"assistant","status":"completed","type":"message"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"all_turns","effort":"low","mode":"pro","summary":null},"safety_identifier":null,"service_tier":"default","status":"completed","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":2130,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":66,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":2196},"user":null}'

--- a/tests/cassettes/openai/gpt_5_6_reasoning/five_turn_streaming_metadata_roundtrip.yaml
+++ b/tests/cassettes/openai/gpt_5_6_reasoning/five_turn_streaming_metadata_roundtrip.yaml
@@ -1,0 +1,219 @@
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Remember the codeword ALPHA-17. Reply exactly: ACK-1","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-5.6-sol","reasoning":{"context":"all_turns","effort":"low","mode":"pro"},"stream":true}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream; charset=utf-8
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.6-sol","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"all_turns","effort":"low","mode":"pro","summary":null},"safety_identifier":null,"service_tier":"auto","status":"in_progress","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.6-sol","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"all_turns","effort":"low","mode":"pro","summary":null},"safety_identifier":null,"service_tier":"auto","status":"in_progress","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"content":[],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"completed","type":"message"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.content_part.added
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"","type":"output_text"},"sequence_number":3,"type":"response.content_part.added"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"ACK-1","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_1","output_index":0,"sequence_number":4,"type":"response.output_text.delta"}
+
+    event: response.output_text.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","logprobs":[],"output_index":0,"sequence_number":5,"text":"ACK-1","type":"response.output_text.done"}
+
+    event: response.content_part.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"ACK-1","type":"output_text"},"sequence_number":6,"type":"response.content_part.done"}
+
+    event: response.output_item.done
+    data: {"item":{"content":[{"annotations":[],"logprobs":[],"text":"ACK-1","type":"output_text"}],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"completed","type":"message"},"output_index":0,"sequence_number":7,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.6-sol","moderation":null,"object":"response","output":[{"content":[{"annotations":[],"logprobs":[],"text":"ACK-1","type":"output_text"}],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"completed","type":"message"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"all_turns","effort":"low","mode":"pro","summary":null},"safety_identifier":null,"service_tier":"default","status":"completed","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":1568,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":1299},"output_tokens":36,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":1604},"user":null},"sequence_number":8,"type":"response.completed"}
+
+---
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Remember the codeword ALPHA-17. Reply exactly: ACK-1","type":"input_text"}],"role":"user","type":"message"},{"content":[{"text":"ACK-1","type":"output_text"}],"id":"msg_REDACTED_1","role":"assistant","status":"completed","type":"message"},{"content":[{"text":"Remember that the shape is octagon. Reply exactly: ACK-2","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-5.6-sol","reasoning":{"context":"all_turns","effort":"low","mode":"pro"},"stream":true}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream; charset=utf-8
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.6-sol","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"all_turns","effort":"low","mode":"pro","summary":null},"safety_identifier":null,"service_tier":"auto","status":"in_progress","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.6-sol","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"all_turns","effort":"low","mode":"pro","summary":null},"safety_identifier":null,"service_tier":"auto","status":"in_progress","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"content":[],"id":"msg_REDACTED_2","phase":"final_answer","role":"assistant","status":"completed","type":"message"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.content_part.added
+    data: {"content_index":0,"item_id":"msg_REDACTED_2","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"","type":"output_text"},"sequence_number":3,"type":"response.content_part.added"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"ACK-2","item_id":"msg_REDACTED_2","logprobs":[],"obfuscation":"obfuscation_REDACTED_2","output_index":0,"sequence_number":4,"type":"response.output_text.delta"}
+
+    event: response.output_text.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_2","logprobs":[],"output_index":0,"sequence_number":5,"text":"ACK-2","type":"response.output_text.done"}
+
+    event: response.content_part.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_2","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"ACK-2","type":"output_text"},"sequence_number":6,"type":"response.content_part.done"}
+
+    event: response.output_item.done
+    data: {"item":{"content":[{"annotations":[],"logprobs":[],"text":"ACK-2","type":"output_text"}],"id":"msg_REDACTED_2","phase":"final_answer","role":"assistant","status":"completed","type":"message"},"output_index":0,"sequence_number":7,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.6-sol","moderation":null,"object":"response","output":[{"content":[{"annotations":[],"logprobs":[],"text":"ACK-2","type":"output_text"}],"id":"msg_REDACTED_2","phase":"final_answer","role":"assistant","status":"completed","type":"message"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"all_turns","effort":"low","mode":"pro","summary":null},"safety_identifier":null,"service_tier":"default","status":"completed","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":1690,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":1340},"output_tokens":36,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":1726},"user":null},"sequence_number":8,"type":"response.completed"}
+
+---
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Remember the codeword ALPHA-17. Reply exactly: ACK-1","type":"input_text"}],"role":"user","type":"message"},{"content":[{"text":"ACK-1","type":"output_text"}],"id":"msg_REDACTED_1","role":"assistant","status":"completed","type":"message"},{"content":[{"text":"Remember that the shape is octagon. Reply exactly: ACK-2","type":"input_text"}],"role":"user","type":"message"},{"content":[{"text":"ACK-2","type":"output_text"}],"id":"msg_REDACTED_2","role":"assistant","status":"completed","type":"message"},{"content":[{"text":"Remember that the city is Kyoto. Reply exactly: ACK-3","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-5.6-sol","reasoning":{"context":"all_turns","effort":"low","mode":"pro"},"stream":true}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream; charset=utf-8
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_3","incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.6-sol","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"all_turns","effort":"low","mode":"pro","summary":null},"safety_identifier":null,"service_tier":"auto","status":"in_progress","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_3","incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.6-sol","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"all_turns","effort":"low","mode":"pro","summary":null},"safety_identifier":null,"service_tier":"auto","status":"in_progress","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"content":[],"id":"msg_REDACTED_3","phase":"final_answer","role":"assistant","status":"completed","type":"message"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.content_part.added
+    data: {"content_index":0,"item_id":"msg_REDACTED_3","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"","type":"output_text"},"sequence_number":3,"type":"response.content_part.added"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"ACK-3","item_id":"msg_REDACTED_3","logprobs":[],"obfuscation":"obfuscation_REDACTED_3","output_index":0,"sequence_number":4,"type":"response.output_text.delta"}
+
+    event: response.output_text.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_3","logprobs":[],"output_index":0,"sequence_number":5,"text":"ACK-3","type":"response.output_text.done"}
+
+    event: response.content_part.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_3","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"ACK-3","type":"output_text"},"sequence_number":6,"type":"response.content_part.done"}
+
+    event: response.output_item.done
+    data: {"item":{"content":[{"annotations":[],"logprobs":[],"text":"ACK-3","type":"output_text"}],"id":"msg_REDACTED_3","phase":"final_answer","role":"assistant","status":"completed","type":"message"},"output_index":0,"sequence_number":7,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_3","incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.6-sol","moderation":null,"object":"response","output":[{"content":[{"annotations":[],"logprobs":[],"text":"ACK-3","type":"output_text"}],"id":"msg_REDACTED_3","phase":"final_answer","role":"assistant","status":"completed","type":"message"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"all_turns","effort":"low","mode":"pro","summary":null},"safety_identifier":null,"service_tier":"default","status":"completed","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":1808,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":1380},"output_tokens":36,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":1844},"user":null},"sequence_number":8,"type":"response.completed"}
+
+---
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Remember the codeword ALPHA-17. Reply exactly: ACK-1","type":"input_text"}],"role":"user","type":"message"},{"content":[{"text":"ACK-1","type":"output_text"}],"id":"msg_REDACTED_1","role":"assistant","status":"completed","type":"message"},{"content":[{"text":"Remember that the shape is octagon. Reply exactly: ACK-2","type":"input_text"}],"role":"user","type":"message"},{"content":[{"text":"ACK-2","type":"output_text"}],"id":"msg_REDACTED_2","role":"assistant","status":"completed","type":"message"},{"content":[{"text":"Remember that the city is Kyoto. Reply exactly: ACK-3","type":"input_text"}],"role":"user","type":"message"},{"content":[{"text":"ACK-3","type":"output_text"}],"id":"msg_REDACTED_3","role":"assistant","status":"completed","type":"message"},{"content":[{"text":"Remember that the number is 8642. Reply exactly: ACK-4","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-5.6-sol","reasoning":{"context":"all_turns","effort":"low","mode":"pro"},"stream":true}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream; charset=utf-8
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_4","incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.6-sol","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"all_turns","effort":"low","mode":"pro","summary":null},"safety_identifier":null,"service_tier":"auto","status":"in_progress","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_4","incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.6-sol","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"all_turns","effort":"low","mode":"pro","summary":null},"safety_identifier":null,"service_tier":"auto","status":"in_progress","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"content":[],"id":"msg_REDACTED_4","phase":"final_answer","role":"assistant","status":"completed","type":"message"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.content_part.added
+    data: {"content_index":0,"item_id":"msg_REDACTED_4","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"","type":"output_text"},"sequence_number":3,"type":"response.content_part.added"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"ACK-4","item_id":"msg_REDACTED_4","logprobs":[],"obfuscation":"obfuscation_REDACTED_4","output_index":0,"sequence_number":4,"type":"response.output_text.delta"}
+
+    event: response.output_text.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_4","logprobs":[],"output_index":0,"sequence_number":5,"text":"ACK-4","type":"response.output_text.done"}
+
+    event: response.content_part.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_4","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"ACK-4","type":"output_text"},"sequence_number":6,"type":"response.content_part.done"}
+
+    event: response.output_item.done
+    data: {"item":{"content":[{"annotations":[],"logprobs":[],"text":"ACK-4","type":"output_text"}],"id":"msg_REDACTED_4","phase":"final_answer","role":"assistant","status":"completed","type":"message"},"output_index":0,"sequence_number":7,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_4","incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.6-sol","moderation":null,"object":"response","output":[{"content":[{"annotations":[],"logprobs":[],"text":"ACK-4","type":"output_text"}],"id":"msg_REDACTED_4","phase":"final_answer","role":"assistant","status":"completed","type":"message"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"all_turns","effort":"low","mode":"pro","summary":null},"safety_identifier":null,"service_tier":"default","status":"completed","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":1934,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":1422},"output_tokens":36,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":1970},"user":null},"sequence_number":8,"type":"response.completed"}
+
+---
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Remember the codeword ALPHA-17. Reply exactly: ACK-1","type":"input_text"}],"role":"user","type":"message"},{"content":[{"text":"ACK-1","type":"output_text"}],"id":"msg_REDACTED_1","role":"assistant","status":"completed","type":"message"},{"content":[{"text":"Remember that the shape is octagon. Reply exactly: ACK-2","type":"input_text"}],"role":"user","type":"message"},{"content":[{"text":"ACK-2","type":"output_text"}],"id":"msg_REDACTED_2","role":"assistant","status":"completed","type":"message"},{"content":[{"text":"Remember that the city is Kyoto. Reply exactly: ACK-3","type":"input_text"}],"role":"user","type":"message"},{"content":[{"text":"ACK-3","type":"output_text"}],"id":"msg_REDACTED_3","role":"assistant","status":"completed","type":"message"},{"content":[{"text":"Remember that the number is 8642. Reply exactly: ACK-4","type":"input_text"}],"role":"user","type":"message"},{"content":[{"text":"ACK-4","type":"output_text"}],"id":"msg_REDACTED_4","role":"assistant","status":"completed","type":"message"},{"content":[{"text":"Reply with exactly these remembered values, including capitalization and separators: ALPHA-17 | octagon | Kyoto | 8642","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-5.6-sol","reasoning":{"context":"all_turns","effort":"low","mode":"pro"},"stream":true}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream; charset=utf-8
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_5","incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.6-sol","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"all_turns","effort":"low","mode":"pro","summary":null},"safety_identifier":null,"service_tier":"auto","status":"in_progress","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_5","incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.6-sol","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"all_turns","effort":"low","mode":"pro","summary":null},"safety_identifier":null,"service_tier":"auto","status":"in_progress","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"content":[],"id":"msg_REDACTED_5","phase":"final_answer","role":"assistant","status":"completed","type":"message"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.content_part.added
+    data: {"content_index":0,"item_id":"msg_REDACTED_5","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"","type":"output_text"},"sequence_number":3,"type":"response.content_part.added"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"ALPHA-17 | octagon | Kyoto | 8642","item_id":"msg_REDACTED_5","logprobs":[],"obfuscation":"obfuscation_REDACTED_5","output_index":0,"sequence_number":4,"type":"response.output_text.delta"}
+
+    event: response.output_text.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_5","logprobs":[],"output_index":0,"sequence_number":5,"text":"ALPHA-17 | octagon | Kyoto | 8642","type":"response.output_text.done"}
+
+    event: response.content_part.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_5","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"ALPHA-17 | octagon | Kyoto | 8642","type":"output_text"},"sequence_number":6,"type":"response.content_part.done"}
+
+    event: response.output_item.done
+    data: {"item":{"content":[{"annotations":[],"logprobs":[],"text":"ALPHA-17 | octagon | Kyoto | 8642","type":"output_text"}],"id":"msg_REDACTED_5","phase":"final_answer","role":"assistant","status":"completed","type":"message"},"output_index":0,"sequence_number":7,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_5","incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.6-sol","moderation":null,"object":"response","output":[{"content":[{"annotations":[],"logprobs":[],"text":"ALPHA-17 | octagon | Kyoto | 8642","type":"output_text"}],"id":"msg_REDACTED_5","phase":"final_answer","role":"assistant","status":"completed","type":"message"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"all_turns","effort":"low","mode":"pro","summary":null},"safety_identifier":null,"service_tier":"default","status":"completed","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":2130,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":66,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":2196},"user":null},"sequence_number":8,"type":"response.completed"}
+

--- a/tests/cassettes/openai/gpt_5_6_reasoning/streaming_metadata.yaml
+++ b/tests/cassettes/openai/gpt_5_6_reasoning/streaming_metadata.yaml
@@ -1,0 +1,43 @@
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: text/event-stream
+  - name: content-type
+    value: application/json
+  body: '{"include":["reasoning.encrypted_content"],"input":[{"content":[{"text":"Reply with exactly: OK","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-5.6-sol","reasoning":{"context":"current_turn","effort":"low","mode":"pro"},"stream":true}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: text/event-stream; charset=utf-8
+  body: |+
+    event: response.created
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.6-sol","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"low","mode":"pro","summary":null},"safety_identifier":null,"service_tier":"auto","status":"in_progress","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":0,"type":"response.created"}
+
+    event: response.in_progress
+    data: {"response":{"background":false,"completed_at":null,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.6-sol","moderation":null,"object":"response","output":[],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"low","mode":"pro","summary":null},"safety_identifier":null,"service_tier":"auto","status":"in_progress","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":null,"user":null},"sequence_number":1,"type":"response.in_progress"}
+
+    event: response.output_item.added
+    data: {"item":{"content":[],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"completed","type":"message"},"output_index":0,"sequence_number":2,"type":"response.output_item.added"}
+
+    event: response.content_part.added
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"","type":"output_text"},"sequence_number":3,"type":"response.content_part.added"}
+
+    event: response.output_text.delta
+    data: {"content_index":0,"delta":"OK","item_id":"msg_REDACTED_1","logprobs":[],"obfuscation":"obfuscation_REDACTED_1","output_index":0,"sequence_number":4,"type":"response.output_text.delta"}
+
+    event: response.output_text.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","logprobs":[],"output_index":0,"sequence_number":5,"text":"OK","type":"response.output_text.done"}
+
+    event: response.content_part.done
+    data: {"content_index":0,"item_id":"msg_REDACTED_1","output_index":0,"part":{"annotations":[],"logprobs":[],"text":"OK","type":"output_text"},"sequence_number":6,"type":"response.content_part.done"}
+
+    event: response.output_item.done
+    data: {"item":{"content":[{"annotations":[],"logprobs":[],"text":"OK","type":"output_text"}],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"completed","type":"message"},"output_index":0,"sequence_number":7,"type":"response.output_item.done"}
+
+    event: response.completed
+    data: {"response":{"background":false,"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-5.6-sol","moderation":null,"object":"response","output":[{"content":[{"annotations":[],"logprobs":[],"text":"OK","type":"output_text"}],"id":"msg_REDACTED_1","phase":"final_answer","role":"assistant","status":"completed","type":"message"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"24h","reasoning":{"context":"current_turn","effort":"low","mode":"pro","summary":null},"safety_identifier":null,"service_tier":"default","status":"completed","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":0.98,"truncation":"disabled","usage":{"input_tokens":1522,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":30,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":1552},"user":null},"sequence_number":8,"type":"response.completed"}
+

--- a/tests/common/reasoning.rs
+++ b/tests/common/reasoning.rs
@@ -56,6 +56,17 @@ where
     M: CompletionModel,
     M::StreamingResponse: WasmCompatSend,
 {
+    run_reasoning_roundtrip_streaming_with_final(agent, |_| {}).await;
+}
+
+pub(crate) async fn run_reasoning_roundtrip_streaming_with_final<M, F>(
+    agent: ReasoningRoundtripAgent<M>,
+    mut inspect_final: F,
+) where
+    M: CompletionModel,
+    M::StreamingResponse: WasmCompatSend,
+    F: FnMut(&M::StreamingResponse),
+{
     let turn1_prompt = Message::User {
         content: OneOrMany::one(UserContent::text(ROUNDTRIP_TURN1_TEXT)),
     };
@@ -92,6 +103,7 @@ where
             Ok(StreamedAssistantContent::ReasoningDelta { reasoning, .. }) => {
                 reasoning_delta_text.push_str(&reasoning);
             }
+            Ok(StreamedAssistantContent::Final(response)) => inspect_final(&response),
             Ok(_) => {}
             Err(error) => panic!("Turn 1 stream error: {error}"),
         }

--- a/tests/providers/copilot/reasoning_roundtrip.rs
+++ b/tests/providers/copilot/reasoning_roundtrip.rs
@@ -1,6 +1,7 @@
 //! Copilot reasoning roundtrip tests.
 
 use rig::client::CompletionClient;
+use rig::providers::copilot::CopilotStreamingResponse;
 
 use crate::copilot::{live_responses_model, with_copilot_cassette};
 use crate::reasoning::{self, ReasoningRoundtripAgent};
@@ -8,12 +9,26 @@ use crate::reasoning::{self, ReasoningRoundtripAgent};
 #[tokio::test]
 async fn streaming() {
     with_copilot_cassette("reasoning_roundtrip/streaming", |client| async move {
-        reasoning::run_reasoning_roundtrip_streaming(ReasoningRoundtripAgent::new(
-            client.completion_model(live_responses_model()),
-            Some(serde_json::json!({
-                "reasoning": { "effort": "medium" }
-            })),
-        ))
+        let expected = serde_json::json!({
+            "context": "current_turn",
+            "effort": "medium",
+            "summary": null
+        });
+        reasoning::run_reasoning_roundtrip_streaming_with_final(
+            ReasoningRoundtripAgent::new(
+                client.completion_model(live_responses_model()),
+                Some(serde_json::json!({
+                    "reasoning": { "effort": "medium" }
+                })),
+            ),
+            |response| {
+                let CopilotStreamingResponse::Responses(response) = response else {
+                    panic!("Copilot reasoning stream should use the Responses route");
+                };
+                assert_eq!(response.reasoning_context.as_deref(), Some("current_turn"));
+                assert_eq!(response.reasoning_metadata.as_ref(), expected.as_object());
+            },
+        )
         .await;
     })
     .await;

--- a/tests/providers/mistralrs/cassette/responses_api.rs
+++ b/tests/providers/mistralrs/cassette/responses_api.rs
@@ -1,7 +1,8 @@
 //! Cassette coverage for mistral.rs through Rig's OpenAI Responses API client.
 
 use rig::client::CompletionClient;
-use rig::completion::{Chat, Prompt};
+use rig::completion::{Chat, CompletionModel, Prompt};
+use rig::message::AssistantContent;
 
 use crate::support::{assert_contains_all_case_insensitive, assert_nonempty_response};
 
@@ -35,21 +36,40 @@ async fn responses_api_reasoning_plus_answer_completes() {
     with_mistralrs_cassette(
         "responses_api/responses_api_reasoning_plus_answer_completes",
         |client| async move {
-            let agent = client
+            let model = client
                 .with_system_instructions_as_messages()
-                .agent(model_name())
-                .preamble(SYSTEM_PROMPT)
-                .max_tokens(512)
-                .build();
-
-            let response = agent
-                .prompt(
+                .completion_model(model_name());
+            let request = model
+                .completion_request(
                     "Think briefly, then answer in one sentence why local OpenAI-compatible servers should report token usage.",
                 )
+                .preamble(SYSTEM_PROMPT.to_owned())
+                .max_tokens(512)
+                .build();
+            let response = model
+                .completion(request)
                 .await
                 .expect("Responses API reasoning plus answer prompt should succeed");
+            let text = response
+                .choice
+                .iter()
+                .filter_map(|content| match content {
+                    AssistantContent::Text(text) => Some(text.text.as_str()),
+                    _ => None,
+                })
+                .collect::<String>();
 
-            assert_nonempty_response(&response);
+            assert_nonempty_response(&text);
+            assert!(
+                response
+                    .raw_response
+                    .provider_reasoning
+                    .as_deref()
+                    .is_some_and(|reasoning| !reasoning.trim().is_empty()),
+                "string-shaped provider reasoning should remain available"
+            );
+            assert_eq!(response.raw_response.reasoning_metadata, None);
+            assert_eq!(response.raw_response.reasoning_context, None);
         },
     )
     .await;

--- a/tests/providers/openai/cassette/gpt_5_6_reasoning.rs
+++ b/tests/providers/openai/cassette/gpt_5_6_reasoning.rs
@@ -8,11 +8,13 @@
 //! Run cassette tests in replay mode by default, or set
 //! `RIG_PROVIDER_TEST_MODE=record` to record against the real provider.
 
+use futures::StreamExt;
 use rig::client::CompletionClient;
 use rig::completion::{CompletionModel, CompletionResponse};
 use rig::message::AssistantContent;
 use rig::providers::openai;
-use serde_json::json;
+use rig::streaming::StreamedAssistantContent;
+use serde_json::{Value, json};
 
 use super::super::support::with_openai_cassette;
 
@@ -44,6 +46,27 @@ fn model_constants() {
     assert_eq!(openai::GPT_5_6_LUNA, "gpt-5.6-luna");
 }
 
+fn assert_reasoning_metadata(
+    response: &CompletionResponse<openai::responses_api::CompletionResponse>,
+    expected: Value,
+) {
+    let expected = expected
+        .as_object()
+        .expect("expected reasoning metadata should be an object");
+    assert_eq!(
+        response.raw_response.reasoning_context.as_deref(),
+        expected.get("context").and_then(Value::as_str)
+    );
+    assert_eq!(
+        response.raw_response.reasoning_metadata.as_ref(),
+        Some(expected)
+    );
+    assert_eq!(
+        serde_json::to_value(&response.raw_response).expect("raw response should serialize")["reasoning"],
+        Value::Object(expected.clone())
+    );
+}
+
 fn assert_has_text(response: &CompletionResponse<openai::responses_api::CompletionResponse>) {
     let text: String = response
         .choice
@@ -65,6 +88,15 @@ async fn effort_max() {
         let model = client.completion_model(openai::GPT_5_6);
         let response = prompt_with_reasoning(&model, json!({ "effort": "max" })).await;
         assert_has_text(&response);
+        assert_reasoning_metadata(
+            &response,
+            json!({
+                "context": "all_turns",
+                "effort": "max",
+                "mode": "standard",
+                "summary": null
+            }),
+        );
     })
     .await;
 }
@@ -78,6 +110,15 @@ async fn mode_pro_with_independent_effort() {
             let response =
                 prompt_with_reasoning(&model, json!({ "effort": "high", "mode": "pro" })).await;
             assert_has_text(&response);
+            assert_reasoning_metadata(
+                &response,
+                json!({
+                    "context": "all_turns",
+                    "effort": "high",
+                    "mode": "pro",
+                    "summary": null
+                }),
+            );
         },
     )
     .await;
@@ -95,20 +136,63 @@ async fn context_current_turn() {
             )
             .await;
             assert_has_text(&response);
-            assert_eq!(
-                response.raw_response.reasoning_context.as_deref(),
-                Some("current_turn")
-            );
-            assert_eq!(
-                response.raw_response.reasoning_metadata.as_ref(),
+            assert_reasoning_metadata(
+                &response,
                 json!({
                     "context": "current_turn",
                     "effort": "low",
                     "mode": "standard",
                     "summary": null
-                })
-                .as_object()
+                }),
             );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn streaming_reasoning_metadata() {
+    with_openai_cassette(
+        "gpt_5_6_reasoning/streaming_metadata",
+        |client| async move {
+            let model = client.completion_model(openai::GPT_5_6_SOL);
+            let request = model
+                .completion_request(PROMPT)
+                .additional_params(json!({
+                    "reasoning": {
+                        "effort": "low",
+                        "mode": "pro",
+                        "context": "current_turn"
+                    }
+                }))
+                .build();
+            let mut stream = model
+                .stream(request)
+                .await
+                .expect("GPT-5.6 reasoning stream should start");
+            let expected = json!({
+                "context": "current_turn",
+                "effort": "low",
+                "mode": "pro",
+                "summary": null
+            });
+
+            while let Some(item) = stream.next().await {
+                if let StreamedAssistantContent::Final(response) =
+                    item.expect("GPT-5.6 reasoning stream should succeed")
+                {
+                    assert_eq!(response.reasoning_context.as_deref(), Some("current_turn"));
+                    assert_eq!(response.reasoning_metadata.as_ref(), expected.as_object());
+                    assert_eq!(
+                        serde_json::to_value(&response)
+                            .expect("streaming response should serialize")["reasoning_metadata"],
+                        expected
+                    );
+                    return;
+                }
+            }
+
+            panic!("GPT-5.6 reasoning stream should yield a final response");
         },
     )
     .await;

--- a/tests/providers/openai/cassette/gpt_5_6_reasoning.rs
+++ b/tests/providers/openai/cassette/gpt_5_6_reasoning.rs
@@ -99,6 +99,16 @@ async fn context_current_turn() {
                 response.raw_response.reasoning_context.as_deref(),
                 Some("current_turn")
             );
+            assert_eq!(
+                response.raw_response.reasoning_metadata.as_ref(),
+                json!({
+                    "context": "current_turn",
+                    "effort": "low",
+                    "mode": "standard",
+                    "summary": null
+                })
+                .as_object()
+            );
         },
     )
     .await;

--- a/tests/providers/openai/cassette/gpt_5_6_reasoning.rs
+++ b/tests/providers/openai/cassette/gpt_5_6_reasoning.rs
@@ -11,14 +11,51 @@
 use futures::StreamExt;
 use rig::client::CompletionClient;
 use rig::completion::{CompletionModel, CompletionResponse};
-use rig::message::AssistantContent;
+use rig::message::{AssistantContent, Message, Reasoning};
 use rig::providers::openai;
 use rig::streaming::StreamedAssistantContent;
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 use super::super::support::with_openai_cassette;
 
 const PROMPT: &str = "Reply with exactly: OK";
+const FIVE_TURN_PROMPTS: [(&str, &str); 5] = [
+    (
+        "Remember the codeword ALPHA-17. Reply exactly: ACK-1",
+        "ACK-1",
+    ),
+    (
+        "Remember that the shape is octagon. Reply exactly: ACK-2",
+        "ACK-2",
+    ),
+    (
+        "Remember that the city is Kyoto. Reply exactly: ACK-3",
+        "ACK-3",
+    ),
+    (
+        "Remember that the number is 8642. Reply exactly: ACK-4",
+        "ACK-4",
+    ),
+    (
+        "Reply with exactly these remembered values, including capitalization and separators: ALPHA-17 | octagon | Kyoto | 8642",
+        "ALPHA-17 | octagon | Kyoto | 8642",
+    ),
+];
+
+#[derive(Debug, Serialize, Deserialize)]
+struct StoredResponseTurn {
+    user: Message,
+    assistant: Message,
+    raw_response: openai::responses_api::CompletionResponse,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct StoredStreamingTurn {
+    user: Message,
+    assistant: Message,
+    final_response: openai::responses_api::streaming::StreamingCompletionResponse,
+}
 
 async fn prompt_with_reasoning<M>(
     model: &M,
@@ -145,6 +182,241 @@ async fn context_current_turn() {
                     "summary": null
                 }),
             );
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn five_turn_reasoning_metadata_roundtrip() {
+    with_openai_cassette(
+        "gpt_5_6_reasoning/five_turn_metadata_roundtrip",
+        |client| async move {
+            let model = client.completion_model(openai::GPT_5_6_SOL);
+            let expected_metadata = json!({
+                "context": "all_turns",
+                "effort": "low",
+                "mode": "pro",
+                "summary": null
+            });
+            let mut stored_turns = Vec::<StoredResponseTurn>::new();
+
+            for (turn_index, (prompt, expected_text)) in FIVE_TURN_PROMPTS.into_iter().enumerate() {
+                let history = stored_turns
+                    .iter()
+                    .flat_map(|turn| [turn.user.clone(), turn.assistant.clone()]);
+                let user_message = Message::user(prompt);
+                let request = model
+                    .completion_request(user_message.clone())
+                    .messages(history)
+                    .additional_params(json!({
+                        "reasoning": {
+                            "context": "all_turns",
+                            "effort": "low",
+                            "mode": "pro"
+                        }
+                    }))
+                    .build();
+                let response = model.completion(request).await.unwrap_or_else(|error| {
+                    panic!("turn {} should succeed: {error}", turn_index + 1)
+                });
+
+                assert_has_text(&response);
+                assert_reasoning_metadata(&response, expected_metadata.clone());
+                let text = response
+                    .choice
+                    .iter()
+                    .filter_map(|content| match content {
+                        AssistantContent::Text(text) => Some(text.text.as_str()),
+                        _ => None,
+                    })
+                    .collect::<String>();
+                assert_eq!(
+                    text.trim(),
+                    expected_text,
+                    "unexpected turn {} text",
+                    turn_index + 1
+                );
+
+                let raw_json = serde_json::to_value(&response.raw_response)
+                    .expect("raw response should serialize");
+                let roundtripped: openai::responses_api::CompletionResponse =
+                    serde_json::from_value(raw_json.clone())
+                        .expect("raw response should deserialize after serialization");
+                assert_eq!(
+                    serde_json::to_value(&roundtripped)
+                        .expect("roundtripped raw response should serialize"),
+                    raw_json,
+                    "all raw response data should survive turn {} serialization roundtrip",
+                    turn_index + 1
+                );
+
+                stored_turns.push(StoredResponseTurn {
+                    user: user_message,
+                    assistant: Message::Assistant {
+                        id: response.message_id,
+                        content: response.choice,
+                    },
+                    raw_response: response.raw_response,
+                });
+                let stored_json =
+                    serde_json::to_value(&stored_turns).expect("all stored turns should serialize");
+                stored_turns = serde_json::from_value(stored_json.clone())
+                    .expect("all stored turns should deserialize before the next request");
+                assert_eq!(
+                    serde_json::to_value(&stored_turns).expect("restored turns should serialize"),
+                    stored_json,
+                    "all session data should survive persistence after turn {}",
+                    turn_index + 1
+                );
+                assert_eq!(stored_turns.len(), turn_index + 1);
+                for (prior_turn, stored) in stored_turns.iter().enumerate() {
+                    assert_eq!(
+                        stored.raw_response.reasoning_metadata.as_ref(),
+                        expected_metadata.as_object(),
+                        "reasoning metadata from turn {} changed by turn {}",
+                        prior_turn + 1,
+                        turn_index + 1
+                    );
+                    assert_eq!(
+                        stored.raw_response.reasoning_context.as_deref(),
+                        Some("all_turns")
+                    );
+                }
+            }
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn five_turn_streaming_reasoning_metadata_roundtrip() {
+    with_openai_cassette(
+        "gpt_5_6_reasoning/five_turn_streaming_metadata_roundtrip",
+        |client| async move {
+            let model = client.completion_model(openai::GPT_5_6_SOL);
+            let expected_metadata = json!({
+                "context": "all_turns",
+                "effort": "low",
+                "mode": "pro",
+                "summary": null
+            });
+            let mut stored_turns = Vec::<StoredStreamingTurn>::new();
+
+            for (turn_index, (prompt, expected_text)) in FIVE_TURN_PROMPTS.into_iter().enumerate() {
+                let history = stored_turns
+                    .iter()
+                    .flat_map(|turn| [turn.user.clone(), turn.assistant.clone()]);
+                let user_message = Message::user(prompt);
+                let request = model
+                    .completion_request(user_message.clone())
+                    .messages(history)
+                    .additional_params(json!({
+                        "reasoning": {
+                            "context": "all_turns",
+                            "effort": "low",
+                            "mode": "pro"
+                        }
+                    }))
+                    .build();
+                let mut stream = model.stream(request).await.unwrap_or_else(|error| {
+                    panic!("turn {} stream should start: {error}", turn_index + 1)
+                });
+                let mut text = String::new();
+                let mut reasoning_blocks = Vec::new();
+                let mut reasoning_delta = String::new();
+                let mut final_response = None;
+
+                while let Some(item) = stream.next().await {
+                    match item.unwrap_or_else(|error| {
+                        panic!("turn {} stream should succeed: {error}", turn_index + 1)
+                    }) {
+                        StreamedAssistantContent::Text(delta) => text.push_str(&delta.text),
+                        StreamedAssistantContent::Reasoning(reasoning) => {
+                            reasoning_blocks.push(AssistantContent::Reasoning(reasoning));
+                        }
+                        StreamedAssistantContent::ReasoningDelta { reasoning, .. } => {
+                            reasoning_delta.push_str(&reasoning);
+                        }
+                        StreamedAssistantContent::Final(response) => {
+                            final_response = Some(response);
+                        }
+                        _ => {}
+                    }
+                }
+
+                assert_eq!(
+                    text.trim(),
+                    expected_text,
+                    "unexpected turn {} text",
+                    turn_index + 1
+                );
+                let final_response = final_response.unwrap_or_else(|| {
+                    panic!("turn {} should yield a final response", turn_index + 1)
+                });
+                assert_eq!(
+                    final_response.reasoning_context.as_deref(),
+                    Some("all_turns")
+                );
+                assert_eq!(
+                    final_response.reasoning_metadata.as_ref(),
+                    expected_metadata.as_object()
+                );
+                let final_json = serde_json::to_value(&final_response)
+                    .expect("final streaming response should serialize");
+                let roundtripped: openai::responses_api::streaming::StreamingCompletionResponse =
+                    serde_json::from_value(final_json.clone())
+                        .expect("final streaming response should deserialize after serialization");
+                assert_eq!(
+                    serde_json::to_value(&roundtripped)
+                        .expect("roundtripped streaming response should serialize"),
+                    final_json,
+                    "all final streaming data should survive turn {} serialization roundtrip",
+                    turn_index + 1
+                );
+
+                if reasoning_blocks.is_empty() && !reasoning_delta.is_empty() {
+                    reasoning_blocks.push(AssistantContent::Reasoning(Reasoning::new(
+                        &reasoning_delta,
+                    )));
+                }
+                reasoning_blocks.push(AssistantContent::text(&text));
+                stored_turns.push(StoredStreamingTurn {
+                    user: user_message,
+                    assistant: Message::Assistant {
+                        id: stream.message_id.clone(),
+                        content: rig::OneOrMany::many(reasoning_blocks)
+                            .expect("streamed assistant message should not be empty"),
+                    },
+                    final_response,
+                });
+                let stored_json = serde_json::to_value(&stored_turns)
+                    .expect("all stored streaming turns should serialize");
+                stored_turns = serde_json::from_value(stored_json.clone()).expect(
+                    "all stored streaming turns should deserialize before the next request",
+                );
+                assert_eq!(
+                    serde_json::to_value(&stored_turns)
+                        .expect("restored streaming turns should serialize"),
+                    stored_json,
+                    "all streaming session data should survive persistence after turn {}",
+                    turn_index + 1
+                );
+                assert_eq!(stored_turns.len(), turn_index + 1);
+                for (prior_turn, stored) in stored_turns.iter().enumerate() {
+                    assert_eq!(
+                        stored.final_response.reasoning_metadata.as_ref(),
+                        expected_metadata.as_object(),
+                        "streaming reasoning metadata from turn {} changed by turn {}",
+                        prior_turn + 1,
+                        turn_index + 1
+                    );
+                    assert_eq!(
+                        stored.final_response.reasoning_context.as_deref(),
+                        Some("all_turns")
+                    );
+                }
+            }
         },
     )
     .await;


### PR DESCRIPTION
Closes #2111

## Summary

Exposes the complete object-shaped top-level reasoning metadata returned by the OpenAI Responses API without replacing the existing string-shaped compatibility surface.

- Adds `reasoning_metadata: Option<serde_json::Map<String, serde_json::Value>>` to blocking and streaming Responses results.
- Preserves known fields, unknown fields and values, nested objects, and null-valued object members value-equivalently.
- Keeps `provider_reasoning: Option<String>` unchanged for OpenAI-compatible providers that return top-level reasoning text.
- Keeps `reasoning_context: Option<String>` as a convenient projection of `reasoning_metadata.context`.
- Propagates metadata through blocking responses, terminal SSE responses, Responses WebSockets, and Copilot Responses streaming.
- Keeps unsupported top-level shapes (`null`, arrays, numbers, and booleans) non-fatal and normalizes them to absence.

## Serialization semantics

For manually constructed responses, the top-level `reasoning` value uses this documented precedence:

1. `provider_reasoning`
2. `reasoning_metadata`
3. a synthesized object from `reasoning_context`

Raw metadata is authoritative and is not mutated to match a conflicting manually assigned `reasoning_context`.

Response serialization also clears the request-side `AdditionalParameters::reasoning` value from the flattened parameter set, ensuring exactly one top-level `reasoning` key is emitted.

## Compatibility

- `provider_reasoning` and `reasoning_context` remain available with their existing types and behavior.
- The request-side `responses_api::Reasoning` type is unchanged.
- Object-shaped reasoning metadata is never injected into assistant reasoning content.
- The new public field is additive, although downstream exhaustive struct literals will need to initialize it.

## Tests

Regression coverage includes:

- known response fields (`context`, `effort`, `mode`, and `summary`);
- unknown fields and unknown values;
- nested and null-valued metadata;
- legacy string-shaped provider reasoning;
- unsupported top-level shapes;
- serialization round trips and precedence;
- duplicate-key prevention with flattened request reasoning;
- terminal OpenAI SSE propagation;
- Responses WebSocket propagation;
- Copilot Responses streaming propagation;
- cassette replay against a recorded GPT-5.6 response.

## Verification

- `cargo fmt --all`
- `git diff --check`
- `cargo test -p rig-core --lib` — 1183 passed, 8 ignored
- `cargo test -p rig-core providers::openai::responses_api --lib`
- `cargo test -p rig-core --features websocket providers::openai::responses_api::websocket::tests::unknown_event_is_skipped_and_reasoning_metadata_is_preserved --lib`
- `cargo test -p rig-core providers::copilot::tests::responses_stream_preserves_reasoning_metadata_on_final_response --lib`
- `cargo test -p rig --all-features --test openai openai::cassette::gpt_5_6_reasoning -- --nocapture --test-threads=1`
- `cargo test -p rig --all-features --test openai cassette_safety -- --test-threads=1`
- `cargo test -p rig-core --doc providers::openai::responses_api`
- `cargo clippy -p rig-core --all-targets --all-features -- -D warnings`
