### PR TITLE
refactor(core): deduplicate HttpClientExt implementations

### DIFF
--- a/crates/rig-core/src/http_client/mod.rs
+++ b/crates/rig-core/src/http_client/mod.rs
@@ -176,7 +176,8 @@ where
 }
 
 macro_rules! impl_http_client_ext {
-    ($client:ty) => {
+    ($(#[$attribute:meta])* $client:ty) => {
+        $(#[$attribute])*
         impl HttpClientExt for $client {
             fn send<T, U>(
                 &self,
@@ -275,6 +276,8 @@ macro_rules! impl_http_client_ext {
 
 impl_http_client_ext!(reqwest::Client);
 
-#[cfg(feature = "reqwest-middleware")]
-#[cfg_attr(docsrs, doc(cfg(feature = "reqwest-middleware")))]
-impl_http_client_ext!(reqwest_middleware::ClientWithMiddleware);
+impl_http_client_ext!(
+    #[cfg(feature = "reqwest-middleware")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "reqwest-middleware")))]
+    reqwest_middleware::ClientWithMiddleware
+);

--- a/crates/rig-core/src/http_client/mod.rs
+++ b/crates/rig-core/src/http_client/mod.rs
@@ -152,268 +152,129 @@ pub trait HttpClientExt: WasmCompatSend + WasmCompatSync {
         T: Into<Bytes> + WasmCompatSend;
 }
 
-impl HttpClientExt for reqwest::Client {
-    fn send<T, U>(
-        &self,
-        req: Request<T>,
-    ) -> impl Future<Output = Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
-    where
-        T: Into<Bytes>,
-        U: From<Bytes> + WasmCompatSend,
-    {
-        let (parts, body) = req.into_parts();
-        let req = self
-            .request(parts.method, parts.uri.to_string())
-            .headers(parts.headers)
-            .body(body.into());
-
-        async move {
-            let response = req.send().await.map_err(instance_error)?;
-            if !response.status().is_success() {
-                return Err(non_success_status_error(response).await);
-            }
-
-            let mut res = Response::builder().status(response.status());
-
-            if let Some(hs) = res.headers_mut() {
-                *hs = response.headers().clone();
-            }
-
-            let body: LazyBody<U> = Box::pin(async {
-                let bytes = response
-                    .bytes()
-                    .await
-                    .map_err(|e| Error::Instance(e.into()))?;
-
-                let body = U::from(bytes);
-                Ok(body)
-            });
-
-            res.body(body).map_err(Error::Protocol)
-        }
+async fn into_lazy_response<U>(response: reqwest::Response) -> Result<Response<LazyBody<U>>>
+where
+    U: From<Bytes>,
+    U: WasmCompatSend + 'static,
+{
+    if !response.status().is_success() {
+        return Err(non_success_status_error(response).await);
     }
 
-    fn send_multipart<U>(
-        &self,
-        req: Request<MultipartForm>,
-    ) -> impl Future<Output = Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
-    where
-        U: From<Bytes>,
-        U: WasmCompatSend + 'static,
-    {
-        let (parts, body) = req.into_parts();
-        let body = reqwest::multipart::Form::from(body);
+    let mut res = Response::builder().status(response.status());
 
-        let req = self
-            .request(parts.method, parts.uri.to_string())
-            .headers(parts.headers)
-            .multipart(body);
-
-        async move {
-            let response = req.send().await.map_err(instance_error)?;
-            if !response.status().is_success() {
-                return Err(non_success_status_error(response).await);
-            }
-
-            let mut res = Response::builder().status(response.status());
-
-            if let Some(hs) = res.headers_mut() {
-                *hs = response.headers().clone();
-            }
-
-            let body: LazyBody<U> = Box::pin(async {
-                let bytes = response
-                    .bytes()
-                    .await
-                    .map_err(|e| Error::Instance(e.into()))?;
-
-                let body = U::from(bytes);
-                Ok(body)
-            });
-
-            res.body(body).map_err(Error::Protocol)
-        }
+    if let Some(headers) = res.headers_mut() {
+        *headers = response.headers().clone();
     }
 
-    fn send_streaming<T>(
-        &self,
-        req: Request<T>,
-    ) -> impl Future<Output = Result<StreamingResponse>> + WasmCompatSend
-    where
-        T: Into<Bytes> + WasmCompatSend,
-    {
-        let (parts, body) = req.into_parts();
+    let body: LazyBody<U> = Box::pin(async {
+        let bytes = response.bytes().await.map_err(instance_error)?;
+        Ok(U::from(bytes))
+    });
 
-        let client = self.clone();
-
-        async move {
-            let req = self
-                .request(parts.method, parts.uri.to_string())
-                .headers(parts.headers)
-                .body(body.into())
-                .build()
-                .map_err(|error| Error::Instance(error.into()))?;
-            let response: reqwest::Response = client.execute(req).await.map_err(instance_error)?;
-            if !response.status().is_success() {
-                return Err(non_success_status_error(response).await);
-            }
-
-            #[cfg(not(target_family = "wasm"))]
-            let mut res = Response::builder()
-                .status(response.status())
-                .version(response.version());
-
-            #[cfg(target_family = "wasm")]
-            let mut res = Response::builder().status(response.status());
-
-            if let Some(hs) = res.headers_mut() {
-                *hs = response.headers().clone();
-            }
-
-            use futures::StreamExt;
-
-            let mapped_stream: Pin<Box<dyn WasmCompatSendStream<InnerItem = Result<Bytes>>>> =
-                Box::pin(
-                    response
-                        .bytes_stream()
-                        .map(|chunk| chunk.map_err(|e| Error::Instance(Box::new(e)))),
-                );
-
-            res.body(mapped_stream).map_err(Error::Protocol)
-        }
-    }
+    res.body(body).map_err(Error::Protocol)
 }
+
+macro_rules! impl_http_client_ext {
+    ($client:ty) => {
+        impl HttpClientExt for $client {
+            fn send<T, U>(
+                &self,
+                req: Request<T>,
+            ) -> impl Future<Output = Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+            where
+                T: Into<Bytes>,
+                U: From<Bytes> + WasmCompatSend + 'static,
+            {
+                let (parts, body) = req.into_parts();
+                let req = self
+                    .request(parts.method, parts.uri.to_string())
+                    .headers(parts.headers)
+                    .body(body.into());
+
+                async move {
+                    let response = req.send().await.map_err(instance_error)?;
+                    into_lazy_response(response).await
+                }
+            }
+
+            fn send_multipart<U>(
+                &self,
+                req: Request<MultipartForm>,
+            ) -> impl Future<Output = Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+            where
+                U: From<Bytes>,
+                U: WasmCompatSend + 'static,
+            {
+                let (parts, body) = req.into_parts();
+                let body = reqwest::multipart::Form::from(body);
+
+                let req = self
+                    .request(parts.method, parts.uri.to_string())
+                    .headers(parts.headers)
+                    .multipart(body);
+
+                async move {
+                    let response = req.send().await.map_err(instance_error)?;
+                    into_lazy_response(response).await
+                }
+            }
+
+            fn send_streaming<T>(
+                &self,
+                req: Request<T>,
+            ) -> impl Future<Output = Result<StreamingResponse>> + WasmCompatSend
+            where
+                T: Into<Bytes> + WasmCompatSend,
+            {
+                let (parts, body) = req.into_parts();
+
+                let client = self.clone();
+
+                async move {
+                    let req = self
+                        .request(parts.method, parts.uri.to_string())
+                        .headers(parts.headers)
+                        .body(body.into())
+                        .build()
+                        .map_err(|error| Error::Instance(error.into()))?;
+                    let response: reqwest::Response =
+                        client.execute(req).await.map_err(instance_error)?;
+                    if !response.status().is_success() {
+                        return Err(non_success_status_error(response).await);
+                    }
+
+                    #[cfg(not(target_family = "wasm"))]
+                    let mut res = Response::builder()
+                        .status(response.status())
+                        .version(response.version());
+
+                    #[cfg(target_family = "wasm")]
+                    let mut res = Response::builder().status(response.status());
+
+                    if let Some(hs) = res.headers_mut() {
+                        *hs = response.headers().clone();
+                    }
+
+                    use futures::StreamExt;
+
+                    let mapped_stream: Pin<
+                        Box<dyn WasmCompatSendStream<InnerItem = Result<Bytes>>>,
+                    > = Box::pin(
+                        response
+                            .bytes_stream()
+                            .map(|chunk| chunk.map_err(|e| Error::Instance(Box::new(e)))),
+                    );
+
+                    res.body(mapped_stream).map_err(Error::Protocol)
+                }
+            }
+        }
+    };
+}
+
+impl_http_client_ext!(reqwest::Client);
 
 #[cfg(feature = "reqwest-middleware")]
 #[cfg_attr(docsrs, doc(cfg(feature = "reqwest-middleware")))]
-impl HttpClientExt for reqwest_middleware::ClientWithMiddleware {
-    fn send<T, U>(
-        &self,
-        req: Request<T>,
-    ) -> impl Future<Output = Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
-    where
-        T: Into<Bytes>,
-        U: From<Bytes> + WasmCompatSend,
-    {
-        let (parts, body) = req.into_parts();
-        let req = self
-            .request(parts.method, parts.uri.to_string())
-            .headers(parts.headers)
-            .body(body.into());
-
-        async move {
-            let response = req.send().await.map_err(instance_error)?;
-            if !response.status().is_success() {
-                return Err(non_success_status_error(response).await);
-            }
-
-            let mut res = Response::builder().status(response.status());
-
-            if let Some(hs) = res.headers_mut() {
-                *hs = response.headers().clone();
-            }
-
-            let body: LazyBody<U> = Box::pin(async {
-                let bytes = response
-                    .bytes()
-                    .await
-                    .map_err(|e| Error::Instance(e.into()))?;
-
-                let body = U::from(bytes);
-                Ok(body)
-            });
-
-            res.body(body).map_err(Error::Protocol)
-        }
-    }
-
-    fn send_multipart<U>(
-        &self,
-        req: Request<MultipartForm>,
-    ) -> impl Future<Output = Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
-    where
-        U: From<Bytes>,
-        U: WasmCompatSend + 'static,
-    {
-        let (parts, body) = req.into_parts();
-        let body = reqwest::multipart::Form::from(body);
-
-        let req = self
-            .request(parts.method, parts.uri.to_string())
-            .headers(parts.headers)
-            .multipart(body);
-
-        async move {
-            let response = req.send().await.map_err(instance_error)?;
-            if !response.status().is_success() {
-                return Err(non_success_status_error(response).await);
-            }
-
-            let mut res = Response::builder().status(response.status());
-
-            if let Some(hs) = res.headers_mut() {
-                *hs = response.headers().clone();
-            }
-
-            let body: LazyBody<U> = Box::pin(async {
-                let bytes = response
-                    .bytes()
-                    .await
-                    .map_err(|e| Error::Instance(e.into()))?;
-
-                let body = U::from(bytes);
-                Ok(body)
-            });
-
-            res.body(body).map_err(Error::Protocol)
-        }
-    }
-
-    fn send_streaming<T>(
-        &self,
-        req: Request<T>,
-    ) -> impl Future<Output = Result<StreamingResponse>> + WasmCompatSend
-    where
-        T: Into<Bytes> + WasmCompatSend,
-    {
-        let (parts, body) = req.into_parts();
-
-        let client = self.clone();
-
-        async move {
-            let req = self
-                .request(parts.method, parts.uri.to_string())
-                .headers(parts.headers)
-                .body(body.into())
-                .build()
-                .map_err(|error| Error::Instance(error.into()))?;
-            let response: reqwest::Response = client.execute(req).await.map_err(instance_error)?;
-            if !response.status().is_success() {
-                return Err(non_success_status_error(response).await);
-            }
-
-            #[cfg(not(target_family = "wasm"))]
-            let mut res = Response::builder()
-                .status(response.status())
-                .version(response.version());
-
-            #[cfg(target_family = "wasm")]
-            let mut res = Response::builder().status(response.status());
-
-            if let Some(hs) = res.headers_mut() {
-                *hs = response.headers().clone();
-            }
-
-            use futures::StreamExt;
-
-            let mapped_stream: Pin<Box<dyn WasmCompatSendStream<InnerItem = Result<Bytes>>>> =
-                Box::pin(
-                    response
-                        .bytes_stream()
-                        .map(|chunk| chunk.map_err(|e| Error::Instance(Box::new(e)))),
-                );
-
-            res.body(mapped_stream).map_err(Error::Protocol)
-        }
-    }
-}
+impl_http_client_ext!(reqwest_middleware::ClientWithMiddleware);


### PR DESCRIPTION
## Summary

- generate the `HttpClientExt` implementations for `reqwest::Client` and `ClientWithMiddleware` from one macro
- share unary and multipart response conversion through a private helper
- preserve the existing request, error, header, body, and streaming behavior while removing 139 net lines

Fixes #2077

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p rig-core --all-targets --all-features -- -D warnings`
- `cargo check -p rig-core --no-default-features`
- `cargo check -p rig-core --all-features`
- `cargo check -p rig-core --target wasm32-unknown-unknown --no-default-features --features wasm`
- `cargo test -p rig-core --lib --features reqwest-middleware` (1,183 passed; 8 ignored)
- `cargo test -p rig-core --all-features http_client --lib`

The full `cargo test -p rig-core --all-features --lib` run reached 1,257 passing tests and one unrelated failure in `providers::gemini::image_generation::tests::image_generation_2xx_error_envelope_preserves_status_and_body`; the same isolated failure reproduces on `origin/main`.

Cassette tests are not applicable because this is a provider-agnostic, behavior-preserving refactor.

## AI assistance

AI assistance was used for implementation and review; the resulting diff and validation output were manually inspected.
