### PR TITLE
feat(agent): add run-scoped steering

### DIFF
--- a/crates/rig-core/src/agent/mod.rs
+++ b/crates/rig-core/src/agent/mod.rs
@@ -110,6 +110,7 @@ pub mod hook;
 pub(crate) mod prompt_request;
 pub mod run;
 pub mod runner;
+mod steering;
 mod tool;
 
 /// Fallback display name used in telemetry spans and logs when an agent has no
@@ -131,3 +132,4 @@ pub use prompt_request::{
 };
 pub use run::{AgentRun, AgentRunStep, ModelTurn, ModelTurnOutcome, OutputMode, PendingToolCall};
 pub use runner::AgentRunner;
+pub use steering::{SteeringError, SteeringHandle};

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -21,6 +21,15 @@ use std::{future::IntoFuture, marker::PhantomData};
 /// `$recv` is the field name to delegate through (`runner` or `inner`).
 macro_rules! forward_prompt_setters {
     ($recv:ident) => {
+        /// Return a cloneable handle for steering this request from another task.
+        ///
+        /// Obtain the handle before moving or awaiting the request. Queued user
+        /// messages are delivered after the current tool batch and before the
+        /// next model call.
+        pub fn steering_handle(&self) -> crate::agent::SteeringHandle {
+            self.$recv.steering_handle()
+        }
+
         /// Attach a per-call [`ToolCallExtensions`] for this request.
         ///
         /// Every tool the agent executes during this request can read the

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -481,6 +481,18 @@ where
         let hook_ctx = HookContext::new(is_streaming, runner.agent_name.clone());
 
         'outer: loop {
+            // Steering is consumed only where the state machine is about to
+            // issue a model request. In particular, a message queued during a
+            // tool batch waits until every sibling has settled and the batch has
+            // committed, preserving the batch's atomic semantics.
+            if run.accepts_steering() {
+                let messages = runner.steering.drain();
+                if let Err(err) = run.apply_steering(messages) {
+                    yield Err(Box::new(err).into());
+                    break 'outer;
+                }
+            }
+
             let step = match run.next_step() {
                 Ok(step) => step,
                 Err(err) => {
@@ -590,6 +602,18 @@ where
                     }
                 }
                 AgentRunStep::Done(response) => {
+                    // Close and settle atomically with respect to senders. If a
+                    // steering message raced with the finishing assistant turn,
+                    // resume from that completed turn instead of dropping the
+                    // message or leaking it into another run.
+                    if let Some(messages) = runner.steering.drain_or_close() {
+                        if let Err(err) = run.apply_steering(messages) {
+                            yield Err(Box::new(err).into());
+                            break 'outer;
+                        }
+                        continue 'outer;
+                    }
+
                     // Run-completion marker, unifying the blocking and streaming
                     // drivers' run-finished logs into one shared event.
                     tracing::info!(

--- a/crates/rig-core/src/agent/run/mod.rs
+++ b/crates/rig-core/src/agent/run/mod.rs
@@ -486,6 +486,34 @@ impl AgentRun {
         matches!(self.state, RunState::Done(_))
     }
 
+    /// Whether the next machine step is a model request, and therefore a safe
+    /// boundary for appending queued steering input.
+    pub(crate) fn accepts_steering(&self) -> bool {
+        matches!(self.state, RunState::PreparingRequest)
+    }
+
+    /// Append run-scoped steering messages at a safe boundary.
+    ///
+    /// A completed assistant turn may be resumed when steering raced with
+    /// finalization; otherwise input is accepted only while preparing the next
+    /// model request. The driver is the sole caller and supplies user messages
+    /// drained from its private steering inbox.
+    pub(crate) fn apply_steering(&mut self, messages: Vec<Message>) -> Result<(), PromptError> {
+        if messages.is_empty() {
+            return Ok(());
+        }
+
+        if !matches!(self.state, RunState::PreparingRequest | RunState::Done(_)) {
+            return Err(
+                self.protocol_violation("steering input applied outside a model-call boundary")
+            );
+        }
+
+        self.new_messages.extend(messages);
+        self.state = RunState::PreparingRequest;
+        Ok(())
+    }
+
     /// The final response once the run is done, without cloning it.
     /// [`AgentRun::next_step`] in the done state returns an owned clone
     /// (including the full accumulated message history); prefer this when
@@ -1470,6 +1498,65 @@ mod tests {
         let messages = response.messages.expect("messages should be recorded");
         assert_eq!(messages.len(), 2);
         assert!(run.is_done());
+    }
+
+    #[test]
+    fn steering_resumes_a_provisionally_completed_turn() {
+        let mut run = AgentRun::new("hello").max_turns(2);
+
+        expect_call_model(&mut run);
+        expect_continue(run.model_response(text_turn("first answer")).unwrap());
+        let first_response = expect_done(&mut run);
+        assert_eq!(first_response.output, "first answer");
+
+        run.apply_steering(vec![
+            Message::user("first update"),
+            Message::user("second update"),
+        ])
+        .unwrap();
+
+        let (prompt, history, turn) = expect_call_model(&mut run);
+        assert_eq!(turn, 2);
+        assert_eq!(prompt, Message::user("second update"));
+        assert_eq!(
+            history,
+            vec![
+                Message::user("hello"),
+                Message::assistant("first answer"),
+                Message::user("first update"),
+            ]
+        );
+
+        expect_continue(run.model_response(text_turn("revised answer")).unwrap());
+        let response = expect_done(&mut run);
+        assert_eq!(response.output, "revised answer");
+    }
+
+    #[test]
+    fn steering_does_not_expand_the_model_call_budget() {
+        let mut run = AgentRun::new("hello").max_turns(1);
+
+        expect_call_model(&mut run);
+        expect_continue(run.model_response(text_turn("answer")).unwrap());
+        expect_done(&mut run);
+        run.apply_steering(vec![Message::user("one more thing")])
+            .unwrap();
+
+        assert!(matches!(
+            run.next_step(),
+            Err(PromptError::MaxTurnsError { max_turns: 1, .. })
+        ));
+    }
+
+    #[test]
+    fn steering_rejects_an_in_flight_model_turn() {
+        let mut run = AgentRun::new("hello");
+        expect_call_model(&mut run);
+
+        assert!(matches!(
+            run.apply_steering(vec![Message::user("too early")]),
+            Err(PromptError::PromptCancelled { .. })
+        ));
     }
 
     #[test]

--- a/crates/rig-core/src/agent/runner.rs
+++ b/crates/rig-core/src/agent/runner.rs
@@ -49,6 +49,7 @@ use super::{
     run::{
         AgentRun, DEFAULT_OUTPUT_RETRIES, ModelTurn, ModelTurnOutcome, OutputMode, PendingToolCall,
     },
+    steering::{SteeringHandle, SteeringInbox},
 };
 use crate::{
     completion::{CompletionError, CompletionModel, Document, Message, PromptError},
@@ -291,6 +292,7 @@ where
     pub(crate) memory: Option<Arc<dyn ConversationMemory>>,
     pub(crate) conversation_id: Option<String>,
     pub(crate) hooks: HookStack<M>,
+    pub(crate) steering: SteeringInbox,
 }
 
 impl<M> AgentRunner<M>
@@ -322,6 +324,7 @@ where
             memory: agent.memory.clone(),
             conversation_id: agent.default_conversation_id.clone(),
             hooks: agent.hooks.clone(),
+            steering: SteeringInbox::new(),
         }
     }
 
@@ -337,6 +340,15 @@ where
     {
         self.hooks.push(hook);
         self
+    }
+
+    /// Return a cloneable handle for steering this run from another task.
+    ///
+    /// Obtain the handle before moving the runner into [`run`](Self::run) or
+    /// [`stream`](Self::stream). Each runner owns an independent queue, so
+    /// steering cannot leak between concurrent runs or conversations.
+    pub fn steering_handle(&self) -> SteeringHandle {
+        self.steering.handle()
     }
 }
 
@@ -1083,26 +1095,390 @@ where
 mod tests {
     use std::sync::{
         Arc, Mutex,
-        atomic::{AtomicU32, Ordering::SeqCst},
+        atomic::{AtomicBool, AtomicU32, Ordering::SeqCst},
     };
 
     use futures::StreamExt;
     use serde_json::json;
 
-    use crate::agent::AgentBuilder;
     use crate::agent::hook::{
         AgentHook, Flow, HookContext, RequestPatch, StepEvent, StepEventKind,
     };
     use crate::agent::prompt_request::streaming::{MultiTurnStreamItem, StreamingError};
     use crate::agent::run::OutputMode;
+    use crate::agent::{AgentBuilder, SteeringHandle};
     use crate::completion::{CompletionModel, Message, Prompt, PromptError};
     use crate::message::{AssistantContent, ToolCall, ToolChoice, ToolFunction, UserContent};
     use crate::streaming::{StreamedAssistantContent, StreamedUserContent, StreamingPrompt};
     use crate::test_utils::{
-        MockAddTool, MockBarrierTool, MockCompletionModel, MockOperationArgs, MockStreamEvent,
-        MockSubtractTool, MockToolError, MockTurn,
+        MockAddTool, MockBarrierTool, MockCompletionModel, MockControlledTool, MockOperationArgs,
+        MockStreamEvent, MockSubtractTool, MockToolError, MockTurn,
     };
     use crate::tool::Tool;
+
+    fn is_user_text(message: &Message, expected: &str) -> bool {
+        matches!(
+            message,
+            Message::User { content }
+                if content.iter().any(|item| matches!(
+                    item,
+                    UserContent::Text(text) if text.text == expected
+                ))
+        )
+    }
+
+    fn is_tool_result(message: &Message) -> bool {
+        matches!(
+            message,
+            Message::User { content }
+                if content.iter().any(|item| matches!(item, UserContent::ToolResult(_)))
+        )
+    }
+
+    #[derive(Clone)]
+    struct SteerAfterFirstModelTurn {
+        steering: SteeringHandle,
+        sent: Arc<AtomicBool>,
+        message: &'static str,
+    }
+
+    impl SteerAfterFirstModelTurn {
+        fn new(steering: SteeringHandle, message: &'static str) -> Self {
+            Self {
+                steering,
+                sent: Arc::new(AtomicBool::new(false)),
+                message,
+            }
+        }
+    }
+
+    impl<M: CompletionModel> AgentHook<M> for SteerAfterFirstModelTurn {
+        async fn on_event(&self, _ctx: &HookContext, event: StepEvent<'_, M>) -> Flow {
+            if matches!(event, StepEvent::ModelTurnFinished { .. })
+                && !self.sent.swap(true, std::sync::atomic::Ordering::SeqCst)
+            {
+                self.steering.steer(self.message).unwrap();
+            }
+            Flow::Continue
+        }
+    }
+
+    #[tokio::test]
+    async fn blocking_steering_racing_with_finalization_resumes_the_run() {
+        let model = MockCompletionModel::new([
+            MockTurn::text("would have finished"),
+            MockTurn::text("finished after steering"),
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model).build();
+        let request = agent.prompt("start").max_turns(2).extended_details();
+        let steering = request.steering_handle();
+        let request = request.add_hook(SteerAfterFirstModelTurn::new(
+            steering.clone(),
+            "terminal update",
+        ));
+
+        let response = request.await.unwrap();
+
+        assert_eq!(response.output, "finished after steering");
+        assert_eq!(recorded.request_count(), 2);
+        assert!(
+            recorded.requests()[1]
+                .chat_history
+                .iter()
+                .any(|message| is_user_text(message, "terminal update"))
+        );
+        assert!(steering.is_closed());
+    }
+
+    #[tokio::test]
+    async fn streaming_steering_racing_with_finalization_resumes_the_run() {
+        let model = MockCompletionModel::from_stream_turns([
+            vec![
+                MockStreamEvent::text("would have finished"),
+                MockStreamEvent::final_response_with_default_usage(),
+            ],
+            vec![
+                MockStreamEvent::text("stream finished after steering"),
+                MockStreamEvent::final_response_with_default_usage(),
+            ],
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model).build();
+        let request = agent.stream_prompt("start").max_turns(2);
+        let steering = request.steering_handle();
+        let request = request.add_hook(SteerAfterFirstModelTurn::new(
+            steering.clone(),
+            "terminal stream update",
+        ));
+
+        let mut stream = request.await;
+        let mut final_response = None;
+        while let Some(item) = stream.next().await {
+            if let MultiTurnStreamItem::FinalResponse(response) = item.unwrap() {
+                final_response = Some(response);
+            }
+        }
+
+        assert_eq!(
+            final_response.unwrap().output,
+            "stream finished after steering"
+        );
+        assert_eq!(recorded.request_count(), 2);
+        assert!(
+            recorded.requests()[1]
+                .chat_history
+                .iter()
+                .any(|message| is_user_text(message, "terminal stream update"))
+        );
+        assert!(steering.is_closed());
+    }
+
+    #[tokio::test]
+    async fn blocking_steering_waits_for_the_active_tool_batch() {
+        let started = Arc::new(tokio::sync::Notify::new());
+        let allow_finish = Arc::new(tokio::sync::Notify::new());
+        let model = MockCompletionModel::new([
+            MockTurn::tool_call("call-1", "controlled", json!({})),
+            MockTurn::text("finished after steering"),
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model)
+            .tool(MockControlledTool::new(
+                started.clone(),
+                allow_finish.clone(),
+            ))
+            .build();
+        let request = agent.prompt("start").max_turns(2).extended_details();
+        let steering = request.steering_handle();
+
+        let task = tokio::spawn(async move { request.await });
+        started.notified().await;
+        steering.steer("first update").unwrap();
+        steering.steer("second update").unwrap();
+
+        assert_eq!(
+            recorded.request_count(),
+            1,
+            "steering must not start another model call while a tool is in flight"
+        );
+        allow_finish.notify_one();
+
+        let response = task.await.unwrap().unwrap();
+        assert_eq!(response.output, "finished after steering");
+        assert!(steering.is_closed());
+        assert_eq!(
+            steering.steer("late update"),
+            Err(crate::agent::SteeringError::RunClosed)
+        );
+
+        let requests = recorded.requests();
+        assert_eq!(requests.len(), 2);
+        let second = requests[1].chat_history.iter().collect::<Vec<_>>();
+        let tool_result_index = second
+            .iter()
+            .position(|message| is_tool_result(message))
+            .unwrap();
+        let first_update_index = second
+            .iter()
+            .position(|message| is_user_text(message, "first update"))
+            .unwrap();
+        let second_update_index = second
+            .iter()
+            .position(|message| is_user_text(message, "second update"))
+            .unwrap();
+        assert!(tool_result_index < first_update_index);
+        assert!(first_update_index < second_update_index);
+
+        let history = response.messages.unwrap();
+        assert_eq!(
+            history
+                .iter()
+                .filter(|message| is_user_text(message, "first update"))
+                .count(),
+            1
+        );
+        assert_eq!(
+            history
+                .iter()
+                .filter(|message| is_user_text(message, "second update"))
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn streaming_steering_uses_the_same_tool_batch_boundary() {
+        let started = Arc::new(tokio::sync::Notify::new());
+        let allow_finish = Arc::new(tokio::sync::Notify::new());
+        let model = MockCompletionModel::from_stream_turns([
+            vec![
+                MockStreamEvent::tool_call("call-1", "controlled", json!({})),
+                MockStreamEvent::final_response_with_default_usage(),
+            ],
+            vec![
+                MockStreamEvent::text("stream finished after steering"),
+                MockStreamEvent::final_response_with_default_usage(),
+            ],
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model)
+            .tool(MockControlledTool::new(
+                started.clone(),
+                allow_finish.clone(),
+            ))
+            .build();
+        let request = agent.stream_prompt("start").max_turns(2);
+        let steering = request.steering_handle();
+
+        let task = tokio::spawn(async move {
+            let mut stream = request.await;
+            let mut final_response = None;
+            while let Some(item) = stream.next().await {
+                if let MultiTurnStreamItem::FinalResponse(response) = item.unwrap() {
+                    final_response = Some(response);
+                }
+            }
+            final_response.unwrap()
+        });
+
+        started.notified().await;
+        steering.steer("stream update").unwrap();
+        assert_eq!(recorded.request_count(), 1);
+        allow_finish.notify_one();
+
+        let response = task.await.unwrap();
+        assert_eq!(response.output, "stream finished after steering");
+        let requests = recorded.requests();
+        assert_eq!(requests.len(), 2);
+        let second = requests[1].chat_history.iter().collect::<Vec<_>>();
+        let tool_result_index = second
+            .iter()
+            .position(|message| is_tool_result(message))
+            .unwrap();
+        let update_index = second
+            .iter()
+            .position(|message| is_user_text(message, "stream update"))
+            .unwrap();
+        assert!(tool_result_index < update_index);
+        assert!(steering.is_closed());
+    }
+
+    #[test]
+    fn dropping_an_unstarted_runner_closes_its_steering_handle() {
+        let agent = AgentBuilder::new(MockCompletionModel::default()).build();
+        let runner = agent.runner("start");
+        let steering = runner.steering_handle();
+
+        drop(runner);
+
+        assert_eq!(
+            steering.steer("too late"),
+            Err(crate::agent::SteeringError::RunClosed)
+        );
+    }
+
+    #[tokio::test]
+    async fn dropping_an_unpolled_stream_closes_its_steering_handle() {
+        let agent = AgentBuilder::new(MockCompletionModel::default()).build();
+        let request = agent.stream_prompt("start");
+        let steering = request.steering_handle();
+
+        let stream = request.await;
+        assert!(!steering.is_closed());
+        drop(stream);
+
+        assert_eq!(
+            steering.steer("too late"),
+            Err(crate::agent::SteeringError::RunClosed)
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_run_closes_its_steering_handle() {
+        let agent = AgentBuilder::new(MockCompletionModel::new([MockTurn::error("boom")])).build();
+        let runner = agent.runner("start");
+        let steering = runner.steering_handle();
+
+        assert!(runner.run().await.is_err());
+        assert_eq!(
+            steering.steer("too late"),
+            Err(crate::agent::SteeringError::RunClosed)
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_same_conversation_runs_have_isolated_steering() {
+        let started = Arc::new(tokio::sync::Notify::new());
+        let allow_finish = Arc::new(tokio::sync::Notify::new());
+        let model = MockCompletionModel::new([
+            MockTurn::tool_call("call-1", "controlled", json!({})),
+            MockTurn::text("second run finished"),
+            MockTurn::text("first run finished"),
+        ]);
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model)
+            .tool(MockControlledTool::new(
+                started.clone(),
+                allow_finish.clone(),
+            ))
+            .build();
+
+        let first = agent
+            .runner("first prompt")
+            .conversation("shared")
+            .max_turns(2);
+        let first_steering = first.steering_handle();
+        let second = agent.runner("second prompt").conversation("shared");
+        let second_steering = second.steering_handle();
+
+        let first_task = tokio::spawn(first.run());
+        started.notified().await;
+        first_steering.steer("only first").unwrap();
+
+        let second_response = second.run().await.unwrap();
+        assert_eq!(second_response.output, "second run finished");
+        assert_eq!(recorded.request_count(), 2);
+        allow_finish.notify_one();
+
+        let first_response = first_task.await.unwrap().unwrap();
+        assert_eq!(first_response.output, "first run finished");
+
+        let requests = recorded.requests();
+        assert_eq!(requests.len(), 3);
+        let second_request = requests
+            .iter()
+            .find(|request| {
+                request
+                    .chat_history
+                    .iter()
+                    .any(|message| is_user_text(message, "second prompt"))
+            })
+            .unwrap();
+        let steered_first_request = requests
+            .iter()
+            .find(|request| {
+                request
+                    .chat_history
+                    .iter()
+                    .any(|message| is_user_text(message, "only first"))
+            })
+            .unwrap();
+        assert!(
+            steered_first_request
+                .chat_history
+                .iter()
+                .any(|message| is_user_text(message, "first prompt"))
+        );
+        assert!(
+            !second_request
+                .chat_history
+                .iter()
+                .any(|message| is_user_text(message, "only first"))
+        );
+        assert!(first_steering.is_closed());
+        assert!(second_steering.is_closed());
+    }
 
     /// Records the kind of every hook event (and every tool-result payload) so a
     /// run() and a stream() of the same scenario can be compared.

--- a/crates/rig-core/src/agent/steering.rs
+++ b/crates/rig-core/src/agent/steering.rs
@@ -1,0 +1,185 @@
+//! Run-scoped steering for active agent prompt loops.
+//!
+//! A [`SteeringHandle`] belongs to one [`AgentRunner`](super::AgentRunner). Messages
+//! submitted through it are delivered at the next safe boundary: after the
+//! current model turn and its tool batch have settled, immediately before the
+//! next model call. Handles are deliberately run-scoped so concurrent runs,
+//! including runs sharing a conversation ID, cannot consume each other's input.
+
+use std::{
+    collections::VecDeque,
+    sync::{Arc, Mutex, MutexGuard},
+};
+
+use crate::completion::Message;
+
+/// Error returned when steering input can no longer be accepted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum SteeringError {
+    /// The associated request has settled or was dropped.
+    #[error("the agent run is no longer accepting steering messages")]
+    RunClosed,
+}
+
+#[derive(Debug, Default)]
+struct SteeringState {
+    pending: VecDeque<Message>,
+    closed: bool,
+}
+
+/// A cloneable, run-scoped handle for steering an active agent.
+///
+/// Obtain one from [`AgentRunner::steering_handle`](super::AgentRunner::steering_handle)
+/// or from a prompt request's `steering_handle` method before moving that request
+/// into another task. Calling [`steer`](Self::steer) queues a user message; it
+/// does not interrupt an in-flight model request or tool. The shared agent driver
+/// drains queued messages after the current tool batch and before the next model
+/// call. If the current assistant turn would otherwise finish the run, queued
+/// steering starts another model turn, subject to the run's `max_turns` budget.
+///
+/// The handle is tied to one request, not a conversation ID. Cloning an [`Agent`](super::Agent)
+/// and starting another request creates a different steering queue. The queue is
+/// intentionally unbounded; callers control how much input they enqueue before
+/// the run reaches its next safe boundary.
+#[derive(Clone)]
+pub struct SteeringHandle {
+    inner: Arc<Mutex<SteeringState>>,
+}
+
+impl std::fmt::Debug for SteeringHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let state = lock_state(&self.inner);
+        f.debug_struct("SteeringHandle")
+            .field("pending", &state.pending.len())
+            .field("closed", &state.closed)
+            .finish()
+    }
+}
+
+impl SteeringHandle {
+    /// Queue a user message for the next safe boundary in this run.
+    ///
+    /// Messages are delivered in submission order. Returns
+    /// [`SteeringError::RunClosed`] once the run has settled or its request has
+    /// been dropped, ensuring late input cannot leak into a later run.
+    pub fn steer(&self, message: impl Into<String>) -> Result<(), SteeringError> {
+        let mut state = lock_state(&self.inner);
+        if state.closed {
+            return Err(SteeringError::RunClosed);
+        }
+        state.pending.push_back(Message::user(message));
+        Ok(())
+    }
+
+    /// Whether the associated run has stopped accepting steering input.
+    pub fn is_closed(&self) -> bool {
+        lock_state(&self.inner).closed
+    }
+}
+
+/// Driver-owned half of a steering queue.
+///
+/// Unlike [`SteeringHandle`], this type is not cloneable. Dropping the request
+/// owner closes the queue even when public handles remain alive.
+pub(crate) struct SteeringInbox {
+    inner: Arc<Mutex<SteeringState>>,
+}
+
+impl std::fmt::Debug for SteeringInbox {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let state = lock_state(&self.inner);
+        f.debug_struct("SteeringInbox")
+            .field("pending", &state.pending.len())
+            .field("closed", &state.closed)
+            .finish()
+    }
+}
+
+impl SteeringInbox {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(SteeringState::default())),
+        }
+    }
+
+    pub(crate) fn handle(&self) -> SteeringHandle {
+        SteeringHandle {
+            inner: self.inner.clone(),
+        }
+    }
+
+    /// Drain input without closing the run. Used immediately before a model call.
+    pub(crate) fn drain(&self) -> Vec<Message> {
+        lock_state(&self.inner).pending.drain(..).collect()
+    }
+
+    /// Atomically drain pending input or close an idle queue.
+    ///
+    /// `Some(messages)` means the run must continue. `None` means no steering
+    /// was pending and the queue is now closed, so a concurrent late sender
+    /// cannot race with finalization and leave input stranded.
+    pub(crate) fn drain_or_close(&self) -> Option<Vec<Message>> {
+        let mut state = lock_state(&self.inner);
+        if state.pending.is_empty() {
+            state.closed = true;
+            None
+        } else {
+            Some(state.pending.drain(..).collect())
+        }
+    }
+
+    fn close(&self) {
+        let mut state = lock_state(&self.inner);
+        state.closed = true;
+        state.pending.clear();
+    }
+}
+
+impl Drop for SteeringInbox {
+    fn drop(&mut self) {
+        self.close();
+    }
+}
+
+fn lock_state(state: &Mutex<SteeringState>) -> MutexGuard<'_, SteeringState> {
+    match state.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn closing_an_idle_inbox_rejects_late_input() {
+        let inbox = SteeringInbox::new();
+        let handle = inbox.handle();
+
+        assert!(inbox.drain_or_close().is_none());
+        assert_eq!(handle.steer("too late"), Err(SteeringError::RunClosed));
+        assert!(handle.is_closed());
+    }
+
+    #[test]
+    fn debug_does_not_expose_queued_messages() {
+        let inbox = SteeringInbox::new();
+        let handle = inbox.handle();
+        handle.steer("secret steering input").unwrap();
+
+        let debug = format!("{handle:?}");
+        assert!(debug.contains("pending: 1"));
+        assert!(!debug.contains("secret steering input"));
+    }
+
+    #[test]
+    fn dropping_the_request_owner_closes_the_handle() {
+        let inbox = SteeringInbox::new();
+        let handle = inbox.handle();
+        drop(inbox);
+
+        assert_eq!(handle.steer("too late"), Err(SteeringError::RunClosed));
+    }
+}


### PR DESCRIPTION
## Summary

Rewrites the steering work from #1858 against Rig's current shared agent driver.

- adds a run-scoped `SteeringHandle` exposed by `AgentRunner`, `PromptRequest`, typed prompt requests, and `StreamingPromptRequest`;
- queues user messages for delivery after the current atomic tool batch and immediately before the next model call;
- uses the same `drive_agent` implementation for streaming and non-streaming parity;
- atomically resolves terminal races so accepted steering resumes a provisionally completed run, while later input receives `SteeringError::RunClosed`;
- closes steering handles when a run completes, fails, is dropped, or its stream is abandoned;
- preserves `max_turns` rather than granting steering an implicit extra model-call budget.

This intentionally replaces #1858's agent-level, conversation-keyed queue. Each runner owns an independent mailbox, so concurrent runs cannot consume one another's messages even when they share an agent and conversation ID.

## Semantics

Steering is cooperative, not interruption:

1. an in-flight model request continues;
2. if that turn requests tools, the entire tool batch settles atomically;
3. queued user messages are appended in FIFO order;
4. the next model call observes them.

If steering arrives while an assistant turn would otherwise finish the run, the terminal handshake resumes from that completed turn when budget remains.

## Validation

- `cargo test -p rig-core --lib` — 1201 passed, 8 ignored
- `cargo test -p rig-core steering --lib` — 14 passed
- `cargo clippy -p rig-core --all-targets --all-features -- -D warnings`
- `cargo check -p rig-core --target wasm32-unknown-unknown --features wasm`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p rig-core --no-deps`
- `cargo test -p rig-core --doc` — 86 passed, 24 ignored
- `git diff --check`

## Coverage

Regression tests cover:

- streaming and non-streaming tool-batch boundaries;
- steering racing with natural finalization on both surfaces;
- concurrent same-conversation run isolation;
- FIFO delivery;
- model-call budget exhaustion;
- completed, failed, dropped, and abandoned-stream handle closure;
- redacted `Debug` output for queued messages.

Supersedes #1858 and advances the interactive run-control work tracked in #2118.
