### PR TITLE
feat(agent): production-grade interactive coding-agent runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "agent_with_message_injection"
+version = "0.40.0"
+dependencies = [
+ "anyhow",
+ "rig",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "agent_with_tools"
 version = "0.40.0"
 dependencies = [

--- a/crates/rig-bedrock/src/types/completion_request.rs
+++ b/crates/rig-bedrock/src/types/completion_request.rs
@@ -273,6 +273,8 @@ mod tests {
             model: None,
             tool_choice: Some(ToolChoice::Auto),
             tools: vec![ToolDefinition {
+                output_schema: None,
+                metadata: Default::default(),
                 name: "test_tool".to_string(),
                 description: "A test tool".to_string(),
                 parameters: serde_json::json!({
@@ -306,6 +308,8 @@ mod tests {
             model: None,
             tool_choice: Some(ToolChoice::Required),
             tools: vec![ToolDefinition {
+                output_schema: None,
+                metadata: Default::default(),
                 name: "test_tool".to_string(),
                 description: "A test tool".to_string(),
                 parameters: serde_json::json!({
@@ -339,6 +343,8 @@ mod tests {
             model: None,
             tool_choice: Some(ToolChoice::None),
             tools: vec![ToolDefinition {
+                output_schema: None,
+                metadata: Default::default(),
                 name: "test_tool".to_string(),
                 description: "A test tool".to_string(),
                 parameters: serde_json::json!({
@@ -366,6 +372,8 @@ mod tests {
                 function_names: vec!["specific_tool".to_string()],
             }),
             tools: vec![ToolDefinition {
+                output_schema: None,
+                metadata: Default::default(),
                 name: "specific_tool".to_string(),
                 description: "A specific tool".to_string(),
                 parameters: serde_json::json!({
@@ -399,6 +407,8 @@ mod tests {
             model: None,
             tool_choice: None, // Not set
             tools: vec![ToolDefinition {
+                output_schema: None,
+                metadata: Default::default(),
                 name: "test_tool".to_string(),
                 description: "A test tool".to_string(),
                 parameters: serde_json::json!({
@@ -426,6 +436,8 @@ mod tests {
         let request = CompletionRequest {
             model: None,
             tools: vec![ToolDefinition {
+                output_schema: None,
+                metadata: Default::default(),
                 name: "document_list".to_string(),
                 description: "Lists all documents".to_string(),
                 parameters: serde_json::json!({
@@ -461,6 +473,8 @@ mod tests {
         let request = CompletionRequest {
             model: None,
             tools: vec![ToolDefinition {
+                output_schema: None,
+                metadata: Default::default(),
                 name: "get_weather".to_string(),
                 description: "Get weather for a location".to_string(),
                 parameters: serde_json::json!({

--- a/crates/rig-core/CHANGELOG.md
+++ b/crates/rig-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- *(agent runtime)* run-bound control handles with steering, follow-up/next-turn queues, cooperative cancellation, status, tool-visible run context, and bounded subagent propagation.
+- *(tools)* output schemas and host metadata, direct rich result content, dynamic catalog enumeration/replacement, call-scoped hook state, and a runtime-agnostic code-mode adapter.
+- *(sessions/skills)* backend-neutral append-only session records and progressive-disclosure skill catalogs.
+
 ### Changed
 
 - *(core)* [**breaking**] Mark `PromptError`, `StructuredOutputError`, `ToolError`, `ToolSetError`, and `VectorStoreError` as non-exhaustive, requiring downstream match expressions to include a wildcard arm. Conversation memory load failures now surface as the typed `PromptError::MemoryError` variant instead of `CompletionError::RequestError`.

--- a/crates/rig-core/Cargo.toml
+++ b/crates/rig-core/Cargo.toml
@@ -42,7 +42,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 rmcp = { workspace = true, optional = true, features = ["client"] }
-tokio = { workspace = true, features = ["rt", "sync"] }
+tokio = { workspace = true, features = ["rt", "sync", "time"] }
 http = { workspace = true }
 tracing-futures = { workspace = true, features = ["futures-03"] }
 serenity = { workspace = true, optional = true }

--- a/crates/rig-core/src/agent/builder.rs
+++ b/crates/rig-core/src/agent/builder.rs
@@ -4,7 +4,8 @@ use schemars::{JsonSchema, Schema, schema_for};
 
 use crate::{
     agent::hook::{AgentHook, HookStack},
-    completion::{CompletionModel, Document},
+    completion::request::merge_provider_tools_into_additional_params,
+    completion::{CompletionModel, Document, ProviderToolDefinition},
     memory::ConversationMemory,
     message::ToolChoice,
     tool::{
@@ -217,6 +218,24 @@ where
     /// Set additional parameters to be passed to the model
     pub fn additional_params(mut self, params: serde_json::Value) -> Self {
         self.additional_params = Some(params);
+        self
+    }
+
+    /// Add a provider-hosted tool to every completion request made by this agent.
+    ///
+    /// Provider-hosted tools execute at the provider and are not registered in
+    /// Rig's client-side [`ToolServer`]. They are merged with existing hosted
+    /// tool configuration under one `tools` array.
+    pub fn provider_tool(mut self, tool: ProviderToolDefinition) -> Self {
+        self.additional_params =
+            merge_provider_tools_into_additional_params(self.additional_params, vec![tool]);
+        self
+    }
+
+    /// Add multiple provider-hosted tools.
+    pub fn provider_tools(mut self, tools: Vec<ProviderToolDefinition>) -> Self {
+        self.additional_params =
+            merge_provider_tools_into_additional_params(self.additional_params, tools);
         self
     }
 

--- a/crates/rig-core/src/agent/completion.rs
+++ b/crates/rig-core/src/agent/completion.rs
@@ -549,6 +549,8 @@ pub(crate) async fn build_prepared_completion_request<M: CompletionModel>(
                           schema."
                 .to_string(),
             parameters: schema.clone().to_value(),
+            output_schema: Some(schema.clone().to_value()),
+            metadata: Default::default(),
         });
     }
 

--- a/crates/rig-core/src/agent/control.rs
+++ b/crates/rig-core/src/agent/control.rs
@@ -9,8 +9,6 @@ use std::sync::{
     atomic::{AtomicBool, AtomicU8, Ordering},
 };
 
-use futures::task::AtomicWaker;
-
 use super::{MessageInjectError, MessageInjector, hook::RunId};
 use crate::completion::Message;
 
@@ -68,7 +66,7 @@ impl RunStatus {
 pub(crate) struct RunControlState {
     run_id: RunId,
     cancelled: AtomicBool,
-    cancel_waker: AtomicWaker,
+    changed: tokio::sync::Notify,
     status: AtomicU8,
     deadline: Mutex<Option<std::time::SystemTime>>,
     follow_ups: Mutex<Vec<Message>>,
@@ -88,7 +86,7 @@ impl RunControlHandle {
             state: Arc::new(RunControlState {
                 run_id: RunId::generate(),
                 cancelled: AtomicBool::new(false),
-                cancel_waker: AtomicWaker::new(),
+                changed: tokio::sync::Notify::new(),
                 status: AtomicU8::new(RunStatus::Pending.as_u8()),
                 deadline: Mutex::new(None),
                 follow_ups: Mutex::new(Vec::new()),
@@ -114,7 +112,7 @@ impl RunControlHandle {
     /// start later work. Tools can also read [`RunContext`] from call extensions.
     pub fn cancel(&self) {
         self.state.cancelled.store(true, Ordering::Release);
-        self.state.cancel_waker.wake();
+        self.state.changed.notify_one();
     }
 
     /// Whether cancellation has been requested.
@@ -129,7 +127,7 @@ impl RunControlHandle {
             .deadline
             .lock()
             .unwrap_or_else(|e| e.into_inner()) = Some(deadline);
-        self.state.cancel_waker.wake();
+        self.state.changed.notify_one();
     }
 
     /// Configured absolute deadline.
@@ -205,28 +203,23 @@ impl RunControlHandle {
     }
 
     pub(crate) async fn cancelled(&self) {
-        let explicit_cancel = std::future::poll_fn(|cx| {
-            if self.state.cancelled.load(Ordering::Acquire) {
-                return std::task::Poll::Ready(());
+        loop {
+            if self.is_cancelled() {
+                return;
             }
-            self.state.cancel_waker.register(cx.waker());
-            if self.state.cancelled.load(Ordering::Acquire) {
-                std::task::Poll::Ready(())
-            } else {
-                std::task::Poll::Pending
-            }
-        });
 
-        if let Some(deadline) = self.deadline() {
-            let duration = deadline
-                .duration_since(std::time::SystemTime::now())
-                .unwrap_or_default();
-            futures::pin_mut!(explicit_cancel);
-            let deadline = tokio::time::sleep(duration);
-            futures::pin_mut!(deadline);
-            let _ = futures::future::select(explicit_cancel, deadline).await;
-        } else {
-            explicit_cancel.await;
+            let changed = self.state.changed.notified();
+            if let Some(deadline) = self.deadline() {
+                let duration = deadline
+                    .duration_since(std::time::SystemTime::now())
+                    .unwrap_or_default();
+                futures::pin_mut!(changed);
+                let deadline = tokio::time::sleep(duration);
+                futures::pin_mut!(deadline);
+                let _ = futures::future::select(changed, deadline).await;
+            } else {
+                changed.await;
+            }
         }
     }
 }

--- a/crates/rig-core/src/agent/control.rs
+++ b/crates/rig-core/src/agent/control.rs
@@ -1,0 +1,288 @@
+//! Host-facing control for an in-flight agent run.
+//!
+//! A [`RunControlHandle`] is bound to one runner invocation. It provides stable
+//! correlation, cooperative cancellation, steering, and queues that a host can
+//! consume after settlement without storing messages on a shared [`Agent`](super::Agent).
+
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, AtomicU8, Ordering},
+};
+
+use futures::task::AtomicWaker;
+
+use super::{MessageInjectError, MessageInjector, hook::RunId};
+use crate::completion::Message;
+
+/// Observable lifecycle state of an agent run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RunStatus {
+    /// The runner has been configured but has not started.
+    Pending,
+    /// Model/tool work is in progress.
+    Running,
+    /// The run produced a final response.
+    Completed,
+    /// The host cancelled the run.
+    Cancelled,
+    /// The model-call budget was exhausted.
+    Exhausted,
+    /// The run failed for another reason.
+    Failed,
+}
+
+impl RunStatus {
+    fn from_u8(value: u8) -> Self {
+        match value {
+            0 => Self::Pending,
+            1 => Self::Running,
+            2 => Self::Completed,
+            3 => Self::Cancelled,
+            4 => Self::Exhausted,
+            _ => Self::Failed,
+        }
+    }
+
+    fn as_u8(self) -> u8 {
+        match self {
+            Self::Pending => 0,
+            Self::Running => 1,
+            Self::Completed => 2,
+            Self::Cancelled => 3,
+            Self::Exhausted => 4,
+            Self::Failed => 5,
+        }
+    }
+
+    /// Whether no more work will be started for this run.
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            Self::Completed | Self::Cancelled | Self::Exhausted | Self::Failed
+        )
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct RunControlState {
+    run_id: RunId,
+    cancelled: AtomicBool,
+    cancel_waker: AtomicWaker,
+    status: AtomicU8,
+    deadline: Mutex<Option<std::time::SystemTime>>,
+    follow_ups: Mutex<Vec<Message>>,
+    next_turn: Mutex<Vec<Message>>,
+}
+
+/// Cloneable host handle for one agent run.
+#[derive(Clone, Debug)]
+pub struct RunControlHandle {
+    pub(crate) state: Arc<RunControlState>,
+    steer: MessageInjector,
+}
+
+impl RunControlHandle {
+    pub(crate) fn new(steer: MessageInjector) -> Self {
+        Self {
+            state: Arc::new(RunControlState {
+                run_id: RunId::generate(),
+                cancelled: AtomicBool::new(false),
+                cancel_waker: AtomicWaker::new(),
+                status: AtomicU8::new(RunStatus::Pending.as_u8()),
+                deadline: Mutex::new(None),
+                follow_ups: Mutex::new(Vec::new()),
+                next_turn: Mutex::new(Vec::new()),
+            }),
+            steer,
+        }
+    }
+
+    /// Stable process-scoped identifier for this run.
+    pub fn run_id(&self) -> &RunId {
+        &self.state.run_id
+    }
+
+    /// Current lifecycle state.
+    pub fn status(&self) -> RunStatus {
+        RunStatus::from_u8(self.state.status.load(Ordering::Acquire))
+    }
+
+    /// Request cooperative cancellation.
+    ///
+    /// The shared driver stops polling the active model/tool future and does not
+    /// start later work. Tools can also read [`RunContext`] from call extensions.
+    pub fn cancel(&self) {
+        self.state.cancelled.store(true, Ordering::Release);
+        self.state.cancel_waker.wake();
+    }
+
+    /// Whether cancellation has been requested.
+    pub fn is_cancelled(&self) -> bool {
+        self.state.cancelled.load(Ordering::Acquire) || self.deadline_exceeded()
+    }
+
+    /// Set an absolute cooperative deadline for model, tool, and child work.
+    pub fn set_deadline(&self, deadline: std::time::SystemTime) {
+        *self
+            .state
+            .deadline
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = Some(deadline);
+        self.state.cancel_waker.wake();
+    }
+
+    /// Configured absolute deadline.
+    pub fn deadline(&self) -> Option<std::time::SystemTime> {
+        *self
+            .state
+            .deadline
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Whether the configured deadline has passed.
+    pub fn deadline_exceeded(&self) -> bool {
+        self.deadline()
+            .is_some_and(|deadline| std::time::SystemTime::now() >= deadline)
+    }
+
+    /// Deliver a user message at the next safe boundary before a model call.
+    pub fn steer(&self, message: impl Into<Message>) -> Result<(), MessageInjectError> {
+        self.steer.inject(message)
+    }
+
+    /// Queue a message for a host-started follow-up after this run settles.
+    pub fn follow_up(&self, message: impl Into<Message>) {
+        self.state
+            .follow_ups
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(message.into());
+    }
+
+    /// Queue input for a later turn without interrupting or starting this run.
+    pub fn queue_next_turn(&self, message: impl Into<Message>) {
+        self.state
+            .next_turn
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(message.into());
+    }
+
+    /// Drain queued follow-up messages in producer order.
+    pub fn take_follow_ups(&self) -> Vec<Message> {
+        std::mem::take(
+            &mut *self
+                .state
+                .follow_ups
+                .lock()
+                .unwrap_or_else(|e| e.into_inner()),
+        )
+    }
+
+    /// Drain queued next-turn messages in producer order.
+    pub fn take_next_turn(&self) -> Vec<Message> {
+        std::mem::take(
+            &mut *self
+                .state
+                .next_turn
+                .lock()
+                .unwrap_or_else(|e| e.into_inner()),
+        )
+    }
+
+    pub(crate) fn message_injector(&self) -> MessageInjector {
+        self.steer.clone()
+    }
+
+    pub(crate) fn set_status(&self, status: RunStatus) {
+        self.state.status.store(status.as_u8(), Ordering::Release);
+    }
+
+    pub(crate) fn status_guard(&self) -> RunStatusGuard {
+        RunStatusGuard(self.clone())
+    }
+
+    pub(crate) async fn cancelled(&self) {
+        let explicit_cancel = std::future::poll_fn(|cx| {
+            if self.state.cancelled.load(Ordering::Acquire) {
+                return std::task::Poll::Ready(());
+            }
+            self.state.cancel_waker.register(cx.waker());
+            if self.state.cancelled.load(Ordering::Acquire) {
+                std::task::Poll::Ready(())
+            } else {
+                std::task::Poll::Pending
+            }
+        });
+
+        if let Some(deadline) = self.deadline() {
+            let duration = deadline
+                .duration_since(std::time::SystemTime::now())
+                .unwrap_or_default();
+            futures::pin_mut!(explicit_cancel);
+            let deadline = tokio::time::sleep(duration);
+            futures::pin_mut!(deadline);
+            let _ = futures::future::select(explicit_cancel, deadline).await;
+        } else {
+            explicit_cancel.await;
+        }
+    }
+}
+
+/// Marks an abandoned driver/stream as cancelled when its future is dropped.
+pub(crate) struct RunStatusGuard(RunControlHandle);
+
+impl Drop for RunStatusGuard {
+    fn drop(&mut self) {
+        if !self.0.status().is_terminal() {
+            self.0.set_status(RunStatus::Cancelled);
+            self.0.cancel();
+        }
+    }
+}
+
+/// Framework-populated, tool-visible context for the current run.
+///
+/// It is inserted into [`ToolCallExtensions`](crate::tool::ToolCallExtensions)
+/// automatically. It remains host-only and is never serialized into model input.
+#[derive(Clone, Debug)]
+pub struct RunContext {
+    control: RunControlHandle,
+    conversation_id: Option<String>,
+}
+
+impl RunContext {
+    pub(crate) fn new(control: RunControlHandle, conversation_id: Option<String>) -> Self {
+        Self {
+            control,
+            conversation_id,
+        }
+    }
+
+    /// Stable process-scoped run identifier.
+    pub fn run_id(&self) -> &RunId {
+        self.control.run_id()
+    }
+
+    /// Durable host conversation identifier, when configured.
+    pub fn conversation_id(&self) -> Option<&str> {
+        self.conversation_id.as_deref()
+    }
+
+    /// Whether cancellation has been requested.
+    pub fn is_cancelled(&self) -> bool {
+        self.control.is_cancelled()
+    }
+
+    /// Configured absolute deadline.
+    pub fn deadline(&self) -> Option<std::time::SystemTime> {
+        self.control.deadline()
+    }
+
+    /// Clone the host control handle.
+    pub fn control(&self) -> RunControlHandle {
+        self.control.clone()
+    }
+}

--- a/crates/rig-core/src/agent/hook.rs
+++ b/crates/rig-core/src/agent/hook.rs
@@ -225,6 +225,7 @@ pub struct Scratchpad {
     // `tool_concurrency > 1` several tools' `ToolCall`/`ToolResult` hooks may
     // touch this concurrently, so the lock is load-bearing, not decorative.
     inner: Arc<std::sync::Mutex<ToolCallExtensions>>,
+    calls: Arc<std::sync::Mutex<std::collections::HashMap<String, ToolCallExtensions>>>,
 }
 
 impl Scratchpad {
@@ -281,6 +282,76 @@ impl Scratchpad {
         guard.insert(val);
         out
     }
+
+    /// Return isolated state for one internal tool-call identifier.
+    ///
+    /// Different concurrent calls cannot overwrite or consume each other's
+    /// values even when they store the same Rust type.
+    pub fn for_call(&self, internal_call_id: impl Into<String>) -> CallScratchpad {
+        CallScratchpad {
+            id: internal_call_id.into(),
+            calls: self.calls.clone(),
+        }
+    }
+}
+
+/// Type-keyed hook state isolated to one tool call.
+#[derive(Clone, Debug)]
+pub struct CallScratchpad {
+    id: String,
+    calls: Arc<std::sync::Mutex<std::collections::HashMap<String, ToolCallExtensions>>>,
+}
+
+impl CallScratchpad {
+    fn lock(
+        &self,
+    ) -> std::sync::MutexGuard<'_, std::collections::HashMap<String, ToolCallExtensions>> {
+        self.calls.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Insert a value for this call, returning the previous value of its type.
+    pub fn insert<T>(&self, value: T) -> Option<T>
+    where
+        T: Clone + WasmCompatSend + WasmCompatSync + 'static,
+    {
+        self.lock()
+            .entry(self.id.clone())
+            .or_default()
+            .insert(value)
+    }
+
+    /// Clone a value stored for this call.
+    pub fn get<T>(&self) -> Option<T>
+    where
+        T: Clone + WasmCompatSend + WasmCompatSync + 'static,
+    {
+        self.lock()
+            .get(&self.id)
+            .and_then(|state| state.get::<T>().cloned())
+    }
+
+    /// Atomically update a value for this call, starting from `Default`.
+    pub fn update<T, R>(&self, f: impl FnOnce(&mut T) -> R) -> R
+    where
+        T: Clone + Default + WasmCompatSend + WasmCompatSync + 'static,
+    {
+        let mut calls = self.lock();
+        let state = calls.entry(self.id.clone()).or_default();
+        let mut value = state.remove::<T>().unwrap_or_default();
+        let output = f(&mut value);
+        state.insert(value);
+        output
+    }
+
+    /// Remove a value stored for this call.
+    pub fn remove<T>(&self) -> Option<T>
+    where
+        T: Clone + WasmCompatSend + WasmCompatSync + 'static,
+    {
+        self.lock()
+            .get_mut(&self.id)
+            .and_then(|state| state.remove::<T>())
+    }
 }
 
 impl std::fmt::Debug for Scratchpad {
@@ -321,9 +392,18 @@ impl HookContext {
     /// Build a fresh run-scoped context. `is_streaming` records which surface is
     /// driving ([`run`](crate::agent::AgentRunner::run) vs.
     /// [`stream`](crate::agent::AgentRunner::stream)).
+    #[cfg(test)]
     pub(crate) fn new(is_streaming: bool, agent_name: Option<String>) -> Self {
+        Self::with_run_id(RunId::generate(), is_streaming, agent_name)
+    }
+
+    pub(crate) fn with_run_id(
+        run_id: RunId,
+        is_streaming: bool,
+        agent_name: Option<String>,
+    ) -> Self {
         Self {
-            run_id: RunId::generate(),
+            run_id,
             turn: AtomicUsize::new(0),
             is_streaming,
             agent_name,

--- a/crates/rig-core/src/agent/inject.rs
+++ b/crates/rig-core/src/agent/inject.rs
@@ -1,0 +1,134 @@
+//! Inject messages into an agent run while it is in flight.
+//!
+//! A long-running agent — a multi-turn tool loop or a background worker —
+//! sometimes needs to hear about something that happened *after* it was
+//! prompted: a user follow-up, an external event, a cancellation note.
+//! [`MessageInjector`] is the handle for that — a cloneable, `Send` mailbox
+//! bound to a single run. A message pushed through it is delivered as its own
+//! user turn immediately before the run's next model call.
+//!
+//! ```rust,ignore
+//! let mut runner = agent.runner("Investigate and report.").max_turns(10);
+//! let injector = runner.message_injector();
+//!
+//! let run = tokio::spawn(async move { runner.run().await });
+//!
+//! // ...from a watcher task, when something happens externally:
+//! injector.inject("Heads up: the deploy just failed, factor that in.")?;
+//!
+//! let response = run.await??;
+//! ```
+//!
+//! # Delivery semantics
+//!
+//! Injection is **best-effort, in-flight delivery**: a message is folded into
+//! the conversation immediately before the next model call (any tool calls
+//! already in flight on the current turn finish first). If the run *finishes*
+//! before that next model call — i.e. there is no further turn to deliver on —
+//! the message is not delivered, and a subsequent [`inject`](MessageInjector::inject)
+//! returns [`MessageInjectError::RunFinished`]. Injection does not resurrect a
+//! completed run; to continue a finished conversation, start a new run with the
+//! prior history.
+//!
+//! The message is delivered as a **separate user turn**, never merged into a
+//! preceding tool-result message: that mixed shape is dropped by OpenAI's
+//! converter and is non-idiomatic on Anthropic, whereas consecutive user turns
+//! are combined by Anthropic and accepted by OpenAI.
+//!
+//! # Design
+//!
+//! The mechanism splits cleanly across the two layers: the sans-IO [`AgentRun`]
+//! owns *folding* injected messages into the conversation
+//! ([`AgentRun::inject_message`]) as a plain, serializable state transition a
+//! hand-driver can call; the async [`AgentRunner`](crate::agent::AgentRunner)
+//! owns the *transport* — a [`futures::channel::mpsc`] queue drained before each
+//! model call. Both the blocking and streaming drivers use the same helpers, so
+//! injection behaves identically.
+//!
+//! The "fold input between steps" point mirrors pydantic-ai's `AgentRun.enqueue`,
+//! Vercel AI SDK's `prepareStep`, and LangGraph's `Command(resume=…)` — but needs
+//! no checkpointer: delivery is in-process for the lifetime of the run.
+
+use futures::channel::mpsc::{UnboundedReceiver, UnboundedSender, unbounded};
+
+use crate::agent::run::AgentRun;
+use crate::completion::Message;
+
+/// A cloneable handle for injecting messages into a single in-flight agent run.
+///
+/// Obtain one from [`AgentRunner::message_injector`](crate::agent::AgentRunner::message_injector)
+/// (or the equivalent on [`PromptRequest`](crate::agent::PromptRequest) /
+/// [`StreamingPromptRequest`](crate::agent::prompt_request::streaming::StreamingPromptRequest))
+/// *before* the run starts, then move the runner into a task and push from
+/// anywhere holding the handle. Cloning yields another producer for the same
+/// run, so several tasks can inject concurrently.
+///
+/// The handle goes inert once the run ends: [`inject`](Self::inject) then returns
+/// [`MessageInjectError::RunFinished`].
+#[derive(Clone, Debug)]
+pub struct MessageInjector {
+    tx: UnboundedSender<Message>,
+}
+
+impl MessageInjector {
+    /// Queue a message for delivery to the run this handle is bound to.
+    ///
+    /// Delivery is best-effort and in-flight: the message is folded into the
+    /// conversation as a user turn before the run's next model call (tool calls
+    /// already in flight on the current turn finish first). It accepts anything
+    /// that converts into a [`Message`]; a `&str`/`String` becomes a user
+    /// message, which is the intended shape.
+    ///
+    /// # Errors
+    /// Returns [`MessageInjectError::RunFinished`] if the run has already
+    /// finished — or if the runner was dropped without being started — so the
+    /// receiver is gone and the message cannot be delivered. (Injecting *before*
+    /// the run starts is fine: the message is folded into the first turn.) Note
+    /// that a message queued while the run is still active but which the run
+    /// finishes before consuming is dropped (and logged) rather than reported
+    /// through this call — see the [module docs](self).
+    pub fn inject(&self, message: impl Into<Message>) -> Result<(), MessageInjectError> {
+        self.tx
+            .unbounded_send(message.into())
+            .map_err(|_| MessageInjectError::RunFinished)
+    }
+
+    /// Whether the bound run is still accepting injected messages.
+    ///
+    /// A best-effort hint: the run may finish between this check and the next
+    /// [`inject`](Self::inject), so a `true` result does not guarantee delivery.
+    pub fn is_active(&self) -> bool {
+        !self.tx.is_closed()
+    }
+}
+
+/// Why a [`MessageInjector::inject`] call could not accept its message.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum MessageInjectError {
+    /// The run has already finished (or never started), so its receiver is gone.
+    #[error("cannot inject a message: the agent run has already finished")]
+    RunFinished,
+}
+
+/// Create a paired injector handle and the receiver the driver drains. The
+/// driver keeps the receiver for the run's lifetime; dropping it (when the run
+/// finishes) is what makes a later [`MessageInjector::inject`] fail.
+pub(crate) fn injector_channel() -> (MessageInjector, UnboundedReceiver<Message>) {
+    let (tx, rx) = unbounded();
+    (MessageInjector { tx }, rx)
+}
+
+/// Drain every message currently queued on `rx` into `run` (a no-op when no
+/// injector was attached). Called at the top of each drive-loop iteration, so
+/// queued messages are folded in by the next [`AgentRun::next_step`].
+pub(crate) fn drain_injections(rx: &mut Option<UnboundedReceiver<Message>>, run: &mut AgentRun) {
+    let Some(rx) = rx.as_mut() else {
+        return;
+    };
+    // `try_recv` yields `Ok(_)` per ready message and `Err` once the queue is
+    // empty (or every sender has dropped); either stops the drain.
+    while let Ok(message) = rx.try_recv() {
+        run.inject_message(message);
+    }
+}

--- a/crates/rig-core/src/agent/mod.rs
+++ b/crates/rig-core/src/agent/mod.rs
@@ -106,7 +106,9 @@
 //! ```
 mod builder;
 mod completion;
+pub mod control;
 pub mod hook;
+pub mod inject;
 pub(crate) mod prompt_request;
 pub mod run;
 pub mod runner;
@@ -119,10 +121,12 @@ pub(crate) const UNKNOWN_AGENT_NAME: &str = "Unnamed Agent";
 pub use crate::message::Text;
 pub use builder::{AgentBuilder, NoToolConfig, WithBuilderTools, WithToolServerHandle};
 pub use completion::Agent;
+pub use control::{RunContext, RunControlHandle, RunStatus};
 pub use hook::{
-    AgentHook, Flow, HookContext, HookStack, InvalidToolCallContext, InvalidToolCallHookAction,
-    RequestPatch, RunId, Scratchpad, StepEvent, StepEventKind,
+    AgentHook, CallScratchpad, Flow, HookContext, HookStack, InvalidToolCallContext,
+    InvalidToolCallHookAction, RequestPatch, RunId, Scratchpad, StepEvent, StepEventKind,
 };
+pub use inject::{MessageInjectError, MessageInjector};
 pub use prompt_request::streaming::{
     MultiTurnStreamItem, StreamingError, StreamingPromptRequest, StreamingResult, stream_to_stdout,
 };
@@ -131,3 +135,4 @@ pub use prompt_request::{
 };
 pub use run::{AgentRun, AgentRunStep, ModelTurn, ModelTurnOutcome, OutputMode, PendingToolCall};
 pub use runner::AgentRunner;
+pub use tool::{DEFAULT_SUBAGENT_DEPTH_LIMIT, SubagentDepth};

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -169,6 +169,19 @@ where
         self
     }
 
+    /// Arm this request for run-scoped message injection.
+    ///
+    /// Obtain the handle before awaiting the request, then inject from another
+    /// task. Messages are delivered before the next model call.
+    pub fn message_injector(&mut self) -> crate::agent::MessageInjector {
+        self.runner.message_injector()
+    }
+
+    /// Obtain the host-control handle before awaiting this request.
+    pub fn run_control(&self) -> crate::agent::RunControlHandle {
+        self.runner.run_control()
+    }
+
     forward_prompt_setters!(runner);
     forward_tool_concurrency!(runner);
 }
@@ -490,6 +503,19 @@ pub(crate) fn tool_result_output(
     output: String,
 ) -> UserContent {
     tool_result_with(id, call_id, ToolResultContent::from_tool_output(output))
+}
+
+/// Shape a real structured execution result, preferring direct rich content and
+/// falling back to the legacy string compatibility parser.
+pub(crate) fn tool_result_execution(
+    id: String,
+    call_id: Option<String>,
+    result: &crate::tool::ToolExecutionResult,
+) -> UserContent {
+    match result.model_content() {
+        Some(content) => tool_result_with(id, call_id, content.clone()),
+        None => tool_result_output(id, call_id, result.model_output().to_owned()),
+    }
 }
 
 /// Shape a **synthetic message** (a hook skip reason, recovery feedback, or a

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -20,14 +20,14 @@ use crate::{
     tool::ToolCallExtensions,
     wasm_compat::{WasmBoxedFuture, WasmCompatSend},
 };
-use futures::{Stream, StreamExt, stream};
+use futures::{FutureExt, Stream, StreamExt, stream};
 use serde::{Deserialize, Serialize};
 use std::{collections::VecDeque, pin::Pin, sync::Arc};
 use tracing_futures::Instrument;
 
 use super::{CompletionCall, PromptResponse, forward_prompt_setters};
 use crate::{
-    agent::Agent,
+    agent::{Agent, RunStatus, inject::drain_injections},
     completion::{CompletionError, CompletionModel, PromptError},
     message::{Message, Text},
     tool::ToolSetError,
@@ -342,6 +342,16 @@ where
         self
     }
 
+    /// Arm this request for run-scoped message injection.
+    pub fn message_injector(&mut self) -> crate::agent::MessageInjector {
+        self.runner.message_injector()
+    }
+
+    /// Obtain the host-control handle before starting this stream.
+    pub fn run_control(&self) -> crate::agent::RunControlHandle {
+        self.runner.run_control()
+    }
+
     forward_prompt_setters!(runner);
 
     async fn send(self) -> StreamingResult<M::StreamingResponse> {
@@ -462,7 +472,7 @@ pub(crate) fn streaming_error_into_prompt(err: StreamingError) -> PromptError {
 /// a [`TurnSource`]. The streaming surface forwards the yielded [`DriveItem`]s;
 /// the blocking surface folds them to `Done`.
 pub(crate) fn drive_agent<M, S>(
-    runner: AgentRunner<M>,
+    mut runner: AgentRunner<M>,
     mut source: S,
     mut run: AgentRun,
     agent_span: tracing::Span,
@@ -475,15 +485,37 @@ where
     S: TurnSource<M>,
 {
     async_stream::stream! {
-        // Run-scoped hook context: minted once, shared by every hook event on
-        // both surfaces. `is_streaming` records which surface is driving; the
-        // per-turn index is advanced on each `CallModel` step below.
-        let hook_ctx = HookContext::new(is_streaming, runner.agent_name.clone());
+        runner.prepare_run_context();
+        runner.run_control.set_status(RunStatus::Running);
+        let _status_guard = runner.run_control.status_guard();
+        // Hooks and the host handle share exactly one run identity.
+        let hook_ctx = HookContext::with_run_id(
+            runner.run_control.run_id().clone(),
+            is_streaming,
+            runner.agent_name.clone(),
+        );
 
         'outer: loop {
+            // Delivery and cancellation are run-scoped and observed at every
+            // state-machine boundary.
+            drain_injections(&mut runner.injection_rx, &mut run);
+            if runner.run_control.is_cancelled() {
+                runner.run_control.set_status(RunStatus::Cancelled);
+                yield Err(StreamingError::Prompt(Box::new(
+                    run.cancel_error("cancelled by host")
+                )));
+                break 'outer;
+            }
+
             let step = match run.next_step() {
                 Ok(step) => step,
                 Err(err) => {
+                    let status = if matches!(err, PromptError::MaxTurnsError { .. }) {
+                        RunStatus::Exhausted
+                    } else {
+                        RunStatus::Failed
+                    };
+                    runner.run_control.set_status(status);
                     yield Err(Box::new(err).into());
                     break 'outer;
                 }
@@ -499,6 +531,7 @@ where
                     let request_patch =
                         match resolve_completion_call(&runner.hooks, &hook_ctx, &prompt, &history, turn).await {
                             CompletionCallOutcome::Terminate(reason) => {
+                                runner.run_control.set_status(RunStatus::Cancelled);
                                 yield Err(StreamingError::Prompt(Box::new(run.cancel_error(reason))));
                                 break 'outer;
                             }
@@ -540,6 +573,7 @@ where
                     {
                         Ok(prepared) => prepared,
                         Err(err) => {
+                            runner.run_control.set_status(RunStatus::Failed);
                             yield Err(err.into());
                             break 'outer;
                         }
@@ -556,17 +590,36 @@ where
                         prompt,
                     );
                     let mut errored = false;
-                    while let Some(item) = turn_stream.next().await {
-                        match item {
-                            Ok(item) => yield Ok(DriveItem::Item(item)),
-                            Err(err) => {
+                    let mut cancelled_by_host = false;
+                    loop {
+                        let next_item = turn_stream.next().fuse();
+                        let cancelled = runner.run_control.cancelled().fuse();
+                        futures::pin_mut!(next_item, cancelled);
+                        futures::select_biased! {
+                            _ = cancelled => {
+                                runner.run_control.set_status(RunStatus::Cancelled);
                                 errored = true;
-                                yield Err(err);
+                                cancelled_by_host = true;
                                 break;
+                            }
+                            item = next_item => match item {
+                                Some(Ok(item)) => yield Ok(DriveItem::Item(item)),
+                                Some(Err(err)) => {
+                                    runner.run_control.set_status(RunStatus::Failed);
+                                    errored = true;
+                                    yield Err(err);
+                                    break;
+                                }
+                                None => break,
                             }
                         }
                     }
                     drop(turn_stream);
+                    if cancelled_by_host {
+                        yield Err(StreamingError::Prompt(Box::new(
+                            run.cancel_error("cancelled by host")
+                        )));
+                    }
                     if errored {
                         break 'outer;
                     }
@@ -574,22 +627,52 @@ where
                 AgentRunStep::CallTools { calls } => {
                     let mut tool_stream = source.run_tool_calls(&runner, &hook_ctx, &mut run, calls);
                     let mut errored = false;
-                    while let Some(item) = tool_stream.next().await {
-                        match item {
-                            Ok(item) => yield Ok(DriveItem::Item(item)),
-                            Err(err) => {
+                    let mut cancelled_by_host = false;
+                    loop {
+                        let next_item = tool_stream.next().fuse();
+                        let cancelled = runner.run_control.cancelled().fuse();
+                        futures::pin_mut!(next_item, cancelled);
+                        futures::select_biased! {
+                            _ = cancelled => {
+                                runner.run_control.set_status(RunStatus::Cancelled);
                                 errored = true;
-                                yield Err(err);
+                                cancelled_by_host = true;
                                 break;
+                            }
+                            item = next_item => match item {
+                                Some(Ok(item)) => yield Ok(DriveItem::Item(item)),
+                                Some(Err(err)) => {
+                                    runner.run_control.set_status(RunStatus::Failed);
+                                    errored = true;
+                                    yield Err(err);
+                                    break;
+                                }
+                                None => break,
                             }
                         }
                     }
                     drop(tool_stream);
+                    if cancelled_by_host {
+                        yield Err(StreamingError::Prompt(Box::new(
+                            run.cancel_error("cancelled by host")
+                        )));
+                    }
                     if errored {
                         break 'outer;
                     }
                 }
                 AgentRunStep::Done(response) => {
+                    // Close the mailbox before persistence/telemetry so late
+                    // producers fail rather than queueing undeliverable input.
+                    drain_injections(&mut runner.injection_rx, &mut run);
+                    if run.has_pending_injections() {
+                        tracing::warn!(
+                            "message injected as the run was finishing was not delivered"
+                        );
+                    }
+                    let _ = runner.injection_rx.take();
+                    runner.run_control.set_status(RunStatus::Completed);
+
                     // Run-completion marker, unifying the blocking and streaming
                     // drivers' run-finished logs into one shared event.
                     tracing::info!(
@@ -1929,6 +2012,8 @@ mod tests {
 
     fn arithmetic_tool_definition(name: &str, description: &str) -> ToolDefinition {
         ToolDefinition {
+            output_schema: None,
+            metadata: Default::default(),
             name: name.to_string(),
             description: description.to_string(),
             parameters: serde_json::json!({

--- a/crates/rig-core/src/agent/run/mod.rs
+++ b/crates/rig-core/src/agent/run/mod.rs
@@ -306,6 +306,18 @@ pub struct AgentRun {
     /// [`AgentRunStep::CallModel`] is emitted.
     #[serde(default)]
     streamed_completion_call_recorded: bool,
+    /// Messages enqueued by an external driver (via [`AgentRun::inject_message`])
+    /// to fold into the conversation immediately before the next model call. See
+    /// the [`inject`](crate::agent::inject) module.
+    #[serde(default)]
+    pending_injections: Vec<Message>,
+    /// Set when the next [`RunState::PreparingRequest`] is a *re-entry* that
+    /// already appended its own trailing message — an output-mode reprompt or an
+    /// invalid-tool-call retry — so injected messages are not folded in after
+    /// that feedback (which would derail it). Cleared when consumed; injections
+    /// wait for the next ordinary turn.
+    #[serde(default)]
+    skip_injection_fold: bool,
     state: RunState,
 }
 
@@ -330,6 +342,8 @@ impl AgentRun {
             invalid_tool_call_retries: 0,
             rollback_pending: false,
             streamed_completion_call_recorded: false,
+            pending_injections: Vec::new(),
+            skip_injection_fold: false,
             state: RunState::PreparingRequest,
         }
     }
@@ -408,6 +422,8 @@ impl AgentRun {
     /// [`AgentRunStep::CallModel`].
     fn reprompt_for_output(&mut self) -> Result<AgentRunStep, PromptError> {
         self.output_retries += 1;
+        // The corrective feedback must remain the prompt for the reprompt turn.
+        self.skip_injection_fold = true;
         self.state = RunState::PreparingRequest;
         self.next_step()
     }
@@ -481,6 +497,50 @@ impl AgentRun {
         build_full_history(self.chat_history.as_deref(), self.new_messages.clone())
     }
 
+    /// Enqueue a message to fold into the conversation immediately before the
+    /// next model call.
+    ///
+    /// The message is buffered (not appended right away) and folded in at the
+    /// next [`AgentRunStep::CallModel`] boundary, so injecting mid-turn — while a
+    /// model response or tool results are still pending — never corrupts the
+    /// in-flight turn. It is folded in as its **own** message (never merged into
+    /// a preceding message): an injected user message becomes a distinct user
+    /// turn, which providers either combine with an adjacent user turn (Anthropic)
+    /// or accept as-is (OpenAI), and which — unlike merging into a tool-result
+    /// message — is never silently dropped. Injection delivers **user** turns:
+    /// a non-user message (the `&str`/`String` path always produces a user one)
+    /// is ignored with a warning rather than allowed to corrupt the request. See
+    /// the [`inject`](crate::agent::inject) module for the async, channel-driven
+    /// handle most callers use.
+    pub fn inject_message(&mut self, message: impl Into<Message>) {
+        let message = message.into();
+        // Injection delivers a *user* turn (the `&str`/`String` conversion
+        // produces one). A non-user message would become the next prompt and
+        // break the request's role structure, so drop it with a warning rather
+        // than corrupt the turn.
+        if !matches!(message, Message::User { .. }) {
+            tracing::warn!(
+                "inject_message ignored a non-user message; injection delivers user turns only"
+            );
+            return;
+        }
+        self.pending_injections.push(message);
+    }
+
+    /// Whether any injected messages are buffered but not yet folded in.
+    pub fn has_pending_injections(&self) -> bool {
+        !self.pending_injections.is_empty()
+    }
+
+    /// Fold every buffered injected message into the accumulated conversation as
+    /// its own message, in injection order. Called at the
+    /// [`RunState::PreparingRequest`] boundary so the messages become part of the
+    /// request the driver is about to build (the last one becomes this turn's
+    /// prompt; the rest precede it in history).
+    fn apply_pending_injections(&mut self) {
+        self.new_messages.append(&mut self.pending_injections);
+    }
+
     /// Whether the run reached [`AgentRunStep::Done`].
     pub fn is_done(&self) -> bool {
         matches!(self.state, RunState::Done(_))
@@ -546,6 +606,15 @@ impl AgentRun {
     pub fn next_step(&mut self) -> Result<AgentRunStep, PromptError> {
         match std::mem::replace(&mut self.state, RunState::Failed) {
             RunState::PreparingRequest => {
+                // Fold in any messages injected since the last model call before
+                // choosing this turn's prompt/history (see the `inject` module) —
+                // unless this is a reprompt/retry re-entry that already appended
+                // its own trailing feedback message, which an injection must not
+                // displace as the prompt.
+                if !std::mem::take(&mut self.skip_injection_fold) {
+                    self.apply_pending_injections();
+                }
+
                 let Some((prompt_ref, history_for_turn)) = self.new_messages.split_last() else {
                     return Err(PromptError::prompt_cancelled(
                         self.full_history(),
@@ -915,6 +984,8 @@ impl AgentRun {
                     ));
                 };
                 self.new_messages.push(user_message);
+                // The retry feedback must remain the prompt for the retry turn.
+                self.skip_injection_fold = true;
                 self.state = RunState::PreparingRequest;
                 Ok(ModelTurnOutcome::TurnRetried)
             }
@@ -2418,5 +2489,168 @@ mod tests {
         );
         let response = expect_done(&mut resumed);
         assert_eq!(response.output, "done");
+    }
+
+    // ---- Message injection ----
+
+    /// Whether a message is a user turn carrying a tool result (and no injected
+    /// text) — i.e. the injection was *not* merged into it.
+    fn is_tool_result_only_user(message: &Message) -> bool {
+        matches!(message, Message::User { content }
+            if content.iter().all(|c| matches!(c, UserContent::ToolResult(_))))
+    }
+
+    #[test]
+    fn injected_message_is_delivered_as_its_own_user_turn_after_tool_results() {
+        let mut run = AgentRun::new("start").max_turns(3);
+
+        // Turn 1: the model calls a tool, so the run keeps going.
+        expect_call_model(&mut run);
+        expect_continue(
+            run.model_response(tool_call_turn("c1", "add"))
+                .expect("model_response 1"),
+        );
+        expect_call_tools(&mut run);
+
+        // A message injected while tools execute is buffered, not folded mid-turn.
+        run.inject_message("heads up: prioritize correctness");
+        assert!(run.has_pending_injections());
+        run.tool_results(vec![tool_result("c1", "2")])
+            .expect("tool_results");
+
+        // Turn 2: the injection is delivered as its OWN user turn (the prompt),
+        // NOT merged into the trailing tool-result message — that mixed shape is
+        // what OpenAI's converter silently drops.
+        let (prompt, history, turn) = expect_call_model(&mut run);
+        assert_eq!(turn, 2);
+        assert!(!run.has_pending_injections());
+        assert_eq!(prompt, Message::user("heads up: prioritize correctness"));
+        assert!(
+            is_tool_result_only_user(history.last().expect("history has the tool-result turn")),
+            "the tool result stays its own message; the injection is not merged into it"
+        );
+    }
+
+    #[test]
+    fn injected_messages_fold_in_order_each_as_its_own_turn() {
+        let mut run = AgentRun::new("prompt");
+        run.inject_message("first");
+        run.inject_message("second");
+
+        let (prompt, history, _turn) = expect_call_model(&mut run);
+        // new_messages = [user(prompt), user(first), user(second)]; the last is
+        // this turn's prompt, the rest precede it in history, each distinct.
+        assert_eq!(prompt, Message::user("second"));
+        assert_eq!(
+            history,
+            vec![Message::user("prompt"), Message::user("first")]
+        );
+    }
+
+    #[test]
+    fn pending_injection_survives_serialization_mid_tool_loop() {
+        let mut run = AgentRun::new("pay invoice").max_turns(3);
+        expect_call_model(&mut run);
+        expect_continue(
+            run.model_response(tool_call_turn("c1", "add"))
+                .expect("model_response"),
+        );
+        // Suspend in the ExecutingTools state with a buffered injection — the
+        // durable-interrupt scenario.
+        expect_call_tools(&mut run);
+        run.inject_message("urgent: also check the balance");
+        assert!(run.has_pending_injections());
+
+        let checkpoint = serde_json::to_string(&run).expect("serialize");
+        let mut resumed: AgentRun = serde_json::from_str(&checkpoint).expect("deserialize");
+        assert!(
+            resumed.has_pending_injections(),
+            "the buffered injection must survive an ExecutingTools round-trip"
+        );
+
+        // Re-emit the pending calls from state, answer them, and confirm the
+        // injected message is delivered on the next turn.
+        let calls = expect_call_tools(&mut resumed);
+        resumed
+            .tool_results(vec![tool_result(&calls[0].tool_call.id, "balance ok")])
+            .expect("tool_results");
+        let (prompt, _history, _turn) = expect_call_model(&mut resumed);
+        // Compare on text, not full-message equality: a serde round-trip
+        // normalizes `Text.additional_params` from `None` to `Some({})`.
+        let Message::User { content } = &prompt else {
+            panic!("expected a user prompt, got {prompt:?}");
+        };
+        assert!(
+            content.iter().any(|c| matches!(
+                c,
+                UserContent::Text(text) if text.text == "urgent: also check the balance"
+            )),
+            "the resumed turn must carry the injected text"
+        );
+    }
+
+    #[test]
+    fn injection_does_not_derail_an_invalid_tool_call_retry() {
+        let mut run = AgentRun::new("call something")
+            .max_turns(5)
+            .max_invalid_tool_call_retries(1);
+
+        expect_call_model(&mut run);
+        expect_needs_resolution(
+            run.model_response(tool_call_turn("call_1", "unknown"))
+                .expect("model_response"),
+        );
+
+        // Inject before the retry resolves: the retry's corrective feedback must
+        // remain the prompt, not be displaced by the injection.
+        run.inject_message("injected mid-retry");
+        let outcome = run
+            .resolve_invalid_tool_call(InvalidToolCallHookAction::retry("use add instead"))
+            .expect("retry accepted");
+        assert!(matches!(outcome, ModelTurnOutcome::TurnRetried));
+
+        // Turn 2 (the retry): the prompt is the feedback (a tool-result message),
+        // and the injection is still buffered for a later turn.
+        let (prompt, _history, turn) = expect_call_model(&mut run);
+        assert_eq!(turn, 2);
+        assert!(
+            matches!(prompt, Message::User { ref content }
+                if matches!(content.first(), UserContent::ToolResult(_))),
+            "the retry feedback, not the injection, must be the prompt"
+        );
+        assert!(
+            run.has_pending_injections(),
+            "the injection waits for the next ordinary turn"
+        );
+
+        // The model makes progress with a real tool, keeping the run going.
+        expect_continue(
+            run.model_response(tool_call_turn("call_2", "add"))
+                .expect("model_response"),
+        );
+        let calls = expect_call_tools(&mut run);
+        run.tool_results(vec![tool_result(&calls[0].tool_call.id, "5")])
+            .expect("tool_results");
+
+        // Turn 3 (ordinary): now the buffered injection is delivered as the prompt.
+        let (prompt, _history, turn) = expect_call_model(&mut run);
+        assert_eq!(turn, 3);
+        assert_eq!(prompt, Message::user("injected mid-retry"));
+        assert!(!run.has_pending_injections());
+    }
+
+    #[test]
+    fn non_user_injection_is_ignored() {
+        let mut run = AgentRun::new("hello");
+        run.inject_message(Message::assistant("I am an assistant message"));
+        assert!(
+            !run.has_pending_injections(),
+            "a non-user injected message is dropped, not buffered"
+        );
+
+        // The run proceeds with only the original prompt.
+        let (prompt, history, _turn) = expect_call_model(&mut run);
+        assert_eq!(prompt, Message::user("hello"));
+        assert!(history.is_empty());
     }
 }

--- a/crates/rig-core/src/agent/runner.rs
+++ b/crates/rig-core/src/agent/runner.rs
@@ -30,21 +30,23 @@ use std::sync::{
     atomic::{AtomicU64, Ordering},
 };
 
-use futures::StreamExt;
+use futures::{StreamExt, channel::mpsc::UnboundedReceiver};
 use tracing::{Instrument, info_span, span::Id};
 
 use super::{
     completion::{Agent, DynamicContextStore, PreparedCompletionRequest},
+    control::{RunContext, RunControlHandle},
     hook::{
         AgentHook, Flow, HookContext, HookStack, InvalidToolCallHookAction, RequestPatch, StepEvent,
     },
+    inject::{MessageInjector, injector_channel},
     prompt_request::{
         PromptResponse,
         streaming::{
             DriveItem, DriveStream, MultiTurnStreamItem, StreamingError, TurnSource, drive_agent,
             drive_tool_calls, record_usage_on_span, streaming_error_into_prompt,
         },
-        tool_result_message, tool_result_output,
+        tool_result_execution, tool_result_message,
     },
     run::{
         AgentRun, DEFAULT_OUTPUT_RETRIES, ModelTurn, ModelTurnOutcome, OutputMode, PendingToolCall,
@@ -291,6 +293,9 @@ where
     pub(crate) memory: Option<Arc<dyn ConversationMemory>>,
     pub(crate) conversation_id: Option<String>,
     pub(crate) hooks: HookStack<M>,
+    /// Receiver for messages injected into this run at safe model-call boundaries.
+    pub(crate) injection_rx: Option<UnboundedReceiver<Message>>,
+    pub(crate) run_control: RunControlHandle,
 }
 
 impl<M> AgentRunner<M>
@@ -300,6 +305,8 @@ where
     /// Build a runner from an agent, seeding it with the agent's default hook
     /// stack. Prefer [`Agent::runner`].
     pub fn from_agent(agent: &Agent<M>, prompt: impl Into<Message>) -> Self {
+        let (injector, injection_rx) = injector_channel();
+        let run_control = RunControlHandle::new(injector);
         Self {
             prompt: prompt.into(),
             chat_history: None,
@@ -322,7 +329,24 @@ where
             memory: agent.memory.clone(),
             conversation_id: agent.default_conversation_id.clone(),
             hooks: agent.hooks.clone(),
+            injection_rx: Some(injection_rx),
+            run_control,
         }
+    }
+
+    /// Arm this runner for message injection and return its run-bound handle.
+    ///
+    /// Messages are delivered in producer order immediately before the next
+    /// model call. An active tool batch settles before delivery. Clone the
+    /// returned handle for multiple producers rather than calling this method
+    /// again, which replaces the mailbox.
+    pub fn message_injector(&mut self) -> MessageInjector {
+        self.run_control.message_injector()
+    }
+
+    /// Return a cloneable host-control handle bound to this run.
+    pub fn run_control(&self) -> RunControlHandle {
+        self.run_control.clone()
     }
 
     /// Append a hook to the stack (on top of any the agent already carries).
@@ -349,6 +373,13 @@ where
     /// initial call. Exceeding the budget returns [`PromptError::MaxTurnsError`].
     pub fn max_turns(mut self, max_turns: usize) -> Self {
         self.max_turns = max_turns;
+        self
+    }
+
+    /// Set a cooperative deadline relative to when this builder is configured.
+    pub fn deadline_after(self, duration: std::time::Duration) -> Self {
+        self.run_control
+            .set_deadline(std::time::SystemTime::now() + duration);
         self
     }
 
@@ -427,6 +458,11 @@ where
     /// `history_override` replaces the configured chat history (e.g. with
     /// memory-loaded history). Delegates to [`build_agent_run`] — the single
     /// construction site shared with the streaming driver.
+    pub(crate) fn prepare_run_context(&mut self) {
+        let context = RunContext::new(self.run_control.clone(), self.conversation_id.clone());
+        self.tool_extensions.insert(context);
+    }
+
     pub(crate) fn build_run(&self, history_override: Option<Vec<Message>>) -> AgentRun {
         build_agent_run(
             self.prompt.clone(),
@@ -774,14 +810,10 @@ where
                 tool_result_message(
                     tool_call.id.clone(),
                     tool_call.call_id.clone(),
-                    exec.model_output,
+                    exec.model_output.clone(),
                 )
             } else {
-                tool_result_output(
-                    tool_call.id.clone(),
-                    tool_call.call_id.clone(),
-                    exec.model_output,
-                )
+                tool_result_execution(tool_call.id.clone(), tool_call.call_id.clone(), &exec)
             };
             Ok(ToolCallOutcome { content, execution })
         }
@@ -6197,5 +6229,36 @@ mod tests {
             tool_result_text_in_history(&messages, "denied by policy: `subtract` not allowed"),
             "the policy denial reason must reach the model as the subtract tool result"
         );
+    }
+
+    #[tokio::test]
+    async fn run_control_tracks_completion_and_steering() {
+        let model = MockCompletionModel::from_turns([MockTurn::text("done")]);
+        let runner = AgentBuilder::new(model.clone())
+            .build()
+            .runner("primary")
+            .max_turns(2);
+        let control = runner.run_control();
+        assert_eq!(control.status(), crate::agent::RunStatus::Pending);
+        control.steer("additional context").expect("steer accepted");
+
+        let response = runner.run().await.expect("run succeeds");
+        assert_eq!(response.output, "done");
+        assert_eq!(control.status(), crate::agent::RunStatus::Completed);
+        let request = serde_json::to_string(&model.requests()[0]).expect("request json");
+        assert!(request.contains("additional context"));
+    }
+
+    #[tokio::test]
+    async fn run_control_cancel_before_start_is_terminal() {
+        let model = MockCompletionModel::from_turns([MockTurn::text("unused")]);
+        let runner = AgentBuilder::new(model.clone()).build().runner("task");
+        let control = runner.run_control();
+        control.cancel();
+
+        let error = runner.run().await.expect_err("cancelled run must fail");
+        assert!(matches!(error, PromptError::PromptCancelled { .. }));
+        assert_eq!(control.status(), crate::agent::RunStatus::Cancelled);
+        assert_eq!(model.request_count(), 0);
     }
 }

--- a/crates/rig-core/src/agent/tool.rs
+++ b/crates/rig-core/src/agent/tool.rs
@@ -1,5 +1,5 @@
 use crate::{
-    agent::Agent,
+    agent::{Agent, RunContext},
     completion::{CompletionModel, Prompt, PromptError},
     tool::{Tool, ToolCallExtensions},
 };
@@ -12,6 +12,13 @@ pub struct AgentToolArgs {
     /// The prompt for the agent to call.
     prompt: String,
 }
+
+/// Parent/child delegation depth propagated through tool extensions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SubagentDepth(pub usize);
+
+/// Default maximum nested agent-as-tool depth.
+pub const DEFAULT_SUBAGENT_DEPTH_LIMIT: usize = 8;
 
 impl<M: CompletionModel + 'static> Tool for Agent<M> {
     const NAME: &'static str = "agent_tool";
@@ -52,9 +59,40 @@ impl<M: CompletionModel + 'static> Tool for Agent<M> {
         args: Self::Args,
         extensions: &ToolCallExtensions,
     ) -> Result<Self::Output, Self::Error> {
-        self.prompt(args.prompt)
-            .tool_extensions(extensions.clone())
-            .await
+        let depth = extensions
+            .get::<SubagentDepth>()
+            .copied()
+            .unwrap_or(SubagentDepth(0));
+        if depth.0 >= DEFAULT_SUBAGENT_DEPTH_LIMIT {
+            return Err(PromptError::prompt_cancelled(
+                Vec::new(),
+                format!("subagent depth limit ({DEFAULT_SUBAGENT_DEPTH_LIMIT}) reached"),
+            ));
+        }
+
+        let mut child_extensions = extensions.clone();
+        child_extensions.insert(SubagentDepth(depth.0 + 1));
+        let runner = self.runner(args.prompt).tool_extensions(child_extensions);
+        let child_control = runner.run_control();
+
+        if let Some(parent) = extensions.get::<RunContext>().cloned() {
+            let run = runner.run();
+            futures::pin_mut!(run);
+            let parent_control = parent.control();
+            let cancelled = parent_control.cancelled();
+            futures::pin_mut!(cancelled);
+            match futures::future::select(run, cancelled).await {
+                futures::future::Either::Left((result, _)) => {
+                    result.map(|response| response.output)
+                }
+                futures::future::Either::Right(((), run)) => {
+                    child_control.cancel();
+                    run.await.map(|response| response.output)
+                }
+            }
+        } else {
+            runner.run().await.map(|response| response.output)
+        }
     }
 
     fn name(&self) -> String {

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -371,7 +371,7 @@ pub struct ToolDefinition {
     /// JSON Schema describing tool arguments.
     pub parameters: serde_json::Value,
     /// Optional JSON Schema describing the model-visible result.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip)]
     pub output_schema: Option<serde_json::Value>,
     /// Host-only operational metadata. It is never sent to a model provider.
     #[serde(default, skip)]

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -321,6 +321,47 @@ impl std::fmt::Display for Document {
     }
 }
 
+/// Operational family of a registered tool. This metadata is host-only.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ToolKind {
+    /// In-process Rust tool.
+    #[default]
+    Native,
+    /// Model Context Protocol tool.
+    Mcp,
+    /// Dynamically discovered tool.
+    Dynamic,
+    /// Provider-hosted tool.
+    ProviderHosted,
+    /// Composite/wrapper tool.
+    Composite,
+}
+
+/// Per-tool execution scheduling policy. This metadata is host-only.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ToolExecutionPolicy {
+    /// The tool may execute alongside parallel-safe siblings.
+    #[default]
+    ParallelSafe,
+    /// The host should serialize this tool's execution.
+    Sequential,
+}
+
+/// Host-only catalog metadata attached to a tool definition.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
+pub struct ToolMetadata {
+    /// Tool operational family.
+    pub kind: ToolKind,
+    /// Scheduling policy.
+    pub execution: ToolExecutionPolicy,
+    /// Registration source or server identifier.
+    pub source: Option<String>,
+    /// Arbitrary host selector metadata.
+    pub attributes: serde_json::Map<String, serde_json::Value>,
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct ToolDefinition {
     /// Tool name exposed to the model. It must match the registered tool name.
@@ -329,6 +370,41 @@ pub struct ToolDefinition {
     pub description: String,
     /// JSON Schema describing tool arguments.
     pub parameters: serde_json::Value,
+    /// Optional JSON Schema describing the model-visible result.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_schema: Option<serde_json::Value>,
+    /// Host-only operational metadata. It is never sent to a model provider.
+    #[serde(default, skip)]
+    pub metadata: ToolMetadata,
+}
+
+impl ToolDefinition {
+    /// Construct a tool definition with conservative metadata and no output schema.
+    pub fn new(
+        name: impl Into<String>,
+        description: impl Into<String>,
+        parameters: serde_json::Value,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            description: description.into(),
+            parameters,
+            output_schema: None,
+            metadata: ToolMetadata::default(),
+        }
+    }
+
+    /// Attach a model-facing output schema.
+    pub fn with_output_schema(mut self, schema: serde_json::Value) -> Self {
+        self.output_schema = Some(schema);
+        self
+    }
+
+    /// Attach host-only operational metadata.
+    pub fn with_metadata(mut self, metadata: ToolMetadata) -> Self {
+        self.metadata = metadata;
+        self
+    }
 }
 
 /// Provider-native tool definition.
@@ -479,6 +555,36 @@ pub trait Completion<M: CompletionModel> {
         T: Into<Message>;
 }
 
+/// Provider-independent reason a model completion ended.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum CompletionFinishReason {
+    /// Natural model stop.
+    Stop,
+    /// Token/output limit truncation.
+    Length,
+    /// Provider content filtering.
+    ContentFilter,
+    /// Model handed control to tool execution.
+    ToolCalls,
+    /// Request cancellation.
+    Cancelled,
+    /// Provider-side failure.
+    Failed,
+    /// Unrecognized provider reason.
+    Other(String),
+}
+
+/// Normalized and raw provider terminal metadata.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompletionTerminalMetadata {
+    /// Normalized reason.
+    pub reason: CompletionFinishReason,
+    /// Provider-native reason/status when available.
+    pub raw_reason: Option<String>,
+}
+
 /// General completion response struct that contains the high-level completion choice
 /// and the raw response. The completion choice contains one or more assistant content.
 #[derive(Debug)]
@@ -495,6 +601,56 @@ pub struct CompletionResponse<T> {
     pub message_id: Option<String>,
 }
 
+impl<T> CompletionResponse<T>
+where
+    T: Serialize,
+{
+    /// Normalize common provider finish/status fields without requiring callers
+    /// to couple retry policy to a provider response type.
+    pub fn terminal_metadata(&self) -> Option<CompletionTerminalMetadata> {
+        fn find_reason(value: &serde_json::Value) -> Option<&str> {
+            match value {
+                serde_json::Value::Object(map) => {
+                    for key in [
+                        "finish_reason",
+                        "finishReason",
+                        "stop_reason",
+                        "stopReason",
+                        "status",
+                    ] {
+                        if let Some(reason) = map.get(key).and_then(serde_json::Value::as_str) {
+                            return Some(reason);
+                        }
+                    }
+                    map.values().find_map(find_reason)
+                }
+                serde_json::Value::Array(values) => values.iter().find_map(find_reason),
+                _ => None,
+            }
+        }
+
+        let raw = serde_json::to_value(&self.raw_response).ok()?;
+        let raw_reason = find_reason(&raw)?.to_owned();
+        let normalized = match raw_reason.to_ascii_lowercase().as_str() {
+            "stop" | "end_turn" | "completed" | "complete" => CompletionFinishReason::Stop,
+            "length" | "max_tokens" | "max_output_tokens" | "incomplete" => {
+                CompletionFinishReason::Length
+            }
+            "content_filter" | "safety" | "blocked" | "recitation" => {
+                CompletionFinishReason::ContentFilter
+            }
+            "tool_calls" | "tool_call" | "function_call" => CompletionFinishReason::ToolCalls,
+            "cancelled" | "canceled" => CompletionFinishReason::Cancelled,
+            "failed" | "error" => CompletionFinishReason::Failed,
+            _ => CompletionFinishReason::Other(raw_reason.clone()),
+        };
+        Some(CompletionTerminalMetadata {
+            reason: normalized,
+            raw_reason: Some(raw_reason),
+        })
+    }
+}
+
 /// A trait for grabbing the token usage of a completion response.
 ///
 /// Primarily designed for streamed completion responses in streamed multi-turn, as otherwise it would be impossible to do.
@@ -503,6 +659,11 @@ pub trait GetTokenUsage {
     /// [`Usage`]'s documented sentinel for missing provider usage metrics;
     /// response types that carry no usage return [`Usage::new`].
     fn token_usage(&self) -> crate::completion::Usage;
+
+    /// Terminal metadata for a completed stream, when the provider exposes it.
+    fn terminal_metadata(&self) -> Option<CompletionTerminalMetadata> {
+        None
+    }
 }
 
 impl GetTokenUsage for () {
@@ -760,7 +921,7 @@ impl CompletionRequest {
     }
 }
 
-fn merge_provider_tools_into_additional_params(
+pub(crate) fn merge_provider_tools_into_additional_params(
     additional_params: Option<serde_json::Value>,
     provider_tools: Vec<ProviderToolDefinition>,
 ) -> Option<serde_json::Value> {

--- a/crates/rig-core/src/lib.rs
+++ b/crates/rig-core/src/lib.rs
@@ -166,6 +166,8 @@ pub mod prelude;
 pub(crate) mod provider_response;
 pub mod providers;
 pub mod rerank;
+pub mod session;
+pub mod skills;
 
 pub mod streaming;
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -3026,6 +3026,8 @@ mod tests {
 
     fn generic_tool(name: &str) -> completion::ToolDefinition {
         completion::ToolDefinition {
+            output_schema: None,
+            metadata: Default::default(),
             name: name.to_string(),
             description: format!("{name} description"),
             parameters: json!({

--- a/crates/rig-core/src/providers/anthropic/streaming.rs
+++ b/crates/rig-core/src/providers/anthropic/streaming.rs
@@ -587,6 +587,8 @@ mod tests {
 
         let mut tools = build_tool_definitions(
             vec![crate::completion::ToolDefinition {
+                output_schema: None,
+                metadata: Default::default(),
                 name: "rig_tool".to_string(),
                 description: "Rig tool".to_string(),
                 parameters: json!({"type": "object", "properties": {}}),
@@ -737,6 +739,8 @@ mod tests {
             chat_history: OneOrMany::one(RigMessage::user("Add 2 and 3")),
             documents: vec![],
             tools: vec![crate::completion::ToolDefinition {
+                output_schema: None,
+                metadata: Default::default(),
                 name: "add".to_string(),
                 description: "Add x and y".to_string(),
                 parameters: json!({
@@ -813,6 +817,8 @@ mod tests {
             resolve_top_level_cache_control(false, None, &mut additional_params).unwrap();
         let mut tools = build_tool_definitions(
             vec![crate::completion::ToolDefinition {
+                output_schema: None,
+                metadata: Default::default(),
                 name: "rig_tool".to_string(),
                 description: "Rig tool".to_string(),
                 parameters: json!({"type": "object", "properties": {}}),

--- a/crates/rig-core/src/providers/deepseek.rs
+++ b/crates/rig-core/src/providers/deepseek.rs
@@ -583,6 +583,8 @@ mod tests {
     fn deepseek_request_serializes_specific_tool_choice_as_chat_completions_object() {
         let request = CompletionRequestBuilder::new(MockCompletionModel::default(), "Use a tool.")
             .tool(RigToolDefinition {
+                output_schema: None,
+                metadata: Default::default(),
                 name: "alpha".to_string(),
                 description: "Alpha tool".to_string(),
                 parameters: serde_json::json!({
@@ -592,6 +594,8 @@ mod tests {
                 }),
             })
             .tool(RigToolDefinition {
+                output_schema: None,
+                metadata: Default::default(),
                 name: "beta".to_string(),
                 description: "Beta tool".to_string(),
                 parameters: serde_json::json!({
@@ -618,6 +622,8 @@ mod tests {
     fn deepseek_request_suppresses_required_tool_choice_when_thinking_is_not_disabled() {
         let request = CompletionRequestBuilder::new(MockCompletionModel::default(), "Use a tool.")
             .tool(RigToolDefinition {
+                output_schema: None,
+                metadata: Default::default(),
                 name: "alpha".to_string(),
                 description: "Alpha tool".to_string(),
                 parameters: serde_json::json!({

--- a/crates/rig-core/src/providers/groq.rs
+++ b/crates/rig-core/src/providers/groq.rs
@@ -372,6 +372,8 @@ mod tests {
         let request = CompletionRequestBuilder::new(MockCompletionModel::default(), "Return JSON")
             .max_tokens(64)
             .tool(crate::completion::ToolDefinition {
+                output_schema: None,
+                metadata: Default::default(),
                 name: "choose_beta".to_string(),
                 description: "Choose beta".to_string(),
                 parameters: serde_json::json!({"type":"object","properties":{},"required":[]}),
@@ -424,6 +426,8 @@ mod tests {
     fn groq_prepare_request_merges_native_tools_into_compound_custom() {
         let request = CompletionRequestBuilder::new(MockCompletionModel::default(), "search")
             .tool(crate::completion::ToolDefinition {
+                output_schema: None,
+                metadata: Default::default(),
                 name: "local_tool".to_string(),
                 description: "A local function tool".to_string(),
                 parameters: serde_json::json!({"type":"object","properties":{},"required":[]}),

--- a/crates/rig-core/src/providers/hyperbolic.rs
+++ b/crates/rig-core/src/providers/hyperbolic.rs
@@ -443,6 +443,8 @@ mod tests {
             "hello",
         )
         .tool(crate::completion::ToolDefinition {
+            output_schema: None,
+            metadata: Default::default(),
             name: "lookup".to_string(),
             description: "Lookup".to_string(),
             parameters: serde_json::json!({"type":"object","properties":{},"required":[]}),

--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -885,6 +885,8 @@ impl From<crate::completion::ToolDefinition> for ToolDefinition {
                 name: tool.name,
                 description: tool.description,
                 parameters: tool.parameters,
+                output_schema: tool.output_schema,
+                metadata: tool.metadata,
             },
         }
     }
@@ -1320,6 +1322,8 @@ mod tests {
     fn test_tool_definition_conversion() {
         // Internal tool definition from the completion module.
         let internal_tool = crate::completion::ToolDefinition {
+            output_schema: None,
+            metadata: Default::default(),
             name: "get_current_weather".to_owned(),
             description: "Get the current weather for a location".to_owned(),
             parameters: json!({

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -2603,6 +2603,8 @@ mod tests {
             )),
             documents: vec![],
             tools: vec![completion::ToolDefinition {
+                output_schema: None,
+                metadata: Default::default(),
                 name: "weather".to_string(),
                 description: "Get the weather".to_string(),
                 parameters: serde_json::json!({
@@ -2673,6 +2675,8 @@ mod tests {
             .expect("history should be non-empty"),
             documents: vec![],
             tools: vec![completion::ToolDefinition {
+                output_schema: None,
+                metadata: Default::default(),
                 name: "weather".to_string(),
                 description: "Get the weather".to_string(),
                 parameters: serde_json::json!({

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -733,6 +733,7 @@ impl From<completion::ToolDefinition> for ResponsesToolDefinition {
             name,
             parameters,
             description,
+            ..
         } = value;
 
         Self::function(name, description, parameters)
@@ -2686,6 +2687,8 @@ mod tests {
 
     fn weather_tool_definition() -> completion::ToolDefinition {
         completion::ToolDefinition {
+            output_schema: None,
+            metadata: Default::default(),
             name: "get_weather".to_string(),
             description: "Get the weather".to_string(),
             parameters: json!({
@@ -3077,6 +3080,8 @@ mod tests {
         let model = ResponsesCompletionModel::new(client, "gpt-4o-mini")
             .with_strict_tools()
             .with_tool(completion::ToolDefinition {
+                output_schema: None,
+                metadata: Default::default(),
                 name: "lookup".to_string(),
                 description: "Look something up".to_string(),
                 parameters: json!({

--- a/crates/rig-core/src/providers/perplexity.rs
+++ b/crates/rig-core/src/providers/perplexity.rs
@@ -214,6 +214,8 @@ mod tests {
             output_schema: None,
         };
         request.tools = vec![crate::completion::ToolDefinition {
+            output_schema: None,
+            metadata: Default::default(),
             name: "lookup".to_string(),
             description: String::new(),
             parameters: serde_json::json!({}),
@@ -274,6 +276,8 @@ mod tests {
             "What's new today?",
         )
         .tool(crate::completion::ToolDefinition {
+            output_schema: None,
+            metadata: Default::default(),
             name: "lookup".to_string(),
             description: "Lookup".to_string(),
             parameters: serde_json::json!({"type":"object","properties":{},"required":[]}),

--- a/crates/rig-core/src/providers/xai/completion.rs
+++ b/crates/rig-core/src/providers/xai/completion.rs
@@ -365,6 +365,8 @@ mod tests {
     fn xai_request_uses_responses_tool_choice_for_specific_tool() {
         let request = CompletionRequestBuilder::new(MockCompletionModel::default(), "Use a tool.")
             .tool(ToolDefinition {
+                output_schema: None,
+                metadata: Default::default(),
                 name: "alpha".to_string(),
                 description: "Alpha tool".to_string(),
                 parameters: serde_json::json!({
@@ -374,6 +376,8 @@ mod tests {
                 }),
             })
             .tool(ToolDefinition {
+                output_schema: None,
+                metadata: Default::default(),
                 name: "beta".to_string(),
                 description: "Beta tool".to_string(),
                 parameters: serde_json::json!({

--- a/crates/rig-core/src/session.rs
+++ b/crates/rig-core/src/session.rs
@@ -1,0 +1,254 @@
+//! Backend-neutral append-only agent session records.
+//!
+//! Session storage intentionally remains separate from
+//! [`ConversationMemory`](crate::memory::ConversationMemory): memory supplies
+//! model prompt history, while this module preserves attempts, branches,
+//! checkpoints, compaction records, and host events.
+
+use std::{
+    sync::{Arc, Mutex},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    completion::Message,
+    wasm_compat::{WasmBoxedFuture, WasmCompatSend, WasmCompatSync},
+};
+
+/// Typed payload retained in an append-only session.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[serde(tag = "type", content = "data", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum SessionEventData {
+    /// Conversation message accepted into history.
+    Message(Message),
+    /// Model-call request/response metadata owned by the host.
+    ModelCall(serde_json::Value),
+    /// Tool invocation metadata.
+    ToolCall(serde_json::Value),
+    /// Tool result metadata.
+    ToolResult(serde_json::Value),
+    /// Non-destructive compaction summary.
+    Compaction {
+        summary: String,
+        covered_event_ids: Vec<String>,
+    },
+    /// Named durable checkpoint, optionally carrying an `AgentRun` snapshot.
+    Checkpoint {
+        name: String,
+        snapshot: Option<serde_json::Value>,
+    },
+    /// Bookmark pointing at another event.
+    Bookmark { name: String, event_id: String },
+    /// Host-defined typed entry.
+    Custom {
+        kind: String,
+        value: serde_json::Value,
+    },
+}
+
+/// Input for appending one event.
+#[derive(Clone, Debug)]
+pub struct NewSessionEvent {
+    /// Session receiving the event.
+    pub session_id: String,
+    /// Parent event; choosing an older parent creates a branch.
+    pub parent_id: Option<String>,
+    /// Event payload.
+    pub data: SessionEventData,
+    /// Optional model/config/usage metadata.
+    pub metadata: serde_json::Map<String, serde_json::Value>,
+}
+
+impl NewSessionEvent {
+    /// Construct an event at the current active leaf.
+    pub fn new(session_id: impl Into<String>, data: SessionEventData) -> Self {
+        Self {
+            session_id: session_id.into(),
+            parent_id: None,
+            data,
+            metadata: Default::default(),
+        }
+    }
+
+    /// Explicitly branch from a parent event.
+    pub fn with_parent(mut self, parent_id: impl Into<String>) -> Self {
+        self.parent_id = Some(parent_id.into());
+        self
+    }
+}
+
+/// Stored append-only session event.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct SessionEvent {
+    /// Stable event identifier.
+    pub id: String,
+    /// Session identifier.
+    pub session_id: String,
+    /// Parent event in the branch graph.
+    pub parent_id: Option<String>,
+    /// Unix timestamp in milliseconds.
+    pub timestamp_ms: u64,
+    /// Typed payload.
+    pub data: SessionEventData,
+    /// Host metadata.
+    pub metadata: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Session backend failure.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum SessionStoreError {
+    /// Referenced session/event does not exist.
+    #[error("session record not found: {0}")]
+    NotFound(String),
+    /// Backend failure.
+    #[error("session backend error: {0}")]
+    Backend(String),
+}
+
+/// Append-only backend contract for resumable, branchable sessions.
+pub trait SessionStore: WasmCompatSend + WasmCompatSync {
+    /// Append one event atomically and return its stored identity.
+    fn append(
+        &self,
+        event: NewSessionEvent,
+    ) -> WasmBoxedFuture<'_, Result<SessionEvent, SessionStoreError>>;
+
+    /// Read all events for a session in append order, retaining every branch.
+    fn events<'a>(
+        &'a self,
+        session_id: &'a str,
+    ) -> WasmBoxedFuture<'a, Result<Vec<SessionEvent>, SessionStoreError>>;
+
+    /// Resolve an event by identifier.
+    fn get<'a>(
+        &'a self,
+        event_id: &'a str,
+    ) -> WasmBoxedFuture<'a, Result<Option<SessionEvent>, SessionStoreError>>;
+}
+
+impl<S> SessionStore for Arc<S>
+where
+    S: SessionStore + ?Sized,
+{
+    fn append(
+        &self,
+        event: NewSessionEvent,
+    ) -> WasmBoxedFuture<'_, Result<SessionEvent, SessionStoreError>> {
+        (**self).append(event)
+    }
+    fn events<'a>(
+        &'a self,
+        id: &'a str,
+    ) -> WasmBoxedFuture<'a, Result<Vec<SessionEvent>, SessionStoreError>> {
+        (**self).events(id)
+    }
+    fn get<'a>(
+        &'a self,
+        id: &'a str,
+    ) -> WasmBoxedFuture<'a, Result<Option<SessionEvent>, SessionStoreError>> {
+        (**self).get(id)
+    }
+}
+
+/// In-process reference session store.
+#[derive(Clone, Default)]
+pub struct InMemorySessionStore {
+    events: Arc<Mutex<Vec<SessionEvent>>>,
+}
+
+impl SessionStore for InMemorySessionStore {
+    fn append(
+        &self,
+        event: NewSessionEvent,
+    ) -> WasmBoxedFuture<'_, Result<SessionEvent, SessionStoreError>> {
+        Box::pin(async move {
+            let mut events = self.events.lock().unwrap_or_else(|e| e.into_inner());
+            if let Some(parent) = event.parent_id.as_ref()
+                && !events
+                    .iter()
+                    .any(|stored| &stored.id == parent && stored.session_id == event.session_id)
+            {
+                return Err(SessionStoreError::NotFound(parent.clone()));
+            }
+            let stored = SessionEvent {
+                id: crate::id::generate(),
+                session_id: event.session_id,
+                parent_id: event.parent_id,
+                timestamp_ms: SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_millis() as u64,
+                data: event.data,
+                metadata: event.metadata,
+            };
+            events.push(stored.clone());
+            Ok(stored)
+        })
+    }
+
+    fn events<'a>(
+        &'a self,
+        session_id: &'a str,
+    ) -> WasmBoxedFuture<'a, Result<Vec<SessionEvent>, SessionStoreError>> {
+        Box::pin(async move {
+            Ok(self
+                .events
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .iter()
+                .filter(|event| event.session_id == session_id)
+                .cloned()
+                .collect())
+        })
+    }
+
+    fn get<'a>(
+        &'a self,
+        event_id: &'a str,
+    ) -> WasmBoxedFuture<'a, Result<Option<SessionEvent>, SessionStoreError>> {
+        Box::pin(async move {
+            Ok(self
+                .events
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .iter()
+                .find(|event| event.id == event_id)
+                .cloned())
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    #[allow(clippy::panic_in_result_fn)]
+    async fn appends_and_branches_without_destroying_history() -> Result<(), SessionStoreError> {
+        let store = InMemorySessionStore::default();
+        let root = store
+            .append(NewSessionEvent::new(
+                "s",
+                SessionEventData::Message(Message::user("root")),
+            ))
+            .await?;
+        store
+            .append(
+                NewSessionEvent::new("s", SessionEventData::Message(Message::user("a")))
+                    .with_parent(root.id.clone()),
+            )
+            .await?;
+        store
+            .append(
+                NewSessionEvent::new("s", SessionEventData::Message(Message::user("b")))
+                    .with_parent(root.id),
+            )
+            .await?;
+        assert_eq!(store.events("s").await?.len(), 3);
+        Ok(())
+    }
+}

--- a/crates/rig-core/src/skills.rs
+++ b/crates/rig-core/src/skills.rs
@@ -1,0 +1,166 @@
+//! Provider-independent, progressively disclosed agent skills.
+//!
+//! Catalog listings contain only names/descriptions. Full instructions and
+//! assets are loaded on demand through [`SkillCatalog`], allowing hosts to own
+//! filesystem discovery, trust, and provenance policy.
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+
+use crate::wasm_compat::{WasmBoxedFuture, WasmCompatSend, WasmCompatSync};
+
+/// Lightweight skill advertisement suitable for model context.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SkillSummary {
+    /// Stable catalog name.
+    pub name: String,
+    /// Short progressive-disclosure description.
+    pub description: String,
+    /// Host-defined provenance (package, project, provider, and so on).
+    pub provenance: Option<String>,
+}
+
+/// Asset bundled with a loaded skill.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SkillAsset {
+    /// Relative logical path.
+    pub path: String,
+    /// Raw asset bytes.
+    pub content: Vec<u8>,
+    /// Optional media type.
+    pub media_type: Option<String>,
+}
+
+/// Fully loaded skill instructions and assets.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Skill {
+    /// Lightweight catalog metadata.
+    pub summary: SkillSummary,
+    /// Full instructions loaded only after selection.
+    pub instructions: String,
+    /// Optional supporting assets.
+    pub assets: Vec<SkillAsset>,
+    /// Optional allowlist of tool names the host may enforce.
+    pub allowed_tools: Option<Vec<String>>,
+}
+
+/// Skill catalog failure.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum SkillError {
+    /// No skill exists under the requested name.
+    #[error("skill `{0}` was not found")]
+    NotFound(String),
+    /// Catalog backend failure.
+    #[error("skill catalog backend error: {0}")]
+    Backend(String),
+}
+
+/// Provider-independent progressive-disclosure skill catalog.
+pub trait SkillCatalog: WasmCompatSend + WasmCompatSync {
+    /// List lightweight advertisements without loading full instructions/assets.
+    fn list(&self) -> WasmBoxedFuture<'_, Result<Vec<SkillSummary>, SkillError>>;
+
+    /// Load one full skill by stable name.
+    fn load<'a>(&'a self, name: &'a str) -> WasmBoxedFuture<'a, Result<Skill, SkillError>>;
+}
+
+impl<C> SkillCatalog for Arc<C>
+where
+    C: SkillCatalog + ?Sized,
+{
+    fn list(&self) -> WasmBoxedFuture<'_, Result<Vec<SkillSummary>, SkillError>> {
+        (**self).list()
+    }
+
+    fn load<'a>(&'a self, name: &'a str) -> WasmBoxedFuture<'a, Result<Skill, SkillError>> {
+        (**self).load(name)
+    }
+}
+
+/// Mutable in-process catalog useful for hosts and tests.
+#[derive(Clone, Default)]
+pub struct InMemorySkillCatalog {
+    skills: Arc<RwLock<HashMap<String, Skill>>>,
+}
+
+impl InMemorySkillCatalog {
+    /// Create an empty catalog.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add or replace a skill by its summary name.
+    pub fn insert(&self, skill: Skill) -> Option<Skill> {
+        self.skills
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(skill.summary.name.clone(), skill)
+    }
+
+    /// Remove a skill.
+    pub fn remove(&self, name: &str) -> Option<Skill> {
+        self.skills
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(name)
+    }
+}
+
+impl SkillCatalog for InMemorySkillCatalog {
+    fn list(&self) -> WasmBoxedFuture<'_, Result<Vec<SkillSummary>, SkillError>> {
+        Box::pin(async move {
+            let mut summaries = self
+                .skills
+                .read()
+                .unwrap_or_else(|e| e.into_inner())
+                .values()
+                .map(|skill| skill.summary.clone())
+                .collect::<Vec<_>>();
+            summaries.sort_by(|a, b| a.name.cmp(&b.name));
+            Ok(summaries)
+        })
+    }
+
+    fn load<'a>(&'a self, name: &'a str) -> WasmBoxedFuture<'a, Result<Skill, SkillError>> {
+        Box::pin(async move {
+            self.skills
+                .read()
+                .unwrap_or_else(|e| e.into_inner())
+                .get(name)
+                .cloned()
+                .ok_or_else(|| SkillError::NotFound(name.to_owned()))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    #[allow(clippy::panic_in_result_fn)]
+    async fn lists_summaries_before_loading_instructions() -> Result<(), SkillError> {
+        let catalog = InMemorySkillCatalog::new();
+        catalog.insert(Skill {
+            summary: SkillSummary {
+                name: "rust".into(),
+                description: "Rust help".into(),
+                provenance: Some("project".into()),
+            },
+            instructions: "Full private instructions".into(),
+            assets: Vec::new(),
+            allowed_tools: Some(vec!["cargo".into()]),
+        });
+        let summaries = catalog.list().await?;
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(summaries[0].description, "Rust help");
+        assert_eq!(
+            catalog.load("rust").await?.instructions,
+            "Full private instructions"
+        );
+        Ok(())
+    }
+}

--- a/crates/rig-core/src/tool/code_mode.rs
+++ b/crates/rig-core/src/tool/code_mode.rs
@@ -1,0 +1,190 @@
+//! Runtime-agnostic code-mode adapter.
+//!
+//! Core defines resource/cancellation/catalog boundaries; JavaScript, Python,
+//! Lua, shell, and WebAssembly engines remain optional adapters.
+
+use std::sync::Arc;
+
+use serde::Deserialize;
+
+use crate::{
+    completion::ToolDefinition,
+    tool::{ToolCallExtensions, ToolDyn, ToolError, ToolExecutionResult, server::ToolServerHandle},
+    wasm_compat::{WasmBoxedFuture, WasmCompatSend, WasmCompatSync},
+};
+
+/// Limits enforced by a code runtime adapter.
+#[derive(Clone, Debug)]
+pub struct CodeModeLimits {
+    /// Maximum nested tool calls made by one program.
+    pub max_tool_calls: usize,
+    /// Maximum nested call depth.
+    pub max_depth: usize,
+    /// Maximum program source bytes.
+    pub max_source_bytes: usize,
+}
+
+impl Default for CodeModeLimits {
+    fn default() -> Self {
+        Self {
+            max_tool_calls: 64,
+            max_depth: 8,
+            max_source_bytes: 256 * 1024,
+        }
+    }
+}
+
+/// Host capabilities passed to an installed runtime adapter.
+#[derive(Clone)]
+pub struct CodeExecutionContext {
+    /// Catalog selected for exposure inside the runtime.
+    pub catalog: Vec<ToolDefinition>,
+    /// Context-aware native/MCP dispatch handle.
+    pub tool_server: ToolServerHandle,
+    /// Host-only call/run extensions, including [`RunContext`](crate::agent::RunContext).
+    pub extensions: ToolCallExtensions,
+    /// Resource and recursion limits.
+    pub limits: CodeModeLimits,
+}
+
+/// Pluggable language/sandbox runtime for [`CodeModeTool`].
+pub trait CodeRuntime: WasmCompatSend + WasmCompatSync {
+    /// Execute source with an explicit allowlisted host context.
+    fn execute<'a>(
+        &'a self,
+        code: &'a str,
+        context: CodeExecutionContext,
+    ) -> WasmBoxedFuture<'a, ToolExecutionResult>;
+}
+
+#[derive(Deserialize)]
+struct CodeModeArgs {
+    code: String,
+    #[allow(dead_code)]
+    description: Option<String>,
+}
+
+/// One model-facing `run_code` tool backed by an optional runtime adapter.
+///
+/// The wrapped catalog is not automatically registered alongside this tool,
+/// preventing accidental exposure of both wrapped and unwrapped tools.
+#[derive(Clone)]
+pub struct CodeModeTool<R> {
+    runtime: Arc<R>,
+    tool_server: ToolServerHandle,
+    catalog: Vec<ToolDefinition>,
+    limits: CodeModeLimits,
+    name: String,
+}
+
+impl<R> CodeModeTool<R>
+where
+    R: CodeRuntime,
+{
+    /// Build a code-mode tool over an explicitly selected catalog.
+    pub fn new(runtime: R, tool_server: ToolServerHandle, catalog: Vec<ToolDefinition>) -> Self {
+        Self {
+            runtime: Arc::new(runtime),
+            tool_server,
+            catalog,
+            limits: CodeModeLimits::default(),
+            name: "run_code".to_owned(),
+        }
+    }
+
+    /// Override resource limits.
+    pub fn with_limits(mut self, limits: CodeModeLimits) -> Self {
+        self.limits = limits;
+        self
+    }
+
+    /// Override the model-facing wrapper name.
+    pub fn with_name(mut self, name: impl Into<String>) -> Self {
+        self.name = name.into();
+        self
+    }
+}
+
+impl<R> ToolDyn for CodeModeTool<R>
+where
+    R: CodeRuntime + 'static,
+{
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    fn description(&self) -> String {
+        "Execute a bounded program that can call the selected tool catalog.".to_owned()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "required": ["code"],
+            "properties": {
+                "code": {"type": "string"},
+                "description": {"type": "string"}
+            }
+        })
+    }
+
+    fn metadata(&self) -> crate::completion::ToolMetadata {
+        crate::completion::ToolMetadata {
+            kind: crate::completion::ToolKind::Composite,
+            execution: crate::completion::ToolExecutionPolicy::Sequential,
+            source: Some("code_mode".to_owned()),
+            attributes: Default::default(),
+        }
+    }
+
+    fn call<'a>(&'a self, args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
+        Box::pin(async move {
+            let result = self.call_structured(args, &ToolCallExtensions::EMPTY).await;
+            Ok(result.model_output().to_owned())
+        })
+    }
+
+    fn call_structured<'a>(
+        &'a self,
+        args: String,
+        extensions: &'a ToolCallExtensions,
+    ) -> WasmBoxedFuture<'a, ToolExecutionResult> {
+        Box::pin(async move {
+            let parsed: CodeModeArgs = match serde_json::from_str(&args) {
+                Ok(parsed) => parsed,
+                Err(error) => {
+                    return ToolExecutionResult::failed(
+                        format!("invalid code-mode arguments: {error}"),
+                        crate::tool::ToolFailure::invalid_args(error.to_string()),
+                    );
+                }
+            };
+            if parsed.code.len() > self.limits.max_source_bytes {
+                return ToolExecutionResult::failed(
+                    "code exceeds configured source limit",
+                    crate::tool::ToolFailure::invalid_args("source too large"),
+                );
+            }
+            if extensions
+                .get::<crate::agent::RunContext>()
+                .is_some_and(crate::agent::RunContext::is_cancelled)
+            {
+                return ToolExecutionResult::failed(
+                    "run cancelled",
+                    crate::tool::ToolFailure::cancelled("run cancelled"),
+                );
+            }
+            self.runtime
+                .execute(
+                    &parsed.code,
+                    CodeExecutionContext {
+                        catalog: self.catalog.clone(),
+                        tool_server: self.tool_server.clone(),
+                        extensions: extensions.clone(),
+                        limits: self.limits.clone(),
+                    },
+                )
+                .await
+        })
+    }
+}

--- a/crates/rig-core/src/tool/mod.rs
+++ b/crates/rig-core/src/tool/mod.rs
@@ -21,6 +21,7 @@
 //! richer outcomes/metadata via [`Tool::call_structured`] and [`ToolReturn`].
 
 pub mod builtin;
+pub mod code_mode;
 mod extensions;
 mod result;
 pub mod server;
@@ -153,6 +154,16 @@ pub trait Tool: Sized + WasmCompatSend + WasmCompatSync {
 
     /// JSON Schema for the tool arguments.
     fn parameters(&self) -> serde_json::Value;
+
+    /// Optional JSON Schema for the model-visible result.
+    fn output_schema(&self) -> Option<serde_json::Value> {
+        None
+    }
+
+    /// Host-only operational metadata.
+    fn metadata(&self) -> crate::completion::ToolMetadata {
+        crate::completion::ToolMetadata::default()
+    }
 
     /// The tool execution method.
     /// Both the arguments and return value are a String since these values are meant to
@@ -289,6 +300,16 @@ pub trait ToolDyn: WasmCompatSend + WasmCompatSync {
     /// JSON Schema for the tool arguments.
     fn parameters(&self) -> serde_json::Value;
 
+    /// Optional JSON Schema for the model-visible result.
+    fn output_schema(&self) -> Option<serde_json::Value> {
+        None
+    }
+
+    /// Host-only operational metadata.
+    fn metadata(&self) -> crate::completion::ToolMetadata {
+        crate::completion::ToolMetadata::default()
+    }
+
     /// Calls the tool with JSON-encoded arguments and returns model-facing text.
     fn call<'a>(&'a self, args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>>;
 
@@ -393,6 +414,8 @@ pub(crate) fn tool_definition_with_name(
         name: name.into(),
         description: tool.description(),
         parameters: tool.parameters(),
+        output_schema: tool.output_schema(),
+        metadata: tool.metadata(),
     }
 }
 
@@ -407,6 +430,14 @@ impl<T: Tool> ToolDyn for T {
 
     fn parameters(&self) -> serde_json::Value {
         <Self as Tool>::parameters(self)
+    }
+
+    fn output_schema(&self) -> Option<serde_json::Value> {
+        <Self as Tool>::output_schema(self)
+    }
+
+    fn metadata(&self) -> crate::completion::ToolMetadata {
+        <Self as Tool>::metadata(self)
     }
 
     fn call<'a>(&'a self, args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>> {

--- a/crates/rig-core/src/tool/result.rs
+++ b/crates/rig-core/src/tool/result.rs
@@ -17,7 +17,7 @@
 //! resulting [`ToolExecutionResult`] all the way through to the
 //! [`StepEvent::ToolResult`](crate::agent::StepEvent::ToolResult) hook event.
 
-use crate::tool::ToolResultExtensions;
+use crate::{OneOrMany, message::ToolResultContent, tool::ToolResultExtensions};
 use serde::Serialize;
 
 /// How a tool execution failed, as a closed set of standard kinds.
@@ -420,6 +420,7 @@ impl From<ToolReturnOutcome> for ToolOutcome {
 #[non_exhaustive]
 pub struct ToolExecutionResult {
     pub(crate) model_output: String,
+    pub(crate) model_content: Option<OneOrMany<ToolResultContent>>,
     pub(crate) outcome: ToolOutcome,
     pub(crate) extensions: ToolResultExtensions,
 }
@@ -435,6 +436,7 @@ impl ToolExecutionResult {
     pub(crate) fn new(model_output: impl Into<String>, outcome: ToolOutcome) -> Self {
         Self {
             model_output: model_output.into(),
+            model_content: None,
             outcome,
             extensions: ToolResultExtensions::new(),
         }
@@ -443,6 +445,17 @@ impl ToolExecutionResult {
     /// A successful result whose model output is `model_output` verbatim.
     pub fn success(model_output: impl Into<String>) -> Self {
         Self::new(model_output, ToolOutcome::Success)
+    }
+
+    /// A successful rich result that bypasses legacy string-envelope parsing.
+    pub fn success_content(content: OneOrMany<ToolResultContent>) -> Self {
+        let model_output = serde_json::to_string(&content).unwrap_or_default();
+        Self {
+            model_output,
+            model_content: Some(content),
+            outcome: ToolOutcome::Success,
+            extensions: ToolResultExtensions::new(),
+        }
     }
 
     /// A failed result: `model_output` is the model-visible feedback, `failure`
@@ -493,6 +506,11 @@ impl ToolExecutionResult {
     /// failure, so the model gets useful feedback (a handled error message).
     pub fn model_output(&self) -> &str {
         &self.model_output
+    }
+
+    /// Structured model-visible content, when returned directly by the tool.
+    pub fn model_content(&self) -> Option<&OneOrMany<ToolResultContent>> {
+        self.model_content.as_ref()
     }
 
     /// The structured [`ToolOutcome`] of the call.
@@ -641,6 +659,7 @@ impl<T: Serialize> ToolReturn<T> {
         match super::serialize_tool_output(&output) {
             Ok(model_output) => ToolExecutionResult {
                 model_output,
+                model_content: None,
                 outcome: outcome.into(),
                 extensions,
             },
@@ -655,6 +674,7 @@ impl<T: Serialize> ToolReturn<T> {
                 };
                 ToolExecutionResult {
                     model_output: format!("failed to serialize tool output: {err}"),
+                    model_content: None,
                     outcome,
                     extensions,
                 }

--- a/crates/rig-core/src/tool/rmcp.rs
+++ b/crates/rig-core/src/tool/rmcp.rs
@@ -133,21 +133,23 @@ impl McpTool {
 
 impl From<&rmcp::model::Tool> for ToolDefinition {
     fn from(val: &rmcp::model::Tool) -> Self {
-        Self {
-            name: val.name.to_string(),
-            description: val.description.clone().unwrap_or(Cow::from("")).to_string(),
-            parameters: val.schema_as_json_value(),
-        }
+        let mut definition = Self::new(
+            val.name.to_string(),
+            val.description.clone().unwrap_or(Cow::from("")).to_string(),
+            val.schema_as_json_value(),
+        );
+        definition.output_schema = val
+            .output_schema
+            .as_ref()
+            .map(|schema| serde_json::Value::Object((**schema).clone()));
+        definition.metadata.kind = crate::completion::ToolKind::Mcp;
+        definition
     }
 }
 
 impl From<rmcp::model::Tool> for ToolDefinition {
     fn from(val: rmcp::model::Tool) -> Self {
-        Self {
-            name: val.name.to_string(),
-            description: val.description.clone().unwrap_or(Cow::from("")).to_string(),
-            parameters: val.schema_as_json_value(),
-        }
+        Self::from(&val)
     }
 }
 
@@ -366,6 +368,22 @@ impl ToolDyn for McpTool {
 
     fn parameters(&self) -> serde_json::Value {
         self.definition.schema_as_json_value()
+    }
+
+    fn output_schema(&self) -> Option<serde_json::Value> {
+        self.definition
+            .output_schema
+            .as_ref()
+            .map(|schema| serde_json::Value::Object((**schema).clone()))
+    }
+
+    fn metadata(&self) -> crate::completion::ToolMetadata {
+        crate::completion::ToolMetadata {
+            kind: crate::completion::ToolKind::Mcp,
+            execution: crate::completion::ToolExecutionPolicy::ParallelSafe,
+            source: None,
+            attributes: Default::default(),
+        }
     }
 
     fn call(&self, args: String) -> WasmBoxedFuture<'_, Result<String, ToolError>> {

--- a/crates/rig-core/src/tool/server.rs
+++ b/crates/rig-core/src/tool/server.rs
@@ -173,6 +173,35 @@ impl ToolServerHandle {
         Ok(())
     }
 
+    /// Replace a static tool atomically for future lookups.
+    ///
+    /// A call that already cloned the previous implementation continues with
+    /// that snapshot; subsequent calls observe the replacement.
+    pub async fn replace_tool(&self, tool: impl ToolDyn + 'static) -> Result<(), ToolServerError> {
+        self.add_tool(tool).await
+    }
+
+    /// Enumerate the current host-facing catalog in registration order.
+    ///
+    /// This snapshots definitions under one read lock. Host-only metadata is
+    /// retained on the returned definitions and never serialized to providers.
+    pub async fn catalog(&self) -> Vec<ToolDefinition> {
+        let state = self.0.read().await;
+        state
+            .toolset
+            .ordered_names()
+            .filter_map(|name| {
+                state.toolset.get(name).map(|tool| {
+                    let mut definition = tool.definition_with_name(name.clone());
+                    if !state.static_tool_names.contains(name) {
+                        definition.metadata.kind = crate::completion::ToolKind::Dynamic;
+                    }
+                    definition
+                })
+            })
+            .collect()
+    }
+
     /// Remove a tool by name from both the toolset and the static list.
     pub async fn remove_tool(&self, tool_name: &str) -> Result<(), ToolServerError> {
         let mut state = self.0.write().await;

--- a/crates/rig-gemini-grpc/src/completion.rs
+++ b/crates/rig-gemini-grpc/src/completion.rs
@@ -953,6 +953,8 @@ mod tests {
         use rig_core::completion::ToolDefinition;
 
         let tool = ToolDefinition {
+            output_schema: None,
+            metadata: Default::default(),
             name: "get_weather".to_string(),
             description: "Look up the current weather for a city.".to_string(),
             parameters: serde_json::json!({

--- a/crates/rig-sqlite/CHANGELOG.md
+++ b/crates/rig-sqlite/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+- Durable, ordered `SqliteConversationMemory` backend with transactional appends.
+
 ## [0.40.0](https://github.com/0xPlaygrounds/rig/compare/rig-sqlite-v0.39.0...rig-sqlite-v0.40.0) - 2026-07-10
 
 ### Other

--- a/crates/rig-sqlite/src/lib.rs
+++ b/crates/rig-sqlite/src/lib.rs
@@ -1,4 +1,4 @@
-//! SQLite vector store integration for Rig.
+//! SQLite vector store and durable conversation-memory integration for Rig.
 //!
 //! This crate provides [`SqliteVectorStore`] and [`SqliteVectorIndex`] for
 //! storing embedded documents in SQLite with the `sqlite-vec` extension. Define
@@ -6,6 +6,10 @@
 //!
 //! The root `rig` facade re-exports this crate as `rig::sqlite` when the
 //! `sqlite` feature is enabled.
+
+mod memory;
+
+pub use memory::SqliteConversationMemory;
 
 use rig_core::embeddings::{Embedding, EmbeddingModel};
 use rig_core::vector_store::request::{FilterError, SearchFilter, VectorSearchRequest};

--- a/crates/rig-sqlite/src/memory.rs
+++ b/crates/rig-sqlite/src/memory.rs
@@ -1,0 +1,156 @@
+//! Durable SQLite conversation memory.
+
+use rig_core::{
+    completion::Message,
+    memory::{ConversationMemory, MemoryError},
+    wasm_compat::WasmBoxedFuture,
+};
+use tokio_rusqlite::Connection;
+
+/// Durable ordered [`ConversationMemory`] backed by SQLite.
+///
+/// Appends use one transaction, so messages from concurrent turns never
+/// interleave within an appended batch. The schema stores versioned JSON to
+/// permit future migrations without conflating message history with a session
+/// event log.
+#[derive(Clone)]
+pub struct SqliteConversationMemory {
+    connection: Connection,
+}
+
+impl SqliteConversationMemory {
+    /// Open a database and create the memory table when absent.
+    pub async fn open(path: impl AsRef<std::path::Path>) -> Result<Self, MemoryError> {
+        let connection = Connection::open(path).await.map_err(MemoryError::backend)?;
+        Self::from_connection(connection).await
+    }
+
+    /// Use an existing connection and create the memory table when absent.
+    pub async fn from_connection(connection: Connection) -> Result<Self, MemoryError> {
+        connection
+            .call(|conn| {
+                conn.execute_batch(
+                    "PRAGMA foreign_keys = ON;
+                     CREATE TABLE IF NOT EXISTS rig_conversation_messages (
+                       sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+                       conversation_id TEXT NOT NULL,
+                       format_version INTEGER NOT NULL DEFAULT 1,
+                       message_json TEXT NOT NULL
+                     );
+                     CREATE INDEX IF NOT EXISTS rig_conversation_messages_lookup
+                       ON rig_conversation_messages(conversation_id, sequence);",
+                )?;
+                Ok(())
+            })
+            .await
+            .map_err(MemoryError::backend)?;
+        Ok(Self { connection })
+    }
+
+    /// Borrow the shared SQLite connection.
+    pub fn connection(&self) -> &Connection {
+        &self.connection
+    }
+}
+
+impl ConversationMemory for SqliteConversationMemory {
+    fn load<'a>(
+        &'a self,
+        conversation_id: &'a str,
+    ) -> WasmBoxedFuture<'a, Result<Vec<Message>, MemoryError>> {
+        let connection = self.connection.clone();
+        let conversation_id = conversation_id.to_owned();
+        Box::pin(async move {
+            let encoded: Vec<String> = connection
+                .call(move |conn| {
+                    let mut statement = conn.prepare(
+                        "SELECT message_json FROM rig_conversation_messages
+                         WHERE conversation_id = ?1 ORDER BY sequence ASC",
+                    )?;
+                    let rows =
+                        statement.query_map([conversation_id], |row| row.get::<_, String>(0))?;
+                    Ok(rows.collect::<Result<Vec<_>, _>>()?)
+                })
+                .await
+                .map_err(MemoryError::backend)?;
+            encoded
+                .into_iter()
+                .map(|json| serde_json::from_str(&json).map_err(MemoryError::backend))
+                .collect()
+        })
+    }
+
+    fn append<'a>(
+        &'a self,
+        conversation_id: &'a str,
+        messages: Vec<Message>,
+    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+        let connection = self.connection.clone();
+        let conversation_id = conversation_id.to_owned();
+        Box::pin(async move {
+            let encoded = messages
+                .into_iter()
+                .map(|message| serde_json::to_string(&message).map_err(MemoryError::backend))
+                .collect::<Result<Vec<_>, _>>()?;
+            connection
+                .call(move |conn| {
+                    let transaction = conn.transaction()?;
+                    {
+                        let mut statement = transaction.prepare(
+                            "INSERT INTO rig_conversation_messages
+                             (conversation_id, format_version, message_json)
+                             VALUES (?1, 1, ?2)",
+                        )?;
+                        for message in encoded {
+                            statement.execute(rusqlite::params![conversation_id, message])?;
+                        }
+                    }
+                    transaction.commit()?;
+                    Ok(())
+                })
+                .await
+                .map_err(MemoryError::backend)
+        })
+    }
+
+    fn clear<'a>(
+        &'a self,
+        conversation_id: &'a str,
+    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+        let connection = self.connection.clone();
+        let conversation_id = conversation_id.to_owned();
+        Box::pin(async move {
+            connection
+                .call(move |conn| {
+                    conn.execute(
+                        "DELETE FROM rig_conversation_messages WHERE conversation_id = ?1",
+                        [conversation_id],
+                    )?;
+                    Ok(())
+                })
+                .await
+                .map_err(MemoryError::backend)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    #[allow(clippy::panic_in_result_fn)]
+    async fn persists_order_and_clears_conversations() -> anyhow::Result<()> {
+        let memory =
+            SqliteConversationMemory::from_connection(Connection::open_in_memory().await?).await?;
+        memory
+            .append("a", vec![Message::user("one"), Message::assistant("two")])
+            .await?;
+        memory.append("a", vec![Message::user("three")]).await?;
+        assert_eq!(memory.load("a").await?.len(), 3);
+        assert!(memory.load("b").await?.is_empty());
+        memory.clear("a").await?;
+        assert!(memory.load("a").await?.is_empty());
+        Ok(())
+    }
+}

--- a/crates/rig-vertexai/src/types/completion_request.rs
+++ b/crates/rig-vertexai/src/types/completion_request.rs
@@ -339,6 +339,8 @@ mod tests {
             model: None,
             tool_choice: Some(ToolChoice::Auto),
             tools: vec![ToolDefinition {
+                output_schema: None,
+                metadata: Default::default(),
                 name: "test_tool".to_string(),
                 description: "A test tool".to_string(),
                 parameters: serde_json::json!({
@@ -370,6 +372,8 @@ mod tests {
             model: None,
             tool_choice: Some(ToolChoice::Required),
             tools: vec![ToolDefinition {
+                output_schema: None,
+                metadata: Default::default(),
                 name: "test_tool".to_string(),
                 description: "A test tool".to_string(),
                 parameters: serde_json::json!({
@@ -401,6 +405,8 @@ mod tests {
             model: None,
             tool_choice: Some(ToolChoice::None),
             tools: vec![ToolDefinition {
+                output_schema: None,
+                metadata: Default::default(),
                 name: "test_tool".to_string(),
                 description: "A test tool".to_string(),
                 parameters: serde_json::json!({
@@ -434,6 +440,8 @@ mod tests {
                 function_names: vec!["test_tool".to_string()],
             }),
             tools: vec![ToolDefinition {
+                output_schema: None,
+                metadata: Default::default(),
                 name: "test_tool".to_string(),
                 description: "A test tool".to_string(),
                 parameters: serde_json::json!({
@@ -522,6 +530,8 @@ mod tests {
         let request = CompletionRequest {
             model: None,
             tools: vec![ToolDefinition {
+                output_schema: None,
+                metadata: Default::default(),
                 name: "add".to_string(),
                 description: "Add two numbers".to_string(),
                 parameters: serde_json::json!({
@@ -558,6 +568,8 @@ mod tests {
             model: None,
             tool_choice: None, // Not set
             tools: vec![ToolDefinition {
+                output_schema: None,
+                metadata: Default::default(),
                 name: "test_tool".to_string(),
                 description: "A test tool".to_string(),
                 parameters: serde_json::json!({
@@ -589,6 +601,8 @@ mod tests {
         let request = CompletionRequest {
             model: None,
             tools: vec![ToolDefinition {
+                output_schema: None,
+                metadata: Default::default(),
                 name: "document_list".to_string(),
                 description: "Lists all documents".to_string(),
                 parameters: serde_json::json!({
@@ -619,6 +633,8 @@ mod tests {
         let request = CompletionRequest {
             model: None,
             tools: vec![ToolDefinition {
+                output_schema: None,
+                metadata: Default::default(),
                 name: "get_weather".to_string(),
                 description: "Get weather for a location".to_string(),
                 parameters: serde_json::json!({

--- a/examples/agent_with_message_injection/Cargo.toml
+++ b/examples/agent_with_message_injection/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "agent_with_message_injection"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+rig.workspace = true
+anyhow = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }

--- a/examples/agent_with_message_injection/src/main.rs
+++ b/examples/agent_with_message_injection/src/main.rs
@@ -1,0 +1,122 @@
+//! Inject a message into an agent run while it is in flight.
+//!
+//! A long-running agent — a multi-turn tool loop — sometimes needs to hear about
+//! something that happened *after* it was prompted: a user follow-up, an
+//! external event, a cancellation note. [`AgentRunner::message_injector`] hands
+//! back a cloneable [`MessageInjector`] bound to the run; a message pushed
+//! through it is delivered as its own user turn immediately before the run's
+//! next model call.
+//!
+//! Delivery is **best-effort and in-flight**: if the run finishes before the
+//! next model call, the message is not delivered (and a later `inject` reports
+//! `RunFinished`). Injection does not resurrect a completed run — to continue a
+//! finished conversation, start a new run with the prior history.
+//!
+//! Here the agent researches a topic with a (deliberately slow) `research` tool
+//! while a background "watcher" task injects a steering note partway through.
+//! The "fold input between steps" point mirrors pydantic-ai's `AgentRun.enqueue`,
+//! Vercel AI SDK's `prepareStep`, and LangGraph's `Command(resume=…)` — but needs
+//! no checkpointer.
+//!
+//! Requires `OPENAI_API_KEY`. Run with: `cargo run -p agent_with_message_injection`
+
+use std::time::Duration;
+
+use anyhow::Result;
+use rig::client::{CompletionClient, ProviderClient};
+use rig::providers::openai;
+use rig::tool::Tool;
+use serde::Deserialize;
+use serde_json::json;
+
+// ---------------------------------------------------------------------------
+// A deliberately slow tool, so the run lasts long enough to inject into.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, thiserror::Error)]
+#[error("tool failed: {0}")]
+struct ToolError(String);
+
+#[derive(Deserialize)]
+struct ResearchArgs {
+    topic: String,
+}
+
+struct Research;
+
+impl Tool for Research {
+    const NAME: &'static str = "research";
+    type Error = ToolError;
+    type Args = ResearchArgs;
+    type Output = String;
+
+    fn description(&self) -> String {
+        "Look up a short finding about a single topic.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "topic": { "type": "string", "description": "The topic to research" }
+            },
+            "required": ["topic"]
+        })
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        println!("   🔎 [research] -> {}", args.topic);
+        // Simulate a slow lookup, leaving a window for a message to be injected.
+        tokio::time::sleep(Duration::from_millis(900)).await;
+        Ok(format!(
+            "Finding on '{}': it is widely adopted and well documented.",
+            args.topic
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let agent = openai::Client::from_env()?
+        .agent(openai::GPT_4O)
+        .preamble(
+            "You are a research assistant. Use the `research` tool to investigate each aspect \
+             of the user's request, one tool call at a time, then write a short final summary.",
+        )
+        .tool(Research)
+        .build();
+
+    let prompt = "Compare Postgres and SQLite for a small web app. Research them one at a time.";
+    println!("User: {prompt}\n");
+
+    // Build a runner instead of calling `agent.prompt(..)` directly, so we can
+    // take an injector handle *before* the run starts.
+    let mut runner = agent.runner(prompt).max_turns(10);
+    let injector = runner.message_injector();
+
+    // Drive the agent on a task; hold the injector here in `main`.
+    let run = tokio::spawn(async move { runner.run().await });
+
+    // ...meanwhile, a watcher reacts to an external event and steers the run
+    // while it is still mid-tool-loop. (In a real app this might be a user
+    // keystroke, a webhook, or a DB poll.)
+    tokio::time::sleep(Duration::from_millis(1200)).await;
+    println!("\n💬 [watcher] injecting a mid-run steering note...\n");
+    match injector.inject(
+        "One more requirement from the user: weigh operational cost and ops burden, \
+         not just raw performance.",
+    ) {
+        Ok(()) => {}
+        // The run already finished — nothing more to steer.
+        Err(err) => println!("   (could not inject: {err})"),
+    }
+
+    let response = run.await??;
+    println!("\nFinal response:\n{}", response.output);
+
+    Ok(())
+}

--- a/tests/common/support.rs
+++ b/tests/common/support.rs
@@ -233,6 +233,8 @@ pub(crate) fn zero_arg_tool_definition(name: &str) -> ToolDefinition {
             "properties": {},
             "required": [],
         }),
+        output_schema: None,
+        metadata: Default::default(),
     }
 }
 

--- a/tests/providers/anthropic/cassette/empty_end_turn.rs
+++ b/tests/providers/anthropic/cassette/empty_end_turn.rs
@@ -41,6 +41,8 @@ struct NotifyError;
 
 fn notify_tool_definition() -> ToolDefinition {
     ToolDefinition {
+        output_schema: None,
+        metadata: Default::default(),
         name: Notify::NAME.to_string(),
         description: "Send a short notification for a user status update.".to_string(),
         parameters: json!({

--- a/tests/providers/anthropic/cassette/messages_tool_args.rs
+++ b/tests/providers/anthropic/cassette/messages_tool_args.rs
@@ -311,6 +311,8 @@ async fn unicode_arguments_streaming() {
                 )
                 .max_tokens(1024)
                 .tool(ToolDefinition {
+                    output_schema: None,
+                    metadata: Default::default(),
                     name: "echo".to_string(),
                     description: "Echo a message back to the user.".to_string(),
                     parameters: json!({

--- a/tests/providers/anthropic/cassette/prompt_caching.rs
+++ b/tests/providers/anthropic/cassette/prompt_caching.rs
@@ -253,6 +253,8 @@ fn cache_probe_preamble_for(label: &str) -> String {
 fn cache_probe_tools() -> Vec<ToolDefinition> {
     vec![
         ToolDefinition {
+            output_schema: None,
+            metadata: Default::default(),
             name: "lookup_cache_policy".to_string(),
             description: format!(
                 "Return internal prompt cache policy notes. {}",
@@ -270,6 +272,8 @@ fn cache_probe_tools() -> Vec<ToolDefinition> {
             }),
         },
         ToolDefinition {
+            output_schema: None,
+            metadata: Default::default(),
             name: "lookup_cache_fixture".to_string(),
             description: format!(
                 "Return prompt cache fixture notes. {}",
@@ -292,6 +296,8 @@ fn cache_probe_tools() -> Vec<ToolDefinition> {
 fn cache_probe_tools_for(label: &str) -> Vec<ToolDefinition> {
     vec![
         ToolDefinition {
+            output_schema: None,
+            metadata: Default::default(),
             name: "lookup_cache_policy".to_string(),
             description: format!(
                 "Return {label} internal prompt cache policy notes. {}",
@@ -309,6 +315,8 @@ fn cache_probe_tools_for(label: &str) -> Vec<ToolDefinition> {
             }),
         },
         ToolDefinition {
+            output_schema: None,
+            metadata: Default::default(),
             name: "lookup_cache_fixture".to_string(),
             description: format!(
                 "Return prompt cache fixture notes. {}",

--- a/tests/providers/chatgpt/cassette/codex_tool_args.rs
+++ b/tests/providers/chatgpt/cassette/codex_tool_args.rs
@@ -306,6 +306,8 @@ async fn unicode_arguments_streaming() {
                         .to_string(),
                 )
                 .tool(ToolDefinition {
+                    output_schema: None,
+                    metadata: Default::default(),
                     name: "echo".to_string(),
                     description: "Echo a message back to the user.".to_string(),
                     parameters: json!({

--- a/tests/providers/gemini/agent_run_support.rs
+++ b/tests/providers/gemini/agent_run_support.rs
@@ -30,6 +30,8 @@ pub(crate) struct MathError;
 
 fn operation_definition(name: &str, description: &str) -> ToolDefinition {
     ToolDefinition {
+        output_schema: None,
+        metadata: Default::default(),
         name: name.to_string(),
         description: description.to_string(),
         parameters: json!({

--- a/tests/providers/gemini/cassette/generate_tool_args.rs
+++ b/tests/providers/gemini/cassette/generate_tool_args.rs
@@ -247,6 +247,8 @@ async fn unicode_arguments_streaming() {
                 )
                 .temperature(0.0)
                 .tool(ToolDefinition {
+                    output_schema: None,
+                    metadata: Default::default(),
                     name: "echo".to_string(),
                     description: "Echo a message back to the user.".to_string(),
                     parameters: json!({
@@ -312,6 +314,8 @@ async fn optional_nullable_argument_omitted_when_not_requested() {
                 )
                 .temperature(0.0)
                 .tool(ToolDefinition {
+                    output_schema: None,
+                    metadata: Default::default(),
                     name: "log_event".to_string(),
                     description: "Record an event with an optional free-form note.".to_string(),
                     parameters: json!({

--- a/tests/providers/gemini/cassette/interactions_api.rs
+++ b/tests/providers/gemini/cassette/interactions_api.rs
@@ -143,6 +143,8 @@ async fn tool_result_roundtrip() {
         |client| async move {
             let model = client.completion_model("gemini-3-flash-preview");
             let tool = rig::completion::ToolDefinition {
+                output_schema: None,
+                metadata: Default::default(),
                 name: "add".to_string(),
                 description: "Add two numbers together".to_string(),
                 parameters: serde_json::json!({

--- a/tests/providers/gemini/tools_support.rs
+++ b/tests/providers/gemini/tools_support.rs
@@ -65,6 +65,8 @@ pub(crate) struct MathError;
 
 fn operation_definition(name: &str, description: &str) -> ToolDefinition {
     ToolDefinition {
+        output_schema: None,
+        metadata: Default::default(),
         name: name.to_string(),
         description: description.to_string(),
         parameters: json!({

--- a/tests/providers/openai/cassette/response_schema.rs
+++ b/tests/providers/openai/cassette/response_schema.rs
@@ -75,6 +75,8 @@ fn check_add_prps(schema: &Value) -> bool {
 fn test_nested_objects() {
     let schema = schema_for!(Person);
     let tool_def = ToolDefinition {
+        output_schema: None,
+        metadata: Default::default(),
         name: "submit".to_string(),
         description: "Submit".to_string(),
         parameters: serde_json::to_value(schema).unwrap(),
@@ -91,6 +93,8 @@ fn test_nested_objects() {
 fn test_array_items() {
     let schema = schema_for!(Company);
     let tool_def = ToolDefinition {
+        output_schema: None,
+        metadata: Default::default(),
         name: "submit".to_string(),
         description: "Submit".to_string(),
         parameters: serde_json::to_value(schema).unwrap(),
@@ -107,6 +111,8 @@ fn test_array_items() {
 fn test_enum_schemas() {
     let schema = schema_for!(Product);
     let tool_def = ToolDefinition {
+        output_schema: None,
+        metadata: Default::default(),
         name: "submit".to_string(),
         description: "Submit".to_string(),
         parameters: serde_json::to_value(schema).unwrap(),

--- a/tests/providers/openai/cassette/responses_tool_args.rs
+++ b/tests/providers/openai/cassette/responses_tool_args.rs
@@ -306,6 +306,8 @@ async fn unicode_arguments_streaming() {
                         .to_string(),
                 )
                 .tool(ToolDefinition {
+                    output_schema: None,
+                    metadata: Default::default(),
                     name: "echo".to_string(),
                     description: "Echo a message back to the user.".to_string(),
                     parameters: json!({


### PR DESCRIPTION
## Summary

This PR implements a **foundational subset** of the production coding-agent roadmap in #2118. It does not complete the epic and is not intended to close every linked issue.

### Implemented

#### Interactive run foundations

- run-bound `RunControlHandle` with stable `RunId`, observable status, cooperative cancellation/deadlines, steering, follow-up storage, and queued-next-turn storage
- shared cancellation/steering behavior through the existing streaming/non-streaming drive loop
- host-only `RunContext` injection into tool extensions
- serializable `AgentRun` message injection at safe state-machine boundaries and an end-to-end example
- cancellation and bounded depth propagation for existing agent-as-tool child runs
- best-effort normalization of common terminal fields exposed by serializable provider responses

#### Tool-platform foundations

- host-side tool output schemas and operational kind/execution/source metadata
- corresponding `Tool`/`ToolDyn` metadata hooks and MCP schema/kind projection
- ordered catalog snapshots and atomic replacement through `ToolServerHandle`
- direct rich `ToolResultContent` results with legacy string compatibility
- isolated `Scratchpad::for_call` state for concurrent hooks
- `AgentBuilder::provider_tool` / `provider_tools`, routed through existing provider tool-array merge paths
- runtime-agnostic `CodeRuntime` / `CodeModeTool` adapter contracts with explicit catalogs and limits

#### Persistence and reusable capabilities

- transactional, ordered `SqliteConversationMemory`, separate from session events
- backend-neutral append-only `SessionStore` types plus an in-memory reference implementation
- provider-independent progressive-disclosure `SkillCatalog` types plus an in-memory catalog

## Explicitly not completed

This PR does **not** yet provide:

- pause/checkpoint/resume operations over an active async runner
- guaranteed cancellation of subprocess trees or every provider/MCP transport
- a hook-aware nested executor with call ancestry, allowlists, recursion guards, and structured nested outcomes
- run-scoped tool factories and deterministic cleanup
- complete provider-specific unary/streaming terminal-reason mappings
- a public hook test harness, classified-error extension hook, or graceful `Flow::Finish`
- per-run/per-turn catalog activation or complete typed provenance for every tool family
- bounded tool execution repair/retry
- output truncation artifacts, per-resource mutation queues, shell backends, remote/sandbox backends, progress reporting, or permission/trust implementations
- a durable session-event backend, runner event persistence, interrupted-turn recovery, import/export, or durable branch navigation
- filesystem `SKILL.md` discovery, Agent Skills standard loading, or project-trust enforcement
- full subagent orchestration with fresh/forked context, bounded concurrency, progress/status subscriptions, typed handoffs, and session correlation
- a concrete JavaScript/Python/Lua/Wasm code runtime

`ToolDefinition::output_schema` is currently host/catalog metadata and is intentionally excluded from generic provider serialization. Therefore this PR does not complete #1613's model-wire requirement.

## Compatibility

Existing string-returning tools, native tools, MCP dispatch, hooks, `ConversationMemory`, blocking prompts, and streaming prompts remain supported. `ToolDefinition` gains output-schema and host-metadata fields, so in-workspace struct literals are updated explicitly.

## Validation

- `cargo fmt`
- `cargo check --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p rig-core -p rig-sqlite --all-features --no-deps`
- `cargo test -p rig-sqlite --lib`
- targeted run-control and Ollama cassette regression tests
- GitHub `Lint & Test`: fmt, WASM check, clippy, docs, doctests, and full tests all pass

## Issue scope

Closes #1968
Closes #1890

Partial progress toward #2118, #2116, #2090, #2095, #2094, #1906, #1613, #1264, and #1439.

Implements a run-scoped alternative informed by #1858, but does not claim to complete all steering/follow-up semantics from the epic. Incorporates part of the terminal-metadata direction from #1886 without superseding that PR's provider-specific streaming mappings.
