### PR TITLE
refactor(telemetry): centralize completion span lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9572,6 +9572,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "tracing-futures",
  "tracing-subscriber",
  "uuid",
 ]

--- a/crates/rig-bedrock/Cargo.toml
+++ b/crates/rig-bedrock/Cargo.toml
@@ -27,6 +27,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
+tracing-futures = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]

--- a/crates/rig-bedrock/src/completion.rs
+++ b/crates/rig-bedrock/src/completion.rs
@@ -10,7 +10,7 @@ use crate::{
 
 use rig_core::completion::{self, CompletionError, CompletionRequest};
 use rig_core::streaming::StreamingCompletionResponse;
-use rig_core::telemetry::SpanCombinator;
+use rig_core::telemetry::{CompletionOperation, CompletionSpanBuilder, SpanCombinator};
 use tracing::Instrument;
 
 /// `ai21.jamba-1-5-large-v1:0`
@@ -225,24 +225,10 @@ impl completion::CompletionModel for CompletionModel {
     ) -> Result<completion::CompletionResponse<AwsConverseOutput>, CompletionError> {
         let request_model = resolve_request_model(&self.model, &completion_request);
 
-        let span = if tracing::Span::current().is_disabled() {
-            tracing::info_span!(
-                target: "rig_core::completions",
-                "chat",
-                gen_ai.operation.name = "chat",
-                gen_ai.provider.name = "aws_bedrock",
-                gen_ai.request.model = &request_model,
-                gen_ai.system_instructions = &completion_request.preamble,
-                gen_ai.response.id = tracing::field::Empty,
-                gen_ai.response.model = tracing::field::Empty,
-                gen_ai.usage.output_tokens = tracing::field::Empty,
-                gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
-            )
-        } else {
-            tracing::Span::current()
-        };
+        let span =
+            CompletionSpanBuilder::new("aws_bedrock", &request_model, CompletionOperation::Chat)
+                .system_instructions(completion_request.preamble.as_deref())
+                .build();
 
         let request = AwsCompletionRequest {
             inner: completion_request,

--- a/crates/rig-bedrock/src/streaming.rs
+++ b/crates/rig-bedrock/src/streaming.rs
@@ -1,18 +1,20 @@
 use crate::types::completion_request::AwsCompletionRequest;
 use crate::{
     completion::{CompletionModel, resolve_request_model},
-    types::errors::AwsSdkConverseStreamError,
+    types::errors::{AwsSdkConverseStreamError, converse_stream_output_completion_error},
 };
 use async_stream::stream;
 use aws_sdk_bedrockruntime::types as aws_bedrock;
 use rig_core::completion::GetTokenUsage;
 use rig_core::streaming::StreamingCompletionResponse;
+use rig_core::telemetry::{CompletionOperation, CompletionSpanBuilder, SpanCombinator};
 use rig_core::{
     completion::CompletionError,
     message::ReasoningContent,
     streaming::{RawStreamingChoice, RawStreamingToolCall, ToolCallDeltaContent},
 };
 use serde::{Deserialize, Serialize};
+use tracing_futures::Instrument;
 
 #[derive(Clone, Deserialize, Serialize)]
 pub struct BedrockStreamingResponse {
@@ -91,10 +93,18 @@ impl CompletionModel {
         completion_request: rig_core::completion::CompletionRequest,
     ) -> Result<StreamingCompletionResponse<BedrockStreamingResponse>, CompletionError> {
         let request_model = resolve_request_model(&self.model, &completion_request);
+        let system_instructions = completion_request.preamble.clone();
         let request = AwsCompletionRequest {
             inner: completion_request,
             prompt_caching: self.prompt_caching,
         };
+        let span = CompletionSpanBuilder::new(
+            "aws_bedrock",
+            &request_model,
+            CompletionOperation::ChatStreaming,
+        )
+        .system_instructions(system_instructions.as_deref())
+        .build();
 
         let mut converse_builder = self
             .client
@@ -114,15 +124,28 @@ impl CompletionModel {
             .set_messages(Some(prompt_with_history))
             .set_output_config(output_config);
 
-        let response = converse_builder.send().await.map_err(|sdk_error| {
-            Into::<CompletionError>::into(AwsSdkConverseStreamError(sdk_error))
-        })?;
+        let response = converse_builder
+            .send()
+            .instrument(span.clone())
+            .await
+            .map_err(|sdk_error| {
+                Into::<CompletionError>::into(AwsSdkConverseStreamError(sdk_error))
+            })?;
 
         let stream = Box::pin(stream! {
+            let span = tracing::Span::current();
             let mut current_tool_call: Option<ToolCallState> = None;
             let mut current_reasoning: Option<ReasoningState> = None;
             let mut stream = response.stream;
-            while let Ok(Some(output)) = stream.recv().await {
+            loop {
+                let output = match stream.recv().await {
+                    Ok(Some(output)) => output,
+                    Ok(None) => break,
+                    Err(err) => {
+                        yield Err(converse_stream_output_completion_error(err.into_service_error()));
+                        break;
+                    }
+                };
                 match output {
                     aws_bedrock::ConverseStreamOutput::ContentBlockDelta(event) => {
                         let delta = event.delta.ok_or(CompletionError::ProviderError("The delta for a content block is missing".into()))?;
@@ -230,7 +253,7 @@ impl CompletionModel {
                     aws_bedrock::ConverseStreamOutput::Metadata(metadata_event) => {
                         // Extract usage information from metadata
                         if let Some(usage) = metadata_event.usage {
-                            yield Ok(RawStreamingChoice::FinalResponse(BedrockStreamingResponse {
+                            let final_response = BedrockStreamingResponse {
                                 usage: Some(BedrockUsage {
                                     input_tokens: usage.input_tokens,
                                     output_tokens: usage.output_tokens,
@@ -238,13 +261,15 @@ impl CompletionModel {
                                     cache_read_input_tokens: usage.cache_read_input_tokens,
                                     cache_write_input_tokens: usage.cache_write_input_tokens,
                                 }),
-                            }));
+                            };
+                            span.record_token_usage(&final_response);
+                            yield Ok(RawStreamingChoice::FinalResponse(final_response));
                         }
                     },
                     _ => {}
                 }
             }
-        });
+        }.instrument(span));
 
         Ok(StreamingCompletionResponse::stream(stream))
     }

--- a/crates/rig-bedrock/src/types/errors.rs
+++ b/crates/rig-bedrock/src/types/errors.rs
@@ -5,6 +5,7 @@ use aws_sdk_bedrockruntime::error::SdkError;
 use aws_sdk_bedrockruntime::operation::converse::ConverseError;
 use aws_sdk_bedrockruntime::operation::converse_stream::ConverseStreamError;
 use aws_sdk_bedrockruntime::operation::invoke_model::InvokeModelError;
+use aws_sdk_bedrockruntime::types::error::ConverseStreamOutputError;
 use rig_core::completion::CompletionError;
 use rig_core::embeddings::EmbeddingError;
 use rig_core::image_generation::ImageGenerationError;
@@ -120,13 +121,45 @@ impl From<AwsSdkConverseError> for CompletionError {
     }
 }
 
+pub(crate) fn converse_stream_output_completion_error(
+    err: ConverseStreamOutputError,
+) -> CompletionError {
+    let (message, fallback) = match err {
+        ConverseStreamOutputError::InternalServerException(err) => {
+            (err.message, "Bedrock internal server error".into())
+        }
+        ConverseStreamOutputError::ModelStreamErrorException(err) => {
+            (err.message, "Bedrock streaming model error".into())
+        }
+        ConverseStreamOutputError::ValidationException(err) => {
+            (err.message, "Bedrock validation error".into())
+        }
+        ConverseStreamOutputError::ThrottlingException(err) => {
+            (err.message, "Bedrock request throttled".into())
+        }
+        ConverseStreamOutputError::ServiceUnavailableException(err) => {
+            (err.message, "Bedrock service unavailable".into())
+        }
+        _ => (None, "Bedrock event stream failed".into()),
+    };
+
+    match message {
+        Some(message) => CompletionError::from_provider_body(message),
+        None => CompletionError::ProviderError(fallback),
+    }
+}
+
+fn converse_stream_completion_error(err: ConverseStreamError) -> CompletionError {
+    match converse_stream_message(err) {
+        (Some(msg), _) => CompletionError::from_provider_body(msg),
+        (None, fallback) => CompletionError::ProviderError(fallback),
+    }
+}
+
 pub struct AwsSdkConverseStreamError(pub SdkError<ConverseStreamError, HttpResponse>);
 impl From<AwsSdkConverseStreamError> for CompletionError {
     fn from(value: AwsSdkConverseStreamError) -> Self {
-        match converse_stream_message(value.0.into_service_error()) {
-            (Some(msg), _) => CompletionError::from_provider_body(msg),
-            (None, fallback) => CompletionError::ProviderError(fallback),
-        }
+        converse_stream_completion_error(value.0.into_service_error())
     }
 }
 
@@ -295,6 +328,25 @@ mod tests {
             (Some(msg), _) => CompletionError::from_provider_body(msg),
             (None, fallback) => CompletionError::ProviderError(fallback),
         };
+        assert_eq!(error.provider_response_body(), None);
+        assert_eq!(error.provider_response_status(), None);
+    }
+
+    #[test]
+    fn converse_stream_output_with_provider_message_yields_provider_response() {
+        let err = ConverseStreamOutputError::ValidationException(
+            ValidationException::builder().message("boom").build(),
+        );
+        let error = converse_stream_output_completion_error(err);
+        assert_eq!(error.provider_response_body(), Some("boom"));
+        assert_eq!(error.provider_response_status(), None);
+    }
+
+    #[test]
+    fn converse_stream_output_without_provider_message_yields_provider_error() {
+        let err =
+            ConverseStreamOutputError::ValidationException(ValidationException::builder().build());
+        let error = converse_stream_output_completion_error(err);
         assert_eq!(error.provider_response_body(), None);
         assert_eq!(error.provider_response_status(), None);
     }

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -972,7 +972,7 @@ where
         runner: &AgentRunner<M>,
         effective_preamble: Option<&str>,
     ) -> tracing::Span {
-        build_chat_span!(runner, effective_preamble, "chat_streaming")
+        build_chat_span!(runner, effective_preamble, "chat_streaming", "chat")
     }
 
     fn run_model_turn<'a>(
@@ -2024,6 +2024,7 @@ mod tests {
         name: String,
         parent_id: Option<u64>,
         fields: HashMap<String, u64>,
+        string_fields: HashMap<String, String>,
     }
 
     #[derive(Clone, Default)]
@@ -2044,6 +2045,7 @@ mod tests {
                     name: name.to_string(),
                     parent_id,
                     fields: HashMap::new(),
+                    string_fields: HashMap::new(),
                 });
             }
         }
@@ -2053,6 +2055,14 @@ mod tests {
                 && let Some(span) = spans.iter_mut().rev().find(|span| span.id == id.into_u64())
             {
                 span.fields.extend(fields);
+            }
+        }
+
+        fn record_strings(&self, id: &Id, fields: Vec<(String, String)>) {
+            if let Ok(mut spans) = self.0.lock()
+                && let Some(span) = spans.iter_mut().rev().find(|span| span.id == id.into_u64())
+            {
+                span.string_fields.extend(fields);
             }
         }
 
@@ -2076,6 +2086,11 @@ mod tests {
                 .map(Id::into_u64)
                 .or_else(|| ctx.current_span().id().map(Id::into_u64));
             self.spans.insert(id, attrs.metadata().name(), parent_id);
+            let mut string_fields = Vec::new();
+            attrs.record(&mut SpanStringCaptureVisitor {
+                fields: &mut string_fields,
+            });
+            self.spans.record_strings(id, string_fields);
         }
 
         fn on_record(&self, span: &Id, values: &tracing::span::Record<'_>, _ctx: Context<'_, S>) {
@@ -2084,11 +2099,32 @@ mod tests {
                 fields: &mut fields,
             });
             self.spans.record(span, fields);
+            let mut string_fields = Vec::new();
+            values.record(&mut SpanStringCaptureVisitor {
+                fields: &mut string_fields,
+            });
+            self.spans.record_strings(span, string_fields);
         }
     }
 
     struct SpanFieldCaptureVisitor<'a> {
         fields: &'a mut Vec<(String, u64)>,
+    }
+
+    struct SpanStringCaptureVisitor<'a> {
+        fields: &'a mut Vec<(String, String)>,
+    }
+
+    impl Visit for SpanStringCaptureVisitor<'_> {
+        fn record_str(&mut self, field: &Field, value: &str) {
+            self.fields
+                .push((field.name().to_string(), value.to_string()));
+        }
+
+        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+            self.fields
+                .push((field.name().to_string(), format!("{value:?}")));
+        }
     }
 
     impl Visit for SpanFieldCaptureVisitor<'_> {
@@ -2190,6 +2226,13 @@ mod tests {
 
         for (chat_span, expected_usage) in chat_spans.into_iter().zip(expected_usages) {
             assert_eq!(chat_span.parent_id, Some(outer_span_id));
+            assert_eq!(
+                chat_span
+                    .string_fields
+                    .get("gen_ai.operation.name")
+                    .map(String::as_str),
+                Some("chat")
+            );
             assert_eq!(
                 chat_span.fields.get("gen_ai.usage.input_tokens"),
                 Some(&expected_usage.input_tokens)

--- a/crates/rig-core/src/agent/runner.rs
+++ b/crates/rig-core/src/agent/runner.rs
@@ -65,16 +65,16 @@ use super::UNKNOWN_AGENT_NAME;
 /// The span *name* must be a string literal — `tracing` bakes it into static
 /// metadata — so this is a macro parameterized by the name rather than a
 /// function (the two surfaces keep distinct names, `chat` vs `chat_streaming`,
-/// which dashboards split on). Every other field is identical across the
-/// blocking and streaming surfaces, so it lives here once instead of being
-/// copy-pasted into each `TurnSource::open_chat_span`.
+/// which dashboards split on). The matching operation value is passed with the
+/// name; every other field is identical across the two surfaces, so it lives
+/// here once instead of being copy-pasted into each `TurnSource::open_chat_span`.
 macro_rules! build_chat_span {
-    ($runner:expr, $effective_preamble:expr, $name:literal) => {
+    ($runner:expr, $effective_preamble:expr, $name:literal, $operation:literal) => {
         ::tracing::info_span!(
             target: "rig::agent_chat",
             parent: ::tracing::Span::current(),
             $name,
-            gen_ai.operation.name = "chat",
+            gen_ai.operation.name = $operation,
             gen_ai.agent.name = $runner.agent_name_or_default(),
             gen_ai.system_instructions = $effective_preamble,
             gen_ai.provider.name = ::tracing::field::Empty,
@@ -868,7 +868,7 @@ where
         runner: &AgentRunner<M>,
         effective_preamble: Option<&str>,
     ) -> tracing::Span {
-        let chat_span = build_chat_span!(runner, effective_preamble, "chat");
+        let chat_span = build_chat_span!(runner, effective_preamble, "chat", "chat");
         self.chain_span(chat_span)
     }
 

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -9,13 +9,13 @@ use crate::{
     http_client::HttpClientExt,
     message::{self, DocumentMediaType, DocumentSourceKind, MessageError, MimeType, Reasoning},
     one_or_many::string_or_one_or_many,
-    telemetry::{ProviderResponseExt, SpanCombinator},
+    telemetry::{CompletionOperation, CompletionSpanBuilder, ProviderResponseExt, SpanCombinator},
     wasm_compat::*,
 };
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use std::{convert::Infallible, str::FromStr};
-use tracing::{Instrument, Level, enabled, info_span};
+use tracing::{Instrument, Level, enabled};
 
 // ================================================================
 // Anthropic Completion API
@@ -2457,24 +2457,13 @@ where
             .model
             .clone()
             .unwrap_or_else(|| self.model.clone());
-        let span = if tracing::Span::current().is_disabled() {
-            info_span!(
-                target: "rig::completions",
-                "chat",
-                gen_ai.operation.name = "chat",
-                gen_ai.provider.name = Ext::PROVIDER_NAME,
-                gen_ai.request.model = &request_model,
-                gen_ai.system_instructions = &completion_request.preamble,
-                gen_ai.response.id = tracing::field::Empty,
-                gen_ai.response.model = tracing::field::Empty,
-                gen_ai.usage.output_tokens = tracing::field::Empty,
-                gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
-            )
-        } else {
-            tracing::Span::current()
-        };
+        let span = CompletionSpanBuilder::new(
+            Ext::PROVIDER_NAME,
+            &request_model,
+            CompletionOperation::Chat,
+        )
+        .system_instructions(completion_request.preamble.as_deref())
+        .build();
 
         // Check if max_tokens is set, required for Anthropic
         if completion_request.max_tokens.is_none() {

--- a/crates/rig-core/src/providers/anthropic/streaming.rs
+++ b/crates/rig-core/src/providers/anthropic/streaming.rs
@@ -2,7 +2,7 @@ use async_stream::stream;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use tracing::{Level, enabled, info_span};
+use tracing::{Level, enabled};
 use tracing_futures::Instrument;
 
 use super::completion::{
@@ -16,7 +16,7 @@ use crate::message::ReasoningContent;
 use crate::streaming::{
     self, RawStreamingChoice, RawStreamingToolCall, StreamingResult, ToolCallDeltaContent,
 };
-use crate::telemetry::SpanCombinator;
+use crate::telemetry::{CompletionOperation, CompletionSpanBuilder, SpanCombinator};
 use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
 use std::collections::HashMap;
 
@@ -228,26 +228,13 @@ where
             .model
             .clone()
             .unwrap_or_else(|| self.model.clone());
-        let span = if tracing::Span::current().is_disabled() {
-            info_span!(
-                target: "rig::completions",
-                "chat_streaming",
-                gen_ai.operation.name = "chat_streaming",
-                gen_ai.provider.name = Ext::PROVIDER_NAME,
-                gen_ai.request.model = &request_model,
-                gen_ai.system_instructions = &completion_request.preamble,
-                gen_ai.response.id = tracing::field::Empty,
-                gen_ai.response.model = &request_model,
-                gen_ai.usage.output_tokens = tracing::field::Empty,
-                gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
-                gen_ai.input.messages = tracing::field::Empty,
-                gen_ai.output.messages = tracing::field::Empty,
-            )
-        } else {
-            tracing::Span::current()
-        };
+        let span = CompletionSpanBuilder::new(
+            Ext::PROVIDER_NAME,
+            &request_model,
+            CompletionOperation::ChatStreaming,
+        )
+        .system_instructions(completion_request.preamble.as_deref())
+        .build();
         let max_tokens = if let Some(tokens) = completion_request.max_tokens {
             tokens
         } else if let Some(tokens) = self.default_max_tokens {

--- a/crates/rig-core/src/providers/chatgpt/mod.rs
+++ b/crates/rig-core/src/providers/chatgpt/mod.rs
@@ -28,10 +28,11 @@ use crate::providers::openai::responses_api::{
     self, CompletionRequest as ResponsesRequest, Include,
 };
 use crate::streaming::StreamingCompletionResponse;
+use crate::telemetry::{CompletionOperation, CompletionSpanBuilder};
 use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
-use tracing::{Level, enabled, info_span};
+use tracing::{Level, enabled};
 
 const CHATGPT_API_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
 const DEFAULT_ORIGINATOR: &str = "rig";
@@ -505,24 +506,9 @@ where
     ) -> Result<completion::CompletionResponse<Self::Response>, CompletionError> {
         let request = self.create_request(completion_request)?;
 
-        let span = if tracing::Span::current().is_disabled() {
-            info_span!(
-                target: "rig::completions",
-                "chat",
-                gen_ai.operation.name = "chat",
-                gen_ai.provider.name = "chatgpt",
-                gen_ai.request.model = self.model,
-                gen_ai.response.id = tracing::field::Empty,
-                gen_ai.response.model = tracing::field::Empty,
-                gen_ai.usage.output_tokens = tracing::field::Empty,
-                gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
-                gen_ai.input.messages = tracing::field::Empty,
-                gen_ai.output.messages = tracing::field::Empty,
-            )
-        } else {
-            tracing::Span::current()
-        };
+        let span = CompletionSpanBuilder::new("chatgpt", &request.model, CompletionOperation::Chat)
+            .system_instructions(request.instructions.as_deref())
+            .build();
 
         tracing_futures::Instrument::instrument(
             async move {
@@ -587,22 +573,13 @@ where
             .body(body)
             .map_err(|err| CompletionError::HttpError(err.into()))?;
 
-        let span = if tracing::Span::current().is_disabled() {
-            info_span!(
-                target: "rig::completions",
-                "chat_streaming",
-                gen_ai.operation.name = "chat_streaming",
-                gen_ai.provider.name = "chatgpt",
-                gen_ai.request.model = self.model,
-                gen_ai.response.id = tracing::field::Empty,
-                gen_ai.response.model = tracing::field::Empty,
-                gen_ai.usage.output_tokens = tracing::field::Empty,
-                gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
-            )
-        } else {
-            tracing::Span::current()
-        };
+        let span = CompletionSpanBuilder::new(
+            "chatgpt",
+            &request.model,
+            CompletionOperation::ChatStreaming,
+        )
+        .system_instructions(request.instructions.as_deref())
+        .build();
 
         let client = self.client.clone();
         let event_source = crate::http_client::sse::GenericEventSource::new(client, req)
@@ -765,6 +742,33 @@ data: [DONE]"#;
             Some("System one\n\nMid-conversation instruction")
         );
         assert_eq!(request.input.len(), 2);
+    }
+
+    #[test]
+    fn test_create_request_merges_default_and_request_instructions() {
+        let client = crate::providers::chatgpt::Client::builder()
+            .oauth()
+            .build()
+            .expect("client");
+        let model = ResponsesCompletionModel::new(client, GPT_5_3_CODEX);
+
+        let request = model
+            .create_request(completion::CompletionRequest {
+                model: None,
+                preamble: Some("Respond tersely.".to_string()),
+                chat_history: OneOrMany::one(completion::Message::user("hello")),
+                documents: Vec::new(),
+                tools: Vec::new(),
+                temperature: None,
+                max_tokens: None,
+                tool_choice: None,
+                additional_params: None,
+                output_schema: None,
+            })
+            .expect("request");
+
+        let expected = format!("{DEFAULT_INSTRUCTIONS}\n\nRespond tersely.");
+        assert_eq!(request.instructions.as_deref(), Some(expected.as_str()));
     }
 
     #[test]

--- a/crates/rig-core/src/providers/cohere/completion.rs
+++ b/crates/rig-core/src/providers/cohere/completion.rs
@@ -4,7 +4,7 @@ use crate::{
     http_client::{self, HttpClientExt},
     json_utils,
     message::{self, Reasoning, ToolChoice},
-    telemetry::SpanCombinator,
+    telemetry::{CompletionOperation, CompletionSpanBuilder, SpanCombinator},
 };
 use std::collections::HashMap;
 
@@ -12,7 +12,7 @@ use super::client::Client;
 use crate::completion::CompletionRequest;
 use crate::providers::cohere::streaming::StreamingCompletionResponse;
 use serde::{Deserialize, Serialize};
-use tracing::{Instrument, Level, enabled, info_span};
+use tracing::{Instrument, Level, enabled};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CompletionResponse {
@@ -538,7 +538,7 @@ pub struct CompletionModel<T = reqwest::Client> {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub(super) struct CohereCompletionRequest {
-    model: String,
+    pub(super) model: String,
     pub messages: Vec<Message>,
     documents: Vec<crate::completion::Document>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -630,24 +630,13 @@ where
         &self,
         completion_request: completion::CompletionRequest,
     ) -> Result<completion::CompletionResponse<CompletionResponse>, CompletionError> {
+        let system_instructions = completion_request.preamble.clone();
         let request = CohereCompletionRequest::try_from((self.model.as_ref(), completion_request))?;
 
-        let llm_span = if tracing::Span::current().is_disabled() {
-            info_span!(
-            target: "rig::completions",
-            "chat",
-            gen_ai.operation.name = "chat",
-            gen_ai.provider.name = "cohere",
-            gen_ai.request.model = self.model,
-            gen_ai.response.id = tracing::field::Empty,
-            gen_ai.response.model = self.model,
-            gen_ai.usage.output_tokens = tracing::field::Empty,
-            gen_ai.usage.input_tokens = tracing::field::Empty,
-            gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
-            )
-        } else {
-            tracing::Span::current()
-        };
+        let llm_span =
+            CompletionSpanBuilder::new("cohere", &request.model, CompletionOperation::Chat)
+                .system_instructions(system_instructions.as_deref())
+                .build();
 
         if enabled!(Level::TRACE) {
             tracing::trace!(

--- a/crates/rig-core/src/providers/cohere/streaming.rs
+++ b/crates/rig-core/src/providers/cohere/streaming.rs
@@ -4,12 +4,12 @@ use crate::http_client::sse::{Event, GenericEventSource};
 use crate::providers::cohere::CompletionModel;
 use crate::providers::cohere::completion::{CohereCompletionRequest, Usage};
 use crate::streaming::{RawStreamingChoice, RawStreamingToolCall, ToolCallDeltaContent};
-use crate::telemetry::SpanCombinator;
+use crate::telemetry::{CompletionOperation, CompletionSpanBuilder, SpanCombinator};
 use crate::{json_utils, streaming};
 use async_stream::stream;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
-use tracing::{Level, enabled, info_span};
+use tracing::{Level, enabled};
 use tracing_futures::Instrument;
 
 #[derive(Debug, Deserialize)]
@@ -97,23 +97,15 @@ where
         request: CompletionRequest,
     ) -> Result<streaming::StreamingCompletionResponse<StreamingCompletionResponse>, CompletionError>
     {
+        let system_instructions = request.preamble.clone();
         let mut request = CohereCompletionRequest::try_from((self.model.as_ref(), request))?;
-        let span = if tracing::Span::current().is_disabled() {
-            info_span!(
-                target: "rig::completions",
-                "chat_streaming",
-                gen_ai.operation.name = "chat_streaming",
-                gen_ai.provider.name = "cohere",
-                gen_ai.request.model = self.model,
-                gen_ai.response.id = tracing::field::Empty,
-                gen_ai.response.model = self.model,
-                gen_ai.usage.output_tokens = tracing::field::Empty,
-                gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
-            )
-        } else {
-            tracing::Span::current()
-        };
+        let span = CompletionSpanBuilder::new(
+            "cohere",
+            &request.model,
+            CompletionOperation::ChatStreaming,
+        )
+        .system_instructions(system_instructions.as_deref())
+        .build();
 
         let params = json_utils::merge(
             request.additional_params.unwrap_or(serde_json::json!({})),

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -37,6 +37,7 @@ use crate::providers::internal::openai_chat_completions_compatible::{
 use crate::providers::openai;
 use crate::providers::openai::responses_api::{self, CompletionRequest as ResponsesRequest};
 use crate::streaming::{self, RawStreamingChoice, StreamingCompletionResponse};
+use crate::telemetry::{CompletionOperation, CompletionSpanBuilder};
 use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
 use async_stream::stream;
 use futures::StreamExt;
@@ -47,7 +48,6 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
-use tracing::info_span;
 use tracing_futures::Instrument as _;
 
 const GITHUB_COPILOT_API_BASE_URL: &str = "https://api.githubcopilot.com";
@@ -823,6 +823,7 @@ where
     ) -> Result<completion::CompletionResponse<CopilotCompletionResponse>, CompletionError> {
         let initiator = request_initiator(&completion_request);
         let has_vision = request_has_vision(&completion_request);
+        let system_instructions = completion_request.preamble.clone();
         let request = self.chat_request(completion_request)?;
         let body = serde_json::to_vec(&request)?;
         let auth = self.auth_context().await?;
@@ -835,22 +836,9 @@ where
         .body(body)
         .map_err(|err| CompletionError::HttpError(err.into()))?;
 
-        let span = if tracing::Span::current().is_disabled() {
-            info_span!(
-                target: "rig::completions",
-                "chat",
-                gen_ai.operation.name = "chat",
-                gen_ai.provider.name = "copilot",
-                gen_ai.request.model = self.model,
-                gen_ai.response.id = tracing::field::Empty,
-                gen_ai.response.model = tracing::field::Empty,
-                gen_ai.usage.output_tokens = tracing::field::Empty,
-                gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
-            )
-        } else {
-            tracing::Span::current()
-        };
+        let span = CompletionSpanBuilder::new("copilot", &request.model, CompletionOperation::Chat)
+            .system_instructions(system_instructions.as_deref())
+            .build();
 
         async move {
             let response = self.client.send(req).await?;
@@ -910,6 +898,7 @@ where
     ) -> Result<completion::CompletionResponse<CopilotCompletionResponse>, CompletionError> {
         let initiator = request_initiator(&completion_request);
         let has_vision = request_has_vision(&completion_request);
+        let system_instructions = completion_request.preamble.clone();
         let request = self.responses_request(completion_request)?;
         let auth = self.auth_context().await?;
 
@@ -921,22 +910,9 @@ where
         .body(serde_json::to_vec(&request)?)
         .map_err(|err| CompletionError::HttpError(err.into()))?;
 
-        let span = if tracing::Span::current().is_disabled() {
-            info_span!(
-                target: "rig::completions",
-                "chat",
-                gen_ai.operation.name = "chat",
-                gen_ai.provider.name = "copilot",
-                gen_ai.request.model = self.model,
-                gen_ai.response.id = tracing::field::Empty,
-                gen_ai.response.model = tracing::field::Empty,
-                gen_ai.usage.output_tokens = tracing::field::Empty,
-                gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
-            )
-        } else {
-            tracing::Span::current()
-        };
+        let span = CompletionSpanBuilder::new("copilot", &request.model, CompletionOperation::Chat)
+            .system_instructions(system_instructions.as_deref())
+            .build();
 
         async move {
             let response = self.client.send(req).await?;
@@ -983,6 +959,7 @@ where
     ) -> Result<StreamingCompletionResponse<CopilotStreamingResponse>, CompletionError> {
         let initiator = request_initiator(&completion_request);
         let has_vision = request_has_vision(&completion_request);
+        let system_instructions = completion_request.preamble.clone();
         let request = self.chat_request(completion_request)?;
         let auth = self.auth_context().await?;
         let headers = default_headers(&auth.api_key, initiator, has_vision, self.intent);
@@ -1003,22 +980,13 @@ where
         .body(serde_json::to_vec(&request_json)?)
         .map_err(|err| CompletionError::HttpError(err.into()))?;
 
-        let span = if tracing::Span::current().is_disabled() {
-            info_span!(
-                target: "rig::completions",
-                "chat_streaming",
-                gen_ai.operation.name = "chat_streaming",
-                gen_ai.provider.name = "copilot",
-                gen_ai.request.model = self.model,
-                gen_ai.response.id = tracing::field::Empty,
-                gen_ai.response.model = tracing::field::Empty,
-                gen_ai.usage.output_tokens = tracing::field::Empty,
-                gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
-            )
-        } else {
-            tracing::Span::current()
-        };
+        let span = CompletionSpanBuilder::new(
+            "copilot",
+            &request.model,
+            CompletionOperation::ChatStreaming,
+        )
+        .system_instructions(system_instructions.as_deref())
+        .build();
 
         tracing::Instrument::instrument(
             send_copilot_chat_streaming_request(self.client.clone(), req),
@@ -1033,6 +1001,7 @@ where
     ) -> Result<StreamingCompletionResponse<CopilotStreamingResponse>, CompletionError> {
         let initiator = request_initiator(&completion_request);
         let has_vision = request_has_vision(&completion_request);
+        let system_instructions = completion_request.preamble.clone();
         let mut request = self.responses_request(completion_request)?;
         request.stream = Some(true);
         let auth = self.auth_context().await?;
@@ -1045,22 +1014,13 @@ where
         .body(serde_json::to_vec(&request)?)
         .map_err(|err| CompletionError::HttpError(err.into()))?;
 
-        let span = if tracing::Span::current().is_disabled() {
-            info_span!(
-                target: "rig::completions",
-                "chat_streaming",
-                gen_ai.operation.name = "chat_streaming",
-                gen_ai.provider.name = "copilot",
-                gen_ai.request.model = self.model,
-                gen_ai.response.id = tracing::field::Empty,
-                gen_ai.response.model = tracing::field::Empty,
-                gen_ai.usage.output_tokens = tracing::field::Empty,
-                gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
-            )
-        } else {
-            tracing::Span::current()
-        };
+        let span = CompletionSpanBuilder::new(
+            "copilot",
+            &request.model,
+            CompletionOperation::ChatStreaming,
+        )
+        .system_instructions(system_instructions.as_deref())
+        .build();
 
         let client = self.client.clone();
         let mut event_source = crate::http_client::sse::GenericEventSource::new(client, req);

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -30,12 +30,11 @@ pub const GEMINI_2_0_FLASH: &str = "gemini-2.0-flash";
 use self::gemini_api_types::tool_parameters_to_schema;
 use crate::http_client::HttpClientExt;
 use crate::message::{self, MimeType, Reasoning};
-
 use crate::providers::gemini::completion::gemini_api_types::{
     AdditionalParameters, FunctionCallingMode, ToolConfig,
 };
 use crate::providers::gemini::streaming::StreamingCompletionResponse;
-use crate::telemetry::SpanCombinator;
+use crate::telemetry::{CompletionOperation, CompletionSpanBuilder, SpanCombinator};
 use crate::{
     OneOrMany,
     completion::{self, CompletionError, CompletionRequest, GetTokenUsage},
@@ -46,7 +45,7 @@ use gemini_api_types::{
 };
 use serde_json::{Map, Value};
 use std::convert::TryFrom;
-use tracing::{Level, enabled, info_span};
+use tracing::{Level, enabled};
 use tracing_futures::Instrument;
 
 use super::Client;
@@ -94,26 +93,13 @@ where
         completion_request: CompletionRequest,
     ) -> Result<completion::CompletionResponse<GenerateContentResponse>, CompletionError> {
         let request_model = resolve_request_model(&self.model, &completion_request);
-        let span = if tracing::Span::current().is_disabled() {
-            info_span!(
-                target: "rig::completions",
-                "generate_content",
-                gen_ai.operation.name = "generate_content",
-                gen_ai.provider.name = "gcp.gemini",
-                gen_ai.request.model = &request_model,
-                gen_ai.system_instructions = &completion_request.preamble,
-                gen_ai.response.id = tracing::field::Empty,
-                gen_ai.response.model = tracing::field::Empty,
-                gen_ai.usage.output_tokens = tracing::field::Empty,
-                gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
-                gen_ai.usage.tool_use_prompt_tokens = tracing::field::Empty,
-                gen_ai.usage.reasoning_tokens = tracing::field::Empty,
-            )
-        } else {
-            tracing::Span::current()
-        };
+        let span = CompletionSpanBuilder::new(
+            "gcp.gemini",
+            &request_model,
+            CompletionOperation::GenerateContent,
+        )
+        .system_instructions(completion_request.preamble.as_deref())
+        .build();
 
         let request = create_request_body(completion_request)?;
 

--- a/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
@@ -7,9 +7,9 @@ use crate::OneOrMany;
 use crate::completion::{self, CompletionError, CompletionRequest, GetTokenUsage};
 use crate::http_client::HttpClientExt;
 use crate::message::{self, MimeType, Reasoning};
-use crate::telemetry::SpanCombinator;
+use crate::telemetry::{CompletionOperation, CompletionSpanBuilder, SpanCombinator};
 use serde_json::{Map, Value};
-use tracing::{Level, enabled, info_span};
+use tracing::{Level, enabled};
 use tracing_futures::Instrument;
 use url::form_urlencoded;
 
@@ -122,26 +122,13 @@ where
         &self,
         completion_request: CompletionRequest,
     ) -> Result<completion::CompletionResponse<Interaction>, CompletionError> {
-        let span = if tracing::Span::current().is_disabled() {
-            info_span!(
-                target: "rig::completions",
-                "interactions",
-                gen_ai.operation.name = "interactions",
-                gen_ai.provider.name = "gcp.gemini",
-                gen_ai.request.model = self.model,
-                gen_ai.system_instructions = &completion_request.preamble,
-                gen_ai.response.id = tracing::field::Empty,
-                gen_ai.response.model = tracing::field::Empty,
-                gen_ai.usage.output_tokens = tracing::field::Empty,
-                gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
-                gen_ai.usage.tool_use_prompt_tokens = tracing::field::Empty,
-                gen_ai.usage.reasoning_tokens = tracing::field::Empty,
-            )
-        } else {
-            tracing::Span::current()
-        };
+        let span = CompletionSpanBuilder::new(
+            "gcp.gemini",
+            &self.model,
+            CompletionOperation::Interactions,
+        )
+        .system_instructions(completion_request.preamble.as_deref())
+        .build();
 
         let request = self.create_completion_request(completion_request, Some(false))?;
 

--- a/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
@@ -2,7 +2,7 @@ use async_stream::stream;
 use futures::{Stream, StreamExt};
 use serde::{Deserialize, Serialize};
 use std::pin::Pin;
-use tracing::{Level, enabled, info_span};
+use tracing::{Level, enabled};
 use tracing_futures::Instrument;
 
 use super::InteractionsCompletionModel;
@@ -17,7 +17,7 @@ use crate::http_client::HttpClientExt;
 use crate::http_client::Request;
 use crate::http_client::sse::{Event, GenericEventSource};
 use crate::streaming;
-use crate::telemetry::SpanCombinator;
+use crate::telemetry::{CompletionOperation, CompletionSpanBuilder, SpanCombinator};
 use serde_json::{Map, Value};
 
 /// Final metadata yielded by an Interactions streaming response.
@@ -58,26 +58,13 @@ where
         completion_request: CompletionRequest,
     ) -> Result<streaming::StreamingCompletionResponse<StreamingCompletionResponse>, CompletionError>
     {
-        let span = if tracing::Span::current().is_disabled() {
-            info_span!(
-                target: "rig::completions",
-                "interactions_streaming",
-                gen_ai.operation.name = "interactions_streaming",
-                gen_ai.provider.name = "gcp.gemini",
-                gen_ai.request.model = self.model,
-                gen_ai.system_instructions = &completion_request.preamble,
-                gen_ai.response.id = tracing::field::Empty,
-                gen_ai.response.model = tracing::field::Empty,
-                gen_ai.usage.output_tokens = tracing::field::Empty,
-                gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
-                gen_ai.usage.tool_use_prompt_tokens = tracing::field::Empty,
-                gen_ai.usage.reasoning_tokens = tracing::field::Empty,
-            )
-        } else {
-            tracing::Span::current()
-        };
+        let span = CompletionSpanBuilder::new(
+            "gcp.gemini",
+            &self.model,
+            CompletionOperation::InteractionsStreaming,
+        )
+        .system_instructions(completion_request.preamble.as_deref())
+        .build();
 
         let request = create_request_body(self.model.clone(), completion_request, Some(true))?;
 

--- a/crates/rig-core/src/providers/gemini/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/streaming.rs
@@ -1,7 +1,7 @@
 use async_stream::stream;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
-use tracing::{Level, enabled, info_span};
+use tracing::{Level, enabled};
 use tracing_futures::Instrument;
 
 use super::completion::gemini_api_types::{
@@ -16,7 +16,7 @@ use crate::completion::{CompletionError, CompletionRequest, GetTokenUsage};
 use crate::http_client::HttpClientExt;
 use crate::http_client::sse::{Event, GenericEventSource};
 use crate::streaming;
-use crate::telemetry::SpanCombinator;
+use crate::telemetry::{CompletionOperation, CompletionSpanBuilder, SpanCombinator};
 
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -103,26 +103,13 @@ where
     ) -> Result<streaming::StreamingCompletionResponse<StreamingCompletionResponse>, CompletionError>
     {
         let request_model = resolve_request_model(&self.model, &completion_request);
-        let span = if tracing::Span::current().is_disabled() {
-            info_span!(
-                target: "rig::completions",
-                "chat_streaming",
-                gen_ai.operation.name = "chat_streaming",
-                gen_ai.provider.name = "gcp.gemini",
-                gen_ai.request.model = &request_model,
-                gen_ai.system_instructions = &completion_request.preamble,
-                gen_ai.response.id = tracing::field::Empty,
-                gen_ai.response.model = &request_model,
-                gen_ai.usage.output_tokens = tracing::field::Empty,
-                gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
-                gen_ai.usage.tool_use_prompt_tokens = tracing::field::Empty,
-                gen_ai.usage.reasoning_tokens = tracing::field::Empty,
-            )
-        } else {
-            tracing::Span::current()
-        };
+        let span = CompletionSpanBuilder::new(
+            "gcp.gemini",
+            &request_model,
+            CompletionOperation::ChatStreaming,
+        )
+        .system_instructions(completion_request.preamble.as_deref())
+        .build();
         let request = create_request_body(completion_request)?;
 
         if enabled!(Level::TRACE) {

--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -46,6 +46,7 @@ use crate::http_client::{self, HttpClientExt};
 use crate::message::DocumentSourceKind;
 use crate::model::{Model, ModelList, ModelListingError};
 use crate::streaming::RawStreamingChoice;
+use crate::telemetry::{CompletionOperation, CompletionSpanBuilder};
 use crate::{
     OneOrMany,
     completion::{self, CompletionError, CompletionRequest},
@@ -61,7 +62,6 @@ use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::{convert::TryFrom, str::FromStr};
-use tracing::info_span;
 use tracing_futures::Instrument;
 // ---------- Main Client ----------
 
@@ -627,26 +627,11 @@ where
         &self,
         completion_request: CompletionRequest,
     ) -> Result<completion::CompletionResponse<Self::Response>, CompletionError> {
-        let span = if tracing::Span::current().is_disabled() {
-            info_span!(
-                target: "rig::completions",
-                "chat",
-                gen_ai.operation.name = "chat",
-                gen_ai.provider.name = "ollama",
-                gen_ai.request.model = self.model,
-                gen_ai.system_instructions = tracing::field::Empty,
-                gen_ai.response.id = tracing::field::Empty,
-                gen_ai.response.model = tracing::field::Empty,
-                gen_ai.usage.output_tokens = tracing::field::Empty,
-                gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
-            )
-        } else {
-            tracing::Span::current()
-        };
-
-        span.record("gen_ai.system_instructions", &completion_request.preamble);
+        let system_instructions = completion_request.preamble.clone();
         let request = OllamaCompletionRequest::try_from((self.model.as_ref(), completion_request))?;
+        let span = CompletionSpanBuilder::new("ollama", &request.model, CompletionOperation::Chat)
+            .system_instructions(system_instructions.as_deref())
+            .build();
 
         if tracing::enabled!(tracing::Level::TRACE) {
             tracing::trace!(target: "rig::completions",
@@ -708,27 +693,15 @@ where
         request: CompletionRequest,
     ) -> Result<streaming::StreamingCompletionResponse<Self::StreamingResponse>, CompletionError>
     {
-        let span = if tracing::Span::current().is_disabled() {
-            info_span!(
-                target: "rig::completions",
-                "chat_streaming",
-                gen_ai.operation.name = "chat_streaming",
-                gen_ai.provider.name = "ollama",
-                gen_ai.request.model = self.model,
-                gen_ai.system_instructions = tracing::field::Empty,
-                gen_ai.response.id = tracing::field::Empty,
-                gen_ai.response.model = self.model,
-                gen_ai.usage.output_tokens = tracing::field::Empty,
-                gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
-            )
-        } else {
-            tracing::Span::current()
-        };
-
-        span.record("gen_ai.system_instructions", &request.preamble);
-
+        let system_instructions = request.preamble.clone();
         let mut request = OllamaCompletionRequest::try_from((self.model.as_ref(), request))?;
+        let span = CompletionSpanBuilder::new(
+            "ollama",
+            &request.model,
+            CompletionOperation::ChatStreaming,
+        )
+        .system_instructions(system_instructions.as_deref())
+        .build();
         request.stream = true;
 
         if tracing::enabled!(tracing::Level::TRACE) {
@@ -746,7 +719,11 @@ where
             .body(body)
             .map_err(http_client::Error::from)?;
 
-        let response = self.client.send_streaming(req).await?;
+        let response = self
+            .client
+            .send_streaming(req)
+            .instrument(span.clone())
+            .await?;
         let status = response.status();
         let mut byte_stream = response.into_body();
 
@@ -778,6 +755,10 @@ where
                     tracing::debug!(target: "rig", "Received NDJSON line from Ollama: {}", String::from_utf8_lossy(&line));
 
                     let response: CompletionResponse = serde_json::from_slice(&line)?;
+
+                    if response.done {
+                        span.record("gen_ai.response.model", &response.model);
+                    }
 
                     if let Message::Assistant { content, thinking, tool_calls, .. } = response.message {
                         if let Some(thinking_content) = thinking && !thinking_content.is_empty() {

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -9,13 +9,15 @@ use crate::completion::{
 use crate::http_client::{self, HttpClientExt};
 use crate::message::{AudioMediaType, DocumentSourceKind, ImageDetail, MimeType};
 use crate::one_or_many::string_or_one_or_many;
-use crate::telemetry::{ProviderResponseExt, SpanCombinator};
+use crate::telemetry::{
+    CompletionOperation, CompletionSpanBuilder, ProviderResponseExt, SpanCombinator,
+};
 use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
 use crate::{OneOrMany, completion, json_utils, message};
 use serde::{Deserialize, Serialize, Serializer};
 use std::convert::Infallible;
 use std::fmt;
-use tracing::{Instrument, Level, enabled, info_span};
+use tracing::{Instrument, Level, enabled};
 
 use std::str::FromStr;
 
@@ -1937,24 +1939,7 @@ where
         &self,
         completion_request: CoreCompletionRequest,
     ) -> Result<completion::CompletionResponse<Ext::Response>, CompletionError> {
-        let span = if tracing::Span::current().is_disabled() {
-            info_span!(
-                target: "rig::completions",
-                "chat",
-                gen_ai.operation.name = "chat",
-                gen_ai.provider.name = Ext::PROVIDER_NAME,
-                gen_ai.request.model = self.model,
-                gen_ai.system_instructions = &completion_request.preamble,
-                gen_ai.response.id = tracing::field::Empty,
-                gen_ai.response.model = tracing::field::Empty,
-                gen_ai.usage.output_tokens = tracing::field::Empty,
-                gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
-            )
-        } else {
-            tracing::Span::current()
-        };
-
+        let system_instructions = completion_request.preamble.clone();
         let options = CompletionModelOptions {
             strict_tools: self.strict_tools,
             tool_result_array_content: self.tool_result_array_content,
@@ -1966,9 +1951,13 @@ where
             options,
         )?;
         self.client.ext().prepare_request(&mut request)?;
-        // The span was opened with the configured model; report the model
-        // actually requested when a per-request override applies.
-        span.record("gen_ai.request.model", &request.model);
+        let span = CompletionSpanBuilder::new(
+            Ext::PROVIDER_NAME,
+            &request.model,
+            CompletionOperation::Chat,
+        )
+        .system_instructions(system_instructions.as_deref())
+        .build();
 
         let mut request_body = serde_json::to_value(&request)?;
         self.client

--- a/crates/rig-core/src/providers/openai/completion/streaming.rs
+++ b/crates/rig-core/src/providers/openai/completion/streaming.rs
@@ -1,7 +1,8 @@
+use crate::telemetry::{CompletionOperation, CompletionSpanBuilder};
 use http::Request;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use tracing::{Level, enabled, info_span};
+use tracing::{Level, enabled};
 
 use crate::completion::{CompletionError, CompletionRequest, GetTokenUsage};
 use crate::http_client::HttpClientExt;
@@ -203,25 +204,13 @@ where
             .body(req_body)
             .map_err(|e| CompletionError::HttpError(e.into()))?;
 
-        let span = if tracing::Span::current().is_disabled() {
-            info_span!(
-                target: "rig::completions",
-                "chat",
-                gen_ai.operation.name = "chat",
-                gen_ai.provider.name = Ext::PROVIDER_NAME,
-                gen_ai.request.model = resolved_model,
-                gen_ai.system_instructions = preamble,
-                gen_ai.response.id = tracing::field::Empty,
-                gen_ai.response.model = tracing::field::Empty,
-                gen_ai.usage.output_tokens = tracing::field::Empty,
-                gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
-                gen_ai.input.messages = tracing::field::Empty,
-                gen_ai.output.messages = tracing::field::Empty,
-            )
-        } else {
-            tracing::Span::current()
-        };
+        let span = CompletionSpanBuilder::new(
+            Ext::PROVIDER_NAME,
+            &resolved_model,
+            CompletionOperation::Chat,
+        )
+        .system_instructions(preamble.as_deref())
+        .build();
 
         let client = self.client.clone();
 

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -24,12 +24,13 @@ use crate::message::{
     MimeType, Text,
 };
 use crate::one_or_many::string_or_one_or_many;
+use crate::telemetry::{CompletionOperation, CompletionSpanBuilder};
 
 use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
 use crate::{OneOrMany, completion, message};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::{Map, Value};
-use tracing::{Instrument, Level, enabled, info_span};
+use tracing::{Instrument, Level, enabled};
 
 use std::convert::Infallible;
 use std::ops::Add;
@@ -2139,28 +2140,11 @@ where
         &self,
         completion_request: crate::completion::CompletionRequest,
     ) -> Result<completion::CompletionResponse<Self::Response>, CompletionError> {
-        let span = if tracing::Span::current().is_disabled() {
-            info_span!(
-                target: "rig::completions",
-                "chat",
-                gen_ai.operation.name = "chat",
-                gen_ai.provider.name = tracing::field::Empty,
-                gen_ai.request.model = tracing::field::Empty,
-                gen_ai.response.id = tracing::field::Empty,
-                gen_ai.response.model = tracing::field::Empty,
-                gen_ai.usage.output_tokens = tracing::field::Empty,
-                gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
-                gen_ai.input.messages = tracing::field::Empty,
-                gen_ai.output.messages = tracing::field::Empty,
-            )
-        } else {
-            tracing::Span::current()
-        };
-
-        span.record("gen_ai.provider.name", "openai");
-        span.record("gen_ai.request.model", &self.model);
+        let system_instructions = completion_request.preamble.clone();
         let request = self.create_completion_request(completion_request)?;
+        let span = CompletionSpanBuilder::new("openai", &request.model, CompletionOperation::Chat)
+            .system_instructions(system_instructions.as_deref())
+            .build();
         let body = serde_json::to_vec(&request)?;
 
         if enabled!(Level::TRACE) {

--- a/crates/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -7,11 +7,12 @@ use crate::message::ReasoningContent;
 use crate::providers::openai::responses_api::{ReasoningSummary, ResponsesUsage};
 use crate::streaming;
 use crate::streaming::RawStreamingChoice;
+use crate::telemetry::{CompletionOperation, CompletionSpanBuilder};
 use crate::wasm_compat::WasmCompatSend;
 use async_stream::stream;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
-use tracing::{Level, debug, enabled, info_span};
+use tracing::{Level, debug, enabled};
 use tracing_futures::Instrument as _;
 
 use super::{CompletionResponse, GenericResponsesCompletionModel, Output};
@@ -860,6 +861,7 @@ where
         completion_request: crate::completion::CompletionRequest,
     ) -> Result<streaming::StreamingCompletionResponse<StreamingCompletionResponse>, CompletionError>
     {
+        let system_instructions = completion_request.preamble.clone();
         let mut request = self.create_completion_request(completion_request)?;
         request.stream = Some(true);
 
@@ -879,24 +881,13 @@ where
             .body(body)
             .map_err(|e| CompletionError::HttpError(e.into()))?;
 
-        let span = if tracing::Span::current().is_disabled() {
-            info_span!(
-                target: "rig::completions",
-                "chat_streaming",
-                gen_ai.operation.name = "chat_streaming",
-                gen_ai.provider.name = tracing::field::Empty,
-                gen_ai.request.model = tracing::field::Empty,
-                gen_ai.response.id = tracing::field::Empty,
-                gen_ai.response.model = tracing::field::Empty,
-                gen_ai.usage.output_tokens = tracing::field::Empty,
-                gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
-            )
-        } else {
-            tracing::Span::current()
-        };
-        span.record("gen_ai.provider.name", "openai");
-        span.record("gen_ai.request.model", &self.model);
+        let span = CompletionSpanBuilder::new(
+            "openai",
+            &request.model,
+            CompletionOperation::ChatStreaming,
+        )
+        .system_instructions(system_instructions.as_deref())
+        .build();
         let client = self.client.clone();
         let event_source = GenericEventSource::new(client, req);
 

--- a/crates/rig-core/src/providers/xai/completion.rs
+++ b/crates/rig-core/src/providers/xai/completion.rs
@@ -2,10 +2,11 @@
 //!
 //! Uses the xAI Responses API: <https://docs.x.ai/docs/guides/chat>
 
+use crate::telemetry::{CompletionOperation, CompletionSpanBuilder, SpanCombinator};
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use tracing::{Instrument, Level, enabled, info_span};
+use tracing::{Instrument, Level, enabled};
 
 use super::api::{ApiResponse, Message, ToolDefinition};
 use super::client::Client;
@@ -33,7 +34,7 @@ pub const GROK_4: &str = "grok-4-0709";
 
 #[derive(Debug, Serialize, Deserialize)]
 pub(super) struct XAICompletionRequest {
-    model: String,
+    pub(super) model: String,
     pub input: Vec<Message>,
     #[serde(skip_serializing_if = "Option::is_none")]
     temperature: Option<f64>,
@@ -200,28 +201,12 @@ where
         &self,
         completion_request: completion::CompletionRequest,
     ) -> Result<completion::CompletionResponse<CompletionResponse>, CompletionError> {
-        let span = if tracing::Span::current().is_disabled() {
-            info_span!(
-                target: "rig::completions",
-                "chat",
-                gen_ai.operation.name = "chat",
-                gen_ai.provider.name = "xai",
-                gen_ai.request.model = self.model,
-                gen_ai.system_instructions = tracing::field::Empty,
-                gen_ai.response.id = tracing::field::Empty,
-                gen_ai.response.model = tracing::field::Empty,
-                gen_ai.usage.output_tokens = tracing::field::Empty,
-                gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
-            )
-        } else {
-            tracing::Span::current()
-        };
-
-        span.record("gen_ai.system_instructions", &completion_request.preamble);
-
+        let system_instructions = completion_request.preamble.clone();
         let request =
             XAICompletionRequest::try_from((self.model.to_string().as_ref(), completion_request))?;
+        let span = CompletionSpanBuilder::new("xai", &request.model, CompletionOperation::Chat)
+            .system_instructions(system_instructions.as_deref())
+            .build();
 
         if enabled!(Level::TRACE) {
             tracing::trace!(target: "rig::completions",
@@ -245,6 +230,13 @@ where
             if status.is_success() {
                 match serde_json::from_slice::<ApiResponse<CompletionResponse>>(&response_body)? {
                     ApiResponse::Ok(response) => {
+                        let span = tracing::Span::current();
+                        span.record("gen_ai.response.id", response.id.as_str());
+                        span.record("gen_ai.response.model", response.model.as_str());
+                        if let Some(usage) = &response.usage {
+                            span.record_token_usage(usage);
+                        }
+
                         if enabled!(Level::TRACE) {
                             tracing::trace!(target: "rig::completions",
                                 "xAI completion response: {}",

--- a/crates/rig-core/src/providers/xai/streaming.rs
+++ b/crates/rig-core/src/providers/xai/streaming.rs
@@ -3,7 +3,8 @@
 //! This module reuses OpenAI's Responses API streaming types since xAI's API
 //! is designed to be compatible with OpenAI's format.
 
-use tracing::{Level, enabled, info_span};
+use crate::telemetry::{CompletionOperation, CompletionSpanBuilder};
+use tracing::{Level, enabled};
 use tracing_futures::Instrument;
 
 use crate::completion::{CompletionError, CompletionRequest};
@@ -50,23 +51,10 @@ where
             .body(body)
             .map_err(|e| CompletionError::HttpError(e.into()))?;
 
-        let span = if tracing::Span::current().is_disabled() {
-            info_span!(
-                target: "rig::completions",
-                "chat_streaming",
-                gen_ai.operation.name = "chat_streaming",
-                gen_ai.provider.name = "xai",
-                gen_ai.request.model = self.model,
-                gen_ai.system_instructions = preamble,
-                gen_ai.response.id = tracing::field::Empty,
-                gen_ai.response.model = tracing::field::Empty,
-                gen_ai.usage.output_tokens = tracing::field::Empty,
-                gen_ai.usage.input_tokens = tracing::field::Empty,
-                gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
-            )
-        } else {
-            tracing::Span::current()
-        };
+        let span =
+            CompletionSpanBuilder::new("xai", &request.model, CompletionOperation::ChatStreaming)
+                .system_instructions(preamble.as_deref())
+                .build();
 
         send_xai_streaming_request(self.client.clone(), req)
             .instrument(span)

--- a/crates/rig-core/src/telemetry/mod.rs
+++ b/crates/rig-core/src/telemetry/mod.rs
@@ -33,7 +33,7 @@ macro_rules! new_completion_span {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum CompletionOperation {
-    /// A non-streaming chat completion.
+    /// A chat completion.
     Chat,
     /// A streaming chat completion.
     ChatStreaming,

--- a/crates/rig-core/src/telemetry/mod.rs
+++ b/crates/rig-core/src/telemetry/mod.rs
@@ -6,6 +6,143 @@
 use crate::completion::GetTokenUsage;
 use serde::Serialize;
 
+macro_rules! new_completion_span {
+    ($name:literal, $provider:expr, $request_model:expr, $operation:expr, $system:expr) => {
+        tracing::info_span!(
+            target: "rig::completions",
+            $name,
+            gen_ai.operation.name = $operation,
+            gen_ai.provider.name = $provider,
+            gen_ai.request.model = $request_model,
+            gen_ai.system_instructions = $system,
+            gen_ai.response.id = tracing::field::Empty,
+            gen_ai.response.model = tracing::field::Empty,
+            gen_ai.usage.input_tokens = tracing::field::Empty,
+            gen_ai.usage.output_tokens = tracing::field::Empty,
+            gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
+            gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
+            gen_ai.usage.tool_use_prompt_tokens = tracing::field::Empty,
+            gen_ai.usage.reasoning_tokens = tracing::field::Empty,
+            gen_ai.input.messages = tracing::field::Empty,
+            gen_ai.output.messages = tracing::field::Empty,
+        )
+    };
+}
+
+/// A supported GenAI completion operation and its canonical span name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CompletionOperation {
+    /// A non-streaming chat completion.
+    Chat,
+    /// A streaming chat completion.
+    ChatStreaming,
+    /// A Gemini generate-content request.
+    GenerateContent,
+    /// A Gemini Interactions API request.
+    Interactions,
+    /// A streaming Gemini Interactions API request.
+    InteractionsStreaming,
+}
+
+impl CompletionOperation {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Chat => "chat",
+            Self::ChatStreaming => "chat_streaming",
+            Self::GenerateContent => "generate_content",
+            Self::Interactions => "interactions",
+            Self::InteractionsStreaming => "interactions_streaming",
+        }
+    }
+}
+
+/// Builder for a canonical GenAI completion span.
+///
+/// Rig-owned `rig::agent_chat` spans are enriched and reused so an agent turn
+/// has exactly one model span. Other ambient spans remain parents of a newly
+/// created `rig::completions` span.
+pub struct CompletionSpanBuilder<'a> {
+    provider: &'a str,
+    request_model: &'a str,
+    operation: CompletionOperation,
+    system_instructions: Option<&'a str>,
+}
+
+impl<'a> CompletionSpanBuilder<'a> {
+    /// Create a completion-span builder for a provider request.
+    pub fn new(provider: &'a str, request_model: &'a str, operation: CompletionOperation) -> Self {
+        Self {
+            provider,
+            request_model,
+            operation,
+            system_instructions: None,
+        }
+    }
+
+    /// Set the system instructions sent with the request.
+    pub fn system_instructions(mut self, system_instructions: Option<&'a str>) -> Self {
+        self.system_instructions = system_instructions;
+        self
+    }
+
+    /// Build a canonical completion span or enrich Rig's current agent-chat span.
+    pub fn build(self) -> tracing::Span {
+        let current = tracing::Span::current();
+        if current
+            .metadata()
+            .is_some_and(|metadata| metadata.target() == "rig::agent_chat")
+        {
+            current.record("gen_ai.operation.name", self.operation.as_str());
+            current.record("gen_ai.provider.name", self.provider);
+            current.record("gen_ai.request.model", self.request_model);
+            if let Some(system_instructions) = self.system_instructions {
+                current.record("gen_ai.system_instructions", system_instructions);
+            }
+            return current;
+        }
+
+        let operation = self.operation.as_str();
+        match self.operation {
+            CompletionOperation::Chat => new_completion_span!(
+                "chat",
+                self.provider,
+                self.request_model,
+                operation,
+                self.system_instructions
+            ),
+            CompletionOperation::ChatStreaming => new_completion_span!(
+                "chat_streaming",
+                self.provider,
+                self.request_model,
+                operation,
+                self.system_instructions
+            ),
+            CompletionOperation::GenerateContent => new_completion_span!(
+                "generate_content",
+                self.provider,
+                self.request_model,
+                operation,
+                self.system_instructions
+            ),
+            CompletionOperation::Interactions => new_completion_span!(
+                "interactions",
+                self.provider,
+                self.request_model,
+                operation,
+                self.system_instructions
+            ),
+            CompletionOperation::InteractionsStreaming => new_completion_span!(
+                "interactions_streaming",
+                self.provider,
+                self.request_model,
+                operation,
+                self.system_instructions
+            ),
+        }
+    }
+}
+
 /// Provider response metadata used to populate GenAI telemetry spans.
 pub trait ProviderResponseExt {
     /// Provider-native output message type.
@@ -156,6 +293,277 @@ mod tests {
         }
 
         fn record_debug(&mut self, _field: &Field, _value: &dyn std::fmt::Debug) {}
+    }
+
+    #[derive(Clone, Default)]
+    struct CapturedSpan(Arc<Mutex<Option<CapturedSpanData>>>);
+
+    struct CapturedSpanData {
+        name: String,
+        target: String,
+        parent_name: Option<String>,
+        fields: Vec<String>,
+        initial_values: Vec<(String, String)>,
+        recorded_values: Vec<(String, String)>,
+    }
+
+    struct SpanCaptureLayer {
+        span: CapturedSpan,
+    }
+
+    #[derive(Default)]
+    struct StringFieldVisitor {
+        values: Vec<(String, String)>,
+    }
+
+    impl Visit for StringFieldVisitor {
+        fn record_str(&mut self, field: &Field, value: &str) {
+            self.values
+                .push((field.name().to_owned(), value.to_owned()));
+        }
+
+        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+            self.values
+                .push((field.name().to_owned(), format!("{value:?}")));
+        }
+    }
+
+    impl<S> Layer<S> for SpanCaptureLayer
+    where
+        S: Subscriber,
+        S: for<'lookup> LookupSpan<'lookup>,
+    {
+        fn on_new_span(
+            &self,
+            attrs: &tracing::span::Attributes<'_>,
+            _id: &Id,
+            ctx: Context<'_, S>,
+        ) {
+            if let Ok(mut captured) = self.span.0.lock() {
+                let mut visitor = StringFieldVisitor::default();
+                attrs.record(&mut visitor);
+                let parent_name = if let Some(parent) = attrs.parent() {
+                    ctx.span(parent)
+                        .map(|span| span.metadata().name().to_owned())
+                } else if attrs.is_contextual() {
+                    ctx.lookup_current()
+                        .map(|span| span.metadata().name().to_owned())
+                } else {
+                    None
+                };
+                *captured = Some(CapturedSpanData {
+                    name: attrs.metadata().name().to_owned(),
+                    target: attrs.metadata().target().to_owned(),
+                    parent_name,
+                    fields: attrs
+                        .metadata()
+                        .fields()
+                        .iter()
+                        .map(|field| field.name().to_owned())
+                        .collect(),
+                    initial_values: visitor.values,
+                    recorded_values: Vec::new(),
+                });
+            }
+        }
+
+        fn on_record(&self, _span: &Id, values: &tracing::span::Record<'_>, _ctx: Context<'_, S>) {
+            if let Ok(mut captured) = self.span.0.lock()
+                && let Some(captured) = captured.as_mut()
+            {
+                let mut visitor = StringFieldVisitor::default();
+                values.record(&mut visitor);
+                captured.recorded_values.extend(visitor.values);
+            }
+        }
+    }
+
+    fn contains_string(values: &[(String, String)], field: &str, value: &str) -> bool {
+        values
+            .iter()
+            .any(|candidate| candidate == &(field.to_owned(), value.to_owned()))
+    }
+
+    #[test]
+    fn completion_span_uses_canonical_names_fields_and_initial_attributes() {
+        let _isolation = crate::test_utils::scoped_tracing_subscriber_guard_blocking();
+
+        for (operation, expected_name) in [
+            (CompletionOperation::Chat, "chat"),
+            (CompletionOperation::ChatStreaming, "chat_streaming"),
+            (CompletionOperation::GenerateContent, "generate_content"),
+            (CompletionOperation::Interactions, "interactions"),
+            (
+                CompletionOperation::InteractionsStreaming,
+                "interactions_streaming",
+            ),
+        ] {
+            let captured = CapturedSpan::default();
+            let subscriber = Registry::default().with(SpanCaptureLayer {
+                span: captured.clone(),
+            });
+            tracing::subscriber::with_default(subscriber, || {
+                let span = CompletionSpanBuilder::new("openai", "gpt-5", operation)
+                    .system_instructions(Some("system prompt"))
+                    .build();
+                assert!(!span.is_disabled());
+            });
+
+            let Ok(captured) = captured.0.lock() else {
+                panic!("captured span lock poisoned");
+            };
+            let Some(span) = captured.as_ref() else {
+                panic!("completion span was not created");
+            };
+            assert_eq!(span.name, expected_name);
+            assert_eq!(span.target, "rig::completions");
+            assert_eq!(span.parent_name, None);
+            for (field, value) in [
+                ("gen_ai.operation.name", expected_name),
+                ("gen_ai.provider.name", "openai"),
+                ("gen_ai.request.model", "gpt-5"),
+                ("gen_ai.system_instructions", "system prompt"),
+            ] {
+                assert!(
+                    contains_string(&span.initial_values, field, value),
+                    "missing initial {field}={value}"
+                );
+            }
+            assert!(span.recorded_values.is_empty());
+            assert!(
+                !span
+                    .initial_values
+                    .iter()
+                    .any(|(field, _)| field == "gen_ai.response.model")
+            );
+            for field in [
+                "gen_ai.operation.name",
+                "gen_ai.provider.name",
+                "gen_ai.request.model",
+                "gen_ai.system_instructions",
+                "gen_ai.response.id",
+                "gen_ai.response.model",
+                "gen_ai.usage.input_tokens",
+                "gen_ai.usage.output_tokens",
+                "gen_ai.usage.cache_read.input_tokens",
+                "gen_ai.usage.cache_creation.input_tokens",
+                "gen_ai.usage.tool_use_prompt_tokens",
+                "gen_ai.usage.reasoning_tokens",
+                "gen_ai.input.messages",
+                "gen_ai.output.messages",
+            ] {
+                assert!(
+                    span.fields.iter().any(|candidate| candidate == field),
+                    "missing {field}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn unrelated_ambient_span_is_parent_not_adopted() {
+        let captured = CapturedSpan::default();
+        let subscriber = Registry::default().with(SpanCaptureLayer {
+            span: captured.clone(),
+        });
+        let _isolation = crate::test_utils::scoped_tracing_subscriber_guard_blocking();
+        tracing::subscriber::with_default(subscriber, || {
+            let ambient = tracing::info_span!(target: "application", "ambient");
+            let _guard = ambient.enter();
+            let span =
+                CompletionSpanBuilder::new("openai", "gpt-5", CompletionOperation::Chat).build();
+            assert_ne!(span.id(), ambient.id());
+        });
+
+        let Ok(captured) = captured.0.lock() else {
+            panic!("captured span lock poisoned");
+        };
+        let Some(span) = captured.as_ref() else {
+            panic!("completion span was not captured");
+        };
+        assert_eq!(span.target, "rig::completions");
+        assert_eq!(span.parent_name.as_deref(), Some("ambient"));
+    }
+
+    #[test]
+    fn agent_chat_span_is_adopted_and_enriched() {
+        let captured = CapturedSpan::default();
+        let subscriber = Registry::default().with(SpanCaptureLayer {
+            span: captured.clone(),
+        });
+        let _isolation = crate::test_utils::scoped_tracing_subscriber_guard_blocking();
+        tracing::subscriber::with_default(subscriber, || {
+            let agent_chat = tracing::info_span!(
+                target: "rig::agent_chat",
+                "chat_streaming",
+                gen_ai.operation.name = tracing::field::Empty,
+                gen_ai.provider.name = tracing::field::Empty,
+                gen_ai.request.model = tracing::field::Empty,
+                gen_ai.system_instructions = tracing::field::Empty,
+            );
+            let _guard = agent_chat.enter();
+            let span = CompletionSpanBuilder::new(
+                "anthropic",
+                "claude-sonnet",
+                CompletionOperation::ChatStreaming,
+            )
+            .system_instructions(Some("provider system"))
+            .build();
+            assert_eq!(span.id(), agent_chat.id());
+        });
+
+        let Ok(captured) = captured.0.lock() else {
+            panic!("captured span lock poisoned");
+        };
+        let Some(span) = captured.as_ref() else {
+            panic!("agent chat span was not captured");
+        };
+        for (field, value) in [
+            ("gen_ai.operation.name", "chat_streaming"),
+            ("gen_ai.provider.name", "anthropic"),
+            ("gen_ai.request.model", "claude-sonnet"),
+            ("gen_ai.system_instructions", "provider system"),
+        ] {
+            assert!(contains_string(&span.recorded_values, field, value));
+        }
+    }
+
+    #[test]
+    fn absent_provider_system_does_not_overwrite_agent_instructions() {
+        let captured = CapturedSpan::default();
+        let subscriber = Registry::default().with(SpanCaptureLayer {
+            span: captured.clone(),
+        });
+        let _isolation = crate::test_utils::scoped_tracing_subscriber_guard_blocking();
+        tracing::subscriber::with_default(subscriber, || {
+            let agent_chat = tracing::info_span!(
+                target: "rig::agent_chat",
+                "chat",
+                gen_ai.provider.name = tracing::field::Empty,
+                gen_ai.request.model = tracing::field::Empty,
+                gen_ai.system_instructions = "effective agent instructions",
+            );
+            let _guard = agent_chat.enter();
+            CompletionSpanBuilder::new("openai", "gpt-5", CompletionOperation::Chat).build();
+        });
+
+        let Ok(captured) = captured.0.lock() else {
+            panic!("captured span lock poisoned");
+        };
+        let Some(span) = captured.as_ref() else {
+            panic!("agent chat span was not captured");
+        };
+        assert!(contains_string(
+            &span.initial_values,
+            "gen_ai.system_instructions",
+            "effective agent instructions"
+        ));
+        assert!(
+            !span
+                .recorded_values
+                .iter()
+                .any(|(field, _)| field == "gen_ai.system_instructions")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

Centralizes GenAI model-call telemetry behind a typed `CompletionSpanBuilder` and `CompletionOperation` lifecycle.

- Direct provider calls create a canonical `rig::completions` span, parented to any ambient application span.
- Agent calls enrich and reuse only Rig-owned `rig::agent_chat` spans, preserving one model span per turn.
- Stable request attributes are attached when direct spans are created, so sampling and routing layers can inspect them in `on_new_span`.
- Response IDs, actual response models, and usage are recorded from provider responses rather than configured-model fallbacks.
- Streaming and non-streaming operations use explicit typed operation names.
- All hand-written provider constructors are migrated, including Bedrock streaming.

The builder declares one canonical post-#2066 field set, removing provider drift without compatibility branches or provider-specific span-construction exceptions.

Fixes #2080

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p rig-core --lib`
- [x] `cargo test -p rig-core --lib agent::runner::tests`
- [x] `cargo test -p rig-core --lib agent::prompt_request::streaming::tests`
- [x] `cargo test -p rig-core --lib providers:: --no-fail-fast`
- [x] `cargo test -p rig-bedrock --lib`
- [x] `cargo check -p rig-core --all-features`
- [x] `cargo check -p rig-bedrock --all-features`
- [x] `cargo clippy -p rig-core -p rig-bedrock --all-targets --all-features -- -D warnings`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have added tests that prove the telemetry lifecycle and field contract
- [x] Focused existing unit tests pass locally with my changes

## Notes

Live provider telemetry was not exercised because it requires external credentials. Provider request/response paths are covered by compilation, unit tests, and focused mocked-provider tests.
