### PR TITLE
feat(agent)!: production-grade interactive coding-agent runtime

### DIFF
--- a/crates/rig-bedrock/src/types/assistant_content.rs
+++ b/crates/rig-bedrock/src/types/assistant_content.rs
@@ -115,6 +115,7 @@ impl TryFrom<AwsConverseOutput> for completion::CompletionResponse<AwsConverseOu
             usage,
             raw_response: value,
             message_id: None,
+            finish_reason: None,
         })
     }
 }

--- a/crates/rig-bedrock/src/types/completion_request.rs
+++ b/crates/rig-bedrock/src/types/completion_request.rs
@@ -279,6 +279,7 @@ mod tests {
                     "type": "object",
                     "properties": {}
                 }),
+                output_schema: None,
             }],
             ..minimal_request()
         };
@@ -312,6 +313,7 @@ mod tests {
                     "type": "object",
                     "properties": {}
                 }),
+                output_schema: None,
             }],
             ..minimal_request()
         };
@@ -345,6 +347,7 @@ mod tests {
                     "type": "object",
                     "properties": {}
                 }),
+                output_schema: None,
             }],
             ..minimal_request()
         };
@@ -372,6 +375,7 @@ mod tests {
                     "type": "object",
                     "properties": {}
                 }),
+                output_schema: None,
             }],
             ..minimal_request()
         };
@@ -405,6 +409,7 @@ mod tests {
                     "type": "object",
                     "properties": {}
                 }),
+                output_schema: None,
             }],
             ..minimal_request()
         };
@@ -432,6 +437,7 @@ mod tests {
                     "type": "object",
                     "properties": {}
                 }),
+                output_schema: None,
             }],
             ..minimal_request()
         };
@@ -477,6 +483,7 @@ mod tests {
                     },
                     "required": ["location"]
                 }),
+                output_schema: None,
             }],
             ..minimal_request()
         };

--- a/crates/rig-core/Cargo.toml
+++ b/crates/rig-core/Cargo.toml
@@ -42,7 +42,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 rmcp = { workspace = true, optional = true, features = ["client"] }
-tokio = { workspace = true, features = ["rt", "sync"] }
+tokio = { workspace = true, features = ["macros", "rt", "sync", "time"] }
 http = { workspace = true }
 tracing-futures = { workspace = true, features = ["futures-03"] }
 serenity = { workspace = true, optional = true }

--- a/crates/rig-core/src/agent/builder.rs
+++ b/crates/rig-core/src/agent/builder.rs
@@ -4,7 +4,8 @@ use schemars::{JsonSchema, Schema, schema_for};
 
 use crate::{
     agent::hook::{AgentHook, HookStack},
-    completion::{CompletionModel, Document},
+    completion::request::merge_provider_tools_into_additional_params,
+    completion::{CompletionModel, Document, ProviderToolDefinition},
     memory::ConversationMemory,
     message::ToolChoice,
     tool::{
@@ -217,6 +218,21 @@ where
     /// Set additional parameters to be passed to the model
     pub fn additional_params(mut self, params: serde_json::Value) -> Self {
         self.additional_params = Some(params);
+        self
+    }
+
+    /// Add a provider-hosted tool executed by the model provider rather than
+    /// Rig's local tool server.
+    pub fn provider_tool(mut self, tool: ProviderToolDefinition) -> Self {
+        self.additional_params =
+            merge_provider_tools_into_additional_params(self.additional_params, vec![tool]);
+        self
+    }
+
+    /// Add provider-hosted tools executed by the model provider.
+    pub fn provider_tools(mut self, tools: Vec<ProviderToolDefinition>) -> Self {
+        self.additional_params =
+            merge_provider_tools_into_additional_params(self.additional_params, tools);
         self
     }
 

--- a/crates/rig-core/src/agent/completion.rs
+++ b/crates/rig-core/src/agent/completion.rs
@@ -549,6 +549,7 @@ pub(crate) async fn build_prepared_completion_request<M: CompletionModel>(
                           schema."
                 .to_string(),
             parameters: schema.clone().to_value(),
+            output_schema: None,
         });
     }
 

--- a/crates/rig-core/src/agent/control.rs
+++ b/crates/rig-core/src/agent/control.rs
@@ -1,0 +1,396 @@
+//! Run-scoped identity, cancellation, steering, and lifecycle control.
+//!
+//! A [`RunControlHandle`] is created with every [`AgentRunner`](super::AgentRunner).
+//! Clone it before starting the runner to steer, follow up, pause, resume, or
+//! cancel the same run from another task. Control is observed at safe agent-loop
+//! boundaries and while model/tool futures are pending.
+
+use std::{
+    collections::VecDeque,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU8, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+use tokio::sync::watch;
+
+use crate::completion::Message;
+
+use super::RunId;
+
+/// Observable lifecycle state of an agent run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RunStatus {
+    /// Constructed but not yet driven.
+    Pending,
+    /// Model or tool work is active.
+    Running,
+    /// Paused at a safe boundary.
+    Paused,
+    /// Completed successfully.
+    Completed,
+    /// Cancelled by the host or deadline.
+    Cancelled,
+    /// Failed with an error.
+    Failed,
+    /// Exhausted its configured turn budget.
+    Exhausted,
+}
+
+impl RunStatus {
+    const fn code(self) -> u8 {
+        match self {
+            Self::Pending => 0,
+            Self::Running => 1,
+            Self::Paused => 2,
+            Self::Completed => 3,
+            Self::Cancelled => 4,
+            Self::Failed => 5,
+            Self::Exhausted => 6,
+        }
+    }
+
+    const fn from_code(code: u8) -> Self {
+        match code {
+            1 => Self::Running,
+            2 => Self::Paused,
+            3 => Self::Completed,
+            4 => Self::Cancelled,
+            5 => Self::Failed,
+            6 => Self::Exhausted,
+            _ => Self::Pending,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct Queues {
+    steer: VecDeque<Message>,
+    follow_up: VecDeque<Message>,
+    next_turn: VecDeque<Message>,
+}
+
+#[derive(Debug)]
+struct RunControlInner {
+    run_id: RunId,
+    status: AtomicU8,
+    queues: Mutex<Queues>,
+    changed: watch::Sender<u64>,
+    deadline: Mutex<Option<Instant>>,
+}
+
+/// Cloneable host control for one agent run.
+///
+/// Queue ownership is run-scoped: steering and follow-up messages are consumed
+/// only by the runner that created this handle. `next_turn` messages are never
+/// consumed by an active run and can be drained by the host after it settles.
+#[derive(Debug, Clone)]
+pub struct RunControlHandle(Arc<RunControlInner>);
+
+impl Default for RunControlHandle {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RunControlHandle {
+    /// Create an independent run control handle.
+    pub fn new() -> Self {
+        Self(Arc::new(RunControlInner {
+            run_id: RunId::generate(),
+            status: AtomicU8::new(RunStatus::Pending.code()),
+            queues: Mutex::new(Queues::default()),
+            changed: watch::channel(0).0,
+            deadline: Mutex::new(None),
+        }))
+    }
+
+    /// Stable process-scoped identity for this run.
+    pub fn run_id(&self) -> &RunId {
+        &self.0.run_id
+    }
+
+    /// Current lifecycle state.
+    pub fn status(&self) -> RunStatus {
+        RunStatus::from_code(self.0.status.load(Ordering::Acquire))
+    }
+
+    /// Request cancellation. Repeated calls are idempotent.
+    pub fn cancel(&self) {
+        if matches!(
+            self.status(),
+            RunStatus::Completed | RunStatus::Cancelled | RunStatus::Failed | RunStatus::Exhausted
+        ) {
+            return;
+        }
+        let mut queues = self.lock_queues();
+        queues.steer.clear();
+        queues.follow_up.clear();
+        drop(queues);
+        self.set_status(RunStatus::Cancelled);
+    }
+
+    /// Queue a message for the next safe boundary before a model call.
+    pub fn steer(&self, message: impl Into<Message>) {
+        self.lock_queues().steer.push_back(message.into());
+        self.notify();
+    }
+
+    /// Queue a message to run only when the active run would otherwise finish.
+    pub fn follow_up(&self, message: impl Into<Message>) {
+        self.lock_queues().follow_up.push_back(message.into());
+        self.notify();
+    }
+
+    /// Queue a message for a future host-started turn. Active runs never drain it.
+    pub fn next_turn(&self, message: impl Into<Message>) {
+        self.lock_queues().next_turn.push_back(message.into());
+        self.notify();
+    }
+
+    /// Drain messages queued for future host-started turns.
+    pub fn drain_next_turn(&self) -> Vec<Message> {
+        self.lock_queues().next_turn.drain(..).collect()
+    }
+
+    /// Ask the run to pause at its next safe boundary.
+    pub fn pause(&self) {
+        if !matches!(
+            self.status(),
+            RunStatus::Completed | RunStatus::Cancelled | RunStatus::Failed | RunStatus::Exhausted
+        ) {
+            self.set_status(RunStatus::Paused);
+        }
+    }
+
+    /// Resume a paused run.
+    pub fn resume(&self) {
+        if self.status() == RunStatus::Paused {
+            self.set_status(RunStatus::Running);
+        }
+    }
+
+    /// Set a relative deadline for the run.
+    pub fn deadline_after(&self, duration: Duration) {
+        *self.lock_deadline() = Instant::now().checked_add(duration);
+        self.notify();
+    }
+
+    /// Clear the configured deadline.
+    pub fn clear_deadline(&self) {
+        *self.lock_deadline() = None;
+    }
+
+    pub(crate) fn set_status(&self, status: RunStatus) {
+        let current = self.status();
+        if matches!(
+            current,
+            RunStatus::Completed | RunStatus::Cancelled | RunStatus::Failed | RunStatus::Exhausted
+        ) && current != status
+        {
+            return;
+        }
+        self.0.status.store(status.code(), Ordering::Release);
+        self.notify();
+    }
+
+    pub(crate) fn cancellation_reason(&self) -> Option<&'static str> {
+        if self.status() == RunStatus::Cancelled {
+            return Some("run cancelled by host");
+        }
+        if self
+            .lock_deadline()
+            .is_some_and(|deadline| Instant::now() >= deadline)
+        {
+            self.set_status(RunStatus::Cancelled);
+            return Some("run deadline exceeded");
+        }
+        None
+    }
+
+    pub(crate) async fn cancelled(&self) -> &'static str {
+        let mut changes = self.0.changed.subscribe();
+        loop {
+            if let Some(reason) = self.cancellation_reason() {
+                return reason;
+            }
+            let deadline = *self.lock_deadline();
+            match deadline {
+                Some(deadline) => {
+                    tokio::select! {
+                        _ = changes.changed() => {}
+                        _ = tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)) => {}
+                    }
+                }
+                None => {
+                    let _ = changes.changed().await;
+                }
+            }
+        }
+    }
+
+    pub(crate) async fn wait_if_paused(&self) {
+        let mut changes = self.0.changed.subscribe();
+        while self.status() == RunStatus::Paused {
+            let _ = changes.changed().await;
+        }
+    }
+
+    pub(crate) fn drain_steer(&self) -> Vec<Message> {
+        self.lock_queues().steer.drain(..).collect()
+    }
+
+    pub(crate) fn pop_follow_up(&self) -> Option<Message> {
+        self.lock_queues().follow_up.pop_front()
+    }
+
+    fn notify(&self) {
+        self.0
+            .changed
+            .send_modify(|version| *version = version.wrapping_add(1));
+    }
+
+    fn lock_queues(&self) -> std::sync::MutexGuard<'_, Queues> {
+        self.0
+            .queues
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+    }
+
+    fn lock_deadline(&self) -> std::sync::MutexGuard<'_, Option<Instant>> {
+        self.0
+            .deadline
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn queues_are_distinct_and_cancel_wakes_waiters() {
+        let control = RunControlHandle::new();
+        control.steer("steer");
+        control.follow_up("follow");
+        control.next_turn("next");
+        assert_eq!(control.drain_steer().len(), 1);
+        assert!(control.pop_follow_up().is_some());
+        assert_eq!(control.drain_next_turn().len(), 1);
+
+        let waiter = {
+            let control = control.clone();
+            tokio::spawn(async move { control.cancelled().await })
+        };
+        control.cancel();
+        assert_eq!(waiter.await.expect("waiter"), "run cancelled by host");
+        assert_eq!(control.status(), RunStatus::Cancelled);
+    }
+
+    #[tokio::test]
+    async fn pause_and_resume_are_boundary_state() {
+        let control = RunControlHandle::new();
+        control.set_status(RunStatus::Running);
+        control.pause();
+        assert_eq!(control.status(), RunStatus::Paused);
+        control.resume();
+        control.wait_if_paused().await;
+        assert_eq!(control.status(), RunStatus::Running);
+    }
+
+    #[tokio::test]
+    async fn cancellation_before_start_prevents_model_io() {
+        use crate::{
+            agent::AgentBuilder, completion::PromptError, test_utils::MockCompletionModel,
+        };
+
+        let model = MockCompletionModel::text("unused");
+        let recorded = model.clone();
+        let runner = AgentBuilder::new(model).build().runner("start");
+        let control = runner.control_handle();
+        control.cancel();
+        let error = runner.run().await.expect_err("cancelled run");
+        assert!(matches!(error, PromptError::PromptCancelled { .. }));
+        assert_eq!(recorded.request_count(), 0);
+        assert_eq!(control.status(), RunStatus::Cancelled);
+    }
+
+    #[tokio::test]
+    async fn steer_and_follow_up_use_separate_safe_boundaries() {
+        use crate::{
+            agent::AgentBuilder,
+            completion::Message,
+            test_utils::{MockCompletionModel, MockTurn},
+        };
+
+        let model = MockCompletionModel::new([MockTurn::text("first"), MockTurn::text("second")]);
+        let recorded = model.clone();
+        let runner = AgentBuilder::new(model)
+            .build()
+            .runner("initial")
+            .max_turns(2);
+        let control = runner.control_handle();
+        control.steer("steered");
+        control.follow_up("after settle");
+        let response = runner.run().await.expect("controlled run");
+        assert_eq!(response.output, "second");
+
+        let requests = recorded.requests();
+        assert_eq!(requests.len(), 2);
+        let first = requests.first().expect("first request");
+        assert_eq!(first.chat_history.last(), Message::user("steered"));
+        let second = requests.get(1).expect("follow-up request");
+        assert_eq!(second.chat_history.last(), Message::user("after settle"));
+        assert_eq!(control.status(), RunStatus::Completed);
+    }
+}
+
+/// Context automatically attached to every tool call in a run.
+#[derive(Debug, Clone)]
+pub struct RunContext {
+    control: RunControlHandle,
+    conversation_id: Option<String>,
+}
+
+impl RunContext {
+    pub(crate) fn new(control: RunControlHandle, conversation_id: Option<String>) -> Self {
+        Self {
+            control,
+            conversation_id,
+        }
+    }
+
+    /// Stable run identity.
+    pub fn run_id(&self) -> &RunId {
+        self.control.run_id()
+    }
+
+    /// Durable host conversation identity, when configured.
+    pub fn conversation_id(&self) -> Option<&str> {
+        self.conversation_id.as_deref()
+    }
+
+    /// Cloneable control handle carrying cancellation and deadline state.
+    pub fn control(&self) -> &RunControlHandle {
+        &self.control
+    }
+}
+
+/// Correlation metadata automatically attached to one tool invocation.
+#[derive(Debug, Clone)]
+pub struct ToolCallContext {
+    /// Run-scoped context inherited by this call.
+    pub run: RunContext,
+    /// Rig-generated call identity.
+    pub internal_call_id: String,
+    /// Provider-generated call identity, when available.
+    pub provider_call_id: Option<String>,
+    /// Parent call identity for nested dispatch, when applicable.
+    pub parent_internal_call_id: Option<String>,
+    /// Zero for top-level calls, increasing for nested dispatch.
+    pub depth: usize,
+}

--- a/crates/rig-core/src/agent/hook.rs
+++ b/crates/rig-core/src/agent/hook.rs
@@ -140,6 +140,7 @@
 //! }
 //! ```
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -291,6 +292,60 @@ impl std::fmt::Debug for Scratchpad {
     }
 }
 
+#[derive(Clone, Default)]
+struct CallScratchpads(HashMap<String, Scratchpad>);
+
+/// Typed scratchpad isolated to one internal tool-call identity.
+#[derive(Clone, Debug)]
+pub struct CallScratchpad(Scratchpad);
+
+impl CallScratchpad {
+    /// Insert a typed value, returning the previous value.
+    pub fn insert<T: Clone + WasmCompatSend + WasmCompatSync + 'static>(
+        &self,
+        value: T,
+    ) -> Option<T> {
+        self.0.insert(value)
+    }
+
+    /// Clone a typed value from this call's state.
+    pub fn get<T: Clone + WasmCompatSend + WasmCompatSync + 'static>(&self) -> Option<T> {
+        self.0.get::<T>()
+    }
+
+    /// Atomically update a typed value, starting from `Default`.
+    pub fn update<T, R>(&self, f: impl FnOnce(&mut T) -> R) -> R
+    where
+        T: Clone + Default + WasmCompatSend + WasmCompatSync + 'static,
+    {
+        self.0.update(f)
+    }
+
+    /// Remove a typed value from this call's state.
+    pub fn remove<T: Clone + WasmCompatSend + WasmCompatSync + 'static>(&self) -> Option<T> {
+        self.0.remove::<T>()
+    }
+}
+
+impl Scratchpad {
+    /// Obtain state isolated by `internal_call_id`.
+    ///
+    /// Concurrent tool calls receive independent type maps instead of racing on
+    /// a run-global "latest result" slot.
+    pub fn for_call(&self, internal_call_id: impl Into<String>) -> CallScratchpad {
+        let internal_call_id = internal_call_id.into();
+        let pad = self.update(|calls: &mut CallScratchpads| {
+            calls.0.entry(internal_call_id).or_default().clone()
+        });
+        CallScratchpad(pad)
+    }
+
+    /// Remove all state associated with a completed call.
+    pub fn remove_call(&self, internal_call_id: &str) -> bool {
+        self.update(|calls: &mut CallScratchpads| calls.0.remove(internal_call_id).is_some())
+    }
+}
+
 /// Run-scoped context passed by shared reference to every [`AgentHook::on_event`]
 /// call.
 ///
@@ -306,12 +361,12 @@ impl std::fmt::Debug for Scratchpad {
 /// hooks for different tools in a turn can run concurrently against this shared
 /// context — see the [`Scratchpad` concurrency note](Scratchpad#concurrency) for
 /// how to store run-scoped state safely under that concurrency.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct HookContext {
-    run_id: RunId,
+    run_context: crate::agent::RunContext,
     // Interior-mutable so the driver can advance it each turn while hooks hold a
     // shared `&HookContext`; also the reason the context is `Sync`.
-    turn: AtomicUsize,
+    turn: Arc<AtomicUsize>,
     is_streaming: bool,
     agent_name: Option<String>,
     scratchpad: Scratchpad,
@@ -321,10 +376,14 @@ impl HookContext {
     /// Build a fresh run-scoped context. `is_streaming` records which surface is
     /// driving ([`run`](crate::agent::AgentRunner::run) vs.
     /// [`stream`](crate::agent::AgentRunner::stream)).
-    pub(crate) fn new(is_streaming: bool, agent_name: Option<String>) -> Self {
+    pub(crate) fn new(
+        run_context: crate::agent::RunContext,
+        is_streaming: bool,
+        agent_name: Option<String>,
+    ) -> Self {
         Self {
-            run_id: RunId::generate(),
-            turn: AtomicUsize::new(0),
+            run_context,
+            turn: Arc::new(AtomicUsize::new(0)),
             is_streaming,
             agent_name,
             scratchpad: Scratchpad::default(),
@@ -339,7 +398,12 @@ impl HookContext {
 
     /// The run's stable identifier.
     pub fn run_id(&self) -> &RunId {
-        &self.run_id
+        self.run_context.run_id()
+    }
+
+    /// Full run identity, conversation, cancellation, and deadline context.
+    pub fn run_context(&self) -> &crate::agent::RunContext {
+        &self.run_context
     }
 
     /// The current one-based model-call index (0 before the first turn).
@@ -1583,7 +1647,11 @@ mod tests {
     type M = MockCompletionModel;
 
     fn ctx() -> HookContext {
-        HookContext::new(false, Some("test-agent".to_string()))
+        HookContext::new(
+            crate::agent::RunContext::new(crate::agent::RunControlHandle::new(), None),
+            false,
+            Some("test-agent".to_string()),
+        )
     }
 
     /// Pushes its label when invoked and returns `Continue` or `Terminate`.
@@ -1986,7 +2054,11 @@ mod tests {
 
     #[test]
     fn hook_context_reports_identity_and_turn() {
-        let ctx = HookContext::new(true, Some("agent".to_string()));
+        let ctx = HookContext::new(
+            crate::agent::RunContext::new(crate::agent::RunControlHandle::new(), None),
+            true,
+            Some("agent".to_string()),
+        );
         assert!(ctx.is_streaming());
         assert_eq!(ctx.agent_name(), Some("agent"));
         assert_eq!(ctx.turn(), 0);

--- a/crates/rig-core/src/agent/mod.rs
+++ b/crates/rig-core/src/agent/mod.rs
@@ -106,10 +106,13 @@
 //! ```
 mod builder;
 mod completion;
+pub mod control;
 pub mod hook;
 pub(crate) mod prompt_request;
 pub mod run;
 pub mod runner;
+pub mod scoped_executor;
+pub mod subagent;
 mod tool;
 
 /// Fallback display name used in telemetry spans and logs when an agent has no
@@ -119,9 +122,10 @@ pub(crate) const UNKNOWN_AGENT_NAME: &str = "Unnamed Agent";
 pub use crate::message::Text;
 pub use builder::{AgentBuilder, NoToolConfig, WithBuilderTools, WithToolServerHandle};
 pub use completion::Agent;
+pub use control::{RunContext, RunControlHandle, RunStatus, ToolCallContext};
 pub use hook::{
-    AgentHook, Flow, HookContext, HookStack, InvalidToolCallContext, InvalidToolCallHookAction,
-    RequestPatch, RunId, Scratchpad, StepEvent, StepEventKind,
+    AgentHook, CallScratchpad, Flow, HookContext, HookStack, InvalidToolCallContext,
+    InvalidToolCallHookAction, RequestPatch, RunId, Scratchpad, StepEvent, StepEventKind,
 };
 pub use prompt_request::streaming::{
     MultiTurnStreamItem, StreamingError, StreamingPromptRequest, StreamingResult, stream_to_stdout,
@@ -129,5 +133,10 @@ pub use prompt_request::streaming::{
 pub use prompt_request::{
     CompletionCall, PromptRequest, PromptResponse, TypedPromptRequest, TypedPromptResponse,
 };
-pub use run::{AgentRun, AgentRunStep, ModelTurn, ModelTurnOutcome, OutputMode, PendingToolCall};
+pub use run::{
+    AgentCheckpoint, AgentRun, AgentRunStep, CheckpointError, ModelTurn, ModelTurnOutcome,
+    OutputMode, PendingToolCall,
+};
 pub use runner::AgentRunner;
+pub use scoped_executor::{ScopedExecutionPolicy, ScopedToolExecutor};
+pub use subagent::{Subagent, SubagentArgs, SubagentContextMode, SubagentError, SubagentHandoff};

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -202,7 +202,7 @@ where
 
 impl<M> PromptRequest<Standard, M>
 where
-    M: CompletionModel,
+    M: CompletionModel + 'static,
 {
     async fn send(self) -> Result<String, PromptError> {
         self.extended_details().send().await.map(|resp| resp.output)
@@ -492,6 +492,15 @@ pub(crate) fn tool_result_output(
     tool_result_with(id, call_id, ToolResultContent::from_tool_output(output))
 }
 
+/// Shape explicit rich content without interpreting JSON strings.
+pub(crate) fn tool_result_content(
+    id: String,
+    call_id: Option<String>,
+    content: OneOrMany<ToolResultContent>,
+) -> UserContent {
+    tool_result_with(id, call_id, content)
+}
+
 /// Shape a **synthetic message** (a hook skip reason, recovery feedback, or a
 /// "not executed" notice) as a tool result. Emitted **verbatim as text** and
 /// never re-parsed as structured tool output, so a JSON-shaped message is not
@@ -558,7 +567,7 @@ pub(crate) fn assistant_text_from_choice(choice: &OneOrMany<AssistantContent>) -
 
 impl<M> PromptRequest<Extended, M>
 where
-    M: CompletionModel,
+    M: CompletionModel + 'static,
 {
     async fn send(self) -> Result<PromptResponse, PromptError> {
         self.runner.run().await
@@ -691,7 +700,7 @@ fn deserialize_structured_output<T: DeserializeOwned>(text: &str) -> Result<T, s
 impl<T, M> TypedPromptRequest<T, Standard, M>
 where
     T: JsonSchema + DeserializeOwned + WasmCompatSend,
-    M: CompletionModel,
+    M: CompletionModel + 'static,
 {
     /// Send the typed prompt request and deserialize the response.
     async fn send(self) -> Result<T, StructuredOutputError> {
@@ -709,7 +718,7 @@ where
 impl<T, M> TypedPromptRequest<T, Extended, M>
 where
     T: JsonSchema + DeserializeOwned + WasmCompatSend,
-    M: CompletionModel,
+    M: CompletionModel + 'static,
 {
     /// Send the typed prompt request with extended details and deserialize the response.
     async fn send(self) -> Result<TypedPromptResponse<T>, StructuredOutputError> {

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -454,6 +454,45 @@ pub(crate) fn streaming_error_into_prompt(err: StreamingError) -> PromptError {
     }
 }
 
+struct FactoryCleanupGuard {
+    factory: Option<Arc<dyn crate::tool::factory::RunToolsetFactory>>,
+    context: crate::agent::RunContext,
+}
+
+impl FactoryCleanupGuard {
+    async fn cleanup(&mut self) -> Result<(), crate::tool::factory::ToolFactoryError> {
+        if let Some(factory) = self.factory.take() {
+            factory.close(&self.context).await
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl Drop for FactoryCleanupGuard {
+    fn drop(&mut self) {
+        let Some(factory) = self.factory.take() else {
+            return;
+        };
+        let context = self.context.clone();
+        #[cfg(not(target_family = "wasm"))]
+        if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+            runtime.spawn(async move {
+                if let Err(error) = factory.close(&context).await {
+                    tracing::warn!(error = %error, "run toolset cleanup failed after driver drop");
+                }
+            });
+        }
+        #[cfg(target_family = "wasm")]
+        {
+            // Browser hosts cannot synchronously block in Drop. The factory's
+            // resources are Arc-owned and cancellation-aware; normal stream
+            // exhaustion still uses the awaited cleanup path above.
+            let _ = (factory, context);
+        }
+    }
+}
+
 /// The single agent drive loop, shared by the blocking and streaming surfaces.
 ///
 /// Owns the medium-independent loop — `next_step` dispatch, the `CompletionCall`
@@ -462,7 +501,7 @@ pub(crate) fn streaming_error_into_prompt(err: StreamingError) -> PromptError {
 /// a [`TurnSource`]. The streaming surface forwards the yielded [`DriveItem`]s;
 /// the blocking surface folds them to `Done`.
 pub(crate) fn drive_agent<M, S>(
-    runner: AgentRunner<M>,
+    mut runner: AgentRunner<M>,
     mut source: S,
     mut run: AgentRun,
     agent_span: tracing::Span,
@@ -478,12 +517,76 @@ where
         // Run-scoped hook context: minted once, shared by every hook event on
         // both surfaces. `is_streaming` records which surface is driving; the
         // per-turn index is advanced on each `CallModel` step below.
-        let hook_ctx = HookContext::new(is_streaming, runner.agent_name.clone());
+        if runner.control.status() == crate::agent::RunStatus::Pending {
+            runner.control.set_status(crate::agent::RunStatus::Running);
+        }
+        let lifecycle_context = crate::agent::RunContext::new(
+            runner.control.clone(),
+            runner.conversation_id.clone(),
+        );
+        let mut factory_cleanup: Option<FactoryCleanupGuard> = None;
+        if let Some(reason) = runner.control.cancellation_reason() {
+            yield Err(StreamingError::Prompt(Box::new(run.cancel_error(reason))));
+            return;
+        }
+        if let Some(factory) = runner.toolset_factory.clone() {
+            runner.tool_server_handle = runner.tool_server_handle.fork().await;
+            match factory.create(&lifecycle_context).await {
+                Ok(toolset) => {
+                    if let Err(error) = runner.tool_server_handle.append_toolset(toolset).await {
+                        runner.control.set_status(crate::agent::RunStatus::Failed);
+                        if let Err(cleanup_error) = factory.close(&lifecycle_context).await {
+                            tracing::warn!(error = %cleanup_error, "run toolset cleanup failed after registration error");
+                        }
+                        yield Err(StreamingError::Completion(crate::completion::CompletionError::ResponseError(error.to_string())));
+                        return;
+                    }
+                    factory_cleanup = Some(FactoryCleanupGuard {
+                        factory: Some(factory.clone()),
+                        context: lifecycle_context.clone(),
+                    });
+                }
+                Err(error) => {
+                    runner.control.set_status(crate::agent::RunStatus::Failed);
+                    if let Err(cleanup_error) = factory.close(&lifecycle_context).await {
+                        tracing::warn!(error = %cleanup_error, "run toolset cleanup failed after setup error");
+                    }
+                    yield Err(StreamingError::Completion(crate::completion::CompletionError::ResponseError(error.to_string())));
+                    return;
+                }
+            }
+        }
+        let hook_ctx = HookContext::new(
+            lifecycle_context.clone(),
+            is_streaming,
+            runner.agent_name.clone(),
+        );
 
         'outer: loop {
+            runner.control.wait_if_paused().await;
+            if let Some(reason) = runner.control.cancellation_reason() {
+                yield Err(StreamingError::Prompt(Box::new(run.cancel_error(reason))));
+                break 'outer;
+            }
+
+            if run.can_accept_input() {
+                for message in runner.control.drain_steer() {
+                    if let Err(err) = run.inject_message(message) {
+                        runner.control.set_status(crate::agent::RunStatus::Failed);
+                        yield Err(Box::new(err).into());
+                        break 'outer;
+                    }
+                }
+            }
+
             let step = match run.next_step() {
                 Ok(step) => step,
                 Err(err) => {
+                    runner.control.set_status(if matches!(err, crate::completion::PromptError::MaxTurnsError { .. }) {
+                        crate::agent::RunStatus::Exhausted
+                    } else {
+                        crate::agent::RunStatus::Failed
+                    });
                     yield Err(Box::new(err).into());
                     break 'outer;
                 }
@@ -499,6 +602,7 @@ where
                     let request_patch =
                         match resolve_completion_call(&runner.hooks, &hook_ctx, &prompt, &history, turn).await {
                             CompletionCallOutcome::Terminate(reason) => {
+                                runner.control.set_status(crate::agent::RunStatus::Cancelled);
                                 yield Err(StreamingError::Prompt(Box::new(run.cancel_error(reason))));
                                 break 'outer;
                             }
@@ -540,12 +644,14 @@ where
                     {
                         Ok(prepared) => prepared,
                         Err(err) => {
+                            runner.control.set_status(crate::agent::RunStatus::Failed);
                             yield Err(err.into());
                             break 'outer;
                         }
                     };
                     run.set_output_tool_name(prepared.output_tool_name.clone());
 
+                    let cancellation_history = run.full_history();
                     let mut turn_stream = source.run_model_turn(
                         &runner,
                         &hook_ctx,
@@ -556,11 +662,26 @@ where
                         prompt,
                     );
                     let mut errored = false;
-                    while let Some(item) = turn_stream.next().await {
+                    loop {
+                        let next = tokio::select! {
+                            reason = runner.control.cancelled() => {
+                                errored = true;
+                                yield Err(StreamingError::Prompt(Box::new(
+                                    crate::completion::PromptError::prompt_cancelled(
+                                        cancellation_history.clone(),
+                                        reason,
+                                    ),
+                                )));
+                                None
+                            }
+                            item = turn_stream.next() => item,
+                        };
+                        let Some(item) = next else { break; };
                         match item {
                             Ok(item) => yield Ok(DriveItem::Item(item)),
                             Err(err) => {
                                 errored = true;
+                                runner.control.set_status(crate::agent::RunStatus::Failed);
                                 yield Err(err);
                                 break;
                             }
@@ -572,13 +693,29 @@ where
                     }
                 }
                 AgentRunStep::CallTools { calls } => {
+                    let cancellation_history = run.full_history();
                     let mut tool_stream = source.run_tool_calls(&runner, &hook_ctx, &mut run, calls);
                     let mut errored = false;
-                    while let Some(item) = tool_stream.next().await {
+                    loop {
+                        let next = tokio::select! {
+                            reason = runner.control.cancelled() => {
+                                errored = true;
+                                yield Err(StreamingError::Prompt(Box::new(
+                                    crate::completion::PromptError::prompt_cancelled(
+                                        cancellation_history.clone(),
+                                        reason,
+                                    ),
+                                )));
+                                None
+                            }
+                            item = tool_stream.next() => item,
+                        };
+                        let Some(item) = next else { break; };
                         match item {
                             Ok(item) => yield Ok(DriveItem::Item(item)),
                             Err(err) => {
                                 errored = true;
+                                runner.control.set_status(crate::agent::RunStatus::Failed);
                                 yield Err(err);
                                 break;
                             }
@@ -590,6 +727,25 @@ where
                     }
                 }
                 AgentRunStep::Done(response) => {
+                    if let Some(message) = runner.control.pop_follow_up() {
+                        if let Err(err) = run.inject_message(message) {
+                            runner.control.set_status(crate::agent::RunStatus::Failed);
+                            yield Err(Box::new(err).into());
+                            break 'outer;
+                        }
+                        continue 'outer;
+                    }
+
+                    if let Some(cleanup) = factory_cleanup.as_mut()
+                        && let Err(error) = cleanup.cleanup().await
+                    {
+                        runner.control.set_status(crate::agent::RunStatus::Failed);
+                        yield Err(StreamingError::Completion(
+                            crate::completion::CompletionError::ResponseError(error.to_string()),
+                        ));
+                        break 'outer;
+                    }
+
                     // Run-completion marker, unifying the blocking and streaming
                     // drivers' run-finished logs into one shared event.
                     tracing::info!(
@@ -609,10 +765,17 @@ where
                     if let Some(final_item) = source.final_item(&response) {
                         yield Ok(DriveItem::Item(final_item));
                     }
+                    runner.control.set_status(crate::agent::RunStatus::Completed);
                     yield Ok(DriveItem::Done(Box::new(response)));
                     break 'outer;
                 }
             }
+        }
+
+        if let Some(cleanup) = factory_cleanup.as_mut()
+            && let Err(error) = cleanup.cleanup().await
+        {
+            tracing::warn!(error = %error, "run toolset cleanup failed after run error");
         }
     }
 }
@@ -649,7 +812,7 @@ pub(crate) fn drive_tool_calls<'a, M, R, F>(
     forward_items: bool,
 ) -> DriveStream<'a, R>
 where
-    M: CompletionModel,
+    M: CompletionModel + 'static,
     R: WasmCompatSend + 'a,
     F: Fn(tracing::Span) -> tracing::Span + WasmCompatSend + 'a,
 {
@@ -742,11 +905,17 @@ where
                     }
                     continue;
                 }
+                let call_extensions = runner.tool_call_extensions(
+                    hook_ctx,
+                    &tool_call.function.name,
+                    &internal_call_id,
+                    tool_call.call_id.as_deref(),
+                );
                 let outcome = run_single_tool(
                     &runner.hooks,
                     hook_ctx,
                     &runner.tool_server_handle,
-                    &runner.tool_extensions,
+                    &call_extensions,
                     &tool_call,
                     &internal_call_id,
                     &full_history_for_errors,
@@ -785,7 +954,12 @@ where
                     let PreparedToolCall { tool_call, preresolved_result, internal_call_id, span } = call;
                     let hooks = &runner.hooks;
                     let tool_server_handle = &runner.tool_server_handle;
-                    let tool_extensions = &runner.tool_extensions;
+                    let tool_extensions = runner.tool_call_extensions(
+                        hook_ctx,
+                        &tool_call.function.name,
+                        &internal_call_id,
+                        tool_call.call_id.as_deref(),
+                    );
                     let full_history_for_errors = &full_history_for_errors;
                     let terminating = terminating.clone();
                     async move {
@@ -807,7 +981,7 @@ where
                             hooks,
                             hook_ctx,
                             tool_server_handle,
-                            tool_extensions,
+                            &tool_extensions,
                             &tool_call,
                             &internal_call_id,
                             full_history_for_errors,
@@ -962,7 +1136,7 @@ impl StreamingTurnSource {
 
 impl<M> TurnSource<M> for StreamingTurnSource
 where
-    M: CompletionModel,
+    M: CompletionModel + 'static,
     <M as CompletionModel>::StreamingResponse: WasmCompatSend + GetTokenUsage,
 {
     type Raw = M::StreamingResponse;
@@ -1945,6 +2119,7 @@ mod tests {
                 },
                 "required": ["x", "y"],
             }),
+            output_schema: None,
         }
     }
 

--- a/crates/rig-core/src/agent/run/mod.rs
+++ b/crates/rig-core/src/agent/run/mod.rs
@@ -267,6 +267,24 @@ enum RunState {
     Failed,
 }
 
+/// Serialized agent state captured only at a safe step boundary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentCheckpoint {
+    state: String,
+}
+
+/// Checkpoint creation/restoration failure.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum CheckpointError {
+    /// A provider/tool/hook future or invalid-call decision is still pending.
+    #[error("agent run is not at a checkpoint-safe boundary")]
+    UnsafeBoundary,
+    /// State serialization or deserialization failed.
+    #[error("invalid agent checkpoint: {0}")]
+    Serialization(#[from] serde_json::Error),
+}
+
 /// The sans-IO agent loop state machine. See the [module docs](self) for the
 /// driving protocol.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -481,9 +499,52 @@ impl AgentRun {
         build_full_history(self.chat_history.as_deref(), self.new_messages.clone())
     }
 
+    /// Capture resumable state at a safe boundary.
+    ///
+    /// Arbitrary Rust futures are never suspended. A checkpoint is rejected
+    /// while a model response or invalid-call hook decision is pending.
+    pub fn checkpoint(&self) -> Result<AgentCheckpoint, CheckpointError> {
+        if matches!(
+            self.state,
+            RunState::AwaitingModel | RunState::ResolvingToolCalls(_)
+        ) {
+            return Err(CheckpointError::UnsafeBoundary);
+        }
+        Ok(AgentCheckpoint {
+            state: serde_json::to_string(self)?,
+        })
+    }
+
+    /// Restore a run captured by [`checkpoint`](Self::checkpoint).
+    pub fn from_checkpoint(checkpoint: &AgentCheckpoint) -> Result<Self, CheckpointError> {
+        Ok(serde_json::from_str(&checkpoint.state)?)
+    }
+
     /// Whether the run reached [`AgentRunStep::Done`].
     pub fn is_done(&self) -> bool {
         matches!(self.state, RunState::Done(_))
+    }
+
+    /// Whether a host message can be injected without interrupting an in-flight
+    /// model response, tool batch, or invalid-call recovery.
+    pub fn can_accept_input(&self) -> bool {
+        matches!(self.state, RunState::PreparingRequest | RunState::Done(_))
+    }
+
+    /// Inject a host message at a safe boundary.
+    ///
+    /// In a preparing run the message becomes the next prompt. In a completed
+    /// run it starts a follow-up turn while retaining the accumulated transcript.
+    /// Arbitrary in-flight futures are never suspended or serialized.
+    pub fn inject_message(&mut self, message: impl Into<Message>) -> Result<(), PromptError> {
+        if !self.can_accept_input() {
+            return Err(self.protocol_violation(
+                "host input can only be injected before a model call or after completion",
+            ));
+        }
+        self.new_messages.push(message.into());
+        self.state = RunState::PreparingRequest;
+        Ok(())
     }
 
     /// The final response once the run is done, without cloning it.

--- a/crates/rig-core/src/agent/runner.rs
+++ b/crates/rig-core/src/agent/runner.rs
@@ -35,6 +35,7 @@ use tracing::{Instrument, info_span, span::Id};
 
 use super::{
     completion::{Agent, DynamicContextStore, PreparedCompletionRequest},
+    control::{RunContext, RunControlHandle, ToolCallContext},
     hook::{
         AgentHook, Flow, HookContext, HookStack, InvalidToolCallHookAction, RequestPatch, StepEvent,
     },
@@ -44,18 +45,23 @@ use super::{
             DriveItem, DriveStream, MultiTurnStreamItem, StreamingError, TurnSource, drive_agent,
             drive_tool_calls, record_usage_on_span, streaming_error_into_prompt,
         },
-        tool_result_message, tool_result_output,
+        tool_result_content, tool_result_message, tool_result_output,
     },
     run::{
         AgentRun, DEFAULT_OUTPUT_RETRIES, ModelTurn, ModelTurnOutcome, OutputMode, PendingToolCall,
     },
+    scoped_executor::{NestedDispatchDyn, ScopedToolExecutor},
 };
 use crate::{
     completion::{CompletionError, CompletionModel, Document, Message, PromptError},
     json_utils,
     memory::ConversationMemory,
     message::{ToolCall, ToolChoice, UserContent},
-    tool::{ToolCallExtensions, ToolExecutionResult, ToolOutcome, server::ToolServerHandle},
+    tool::{
+        ToolCallExtensions, ToolExecutionResult, ToolOutcome, ToolOutput,
+        factory::RunToolsetFactory, server::ToolServerHandle,
+    },
+    wasm_compat::WasmBoxedFuture,
 };
 
 use super::UNKNOWN_AGENT_NAME;
@@ -291,6 +297,8 @@ where
     pub(crate) memory: Option<Arc<dyn ConversationMemory>>,
     pub(crate) conversation_id: Option<String>,
     pub(crate) hooks: HookStack<M>,
+    pub(crate) control: RunControlHandle,
+    pub(crate) toolset_factory: Option<Arc<dyn RunToolsetFactory>>,
 }
 
 impl<M> AgentRunner<M>
@@ -322,6 +330,8 @@ where
             memory: agent.memory.clone(),
             conversation_id: agent.default_conversation_id.clone(),
             hooks: agent.hooks.clone(),
+            control: RunControlHandle::new(),
+            toolset_factory: None,
         }
     }
 
@@ -336,6 +346,28 @@ where
         H: AgentHook<M> + 'static,
     {
         self.hooks.push(hook);
+        self
+    }
+
+    /// Clone the host control handle before consuming this runner with
+    /// [`run`](Self::run) or [`stream`](Self::stream).
+    pub fn control_handle(&self) -> RunControlHandle {
+        self.control.clone()
+    }
+
+    /// Replace the generated control handle, useful when a host allocates run
+    /// identity and control before constructing the runner.
+    pub fn with_control(mut self, control: RunControlHandle) -> Self {
+        self.control = control;
+        self
+    }
+
+    /// Attach a factory whose toolset exists only for this run.
+    pub fn run_toolset_factory<F>(mut self, factory: F) -> Self
+    where
+        F: RunToolsetFactory + 'static,
+    {
+        self.toolset_factory = Some(Arc::new(factory));
         self
     }
 }
@@ -421,6 +453,45 @@ where
 
     pub(crate) fn agent_name_or_default(&self) -> &str {
         self.agent_name.as_deref().unwrap_or(UNKNOWN_AGENT_NAME)
+    }
+
+    pub(crate) fn tool_call_extensions(
+        &self,
+        hook_ctx: &HookContext,
+        tool_name: &str,
+        internal_call_id: &str,
+        provider_call_id: Option<&str>,
+    ) -> ToolCallExtensions
+    where
+        M: 'static,
+    {
+        let inherited_call = self.tool_extensions.get::<ToolCallContext>().cloned();
+        let run = RunContext::new(self.control.clone(), self.conversation_id.clone());
+        let mut extensions = self.tool_extensions.clone();
+        extensions.remove::<ScopedToolExecutor>();
+        extensions.insert(run.clone());
+        let call_context = ToolCallContext {
+            run,
+            internal_call_id: internal_call_id.to_owned(),
+            provider_call_id: provider_call_id.map(str::to_owned),
+            parent_internal_call_id: inherited_call
+                .as_ref()
+                .map(|call| call.internal_call_id.clone()),
+            depth: inherited_call.map_or(0, |call| call.depth.saturating_add(1)),
+        };
+        extensions.insert(call_context.clone());
+        let dispatcher: Arc<dyn NestedDispatchDyn> = Arc::new(HookAwareNestedDispatcher {
+            hooks: self.hooks.clone(),
+            hook_ctx: hook_ctx.clone(),
+            tool_server: self.tool_server_handle.clone(),
+        });
+        extensions.insert(ScopedToolExecutor::new(
+            dispatcher,
+            extensions.clone(),
+            call_context,
+            tool_name.to_owned(),
+        ));
+        extensions
     }
 
     /// Build the sans-IO [`AgentRun`] for this runner's configuration.
@@ -584,6 +655,104 @@ pub(crate) struct ToolCallOutcome {
     pub execution: ToolExecution,
 }
 
+struct HookAwareNestedDispatcher<M>
+where
+    M: CompletionModel,
+{
+    hooks: HookStack<M>,
+    hook_ctx: HookContext,
+    tool_server: ToolServerHandle,
+}
+
+impl<M> NestedDispatchDyn for HookAwareNestedDispatcher<M>
+where
+    M: CompletionModel + 'static,
+{
+    fn dispatch<'a>(
+        &'a self,
+        tool_name: &'a str,
+        args: &'a str,
+        extensions: &'a ToolCallExtensions,
+        call_context: &'a ToolCallContext,
+    ) -> WasmBoxedFuture<'a, ToolExecutionResult> {
+        Box::pin(async move {
+            let flow = self
+                .hooks
+                .on_event(
+                    &self.hook_ctx,
+                    StepEvent::ToolCall {
+                        tool_name,
+                        tool_call_id: None,
+                        internal_call_id: &call_context.internal_call_id,
+                        args,
+                    },
+                )
+                .await;
+            let (effective_args, skipped) = match flow_into_tool_call(flow) {
+                ToolCallDecision::Proceed => (args.to_owned(), None),
+                ToolCallDecision::ProceedWith(replacement) => {
+                    (json_utils::value_to_json_string(&replacement), None)
+                }
+                ToolCallDecision::Skip(reason) => {
+                    (args.to_owned(), Some(ToolExecutionResult::skipped(reason)))
+                }
+                ToolCallDecision::Terminate(reason) => {
+                    return ToolExecutionResult::failed(
+                        reason.clone(),
+                        crate::tool::ToolFailure::cancelled(reason),
+                    );
+                }
+            };
+            let mut result = match skipped {
+                Some(result) => result,
+                None => {
+                    self.tool_server
+                        .call_tool_structured(tool_name, &effective_args, extensions)
+                        .await
+                }
+            };
+            match flow_into_tool_result(
+                self.hooks
+                    .on_event(
+                        &self.hook_ctx,
+                        StepEvent::ToolResult {
+                            tool_name,
+                            tool_call_id: None,
+                            internal_call_id: &call_context.internal_call_id,
+                            args: &effective_args,
+                            result: result.model_output(),
+                            outcome: result.outcome(),
+                            extensions: result.extensions(),
+                        },
+                    )
+                    .await,
+            ) {
+                ToolResultDecision::Keep => result,
+                ToolResultDecision::Replace(replacement) => {
+                    result.model_output = replacement.clone();
+                    result.output = ToolOutput::LegacyText(replacement);
+                    result
+                }
+                ToolResultDecision::Terminate(reason) => ToolExecutionResult::failed(
+                    reason.clone(),
+                    crate::tool::ToolFailure::cancelled(reason),
+                ),
+            }
+        })
+    }
+}
+
+struct CallScratchpadCleanup {
+    scratchpad: crate::agent::Scratchpad,
+    internal_call_id: String,
+}
+
+impl Drop for CallScratchpadCleanup {
+    fn drop(&mut self) {
+        self.scratchpad.remove_call(&self.internal_call_id);
+    }
+}
+
 /// Execute a single tool call, firing the `ToolCall` and `ToolResult` hooks and
 /// shaping the result. **Shared by the blocking and streaming drivers** so a
 /// tool call behaves identically in both: same hook events, same fail-closed
@@ -604,6 +773,10 @@ pub(crate) async fn run_single_tool<M>(
 where
     M: CompletionModel,
 {
+    let _call_scratchpad_cleanup = CallScratchpadCleanup {
+        scratchpad: ctx.scratchpad().clone(),
+        internal_call_id: internal_call_id.to_owned(),
+    };
     let tool_name = &tool_call.function.name;
     // `mut` so a `Flow::RewriteArgs` hook can rewrite the arguments the tool
     // runs with (the model's emitted arguments are otherwise used verbatim).
@@ -777,11 +950,16 @@ where
                     exec.model_output,
                 )
             } else {
-                tool_result_output(
-                    tool_call.id.clone(),
-                    tool_call.call_id.clone(),
-                    exec.model_output,
-                )
+                match exec.output {
+                    ToolOutput::LegacyText(output) => {
+                        tool_result_output(tool_call.id.clone(), tool_call.call_id.clone(), output)
+                    }
+                    ToolOutput::Content(content) => tool_result_content(
+                        tool_call.id.clone(),
+                        tool_call.call_id.clone(),
+                        content,
+                    ),
+                }
             };
             Ok(ToolCallOutcome { content, execution })
         }
@@ -859,7 +1037,7 @@ impl UnaryTurnSource {
 
 impl<M> TurnSource<M> for UnaryTurnSource
 where
-    M: CompletionModel,
+    M: CompletionModel + 'static,
 {
     type Raw = M::Response;
 
@@ -1016,7 +1194,7 @@ where
 
 impl<M> AgentRunner<M>
 where
-    M: CompletionModel,
+    M: CompletionModel + 'static,
 {
     /// Drive the agent loop to completion, returning the aggregated
     /// [`PromptResponse`]. Hooks fire at every observable point; the first hook

--- a/crates/rig-core/src/agent/scoped_executor.rs
+++ b/crates/rig-core/src/agent/scoped_executor.rs
@@ -1,0 +1,153 @@
+//! Scoped nested tool dispatch for composite tools and code runtimes.
+
+use std::{collections::BTreeSet, sync::Arc};
+
+use crate::{
+    tool::{ToolCallExtensions, ToolExecutionResult, ToolFailure},
+    wasm_compat::{WasmBoxedFuture, WasmCompatSend, WasmCompatSync},
+};
+
+use super::{RunContext, ToolCallContext};
+
+/// Limits and allowlist for nested dispatch.
+#[derive(Debug, Clone)]
+pub struct ScopedExecutionPolicy {
+    /// Allowed tool names; `None` allows every registered tool except recursion.
+    pub allowlist: Option<BTreeSet<String>>,
+    /// Maximum nested call depth.
+    pub max_depth: usize,
+}
+
+impl Default for ScopedExecutionPolicy {
+    fn default() -> Self {
+        Self {
+            allowlist: None,
+            max_depth: 8,
+        }
+    }
+}
+
+pub(crate) trait NestedDispatchDyn: WasmCompatSend + WasmCompatSync {
+    fn dispatch<'a>(
+        &'a self,
+        tool_name: &'a str,
+        args: &'a str,
+        extensions: &'a ToolCallExtensions,
+        call_context: &'a ToolCallContext,
+    ) -> WasmBoxedFuture<'a, ToolExecutionResult>;
+}
+
+/// Cloneable executor automatically attached to each top-level tool call.
+#[derive(Clone)]
+pub struct ScopedToolExecutor {
+    dispatcher: Arc<dyn NestedDispatchDyn>,
+    inherited_extensions: ToolCallExtensions,
+    parent: ToolCallContext,
+    active_tools: Arc<Vec<String>>,
+    policy: ScopedExecutionPolicy,
+}
+
+impl std::fmt::Debug for ScopedToolExecutor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ScopedToolExecutor")
+            .field("parent", &self.parent.internal_call_id)
+            .field("depth", &self.parent.depth)
+            .field("policy", &self.policy)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ScopedToolExecutor {
+    pub(crate) fn new(
+        dispatcher: Arc<dyn NestedDispatchDyn>,
+        inherited_extensions: ToolCallExtensions,
+        parent: ToolCallContext,
+        active_tool: String,
+    ) -> Self {
+        Self {
+            dispatcher,
+            inherited_extensions,
+            parent,
+            active_tools: Arc::new(vec![active_tool]),
+            policy: ScopedExecutionPolicy::default(),
+        }
+    }
+
+    /// Narrow the tools available to nested calls.
+    pub fn with_allowlist(mut self, allowlist: impl IntoIterator<Item = String>) -> Self {
+        self.policy.allowlist = Some(allowlist.into_iter().collect());
+        self
+    }
+
+    /// Set the maximum nested depth.
+    pub fn with_max_depth(mut self, max_depth: usize) -> Self {
+        self.policy.max_depth = max_depth;
+        self
+    }
+
+    /// Parent run context inherited by nested calls.
+    pub fn run_context(&self) -> &RunContext {
+        &self.parent.run
+    }
+
+    /// Dispatch a nested call with inherited extensions, a fresh internal ID,
+    /// parent correlation, cancellation, allowlist, depth, and recursion guards.
+    pub async fn call(&self, tool_name: &str, args: &serde_json::Value) -> ToolExecutionResult {
+        if let Some(reason) = self.parent.run.control().cancellation_reason() {
+            return ToolExecutionResult::failed(reason, ToolFailure::cancelled(reason));
+        }
+        if self.parent.depth.saturating_add(1) > self.policy.max_depth {
+            return ToolExecutionResult::failed(
+                "nested tool depth exceeded",
+                ToolFailure::permission_denied("nested tool depth exceeded"),
+            );
+        }
+        if self
+            .policy
+            .allowlist
+            .as_ref()
+            .is_some_and(|allowlist| !allowlist.contains(tool_name))
+        {
+            return ToolExecutionResult::failed(
+                format!("nested tool `{tool_name}` is not allowed"),
+                ToolFailure::permission_denied("nested tool is not in the scoped allowlist"),
+            );
+        }
+        if self.active_tools.iter().any(|active| active == tool_name) {
+            return ToolExecutionResult::failed(
+                format!("recursive nested call to `{tool_name}` rejected"),
+                ToolFailure::invalid_args("recursive nested tool call"),
+            );
+        }
+
+        let internal_call_id = crate::id::generate();
+        let call_context = ToolCallContext {
+            run: self.parent.run.clone(),
+            internal_call_id,
+            provider_call_id: None,
+            parent_internal_call_id: Some(self.parent.internal_call_id.clone()),
+            depth: self.parent.depth.saturating_add(1),
+        };
+        let mut extensions = self.inherited_extensions.clone();
+        extensions.insert(call_context.clone());
+        extensions.insert(call_context.run.clone());
+        let mut active_tools = (*self.active_tools).clone();
+        active_tools.push(tool_name.to_owned());
+        extensions.insert(Self {
+            dispatcher: self.dispatcher.clone(),
+            inherited_extensions: extensions.clone(),
+            parent: call_context.clone(),
+            active_tools: Arc::new(active_tools),
+            policy: self.policy.clone(),
+        });
+
+        self.dispatcher
+            .dispatch(
+                tool_name,
+                &crate::json_utils::value_to_json_string(args),
+                &extensions,
+                &call_context,
+            )
+            .await
+    }
+}

--- a/crates/rig-core/src/agent/subagent.rs
+++ b/crates/rig-core/src/agent/subagent.rs
@@ -1,0 +1,192 @@
+//! Bounded child-agent orchestration built on the shared agent runner.
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::{
+    completion::{CompletionModel, PromptError},
+    tool::{Tool, ToolCallExtensions, ToolErrorReport, ToolFailure},
+};
+
+use super::{Agent, RunControlHandle, ToolCallContext};
+
+/// Whether child tools inherit caller-provided runtime extensions.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum SubagentContextMode {
+    /// Start with no caller extensions.
+    Fresh,
+    /// Preserve caller extensions and call ancestry.
+    #[default]
+    Inherited,
+}
+
+/// Typed handoff returned by a child agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubagentHandoff {
+    /// Child's final model-visible output.
+    pub output: String,
+    /// Child run identity for trace/session correlation.
+    pub run_id: String,
+}
+
+/// Subagent invocation arguments.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubagentArgs {
+    /// Task delegated to the child.
+    pub prompt: String,
+}
+
+/// Child orchestration failure.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum SubagentError {
+    /// Configured ancestry depth was exceeded.
+    #[error("subagent depth {depth} exceeds maximum {max_depth}")]
+    DepthExceeded { depth: usize, max_depth: usize },
+    /// Parent run was cancelled.
+    #[error("subagent cancelled with parent: {0}")]
+    Cancelled(String),
+    /// Child runner failed.
+    #[error(transparent)]
+    Prompt(#[from] PromptError),
+}
+
+/// An agent exposed as a bounded, cancellation-aware child tool.
+#[derive(Clone)]
+pub struct Subagent<M>
+where
+    M: CompletionModel,
+{
+    agent: Agent<M>,
+    max_depth: usize,
+    max_turns: usize,
+    context_mode: SubagentContextMode,
+}
+
+impl<M> Subagent<M>
+where
+    M: CompletionModel,
+{
+    /// Wrap an agent with conservative depth and turn budgets.
+    pub fn new(agent: Agent<M>) -> Self {
+        Self {
+            agent,
+            max_depth: 4,
+            max_turns: 8,
+            context_mode: SubagentContextMode::Inherited,
+        }
+    }
+
+    /// Set the maximum parent/child call depth.
+    pub fn max_depth(mut self, max_depth: usize) -> Self {
+        self.max_depth = max_depth;
+        self
+    }
+
+    /// Set the child model-call budget.
+    pub fn max_turns(mut self, max_turns: usize) -> Self {
+        self.max_turns = max_turns;
+        self
+    }
+
+    /// Choose fresh or inherited caller extensions.
+    pub fn context_mode(mut self, mode: SubagentContextMode) -> Self {
+        self.context_mode = mode;
+        self
+    }
+}
+
+impl<M> Tool for Subagent<M>
+where
+    M: CompletionModel + 'static,
+{
+    const NAME: &'static str = "subagent";
+
+    type Error = SubagentError;
+    type Args = SubagentArgs;
+    type Output = SubagentHandoff;
+
+    fn name(&self) -> String {
+        self.agent
+            .name
+            .clone()
+            .unwrap_or_else(|| Self::NAME.to_owned())
+    }
+
+    fn description(&self) -> String {
+        self.agent
+            .description
+            .clone()
+            .unwrap_or_else(|| "Delegate a bounded task to a child agent".to_owned())
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": { "prompt": { "type": "string" } },
+            "required": ["prompt"]
+        })
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        self.call_with_extensions(args, &ToolCallExtensions::new())
+            .await
+    }
+
+    async fn call_with_extensions(
+        &self,
+        args: Self::Args,
+        extensions: &ToolCallExtensions,
+    ) -> Result<Self::Output, Self::Error> {
+        let parent = extensions.get::<ToolCallContext>().cloned();
+        let depth = parent
+            .as_ref()
+            .map_or(0, |call| call.depth.saturating_add(1));
+        if depth > self.max_depth {
+            return Err(SubagentError::DepthExceeded {
+                depth,
+                max_depth: self.max_depth,
+            });
+        }
+
+        let mut runner = self.agent.runner(args.prompt).max_turns(self.max_turns);
+        if self.context_mode == SubagentContextMode::Inherited {
+            runner = runner.tool_extensions(extensions.clone());
+        }
+        let child_control: RunControlHandle = runner.control_handle();
+        let child_run_id = child_control.run_id().to_string();
+
+        let response = if let Some(parent) = parent {
+            let child_run = runner.run();
+            tokio::pin!(child_run);
+            tokio::select! {
+                response = &mut child_run => response.map_err(SubagentError::from)?,
+                reason = parent.run.control().cancelled() => {
+                    child_control.cancel();
+                    // Drive cancellation through the shared loop so run-scoped
+                    // factories and in-flight provider/tool futures settle.
+                    let _ = child_run.await;
+                    return Err(SubagentError::Cancelled(reason.to_owned()));
+                }
+            }
+        } else {
+            runner.run().await?
+        };
+
+        Ok(SubagentHandoff {
+            output: response.output,
+            run_id: child_run_id,
+        })
+    }
+
+    fn classify_error_report(&self, error: &Self::Error) -> ToolErrorReport {
+        let failure = match error {
+            SubagentError::DepthExceeded { .. } => {
+                ToolFailure::permission_denied(error.to_string())
+            }
+            SubagentError::Cancelled(_) => ToolFailure::cancelled(error.to_string()),
+            SubagentError::Prompt(_) => ToolFailure::other(error.to_string()),
+        };
+        ToolErrorReport::new(failure)
+    }
+}

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -329,6 +329,9 @@ pub struct ToolDefinition {
     pub description: String,
     /// JSON Schema describing tool arguments.
     pub parameters: serde_json::Value,
+    /// Optional model-facing JSON Schema describing the tool result.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_schema: Option<serde_json::Value>,
 }
 
 /// Provider-native tool definition.
@@ -479,6 +482,26 @@ pub trait Completion<M: CompletionModel> {
         T: Into<Message>;
 }
 
+/// Provider-independent reason a model generation ended.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum FinishReason {
+    /// Natural model stop.
+    Stop,
+    /// Token/output limit truncation.
+    Length,
+    /// Provider safety/content filter.
+    ContentFilter,
+    /// Model handed control to one or more tools.
+    ToolCalls,
+    /// Host cancellation ended generation.
+    Cancelled,
+    /// Provider failed after beginning generation.
+    ProviderFailure,
+    /// Provider reason without a normalized mapping.
+    Other(String),
+}
+
 /// General completion response struct that contains the high-level completion choice
 /// and the raw response. The completion choice contains one or more assistant content.
 #[derive(Debug)]
@@ -493,6 +516,8 @@ pub struct CompletionResponse<T> {
     /// Provider-assigned message ID (e.g. OpenAI Responses API `msg_` ID).
     /// Used to pair reasoning input items with their output items in multi-turn.
     pub message_id: Option<String>,
+    /// Normalized reason generation ended, when supplied by the provider.
+    pub finish_reason: Option<FinishReason>,
 }
 
 /// A trait for grabbing the token usage of a completion response.
@@ -503,6 +528,11 @@ pub trait GetTokenUsage {
     /// [`Usage`]'s documented sentinel for missing provider usage metrics;
     /// response types that carry no usage return [`Usage::new`].
     fn token_usage(&self) -> crate::completion::Usage;
+
+    /// Normalized terminal reason for a streamed provider response.
+    fn finish_reason(&self) -> Option<FinishReason> {
+        None
+    }
 }
 
 impl GetTokenUsage for () {
@@ -760,7 +790,7 @@ impl CompletionRequest {
     }
 }
 
-fn merge_provider_tools_into_additional_params(
+pub(crate) fn merge_provider_tools_into_additional_params(
     additional_params: Option<serde_json::Value>,
     provider_tools: Vec<ProviderToolDefinition>,
 ) -> Option<serde_json::Value> {

--- a/crates/rig-core/src/lib.rs
+++ b/crates/rig-core/src/lib.rs
@@ -166,6 +166,8 @@ pub mod prelude;
 pub(crate) mod provider_response;
 pub mod providers;
 pub mod rerank;
+pub mod session;
+pub mod skills;
 
 pub mod streaming;
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -258,6 +258,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             usage,
             raw_response: response,
             message_id: None,
+            finish_reason: None,
         })
     }
 }
@@ -3032,6 +3033,7 @@ mod tests {
                 "type": "object",
                 "properties": {}
             }),
+            output_schema: None,
         }
     }
 

--- a/crates/rig-core/src/providers/anthropic/streaming.rs
+++ b/crates/rig-core/src/providers/anthropic/streaming.rs
@@ -196,6 +196,7 @@ struct ThinkingState {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StreamingCompletionResponse {
     pub usage: PartialUsage,
+    pub stop_reason: Option<String>,
 }
 
 impl GetTokenUsage for StreamingCompletionResponse {
@@ -211,6 +212,16 @@ impl GetTokenUsage for StreamingCompletionResponse {
             + usage.output_tokens;
 
         usage
+    }
+
+    fn finish_reason(&self) -> Option<crate::completion::FinishReason> {
+        self.stop_reason.as_deref().map(|reason| match reason {
+            "end_turn" | "stop_sequence" | "pause_turn" => crate::completion::FinishReason::Stop,
+            "max_tokens" => crate::completion::FinishReason::Length,
+            "tool_use" => crate::completion::FinishReason::ToolCalls,
+            "refusal" => crate::completion::FinishReason::ContentFilter,
+            other => crate::completion::FinishReason::Other(other.to_owned()),
+        })
     }
 }
 
@@ -280,6 +291,7 @@ where
             let mut sse_stream = Box::pin(stream);
             let mut input_tokens = 0;
             let mut final_usage = None;
+            let mut final_stop_reason = None;
 
             let mut text_content = String::new();
 
@@ -300,6 +312,7 @@ where
                                     },
                                     StreamingEvent::MessageDelta { delta, usage } => {
                                         if delta.stop_reason.is_some() {
+                                            final_stop_reason = delta.stop_reason.clone();
                                             // cache_creation_input_tokens and cache_read_input_tokens
                                             // are cumulative totals on message_delta.usage per the
                                             // Anthropic streaming API spec — use them directly.
@@ -351,7 +364,8 @@ where
             sse_stream.close();
 
             yield Ok(RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
-                usage: final_usage.unwrap_or_default()
+                usage: final_usage.unwrap_or_default(),
+                stop_reason: final_stop_reason,
             }))
         }.instrument(span));
 
@@ -590,6 +604,7 @@ mod tests {
                 name: "rig_tool".to_string(),
                 description: "Rig tool".to_string(),
                 parameters: json!({"type": "object", "properties": {}}),
+                output_schema: None,
             }],
             &mut additional_params,
         )
@@ -743,6 +758,7 @@ mod tests {
                     "type": "object",
                     "properties": { "x": { "type": "integer" } }
                 }),
+                output_schema: None,
             }],
             temperature: None,
             max_tokens: Some(64),
@@ -816,6 +832,7 @@ mod tests {
                 name: "rig_tool".to_string(),
                 description: "Rig tool".to_string(),
                 parameters: json!({"type": "object", "properties": {}}),
+                output_schema: None,
             }],
             &mut additional_params,
         )
@@ -1563,6 +1580,7 @@ mod tests {
 
             yield Ok(RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
                 usage: PartialUsage::default(),
+                stop_reason: None,
             }));
         };
 
@@ -1708,6 +1726,7 @@ mod tests {
 
             yield Ok(RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
                 usage: PartialUsage::default(),
+                stop_reason: None,
             }));
         };
 

--- a/crates/rig-core/src/providers/cohere/completion.rs
+++ b/crates/rig-core/src/providers/cohere/completion.rs
@@ -200,6 +200,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             usage,
             raw_response: response,
             message_id: None,
+            finish_reason: None,
         })
     }
 }

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -691,6 +691,7 @@ impl TryFrom<ChatCompletionResponse> for completion::CompletionResponse<ChatComp
             usage,
             raw_response: response,
             message_id: None,
+            finish_reason: None,
         })
     }
 }
@@ -873,6 +874,7 @@ where
                             usage: core.usage,
                             raw_response: CopilotCompletionResponse::Chat(Box::new(response)),
                             message_id: core.message_id,
+                            finish_reason: None,
                         })
                     }
                     ChatApiResponse::Err(err) => {
@@ -943,6 +945,7 @@ where
                     usage: core.usage,
                     raw_response: CopilotCompletionResponse::Responses(Box::new(response)),
                     message_id: core.message_id,
+                    finish_reason: None,
                 })
             } else {
                 let body = http_client::text(response).await?;
@@ -1594,10 +1597,14 @@ impl CompatibleStreamProfile for CopilotChatCompatibleProfile {
                 data.usage,
                 &data.choices,
                 |choice| CompatibleChoiceData {
-                    finish_reason: if choice.finish_reason == Some(ChatFinishReason::ToolCalls) {
-                        CompatibleFinishReason::ToolCalls
-                    } else {
-                        CompatibleFinishReason::Other
+                    finish_reason: match choice.finish_reason.as_ref() {
+                        Some(ChatFinishReason::ToolCalls) => CompatibleFinishReason::ToolCalls,
+                        Some(ChatFinishReason::Stop) => CompatibleFinishReason::Stop,
+                        Some(ChatFinishReason::ContentFilter) => {
+                            CompatibleFinishReason::ContentFilter
+                        }
+                        Some(ChatFinishReason::Length) => CompatibleFinishReason::Length,
+                        Some(ChatFinishReason::Other(_)) | None => CompatibleFinishReason::Other,
                     },
                     text: choice.delta.content.clone(),
                     reasoning: choice.delta.reasoning_content.clone(),
@@ -1610,9 +1617,14 @@ impl CompatibleStreamProfile for CopilotChatCompatibleProfile {
         ))
     }
 
-    fn build_final_response(&self, usage: Self::Usage) -> Self::FinalResponse {
+    fn build_final_response(
+        &self,
+        usage: Self::Usage,
+        finish_reason: Option<crate::completion::FinishReason>,
+    ) -> Self::FinalResponse {
         CopilotStreamingResponse::Chat(openai::completion::streaming::StreamingCompletionResponse {
             usage,
+            finish_reason,
         })
     }
 

--- a/crates/rig-core/src/providers/deepseek.rs
+++ b/crates/rig-core/src/providers/deepseek.rs
@@ -404,6 +404,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             usage,
             raw_response: response,
             message_id: None,
+            finish_reason: None,
         })
     }
 }
@@ -590,6 +591,7 @@ mod tests {
                     "properties": {},
                     "required": []
                 }),
+                output_schema: None,
             })
             .tool(RigToolDefinition {
                 name: "beta".to_string(),
@@ -599,6 +601,7 @@ mod tests {
                     "properties": {},
                     "required": []
                 }),
+                output_schema: None,
             })
             .tool_choice(RigToolChoice::Specific {
                 function_names: vec!["beta".to_string()],
@@ -625,6 +628,7 @@ mod tests {
                     "properties": {},
                     "required": []
                 }),
+                output_schema: None,
             })
             .tool_choice(RigToolChoice::Required)
             .build();

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -508,11 +508,23 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse<Generat
             .map(GetTokenUsage::token_usage)
             .unwrap_or_default();
 
+        let finish_reason = candidate.finish_reason.as_ref().map(|reason| match reason {
+            FinishReason::Stop => completion::FinishReason::Stop,
+            FinishReason::MaxTokens => completion::FinishReason::Length,
+            FinishReason::Safety
+            | FinishReason::Recitation
+            | FinishReason::Blocklist
+            | FinishReason::ProhibitedContent
+            | FinishReason::Spii => completion::FinishReason::ContentFilter,
+            other => completion::FinishReason::Other(format!("{other:?}")),
+        });
+
         Ok(completion::CompletionResponse {
             choice,
             usage,
             raw_response: response,
             message_id: None,
+            finish_reason,
         })
     }
 }

--- a/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
@@ -500,6 +500,7 @@ impl TryFrom<Interaction> for completion::CompletionResponse<Interaction> {
             usage,
             raw_response: response,
             message_id: None,
+            finish_reason: None,
         })
     }
 }

--- a/crates/rig-core/src/providers/gemini/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/streaming.rs
@@ -86,6 +86,19 @@ impl GetTokenUsage for StreamingCompletionResponse {
     fn token_usage(&self) -> crate::completion::Usage {
         self.usage_metadata.token_usage()
     }
+
+    fn finish_reason(&self) -> Option<crate::completion::FinishReason> {
+        self.finish_reason.as_ref().map(|reason| match reason {
+            FinishReason::Stop => crate::completion::FinishReason::Stop,
+            FinishReason::MaxTokens => crate::completion::FinishReason::Length,
+            FinishReason::Safety
+            | FinishReason::Recitation
+            | FinishReason::Blocklist
+            | FinishReason::ProhibitedContent
+            | FinishReason::Spii => crate::completion::FinishReason::ContentFilter,
+            other => crate::completion::FinishReason::Other(format!("{other:?}")),
+        })
+    }
 }
 
 fn tool_protocol_finish_reason_error(choice: &ContentCandidate) -> Option<CompletionError> {

--- a/crates/rig-core/src/providers/groq.rs
+++ b/crates/rig-core/src/providers/groq.rs
@@ -56,25 +56,38 @@ impl openai::completion::OpenAICompatibleProvider for GroqExt {
         request: &mut openai::completion::CompletionRequest,
     ) -> Result<(), CompletionError> {
         // Groq's provider-native tools (`browser_search`, `code_interpreter`,
-        // ...) arrive via `additional_params.tools`. Left in place they would
-        // clobber the function-tool array on serialization, so fold them into
-        // `compound_custom.enabled_tools` (deduplicated by tool type).
-        let Some(map) = request
+        // ...) share the generic request's single tools array with functions.
+        // Move only non-function rows into `compound_custom.enabled_tools`.
+        let mut native_tools = Vec::new();
+        request.tools.retain(|tool| {
+            let is_function = tool
+                .get("type")
+                .and_then(Value::as_str)
+                .is_some_and(|kind| kind == "function");
+            if !is_function {
+                native_tools.push(tool.clone());
+            }
+            is_function
+        });
+
+        let additional_params = request
             .additional_params
-            .as_mut()
-            .and_then(Value::as_object_mut)
-        else {
-            return Ok(());
-        };
-        let Some(raw_tools) = map.remove("tools") else {
-            return Ok(());
-        };
-        let native_tools = serde_json::from_value::<Vec<Value>>(raw_tools).map_err(|err| {
-            CompletionError::RequestError(
-                format!("Invalid Groq `additional_params.tools` payload: {err}").into(),
-            )
+            .get_or_insert_with(|| Value::Object(serde_json::Map::new()));
+        let map = additional_params.as_object_mut().ok_or_else(|| {
+            CompletionError::RequestError("Groq additional_params must be an object".into())
         })?;
-        apply_native_tools_to_additional_params(map, native_tools);
+        if let Some(raw_tools) = map.remove("tools") {
+            let mut legacy_tools =
+                serde_json::from_value::<Vec<Value>>(raw_tools).map_err(|err| {
+                    CompletionError::RequestError(
+                        format!("Invalid Groq `additional_params.tools` payload: {err}").into(),
+                    )
+                })?;
+            native_tools.append(&mut legacy_tools);
+        }
+        if !native_tools.is_empty() {
+            apply_native_tools_to_additional_params(map, native_tools);
+        }
 
         Ok(())
     }
@@ -375,6 +388,7 @@ mod tests {
                 name: "choose_beta".to_string(),
                 description: "Choose beta".to_string(),
                 parameters: serde_json::json!({"type":"object","properties":{},"required":[]}),
+                output_schema: None,
             })
             .tool_choice(crate::message::ToolChoice::Specific {
                 function_names: vec!["choose_beta".to_string()],
@@ -427,6 +441,7 @@ mod tests {
                 name: "local_tool".to_string(),
                 description: "A local function tool".to_string(),
                 parameters: serde_json::json!({"type":"object","properties":{},"required":[]}),
+                output_schema: None,
             })
             .additional_params(serde_json::json!({
                 "tools": [{"type": "browser_search"}, {"type": "browser_search"}],

--- a/crates/rig-core/src/providers/hyperbolic.rs
+++ b/crates/rig-core/src/providers/hyperbolic.rs
@@ -446,6 +446,7 @@ mod tests {
             name: "lookup".to_string(),
             description: "Lookup".to_string(),
             parameters: serde_json::json!({"type":"object","properties":{},"required":[]}),
+            output_schema: None,
         })
         .tool_choice(crate::message::ToolChoice::Required)
         .output_schema(schemars::schema_for!(serde_json::Value))

--- a/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
+++ b/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
@@ -43,8 +43,23 @@ fn provider_response_from_compatible_sse_data(data: &str) -> Option<CompletionEr
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CompatibleFinishReason {
+    Stop,
+    Length,
+    ContentFilter,
     ToolCalls,
     Other,
+}
+
+impl CompatibleFinishReason {
+    fn normalized(self) -> Option<crate::completion::FinishReason> {
+        match self {
+            Self::Stop => Some(crate::completion::FinishReason::Stop),
+            Self::Length => Some(crate::completion::FinishReason::Length),
+            Self::ContentFilter => Some(crate::completion::FinishReason::ContentFilter),
+            Self::ToolCalls => Some(crate::completion::FinishReason::ToolCalls),
+            Self::Other => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -162,7 +177,11 @@ pub(crate) trait CompatibleStreamProfile: WasmCompatSend {
 
     fn normalize_chunk(&self, data: &str) -> NormalizedCompatibleChunk<Self::Usage, Self::Detail>;
 
-    fn build_final_response(&self, usage: Self::Usage) -> Self::FinalResponse;
+    fn build_final_response(
+        &self,
+        usage: Self::Usage,
+        finish_reason: Option<crate::completion::FinishReason>,
+    ) -> Self::FinalResponse;
 
     fn uses_distinct_tool_call_eviction(&self) -> bool {
         false
@@ -231,6 +250,7 @@ where
     let stream = stream! {
         let mut tool_calls: HashMap<usize, RawStreamingToolCall> = HashMap::new();
         let mut final_usage = None;
+        let mut terminal_reason = None;
         let mut terminated_with_error = false;
 
         while let Some(event_result) = event_source.next().await {
@@ -351,6 +371,10 @@ where
                         yield Ok(RawStreamingChoice::Message(content));
                     }
 
+                    if let Some(reason) = choice.finish_reason.normalized() {
+                        terminal_reason = Some(reason);
+                    }
+
                     if choice.finish_reason == CompatibleFinishReason::ToolCalls {
                         for tool_call in take_finalized_tool_calls(
                             &mut tool_calls,
@@ -387,7 +411,7 @@ where
         let final_usage = final_usage.unwrap_or_default();
         record_usage(&span, &final_usage);
         yield Ok(RawStreamingChoice::FinalResponse(
-            profile.build_final_response(final_usage),
+            profile.build_final_response(final_usage, terminal_reason),
         ));
     }
     .instrument(instrument_span);

--- a/crates/rig-core/src/providers/mira.rs
+++ b/crates/rig-core/src/providers/mira.rs
@@ -409,6 +409,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             usage,
             raw_response: response,
             message_id: None,
+            finish_reason: None,
         })
     }
 }

--- a/crates/rig-core/src/providers/mistral/completion.rs
+++ b/crates/rig-core/src/providers/mistral/completion.rs
@@ -260,6 +260,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             usage,
             raw_response: response,
             message_id: Some(message_id),
+            finish_reason: None,
         })
     }
 }

--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -392,6 +392,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                     },
                     raw_response,
                     message_id: None,
+                    finish_reason: None,
                 })
             }
             _ => Err(CompletionError::ResponseError(
@@ -885,6 +886,7 @@ impl From<crate::completion::ToolDefinition> for ToolDefinition {
                 name: tool.name,
                 description: tool.description,
                 parameters: tool.parameters,
+                output_schema: tool.output_schema,
             },
         }
     }
@@ -1337,6 +1339,7 @@ mod tests {
                 },
                 "required": ["location", "format"]
             }),
+            output_schema: None,
         };
         // Convert internal tool to Ollama's tool definition.
         let ollama_tool: ToolDefinition = internal_tool.into();

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -1143,6 +1143,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             CompletionError::ResponseError("Response contained no choices".to_owned())
         })?;
 
+        let raw_finish_reason = choice.finish_reason.clone();
         let content = match &choice.message {
             Message::Assistant {
                 content,
@@ -1203,11 +1204,20 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             .map(GetTokenUsage::token_usage)
             .unwrap_or_default();
 
+        let finish_reason = Some(match raw_finish_reason.as_str() {
+            "stop" => completion::FinishReason::Stop,
+            "length" => completion::FinishReason::Length,
+            "content_filter" => completion::FinishReason::ContentFilter,
+            "tool_calls" | "function_call" => completion::FinishReason::ToolCalls,
+            reason => completion::FinishReason::Other(reason.to_owned()),
+        });
+
         Ok(completion::CompletionResponse {
             choice,
             usage,
             raw_response: response,
             message_id: None,
+            finish_reason,
         })
     }
 }
@@ -1586,7 +1596,7 @@ pub struct CompletionRequest {
     pub model: String,
     pub messages: Vec<Message>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub tools: Vec<ToolDefinition>,
+    pub tools: Vec<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_choice: Option<ToolChoice>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1764,6 +1774,14 @@ impl TryFrom<OpenAIRequestParams> for CompletionRequest {
             ..
         } = req;
 
+        let mut additional_params = additional_params;
+        let provider_tools = additional_params
+            .as_mut()
+            .and_then(serde_json::Value::as_object_mut)
+            .and_then(|object| object.remove("tools"))
+            .and_then(|tools| tools.as_array().cloned())
+            .unwrap_or_default();
+
         let mut partial_history = Vec::new();
         partial_history.extend(chat_history);
 
@@ -1802,16 +1820,18 @@ impl TryFrom<OpenAIRequestParams> for CompletionRequest {
 
         let (tools, tool_choice) = if supports_tools {
             let tool_choice = tool_choice.map(ToolChoice::try_from).transpose()?;
-            let tools: Vec<ToolDefinition> = tools
+            let mut tools: Vec<serde_json::Value> = tools
                 .into_iter()
                 .map(|tool| {
                     let def = ToolDefinition::from(tool);
-                    if strict_tools { def.with_strict() } else { def }
+                    let def = if strict_tools { def.with_strict() } else { def };
+                    serde_json::to_value(def).map_err(CompletionError::JsonError)
                 })
-                .collect();
+                .collect::<Result<_, _>>()?;
+            tools.extend(provider_tools);
             (tools, tool_choice)
         } else {
-            if !tools.is_empty() {
+            if !tools.is_empty() || !provider_tools.is_empty() {
                 tracing::warn!("Tool use is not supported by this provider; tools will be ignored");
             }
             if tool_choice.is_some() {
@@ -2612,6 +2632,7 @@ mod tests {
                     },
                     "required": ["city"]
                 }),
+                output_schema: None,
             }],
             temperature: None,
             max_tokens: None,
@@ -2682,6 +2703,7 @@ mod tests {
                     },
                     "required": ["city"]
                 }),
+                output_schema: None,
             }],
             temperature: None,
             max_tokens: None,

--- a/crates/rig-core/src/providers/openai/completion/streaming.rs
+++ b/crates/rig-core/src/providers/openai/completion/streaming.rs
@@ -118,6 +118,7 @@ struct StreamingCompletionChunk<U = Usage> {
 #[derive(Clone, Serialize, Deserialize)]
 pub struct StreamingCompletionResponse<U = Usage> {
     pub usage: U,
+    pub finish_reason: Option<crate::completion::FinishReason>,
 }
 
 impl<U> GetTokenUsage for StreamingCompletionResponse<U>
@@ -126,6 +127,10 @@ where
 {
     fn token_usage(&self) -> crate::completion::Usage {
         self.usage.token_usage()
+    }
+
+    fn finish_reason(&self) -> Option<crate::completion::FinishReason> {
+        self.finish_reason.clone()
     }
 }
 
@@ -275,6 +280,9 @@ where
                     // `function_call` is the deprecated pre-tools finish reason
                     // some compatible providers still emit for tool calls.
                     finish_reason: match &choice.finish_reason {
+                        Some(FinishReason::Stop) => CompatibleFinishReason::Stop,
+                        Some(FinishReason::Length) => CompatibleFinishReason::Length,
+                        Some(FinishReason::ContentFilter) => CompatibleFinishReason::ContentFilter,
                         Some(FinishReason::ToolCalls) => CompatibleFinishReason::ToolCalls,
                         Some(FinishReason::Other(other)) if other == "function_call" => {
                             CompatibleFinishReason::ToolCalls
@@ -296,8 +304,15 @@ where
         ))
     }
 
-    fn build_final_response(&self, usage: Self::Usage) -> Self::FinalResponse {
-        StreamingCompletionResponse { usage }
+    fn build_final_response(
+        &self,
+        usage: Self::Usage,
+        finish_reason: Option<crate::completion::FinishReason>,
+    ) -> Self::FinalResponse {
+        StreamingCompletionResponse {
+            usage,
+            finish_reason,
+        }
     }
 
     fn decorate_tool_call(

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -733,6 +733,7 @@ impl From<completion::ToolDefinition> for ResponsesToolDefinition {
             name,
             parameters,
             description,
+            ..
         } = value;
 
         Self::function(name, description, parameters)
@@ -2255,11 +2256,39 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             .map(GetTokenUsage::token_usage)
             .unwrap_or_default();
 
+        let finish_reason = match response.status {
+            ResponseStatus::Completed => Some(
+                if choice
+                    .iter()
+                    .any(|item| matches!(item, completion::AssistantContent::ToolCall(_)))
+                {
+                    completion::FinishReason::ToolCalls
+                } else {
+                    completion::FinishReason::Stop
+                },
+            ),
+            ResponseStatus::Incomplete => Some(
+                match response
+                    .incomplete_details
+                    .as_ref()
+                    .map(|details| details.reason.as_str())
+                {
+                    Some("max_output_tokens") => completion::FinishReason::Length,
+                    Some(reason) => completion::FinishReason::Other(reason.to_owned()),
+                    None => completion::FinishReason::Other("incomplete".to_owned()),
+                },
+            ),
+            ResponseStatus::Cancelled => Some(completion::FinishReason::Cancelled),
+            ResponseStatus::Failed => Some(completion::FinishReason::ProviderFailure),
+            ResponseStatus::InProgress | ResponseStatus::Queued => None,
+        };
+
         Ok(completion::CompletionResponse {
             choice,
             usage,
             raw_response: response,
             message_id,
+            finish_reason,
         })
     }
 }
@@ -2696,6 +2725,7 @@ mod tests {
                 },
                 "required": ["location"]
             }),
+            output_schema: None,
         }
     }
 
@@ -3083,6 +3113,7 @@ mod tests {
                     "type": "object",
                     "properties": {"q": {"type": "string"}}
                 }),
+                output_schema: None,
             });
 
         let mut request = weather_tool_request();

--- a/crates/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -573,6 +573,7 @@ pub(crate) async fn completion_response_from_sse_body(
             .or_else(|| message_id_from_response(&raw_response)),
         choice: stream.choice,
         raw_response,
+        finish_reason: None,
     })
 }
 

--- a/crates/rig-core/src/providers/openrouter/completion.rs
+++ b/crates/rig-core/src/providers/openrouter/completion.rs
@@ -583,6 +583,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             CompletionError::ResponseError("Response contained no choices".to_owned())
         })?;
 
+        let raw_finish_reason = choice.finish_reason.clone();
         let content = match &choice.message {
             Message::Assistant {
                 content,
@@ -728,11 +729,20 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             })
             .unwrap_or_default();
 
+        let finish_reason = raw_finish_reason.map(|reason| match reason.as_str() {
+            "stop" => completion::FinishReason::Stop,
+            "length" => completion::FinishReason::Length,
+            "content_filter" => completion::FinishReason::ContentFilter,
+            "tool_calls" | "function_call" => completion::FinishReason::ToolCalls,
+            other => completion::FinishReason::Other(other.to_owned()),
+        });
+
         Ok(completion::CompletionResponse {
             choice,
             usage,
             raw_response: response,
             message_id: None,
+            finish_reason,
         })
     }
 }
@@ -1377,15 +1387,16 @@ impl TryFrom<OpenRouterRequestParams<'_>> for OpenrouterCompletionRequest {
             .map(crate::providers::openai::completion::ToolChoice::try_from)
             .transpose()?;
 
-        let tools: Vec<crate::providers::openai::completion::ToolDefinition> = req
+        let mut tools: Vec<serde_json::Value> = req
             .tools
             .clone()
             .into_iter()
             .map(|tool| {
                 let def = crate::providers::openai::completion::ToolDefinition::from(tool);
-                if strict_tools { def.with_strict() } else { def }
+                let def = if strict_tools { def.with_strict() } else { def };
+                serde_json::to_value(def).map_err(CompletionError::JsonError)
             })
-            .collect();
+            .collect::<Result<_, _>>()?;
 
         let additional_params = if let Some(schema) = req.output_schema {
             let name = schema
@@ -1413,6 +1424,15 @@ impl TryFrom<OpenRouterRequestParams<'_>> for OpenrouterCompletionRequest {
         } else {
             req.additional_params
         };
+
+        let mut additional_params = additional_params;
+        let provider_tools = additional_params
+            .as_mut()
+            .and_then(serde_json::Value::as_object_mut)
+            .and_then(|object| object.remove("tools"))
+            .and_then(|tools| tools.as_array().cloned())
+            .unwrap_or_default();
+        tools.extend(provider_tools);
 
         Ok(Self {
             model,

--- a/crates/rig-core/src/providers/perplexity.rs
+++ b/crates/rig-core/src/providers/perplexity.rs
@@ -217,6 +217,7 @@ mod tests {
             name: "lookup".to_string(),
             description: String::new(),
             parameters: serde_json::json!({}),
+            output_schema: None,
         }];
 
         let converted = OpenAICompletionRequest::try_from(OpenAIRequestParams {
@@ -277,6 +278,7 @@ mod tests {
             name: "lookup".to_string(),
             description: "Lookup".to_string(),
             parameters: serde_json::json!({"type":"object","properties":{},"required":[]}),
+            output_schema: None,
         })
         .tool_choice(crate::message::ToolChoice::Required)
         .build();

--- a/crates/rig-core/src/providers/xai/completion.rs
+++ b/crates/rig-core/src/providers/xai/completion.rs
@@ -161,6 +161,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             usage,
             raw_response: response,
             message_id,
+            finish_reason: None,
         })
     }
 }
@@ -372,6 +373,7 @@ mod tests {
                     "properties": {},
                     "required": []
                 }),
+                output_schema: None,
             })
             .tool(ToolDefinition {
                 name: "beta".to_string(),
@@ -381,6 +383,7 @@ mod tests {
                     "properties": {},
                     "required": []
                 }),
+                output_schema: None,
             })
             .tool_choice(ToolChoice::Specific {
                 function_names: vec!["beta".to_string()],

--- a/crates/rig-core/src/session.rs
+++ b/crates/rig-core/src/session.rs
@@ -1,0 +1,294 @@
+//! Backend-neutral append-only agent session event storage.
+//!
+//! Sessions intentionally remain separate from [`ConversationMemory`](crate::memory::ConversationMemory):
+//! memory shapes model-visible messages, while this log preserves operational
+//! history, branches, checkpoints, usage, and interrupted turns.
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    completion::{Message, Usage},
+    wasm_compat::{WasmBoxedFuture, WasmCompatSend, WasmCompatSync},
+};
+
+/// Stable host/session identifier.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SessionId(pub String);
+
+/// Identity of one append-only event.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SessionEventId(pub String);
+
+/// Versioned session event payload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum SessionEventKind {
+    /// Model-visible conversation message.
+    Message { message: Message },
+    /// A model request began.
+    ModelCallStarted {
+        model: String,
+        config: serde_json::Value,
+    },
+    /// A model request completed with usage and normalized provider metadata.
+    ModelCallFinished {
+        usage: Usage,
+        metadata: serde_json::Value,
+    },
+    /// Tool execution began.
+    ToolCall {
+        name: String,
+        internal_call_id: String,
+        args: serde_json::Value,
+    },
+    /// Tool execution settled.
+    ToolResult {
+        internal_call_id: String,
+        outcome: String,
+        result: serde_json::Value,
+    },
+    /// Named resumable safe boundary.
+    Checkpoint { name: String },
+    /// Compaction summary retaining a link to full history.
+    Compaction {
+        summary: String,
+        through: Option<SessionEventId>,
+    },
+    /// Host-defined versioned event.
+    Custom {
+        namespace: String,
+        payload: serde_json::Value,
+    },
+    /// A turn was interrupted before normal completion.
+    Interrupted { reason: String },
+}
+
+/// One record in a session tree.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionEvent {
+    /// Event identity.
+    pub id: SessionEventId,
+    /// Session containing the event.
+    pub session_id: SessionId,
+    /// Parent event; choosing an earlier parent creates a branch.
+    pub parent_id: Option<SessionEventId>,
+    /// Milliseconds since Unix epoch supplied by the host/store.
+    pub timestamp_ms: u64,
+    /// Event payload.
+    pub kind: SessionEventKind,
+}
+
+/// Boxed session backend failure.
+#[cfg(not(target_family = "wasm"))]
+pub type SessionBackendError = Box<dyn std::error::Error + Send + Sync + 'static>;
+/// Boxed session backend failure.
+#[cfg(target_family = "wasm")]
+pub type SessionBackendError = Box<dyn std::error::Error + 'static>;
+
+/// Session storage failure.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum SessionStoreError {
+    /// Backend operation failed.
+    #[error("session backend error: {0}")]
+    Backend(SessionBackendError),
+    /// Imported data violated tree invariants.
+    #[error("invalid session event: {0}")]
+    Invalid(String),
+}
+
+/// Append-only backend-neutral session/event store.
+pub trait SessionEventStore: WasmCompatSend + WasmCompatSync {
+    /// Append an event, returning its allocated identity.
+    fn append<'a>(
+        &'a self,
+        session_id: &'a SessionId,
+        parent_id: Option<SessionEventId>,
+        kind: SessionEventKind,
+    ) -> WasmBoxedFuture<'a, Result<SessionEventId, SessionStoreError>>;
+
+    /// Load every event in append order. Parent IDs reconstruct branches.
+    fn load<'a>(
+        &'a self,
+        session_id: &'a SessionId,
+    ) -> WasmBoxedFuture<'a, Result<Vec<SessionEvent>, SessionStoreError>>;
+
+    /// Import already-versioned events, preserving identities.
+    fn import<'a>(
+        &'a self,
+        session_id: &'a SessionId,
+        events: Vec<SessionEvent>,
+    ) -> WasmBoxedFuture<'a, Result<(), SessionStoreError>>;
+
+    /// Delete a session and all branches.
+    fn clear<'a>(
+        &'a self,
+        session_id: &'a SessionId,
+    ) -> WasmBoxedFuture<'a, Result<(), SessionStoreError>>;
+}
+
+/// Thread-safe process-local reference implementation of [`SessionEventStore`].
+#[derive(Clone, Default)]
+pub struct InMemorySessionEventStore {
+    sessions: Arc<Mutex<HashMap<SessionId, Vec<SessionEvent>>>>,
+}
+
+impl SessionEventStore for InMemorySessionEventStore {
+    fn append<'a>(
+        &'a self,
+        session_id: &'a SessionId,
+        parent_id: Option<SessionEventId>,
+        kind: SessionEventKind,
+    ) -> WasmBoxedFuture<'a, Result<SessionEventId, SessionStoreError>> {
+        Box::pin(async move {
+            let mut sessions = self
+                .sessions
+                .lock()
+                .unwrap_or_else(|error| error.into_inner());
+            let events = sessions.entry(session_id.clone()).or_default();
+            if let Some(parent) = &parent_id
+                && !events.iter().any(|event| &event.id == parent)
+            {
+                return Err(SessionStoreError::Invalid(format!(
+                    "unknown parent event `{}`",
+                    parent.0
+                )));
+            }
+            let id = SessionEventId(crate::id::generate());
+            let timestamp_ms = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map_or(0, |duration| duration.as_millis() as u64);
+            events.push(SessionEvent {
+                id: id.clone(),
+                session_id: session_id.clone(),
+                parent_id,
+                timestamp_ms,
+                kind,
+            });
+            Ok(id)
+        })
+    }
+
+    fn load<'a>(
+        &'a self,
+        session_id: &'a SessionId,
+    ) -> WasmBoxedFuture<'a, Result<Vec<SessionEvent>, SessionStoreError>> {
+        Box::pin(async move {
+            Ok(self
+                .sessions
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .get(session_id)
+                .cloned()
+                .unwrap_or_default())
+        })
+    }
+
+    fn import<'a>(
+        &'a self,
+        session_id: &'a SessionId,
+        events: Vec<SessionEvent>,
+    ) -> WasmBoxedFuture<'a, Result<(), SessionStoreError>> {
+        Box::pin(async move {
+            let mut known = std::collections::HashSet::new();
+            for event in &events {
+                if &event.session_id != session_id {
+                    return Err(SessionStoreError::Invalid(
+                        "event belongs to another session".into(),
+                    ));
+                }
+                if let Some(parent) = &event.parent_id
+                    && !known.contains(parent)
+                {
+                    return Err(SessionStoreError::Invalid(format!(
+                        "parent `{}` precedes no imported event",
+                        parent.0
+                    )));
+                }
+                if !known.insert(event.id.clone()) {
+                    return Err(SessionStoreError::Invalid(format!(
+                        "duplicate event `{}`",
+                        event.id.0
+                    )));
+                }
+            }
+            self.sessions
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .insert(session_id.clone(), events);
+            Ok(())
+        })
+    }
+
+    fn clear<'a>(
+        &'a self,
+        session_id: &'a SessionId,
+    ) -> WasmBoxedFuture<'a, Result<(), SessionStoreError>> {
+        Box::pin(async move {
+            self.sessions
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .remove(session_id);
+            Ok(())
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn append_and_branch_preserve_parent_links() {
+        let store = InMemorySessionEventStore::default();
+        let session = SessionId("session".into());
+        let root = store
+            .append(
+                &session,
+                None,
+                SessionEventKind::Message {
+                    message: Message::user("root"),
+                },
+            )
+            .await
+            .expect("append root");
+        let left = store
+            .append(
+                &session,
+                Some(root.clone()),
+                SessionEventKind::Checkpoint {
+                    name: "left".into(),
+                },
+            )
+            .await
+            .expect("append left");
+        let right = store
+            .append(
+                &session,
+                Some(root.clone()),
+                SessionEventKind::Checkpoint {
+                    name: "right".into(),
+                },
+            )
+            .await
+            .expect("append right");
+
+        let events = store.load(&session).await.expect("load");
+        assert_eq!(events.len(), 3);
+        assert_eq!(
+            events.get(1).and_then(|event| event.parent_id.as_ref()),
+            Some(&root)
+        );
+        assert_eq!(
+            events.get(2).and_then(|event| event.parent_id.as_ref()),
+            Some(&root)
+        );
+        assert_ne!(left, right);
+    }
+}

--- a/crates/rig-core/src/skills.rs
+++ b/crates/rig-core/src/skills.rs
@@ -1,0 +1,112 @@
+//! Provider-independent progressive-disclosure skills.
+//!
+//! Core catalogs descriptors and lazily loads trusted bundles. Filesystem
+//! discovery and project-trust decisions belong in hosts or companion crates.
+
+use std::{collections::HashMap, sync::Arc};
+
+use serde::{Deserialize, Serialize};
+
+use crate::wasm_compat::{WasmBoxedFuture, WasmCompatSend, WasmCompatSync};
+
+/// Lightweight skill advertisement suitable for initial model context.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SkillDescriptor {
+    /// Stable catalog name.
+    pub name: String,
+    /// Short progressive-disclosure description.
+    pub description: String,
+    /// Source identifier retained across loading/import.
+    pub provenance: String,
+    /// Tools this skill may use. Empty means no skill-specific grant; host
+    /// policy still decides effective access.
+    pub allowed_tools: Vec<String>,
+}
+
+/// Named asset loaded only after a skill is activated.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SkillAsset {
+    /// Bundle-relative logical name.
+    pub name: String,
+    /// Media type when known.
+    pub media_type: Option<String>,
+    /// Asset bytes.
+    pub data: Vec<u8>,
+}
+
+/// Full trusted skill content loaded on demand.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SkillBundle {
+    /// Advertised descriptor and provenance.
+    pub descriptor: SkillDescriptor,
+    /// Full instructions injected only on activation.
+    pub instructions: String,
+    /// Optional references/assets.
+    pub assets: Vec<SkillAsset>,
+}
+
+/// Skill catalog failure.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum SkillError {
+    /// Requested skill was not present.
+    #[error("skill `{0}` not found")]
+    NotFound(String),
+    /// Catalog backend failed.
+    #[error("skill catalog error: {0}")]
+    Backend(String),
+}
+
+/// Lazy provider-independent skill catalog.
+pub trait SkillCatalog: WasmCompatSend + WasmCompatSync {
+    /// Enumerate lightweight descriptors without loading full instructions.
+    fn list<'a>(&'a self) -> WasmBoxedFuture<'a, Result<Vec<SkillDescriptor>, SkillError>>;
+
+    /// Load a trusted skill bundle by descriptor name.
+    fn load<'a>(&'a self, name: &'a str) -> WasmBoxedFuture<'a, Result<SkillBundle, SkillError>>;
+}
+
+/// Immutable in-memory catalog useful for hosts and tests.
+#[derive(Clone, Default)]
+pub struct InMemorySkillCatalog {
+    bundles: Arc<HashMap<String, SkillBundle>>,
+}
+
+impl InMemorySkillCatalog {
+    /// Build a catalog, rejecting duplicate names.
+    pub fn new(bundles: impl IntoIterator<Item = SkillBundle>) -> Result<Self, SkillError> {
+        let mut by_name = HashMap::new();
+        for bundle in bundles {
+            let name = bundle.descriptor.name.clone();
+            if by_name.insert(name.clone(), bundle).is_some() {
+                return Err(SkillError::Backend(format!("duplicate skill `{name}`")));
+            }
+        }
+        Ok(Self {
+            bundles: Arc::new(by_name),
+        })
+    }
+}
+
+impl SkillCatalog for InMemorySkillCatalog {
+    fn list<'a>(&'a self) -> WasmBoxedFuture<'a, Result<Vec<SkillDescriptor>, SkillError>> {
+        Box::pin(async move {
+            let mut descriptors = self
+                .bundles
+                .values()
+                .map(|bundle| bundle.descriptor.clone())
+                .collect::<Vec<_>>();
+            descriptors.sort_by(|left, right| left.name.cmp(&right.name));
+            Ok(descriptors)
+        })
+    }
+
+    fn load<'a>(&'a self, name: &'a str) -> WasmBoxedFuture<'a, Result<SkillBundle, SkillError>> {
+        Box::pin(async move {
+            self.bundles
+                .get(name)
+                .cloned()
+                .ok_or_else(|| SkillError::NotFound(name.to_owned()))
+        })
+    }
+}

--- a/crates/rig-core/src/streaming.rs
+++ b/crates/rig-core/src/streaming.rs
@@ -419,6 +419,7 @@ where
             // yields the provider's usage when present and the zero sentinel
             // (`Usage::new`) when the stream produced no final response.
             usage: value.response.token_usage(),
+            finish_reason: value.response.finish_reason(),
             raw_response: value.response,
             message_id: value.message_id,
         }

--- a/crates/rig-core/src/test_utils/completion.rs
+++ b/crates/rig-core/src/test_utils/completion.rs
@@ -151,6 +151,7 @@ impl MockTurn {
             usage: response.usage,
             raw_response: MockResponse::with_usage(response.usage),
             message_id: response.message_id,
+            finish_reason: None,
         })
     }
 }

--- a/crates/rig-core/src/test_utils/hook.rs
+++ b/crates/rig-core/src/test_utils/hook.rs
@@ -1,0 +1,63 @@
+//! Public harness for focused hook policy tests.
+
+use crate::{
+    agent::{AgentHook, Flow, HookContext, HookStack, RunContext, RunControlHandle, StepEvent},
+    completion::CompletionModel,
+};
+
+/// Production-equivalent hook context plus an ordered hook stack.
+pub struct HookTestHarness<M>
+where
+    M: CompletionModel,
+{
+    hooks: HookStack<M>,
+    context: HookContext,
+}
+
+impl<M> HookTestHarness<M>
+where
+    M: CompletionModel,
+{
+    /// Build a non-streaming harness with a fresh run identity.
+    pub fn new(hooks: HookStack<M>) -> Self {
+        Self {
+            hooks,
+            context: HookContext::new(
+                RunContext::new(RunControlHandle::new(), None),
+                false,
+                Some("hook-test".to_owned()),
+            ),
+        }
+    }
+
+    /// Select streaming metadata and an optional conversation identity.
+    pub fn with_run_metadata(
+        hooks: HookStack<M>,
+        streaming: bool,
+        conversation_id: Option<String>,
+    ) -> Self {
+        Self {
+            hooks,
+            context: HookContext::new(
+                RunContext::new(RunControlHandle::new(), conversation_id),
+                streaming,
+                Some("hook-test".to_owned()),
+            ),
+        }
+    }
+
+    /// Set the one-based current turn.
+    pub fn set_turn(&self, turn: usize) {
+        self.context.set_turn(turn);
+    }
+
+    /// Dispatch one event through normal stack ordering semantics.
+    pub async fn dispatch(&self, event: StepEvent<'_, M>) -> Flow {
+        self.hooks.on_event(&self.context, event).await
+    }
+
+    /// Inspect run metadata and scratchpad state.
+    pub fn context(&self) -> &HookContext {
+        &self.context
+    }
+}

--- a/crates/rig-core/src/test_utils/internal_streaming_profiles.rs
+++ b/crates/rig-core/src/test_utils/internal_streaming_profiles.rs
@@ -71,7 +71,11 @@ impl CompatibleStreamProfile for ErrorAfterPendingToolCallProfile {
         }
     }
 
-    fn build_final_response(&self, _usage: Self::Usage) -> Self::FinalResponse {
+    fn build_final_response(
+        &self,
+        _usage: Self::Usage,
+        _finish_reason: Option<crate::completion::FinishReason>,
+    ) -> Self::FinalResponse {
         MockResponse::new()
     }
 }
@@ -134,7 +138,11 @@ impl CompatibleStreamProfile for DistinctToolCallEvictionProfile {
         Ok(choice.map(test_chunk))
     }
 
-    fn build_final_response(&self, _usage: Self::Usage) -> Self::FinalResponse {
+    fn build_final_response(
+        &self,
+        _usage: Self::Usage,
+        _finish_reason: Option<crate::completion::FinishReason>,
+    ) -> Self::FinalResponse {
         MockResponse::new()
     }
 
@@ -176,7 +184,11 @@ impl CompatibleStreamProfile for FinishReasonCleanupProfile {
         Ok(choice.map(test_chunk))
     }
 
-    fn build_final_response(&self, _usage: Self::Usage) -> Self::FinalResponse {
+    fn build_final_response(
+        &self,
+        _usage: Self::Usage,
+        _finish_reason: Option<crate::completion::FinishReason>,
+    ) -> Self::FinalResponse {
         MockResponse::new()
     }
 }

--- a/crates/rig-core/src/test_utils/mod.rs
+++ b/crates/rig-core/src/test_utils/mod.rs
@@ -2,6 +2,7 @@
 
 mod completion;
 mod embeddings;
+mod hook;
 mod http;
 #[cfg(test)]
 pub(crate) mod internal_streaming_profiles;
@@ -13,6 +14,7 @@ mod tracing_isolation;
 
 pub use completion::{MockCompletionModel, MockError, MockTurn};
 pub use embeddings::{MockEmbeddingModel, MockMultiTextDocument, MockTextDocument};
+pub use hook::HookTestHarness;
 pub use http::{
     CapturedHttpRequest, HttpErrorStreamingClient, MockHttpResponse, MockStreamingClient,
     RecordingHttpClient, SequencedStreamingHttpClient,

--- a/crates/rig-core/src/tool/code_mode.rs
+++ b/crates/rig-core/src/tool/code_mode.rs
@@ -1,0 +1,217 @@
+//! Runtime-neutral code-mode adapter contracts.
+//!
+//! Language engines (Boa, Python, Lua, WebAssembly, …) implement
+//! [`CodeModeRuntime`] in companion crates. Core supplies resource limits,
+//! cancellation context, explicit nested-tool allowlists, and a single wrapper
+//! tool without selecting a scripting language.
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::{
+    agent::RunContext,
+    wasm_compat::{WasmBoxedFuture, WasmCompatSend, WasmCompatSync},
+};
+
+use super::{Tool, ToolCallExtensions, ToolExecutionResult, ToolFailure};
+
+/// Hard limits applied by a code-mode runtime.
+#[derive(Debug, Clone)]
+pub struct CodeModeLimits {
+    /// Maximum source bytes.
+    pub max_source_bytes: usize,
+    /// Maximum nested tool calls.
+    pub max_tool_calls: usize,
+    /// Maximum returned bytes.
+    pub max_output_bytes: usize,
+}
+
+impl Default for CodeModeLimits {
+    fn default() -> Self {
+        Self {
+            max_source_bytes: 64 * 1024,
+            max_tool_calls: 64,
+            max_output_bytes: 256 * 1024,
+        }
+    }
+}
+
+/// One nested call requested by sandboxed code.
+#[derive(Debug, Clone)]
+pub struct CodeToolCall {
+    /// Allowlisted tool name.
+    pub name: String,
+    /// Structured arguments.
+    pub args: serde_json::Value,
+}
+
+/// Scoped dispatcher implemented by the host/agent runtime.
+pub trait NestedToolDispatcher: WasmCompatSend + WasmCompatSync {
+    /// Dispatch through the host's normal policy, hooks, tracing, and structured
+    /// result path.
+    fn dispatch<'a>(
+        &'a self,
+        call: CodeToolCall,
+        context: &'a RunContext,
+    ) -> WasmBoxedFuture<'a, ToolExecutionResult>;
+}
+
+/// Runtime-neutral execution input.
+pub struct CodeModeRequest<'a> {
+    /// Generated source code.
+    pub source: &'a str,
+    /// Tools available inside the runtime.
+    pub allowed_tools: &'a BTreeSet<String>,
+    /// Resource limits.
+    pub limits: &'a CodeModeLimits,
+    /// Run cancellation/deadline context.
+    pub context: &'a RunContext,
+    /// Only path for nested tool execution.
+    pub dispatcher: &'a dyn NestedToolDispatcher,
+}
+
+/// Sandboxed language runtime adapter.
+pub trait CodeModeRuntime: WasmCompatSend + WasmCompatSync {
+    /// Language identifier shown to the model/host.
+    fn language(&self) -> &'static str;
+
+    /// Execute source under the supplied limits and host-function allowlist.
+    fn execute<'a>(
+        &'a self,
+        request: CodeModeRequest<'a>,
+    ) -> WasmBoxedFuture<'a, Result<String, CodeModeError>>;
+}
+
+/// Code-mode execution failure.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum CodeModeError {
+    /// Source or output limit was exceeded.
+    #[error("code mode resource limit exceeded: {0}")]
+    Limit(String),
+    /// Run cancellation was observed.
+    #[error("code mode cancelled: {0}")]
+    Cancelled(String),
+    /// Runtime rejected or failed to execute source.
+    #[error("code mode runtime error: {0}")]
+    Runtime(String),
+    /// The run context extension was absent.
+    #[error("code mode requires a run context")]
+    MissingContext,
+}
+
+/// Arguments exposed by the wrapper tool.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CodeModeArgs {
+    /// Source code in the configured runtime language.
+    pub code: String,
+}
+
+/// Single model-facing tool wrapping a selected catalog.
+pub struct CodeModeTool<R, D> {
+    runtime: R,
+    dispatcher: D,
+    allowed_tools: BTreeSet<String>,
+    limits: CodeModeLimits,
+}
+
+impl<R, D> CodeModeTool<R, D> {
+    /// Build a wrapper. The wrapper's own `run_code` name is always removed from
+    /// the nested allowlist to prevent direct recursion.
+    pub fn new(runtime: R, dispatcher: D, allowed_tools: impl IntoIterator<Item = String>) -> Self {
+        let mut allowed_tools = allowed_tools.into_iter().collect::<BTreeSet<_>>();
+        allowed_tools.remove("run_code");
+        Self {
+            runtime,
+            dispatcher,
+            allowed_tools,
+            limits: CodeModeLimits::default(),
+        }
+    }
+
+    /// Override resource limits.
+    pub fn limits(mut self, limits: CodeModeLimits) -> Self {
+        self.limits = limits;
+        self
+    }
+
+    /// Selected tools that should be hidden from the outer model catalog and
+    /// exposed only through this wrapper.
+    pub fn wrapped_tools(&self) -> &BTreeSet<String> {
+        &self.allowed_tools
+    }
+}
+
+impl<R, D> Tool for CodeModeTool<R, D>
+where
+    R: CodeModeRuntime,
+    D: NestedToolDispatcher,
+{
+    const NAME: &'static str = "run_code";
+
+    type Error = CodeModeError;
+    type Args = CodeModeArgs;
+    type Output = String;
+
+    fn description(&self) -> String {
+        format!(
+            "Execute {} code with an explicit allowlist of nested tools",
+            self.runtime.language()
+        )
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": { "code": { "type": "string" } },
+            "required": ["code"]
+        })
+    }
+
+    async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
+        Err(CodeModeError::MissingContext)
+    }
+
+    async fn call_with_extensions(
+        &self,
+        args: Self::Args,
+        extensions: &ToolCallExtensions,
+    ) -> Result<Self::Output, Self::Error> {
+        if args.code.len() > self.limits.max_source_bytes {
+            return Err(CodeModeError::Limit("source is too large".into()));
+        }
+        let context = extensions
+            .get::<RunContext>()
+            .ok_or(CodeModeError::MissingContext)?;
+        if let Some(reason) = context.control().cancellation_reason() {
+            return Err(CodeModeError::Cancelled(reason.into()));
+        }
+        let output = self
+            .runtime
+            .execute(CodeModeRequest {
+                source: &args.code,
+                allowed_tools: &self.allowed_tools,
+                limits: &self.limits,
+                context,
+                dispatcher: &self.dispatcher,
+            })
+            .await?;
+        if output.len() > self.limits.max_output_bytes {
+            return Err(CodeModeError::Limit("output is too large".into()));
+        }
+        Ok(output)
+    }
+
+    fn classify_error(&self, error: &Self::Error) -> ToolFailure {
+        match error {
+            CodeModeError::Cancelled(_) => ToolFailure::cancelled(error.to_string()),
+            CodeModeError::Limit(_) => {
+                ToolFailure::invalid_args(error.to_string()).with_retryable(true)
+            }
+            CodeModeError::Runtime(_) => ToolFailure::other(error.to_string()).with_retryable(true),
+            CodeModeError::MissingContext => ToolFailure::other(error.to_string()),
+        }
+    }
+}

--- a/crates/rig-core/src/tool/factory.rs
+++ b/crates/rig-core/src/tool/factory.rs
@@ -1,0 +1,41 @@
+//! Run-scoped toolset factories for stateful shells, REPLs, sandboxes, and connections.
+
+use thiserror::Error;
+
+use crate::{
+    agent::RunContext,
+    wasm_compat::{WasmBoxedFuture, WasmCompatSend, WasmCompatSync},
+};
+
+use super::ToolSet;
+
+/// Run-tool lifecycle failure.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ToolFactoryError {
+    /// Factory setup failed.
+    #[error("run tool factory setup failed: {0}")]
+    Setup(String),
+    /// Deterministic cleanup failed.
+    #[error("run tool factory cleanup failed: {0}")]
+    Cleanup(String),
+}
+
+/// Creates a toolset exactly once for a run and deterministically closes its
+/// associated resources when the shared driver settles.
+pub trait RunToolsetFactory: WasmCompatSend + WasmCompatSync {
+    /// Create the run-local tool overlay.
+    fn create<'a>(
+        &'a self,
+        context: &'a RunContext,
+    ) -> WasmBoxedFuture<'a, Result<ToolSet, ToolFactoryError>>;
+
+    /// Close state created for this run. Called on success, cancellation, and
+    /// ordinary driver errors. Implementations must make cleanup idempotent.
+    fn close<'a>(
+        &'a self,
+        _context: &'a RunContext,
+    ) -> WasmBoxedFuture<'a, Result<(), ToolFactoryError>> {
+        Box::pin(async { Ok(()) })
+    }
+}

--- a/crates/rig-core/src/tool/mod.rs
+++ b/crates/rig-core/src/tool/mod.rs
@@ -21,13 +21,17 @@
 //! richer outcomes/metadata via [`Tool::call_structured`] and [`ToolReturn`].
 
 pub mod builtin;
+pub mod code_mode;
 mod extensions;
+pub mod factory;
+pub mod operation;
 mod result;
 pub mod server;
 
 pub use extensions::{MissingExtension, ToolCallExtensions, ToolResultExtensions};
 pub use result::{
-    ToolExecutionResult, ToolFailure, ToolFailureKind, ToolOutcome, ToolReturn, ToolReturnOutcome,
+    ToolErrorReport, ToolExecutionResult, ToolFailure, ToolFailureKind, ToolOutcome, ToolOutput,
+    ToolReturn, ToolReturnOutcome,
 };
 use std::collections::HashMap;
 use std::fmt;
@@ -154,6 +158,11 @@ pub trait Tool: Sized + WasmCompatSend + WasmCompatSync {
     /// JSON Schema for the tool arguments.
     fn parameters(&self) -> serde_json::Value;
 
+    /// Optional model-facing JSON Schema for the tool result.
+    fn output_schema(&self) -> Option<serde_json::Value> {
+        None
+    }
+
     /// The tool execution method.
     /// Both the arguments and return value are a String since these values are meant to
     /// be the output and input of LLM models (respectively)
@@ -210,6 +219,15 @@ pub trait Tool: Sized + WasmCompatSend + WasmCompatSync {
     /// ```
     fn classify_error(&self, error: &Self::Error) -> ToolFailure {
         ToolFailure::other(error.to_string())
+    }
+
+    /// Classify an error and attach host-only metadata in one operation.
+    ///
+    /// The default preserves [`classify_error`](Self::classify_error) behavior.
+    /// Override this instead when policy hooks need typed metadata from failed
+    /// executions without reimplementing [`call_structured`](Self::call_structured).
+    fn classify_error_report(&self, error: &Self::Error) -> ToolErrorReport {
+        ToolErrorReport::new(self.classify_error(error))
     }
 
     /// Execute the tool, returning a structured [`ToolReturn`] instead of a bare
@@ -288,6 +306,11 @@ pub trait ToolDyn: WasmCompatSend + WasmCompatSync {
 
     /// JSON Schema for the tool arguments.
     fn parameters(&self) -> serde_json::Value;
+
+    /// Optional model-facing JSON Schema for the tool result.
+    fn output_schema(&self) -> Option<serde_json::Value> {
+        None
+    }
 
     /// Calls the tool with JSON-encoded arguments and returns model-facing text.
     fn call<'a>(&'a self, args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>>;
@@ -393,6 +416,7 @@ pub(crate) fn tool_definition_with_name(
         name: name.into(),
         description: tool.description(),
         parameters: tool.parameters(),
+        output_schema: tool.output_schema(),
     }
 }
 
@@ -407,6 +431,10 @@ impl<T: Tool> ToolDyn for T {
 
     fn parameters(&self) -> serde_json::Value {
         <Self as Tool>::parameters(self)
+    }
+
+    fn output_schema(&self) -> Option<serde_json::Value> {
+        <Self as Tool>::output_schema(self)
     }
 
     fn call<'a>(&'a self, args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
@@ -453,8 +481,9 @@ impl<T: Tool> ToolDyn for T {
             match <Self as Tool>::call_structured(self, parsed, extensions).await {
                 Ok(tool_return) => tool_return.into_execution_result(),
                 Err(err) => {
-                    let failure = self.classify_error(&err);
-                    ToolExecutionResult::failed(err.to_string(), failure)
+                    let report = self.classify_error_report(&err);
+                    ToolExecutionResult::failed(err.to_string(), report.failure)
+                        .with_extensions(report.extensions)
                 }
             }
         })
@@ -558,7 +587,7 @@ pub enum ToolSetError {
 /// (definitions, documents, schemas) follows registration order and the tool
 /// list sent to providers is deterministic across processes. Re-registering an
 /// existing name replaces the implementation but keeps its original position.
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct ToolSet {
     pub(crate) tools: IndexMap<String, ToolType>,
 }

--- a/crates/rig-core/src/tool/operation.rs
+++ b/crates/rig-core/src/tool/operation.rs
@@ -1,0 +1,138 @@
+//! Host-selected operation backends and coding-tool safety primitives.
+//!
+//! Core defines the contract; local process, SSH, container, and sandbox
+//! implementations belong in hosts or optional companion crates.
+
+use std::{
+    collections::HashMap,
+    future::Future,
+    sync::{Arc, Mutex},
+};
+
+use crate::wasm_compat::{WasmBoxedFuture, WasmCompatSend, WasmCompatSync};
+
+use super::ToolFailure;
+
+/// Backend family selected by a host.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum OperationBackendKind {
+    /// Local machine execution.
+    Local,
+    /// Remote SSH execution.
+    Ssh,
+    /// Container execution.
+    Container,
+    /// Sandboxed execution.
+    Sandbox,
+}
+
+/// A backend-neutral operation request.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct OperationRequest {
+    /// Program or operation name.
+    pub program: String,
+    /// Argument vector; no shell interpolation is implied.
+    pub args: Vec<String>,
+    /// Optional working directory selected after host path policy.
+    pub working_directory: Option<String>,
+    /// Maximum model-visible output bytes.
+    pub output_limit: Option<usize>,
+}
+
+/// Reference to complete output retained outside the model transcript.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct OutputArtifact {
+    /// Host-defined stable identifier or URI.
+    pub reference: String,
+    /// Complete output byte length.
+    pub byte_len: usize,
+}
+
+/// Structured backend output with explicit truncation.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct OperationOutput {
+    /// Model-visible bounded output.
+    pub output: String,
+    /// Process/operation status when meaningful.
+    pub status: Option<i32>,
+    /// Complete-output reference when `output` was truncated.
+    pub artifact: Option<OutputArtifact>,
+}
+
+/// Progress update for a long-running operation.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct OperationProgress {
+    /// Human-readable progress message.
+    pub message: String,
+    /// Optional normalized completion fraction.
+    pub fraction: Option<f32>,
+}
+
+/// Receives progress without coupling the backend to a UI.
+pub trait ProgressSink: WasmCompatSend + WasmCompatSync {
+    /// Publish one progress update.
+    fn publish(&self, progress: OperationProgress);
+}
+
+/// Pluggable execution backend for coding tools.
+pub trait ToolOperationBackend: WasmCompatSend + WasmCompatSync {
+    /// Backend family for policy and telemetry.
+    fn kind(&self) -> OperationBackendKind;
+
+    /// Execute an operation while observing run cancellation through the
+    /// automatically injected [`RunContext`](crate::agent::RunContext).
+    fn execute<'a>(
+        &'a self,
+        request: OperationRequest,
+        context: &'a crate::agent::RunContext,
+        progress: Option<&'a dyn ProgressSink>,
+    ) -> WasmBoxedFuture<'a, Result<OperationOutput, ToolFailure>>;
+}
+
+/// Host policy evaluated independently from execution isolation.
+pub trait OperationPolicy: WasmCompatSend + WasmCompatSync {
+    /// Approve or reject a request before a backend sees it.
+    fn authorize(
+        &self,
+        request: &OperationRequest,
+        context: &crate::agent::RunContext,
+    ) -> Result<(), ToolFailure>;
+}
+
+/// Keyed mutation serializer for files or other resources.
+///
+/// Equal normalized resource keys execute one-at-a-time; unrelated resources
+/// remain concurrent. Hosts are responsible for canonicalizing keys according
+/// to project trust and path policy before calling [`run`](Self::run).
+#[derive(Clone, Default)]
+pub struct ResourceMutationQueue {
+    locks: Arc<Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>>,
+}
+
+impl ResourceMutationQueue {
+    /// Construct an empty queue.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Run one mutation under the resource's FIFO Tokio mutex.
+    pub async fn run<F, Fut, T>(&self, resource: impl Into<String>, operation: F) -> T
+    where
+        F: FnOnce() -> Fut + WasmCompatSend,
+        Fut: Future<Output = T> + WasmCompatSend,
+        T: WasmCompatSend,
+    {
+        let resource = resource.into();
+        let lock = {
+            let mut locks = self.locks.lock().unwrap_or_else(|error| error.into_inner());
+            locks.entry(resource).or_default().clone()
+        };
+        let _guard = lock.lock().await;
+        operation().await
+    }
+}

--- a/crates/rig-core/src/tool/result.rs
+++ b/crates/rig-core/src/tool/result.rs
@@ -17,8 +17,60 @@
 //! resulting [`ToolExecutionResult`] all the way through to the
 //! [`StepEvent::ToolResult`](crate::agent::StepEvent::ToolResult) hook event.
 
-use crate::tool::ToolResultExtensions;
+use crate::{OneOrMany, message::ToolResultContent, tool::ToolResultExtensions};
 use serde::Serialize;
+
+/// Model-facing tool output without magic string envelopes.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum ToolOutput {
+    /// Compatibility path for existing string-returning tools. The runner keeps
+    /// supporting Rig's historical multimodal JSON envelope parser.
+    LegacyText(String),
+    /// Explicit rich content that is never guessed by parsing reserved JSON keys.
+    Content(OneOrMany<ToolResultContent>),
+}
+
+impl ToolOutput {
+    fn text_projection(&self) -> String {
+        match self {
+            Self::LegacyText(text) => text.clone(),
+            Self::Content(content) => content
+                .iter()
+                .map(|part| match part {
+                    ToolResultContent::Text(text) => text.text.clone(),
+                    ToolResultContent::Image(_) => "[image]".to_owned(),
+                })
+                .collect::<Vec<_>>()
+                .join("\n"),
+        }
+    }
+}
+
+/// Structured classification and host-only metadata for a tool error.
+#[derive(Debug, Clone)]
+pub struct ToolErrorReport {
+    /// Machine-readable failure classification.
+    pub failure: ToolFailure,
+    /// Metadata surfaced to hooks but never sent to the model.
+    pub extensions: ToolResultExtensions,
+}
+
+impl ToolErrorReport {
+    /// Create a report without extensions.
+    pub fn new(failure: ToolFailure) -> Self {
+        Self {
+            failure,
+            extensions: ToolResultExtensions::new(),
+        }
+    }
+
+    /// Attach error metadata.
+    pub fn with_extensions(mut self, extensions: ToolResultExtensions) -> Self {
+        self.extensions = extensions;
+        self
+    }
+}
 
 /// How a tool execution failed, as a closed set of standard kinds.
 ///
@@ -420,6 +472,7 @@ impl From<ToolReturnOutcome> for ToolOutcome {
 #[non_exhaustive]
 pub struct ToolExecutionResult {
     pub(crate) model_output: String,
+    pub(crate) output: ToolOutput,
     pub(crate) outcome: ToolOutcome,
     pub(crate) extensions: ToolResultExtensions,
 }
@@ -433,8 +486,10 @@ impl ToolExecutionResult {
     /// [`success`](Self::success) / [`failed`](Self::failed) /
     /// [`denied`](Self::denied), which cannot produce `Skipped`.
     pub(crate) fn new(model_output: impl Into<String>, outcome: ToolOutcome) -> Self {
+        let model_output = model_output.into();
         Self {
-            model_output: model_output.into(),
+            output: ToolOutput::LegacyText(model_output.clone()),
+            model_output,
             outcome,
             extensions: ToolResultExtensions::new(),
         }
@@ -443,6 +498,17 @@ impl ToolExecutionResult {
     /// A successful result whose model output is `model_output` verbatim.
     pub fn success(model_output: impl Into<String>) -> Self {
         Self::new(model_output, ToolOutcome::Success)
+    }
+
+    /// A successful explicit rich result, bypassing legacy JSON-envelope parsing.
+    pub fn success_content(content: OneOrMany<ToolResultContent>) -> Self {
+        let output = ToolOutput::Content(content);
+        Self {
+            model_output: output.text_projection(),
+            output,
+            outcome: ToolOutcome::Success,
+            extensions: ToolResultExtensions::new(),
+        }
     }
 
     /// A failed result: `model_output` is the model-visible feedback, `failure`
@@ -493,6 +559,11 @@ impl ToolExecutionResult {
     /// failure, so the model gets useful feedback (a handled error message).
     pub fn model_output(&self) -> &str {
         &self.model_output
+    }
+
+    /// Structured model-facing output.
+    pub fn output(&self) -> &ToolOutput {
+        &self.output
     }
 
     /// The structured [`ToolOutcome`] of the call.
@@ -640,6 +711,7 @@ impl<T: Serialize> ToolReturn<T> {
         } = self;
         match super::serialize_tool_output(&output) {
             Ok(model_output) => ToolExecutionResult {
+                output: ToolOutput::LegacyText(model_output.clone()),
                 model_output,
                 outcome: outcome.into(),
                 extensions,
@@ -653,8 +725,10 @@ impl<T: Serialize> ToolReturn<T> {
                     // A declared failure/denial keeps its classification.
                     other => other.into(),
                 };
+                let model_output = format!("failed to serialize tool output: {err}");
                 ToolExecutionResult {
-                    model_output: format!("failed to serialize tool output: {err}"),
+                    output: ToolOutput::LegacyText(model_output.clone()),
+                    model_output,
                     outcome,
                     extensions,
                 }

--- a/crates/rig-core/src/tool/rmcp.rs
+++ b/crates/rig-core/src/tool/rmcp.rs
@@ -137,6 +137,10 @@ impl From<&rmcp::model::Tool> for ToolDefinition {
             name: val.name.to_string(),
             description: val.description.clone().unwrap_or(Cow::from("")).to_string(),
             parameters: val.schema_as_json_value(),
+            output_schema: val
+                .output_schema
+                .as_ref()
+                .map(|schema| serde_json::Value::Object((**schema).clone())),
         }
     }
 }
@@ -147,6 +151,10 @@ impl From<rmcp::model::Tool> for ToolDefinition {
             name: val.name.to_string(),
             description: val.description.clone().unwrap_or(Cow::from("")).to_string(),
             parameters: val.schema_as_json_value(),
+            output_schema: val
+                .output_schema
+                .as_ref()
+                .map(|schema| serde_json::Value::Object((**schema).clone())),
         }
     }
 }

--- a/crates/rig-core/src/tool/server.rs
+++ b/crates/rig-core/src/tool/server.rs
@@ -10,6 +10,57 @@ use crate::{
     vector_store::{VectorSearchRequest, VectorStoreError, VectorStoreIndexDyn, request::Filter},
 };
 
+/// Operational family of a catalog entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ToolKind {
+    /// In-process Rust tool.
+    Native,
+    /// Tool discovered from an MCP server.
+    Mcp,
+    /// Tool selected dynamically from a vector index.
+    Dynamic,
+    /// Tool executed by the model provider.
+    ProviderHosted,
+}
+
+/// Scheduling policy advertised to a host.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ToolExecutionPolicy {
+    /// Calls may participate in a concurrent batch.
+    #[default]
+    ParallelSafe,
+    /// Calls must be serialized by the host runtime.
+    Sequential,
+}
+
+/// Host-only tool metadata. This is never serialized into a model request.
+#[derive(Debug, Clone, Default, PartialEq)]
+#[non_exhaustive]
+pub struct ToolMetadata {
+    /// Scheduling policy.
+    pub execution: ToolExecutionPolicy,
+    /// Whether a successful result is intended to end a workflow.
+    pub terminating: bool,
+    /// Optional source/provenance label.
+    pub source: Option<String>,
+}
+
+/// One introspectable row from the shared tool server.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct ToolCatalogEntry {
+    /// Registered dispatch name.
+    pub name: String,
+    /// Model-facing definition.
+    pub definition: ToolDefinition,
+    /// Operational family retained for host policy.
+    pub kind: ToolKind,
+    /// Metadata retained only by the host.
+    pub metadata: ToolMetadata,
+}
+
 /// Append `name` to the advertised static-tool list unless already present.
 /// Registration is last-wins on the toolset, so the name list only needs
 /// first-occurrence order: a re-registered name keeps its original position
@@ -150,6 +201,19 @@ impl ToolServer {
 pub struct ToolServerHandle(Arc<RwLock<ToolServerState>>);
 
 impl ToolServerHandle {
+    /// Snapshot this server into an independent run-local handle.
+    ///
+    /// Tools are `Arc`-cloned, while subsequent add/remove/replace mutations are
+    /// isolated from the original handle.
+    pub async fn fork(&self) -> Self {
+        let state = self.0.read().await;
+        Self(Arc::new(RwLock::new(ToolServerState {
+            static_tool_names: state.static_tool_names.clone(),
+            dynamic_tools: state.dynamic_tools.clone(),
+            toolset: state.toolset.clone(),
+        })))
+    }
+
     /// Register a new static tool. Re-registering an existing name replaces
     /// the implementation (last wins) and keeps its position.
     pub async fn add_tool(&self, tool: impl ToolDyn + 'static) -> Result<(), ToolServerError> {
@@ -257,6 +321,40 @@ impl ToolServerHandle {
                 ToolFailure::not_found(format!("no tool named `{tool_name}` is registered")),
             ),
         }
+    }
+
+    /// Enumerate registered tools in stable registration order.
+    ///
+    /// This host-facing projection remains distinct from model serialization:
+    /// metadata and provenance never leak onto the wire. Calls already cloned
+    /// for execution retain snapshot semantics if an entry is replaced/removed.
+    pub async fn catalog(&self) -> Result<Vec<ToolCatalogEntry>, ToolServerError> {
+        let state = self.0.read().await;
+        let mut entries = Vec::with_capacity(state.static_tool_names.len());
+        for name in &state.static_tool_names {
+            let Some(tool) = state.toolset.get(name) else {
+                continue;
+            };
+            entries.push(ToolCatalogEntry {
+                name: name.clone(),
+                definition: tool.definition_with_name(name.clone()),
+                kind: ToolKind::Native,
+                metadata: ToolMetadata::default(),
+            });
+        }
+        Ok(entries)
+    }
+
+    /// Look up one catalog entry by registered name.
+    pub async fn catalog_entry(
+        &self,
+        name: &str,
+    ) -> Result<Option<ToolCatalogEntry>, ToolServerError> {
+        Ok(self
+            .catalog()
+            .await?
+            .into_iter()
+            .find(|entry| entry.name == name))
     }
 
     /// Retrieve tool definitions, optionally using a prompt to select

--- a/crates/rig-gemini-grpc/src/completion.rs
+++ b/crates/rig-gemini-grpc/src/completion.rs
@@ -494,6 +494,7 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse<Generat
             usage,
             raw_response: response,
             message_id: None,
+            finish_reason: None,
         })
     }
 }
@@ -962,6 +963,7 @@ mod tests {
                 },
                 "required": ["city"]
             }),
+            output_schema: None,
         };
 
         let req = create_grpc_request(

--- a/crates/rig-sqlite/README.md
+++ b/crates/rig-sqlite/README.md
@@ -16,7 +16,7 @@
 
 ## Rig-SQLite
 
-This companion crate implements a Rig vector store based on SQLite.
+This companion crate implements a Rig vector store and durable conversation memory based on SQLite.
 
 ## Usage
 
@@ -34,7 +34,32 @@ You can also run `cargo add rig-sqlite rig-core serde_json` and
 `cargo add serde --features derive` to add the most recent versions of the
 dependencies to your project.
 
-See the [`/examples`](./examples) folder for usage examples.
+See the [`/examples`](./examples) folder for vector-store usage examples.
+
+## Durable Conversation Memory
+
+`SqliteConversationMemory` implements `rig_core::memory::ConversationMemory`,
+preserving ordered conversations across process restarts. It composes with
+`rig-memory` policies because it uses the existing core trait.
+
+```rust,no_run
+use rig_sqlite::SqliteConversationMemory;
+use tokio_rusqlite::Connection;
+
+# async fn example() -> Result<(), Box<dyn std::error::Error>> {
+let connection = Connection::open("agent-memory.sqlite").await?;
+let memory = SqliteConversationMemory::new(connection).await?;
+
+// Attach with: client.agent(MODEL).memory(memory).build()
+// Then select a conversation per request with `.conversation("user-123")`.
+# let _ = memory;
+# Ok(())
+# }
+```
+
+Custom table names are available through `with_table`; names are validated as
+SQL identifiers. Call `migrate().await` after selecting a custom table. Appends
+are transactional and sequence messages independently for each conversation.
 
 ## Important Note
 

--- a/crates/rig-sqlite/src/lib.rs
+++ b/crates/rig-sqlite/src/lib.rs
@@ -1,11 +1,16 @@
-//! SQLite vector store integration for Rig.
+//! SQLite vector store and durable conversation-memory integration for Rig.
 //!
-//! This crate provides [`SqliteVectorStore`] and [`SqliteVectorIndex`] for
+//! This crate provides [`SqliteConversationMemory`] plus [`SqliteVectorStore`]
+//! and [`SqliteVectorIndex`] for
 //! storing embedded documents in SQLite with the `sqlite-vec` extension. Define
 //! document table schemas by implementing [`SqliteVectorStoreTable`].
 //!
 //! The root `rig` facade re-exports this crate as `rig::sqlite` when the
 //! `sqlite` feature is enabled.
+
+mod memory;
+
+pub use memory::SqliteConversationMemory;
 
 use rig_core::embeddings::{Embedding, EmbeddingModel};
 use rig_core::vector_store::request::{FilterError, SearchFilter, VectorSearchRequest};

--- a/crates/rig-sqlite/src/memory.rs
+++ b/crates/rig-sqlite/src/memory.rs
@@ -1,0 +1,209 @@
+//! Durable SQLite conversation memory.
+
+use rig_core::{
+    completion::Message,
+    memory::{ConversationMemory, MemoryError},
+    wasm_compat::WasmBoxedFuture,
+};
+use rusqlite::params;
+use tokio_rusqlite::Connection;
+
+/// Durable ordered conversation memory backed by SQLite.
+#[derive(Clone)]
+pub struct SqliteConversationMemory {
+    connection: Connection,
+    table: String,
+}
+
+impl std::fmt::Debug for SqliteConversationMemory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SqliteConversationMemory")
+            .field("table", &self.table)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SqliteConversationMemory {
+    /// Create the default memory store and idempotently migrate its schema.
+    pub async fn new(connection: Connection) -> Result<Self, MemoryError> {
+        let memory = Self {
+            connection,
+            table: "rig_conversation_messages".to_owned(),
+        };
+        memory.migrate().await?;
+        Ok(memory)
+    }
+
+    /// Select a custom table name.
+    ///
+    /// Only ASCII SQL identifiers are accepted because SQLite cannot bind table
+    /// names as parameters.
+    pub fn with_table(mut self, table: impl Into<String>) -> Result<Self, MemoryError> {
+        let table = table.into();
+        validate_identifier(&table)?;
+        self.table = table;
+        Ok(self)
+    }
+
+    /// Create the configured table if needed.
+    pub async fn migrate(&self) -> Result<(), MemoryError> {
+        let table = self.table.clone();
+        validate_identifier(&table)?;
+        self.connection
+            .call(move |connection| {
+                connection.execute_batch(&format!(
+                    "CREATE TABLE IF NOT EXISTS {table} (\
+                     conversation_id TEXT NOT NULL,\
+                     sequence INTEGER NOT NULL,\
+                     message_json TEXT NOT NULL,\
+                     schema_version INTEGER NOT NULL DEFAULT 1,\
+                     PRIMARY KEY (conversation_id, sequence)\
+                     );"
+                ))?;
+                Ok(())
+            })
+            .await
+            .map_err(MemoryError::backend)
+    }
+}
+
+impl ConversationMemory for SqliteConversationMemory {
+    fn load<'a>(
+        &'a self,
+        conversation_id: &'a str,
+    ) -> WasmBoxedFuture<'a, Result<Vec<Message>, MemoryError>> {
+        Box::pin(async move {
+            let table = self.table.clone();
+            let conversation_id = conversation_id.to_owned();
+            let rows = self
+                .connection
+                .call(move |connection| {
+                    let mut statement = connection.prepare(&format!(
+                        "SELECT message_json FROM {table} \
+                         WHERE conversation_id = ?1 ORDER BY sequence ASC"
+                    ))?;
+                    let rows = statement
+                        .query_map(params![conversation_id], |row| row.get::<_, String>(0))?
+                        .collect::<Result<Vec<_>, _>>()?;
+                    Ok(rows)
+                })
+                .await
+                .map_err(MemoryError::backend)?;
+
+            rows.into_iter()
+                .map(|row| serde_json::from_str(&row).map_err(MemoryError::backend))
+                .collect()
+        })
+    }
+
+    fn append<'a>(
+        &'a self,
+        conversation_id: &'a str,
+        messages: Vec<Message>,
+    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+        Box::pin(async move {
+            if messages.is_empty() {
+                return Ok(());
+            }
+            let serialized = messages
+                .into_iter()
+                .map(|message| serde_json::to_string(&message).map_err(MemoryError::backend))
+                .collect::<Result<Vec<_>, _>>()?;
+            let table = self.table.clone();
+            let conversation_id = conversation_id.to_owned();
+            self.connection
+                .call(move |connection| {
+                    let transaction = connection.transaction()?;
+                    let last: Option<i64> = transaction.query_row(
+                        &format!("SELECT MAX(sequence) FROM {table} WHERE conversation_id = ?1"),
+                        params![conversation_id],
+                        |row| row.get(0),
+                    )?;
+                    let mut sequence = last.unwrap_or(-1) + 1;
+                    for message in serialized {
+                        transaction.execute(
+                            &format!(
+                                "INSERT INTO {table} \
+                                 (conversation_id, sequence, message_json, schema_version) \
+                                 VALUES (?1, ?2, ?3, 1)"
+                            ),
+                            params![conversation_id, sequence, message],
+                        )?;
+                        sequence += 1;
+                    }
+                    transaction.commit()?;
+                    Ok(())
+                })
+                .await
+                .map_err(MemoryError::backend)
+        })
+    }
+
+    fn clear<'a>(
+        &'a self,
+        conversation_id: &'a str,
+    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+        Box::pin(async move {
+            let table = self.table.clone();
+            let conversation_id = conversation_id.to_owned();
+            self.connection
+                .call(move |connection| {
+                    connection.execute(
+                        &format!("DELETE FROM {table} WHERE conversation_id = ?1"),
+                        params![conversation_id],
+                    )?;
+                    Ok(())
+                })
+                .await
+                .map_err(MemoryError::backend)
+        })
+    }
+}
+
+fn validate_identifier(identifier: &str) -> Result<(), MemoryError> {
+    let mut chars = identifier.chars();
+    let valid_first = chars
+        .next()
+        .is_some_and(|character| character.is_ascii_alphabetic() || character == '_');
+    if valid_first && chars.all(|character| character.is_ascii_alphanumeric() || character == '_') {
+        Ok(())
+    } else {
+        Err(MemoryError::Internal(format!(
+            "invalid SQLite table identifier `{identifier}`"
+        )))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::panic_in_result_fn)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn round_trip_isolated_conversations_and_clear() -> anyhow::Result<()> {
+        let connection = Connection::open_in_memory().await?;
+        let memory = SqliteConversationMemory::new(connection).await?;
+        memory
+            .append("a", vec![Message::user("one"), Message::assistant("two")])
+            .await?;
+        memory.append("b", vec![Message::user("other")]).await?;
+
+        let loaded = memory.load("a").await?;
+        assert_eq!(loaded.len(), 2);
+        assert!(matches!(loaded.first(), Some(Message::User { .. })));
+        assert!(matches!(loaded.get(1), Some(Message::Assistant { .. })));
+        assert_eq!(memory.load("b").await?.len(), 1);
+        memory.clear("a").await?;
+        assert!(memory.load("a").await?.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn migration_is_idempotent_and_names_are_validated() -> anyhow::Result<()> {
+        let connection = Connection::open_in_memory().await?;
+        let memory = SqliteConversationMemory::new(connection).await?;
+        memory.migrate().await?;
+        assert!(memory.clone().with_table("bad; DROP TABLE x").is_err());
+        Ok(())
+    }
+}

--- a/crates/rig-vertexai/src/types/completion_request.rs
+++ b/crates/rig-vertexai/src/types/completion_request.rs
@@ -345,6 +345,7 @@ mod tests {
                     "type": "object",
                     "properties": {}
                 }),
+                output_schema: None,
             }],
             ..minimal_request()
         };
@@ -376,6 +377,7 @@ mod tests {
                     "type": "object",
                     "properties": {}
                 }),
+                output_schema: None,
             }],
             ..minimal_request()
         };
@@ -407,6 +409,7 @@ mod tests {
                     "type": "object",
                     "properties": {}
                 }),
+                output_schema: None,
             }],
             ..minimal_request()
         };
@@ -440,6 +443,7 @@ mod tests {
                     "type": "object",
                     "properties": {}
                 }),
+                output_schema: None,
             }],
             ..minimal_request()
         };
@@ -532,6 +536,7 @@ mod tests {
                     },
                     "required": ["x", "y"]
                 }),
+                output_schema: None,
             }],
             ..minimal_request()
         };
@@ -564,6 +569,7 @@ mod tests {
                     "type": "object",
                     "properties": {}
                 }),
+                output_schema: None,
             }],
             ..minimal_request()
         };
@@ -595,6 +601,7 @@ mod tests {
                     "type": "object",
                     "properties": {}
                 }),
+                output_schema: None,
             }],
             ..minimal_request()
         };
@@ -635,6 +642,7 @@ mod tests {
                     },
                     "required": ["location"]
                 }),
+                output_schema: None,
             }],
             ..minimal_request()
         };

--- a/crates/rig-vertexai/src/types/completion_response.rs
+++ b/crates/rig-vertexai/src/types/completion_response.rs
@@ -2,7 +2,7 @@ use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use google_cloud_aiplatform_v1 as vertexai;
 use rig_core::OneOrMany;
-use rig_core::completion::{CompletionError, CompletionResponse, Usage};
+use rig_core::completion::{CompletionError, CompletionResponse, FinishReason, Usage};
 use rig_core::message::{
     AssistantContent, ImageDetail, ImageMediaType, MediaType, MimeType, Reasoning, Text, ToolCall,
     ToolFunction,
@@ -137,11 +137,22 @@ impl TryFrom<VertexGenerateContentOutput> for CompletionResponse<VertexGenerateC
             })
             .unwrap_or_default();
 
+        let finish_reason = Some(match candidate.finish_reason.clone() {
+            vertexai::model::candidate::FinishReason::Stop => FinishReason::Stop,
+            vertexai::model::candidate::FinishReason::MaxTokens => FinishReason::Length,
+            vertexai::model::candidate::FinishReason::Safety
+            | vertexai::model::candidate::FinishReason::Blocklist
+            | vertexai::model::candidate::FinishReason::ProhibitedContent
+            | vertexai::model::candidate::FinishReason::Spii => FinishReason::ContentFilter,
+            other => FinishReason::Other(format!("{other:?}")),
+        });
+
         Ok(CompletionResponse {
             choice,
             usage,
             raw_response: value,
             message_id: None,
+            finish_reason,
         })
     }
 }

--- a/tests/common/support.rs
+++ b/tests/common/support.rs
@@ -233,6 +233,7 @@ pub(crate) fn zero_arg_tool_definition(name: &str) -> ToolDefinition {
             "properties": {},
             "required": [],
         }),
+        output_schema: None,
     }
 }
 

--- a/tests/providers/anthropic/cassette/empty_end_turn.rs
+++ b/tests/providers/anthropic/cassette/empty_end_turn.rs
@@ -53,6 +53,7 @@ fn notify_tool_definition() -> ToolDefinition {
             },
             "required": ["msg"]
         }),
+        output_schema: None,
     }
 }
 

--- a/tests/providers/anthropic/cassette/messages_tool_args.rs
+++ b/tests/providers/anthropic/cassette/messages_tool_args.rs
@@ -320,6 +320,7 @@ async fn unicode_arguments_streaming() {
                         },
                         "required": ["message"]
                     }),
+                    output_schema: None,
                 })
                 .build();
 

--- a/tests/providers/anthropic/cassette/prompt_caching.rs
+++ b/tests/providers/anthropic/cassette/prompt_caching.rs
@@ -268,6 +268,7 @@ fn cache_probe_tools() -> Vec<ToolDefinition> {
                 },
                 "required": ["topic"]
             }),
+            output_schema: None,
         },
         ToolDefinition {
             name: "lookup_cache_fixture".to_string(),
@@ -285,6 +286,7 @@ fn cache_probe_tools() -> Vec<ToolDefinition> {
                 },
                 "required": ["fixture"]
             }),
+            output_schema: None,
         },
     ]
 }
@@ -307,6 +309,7 @@ fn cache_probe_tools_for(label: &str) -> Vec<ToolDefinition> {
                 },
                 "required": ["topic"]
             }),
+            output_schema: None,
         },
         ToolDefinition {
             name: "lookup_cache_fixture".to_string(),
@@ -324,6 +327,7 @@ fn cache_probe_tools_for(label: &str) -> Vec<ToolDefinition> {
                 },
                 "required": ["fixture"]
             }),
+            output_schema: None,
         },
     ]
 }

--- a/tests/providers/chatgpt/cassette/codex_tool_args.rs
+++ b/tests/providers/chatgpt/cassette/codex_tool_args.rs
@@ -315,6 +315,7 @@ async fn unicode_arguments_streaming() {
                         },
                         "required": ["message"]
                     }),
+                    output_schema: None,
                 })
                 .build();
 

--- a/tests/providers/gemini/agent_run_support.rs
+++ b/tests/providers/gemini/agent_run_support.rs
@@ -40,6 +40,7 @@ fn operation_definition(name: &str, description: &str) -> ToolDefinition {
             },
             "required": ["x", "y"]
         }),
+        output_schema: None,
     }
 }
 

--- a/tests/providers/gemini/cassette/generate_tool_args.rs
+++ b/tests/providers/gemini/cassette/generate_tool_args.rs
@@ -256,6 +256,7 @@ async fn unicode_arguments_streaming() {
                         },
                         "required": ["message"]
                     }),
+                    output_schema: None,
                 })
                 .build();
 
@@ -326,6 +327,7 @@ async fn optional_nullable_argument_omitted_when_not_requested() {
                         },
                         "required": ["name"]
                     }),
+                    output_schema: None,
                 })
                 .build();
 

--- a/tests/providers/gemini/cassette/interactions_api.rs
+++ b/tests/providers/gemini/cassette/interactions_api.rs
@@ -153,6 +153,7 @@ async fn tool_result_roundtrip() {
                     },
                     "required": ["x", "y"]
                 }),
+                output_schema: None,
             };
 
             let initial = model

--- a/tests/providers/gemini/tools_support.rs
+++ b/tests/providers/gemini/tools_support.rs
@@ -75,6 +75,7 @@ fn operation_definition(name: &str, description: &str) -> ToolDefinition {
             },
             "required": ["x", "y"]
         }),
+        output_schema: None,
     }
 }
 

--- a/tests/providers/openai/cassette/response_schema.rs
+++ b/tests/providers/openai/cassette/response_schema.rs
@@ -78,6 +78,7 @@ fn test_nested_objects() {
         name: "submit".to_string(),
         description: "Submit".to_string(),
         parameters: serde_json::to_value(schema).unwrap(),
+        output_schema: None,
     };
     let response = ResponsesToolDefinition::from(tool_def).with_strict();
 
@@ -94,6 +95,7 @@ fn test_array_items() {
         name: "submit".to_string(),
         description: "Submit".to_string(),
         parameters: serde_json::to_value(schema).unwrap(),
+        output_schema: None,
     };
     let response = ResponsesToolDefinition::from(tool_def).with_strict();
 
@@ -110,6 +112,7 @@ fn test_enum_schemas() {
         name: "submit".to_string(),
         description: "Submit".to_string(),
         parameters: serde_json::to_value(schema).unwrap(),
+        output_schema: None,
     };
     let response = ResponsesToolDefinition::from(tool_def).with_strict();
 

--- a/tests/providers/openai/cassette/responses_tool_args.rs
+++ b/tests/providers/openai/cassette/responses_tool_args.rs
@@ -315,6 +315,7 @@ async fn unicode_arguments_streaming() {
                         },
                         "required": ["message"]
                     }),
+                    output_schema: None,
                 })
                 .build();
 


### PR DESCRIPTION
## Summary

This PR lays a broad set of **foundational APIs** for the production-grade interactive coding-agent roadmap in #2118. It does **not** complete the entire epic: several additions are runtime-neutral contracts or reference implementations that still need concrete adapters, deeper integration, and follow-up hardening.

## Delivered

### Interactive run foundations
- adds a per-run `RunControlHandle` with stable identity, observable status, cancellation/deadlines, pause/resume signals, and separate steer, follow-up, and next-turn queues
- routes control through the shared streaming/non-streaming drive loop
- adds safe-boundary `AgentCheckpoint` capture/restore for manually driven `AgentRun` values
- injects `RunContext` and correlated `ToolCallContext` into tool execution
- adds normalized `FinishReason` to unary and streaming completion surfaces, including the OpenAI Responses and Vertex mappings requested by #2090

### Tool execution foundations
- adds scoped nested dispatch with inherited extensions, child IDs, allowlists, depth limits, recursion guards, hooks, and cancellation propagation
- adds run-scoped toolset factories and cleanup hooks
- adds call-scoped hook scratchpads, structured error reports with typed extensions, and a public hook test harness
- adds ordered catalog enumeration and dynamic add/remove/replace APIs to `ToolServerHandle`
- adds `ToolDefinition::output_schema` and a structured `ToolOutput` representation while retaining legacy string compatibility
- adds `AgentBuilder::provider_tool(s)` and merges hosted and function tools into one OpenAI-compatible wire `tools` array
- adds runtime-neutral operation policy/backend/progress/resource-queue contracts

### Sessions and reusable capabilities
- adds transactional `SqliteConversationMemory` with migration, ordered append/load, isolation, and clear support
- adds a backend-neutral `SessionEventStore` trait plus an in-memory reference implementation
- adds a provider-independent in-memory progressive-disclosure skill catalog
- adds cancellation-aware, depth/turn-bounded subagent primitives with typed handoffs
- adds runtime-neutral code-mode tool/runtime/dispatcher contracts and resource-limit configuration

## Breaking changes

- `ToolDefinition` gains `output_schema`
- `CompletionResponse` gains `finish_reason`
- OpenAI-compatible request tools use a heterogeneous JSON array so hosted and function tools serialize under one key

## Important remaining work

This PR intentionally does **not** claim to finish #2118 or the following linked areas:

- durable runner-integrated session recording, compaction, branching, interrupted-turn recovery, and restoration
- a concrete JavaScript/Python/Wasm code-mode runtime and a Rig-backed adapter from code mode to `ScopedToolExecutor`
- catalog transformation that hides wrapped tools when installing a code-mode tool
- concrete local, SSH, container, or sandbox operation backends; process-tree cancellation; artifact-backed output truncation; and policy examples
- server-side MCP request cancellation
- complete native/MCP/dynamic/provider-hosted catalog classification, provenance, metadata registration, and execution-policy enforcement
- provider-specific propagation of tool output schemas where supported
- bounded repair/retry for failures from valid tool executions
- full nested-call tracing/parent metadata and nested scratchpad cleanup
- complete subagent concurrency budgets, progress observation, and session correlation
- Agent Skills filesystem discovery/activation and enforcement of provenance/tool restrictions
- further pause/deadline/checkpoint hardening, including deadline wakeups while paused and runner-level durable checkpoint resumption

Those items should be handled in focused follow-up issues/PRs rather than treating this PR as completion of the epic.

## Validation

- `cargo fmt --check`
- `cargo check --workspace --all-features`
- `cargo test -p rig-core --lib`
- `cargo test -p rig-sqlite --lib`
- `cargo test -p rig --tests --no-run`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- GitHub Actions: fmt, WASM, clippy, tests, docs, and doctests all pass

Supersedes the implementation approaches in #1858 and #1886 without claiming to complete every follow-up requirement discussed in those threads.

Closes #2090
Closes #1890
Closes #1968

Progresses #2118
Progresses #2116
Progresses #2095
Progresses #2094
Progresses #1906
Progresses #1613
Progresses #1264
Progresses #1439
