### PR TITLE
refactor(core)!: make core error enums non-exhaustive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+
+- *(core)* [**breaking**] Mark `PromptError`, `StructuredOutputError`, `ToolError`, `ToolSetError`, and `VectorStoreError` as non-exhaustive, requiring downstream match expressions to include a wildcard arm. Conversation memory load failures now surface as the typed `PromptError::MemoryError` variant instead of `CompletionError::RequestError`.
+
 ## [0.40.0](https://github.com/0xPlaygrounds/rig/compare/v0.39.0...v0.40.0) - 2026-07-10
 
 ### Added

--- a/crates/rig-core/CHANGELOG.md
+++ b/crates/rig-core/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+
+- *(core)* [**breaking**] Mark `PromptError`, `StructuredOutputError`, `ToolError`, `ToolSetError`, and `VectorStoreError` as non-exhaustive, requiring downstream match expressions to include a wildcard arm. Conversation memory load failures now surface as the typed `PromptError::MemoryError` variant instead of `CompletionError::RequestError`.
+
 ## [0.40.0](https://github.com/0xPlaygrounds/rig/compare/rig-core-v0.39.0...rig-core-v0.40.0) - 2026-07-10
 
 ### Added

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -2523,11 +2523,11 @@ mod tests {
         let result = agent.prompt("hello").conversation("t1").await;
 
         match result {
-            Err(PromptError::CompletionError(CompletionError::RequestError(err))) => {
-                let msg = format!("{err}");
+            Err(PromptError::MemoryError(err)) => {
+                let msg = err.to_string();
                 assert!(msg.contains("load boom"), "got: {msg}");
             }
-            other => panic!("expected PromptError::CompletionError(RequestError), got {other:?}"),
+            other => panic!("expected PromptError::MemoryError, got {other:?}"),
         }
     }
 

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -261,12 +261,9 @@ pub enum StreamingError {
     Tool(#[from] ToolSetError),
 }
 
-/// Surface [`crate::memory::ConversationMemory`] failures through the existing
-/// [`CompletionError::RequestError`] variant so adding memory support does not
-/// require a new top-level [`StreamingError`] arm.
 impl From<crate::memory::MemoryError> for StreamingError {
     fn from(err: crate::memory::MemoryError) -> Self {
-        Self::Completion(CompletionError::RequestError(Box::new(err)))
+        Self::Prompt(Box::new(PromptError::MemoryError(err)))
     }
 }
 
@@ -5860,14 +5857,13 @@ mod tests {
 
         let first = stream.next().await.expect("at least one item");
         match first {
-            Err(err) => {
-                let msg = format!("{err:?}");
-                assert!(
-                    msg.contains("Memory") || msg.contains("memory") || msg.contains("load boom"),
-                    "expected memory error, got: {msg}"
-                );
-            }
-            Ok(other) => panic!("expected memory error, got {other:?}"),
+            Err(StreamingError::Prompt(err)) => match *err {
+                PromptError::MemoryError(err) => {
+                    assert!(err.to_string().contains("load boom"));
+                }
+                other => panic!("expected PromptError::MemoryError, got {other:?}"),
+            },
+            other => panic!("expected StreamingError::Prompt, got {other:?}"),
         }
     }
 

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -145,10 +145,15 @@ impl CompletionError {
 /// [`Self::provider_response_json`], and [`Self::provider_response_status`] forward
 /// to the inner completion error's helpers.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum PromptError {
     /// Something went wrong with the completion
     #[error("CompletionError: {0}")]
     CompletionError(#[from] CompletionError),
+
+    /// Conversation memory failed to load history.
+    #[error("MemoryError: {0}")]
+    MemoryError(#[from] crate::memory::MemoryError),
 
     /// There was an error while using a tool
     #[error("ToolCallError: {0}")]
@@ -186,15 +191,6 @@ pub enum PromptError {
         allowed_tools: Vec<String>,
         chat_history: Box<Vec<Message>>,
     },
-}
-
-/// Surface [`crate::memory::ConversationMemory`] failures through the existing
-/// [`CompletionError::RequestError`] variant so adding memory support does not
-/// require a new top-level [`PromptError`] arm in downstream exhaustive matchers.
-impl From<crate::memory::MemoryError> for PromptError {
-    fn from(err: crate::memory::MemoryError) -> Self {
-        Self::CompletionError(CompletionError::RequestError(Box::new(err)))
-    }
 }
 
 impl PromptError {
@@ -246,6 +242,7 @@ impl PromptError {
 /// [`Self::provider_response_json`], and [`Self::provider_response_status`] forward
 /// through the chain.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum StructuredOutputError {
     /// An error occurred during the prompt execution.
     #[error("PromptError: {0}")]

--- a/crates/rig-core/src/tool/mod.rs
+++ b/crates/rig-core/src/tool/mod.rs
@@ -44,6 +44,7 @@ use crate::{
 };
 
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum ToolError {
     #[cfg(not(target_family = "wasm"))]
     /// Error returned by the tool
@@ -532,6 +533,7 @@ impl ToolType {
 }
 
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum ToolSetError {
     /// Error returned by the tool
     #[error("ToolCallError: {0}")]

--- a/crates/rig-core/src/vector_store/mod.rs
+++ b/crates/rig-core/src/vector_store/mod.rs
@@ -30,6 +30,7 @@ pub mod request;
 
 /// Errors from vector store operations.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum VectorStoreError {
     /// Embedding generation failed while preparing a vector query or insert.
     #[error("Embedding error: {0}")]


### PR DESCRIPTION
## Summary

- mark `PromptError`, `StructuredOutputError`, `ToolError`, `ToolSetError`, and `VectorStoreError` as `#[non_exhaustive]`
- add the typed `PromptError::MemoryError` variant and route blocking and streaming memory-load failures through it
- remove the `CompletionError::RequestError` memory-error workaround
- document the breaking wildcard-match requirement in both root and `rig-core` changelogs

Downstream exhaustive matches over these enums now need a wildcard arm:

```rust
match error {
    // known variants...
    _ => { /* handle future variants */ }
}
```

Fixes #2045

## Testing

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-features`
- `cargo clippy -p rig-core --all-targets --all-features -- -D warnings`
- `cargo test -p rig-core --lib` (1,183 passed; 8 ignored)
- `cargo test -p rig-core --all-features memory_load_error_surfaces_as_prompt_error --lib`
- `cargo test -p rig-core --all-features streaming_load_error_yields_memory_error --lib`
- `cargo check -p rig-core --target wasm32-unknown-unknown --no-default-features --features wasm`
- `cargo doc -p rig-core --all-features --no-deps`

Cassette tests are not applicable because this changes provider-agnostic error typing only.

## AI assistance

AI assistance was used for implementation and review; the diff and validation output were manually inspected.
