### PR TITLE
feat(agent): production-grade interactive runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- *(completion/tool)* [**breaking**] `ToolDefinition` now requires `output_schema`, and `ToolCall`/`ToolResult` carry Rig-only correlation fields. Downstream struct literals must initialize these fields; prefer `ToolDefinition::new`, `ToolDefinition::with_output_schema`, `ToolCall::new`, and the `UserContent::tool_result*` constructors. Legacy serialized values remain compatible through serde defaults.
 - *(core)* [**breaking**] Mark `PromptError`, `StructuredOutputError`, `ToolError`, `ToolSetError`, and `VectorStoreError` as non-exhaustive, requiring downstream match expressions to include a wildcard arm. Conversation memory load failures now surface as the typed `PromptError::MemoryError` variant instead of `CompletionError::RequestError`.
 
 ## [0.40.0](https://github.com/0xPlaygrounds/rig/compare/v0.39.0...v0.40.0) - 2026-07-10

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3525,6 +3525,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "durable_coding_agent"
+version = "0.40.0"
+dependencies = [
+ "anyhow",
+ "rig",
+ "rig-sqlite",
+ "tokio",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9855,6 +9865,7 @@ version = "0.40.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "futures",
  "httpmock",
  "rig-core",
  "rusqlite",

--- a/crates/rig-bedrock/src/types/assistant_content.rs
+++ b/crates/rig-bedrock/src/types/assistant_content.rs
@@ -115,6 +115,8 @@ impl TryFrom<AwsConverseOutput> for completion::CompletionResponse<AwsConverseOu
             usage,
             raw_response: value,
             message_id: None,
+            finish_reason: None,
+            raw_finish_reason: None,
         })
     }
 }

--- a/crates/rig-bedrock/src/types/completion_request.rs
+++ b/crates/rig-bedrock/src/types/completion_request.rs
@@ -279,6 +279,7 @@ mod tests {
                     "type": "object",
                     "properties": {}
                 }),
+                output_schema: None,
             }],
             ..minimal_request()
         };
@@ -312,6 +313,7 @@ mod tests {
                     "type": "object",
                     "properties": {}
                 }),
+                output_schema: None,
             }],
             ..minimal_request()
         };
@@ -345,6 +347,7 @@ mod tests {
                     "type": "object",
                     "properties": {}
                 }),
+                output_schema: None,
             }],
             ..minimal_request()
         };
@@ -372,6 +375,7 @@ mod tests {
                     "type": "object",
                     "properties": {}
                 }),
+                output_schema: None,
             }],
             ..minimal_request()
         };
@@ -405,6 +409,7 @@ mod tests {
                     "type": "object",
                     "properties": {}
                 }),
+                output_schema: None,
             }],
             ..minimal_request()
         };
@@ -432,6 +437,7 @@ mod tests {
                     "type": "object",
                     "properties": {}
                 }),
+                output_schema: None,
             }],
             ..minimal_request()
         };
@@ -477,6 +483,7 @@ mod tests {
                     },
                     "required": ["location"]
                 }),
+                output_schema: None,
             }],
             ..minimal_request()
         };

--- a/crates/rig-bedrock/src/types/user_content.rs
+++ b/crates/rig-bedrock/src/types/user_content.rs
@@ -34,6 +34,8 @@ impl TryFrom<aws_bedrock::ContentBlock> for RigUserContent {
                 Ok(RigUserContent(UserContent::ToolResult(ToolResult {
                     id: tool_result.tool_use_id,
                     call_id: None,
+                    internal_call_id: None,
+                    parent_internal_call_id: None,
                     content: tool_results,
                 })))
             }

--- a/crates/rig-core/Cargo.toml
+++ b/crates/rig-core/Cargo.toml
@@ -62,6 +62,7 @@ reqwest-middleware = { workspace = true, optional = true, features = [
 # Native-only dependency for OpenAI Responses websocket mode.
 # Keeping it target-scoped avoids pulling a tokio socket transport into wasm builds.
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
+tokio = { workspace = true, features = ["process", "io-util", "fs"] }
 tokio-tungstenite = { workspace = true, optional = true }
 
 # futures-timer's default backend uses a background timer thread, which cannot

--- a/crates/rig-core/src/agent/builder.rs
+++ b/crates/rig-core/src/agent/builder.rs
@@ -4,12 +4,14 @@ use schemars::{JsonSchema, Schema, schema_for};
 
 use crate::{
     agent::hook::{AgentHook, HookStack},
-    completion::{CompletionModel, Document},
+    completion::{CompletionModel, Document, ProviderToolDefinition},
     memory::ConversationMemory,
     message::ToolChoice,
+    session::SessionStore,
+    skills::SkillCatalog,
     tool::{
         Tool, ToolDyn, ToolSet,
-        server::{ToolServer, ToolServerHandle},
+        server::{NestedToolPolicy, ToolCatalogKind, ToolServer, ToolServerHandle},
     },
     vector_store::VectorStoreIndexDyn,
 };
@@ -66,6 +68,7 @@ pub struct WithBuilderTools {
     static_tools: Vec<String>,
     tools: ToolSet,
     dynamic_tools: Vec<(usize, Arc<dyn VectorStoreIndexDyn + Send + Sync>)>,
+    tool_kinds: HashMap<String, ToolCatalogKind>,
 }
 
 /// A builder for creating an agent
@@ -131,6 +134,16 @@ where
     memory: Option<Arc<dyn ConversationMemory>>,
     /// Optional default conversation id used when none is set per-request.
     default_conversation_id: Option<String>,
+    /// Optional default wall-clock deadline applied independently to each run.
+    default_run_deadline: Option<std::time::Duration>,
+    /// Provider-hosted tools advertised but never dispatched by Rig.
+    provider_tools: Vec<ProviderToolDefinition>,
+    /// Restrictions inherited by scoped nested tool executors.
+    nested_tool_policy: NestedToolPolicy,
+    session_store: Option<Arc<dyn SessionStore>>,
+    session_id: Option<String>,
+    session_branch: String,
+    skill_catalog: Option<Arc<dyn SkillCatalog>>,
 }
 
 impl<M, ToolState> AgentBuilder<M, ToolState>
@@ -199,6 +212,59 @@ where
     /// every retry or continuation. Zero permits no model calls.
     pub fn default_max_turns(mut self, default_max_turns: usize) -> Self {
         self.default_max_turns = Some(default_max_turns);
+        self
+    }
+
+    /// Set a default wall-clock deadline for every run created by this agent.
+    pub fn run_deadline(mut self, deadline: std::time::Duration) -> Self {
+        self.default_run_deadline = Some(deadline);
+        self
+    }
+
+    /// Add a provider-hosted tool. Hosted tools are advertised to the provider
+    /// but are never added to Rig's executable tool server.
+    pub fn provider_tool(mut self, tool: ProviderToolDefinition) -> Self {
+        self.provider_tools.push(tool);
+        self
+    }
+
+    /// Add provider-hosted tools in registration order.
+    pub fn provider_tools(
+        mut self,
+        tools: impl IntoIterator<Item = ProviderToolDefinition>,
+    ) -> Self {
+        self.provider_tools.extend(tools);
+        self
+    }
+
+    /// Configure allowlist, depth, and recursion restrictions for nested tools.
+    pub fn nested_tool_policy(mut self, policy: NestedToolPolicy) -> Self {
+        self.nested_tool_policy = policy;
+        self
+    }
+
+    /// Attach a durable event session independently of conversation memory.
+    pub fn session<S>(mut self, store: S, id: impl Into<String>) -> Self
+    where
+        S: SessionStore + 'static,
+    {
+        self.session_store = Some(Arc::new(store));
+        self.session_id = Some(id.into());
+        self
+    }
+
+    /// Set the default session branch (`main` by default).
+    pub fn session_branch(mut self, branch: impl Into<String>) -> Self {
+        self.session_branch = branch.into();
+        self
+    }
+
+    /// Attach a provider-independent progressive-disclosure skill catalog.
+    pub fn skills<S>(mut self, catalog: S) -> Self
+    where
+        S: SkillCatalog + 'static,
+    {
+        self.skill_catalog = Some(Arc::new(catalog));
         self
     }
 
@@ -309,6 +375,13 @@ where
             output_mode: OutputMode::default(),
             memory: None,
             default_conversation_id: None,
+            default_run_deadline: None,
+            provider_tools: Vec::new(),
+            nested_tool_policy: NestedToolPolicy::default(),
+            session_store: None,
+            session_id: None,
+            session_branch: "main".into(),
+            skill_catalog: None,
         }
     }
 }
@@ -344,6 +417,13 @@ where
             output_mode: self.output_mode,
             memory: self.memory,
             default_conversation_id: self.default_conversation_id,
+            default_run_deadline: self.default_run_deadline,
+            provider_tools: self.provider_tools,
+            nested_tool_policy: self.nested_tool_policy,
+            session_store: self.session_store,
+            session_id: self.session_id,
+            session_branch: self.session_branch,
+            skill_catalog: self.skill_catalog,
         }
     }
 
@@ -366,6 +446,7 @@ where
             tool_choice: self.tool_choice,
             default_max_turns: self.default_max_turns,
             tool_state: WithBuilderTools {
+                tool_kinds: HashMap::new(),
                 static_tools: vec![toolname],
                 tools: ToolSet::from_tools(vec![tool]),
                 dynamic_tools: vec![],
@@ -375,6 +456,13 @@ where
             output_mode: self.output_mode,
             memory: self.memory,
             default_conversation_id: self.default_conversation_id,
+            default_run_deadline: self.default_run_deadline,
+            provider_tools: self.provider_tools,
+            nested_tool_policy: self.nested_tool_policy,
+            session_store: self.session_store,
+            session_id: self.session_id,
+            session_branch: self.session_branch,
+            skill_catalog: self.skill_catalog,
         }
     }
 
@@ -403,7 +491,15 @@ where
             output_mode: self.output_mode,
             memory: self.memory,
             default_conversation_id: self.default_conversation_id,
+            default_run_deadline: self.default_run_deadline,
+            provider_tools: self.provider_tools,
+            nested_tool_policy: self.nested_tool_policy,
+            session_store: self.session_store,
+            session_id: self.session_id,
+            session_branch: self.session_branch,
+            skill_catalog: self.skill_catalog,
             tool_state: WithBuilderTools {
+                tool_kinds: HashMap::new(),
                 static_tools,
                 tools,
                 dynamic_tools: vec![],
@@ -504,7 +600,15 @@ where
             output_mode: self.output_mode,
             memory: self.memory,
             default_conversation_id: self.default_conversation_id,
+            default_run_deadline: self.default_run_deadline,
+            provider_tools: self.provider_tools,
+            nested_tool_policy: self.nested_tool_policy,
+            session_store: self.session_store,
+            session_id: self.session_id,
+            session_branch: self.session_branch,
+            skill_catalog: self.skill_catalog,
             tool_state: WithBuilderTools {
+                tool_kinds: HashMap::new(),
                 static_tools,
                 tools: ToolSet::from_tools(toolset),
                 dynamic_tools: vec![],
@@ -539,7 +643,15 @@ where
             output_mode: self.output_mode,
             memory: self.memory,
             default_conversation_id: self.default_conversation_id,
+            default_run_deadline: self.default_run_deadline,
+            provider_tools: self.provider_tools,
+            nested_tool_policy: self.nested_tool_policy,
+            session_store: self.session_store,
+            session_id: self.session_id,
+            session_branch: self.session_branch,
+            skill_catalog: self.skill_catalog,
             tool_state: WithBuilderTools {
+                tool_kinds: HashMap::new(),
                 static_tools: vec![],
                 tools: toolset,
                 dynamic_tools: vec![(sample, Arc::new(dynamic_tools))],
@@ -551,7 +663,9 @@ where
     ///
     /// An empty `ToolServer` will be created for the agent.
     pub fn build(self) -> Agent<M> {
-        let tool_server_handle = ToolServer::new().run();
+        let tool_server_handle = ToolServer::new()
+            .provider_tools(self.provider_tools.clone())
+            .run();
 
         Agent {
             name: self.name,
@@ -571,6 +685,13 @@ where
             output_mode: self.output_mode,
             memory: self.memory,
             default_conversation_id: self.default_conversation_id,
+            default_run_deadline: self.default_run_deadline,
+            provider_tools: self.provider_tools,
+            nested_tool_policy: self.nested_tool_policy,
+            session_store: self.session_store,
+            session_id: self.session_id,
+            session_branch: self.session_branch,
+            skill_catalog: self.skill_catalog,
         }
     }
 }
@@ -599,6 +720,13 @@ where
             output_mode: self.output_mode,
             memory: self.memory,
             default_conversation_id: self.default_conversation_id,
+            default_run_deadline: self.default_run_deadline,
+            provider_tools: self.provider_tools,
+            nested_tool_policy: self.nested_tool_policy,
+            session_store: self.session_store,
+            session_id: self.session_id,
+            session_branch: self.session_branch,
+            skill_catalog: self.skill_catalog,
         }
     }
 }
@@ -611,7 +739,10 @@ where
     pub fn tool(mut self, tool: impl Tool + 'static) -> Self {
         let toolname = tool.name();
         self.tool_state.tools.add_tool(tool);
-        self.tool_state.static_tools.push(toolname);
+        self.tool_state.static_tools.push(toolname.clone());
+        self.tool_state
+            .tool_kinds
+            .insert(toolname, ToolCatalogKind::Native);
         self
     }
 
@@ -620,6 +751,11 @@ where
         let toolnames: Vec<String> = tools.iter().map(|tool| tool.name()).collect();
         let tools = ToolSet::from_tools_boxed(tools);
         self.tool_state.tools.add_tools(tools);
+        for name in &toolnames {
+            self.tool_state
+                .tool_kinds
+                .insert(name.clone(), ToolCatalogKind::Native);
+        }
         self.tool_state.static_tools.extend(toolnames);
         self
     }
@@ -658,7 +794,10 @@ where
     #[cfg(feature = "rmcp")]
     fn add_rmcp_tools(mut self, built: Vec<(String, RmcpTool)>) -> Self {
         for (name, tool) in built {
-            self.tool_state.static_tools.push(name);
+            self.tool_state.static_tools.push(name.clone());
+            self.tool_state
+                .tool_kinds
+                .insert(name, ToolCatalogKind::Mcp);
             self.tool_state.tools.add_tool(tool);
         }
 
@@ -676,6 +815,11 @@ where
         self.tool_state
             .dynamic_tools
             .push((sample, Arc::new(dynamic_tools)));
+        for name in toolset.ordered_names() {
+            self.tool_state
+                .tool_kinds
+                .insert(name.clone(), ToolCatalogKind::Dynamic);
+        }
         self.tool_state.tools.add_tools(toolset);
         self
     }
@@ -689,6 +833,8 @@ where
             .static_tool_names(self.tool_state.static_tools)
             .add_tools(self.tool_state.tools)
             .add_dynamic_tools(self.tool_state.dynamic_tools)
+            .catalog_kinds(self.tool_state.tool_kinds)
+            .provider_tools(self.provider_tools.clone())
             .run();
 
         Agent {
@@ -709,6 +855,13 @@ where
             output_mode: self.output_mode,
             memory: self.memory,
             default_conversation_id: self.default_conversation_id,
+            default_run_deadline: self.default_run_deadline,
+            provider_tools: self.provider_tools,
+            nested_tool_policy: self.nested_tool_policy,
+            session_store: self.session_store,
+            session_id: self.session_id,
+            session_branch: self.session_branch,
+            skill_catalog: self.skill_catalog,
         }
     }
 }

--- a/crates/rig-core/src/agent/completion.rs
+++ b/crates/rig-core/src/agent/completion.rs
@@ -234,6 +234,7 @@ pub(crate) async fn build_completion_request<M: CompletionModel>(
     temperature: Option<f64>,
     max_tokens: Option<u64>,
     additional_params: Option<&serde_json::Value>,
+    provider_tools: &[crate::completion::ProviderToolDefinition],
     tool_choice: Option<&ToolChoice>,
     tool_server_handle: &ToolServerHandle,
     dynamic_context: &DynamicContextStore,
@@ -248,6 +249,7 @@ pub(crate) async fn build_completion_request<M: CompletionModel>(
         temperature,
         max_tokens,
         additional_params,
+        provider_tools,
         tool_choice,
         tool_server_handle,
         dynamic_context,
@@ -275,6 +277,7 @@ pub(crate) async fn build_prepared_completion_request<M: CompletionModel>(
     temperature: Option<f64>,
     max_tokens: Option<u64>,
     additional_params: Option<&serde_json::Value>,
+    provider_tools: &[crate::completion::ProviderToolDefinition],
     tool_choice: Option<&ToolChoice>,
     tool_server_handle: &ToolServerHandle,
     dynamic_context: &DynamicContextStore,
@@ -549,6 +552,7 @@ pub(crate) async fn build_prepared_completion_request<M: CompletionModel>(
                           schema."
                 .to_string(),
             parameters: schema.clone().to_value(),
+            output_schema: Some(schema.clone().to_value()),
         });
     }
 
@@ -559,7 +563,8 @@ pub(crate) async fn build_prepared_completion_request<M: CompletionModel>(
         .max_tokens_opt(max_tokens)
         .additional_params_opt(additional_params)
         .documents(static_context.to_vec())
-        .tools(tooldefs);
+        .tools(tooldefs)
+        .provider_tools(provider_tools.to_vec());
 
     if !fetched_context.is_empty() {
         completion_request = completion_request.documents(fetched_context);
@@ -681,6 +686,20 @@ where
     pub memory: Option<Arc<dyn crate::memory::ConversationMemory>>,
     /// Optional default conversation id used when none is set per-request.
     pub default_conversation_id: Option<String>,
+    /// Optional wall-clock deadline applied independently to each run.
+    pub default_run_deadline: Option<std::time::Duration>,
+    /// Provider-hosted tools sent to the model but not executable by Rig.
+    pub provider_tools: Vec<crate::completion::ProviderToolDefinition>,
+    /// Restrictions inherited by scoped nested tool executors.
+    pub nested_tool_policy: crate::tool::server::NestedToolPolicy,
+    /// Optional durable event session store, separate from conversation memory.
+    pub session_store: Option<Arc<dyn crate::session::SessionStore>>,
+    /// Default durable session identifier.
+    pub session_id: Option<String>,
+    /// Default durable session branch.
+    pub session_branch: String,
+    /// Optional progressive-disclosure skill catalog.
+    pub skill_catalog: Option<Arc<dyn crate::skills::SkillCatalog>>,
 }
 
 impl<M> Agent<M>
@@ -697,6 +716,39 @@ where
     /// [`AgentRunner::add_hook`], then call [`AgentRunner::run`].
     pub fn runner(&self, prompt: impl Into<Message>) -> AgentRunner<M> {
         AgentRunner::from_agent(self, prompt)
+    }
+
+    /// List skill names/descriptions without disclosing instructions.
+    pub fn skills(&self) -> Vec<(String, String)> {
+        self.skill_catalog
+            .as_ref()
+            .map_or_else(Vec::new, |catalog| catalog.list())
+    }
+
+    /// Activate one skill and disclose its instructions and restrictions.
+    pub fn activate_skill(&self, name: &str) -> Option<crate::skills::Skill> {
+        self.skill_catalog.as_ref()?.activate(name)
+    }
+
+    /// Return the complete catalog immediately, including hosted tools that
+    /// have not yet been installed into a shared server by a run.
+    pub async fn tool_catalog(&self) -> Vec<crate::tool::server::ToolCatalogEntry> {
+        let mut entries = self.tool_server_handle.catalog().await;
+        for hosted in &self.provider_tools {
+            if !entries.iter().any(|entry| {
+                entry.kind == crate::tool::server::ToolCatalogKind::ProviderHosted
+                    && entry.name == hosted.kind
+            }) {
+                entries.push(crate::tool::server::ToolCatalogEntry {
+                    name: hosted.kind.clone(),
+                    kind: crate::tool::server::ToolCatalogKind::ProviderHosted,
+                    definition: None,
+                    provider_definition: Some(hosted.clone()),
+                    metadata: crate::tool::server::ToolCatalogMetadata::default(),
+                });
+            }
+        }
+        entries
     }
 }
 
@@ -723,6 +775,7 @@ where
             self.temperature,
             self.max_tokens,
             self.additional_params.as_ref(),
+            &self.provider_tools,
             self.tool_choice.as_ref(),
             &self.tool_server_handle,
             &self.dynamic_context,

--- a/crates/rig-core/src/agent/hook.rs
+++ b/crates/rig-core/src/agent/hook.rs
@@ -306,28 +306,39 @@ impl std::fmt::Debug for Scratchpad {
 /// hooks for different tools in a turn can run concurrently against this shared
 /// context — see the [`Scratchpad` concurrency note](Scratchpad#concurrency) for
 /// how to store run-scoped state safely under that concurrency.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct HookContext {
     run_id: RunId,
-    // Interior-mutable so the driver can advance it each turn while hooks hold a
-    // shared `&HookContext`; also the reason the context is `Sync`.
-    turn: AtomicUsize,
+    // Shared so scoped nested executors retain the same turn and scratch state.
+    turn: Arc<AtomicUsize>,
     is_streaming: bool,
     agent_name: Option<String>,
     scratchpad: Scratchpad,
+    call_scratchpads: Arc<std::sync::Mutex<std::collections::HashMap<String, Scratchpad>>>,
 }
 
 impl HookContext {
     /// Build a fresh run-scoped context. `is_streaming` records which surface is
     /// driving ([`run`](crate::agent::AgentRunner::run) vs.
     /// [`stream`](crate::agent::AgentRunner::stream)).
+    #[cfg(test)]
     pub(crate) fn new(is_streaming: bool, agent_name: Option<String>) -> Self {
+        Self::with_run_id(RunId::generate(), is_streaming, agent_name)
+    }
+
+    /// Build a hook context correlated with an externally controlled run.
+    pub(crate) fn with_run_id(
+        run_id: RunId,
+        is_streaming: bool,
+        agent_name: Option<String>,
+    ) -> Self {
         Self {
-            run_id: RunId::generate(),
-            turn: AtomicUsize::new(0),
+            run_id,
+            turn: Arc::new(AtomicUsize::new(0)),
             is_streaming,
             agent_name,
             scratchpad: Scratchpad::default(),
+            call_scratchpads: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         }
     }
 
@@ -360,6 +371,25 @@ impl HookContext {
     /// The run-scoped shared scratchpad.
     pub fn scratchpad(&self) -> &Scratchpad {
         &self.scratchpad
+    }
+
+    /// Returns a scratchpad isolated to one immutable internal call ID.
+    /// Clones for the same ID share state; different IDs never alias.
+    pub fn call_scratchpad(&self, internal_call_id: impl Into<String>) -> Scratchpad {
+        self.call_scratchpads
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .entry(internal_call_id.into())
+            .or_default()
+            .clone()
+    }
+
+    /// Removes call-scoped state after a call has settled.
+    pub fn remove_call_scratchpad(&self, internal_call_id: &str) -> Option<Scratchpad> {
+        self.call_scratchpads
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .remove(internal_call_id)
     }
 }
 
@@ -520,6 +550,8 @@ pub enum StepEvent<'a, M: CompletionModel> {
         tool_call_id: Option<&'a str>,
         /// Internal Rig call ID correlating this call's events.
         internal_call_id: &'a str,
+        /// Internal call ID of the invoking parent tool, for nested calls.
+        parent_internal_call_id: Option<&'a str>,
         /// JSON arguments for the call.
         args: &'a str,
     },
@@ -551,6 +583,8 @@ pub enum StepEvent<'a, M: CompletionModel> {
         tool_call_id: Option<&'a str>,
         /// Internal Rig call ID correlating this call's events.
         internal_call_id: &'a str,
+        /// Internal call ID of the invoking parent tool, for nested calls.
+        parent_internal_call_id: Option<&'a str>,
         /// JSON arguments for the call.
         args: &'a str,
         /// The model-visible tool result. Reflects any earlier hook's
@@ -1116,6 +1150,14 @@ impl Flow {
         }
     }
 
+    /// Ask the model to regenerate a tool call and its arguments.
+    ///
+    /// This is an explicit name for [`retry`](Self::retry); it consumes both the
+    /// invalid-call repair budget and the shared model-turn budget.
+    pub fn regenerate_args(feedback: impl Into<String>) -> Self {
+        Self::retry(feedback)
+    }
+
     /// Repair the emitted tool name (invalid tool calls only).
     pub fn repair(tool_name: impl Into<String>) -> Self {
         Self::Repair {
@@ -1192,6 +1234,7 @@ where
         tool_name: &str,
         tool_call_id: Option<&str>,
         internal_call_id: &str,
+        parent_internal_call_id: Option<&str>,
         args: &str,
     ) -> impl Future<Output = (Flow, Option<serde_json::Value>)> + WasmCompatSend {
         async move {
@@ -1202,6 +1245,7 @@ where
                         tool_name,
                         tool_call_id,
                         internal_call_id,
+                        parent_internal_call_id,
                         args,
                     },
                 )
@@ -1269,6 +1313,7 @@ where
         tool_name: &'a str,
         tool_call_id: Option<&'a str>,
         internal_call_id: &'a str,
+        parent_internal_call_id: Option<&'a str>,
         args: &'a str,
     ) -> WasmBoxedFuture<'a, (Flow, Option<serde_json::Value>)>
     where
@@ -1299,12 +1344,20 @@ where
         tool_name: &'a str,
         tool_call_id: Option<&'a str>,
         internal_call_id: &'a str,
+        parent_internal_call_id: Option<&'a str>,
         args: &'a str,
     ) -> WasmBoxedFuture<'a, (Flow, Option<serde_json::Value>)>
     where
         M: 'a,
     {
-        Box::pin(self.resolve_tool_call(ctx, tool_name, tool_call_id, internal_call_id, args))
+        Box::pin(self.resolve_tool_call(
+            ctx,
+            tool_name,
+            tool_call_id,
+            internal_call_id,
+            parent_internal_call_id,
+            args,
+        ))
     }
 
     fn observes_dyn(&self, kind: StepEventKind) -> bool {
@@ -1435,6 +1488,7 @@ where
         tool_name: &str,
         tool_call_id: Option<&str>,
         internal_call_id: &str,
+        parent_internal_call_id: Option<&str>,
         args: &str,
     ) -> (Flow, Option<serde_json::Value>) {
         let mut effective: Option<serde_json::Value> = None;
@@ -1447,6 +1501,7 @@ where
                     tool_name,
                     tool_call_id,
                     internal_call_id,
+                    parent_internal_call_id,
                     args_for_hook,
                 )
                 .await;
@@ -1508,11 +1563,19 @@ where
                 tool_name,
                 tool_call_id,
                 internal_call_id,
+                parent_internal_call_id,
                 args,
             } => {
-                self.resolve_tool_call(ctx, tool_name, tool_call_id, internal_call_id, args)
-                    .await
-                    .0
+                self.resolve_tool_call(
+                    ctx,
+                    tool_name,
+                    tool_call_id,
+                    internal_call_id,
+                    parent_internal_call_id,
+                    args,
+                )
+                .await
+                .0
             }
             // Chain tool-result rewrites: thread the effective (model-visible)
             // result through each hook (the first hook sees the tool's real
@@ -1523,6 +1586,7 @@ where
                 tool_name,
                 tool_call_id,
                 internal_call_id,
+                parent_internal_call_id,
                 args,
                 result,
                 outcome,
@@ -1535,6 +1599,7 @@ where
                         tool_name,
                         tool_call_id,
                         internal_call_id,
+                        parent_internal_call_id,
                         args,
                         result: result_for_hook,
                         outcome,
@@ -1642,6 +1707,7 @@ mod tests {
             tool_name: "add",
             tool_call_id: Some("tc1"),
             internal_call_id: "ic1",
+            parent_internal_call_id: None,
             args: "{}",
         }
     }
@@ -2069,7 +2135,7 @@ mod tests {
 
         async fn resolve(stack: &HookStack<M>) -> (Flow, Option<Value>) {
             stack
-                .resolve_tool_call(&ctx(), "add", Some("tc1"), "ic1", "{}")
+                .resolve_tool_call(&ctx(), "add", Some("tc1"), "ic1", None, "{}")
                 .await
         }
 

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -32,6 +32,12 @@ macro_rules! forward_prompt_setters {
             self
         }
 
+        /// Set a wall-clock deadline relative to now for this run.
+        pub fn deadline(mut self, duration: std::time::Duration) -> Self {
+            self.$recv = self.$recv.deadline(duration);
+            self
+        }
+
         /// Add chat history to the prompt request.
         pub fn history<H, Item>(mut self, history: H) -> Self
         where
@@ -56,6 +62,13 @@ macro_rules! forward_prompt_setters {
         /// History will neither be loaded from nor saved to the agent's memory backend.
         pub fn without_memory(mut self) -> Self {
             self.$recv = self.$recv.without_memory();
+            self
+        }
+
+        /// Set the bounded budget for model-regenerated tool arguments.
+        /// Repairs also consume the shared model-turn budget.
+        pub fn max_tool_repairs(mut self, repairs: usize) -> Self {
+            self.$recv = self.$recv.max_tool_repairs(repairs);
             self
         }
 
@@ -133,6 +146,11 @@ where
     S: PromptType,
     M: CompletionModel,
 {
+    /// Returns the run-scoped control handle before this request is consumed.
+    pub fn control_handle(&self) -> crate::runtime::RunControlHandle {
+        self.runner.control_handle()
+    }
+
     /// Enable returning extended details for responses (includes aggregated token usage
     /// and the full message history accumulated during the agent loop).
     ///
@@ -202,7 +220,7 @@ where
 
 impl<M> PromptRequest<Standard, M>
 where
-    M: CompletionModel,
+    M: CompletionModel + 'static,
 {
     async fn send(self) -> Result<String, PromptError> {
         self.extended_details().send().await.map(|resp| resp.output)
@@ -210,7 +228,7 @@ where
 }
 
 /// Details for one successfully completed completion request made by an agent run.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct CompletionCall {
     /// Zero-based index of the completion request within this agent run.
@@ -222,12 +240,34 @@ pub struct CompletionCall {
     /// from "unreported".
     #[serde(default, deserialize_with = "usage_null_as_default")]
     pub usage: Usage,
+    /// Provider-neutral reason this request stopped.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub finish_reason: Option<crate::runtime::TerminalReason>,
+    /// Unmodified provider finish/status value.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub raw_finish_reason: Option<String>,
 }
 
 impl CompletionCall {
     /// Create details for one completion request in an agent run.
     pub fn new(call_index: usize, usage: Usage) -> Self {
-        Self { call_index, usage }
+        Self {
+            call_index,
+            usage,
+            finish_reason: None,
+            raw_finish_reason: None,
+        }
+    }
+
+    /// Attach normalized and raw provider finish metadata.
+    pub fn with_finish_reason(
+        mut self,
+        finish_reason: Option<crate::runtime::TerminalReason>,
+        raw_finish_reason: Option<String>,
+    ) -> Self {
+        self.finish_reason = finish_reason;
+        self.raw_finish_reason = raw_finish_reason;
+        self
     }
 }
 
@@ -282,6 +322,8 @@ pub struct PromptResponse {
     /// Where [`output`](Self::output) is the concatenated text, this preserves
     /// the individual content parts (text, reasoning, images, …).
     pub content: OneOrMany<AssistantContent>,
+    /// Normalized reason the agent run settled.
+    pub terminal_reason: crate::runtime::TerminalReason,
 }
 
 /// Serde shadow for [`PromptResponse`]. `content` is an `Option` here so runs
@@ -300,6 +342,8 @@ struct PromptResponseRepr {
     messages: Option<Vec<Message>>,
     #[serde(default)]
     content: Option<OneOrMany<AssistantContent>>,
+    #[serde(default)]
+    terminal_reason: crate::runtime::TerminalReason,
 }
 
 impl From<PromptResponseRepr> for PromptResponse {
@@ -313,6 +357,7 @@ impl From<PromptResponseRepr> for PromptResponse {
             completion_calls: repr.completion_calls,
             messages: repr.messages,
             content,
+            terminal_reason: repr.terminal_reason,
         }
     }
 }
@@ -325,6 +370,7 @@ impl From<PromptResponse> for PromptResponseRepr {
             completion_calls: response.completion_calls,
             messages: response.messages,
             content: Some(response.content),
+            terminal_reason: response.terminal_reason,
         }
     }
 }
@@ -344,6 +390,7 @@ impl PromptResponse {
             usage,
             completion_calls: Vec::new(),
             messages: None,
+            terminal_reason: crate::runtime::TerminalReason::Completed,
         }
     }
 
@@ -377,6 +424,11 @@ impl PromptResponse {
     /// Aggregated token usage across the whole run.
     pub fn usage(&self) -> Usage {
         self.usage
+    }
+
+    /// Returns the normalized terminal reason.
+    pub fn terminal_reason(&self) -> &crate::runtime::TerminalReason {
+        &self.terminal_reason
     }
 
     /// The run's accumulated message history, if tracked.
@@ -492,6 +544,15 @@ pub(crate) fn tool_result_output(
     tool_result_with(id, call_id, ToolResultContent::from_tool_output(output))
 }
 
+/// Shape explicit rich tool content without parsing a string envelope.
+pub(crate) fn tool_result_content(
+    id: String,
+    call_id: Option<String>,
+    content: OneOrMany<ToolResultContent>,
+) -> UserContent {
+    tool_result_with(id, call_id, content)
+}
+
 /// Shape a **synthetic message** (a hook skip reason, recovery feedback, or a
 /// "not executed" notice) as a tool result. Emitted **verbatim as text** and
 /// never re-parsed as structured tool output, so a JSON-shaped message is not
@@ -558,7 +619,7 @@ pub(crate) fn assistant_text_from_choice(choice: &OneOrMany<AssistantContent>) -
 
 impl<M> PromptRequest<Extended, M>
 where
-    M: CompletionModel,
+    M: CompletionModel + 'static,
 {
     async fn send(self) -> Result<PromptResponse, PromptError> {
         self.runner.run().await
@@ -691,7 +752,7 @@ fn deserialize_structured_output<T: DeserializeOwned>(text: &str) -> Result<T, s
 impl<T, M> TypedPromptRequest<T, Standard, M>
 where
     T: JsonSchema + DeserializeOwned + WasmCompatSend,
-    M: CompletionModel,
+    M: CompletionModel + 'static,
 {
     /// Send the typed prompt request and deserialize the response.
     async fn send(self) -> Result<T, StructuredOutputError> {
@@ -709,7 +770,7 @@ where
 impl<T, M> TypedPromptRequest<T, Extended, M>
 where
     T: JsonSchema + DeserializeOwned + WasmCompatSend,
-    M: CompletionModel,
+    M: CompletionModel + 'static,
 {
     /// Send the typed prompt request with extended details and deserialize the response.
     async fn send(self) -> Result<TypedPromptResponse<T>, StructuredOutputError> {
@@ -2532,17 +2593,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn memory_append_error_does_not_drop_response() {
+    async fn memory_append_error_surfaces_as_prompt_error() {
         let model = MockCompletionModel::text("ack");
         let agent = AgentBuilder::new(model)
             .memory(AppendFailingMemory::default())
             .build();
-        let response: String = agent
+        let error = agent
             .prompt("hello")
             .conversation("t1")
             .await
-            .expect("append failure must not block successful completion");
+            .expect_err("append failure must fail successful settlement");
 
-        assert!(!response.is_empty());
+        assert!(matches!(error, PromptError::MemoryError(_)));
+        assert!(error.to_string().contains("append boom"));
     }
 }

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -16,11 +16,12 @@ use crate::{
     },
     completion::GetTokenUsage,
     message::{AssistantContent, UserContent},
+    runtime::TerminalReason,
     streaming::{StreamedAssistantContent, StreamedUserContent, ToolCallDeltaContent},
-    tool::ToolCallExtensions,
+    tool::{ToolCallExtensions, server::ToolScheduling},
     wasm_compat::{WasmBoxedFuture, WasmCompatSend},
 };
-use futures::{Stream, StreamExt, stream};
+use futures::{Stream, StreamExt, future::Either, stream};
 use serde::{Deserialize, Serialize};
 use std::{collections::VecDeque, pin::Pin, sync::Arc};
 use tracing_futures::Instrument;
@@ -33,11 +34,11 @@ use crate::{
     tool::ToolSetError,
 };
 
-#[cfg(not(all(feature = "wasm", target_arch = "wasm32")))]
+#[cfg(not(target_arch = "wasm32"))]
 pub type StreamingResult<R> =
     Pin<Box<dyn Stream<Item = Result<MultiTurnStreamItem<R>, StreamingError>> + Send>>;
 
-#[cfg(all(feature = "wasm", target_arch = "wasm32"))]
+#[cfg(target_arch = "wasm32")]
 pub type StreamingResult<R> =
     Pin<Box<dyn Stream<Item = Result<MultiTurnStreamItem<R>, StreamingError>>>>;
 
@@ -176,21 +177,32 @@ impl<R> MultiTurnStreamItem<R> {
 /// reported usage for the recovered completion call is not lost.
 async fn drain_stream_usage<R>(
     stream: &mut crate::streaming::StreamingCompletionResponse<R>,
-) -> Result<crate::completion::Usage, StreamingError>
+) -> Result<
+    (
+        crate::completion::Usage,
+        Option<crate::runtime::TerminalReason>,
+        Option<String>,
+    ),
+    StreamingError,
+>
 where
     R: Clone + Unpin + GetTokenUsage,
 {
     while let Some(content) = stream.next().await {
         match content {
             Ok(StreamedAssistantContent::Final(final_resp)) => {
-                return Ok(final_resp.token_usage());
+                return Ok((
+                    final_resp.token_usage(),
+                    final_resp.finish_reason(),
+                    final_resp.raw_finish_reason(),
+                ));
             }
             Ok(_) => {}
             Err(err) => return Err(err.into()),
         }
     }
 
-    Ok(crate::completion::Usage::new())
+    Ok((crate::completion::Usage::new(), None, None))
 }
 
 pub(crate) fn record_usage_on_span(span: &tracing::Span, usage: crate::completion::Usage) {
@@ -303,6 +315,11 @@ where
         }
     }
 
+    /// Returns the run-scoped control handle before this stream is consumed.
+    pub fn control_handle(&self) -> crate::runtime::RunControlHandle {
+        self.runner.control_handle()
+    }
+
     /// Set the total model-call budget, including the initial call and every
     /// retry or continuation. Zero emits no model calls; one permits only the
     /// initial call.
@@ -352,11 +369,11 @@ where
 /// A boxed, medium-specific item stream for one engine step (model turn or tool
 /// batch). Boxed so a generic [`drive_agent`] can forward it without the
 /// per-step future leaking into the engine's own (`Send`) inference.
-#[cfg(not(all(feature = "wasm", target_arch = "wasm32")))]
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) type DriveStream<'a, R> =
     Pin<Box<dyn Stream<Item = Result<MultiTurnStreamItem<R>, StreamingError>> + Send + 'a>>;
 
-#[cfg(all(feature = "wasm", target_arch = "wasm32"))]
+#[cfg(target_arch = "wasm32")]
 pub(crate) type DriveStream<'a, R> =
     Pin<Box<dyn Stream<Item = Result<MultiTurnStreamItem<R>, StreamingError>> + 'a>>;
 
@@ -461,8 +478,164 @@ pub(crate) fn streaming_error_into_prompt(err: StreamingError) -> PromptError {
 /// medium-specific model call, tool execution, span shaping and finalization to
 /// a [`TurnSource`]. The streaming surface forwards the yielded [`DriveItem`]s;
 /// the blocking surface folds them to `Done`.
+async fn append_session_event<M>(
+    runner: &AgentRunner<M>,
+    kind: crate::session::SessionEventKind,
+) -> Result<(), crate::session::SessionError>
+where
+    M: CompletionModel,
+{
+    let (Some(store), Some(session_id)) = (&runner.session_store, &runner.session_id) else {
+        return Ok(());
+    };
+    let parent = store
+        .load(session_id, &runner.session_branch)
+        .await?
+        .last()
+        .map(|event| event.sequence);
+    store
+        .append(
+            session_id,
+            &runner.session_branch,
+            parent,
+            Some(runner.session_correlation_id.clone()),
+            kind,
+        )
+        .await?;
+    Ok(())
+}
+
+async fn persist_new_messages<M>(
+    runner: &mut AgentRunner<M>,
+    run: &AgentRun,
+) -> Result<(), crate::session::SessionError>
+where
+    M: CompletionModel,
+{
+    for message in run.messages().iter().skip(runner.session_loaded_messages) {
+        append_session_event(
+            runner,
+            crate::session::SessionEventKind::Message(message.clone()),
+        )
+        .await?;
+    }
+    runner.session_loaded_messages = run.messages().len();
+    Ok(())
+}
+
+async fn persist_new_model_events<M>(
+    runner: &mut AgentRunner<M>,
+    run: &AgentRun,
+) -> Result<(), crate::session::SessionError>
+where
+    M: CompletionModel,
+{
+    for call in run
+        .completion_calls()
+        .iter()
+        .skip(runner.session_loaded_completion_calls)
+    {
+        append_session_event(
+            runner,
+            crate::session::SessionEventKind::ModelResponse {
+                usage: call.usage,
+                finish_reason: call.finish_reason.clone(),
+                raw_finish_reason: call.raw_finish_reason.clone(),
+            },
+        )
+        .await?;
+    }
+    runner.session_loaded_completion_calls = run.completion_calls().len();
+    persist_new_messages(runner, run).await
+}
+
+async fn persist_completed_session<M>(
+    runner: &AgentRunner<M>,
+    response: &crate::agent::prompt_request::PromptResponse,
+) -> Result<(), crate::session::SessionError>
+where
+    M: CompletionModel,
+{
+    append_session_event(
+        runner,
+        crate::session::SessionEventKind::Lifecycle {
+            status: "completed".into(),
+            detail: Some(serde_json::json!({"terminal_reason": response.terminal_reason})),
+        },
+    )
+    .await
+}
+
+async fn persist_interrupted_session<M>(
+    runner: &AgentRunner<M>,
+    run: &AgentRun,
+) -> Result<(), crate::session::SessionError>
+where
+    M: CompletionModel,
+{
+    let (Some(store), Some(session_id)) = (&runner.session_store, &runner.session_id) else {
+        return Ok(());
+    };
+    let checkpoint =
+        if run.is_safe_checkpoint() {
+            Some(serde_json::to_string(run).map_err(|error| {
+                crate::session::SessionError::InvalidCheckpoint(error.to_string())
+            })?)
+        } else {
+            None
+        };
+    let parent = store
+        .load(session_id, &runner.session_branch)
+        .await?
+        .last()
+        .map(|event| event.sequence);
+    store
+        .append(
+            session_id,
+            &runner.session_branch,
+            parent,
+            Some(runner.session_correlation_id.clone()),
+            crate::session::SessionEventKind::Interrupted {
+                run_id: runner.session_correlation_id.clone(),
+                checkpoint,
+            },
+        )
+        .await?;
+    Ok(())
+}
+
+#[derive(Default)]
+struct InterruptionPersistence {
+    attempted: bool,
+    persisted: bool,
+}
+
+async fn persist_terminal_error<M>(
+    runner: &AgentRunner<M>,
+    run: &AgentRun,
+    interruption: &mut InterruptionPersistence,
+    error: StreamingError,
+) -> StreamingError
+where
+    M: CompletionModel,
+{
+    if interruption.attempted {
+        return error;
+    }
+    // Mark the attempt before awaiting: a failed append must not be retried by
+    // the post-loop fallback after its terminal session error is yielded.
+    interruption.attempted = true;
+    match persist_interrupted_session(runner, run).await {
+        Ok(()) => {
+            interruption.persisted = true;
+            error
+        }
+        Err(error) => StreamingError::Prompt(Box::new(PromptError::SessionError(error))),
+    }
+}
+
 pub(crate) fn drive_agent<M, S>(
-    runner: AgentRunner<M>,
+    mut runner: AgentRunner<M>,
     mut source: S,
     mut run: AgentRun,
     agent_span: tracing::Span,
@@ -475,16 +648,134 @@ where
     S: TurnSource<M>,
 {
     async_stream::stream! {
-        // Run-scoped hook context: minted once, shared by every hook event on
-        // both surfaces. `is_streaming` records which surface is driving; the
-        // per-turn index is advanced on each `CallModel` step below.
-        let hook_ctx = HookContext::new(is_streaming, runner.agent_name.clone());
+        // Dropping a polled unary future or streaming response settles the
+        // externally visible handle instead of leaving it permanently Running.
+        let _run_lease = runner.control.lease();
+        let mut interruption = InterruptionPersistence::default();
+        let mut completed_successfully = false;
+        // One identity and cancellation/deadline context is shared by hooks,
+        // model calls, tools, and nested agent tools on both surfaces.
+        let hook_ctx = HookContext::with_run_id(
+            runner.run_context.run_id().clone(),
+            is_streaming,
+            runner.agent_name.clone(),
+        );
+        runner.tool_extensions.insert(runner.run_context.clone());
+        runner.tool_extensions.insert(runner.control.clone());
+        for provider_tool in &runner.provider_tools {
+            runner
+                .tool_server_handle
+                .add_provider_tool(
+                    provider_tool.clone(),
+                    crate::tool::server::ToolCatalogMetadata::default(),
+                )
+                .await;
+        }
 
         'outer: loop {
+            if runner.run_context.should_stop() {
+                let reason = if runner.run_context.cancellation().is_cancelled() {
+                    TerminalReason::Cancelled
+                } else {
+                    TerminalReason::DeadlineExceeded
+                };
+                runner.control.finish(reason.clone());
+                let error = StreamingError::Prompt(Box::new(run.cancel_error(format!("{reason:?}"))));
+                yield Err(persist_terminal_error(&runner, &run, &mut interruption, error).await);
+                break 'outer;
+            }
+
+            if runner.control.checkpoint_requested() {
+                if !run.is_safe_checkpoint() {
+                    runner.control.finish(TerminalReason::Failed);
+                    let error = StreamingError::Prompt(Box::new(PromptError::SessionError(
+                        crate::session::SessionError::UnsafeRecovery,
+                    )));
+                    yield Err(persist_terminal_error(&runner, &run, &mut interruption, error).await);
+                    break 'outer;
+                }
+                match serde_json::to_string(&run) {
+                    Ok(serialized) => {
+                        if let (Some(store), Some(session_id)) = (&runner.session_store, &runner.session_id) {
+                            let parent = match store.load(session_id, &runner.session_branch).await {
+                                Ok(events) => events.last().map(|event| event.sequence),
+                                Err(error) => {
+                                    runner.control.finish(TerminalReason::Failed);
+                                    let error = StreamingError::Prompt(Box::new(PromptError::SessionError(error)));
+                                    yield Err(persist_terminal_error(&runner, &run, &mut interruption, error).await);
+                                    break 'outer;
+                                }
+                            };
+                            if let Err(error) = store.append(
+                                session_id, &runner.session_branch, parent,
+                                Some(runner.session_correlation_id.clone()),
+                                crate::session::SessionEventKind::Checkpoint { snapshot: serialized.clone() },
+                            ).await {
+                                runner.control.finish(TerminalReason::Failed);
+                                let error = StreamingError::Prompt(Box::new(PromptError::SessionError(error)));
+                        yield Err(persist_terminal_error(&runner, &run, &mut interruption, error).await);
+                                break 'outer;
+                            }
+                        }
+                        runner.control.reach_checkpoint(serialized);
+                    }
+                    Err(err) => {
+                        runner.control.finish(TerminalReason::Failed);
+                        let error = StreamingError::Prompt(Box::new(PromptError::CompletionError(
+                            CompletionError::ResponseError(format!(
+                                "failed to serialize agent checkpoint: {err}"
+                            )),
+                        )));
+                        yield Err(persist_terminal_error(&runner, &run, &mut interruption, error).await);
+                        break 'outer;
+                    }
+                }
+            }
+            while runner.control.checkpoint_blocked() {
+                let stopped = runner.run_context.stopped();
+                let delay = futures_timer::Delay::new(std::time::Duration::from_millis(5));
+                futures::pin_mut!(stopped, delay);
+                if matches!(futures::future::select(stopped, delay).await, Either::Left(_)) {
+                    let reason = if runner.run_context.cancellation().is_cancelled() {
+                        TerminalReason::Cancelled
+                    } else {
+                        TerminalReason::DeadlineExceeded
+                    };
+                    runner.control.finish(reason.clone());
+                    let error = StreamingError::Prompt(Box::new(run.cancel_error(format!("{reason:?}"))));
+                    yield Err(persist_terminal_error(&runner, &run, &mut interruption, error).await);
+                    break 'outer;
+                }
+            }
+
+            let steering = runner.control.drain_steering();
+            if !steering.is_empty() {
+                if run.accepts_steering() {
+                    if let Err(err) = run.steer(steering) {
+                        runner.control.finish(TerminalReason::Failed);
+                        let error = StreamingError::Prompt(Box::new(err));
+                        yield Err(persist_terminal_error(&runner, &run, &mut interruption, error).await);
+                        break 'outer;
+                    }
+                } else {
+                    // A steer accepted while the final provider call was in
+                    // flight has no later model boundary. Preserve it as a
+                    // post-settlement follow-up instead of corrupting Done.
+                    runner.control.defer_as_follow_ups(steering);
+                }
+            }
+
             let step = match run.next_step() {
                 Ok(step) => step,
                 Err(err) => {
-                    yield Err(Box::new(err).into());
+                    let reason = if matches!(err, PromptError::MaxTurnsError { .. }) {
+                        TerminalReason::MaxTurns
+                    } else {
+                        TerminalReason::Failed
+                    };
+                    runner.control.finish(reason);
+                    let error = Box::new(err).into();
+                    yield Err(persist_terminal_error(&runner, &run, &mut interruption, error).await);
                     break 'outer;
                 }
             };
@@ -496,14 +787,24 @@ where
                     }
                     hook_ctx.set_turn(turn);
 
-                    let request_patch =
+                    let mut request_patch =
                         match resolve_completion_call(&runner.hooks, &hook_ctx, &prompt, &history, turn).await {
                             CompletionCallOutcome::Terminate(reason) => {
-                                yield Err(StreamingError::Prompt(Box::new(run.cancel_error(reason))));
+                                runner.control.finish(TerminalReason::PolicyTerminated);
+                                let error = StreamingError::Prompt(Box::new(run.cancel_error(reason)));
+                                yield Err(persist_terminal_error(&runner, &run, &mut interruption, error).await);
                                 break 'outer;
                             }
                             CompletionCallOutcome::Proceed(request_patch) => request_patch,
                         };
+                    if let Some(allowed) = &runner.skill_allowed_tools {
+                        let skill_patch = crate::agent::hook::RequestPatch::new()
+                            .active_tools(allowed.clone());
+                        request_patch = Some(match request_patch {
+                            Some(existing) => existing.merge(skill_patch),
+                            None => skill_patch,
+                        });
+                    }
 
                     // Record this turn's base system prompt — the patched-or-baseline
                     // preamble, before any output-mode augmentation the request builder
@@ -528,6 +829,7 @@ where
                         runner.temperature,
                         runner.max_tokens,
                         runner.additional_params.as_ref(),
+                        &runner.provider_tools,
                         runner.tool_choice.as_ref(),
                         &runner.tool_server_handle,
                         &runner.dynamic_context,
@@ -540,11 +842,49 @@ where
                     {
                         Ok(prepared) => prepared,
                         Err(err) => {
-                            yield Err(err.into());
+                            runner.control.finish(TerminalReason::Failed);
+                            let error = err.into();
+                            yield Err(persist_terminal_error(&runner, &run, &mut interruption, error).await);
                             break 'outer;
                         }
                     };
                     run.set_output_tool_name(prepared.output_tool_name.clone());
+                    if let Err(error) = persist_new_messages(&mut runner, &run).await {
+                        runner.control.finish(TerminalReason::Failed);
+                        let error = StreamingError::Prompt(Box::new(PromptError::SessionError(error)));
+                        yield Err(persist_terminal_error(&runner, &run, &mut interruption, error).await);
+                        break 'outer;
+                    }
+                    if let (Some(store), Some(session_id)) = (&runner.session_store, &runner.session_id) {
+                        let parent = match store.load(session_id, &runner.session_branch).await {
+                            Ok(events) => events.last().map(|event| event.sequence),
+                            Err(error) => {
+                                runner.control.finish(TerminalReason::Failed);
+                                let error = StreamingError::Prompt(Box::new(PromptError::SessionError(error)));
+                        yield Err(persist_terminal_error(&runner, &run, &mut interruption, error).await);
+                                break 'outer;
+                            }
+                        };
+                        if let Err(error) = store.append(
+                            session_id, &runner.session_branch, parent,
+                            Some(runner.session_correlation_id.clone()),
+                            crate::session::SessionEventKind::ModelCall {
+                                model: None,
+                                config: serde_json::json!({
+                                    "turn": turn,
+                                    "temperature": runner.temperature,
+                                    "max_tokens": runner.max_tokens,
+                                    "tools": &prepared.executable_tool_names,
+                                }),
+                                usage: crate::completion::Usage::new(),
+                            },
+                        ).await {
+                            runner.control.finish(TerminalReason::Failed);
+                            let error = StreamingError::Prompt(Box::new(PromptError::SessionError(error)));
+                        yield Err(persist_terminal_error(&runner, &run, &mut interruption, error).await);
+                            break 'outer;
+                        }
+                    }
 
                     let mut turn_stream = source.run_model_turn(
                         &runner,
@@ -556,40 +896,104 @@ where
                         prompt,
                     );
                     let mut errored = false;
-                    while let Some(item) = turn_stream.next().await {
-                        match item {
-                            Ok(item) => yield Ok(DriveItem::Item(item)),
-                            Err(err) => {
+                    let mut stopped_reason = None;
+                    let mut drive_error = None;
+                    loop {
+                        let stopped = runner.run_context.stopped();
+                        let next = turn_stream.next();
+                        futures::pin_mut!(stopped, next);
+                        match futures::future::select(stopped, next).await {
+                            Either::Left((reason, _)) => {
                                 errored = true;
-                                yield Err(err);
+                                stopped_reason = Some(reason);
                                 break;
                             }
+                            Either::Right((Some(Ok(item)), _)) => yield Ok(DriveItem::Item(item)),
+                            Either::Right((Some(Err(err)), _)) => {
+                                errored = true;
+                                drive_error = Some(err);
+                                runner.control.finish(TerminalReason::Failed);
+                                break;
+                            }
+                            Either::Right((None, _)) => break,
                         }
                     }
                     drop(turn_stream);
+                    if let Some(error) = drive_error {
+                        yield Err(persist_terminal_error(&runner, &run, &mut interruption, error).await);
+                    }
+                    if let Some(reason) = stopped_reason {
+                        runner.control.finish(reason.clone());
+                        let error = StreamingError::Prompt(Box::new(run.cancel_error(format!("{reason:?}"))));
+                        yield Err(persist_terminal_error(&runner, &run, &mut interruption, error).await);
+                    }
                     if errored {
+                        break 'outer;
+                    }
+                    if let Err(error) = persist_new_model_events(&mut runner, &run).await {
+                        runner.control.finish(TerminalReason::Failed);
+                        let error = StreamingError::Prompt(Box::new(PromptError::SessionError(error)));
+                        yield Err(persist_terminal_error(&runner, &run, &mut interruption, error).await);
                         break 'outer;
                     }
                 }
                 AgentRunStep::CallTools { calls } => {
                     let mut tool_stream = source.run_tool_calls(&runner, &hook_ctx, &mut run, calls);
                     let mut errored = false;
-                    while let Some(item) = tool_stream.next().await {
-                        match item {
-                            Ok(item) => yield Ok(DriveItem::Item(item)),
-                            Err(err) => {
+                    let mut stopped_reason = None;
+                    let mut drive_error = None;
+                    loop {
+                        let stopped = runner.run_context.stopped();
+                        let next = tool_stream.next();
+                        futures::pin_mut!(stopped, next);
+                        match futures::future::select(stopped, next).await {
+                            Either::Left((reason, _)) => {
                                 errored = true;
-                                yield Err(err);
+                                stopped_reason = Some(reason);
                                 break;
                             }
+                            Either::Right((Some(Ok(item)), _)) => yield Ok(DriveItem::Item(item)),
+                            Either::Right((Some(Err(err)), _)) => {
+                                errored = true;
+                                drive_error = Some(err);
+                                runner.control.finish(TerminalReason::Failed);
+                                break;
+                            }
+                            Either::Right((None, _)) => break,
                         }
                     }
                     drop(tool_stream);
+                    if let Some(error) = drive_error {
+                        yield Err(persist_terminal_error(&runner, &run, &mut interruption, error).await);
+                    }
+                    if let Some(reason) = stopped_reason {
+                        runner.control.finish(reason.clone());
+                        let error = StreamingError::Prompt(Box::new(run.cancel_error(format!("{reason:?}"))));
+                        yield Err(persist_terminal_error(&runner, &run, &mut interruption, error).await);
+                    }
                     if errored {
                         break 'outer;
                     }
+                    runner.session_loaded_messages = run.messages().len();
                 }
-                AgentRunStep::Done(response) => {
+                AgentRunStep::Done(mut response) => {
+                    if runner.run_context.should_stop() {
+                        let reason = if runner.run_context.cancellation().is_cancelled() {
+                            TerminalReason::Cancelled
+                        } else {
+                            TerminalReason::DeadlineExceeded
+                        };
+                        runner.control.finish(reason.clone());
+                        let error = StreamingError::Prompt(Box::new(run.cancel_error(format!("{reason:?}"))));
+                        yield Err(persist_terminal_error(&runner, &run, &mut interruption, error).await);
+                        break 'outer;
+                    }
+                    let provider_terminal = response
+                        .completion_calls
+                        .last()
+                        .and_then(|call| call.finish_reason.clone())
+                        .filter(|reason| !matches!(reason, TerminalReason::ToolCalls));
+                    response.terminal_reason = provider_terminal.unwrap_or(TerminalReason::Completed);
                     // Run-completion marker, unifying the blocking and streaming
                     // drivers' run-finished logs into one shared event.
                     tracing::info!(
@@ -598,21 +1002,41 @@ where
                         "Agent run finished"
                     );
                     source.record_run_level_telemetry(&agent_span, &response, created_agent_span);
-                    append_run_messages(
+                    if let Err(error) = append_run_messages(
                         memory_handle.as_ref(),
                         response.messages.as_deref().unwrap_or_default(),
                     )
-                    .await;
+                    .await
+                    {
+                        runner.control.finish(TerminalReason::Failed);
+                        let error = StreamingError::Prompt(Box::new(PromptError::MemoryError(error)));
+                        yield Err(persist_terminal_error(&runner, &run, &mut interruption, error).await);
+                        break 'outer;
+                    }
+                    if let Err(error) = persist_completed_session(&runner, &response).await {
+                        runner.control.finish(TerminalReason::Failed);
+                        let error = StreamingError::Prompt(Box::new(PromptError::SessionError(error)));
+                        yield Err(persist_terminal_error(&runner, &run, &mut interruption, error).await);
+                        break 'outer;
+                    }
+                    runner.control.finish(response.terminal_reason.clone());
                     // Build the final item only when the surface forwards it
                     // (streaming). The blocking fold discards it, so its source
                     // returns `None` and the extra full-response clone is skipped.
                     if let Some(final_item) = source.final_item(&response) {
                         yield Ok(DriveItem::Item(final_item));
                     }
+                    completed_successfully = true;
                     yield Ok(DriveItem::Done(Box::new(response)));
                     break 'outer;
                 }
             }
+        }
+        if !completed_successfully
+            && !interruption.attempted
+            && let Err(error) = persist_interrupted_session(&runner, &run).await
+        {
+            yield Err(StreamingError::Prompt(Box::new(PromptError::SessionError(error))));
         }
     }
 }
@@ -649,7 +1073,7 @@ pub(crate) fn drive_tool_calls<'a, M, R, F>(
     forward_items: bool,
 ) -> DriveStream<'a, R>
 where
-    M: CompletionModel,
+    M: CompletionModel + 'static,
     R: WasmCompatSend + 'a,
     F: Fn(tracing::Span) -> tracing::Span + WasmCompatSend + 'a,
 {
@@ -681,6 +1105,8 @@ where
         content: UserContent,
         internal_call_id: String,
         surface: ToolSurface,
+        final_output: Option<String>,
+        outcome: String,
     }
 
     Box::pin(async_stream::stream! {
@@ -710,6 +1136,21 @@ where
                     (chain_tool_span(new_execute_tool_span()), None)
                 }
             };
+            if preresolved_result.is_none()
+                && let Err(error) = append_session_event(
+                    runner,
+                    crate::session::SessionEventKind::ToolCall {
+                        name: pending.tool_call.function.name.clone(),
+                        arguments: pending.tool_call.function.arguments.clone(),
+                        internal_call_id: internal_call_id.clone(),
+                        parent_internal_call_id: runner.run_context.current_call_id().map(str::to_owned),
+                    },
+                )
+                .await
+            {
+                yield Err(StreamingError::Prompt(Box::new(PromptError::SessionError(error))));
+                return;
+            }
             prepared.push(PreparedToolCall {
                 tool_call: pending.tool_call,
                 preresolved_result,
@@ -726,8 +1167,22 @@ where
         let mut collected: Vec<Option<CollectedToolResult>> =
             (0..call_count).map(|_| None).collect();
         let mut first_error: Option<(usize, PromptError)> = None;
+        let scheduling = futures::future::join_all(
+            prepared
+                .iter()
+                .filter(|call| call.preresolved_result.is_none())
+                .map(|call| {
+                    runner
+                        .tool_server_handle
+                        .scheduling(&call.tool_call.function.name)
+                }),
+        )
+        .await;
+        let parallel_safe = scheduling
+            .iter()
+            .all(|scheduling| *scheduling != ToolScheduling::Serial);
 
-        if runner.concurrency <= 1 {
+        if runner.concurrency <= 1 || !parallel_safe {
             // Sequential: run in call order, fail-fast on the first terminating
             // error so the remaining tools never start.
             for (index, call) in prepared.into_iter().enumerate() {
@@ -738,6 +1193,8 @@ where
                             content: result,
                             internal_call_id,
                             surface: ToolSurface::Preresolved,
+                            final_output: None,
+                            outcome: "skipped".into(),
                         });
                     }
                     continue;
@@ -747,6 +1204,8 @@ where
                     hook_ctx,
                     &runner.tool_server_handle,
                     &runner.tool_extensions,
+                    &runner.run_context,
+                    &runner.nested_tool_policy,
                     &tool_call,
                     &internal_call_id,
                     &full_history_for_errors,
@@ -760,10 +1219,17 @@ where
                             ToolExecution::Skipped => ToolSurface::Skipped,
                         };
                         if let Some(slot) = collected.get_mut(index) {
+                            let final_output = runner
+                                .tool_server_handle
+                                .is_final_result(&tool_call.function.name)
+                                .await
+                                .then_some(outcome.model_output);
                             *slot = Some(CollectedToolResult {
                                 content: outcome.content,
                                 internal_call_id,
                                 surface,
+                                final_output,
+                                outcome: outcome.outcome.as_str().into(),
                             });
                         }
                     }
@@ -786,6 +1252,8 @@ where
                     let hooks = &runner.hooks;
                     let tool_server_handle = &runner.tool_server_handle;
                     let tool_extensions = &runner.tool_extensions;
+                    let run_context = &runner.run_context;
+                    let nested_tool_policy = &runner.nested_tool_policy;
                     let full_history_for_errors = &full_history_for_errors;
                     let terminating = terminating.clone();
                     async move {
@@ -796,6 +1264,8 @@ where
                                     content: result,
                                     internal_call_id,
                                     surface: ToolSurface::Preresolved,
+                                    final_output: None,
+                                    outcome: "skipped".into(),
                                 })),
                             );
                         }
@@ -808,24 +1278,35 @@ where
                             hook_ctx,
                             tool_server_handle,
                             tool_extensions,
+                            run_context,
+                            nested_tool_policy,
                             &tool_call,
                             &internal_call_id,
                             full_history_for_errors,
                         )
                         .await;
-                        let mapped = outcome.map(|o| {
-                            let surface = match o.execution {
-                                ToolExecution::Executed(effective) => {
-                                    ToolSurface::Executed(effective)
-                                }
-                                ToolExecution::Skipped => ToolSurface::Skipped,
-                            };
-                            CollectedToolResult {
-                                content: o.content,
-                                internal_call_id,
-                                surface,
+                        let mapped = match outcome {
+                            Ok(o) => {
+                                let surface = match o.execution {
+                                    ToolExecution::Executed(effective) => {
+                                        ToolSurface::Executed(effective)
+                                    }
+                                    ToolExecution::Skipped => ToolSurface::Skipped,
+                                };
+                                let final_output = tool_server_handle
+                                    .is_final_result(&tool_call.function.name)
+                                    .await
+                                    .then_some(o.model_output);
+                                Ok(CollectedToolResult {
+                                    content: o.content,
+                                    internal_call_id,
+                                    surface,
+                                    final_output,
+                                    outcome: o.outcome.as_str().into(),
+                                })
                             }
-                        });
+                            Err(error) => Err(error),
+                        };
                         (index, Some(mapped))
                     }
                     .instrument(span)
@@ -872,8 +1353,15 @@ where
         // turn) but is still committed. Every non-dropped slot is filled; a
         // dropped slot only occurs after a termination, handled above.
         let mut committed: Vec<UserContent> = Vec::with_capacity(call_count);
+        let mut final_output = None;
         for slot in collected {
-            let CollectedToolResult { content, internal_call_id, surface } = match slot {
+            let CollectedToolResult {
+                content,
+                internal_call_id,
+                surface,
+                final_output: call_final_output,
+                outcome,
+            } = match slot {
                 Some(collected_result) => collected_result,
                 None => {
                     yield Err(StreamingError::Prompt(Box::new(PromptError::CompletionError(
@@ -884,6 +1372,24 @@ where
                     return;
                 }
             };
+            if let UserContent::ToolResult(tool_result) = &content
+                && let Err(error) = append_session_event(
+                    runner,
+                    crate::session::SessionEventKind::ToolResult {
+                        outcome,
+                        content: serde_json::to_value(tool_result).unwrap_or_default(),
+                        internal_call_id: tool_result
+                            .internal_call_id
+                            .clone()
+                            .unwrap_or_else(|| internal_call_id.clone()),
+                        parent_internal_call_id: tool_result.parent_internal_call_id.clone(),
+                    },
+                )
+                .await
+            {
+                yield Err(StreamingError::Prompt(Box::new(PromptError::SessionError(error))));
+                return;
+            }
             if forward_items {
                 // An executed call also surfaces its execution-start; a skipped
                 // call surfaces only its result; a preresolved call surfaces
@@ -910,12 +1416,30 @@ where
                     ));
                 }
             }
+            if call_final_output.is_some() {
+                final_output = call_final_output;
+            }
             committed.push(content);
         }
 
         if let Err(err) = run.tool_results(committed) {
             yield Err(Box::new(err).into());
             return;
+        }
+        if let Some(message) = run.messages().last()
+            && let Err(error) = append_session_event(
+                runner,
+                crate::session::SessionEventKind::Message(message.clone()),
+            )
+            .await
+        {
+            yield Err(StreamingError::Prompt(Box::new(PromptError::SessionError(error))));
+            return;
+        }
+        if let Some(output) = final_output
+            && let Err(err) = run.finish_from_tool(output)
+        {
+            yield Err(Box::new(err).into());
         }
     })
 }
@@ -962,7 +1486,7 @@ impl StreamingTurnSource {
 
 impl<M> TurnSource<M> for StreamingTurnSource
 where
-    M: CompletionModel,
+    M: CompletionModel + 'static,
     <M as CompletionModel>::StreamingResponse: WasmCompatSend + GetTokenUsage,
 {
     type Raw = M::StreamingResponse;
@@ -1006,6 +1530,9 @@ where
                 prepared.executable_tool_names.clone(),
                 prepared.allowed_tool_names.clone(),
             );
+            assembler.set_parent_internal_call_id(
+                runner.run_context.current_call_id().map(str::to_owned),
+            );
             let mut completion_call_emitted = false;
             let mut turn_abandoned = false;
             // Mirrors the blocking driver's `response_hook_suppressed`: a turn
@@ -1021,14 +1548,18 @@ where
             // Returns the item to yield (`Some` the first time, `None` after), or
             // the terminal error to surface.
             macro_rules! emit_completion_call {
-                ($usage:expr) => {{
+                ($usage:expr, $finish_reason:expr, $raw_finish_reason:expr $(,)?) => {{
                     let usage = $usage;
                     last_usage = usage;
                     if !completion_call_emitted {
                         if usage.has_values() {
                             record_usage_on_span(&chat_span, usage);
                         }
-                        match run.record_streamed_completion_call(usage) {
+                        match run.record_streamed_completion_call_with_finish(
+                            usage,
+                            $finish_reason,
+                            $raw_finish_reason,
+                        ) {
                             Ok(call) => {
                                 completion_call_emitted = true;
                                 Ok(Some(MultiTurnStreamItem::CompletionCall(call)))
@@ -1120,8 +1651,13 @@ where
                                 },
                             ));
                         }
-                        StreamedTurnEvent::Completed { usage, emit_final } => {
-                            match emit_completion_call!(usage) {
+                        StreamedTurnEvent::Completed {
+                            usage,
+                            finish_reason,
+                            raw_finish_reason,
+                            emit_final,
+                        } => {
+                            match emit_completion_call!(usage, finish_reason, raw_finish_reason) {
                                 Ok(Some(item)) => yield Ok(item),
                                 Ok(None) => {}
                                 Err(err) => {
@@ -1208,14 +1744,18 @@ where
                                         yield Err(err.into());
                                         return;
                                     }
-                                    let drained_usage = match drain_stream_usage(&mut stream).await {
-                                        Ok(usage) => usage,
+                                    let (drained_usage, finish_reason, raw_finish_reason) = match drain_stream_usage(&mut stream).await {
+                                        Ok(metadata) => metadata,
                                         Err(err) => {
                                             yield Err(err);
                                             return;
                                         }
                                     };
-                                    match emit_completion_call!(drained_usage) {
+                                    match emit_completion_call!(
+                                        drained_usage,
+                                        finish_reason,
+                                        raw_finish_reason,
+                                    ) {
                                         Ok(Some(item)) => yield Ok(item),
                                         Ok(None) => {}
                                         Err(err) => {
@@ -1274,7 +1814,15 @@ where
             }
 
             self.last_message_id = stream.message_id.clone();
-            let streamed_turn = assembler.finish(stream.message_id.clone(), &final_turn_content);
+            let mut streamed_turn = assembler.finish(stream.message_id.clone(), &final_turn_content);
+            for part in streamed_turn.choice.iter_mut() {
+                if let AssistantContent::ToolCall(call) = part {
+                    call.parent_internal_call_id = runner
+                        .run_context
+                        .current_call_id()
+                        .map(str::to_owned);
+                }
+            }
             // The canonical (committed) assistant content: `finish` normalizes
             // reasoning/text/tool ordering, so this can differ from the raw
             // `stream.choice` aggregate. `ModelTurnFinished` — the normalized
@@ -1378,7 +1926,7 @@ where
     /// hook handling with the blocking [`run`](AgentRunner::run) via
     /// `drive_agent`, so the two behave identically apart from the streamed
     /// delta events.
-    pub async fn stream(self) -> StreamingResult<M::StreamingResponse> {
+    pub async fn stream(mut self) -> StreamingResult<M::StreamingResponse> {
         let (agent_span, created_agent_span) =
             acquire_agent_span(self.agent_name_or_default(), self.preamble.as_deref());
 
@@ -1389,12 +1937,13 @@ where
         // When the caller passes explicit history, memory is fully bypassed for
         // this request (no load AND no save). Otherwise, if a memory backend and
         // conversation id are both configured, load prior history.
-        let (history_override, memory_handle) = match &self.chat_history {
+        let (mut history_override, memory_handle) = match &self.chat_history {
             Some(_) => (None, None),
             None => match (&self.memory, &self.conversation_id) {
                 (Some(memory), Some(id)) => match memory.load(id).await {
                     Ok(loaded) => (Some(loaded), Some((memory.clone(), id.clone()))),
                     Err(err) => {
+                        self.control.finish(TerminalReason::Failed);
                         let stream = async_stream::stream! {
                             yield Err(StreamingError::from(err));
                         };
@@ -1407,7 +1956,100 @@ where
             },
         };
 
-        let run = self.build_run(history_override);
+        let mut resumed_run = None;
+        if history_override.is_none()
+            && let (Some(store), Some(session_id)) = (&self.session_store, &self.session_id)
+        {
+            let events = match store.load(session_id, &self.session_branch).await {
+                Ok(events) => events,
+                Err(error) => {
+                    self.control.finish(TerminalReason::Failed);
+                    let stream = async_stream::stream! {
+                        yield Err(StreamingError::Prompt(Box::new(PromptError::SessionError(error))));
+                    };
+                    return Box::pin(stream.instrument(agent_span));
+                }
+            };
+            let mut messages = Vec::new();
+            let mut recovery_snapshot = None;
+            let mut recovery_correlation = None;
+            let mut unsafe_interruption = false;
+            for event in &events {
+                match &event.kind {
+                    crate::session::SessionEventKind::Message(message) => {
+                        messages.push(message.clone())
+                    }
+                    crate::session::SessionEventKind::Checkpoint { snapshot } => {
+                        recovery_snapshot = Some(snapshot.clone());
+                        recovery_correlation = event.correlation_id.clone();
+                        unsafe_interruption = false;
+                    }
+                    crate::session::SessionEventKind::Interrupted { checkpoint, run_id } => {
+                        unsafe_interruption = checkpoint.is_none();
+                        if let Some(checkpoint) = checkpoint {
+                            recovery_snapshot = Some(checkpoint.clone());
+                            recovery_correlation = Some(run_id.clone());
+                        }
+                    }
+                    crate::session::SessionEventKind::Lifecycle { status, .. }
+                        if status == "completed" =>
+                    {
+                        recovery_snapshot = None;
+                        recovery_correlation = None;
+                        unsafe_interruption = false;
+                    }
+                    _ => {}
+                }
+            }
+            if let Some(correlation) = recovery_correlation {
+                self.session_correlation_id = correlation.clone();
+                self.session_loaded_messages = events
+                    .iter()
+                    .filter(|event| {
+                        event.correlation_id.as_deref() == Some(correlation.as_str())
+                            && matches!(&event.kind, crate::session::SessionEventKind::Message(_))
+                    })
+                    .count();
+                self.session_loaded_completion_calls = events
+                    .iter()
+                    .filter(|event| {
+                        event.correlation_id.as_deref() == Some(correlation.as_str())
+                            && matches!(
+                                &event.kind,
+                                crate::session::SessionEventKind::ModelResponse { .. }
+                            )
+                    })
+                    .count();
+            }
+            let recovery_error = if unsafe_interruption {
+                Some(crate::session::SessionError::UnsafeRecovery)
+            } else if let Some(snapshot) = recovery_snapshot {
+                match serde_json::from_str::<AgentRun>(&snapshot) {
+                    Ok(restored) if restored.is_safe_checkpoint() => {
+                        resumed_run = Some(restored);
+                        None
+                    }
+                    Ok(_) => Some(crate::session::SessionError::UnsafeRecovery),
+                    Err(error) => Some(crate::session::SessionError::InvalidCheckpoint(
+                        error.to_string(),
+                    )),
+                }
+            } else {
+                None
+            };
+            if let Some(error) = recovery_error {
+                self.control.finish(TerminalReason::Failed);
+                let stream = async_stream::stream! {
+                    yield Err(StreamingError::Prompt(Box::new(PromptError::SessionError(error))));
+                };
+                return Box::pin(stream.instrument(agent_span));
+            }
+            if !messages.is_empty() {
+                history_override = Some(messages);
+            }
+        }
+
+        let run = resumed_run.unwrap_or_else(|| self.build_run(history_override));
         let source = StreamingTurnSource::new(
             &self.hooks,
             self.agent_name_or_default().to_string(),
@@ -1929,6 +2571,7 @@ mod tests {
 
     fn arithmetic_tool_definition(name: &str, description: &str) -> ToolDefinition {
         ToolDefinition {
+            output_schema: None,
             name: name.to_string(),
             description: description.to_string(),
             parameters: serde_json::json!({
@@ -5956,7 +6599,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn streaming_append_error_does_not_suppress_final_response() {
+    async fn streaming_append_error_is_terminal_and_suppresses_final_response() {
         let agent = AgentBuilder::new(streaming_text_then_final_model())
             .memory(AppendFailingMemory::default())
             .build();
@@ -5964,15 +6607,22 @@ mod tests {
         let mut stream = agent.stream_prompt("hi").conversation("t1").await;
 
         let mut saw_final = false;
+        let mut saw_memory_error = false;
         while let Some(item) = stream.next().await {
-            if let Ok(MultiTurnStreamItem::FinalResponse(_)) = item {
-                saw_final = true;
-                break;
+            match item {
+                Ok(MultiTurnStreamItem::FinalResponse(_)) => saw_final = true,
+                Err(StreamingError::Prompt(error))
+                    if matches!(*error, PromptError::MemoryError(_)) =>
+                {
+                    saw_memory_error = true;
+                }
+                _ => {}
             }
         }
+        assert!(saw_memory_error);
         assert!(
-            saw_final,
-            "FinalResponse must be yielded even when memory.append fails"
+            !saw_final,
+            "an unpersisted response must not settle successfully"
         );
     }
 }

--- a/crates/rig-core/src/agent/run/mod.rs
+++ b/crates/rig-core/src/agent/run/mod.rs
@@ -163,6 +163,12 @@ pub struct ModelTurn {
     pub executable_tool_names: BTreeSet<String>,
     /// Tools allowed by the active [`ToolChoice`] for this turn.
     pub allowed_tool_names: BTreeSet<String>,
+    /// Provider-neutral reason this turn stopped.
+    #[serde(default)]
+    pub finish_reason: Option<crate::runtime::TerminalReason>,
+    /// Unmodified provider finish/status value.
+    #[serde(default)]
+    pub raw_finish_reason: Option<String>,
 }
 
 impl ModelTurn {
@@ -181,7 +187,20 @@ impl ModelTurn {
             usage,
             executable_tool_names,
             allowed_tool_names,
+            finish_reason: None,
+            raw_finish_reason: None,
         }
+    }
+
+    /// Attach normalized and raw provider finish metadata.
+    pub fn with_finish_reason(
+        mut self,
+        finish_reason: Option<crate::runtime::TerminalReason>,
+        raw_finish_reason: Option<String>,
+    ) -> Self {
+        self.finish_reason = finish_reason;
+        self.raw_finish_reason = raw_finish_reason;
+        self
     }
 }
 
@@ -310,6 +329,15 @@ pub struct AgentRun {
 }
 
 impl AgentRun {
+    /// Whether serializing now can be resumed without replaying an in-flight
+    /// provider call or tool side effect.
+    pub(crate) fn is_safe_checkpoint(&self) -> bool {
+        matches!(
+            self.state,
+            RunState::PreparingRequest | RunState::AwaitingAdvance(_) | RunState::Done(_)
+        )
+    }
+
     /// Create a run for one prompt with no input history, a one-model-call
     /// budget, and no invalid tool-call retries.
     pub fn new(prompt: impl Into<Message>) -> Self {
@@ -497,6 +525,29 @@ impl AgentRun {
         }
     }
 
+    /// Returns whether host steering can be appended at this boundary.
+    pub(crate) fn accepts_steering(&self) -> bool {
+        matches!(self.state, RunState::PreparingRequest)
+    }
+
+    /// Appends host steering messages at a safe pre-model boundary.
+    ///
+    /// Messages are accepted only while the machine is preparing a request;
+    /// callers must not inject into an in-flight model or tool step.
+    pub fn steer<I>(&mut self, messages: I) -> Result<(), PromptError>
+    where
+        I: IntoIterator<Item = Message>,
+    {
+        if !matches!(self.state, RunState::PreparingRequest) {
+            return Err(PromptError::prompt_cancelled(
+                self.full_history(),
+                "steering attempted outside a safe pre-model boundary",
+            ));
+        }
+        self.new_messages.extend(messages);
+        Ok(())
+    }
+
     /// Build the cancellation error a driver should return when one of its
     /// hooks terminates the run, carrying the current full history.
     pub fn cancel_error(&self, reason: impl Into<String>) -> PromptError {
@@ -680,7 +731,8 @@ impl AgentRun {
                                 let internal_call_id = internal_call_ids
                                     .iter()
                                     .position(|(id, _)| *id == tool_call.id)
-                                    .map(|index| internal_call_ids.remove(index).1);
+                                    .map(|index| internal_call_ids.remove(index).1)
+                                    .or_else(|| tool_call.internal_call_id.clone());
                                 Some(PendingToolCall {
                                     tool_call: tool_call.clone(),
                                     preresolved_result: skipped.get(&tool_call.id).cloned(),
@@ -774,7 +826,7 @@ impl AgentRun {
             ));
         }
 
-        self.record_completion_call(turn.usage);
+        self.record_completion_call(turn.usage, turn.finish_reason, turn.raw_finish_reason);
 
         let items: Vec<AssistantContent> = turn.choice.iter().cloned().collect();
         let has_tool_calls = items
@@ -803,10 +855,16 @@ impl AgentRun {
     /// ingestion paths. Callers own the once-per-turn `streamed_completion_call_recorded`
     /// guard/flag; this helper never touches it, so it cannot be mistaken for
     /// "a completion call happened" and re-introduce a double count.
-    fn record_completion_call(&mut self, usage: Usage) -> CompletionCall {
-        let call = CompletionCall::new(self.completion_call_index, usage);
+    fn record_completion_call(
+        &mut self,
+        usage: Usage,
+        finish_reason: Option<crate::runtime::TerminalReason>,
+        raw_finish_reason: Option<String>,
+    ) -> CompletionCall {
+        let call = CompletionCall::new(self.completion_call_index, usage)
+            .with_finish_reason(finish_reason, raw_finish_reason);
         self.completion_call_index += 1;
-        self.completion_calls.push(call);
+        self.completion_calls.push(call.clone());
         self.usage += usage;
         call
     }
@@ -964,6 +1022,22 @@ impl AgentRun {
         }
     }
 
+    /// Finish successfully from a host-declared final-result tool after its
+    /// result has been committed to history.
+    pub(crate) fn finish_from_tool(&mut self, output: String) -> Result<(), PromptError> {
+        if !matches!(self.state, RunState::PreparingRequest) {
+            return Err(PromptError::prompt_cancelled(
+                self.full_history(),
+                "final-result tool settled outside a safe boundary",
+            ));
+        }
+        let response = PromptResponse::new(output, self.usage)
+            .with_messages(self.new_messages.clone())
+            .with_completion_calls(self.completion_calls.clone());
+        self.state = RunState::Done(Box::new(response));
+        Ok(())
+    }
+
     /// Feed the tool results for the pending [`AgentRunStep::CallTools`].
     ///
     /// Results may be in any order; they are appended as a single user
@@ -1107,6 +1181,16 @@ impl AgentRun {
         &mut self,
         usage: Usage,
     ) -> Result<CompletionCall, PromptError> {
+        self.record_streamed_completion_call_with_finish(usage, None, None)
+    }
+
+    /// Record a streamed completion call including normalized and raw finish metadata.
+    pub fn record_streamed_completion_call_with_finish(
+        &mut self,
+        usage: Usage,
+        finish_reason: Option<crate::runtime::TerminalReason>,
+        raw_finish_reason: Option<String>,
+    ) -> Result<CompletionCall, PromptError> {
         let recordable = matches!(self.state, RunState::AwaitingModel)
             || (matches!(self.state, RunState::PreparingRequest) && self.rollback_pending);
         if !recordable {
@@ -1121,7 +1205,7 @@ impl AgentRun {
         }
         self.streamed_completion_call_recorded = true;
 
-        Ok(self.record_completion_call(usage))
+        Ok(self.record_completion_call(usage, finish_reason, raw_finish_reason))
     }
 
     /// The recovery-hook context for an invalid tool call surfaced
@@ -1238,6 +1322,8 @@ impl AgentRun {
                 let skipped_tool_result = ToolResult {
                     id: invalid.tool_call.id.clone(),
                     call_id: invalid.tool_call.call_id.clone(),
+                    internal_call_id: Some(invalid.internal_call_id.clone()),
+                    parent_internal_call_id: invalid.tool_call.parent_internal_call_id.clone(),
                     content: OneOrMany::one(ToolResultContent::text(reason.clone())),
                 };
                 let Some((assistant_message, user_message)) =
@@ -1280,7 +1366,7 @@ impl AgentRun {
             // `Usage::new()` is the additive identity for `Usage`'s `AddAssign`,
             // so routing the no-usage fallback through `record_completion_call`
             // leaves the run total unchanged while unifying the accounting.
-            self.record_completion_call(Usage::new());
+            self.record_completion_call(Usage::new(), None, None);
             self.streamed_completion_call_recorded = true;
         }
 

--- a/crates/rig-core/src/agent/run/streamed.rs
+++ b/crates/rig-core/src/agent/run/streamed.rs
@@ -180,17 +180,23 @@ impl PartialStreamedTurn {
             .pending_tool_calls
             .iter()
             .map(|tool_call| {
-                tool_result_message(
-                    tool_call.id.clone(),
-                    tool_call.call_id.clone(),
-                    TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER.to_string(),
+                correlated_tool_result(
+                    tool_result_message(
+                        tool_call.id.clone(),
+                        tool_call.call_id.clone(),
+                        TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER.to_string(),
+                    ),
+                    tool_call,
                 )
             })
             .collect::<Vec<_>>();
-        retry_results.push(tool_result_message(
-            invalid_tool_call.id,
-            invalid_tool_call.call_id,
-            feedback,
+        retry_results.push(correlated_tool_result(
+            tool_result_message(
+                invalid_tool_call.id.clone(),
+                invalid_tool_call.call_id.clone(),
+                feedback,
+            ),
+            &invalid_tool_call,
         ));
 
         let user_message = Message::User {
@@ -198,6 +204,20 @@ impl PartialStreamedTurn {
         };
 
         Some((assistant_message, user_message))
+    }
+}
+
+fn correlated_tool_result(
+    content: crate::message::UserContent,
+    call: &ToolCall,
+) -> crate::message::UserContent {
+    match content {
+        crate::message::UserContent::ToolResult(mut result) => {
+            result.internal_call_id = call.internal_call_id.clone();
+            result.parent_internal_call_id = call.parent_internal_call_id.clone();
+            crate::message::UserContent::ToolResult(result)
+        }
+        other => other,
     }
 }
 
@@ -228,6 +248,7 @@ pub struct StreamedTurn {
 /// Deliberately exhaustive: a driver must handle every resolution, so adding
 /// a variant is a breaking change by design.
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum StreamedResolution {
     /// The tool name was repaired. Apply it via
     /// [`StreamedTurnAssembler::resolve_pending_invalid`] and keep consuming
@@ -279,6 +300,10 @@ pub enum StreamedTurnEvent {
         /// Provider-reported usage for this call. Zero-valued usage means the
         /// provider reported no usage metrics.
         usage: Usage,
+        /// Provider-neutral reason this request stopped.
+        finish_reason: Option<crate::runtime::TerminalReason>,
+        /// Unmodified provider finish/status value.
+        raw_finish_reason: Option<String>,
         /// Whether the ingested final item should be forwarded to the
         /// consumer (set when the turn streamed text).
         emit_final: bool,
@@ -317,9 +342,21 @@ pub struct StreamedTurnAssembler {
     pending_tool_calls: Vec<(ToolCall, String)>,
     delta_states: HashMap<(String, String), ToolCallDeltaState>,
     pending_invalid: Option<PendingInvalid>,
+    parent_internal_call_id: Option<String>,
 }
 
 impl StreamedTurnAssembler {
+    /// Attach the enclosing Rig call ID to every tool call assembled this turn.
+    pub fn set_parent_internal_call_id(&mut self, parent: Option<String>) {
+        self.parent_internal_call_id = parent.clone();
+        for (call, _) in &mut self.pending_tool_calls {
+            call.parent_internal_call_id = parent.clone();
+        }
+        if let Some(PendingInvalid::FullCall { tool_call, .. }) = &mut self.pending_invalid {
+            tool_call.parent_internal_call_id = parent;
+        }
+    }
+
     /// Create an assembler for one streamed turn with the tool names
     /// advertised to the provider for that turn.
     pub fn new(
@@ -337,6 +374,7 @@ impl StreamedTurnAssembler {
             pending_tool_calls: Vec::new(),
             delta_states: HashMap::new(),
             pending_invalid: None,
+            parent_internal_call_id: None,
         }
     }
 
@@ -394,8 +432,11 @@ impl StreamedTurnAssembler {
                 internal_call_id,
             } => {
                 if !self.allowed_tool_names.contains(&tool_call.function.name) {
+                    let mut correlated = tool_call.clone();
+                    correlated.internal_call_id = Some(internal_call_id.clone());
+                    correlated.parent_internal_call_id = self.parent_internal_call_id.clone();
                     let invalid = StreamedInvalidToolCall {
-                        tool_call: tool_call.clone(),
+                        tool_call: correlated.clone(),
                         internal_call_id: internal_call_id.clone(),
                         args: Some(json_utils::value_to_json_string(
                             &tool_call.function.arguments,
@@ -404,14 +445,17 @@ impl StreamedTurnAssembler {
                         allowed_tool_names: self.allowed_tool_names.clone(),
                     };
                     self.pending_invalid = Some(PendingInvalid::FullCall {
-                        tool_call: Box::new(tool_call.clone()),
+                        tool_call: Box::new(correlated),
                         internal_call_id: internal_call_id.clone(),
                     });
                     return Ok(vec![StreamedTurnEvent::InvalidToolCall(Box::new(invalid))]);
                 }
 
+                let mut correlated = tool_call.clone();
+                correlated.internal_call_id = Some(internal_call_id.clone());
+                correlated.parent_internal_call_id = self.parent_internal_call_id.clone();
                 self.pending_tool_calls
-                    .push((tool_call.clone(), internal_call_id.clone()));
+                    .push((correlated, internal_call_id.clone()));
                 Ok(Vec::new())
             }
             StreamedAssistantContent::ToolCallDelta {
@@ -433,6 +477,7 @@ impl StreamedTurnAssembler {
                                     id,
                                     name,
                                     &buffered_args,
+                                    internal_call_id,
                                 ),
                                 internal_call_id: internal_call_id.clone(),
                                 args: Some(buffered_args),
@@ -471,7 +516,12 @@ impl StreamedTurnAssembler {
                 let usage = final_response.token_usage();
                 let emit_final = self.saw_text;
                 self.saw_text = false;
-                Ok(vec![StreamedTurnEvent::Completed { usage, emit_final }])
+                Ok(vec![StreamedTurnEvent::Completed {
+                    usage,
+                    finish_reason: final_response.finish_reason(),
+                    raw_finish_reason: final_response.raw_finish_reason(),
+                    emit_final,
+                }])
             }
             StreamedAssistantContent::Unknown(_) => {
                 // Unmodeled provider item (e.g. a hosted-tool result): forward it
@@ -504,6 +554,8 @@ impl StreamedTurnAssembler {
                 },
             ) => {
                 tool_call.function.name = tool_name.clone();
+                tool_call.internal_call_id = Some(internal_call_id.clone());
+                tool_call.parent_internal_call_id = self.parent_internal_call_id.clone();
                 self.pending_tool_calls.push((*tool_call, internal_call_id));
                 Vec::new()
             }
@@ -604,7 +656,11 @@ impl StreamedTurnAssembler {
                 let tool_items = self
                     .pending_tool_calls
                     .iter()
-                    .map(|(tool_call, _)| AssistantContent::ToolCall(tool_call.clone()))
+                    .map(|(tool_call, internal_call_id)| {
+                        let mut tool_call = tool_call.clone();
+                        tool_call.internal_call_id = Some(internal_call_id.clone());
+                        AssistantContent::ToolCall(tool_call)
+                    })
                     .collect::<Vec<_>>();
                 ordered_streaming_assistant_content(
                     self.accumulated_reasoning.drain(..),
@@ -630,6 +686,7 @@ impl StreamedTurnAssembler {
         id: &str,
         name: &str,
         buffered_args: &str,
+        internal_call_id: &str,
     ) -> ToolCall {
         let diagnostic_args = if buffered_args.trim().is_empty() {
             serde_json::Value::Null
@@ -639,6 +696,10 @@ impl StreamedTurnAssembler {
         ToolCall::new(
             id.to_string(),
             ToolFunction::new(name.to_string(), diagnostic_args),
+        )
+        .with_internal_call_ids(
+            Some(internal_call_id.to_owned()),
+            self.parent_internal_call_id.clone(),
         )
     }
 
@@ -1154,6 +1215,14 @@ mod tests {
         assert_eq!(calls.len(), 2);
         assert_eq!(calls[0].internal_call_id.as_deref(), Some("internal_a"));
         assert_eq!(calls[1].internal_call_id.as_deref(), Some("internal_b"));
+        assert_eq!(
+            calls[0].tool_call.internal_call_id.as_deref(),
+            Some("internal_a")
+        );
+        assert_eq!(
+            calls[1].tool_call.internal_call_id.as_deref(),
+            Some("internal_b")
+        );
     }
 
     #[test]

--- a/crates/rig-core/src/agent/runner.rs
+++ b/crates/rig-core/src/agent/runner.rs
@@ -44,18 +44,27 @@ use super::{
             DriveItem, DriveStream, MultiTurnStreamItem, StreamingError, TurnSource, drive_agent,
             drive_tool_calls, record_usage_on_span, streaming_error_into_prompt,
         },
-        tool_result_message, tool_result_output,
+        tool_result_content, tool_result_message, tool_result_output,
     },
     run::{
         AgentRun, DEFAULT_OUTPUT_RETRIES, ModelTurn, ModelTurnOutcome, OutputMode, PendingToolCall,
     },
 };
 use crate::{
-    completion::{CompletionError, CompletionModel, Document, Message, PromptError},
+    completion::{
+        CompletionError, CompletionModel, Document, Message, PromptError, ProviderToolDefinition,
+    },
     json_utils,
     memory::ConversationMemory,
     message::{ToolCall, ToolChoice, UserContent},
-    tool::{ToolCallExtensions, ToolExecutionResult, ToolOutcome, server::ToolServerHandle},
+    runtime::{RunContext, RunControlHandle},
+    session::{SessionEventKind, SessionStore},
+    skills::SkillCatalog,
+    tool::{
+        ToolCallExtensions, ToolExecutionResult, ToolOutcome,
+        server::{NestedToolPolicy, ScopedToolDispatch, ScopedToolExecutor, ToolServerHandle},
+    },
+    wasm_compat::WasmBoxedFuture,
 };
 
 use super::UNKNOWN_AGENT_NAME;
@@ -277,6 +286,8 @@ where
     pub(crate) temperature: Option<f64>,
     pub(crate) max_tokens: Option<u64>,
     pub(crate) additional_params: Option<serde_json::Value>,
+    pub(crate) provider_tools: Vec<ProviderToolDefinition>,
+    pub(crate) nested_tool_policy: NestedToolPolicy,
     pub(crate) tool_server_handle: ToolServerHandle,
     /// Per-call runtime extensions made available to every tool executed during
     /// this run via [`Tool::call_with_extensions`](crate::tool::Tool::call_with_extensions).
@@ -291,6 +302,31 @@ where
     pub(crate) memory: Option<Arc<dyn ConversationMemory>>,
     pub(crate) conversation_id: Option<String>,
     pub(crate) hooks: HookStack<M>,
+    pub(crate) session_store: Option<Arc<dyn SessionStore>>,
+    pub(crate) session_id: Option<String>,
+    pub(crate) session_branch: String,
+    pub(crate) skill_catalog: Option<Arc<dyn SkillCatalog>>,
+    pub(crate) skill_allowed_tools: Option<Vec<String>>,
+    pub(crate) session_loaded_messages: usize,
+    pub(crate) session_loaded_completion_calls: usize,
+    pub(crate) session_correlation_id: String,
+    pub(crate) control: RunControlHandle,
+    pub(crate) run_context: RunContext,
+}
+
+fn skill_catalog_preamble(catalog: Option<&dyn SkillCatalog>) -> Option<String> {
+    let entries = catalog?.list();
+    if entries.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "\n\nAvailable skills (activate before detailed instructions are disclosed):\n{}",
+        entries
+            .into_iter()
+            .map(|(name, description)| format!("- {name}: {description}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    ))
 }
 
 impl<M> AgentRunner<M>
@@ -300,6 +336,11 @@ where
     /// Build a runner from an agent, seeding it with the agent's default hook
     /// stack. Prefer [`Agent::runner`].
     pub fn from_agent(agent: &Agent<M>, prompt: impl Into<Message>) -> Self {
+        let deadline = agent
+            .default_run_deadline
+            .and_then(|duration| std::time::Instant::now().checked_add(duration));
+        let (control, run_context) =
+            RunControlHandle::new(agent.default_conversation_id.clone(), deadline);
         Self {
             prompt: prompt.into(),
             chat_history: None,
@@ -307,11 +348,21 @@ where
             max_invalid_tool_call_retries: 0,
             model: agent.model.clone(),
             agent_name: agent.name.clone(),
-            preamble: agent.preamble.clone(),
+            preamble: agent.preamble.clone().map_or_else(
+                || skill_catalog_preamble(agent.skill_catalog.as_deref()),
+                |base| {
+                    Some(format!(
+                        "{base}{}",
+                        skill_catalog_preamble(agent.skill_catalog.as_deref()).unwrap_or_default()
+                    ))
+                },
+            ),
             static_context: agent.static_context.clone(),
             temperature: agent.temperature,
             max_tokens: agent.max_tokens,
             additional_params: agent.additional_params.clone(),
+            provider_tools: agent.provider_tools.clone(),
+            nested_tool_policy: agent.nested_tool_policy.clone(),
             tool_server_handle: agent.tool_server_handle.clone(),
             tool_extensions: ToolCallExtensions::new(),
             dynamic_context: agent.dynamic_context.clone(),
@@ -322,7 +373,52 @@ where
             memory: agent.memory.clone(),
             conversation_id: agent.default_conversation_id.clone(),
             hooks: agent.hooks.clone(),
+            session_store: agent.session_store.clone(),
+            session_id: agent.session_id.clone(),
+            session_branch: agent.session_branch.clone(),
+            skill_catalog: agent.skill_catalog.clone(),
+            skill_allowed_tools: None,
+            session_loaded_messages: 0,
+            session_loaded_completion_calls: 0,
+            session_correlation_id: run_context.run_id().to_string(),
+            control,
+            run_context,
         }
+    }
+
+    /// Activate a skill for this run. Its detailed instructions are disclosed
+    /// only now, and its tool allow-list is intersected with every active skill.
+    pub fn skill(mut self, name: &str) -> Result<Self, String> {
+        let skill = self
+            .skill_catalog
+            .as_ref()
+            .and_then(|catalog| catalog.activate(name))
+            .ok_or_else(|| format!("unknown skill `{name}`"))?;
+        let provenance = format!("{:?}", skill.provenance);
+        let guidance = format!(
+            "\n\nActivated skill `{}` ({provenance}):\n{}",
+            skill.name, skill.instructions
+        );
+        self.preamble
+            .get_or_insert_with(String::new)
+            .push_str(&guidance);
+        let allowed = match self.skill_allowed_tools.take() {
+            None => skill.allowed_tools,
+            Some(previous) => previous
+                .into_iter()
+                .filter(|tool| skill.allowed_tools.contains(tool))
+                .collect(),
+        };
+        let allowed_set = allowed
+            .iter()
+            .cloned()
+            .collect::<std::collections::HashSet<_>>();
+        self.nested_tool_policy.allowlist = Some(match self.nested_tool_policy.allowlist.take() {
+            Some(existing) => existing.intersection(&allowed_set).cloned().collect(),
+            None => allowed_set,
+        });
+        self.skill_allowed_tools = Some(allowed);
+        Ok(self)
     }
 
     /// Append a hook to the stack (on top of any the agent already carries).
@@ -360,6 +456,17 @@ where
     /// without the model ever seeing them. Replaces any extensions already set.
     pub fn tool_extensions(mut self, extensions: ToolCallExtensions) -> Self {
         self.tool_extensions = extensions;
+        self
+    }
+
+    /// Inherit runtime identity and control from nested agent execution.
+    pub(crate) fn inherit_runtime(
+        mut self,
+        control: RunControlHandle,
+        context: RunContext,
+    ) -> Self {
+        self.control = control;
+        self.run_context = context;
         self
     }
 
@@ -401,14 +508,37 @@ where
 
     /// Set the conversation id used to load and persist memory for this run.
     pub fn conversation(mut self, id: impl Into<String>) -> Self {
-        self.conversation_id = Some(id.into());
+        let id = id.into();
+        self.conversation_id = Some(id.clone());
+        self.run_context = self.run_context.with_conversation(Some(id));
         self
+    }
+
+    /// Set a wall-clock deadline relative to now for this run.
+    pub fn deadline(mut self, duration: std::time::Duration) -> Self {
+        self.run_context = self
+            .run_context
+            .with_deadline(std::time::Instant::now().checked_add(duration));
+        self
+    }
+
+    /// Returns the cloneable control handle before the runner is consumed.
+    pub fn control_handle(&self) -> RunControlHandle {
+        self.control.clone()
     }
 
     /// Disable conversation memory for this run (no load, no save).
     pub fn without_memory(mut self) -> Self {
         self.memory = None;
         self.conversation_id = None;
+        self.run_context = self.run_context.with_conversation(None);
+        self
+    }
+
+    /// Set the bounded budget for model-regenerated tool names/arguments.
+    /// Every repair also consumes the shared model-turn budget.
+    pub fn max_tool_repairs(mut self, repairs: usize) -> Self {
+        self.max_invalid_tool_call_retries = repairs;
         self
     }
 
@@ -540,22 +670,120 @@ where
     }
 }
 
-/// Append a finished run's messages to conversation memory, logging and
-/// proceeding on failure. Shared `Done`-arm behavior for both drivers.
+/// Append a finished run's messages to conversation memory. Persistence is
+/// part of successful settlement, so failures propagate to both surfaces.
 pub(crate) async fn append_run_messages(
     memory_handle: Option<&(Arc<dyn ConversationMemory>, String)>,
     messages: &[Message],
-) {
-    // Clone into an owned vec only when there is a backend to append to — the
-    // common no-memory path pays nothing.
-    if let Some((memory, id)) = memory_handle
-        && let Err(err) = memory.append(id, messages.to_vec()).await
-    {
-        tracing::warn!(
-            error = %err,
-            conversation_id = %id,
-            "conversation memory append failed; surfacing final response anyway"
-        );
+) -> Result<(), crate::memory::MemoryError> {
+    if let Some((memory, id)) = memory_handle {
+        memory.append(id, messages.to_vec()).await?;
+    }
+    Ok(())
+}
+
+struct RunnerScopedDispatch<M>
+where
+    M: CompletionModel,
+{
+    hooks: HookStack<M>,
+    context: HookContext,
+}
+
+impl<M> ScopedToolDispatch for RunnerScopedDispatch<M>
+where
+    M: CompletionModel + 'static,
+{
+    fn dispatch<'a>(
+        &'a self,
+        server: &'a ToolServerHandle,
+        extensions: ToolCallExtensions,
+        context: RunContext,
+        name: &'a str,
+        args: &'a str,
+        internal_call_id: &'a str,
+        parent_internal_call_id: Option<&'a str>,
+    ) -> WasmBoxedFuture<'a, ToolExecutionResult> {
+        Box::pin(async move {
+            let span = new_execute_tool_span();
+            async move {
+                let (flow, salvaged) = self
+                    .hooks
+                    .resolve_tool_call(
+                        &self.context,
+                        name,
+                        None,
+                        internal_call_id,
+                        parent_internal_call_id,
+                        args,
+                    )
+                    .await;
+                let mut effective_args = salvaged
+                    .map(|value| json_utils::value_to_json_string(&value))
+                    .unwrap_or_else(|| args.to_string());
+                let mut result = match flow_into_tool_call(flow) {
+                    ToolCallDecision::Terminate(reason) => ToolExecutionResult::failed(
+                        reason.clone(),
+                        crate::tool::ToolFailure::cancelled(reason),
+                    ),
+                    ToolCallDecision::Skip(reason) => ToolExecutionResult::skipped(reason),
+                    ToolCallDecision::ProceedWith(value) => {
+                        effective_args = json_utils::value_to_json_string(&value);
+                        server
+                            .call_tool_structured(name, &effective_args, &extensions)
+                            .await
+                    }
+                    ToolCallDecision::Proceed => {
+                        server
+                            .call_tool_structured(name, &effective_args, &extensions)
+                            .await
+                    }
+                };
+                let decision = flow_into_tool_result(
+                    self.hooks
+                        .on_event(
+                            &self.context,
+                            StepEvent::ToolResult {
+                                tool_name: name,
+                                tool_call_id: None,
+                                internal_call_id,
+                                parent_internal_call_id,
+                                args: &effective_args,
+                                result: result.model_output(),
+                                outcome: result.outcome(),
+                                extensions: result.extensions(),
+                            },
+                        )
+                        .await,
+                );
+                match decision {
+                    ToolResultDecision::Keep => {}
+                    ToolResultDecision::Replace(replacement) => {
+                        result.model_output = replacement;
+                        result.content = None;
+                    }
+                    ToolResultDecision::Terminate(reason) => {
+                        result = ToolExecutionResult::failed(
+                            reason.clone(),
+                            crate::tool::ToolFailure::cancelled(reason),
+                        );
+                    }
+                }
+                let current = tracing::Span::current();
+                current.record("gen_ai.tool.name", name);
+                current.record(
+                    "gen_ai.tool.call.parent_internal_id",
+                    parent_internal_call_id,
+                );
+                current.record("gen_ai.tool.call.arguments", &effective_args);
+                current.record("gen_ai.tool.call.result", result.model_output());
+                record_tool_outcome(&current, result.outcome());
+                let _ = context;
+                result
+            }
+            .instrument(span)
+            .await
+        })
     }
 }
 
@@ -580,8 +808,12 @@ pub(crate) struct ToolCallOutcome {
     /// The tool result delivered to the model (a real output, a redacted
     /// replacement, or a hook skip reason).
     pub content: UserContent,
+    /// Effective model-visible string used for final-result tools.
+    pub model_output: String,
     /// How the call resolved: executed (with the effective tool call) or skipped.
     pub execution: ToolExecution,
+    /// Structured execution outcome retained for durable lifecycle records.
+    pub outcome: ToolOutcome,
 }
 
 /// Execute a single tool call, firing the `ToolCall` and `ToolResult` hooks and
@@ -592,17 +824,20 @@ pub(crate) struct ToolCallOutcome {
 /// ([`tool_result_output`]). Records `gen_ai.tool.*` on the current span;
 /// `error_history` builds a cancellation error if a hook terminates the run.
 /// Returns whether the tool body executed via [`ToolCallOutcome::execution`].
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn run_single_tool<M>(
     hooks: &HookStack<M>,
     ctx: &HookContext,
     tool_server: &ToolServerHandle,
     tool_extensions: &ToolCallExtensions,
+    run_context: &RunContext,
+    nested_tool_policy: &NestedToolPolicy,
     tool_call: &ToolCall,
     internal_call_id: &str,
     error_history: &[Message],
 ) -> Result<ToolCallOutcome, PromptError>
 where
-    M: CompletionModel,
+    M: CompletionModel + 'static,
 {
     let tool_name = &tool_call.function.name;
     // `mut` so a `Flow::RewriteArgs` hook can rewrite the arguments the tool
@@ -612,6 +847,9 @@ where
     let tool_span = tracing::Span::current();
     tool_span.record("gen_ai.tool.name", tool_name);
     tool_span.record("gen_ai.tool.call.id", &tool_call.id);
+    if let Some(parent) = run_context.current_call_id() {
+        tool_span.record("gen_ai.tool.call.parent_internal_id", parent);
+    }
     tool_span.record("gen_ai.tool.call.arguments", &args);
 
     // Resolve the `ToolCall` hook chain. A proceeding chain carries any
@@ -626,6 +864,7 @@ where
             tool_name,
             tool_call.call_id.as_deref(),
             internal_call_id,
+            run_context.current_call_id(),
             &args,
         )
         .await;
@@ -686,8 +925,23 @@ where
         None => {
             let mut effective_tool_call = tool_call.clone();
             effective_tool_call.function.arguments = effective_args;
+            let mut call_extensions = tool_extensions.clone();
+            let child_context =
+                run_context.child(tool_name.to_string(), internal_call_id.to_string());
+            let nested = ScopedToolExecutor::new(
+                tool_server.clone(),
+                call_extensions.clone(),
+                child_context.clone(),
+                nested_tool_policy.clone(),
+                Some(Arc::new(RunnerScopedDispatch {
+                    hooks: hooks.clone(),
+                    context: ctx.clone(),
+                })),
+            );
+            call_extensions.insert(child_context);
+            call_extensions.insert(nested);
             let exec = tool_server
-                .call_tool_structured(tool_name, &args, tool_extensions)
+                .call_tool_structured(tool_name, &args, &call_extensions)
                 .await;
             (exec, ToolExecution::Executed(Box::new(effective_tool_call)))
         }
@@ -705,6 +959,7 @@ where
     // tool-end / model-visible output for the same reason.) The hook still
     // observes the tool's actual output via `result` and the structured
     // classification via `outcome` / `extensions`.
+    let structured_outcome = exec.outcome.clone();
     match flow_into_tool_result(
         hooks
             .on_event(
@@ -713,6 +968,7 @@ where
                     tool_name,
                     tool_call_id: tool_call.call_id.as_deref(),
                     internal_call_id,
+                    parent_internal_call_id: run_context.current_call_id(),
                     // The first result hook observes the tool's actual output,
                     // before any `RewriteResult` replacement is applied below.
                     args: &args,
@@ -745,12 +1001,18 @@ where
             tool_span.record("gen_ai.tool.call.result", &replacement);
             tracing::info!("tool {tool_name} with args {args}; result rewritten by a hook");
             Ok(ToolCallOutcome {
-                content: tool_result_message(
-                    tool_call.id.clone(),
-                    tool_call.call_id.clone(),
-                    replacement,
+                content: with_tool_result_correlation(
+                    tool_result_message(
+                        tool_call.id.clone(),
+                        tool_call.call_id.clone(),
+                        replacement.clone(),
+                    ),
+                    internal_call_id,
+                    run_context.current_call_id(),
                 ),
+                model_output: replacement,
                 execution,
+                outcome: structured_outcome,
             })
         }
         ToolResultDecision::Keep => {
@@ -770,12 +1032,15 @@ where
                     exec.model_output
                 );
             }
+            let model_output = exec.model_output.clone();
             let content = if synthetic {
                 tool_result_message(
                     tool_call.id.clone(),
                     tool_call.call_id.clone(),
                     exec.model_output,
                 )
+            } else if let Some(rich) = exec.content {
+                tool_result_content(tool_call.id.clone(), tool_call.call_id.clone(), rich)
             } else {
                 tool_result_output(
                     tool_call.id.clone(),
@@ -783,8 +1048,47 @@ where
                     exec.model_output,
                 )
             };
-            Ok(ToolCallOutcome { content, execution })
+            Ok(ToolCallOutcome {
+                content: with_tool_result_correlation(
+                    content,
+                    internal_call_id,
+                    run_context.current_call_id(),
+                ),
+                model_output,
+                execution,
+                outcome: structured_outcome,
+            })
         }
+    }
+}
+
+fn correlate_tool_calls(
+    choice: crate::OneOrMany<crate::message::AssistantContent>,
+    parent_internal_call_id: Option<&str>,
+) -> crate::OneOrMany<crate::message::AssistantContent> {
+    crate::OneOrMany::from_iter_optional(choice.into_iter().map(|part| match part {
+        crate::message::AssistantContent::ToolCall(mut call) => {
+            call.internal_call_id = Some(crate::id::generate());
+            call.parent_internal_call_id = parent_internal_call_id.map(str::to_owned);
+            crate::message::AssistantContent::ToolCall(call)
+        }
+        other => other,
+    }))
+    .unwrap_or_else(|| crate::OneOrMany::one(crate::message::AssistantContent::text("")))
+}
+
+fn with_tool_result_correlation(
+    content: UserContent,
+    internal_call_id: &str,
+    parent_internal_call_id: Option<&str>,
+) -> UserContent {
+    match content {
+        UserContent::ToolResult(mut result) => {
+            result.internal_call_id = Some(internal_call_id.to_owned());
+            result.parent_internal_call_id = parent_internal_call_id.map(str::to_owned);
+            UserContent::ToolResult(result)
+        }
+        other => other,
     }
 }
 
@@ -812,6 +1116,7 @@ pub(crate) fn new_execute_tool_span() -> tracing::Span {
         gen_ai.tool.type = "function",
         gen_ai.tool.name = tracing::field::Empty,
         gen_ai.tool.call.id = tracing::field::Empty,
+        gen_ai.tool.call.parent_internal_id = tracing::field::Empty,
         gen_ai.tool.call.arguments = tracing::field::Empty,
         gen_ai.tool.call.result = tracing::field::Empty,
         gen_ai.tool.call.outcome = tracing::field::Empty,
@@ -859,7 +1164,7 @@ impl UnaryTurnSource {
 
 impl<M> TurnSource<M> for UnaryTurnSource
 where
-    M: CompletionModel,
+    M: CompletionModel + 'static,
 {
     type Raw = M::Response;
 
@@ -891,13 +1196,17 @@ where
                 }
             };
 
+            let choice = correlate_tool_calls(
+                resp.choice.clone(),
+                runner.run_context.current_call_id(),
+            );
             let mut outcome = match run.model_response(ModelTurn::new(
                 resp.message_id.clone(),
-                resp.choice.clone(),
+                choice,
                 resp.usage,
                 prepared.executable_tool_names,
                 prepared.allowed_tool_names,
-            )) {
+            ).with_finish_reason(resp.finish_reason.clone(), resp.raw_finish_reason.clone())) {
                 Ok(outcome) => outcome,
                 Err(err) => {
                     yield Err(Box::new(err).into());
@@ -1016,12 +1325,12 @@ where
 
 impl<M> AgentRunner<M>
 where
-    M: CompletionModel,
+    M: CompletionModel + 'static,
 {
     /// Drive the agent loop to completion, returning the aggregated
     /// [`PromptResponse`]. Hooks fire at every observable point; the first hook
     /// to terminate cancels the run.
-    pub async fn run(self) -> Result<PromptResponse, PromptError> {
+    pub async fn run(mut self) -> Result<PromptResponse, PromptError> {
         let (agent_span, created_agent_span) =
             acquire_agent_span(self.agent_name_or_default(), self.preamble.as_deref());
 
@@ -1032,18 +1341,102 @@ where
         // When the caller passes explicit history, memory is fully bypassed for
         // this run (no load AND no save). Otherwise, if a memory backend and
         // conversation id are both configured, load prior history.
-        let (history_override, memory_handle) = match &self.chat_history {
+        let (mut history_override, memory_handle) = match &self.chat_history {
             Some(_) => (None, None),
             None => match (&self.memory, &self.conversation_id) {
-                (Some(memory), Some(id)) => {
-                    let loaded = memory.load(id).await?;
-                    (Some(loaded), Some((memory.clone(), id.clone())))
-                }
+                (Some(memory), Some(id)) => match memory.load(id).await {
+                    Ok(loaded) => (Some(loaded), Some((memory.clone(), id.clone()))),
+                    Err(err) => {
+                        self.control.finish(crate::runtime::TerminalReason::Failed);
+                        return Err(err.into());
+                    }
+                },
                 _ => (None, None),
             },
         };
 
-        let run = self.build_run(history_override);
+        let mut resumed_run = None;
+        if history_override.is_none()
+            && let (Some(store), Some(session_id)) = (&self.session_store, &self.session_id)
+        {
+            let events = match store.load(session_id, &self.session_branch).await {
+                Ok(events) => events,
+                Err(error) => {
+                    self.control.finish(crate::runtime::TerminalReason::Failed);
+                    return Err(error.into());
+                }
+            };
+            let mut messages = Vec::new();
+            let mut recovery_snapshot = None;
+            let mut recovery_correlation = None;
+            let mut unsafe_interruption = false;
+            for event in &events {
+                match &event.kind {
+                    SessionEventKind::Message(message) => messages.push(message.clone()),
+                    SessionEventKind::Checkpoint { snapshot } => {
+                        recovery_snapshot = Some(snapshot.clone());
+                        recovery_correlation = event.correlation_id.clone();
+                        unsafe_interruption = false;
+                    }
+                    SessionEventKind::Interrupted { checkpoint, run_id } => {
+                        unsafe_interruption = checkpoint.is_none();
+                        if let Some(checkpoint) = checkpoint {
+                            recovery_snapshot = Some(checkpoint.clone());
+                            recovery_correlation = Some(run_id.clone());
+                        }
+                    }
+                    SessionEventKind::Lifecycle { status, .. } if status == "completed" => {
+                        recovery_snapshot = None;
+                        recovery_correlation = None;
+                        unsafe_interruption = false;
+                    }
+                    _ => {}
+                }
+            }
+            if let Some(correlation) = recovery_correlation {
+                self.session_correlation_id = correlation.clone();
+                self.session_loaded_messages = events
+                    .iter()
+                    .filter(|event| {
+                        event.correlation_id.as_deref() == Some(correlation.as_str())
+                            && matches!(&event.kind, SessionEventKind::Message(_))
+                    })
+                    .count();
+                self.session_loaded_completion_calls = events
+                    .iter()
+                    .filter(|event| {
+                        event.correlation_id.as_deref() == Some(correlation.as_str())
+                            && matches!(&event.kind, SessionEventKind::ModelResponse { .. })
+                    })
+                    .count();
+            }
+            if unsafe_interruption {
+                self.control.finish(crate::runtime::TerminalReason::Failed);
+                return Err(crate::session::SessionError::UnsafeRecovery.into());
+            }
+            if let Some(snapshot) = recovery_snapshot {
+                let restored: AgentRun = match serde_json::from_str(&snapshot) {
+                    Ok(restored) => restored,
+                    Err(error) => {
+                        self.control.finish(crate::runtime::TerminalReason::Failed);
+                        return Err(crate::session::SessionError::InvalidCheckpoint(
+                            error.to_string(),
+                        )
+                        .into());
+                    }
+                };
+                if !restored.is_safe_checkpoint() {
+                    self.control.finish(crate::runtime::TerminalReason::Failed);
+                    return Err(crate::session::SessionError::UnsafeRecovery.into());
+                }
+                resumed_run = Some(restored);
+            }
+            if !messages.is_empty() {
+                history_override = Some(messages);
+            }
+        }
+
+        let run = resumed_run.unwrap_or_else(|| self.build_run(history_override));
 
         // Fold the shared engine to its final response. The blocking surface
         // uses a unary model transport and ignores the intermediate items the
@@ -1062,12 +1455,16 @@ where
         futures::pin_mut!(driver);
 
         let mut response = None;
+        let mut terminal_error = None;
         while let Some(item) = driver.next().await {
             match item {
                 Ok(DriveItem::Done(done)) => response = Some(*done),
                 Ok(DriveItem::Item(_)) => {}
-                Err(err) => return Err(streaming_error_into_prompt(err)),
+                Err(err) => terminal_error = Some(streaming_error_into_prompt(err)),
             }
+        }
+        if let Some(error) = terminal_error {
+            return Err(error);
         }
 
         // The engine yields `Done` unless it errored (handled above).
@@ -1099,8 +1496,8 @@ mod tests {
     use crate::message::{AssistantContent, ToolCall, ToolChoice, ToolFunction, UserContent};
     use crate::streaming::{StreamedAssistantContent, StreamedUserContent, StreamingPrompt};
     use crate::test_utils::{
-        MockAddTool, MockBarrierTool, MockCompletionModel, MockOperationArgs, MockStreamEvent,
-        MockSubtractTool, MockToolError, MockTurn,
+        MockAddTool, MockBarrierTool, MockCompletionModel, MockDeniedTool, MockOperationArgs,
+        MockResponse, MockStreamEvent, MockSubtractTool, MockToolError, MockTurn,
     };
     use crate::tool::Tool;
 
@@ -1326,16 +1723,83 @@ mod tests {
         assert_eq!(blocking_hook.tool_results(), streaming_hook.tool_results());
         assert_eq!(blocking_hook.tool_results(), vec!["5".to_string()]);
 
-        // Same final message history (compared via serialized form to normalize).
+        // Both surfaces preserve exact Rig correlation from call to result.
         let blocking_messages = blocking.messages.expect("blocking messages");
         let streaming_messages = final_response
             .messages()
             .expect("streaming history")
             .to_vec();
+        fn assert_exact_correlation(messages: &[Message]) {
+            let call = messages
+                .iter()
+                .find_map(|message| match message {
+                    Message::Assistant { content, .. } => {
+                        content.iter().find_map(|part| match part {
+                            AssistantContent::ToolCall(call) => Some(call),
+                            _ => None,
+                        })
+                    }
+                    _ => None,
+                })
+                .expect("tool call");
+            let result = messages
+                .iter()
+                .find_map(|message| match message {
+                    Message::User { content } => content.iter().find_map(|part| match part {
+                        UserContent::ToolResult(result) => Some(result),
+                        _ => None,
+                    }),
+                    _ => None,
+                })
+                .expect("tool result");
+            assert!(call.internal_call_id.is_some());
+            assert_eq!(result.internal_call_id, call.internal_call_id);
+            assert_eq!(result.parent_internal_call_id, call.parent_internal_call_id);
+            assert_ne!(call.internal_call_id.as_deref(), call.call_id.as_deref());
+        }
+        assert_exact_correlation(&blocking_messages);
+        assert_exact_correlation(&streaming_messages);
+    }
+
+    #[tokio::test]
+    async fn normalized_and_raw_finish_metadata_have_unary_streaming_parity() {
+        let unary = AgentBuilder::new(MockCompletionModel::from_turns([MockTurn::text("done")
+            .with_finish_reason(crate::runtime::TerminalReason::MaxTokens, "length")]))
+        .build()
+        .runner("go")
+        .run()
+        .await
+        .unwrap();
+        let mut stream = AgentBuilder::new(MockCompletionModel::from_stream_turns([[
+            MockStreamEvent::text("done"),
+            MockStreamEvent::FinalResponse(
+                MockResponse::new()
+                    .with_finish_reason(crate::runtime::TerminalReason::MaxTokens, "length"),
+            ),
+        ]]))
+        .build()
+        .runner("go")
+        .stream()
+        .await;
+        let mut streamed = None;
+        while let Some(item) = stream.next().await {
+            if let MultiTurnStreamItem::FinalResponse(response) = item.unwrap() {
+                streamed = Some(response);
+            }
+        }
+        let streamed = streamed.unwrap();
+        assert_eq!(unary.completion_calls, streamed.completion_calls().to_vec());
         assert_eq!(
-            serde_json::to_value(&blocking_messages).expect("serialize blocking"),
-            serde_json::to_value(&streaming_messages).expect("serialize streaming"),
+            unary.completion_calls[0].finish_reason,
+            Some(crate::runtime::TerminalReason::MaxTokens)
         );
+        assert_eq!(
+            unary.completion_calls[0].raw_finish_reason.as_deref(),
+            Some("length")
+        );
+        let round_trip: crate::agent::prompt_request::PromptResponse =
+            serde_json::from_value(serde_json::to_value(&unary).unwrap()).unwrap();
+        assert_eq!(round_trip.completion_calls, unary.completion_calls);
     }
 
     /// Structured tool-execution results reach `StepEvent::ToolResult` as machine
@@ -2465,6 +2929,29 @@ mod tests {
         })
     }
 
+    fn without_rig_correlation<T: serde::Serialize>(value: &T) -> serde_json::Value {
+        fn strip(value: &mut serde_json::Value) {
+            match value {
+                serde_json::Value::Object(map) => {
+                    map.remove("internal_call_id");
+                    map.remove("parent_internal_call_id");
+                    for child in map.values_mut() {
+                        strip(child);
+                    }
+                }
+                serde_json::Value::Array(values) => {
+                    for child in values {
+                        strip(child);
+                    }
+                }
+                _ => {}
+            }
+        }
+        let mut value = serde_json::to_value(value).expect("serialize messages");
+        strip(&mut value);
+        value
+    }
+
     /// Even with `run()` executing tools concurrently, the tool-result order —
     /// and so the whole message history — matches the sequential streaming
     /// driver. (`run()` runs tools with `buffer_unordered` but writes each result
@@ -2523,8 +3010,8 @@ mod tests {
             .expect("streaming history")
             .to_vec();
         assert_eq!(
-            serde_json::to_value(&blocking_messages).expect("serialize blocking"),
-            serde_json::to_value(&streaming_messages).expect("serialize streaming"),
+            without_rig_correlation(&blocking_messages),
+            without_rig_correlation(&streaming_messages),
         );
     }
 
@@ -2696,8 +3183,8 @@ mod tests {
             .expect("streaming history")
             .to_vec();
         assert_eq!(
-            serde_json::to_value(&blocking_messages).expect("serialize blocking"),
-            serde_json::to_value(&streaming_messages).expect("serialize streaming"),
+            without_rig_correlation(&blocking_messages),
+            without_rig_correlation(&streaming_messages),
         );
     }
 
@@ -4094,8 +4581,8 @@ mod tests {
             .expect("streaming history")
             .to_vec();
         assert_eq!(
-            serde_json::to_value(&blocking_messages).expect("serialize blocking"),
-            serde_json::to_value(&streaming_messages).expect("serialize streaming"),
+            without_rig_correlation(&blocking_messages),
+            without_rig_correlation(&streaming_messages),
         );
     }
 
@@ -4282,8 +4769,8 @@ mod tests {
             "{label}: tool-result content diverged"
         );
         assert_eq!(
-            serde_json::to_value(&blocking.messages).expect("serialize blocking"),
-            serde_json::to_value(&streaming.messages).expect("serialize streaming"),
+            without_rig_correlation(&blocking.messages),
+            without_rig_correlation(&streaming.messages),
             "{label}: message history diverged"
         );
     }
@@ -4441,8 +4928,8 @@ mod tests {
             .expect("streaming history")
             .to_vec();
         assert_eq!(
-            serde_json::to_value(&blocking_messages).expect("serialize blocking"),
-            serde_json::to_value(&streaming_messages).expect("serialize streaming"),
+            without_rig_correlation(&blocking_messages),
+            without_rig_correlation(&streaming_messages),
         );
         // Pin the actual reason, not just blocking == streaming (see the valid-tool
         // skip test): a reason dropped or altered on BOTH paths would still pass.
@@ -4683,8 +5170,8 @@ mod tests {
             .expect("streaming history")
             .to_vec();
         assert_eq!(
-            serde_json::to_value(&blocking_messages).expect("serialize blocking"),
-            serde_json::to_value(&streaming_messages).expect("serialize streaming"),
+            without_rig_correlation(&blocking_messages),
+            without_rig_correlation(&streaming_messages),
         );
         // Pin the actual reason, not just blocking == streaming: a reason dropped
         // or altered on BOTH paths would still satisfy the equality above.
@@ -4929,8 +5416,8 @@ mod tests {
             .expect("streaming history")
             .to_vec();
         assert_eq!(
-            serde_json::to_value(&blocking_messages).expect("serialize blocking"),
-            serde_json::to_value(&streaming_messages).expect("serialize streaming"),
+            without_rig_correlation(&blocking_messages),
+            without_rig_correlation(&streaming_messages),
         );
         assert!(
             tool_result_text_in_history(&blocking_messages, "redacted-result"),
@@ -6013,8 +6500,8 @@ mod tests {
             .expect("streaming history")
             .to_vec();
         assert_eq!(
-            serde_json::to_value(&blocking_messages).expect("serialize blocking"),
-            serde_json::to_value(&streaming_messages).expect("serialize streaming"),
+            without_rig_correlation(&blocking_messages),
+            without_rig_correlation(&streaming_messages),
         );
         assert!(
             tool_result_text_in_history(&blocking_messages, denial),
@@ -6196,6 +6683,507 @@ mod tests {
         assert!(
             tool_result_text_in_history(&messages, "denied by policy: `subtract` not allowed"),
             "the policy denial reason must reach the model as the subtract tool result"
+        );
+    }
+
+    #[derive(Clone, Default)]
+    struct RecordingSessionStore(Arc<std::sync::Mutex<Vec<crate::session::SessionEvent>>>);
+
+    impl RecordingSessionStore {
+        fn events(&self) -> Vec<crate::session::SessionEvent> {
+            self.0.lock().unwrap().clone()
+        }
+    }
+
+    impl crate::session::SessionStore for RecordingSessionStore {
+        fn load<'a>(
+            &'a self,
+            session: &'a str,
+            branch: &'a str,
+        ) -> crate::wasm_compat::WasmBoxedFuture<
+            'a,
+            Result<Vec<crate::session::SessionEvent>, crate::session::SessionError>,
+        > {
+            Box::pin(async move {
+                Ok(self
+                    .events()
+                    .into_iter()
+                    .filter(|event| event.session_id == session && event.branch == branch)
+                    .collect())
+            })
+        }
+
+        fn append<'a>(
+            &'a self,
+            session: &'a str,
+            branch: &'a str,
+            parent_sequence: Option<u64>,
+            correlation_id: Option<String>,
+            kind: crate::session::SessionEventKind,
+        ) -> crate::wasm_compat::WasmBoxedFuture<
+            'a,
+            Result<crate::session::SessionEvent, crate::session::SessionError>,
+        > {
+            Box::pin(async move {
+                let mut events = self.0.lock().unwrap();
+                let sequence = events
+                    .iter()
+                    .filter(|event| event.session_id == session && event.branch == branch)
+                    .count() as u64;
+                let event = crate::session::SessionEvent {
+                    session_id: session.into(),
+                    branch: branch.into(),
+                    sequence,
+                    parent_sequence,
+                    correlation_id,
+                    kind,
+                };
+                events.push(event.clone());
+                Ok(event)
+            })
+        }
+
+        fn branch<'a>(
+            &'a self,
+            _: &'a str,
+            _: &'a str,
+            _: &'a str,
+            _: u64,
+        ) -> crate::wasm_compat::WasmBoxedFuture<'a, Result<(), crate::session::SessionError>>
+        {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    #[tokio::test]
+    async fn sequential_session_runs_persist_each_run_without_cross_run_deduplication() {
+        let store = RecordingSessionStore::default();
+        let model = MockCompletionModel::from_turns([
+            MockTurn::text("first")
+                .with_finish_reason(crate::runtime::TerminalReason::MaxTokens, "MAX_TOKENS"),
+            MockTurn::text("second"),
+        ]);
+        let agent = AgentBuilder::new(model)
+            .session(store.clone(), "session")
+            .build();
+        assert_eq!(agent.runner("one").run().await.unwrap().output, "first");
+        assert_eq!(agent.runner("two").run().await.unwrap().output, "second");
+
+        let events = store.events();
+        let completed = events
+            .iter()
+            .filter(|event| matches!(&event.kind, crate::session::SessionEventKind::Lifecycle { status, .. } if status == "completed"))
+            .count();
+        assert_eq!(completed, 2);
+        assert!(
+            events.iter().all(|event| !matches!(
+                event.kind,
+                crate::session::SessionEventKind::Interrupted { .. }
+            )),
+            "successful non-Completed terminal reasons must not be marked interrupted"
+        );
+        let correlations = events
+            .iter()
+            .filter_map(|event| event.correlation_id.clone())
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(correlations.len(), 2);
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(
+                    event.kind,
+                    crate::session::SessionEventKind::ModelResponse { .. }
+                ))
+                .count(),
+            2
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event.kind, crate::session::SessionEventKind::Message(_)))
+                .count(),
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn session_events_follow_lifecycle_order_and_preserve_denied_outcome() {
+        let store = RecordingSessionStore::default();
+        let model = MockCompletionModel::from_turns([
+            MockTurn::tool_call("call-1", "guarded", json!({})),
+            MockTurn::text("done"),
+        ]);
+        AgentBuilder::new(model)
+            .tool(MockDeniedTool)
+            .session(store.clone(), "session")
+            .build()
+            .runner("go")
+            .max_turns(2)
+            .run()
+            .await
+            .unwrap();
+
+        let events = store.events();
+        let model_call = events
+            .iter()
+            .position(|event| {
+                matches!(
+                    event.kind,
+                    crate::session::SessionEventKind::ModelCall { .. }
+                )
+            })
+            .unwrap();
+        let model_response = events
+            .iter()
+            .position(|event| {
+                matches!(
+                    event.kind,
+                    crate::session::SessionEventKind::ModelResponse { .. }
+                )
+            })
+            .unwrap();
+        let tool_call = events
+            .iter()
+            .position(|event| {
+                matches!(
+                    event.kind,
+                    crate::session::SessionEventKind::ToolCall { .. }
+                )
+            })
+            .unwrap();
+        let tool_result = events
+            .iter()
+            .position(|event| matches!(&event.kind, crate::session::SessionEventKind::ToolResult { outcome, .. } if outcome == "denied"))
+            .expect("tool-side denial must retain its structured outcome");
+        let lifecycle = events
+            .iter()
+            .position(|event| matches!(&event.kind, crate::session::SessionEventKind::Lifecycle { status, .. } if status == "completed"))
+            .unwrap();
+        assert!(model_call < model_response);
+        assert!(model_response < tool_call);
+        assert!(tool_call < tool_result);
+        assert!(tool_result < lifecycle);
+    }
+
+    struct FailingSessionStore;
+    impl crate::session::SessionStore for FailingSessionStore {
+        fn load<'a>(
+            &'a self,
+            _: &'a str,
+            _: &'a str,
+        ) -> crate::wasm_compat::WasmBoxedFuture<
+            'a,
+            Result<Vec<crate::session::SessionEvent>, crate::session::SessionError>,
+        > {
+            Box::pin(async {
+                Err(crate::session::SessionError::Backend(
+                    "injected load failure".into(),
+                ))
+            })
+        }
+        fn append<'a>(
+            &'a self,
+            _: &'a str,
+            _: &'a str,
+            _: Option<u64>,
+            _: Option<String>,
+            _: crate::session::SessionEventKind,
+        ) -> crate::wasm_compat::WasmBoxedFuture<
+            'a,
+            Result<crate::session::SessionEvent, crate::session::SessionError>,
+        > {
+            Box::pin(async {
+                Err(crate::session::SessionError::Backend(
+                    "injected append failure".into(),
+                ))
+            })
+        }
+        fn branch<'a>(
+            &'a self,
+            _: &'a str,
+            _: &'a str,
+            _: &'a str,
+            _: u64,
+        ) -> crate::wasm_compat::WasmBoxedFuture<'a, Result<(), crate::session::SessionError>>
+        {
+            Box::pin(async {
+                Err(crate::session::SessionError::Backend(
+                    "injected branch failure".into(),
+                ))
+            })
+        }
+    }
+
+    struct InvalidCheckpointStore;
+    impl crate::session::SessionStore for InvalidCheckpointStore {
+        fn load<'a>(
+            &'a self,
+            session: &'a str,
+            branch: &'a str,
+        ) -> crate::wasm_compat::WasmBoxedFuture<
+            'a,
+            Result<Vec<crate::session::SessionEvent>, crate::session::SessionError>,
+        > {
+            Box::pin(async move {
+                Ok(vec![crate::session::SessionEvent {
+                    session_id: session.into(),
+                    branch: branch.into(),
+                    sequence: 0,
+                    parent_sequence: None,
+                    correlation_id: Some("run".into()),
+                    kind: crate::session::SessionEventKind::Checkpoint {
+                        snapshot: "not-json".into(),
+                    },
+                }])
+            })
+        }
+        fn append<'a>(
+            &'a self,
+            _: &'a str,
+            _: &'a str,
+            _: Option<u64>,
+            _: Option<String>,
+            _: crate::session::SessionEventKind,
+        ) -> crate::wasm_compat::WasmBoxedFuture<
+            'a,
+            Result<crate::session::SessionEvent, crate::session::SessionError>,
+        > {
+            Box::pin(async {
+                Err(crate::session::SessionError::Backend(
+                    "unexpected append".into(),
+                ))
+            })
+        }
+        fn branch<'a>(
+            &'a self,
+            _: &'a str,
+            _: &'a str,
+            _: &'a str,
+            _: u64,
+        ) -> crate::wasm_compat::WasmBoxedFuture<'a, Result<(), crate::session::SessionError>>
+        {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    struct AppendFailSessionStore;
+    impl crate::session::SessionStore for AppendFailSessionStore {
+        fn load<'a>(
+            &'a self,
+            _: &'a str,
+            _: &'a str,
+        ) -> crate::wasm_compat::WasmBoxedFuture<
+            'a,
+            Result<Vec<crate::session::SessionEvent>, crate::session::SessionError>,
+        > {
+            Box::pin(async { Ok(Vec::new()) })
+        }
+        fn append<'a>(
+            &'a self,
+            _: &'a str,
+            _: &'a str,
+            _: Option<u64>,
+            _: Option<String>,
+            _: crate::session::SessionEventKind,
+        ) -> crate::wasm_compat::WasmBoxedFuture<
+            'a,
+            Result<crate::session::SessionEvent, crate::session::SessionError>,
+        > {
+            Box::pin(async {
+                Err(crate::session::SessionError::Backend(
+                    "injected append failure".into(),
+                ))
+            })
+        }
+        fn branch<'a>(
+            &'a self,
+            _: &'a str,
+            _: &'a str,
+            _: &'a str,
+            _: u64,
+        ) -> crate::wasm_compat::WasmBoxedFuture<'a, Result<(), crate::session::SessionError>>
+        {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    struct AppendFailMemory;
+    impl crate::memory::ConversationMemory for AppendFailMemory {
+        fn load<'a>(
+            &'a self,
+            _: &'a str,
+        ) -> crate::wasm_compat::WasmBoxedFuture<'a, Result<Vec<Message>, crate::memory::MemoryError>>
+        {
+            Box::pin(async { Ok(Vec::new()) })
+        }
+
+        fn append<'a>(
+            &'a self,
+            _: &'a str,
+            _: Vec<Message>,
+        ) -> crate::wasm_compat::WasmBoxedFuture<'a, Result<(), crate::memory::MemoryError>>
+        {
+            Box::pin(async {
+                Err(crate::memory::MemoryError::Internal(
+                    "injected memory append failure".into(),
+                ))
+            })
+        }
+
+        fn clear<'a>(
+            &'a self,
+            _: &'a str,
+        ) -> crate::wasm_compat::WasmBoxedFuture<'a, Result<(), crate::memory::MemoryError>>
+        {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    #[tokio::test]
+    async fn memory_append_failure_is_typed_and_settles_unary_and_streaming() {
+        let agent = AgentBuilder::new(MockCompletionModel::text("done"))
+            .memory(AppendFailMemory)
+            .conversation("conversation")
+            .build();
+        let runner = agent.runner("go");
+        let control = runner.control_handle();
+        let error = runner.run().await.unwrap_err();
+        assert!(matches!(error, PromptError::MemoryError(_)));
+        assert_eq!(
+            control.status(),
+            crate::runtime::RunStatus::Terminal(crate::runtime::TerminalReason::Failed)
+        );
+
+        let agent = AgentBuilder::new(MockCompletionModel::from_stream_turns([[
+            MockStreamEvent::text("done"),
+            MockStreamEvent::final_response_with_total_tokens(0),
+        ]]))
+        .memory(AppendFailMemory)
+        .conversation("conversation")
+        .build();
+        let runner = agent.runner("go");
+        let control = runner.control_handle();
+        let mut stream = runner.stream().await;
+        let error = loop {
+            if let Some(Err(error)) = stream.next().await {
+                break error;
+            }
+        };
+        assert!(matches!(
+            error,
+            StreamingError::Prompt(error) if matches!(*error, PromptError::MemoryError(_))
+        ));
+        assert_eq!(
+            control.status(),
+            crate::runtime::RunStatus::Terminal(crate::runtime::TerminalReason::Failed)
+        );
+    }
+
+    #[tokio::test]
+    async fn unary_session_load_failure_is_typed_and_settles_control() {
+        let agent = AgentBuilder::new(MockCompletionModel::text("unused"))
+            .session(FailingSessionStore, "session")
+            .build();
+        let runner = agent.runner("go");
+        let control = runner.control_handle();
+        let error = runner.run().await.unwrap_err();
+        assert!(matches!(error, PromptError::SessionError(_)));
+        assert_eq!(
+            control.status(),
+            crate::runtime::RunStatus::Terminal(crate::runtime::TerminalReason::Failed)
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_durable_checkpoint_errors_without_starting_model() {
+        let model = MockCompletionModel::text("must not run");
+        let recorded = model.clone();
+        let error = AgentBuilder::new(model)
+            .session(InvalidCheckpointStore, "session")
+            .build()
+            .runner("go")
+            .run()
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            PromptError::SessionError(crate::session::SessionError::InvalidCheckpoint(_))
+        ));
+        assert_eq!(recorded.request_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn session_append_failure_is_typed_on_unary_and_streaming() {
+        let unary = AgentBuilder::new(MockCompletionModel::text("done"))
+            .session(AppendFailSessionStore, "session")
+            .build()
+            .runner("go")
+            .run()
+            .await
+            .unwrap_err();
+        assert!(matches!(unary, PromptError::SessionError(_)));
+
+        let mut stream = AgentBuilder::new(MockCompletionModel::from_stream_turns([[
+            MockStreamEvent::text("done"),
+            MockStreamEvent::final_response_with_total_tokens(0),
+        ]]))
+        .session(AppendFailSessionStore, "session")
+        .build()
+        .runner("go")
+        .stream()
+        .await;
+        let mut errors = Vec::new();
+        while let Some(item) = stream.next().await {
+            if let Err(error) = item {
+                errors.push(error);
+            }
+        }
+        assert_eq!(
+            errors.len(),
+            1,
+            "a failed Interrupted append must yield one terminal error without a fallback retry"
+        );
+        assert!(matches!(
+            errors.first(),
+            Some(StreamingError::Prompt(error))
+                if matches!(**error, PromptError::SessionError(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn activated_skill_discloses_instructions_and_narrows_tools() {
+        use crate::skills::{InMemorySkillCatalog, Skill, SkillProvenance};
+        let catalog = InMemorySkillCatalog::default();
+        catalog.insert(Skill {
+            name: "math".into(),
+            description: "safe math".into(),
+            instructions: "Only use approved arithmetic.".into(),
+            provenance: SkillProvenance::ProviderHosted("host-1".into()),
+            assets: vec![],
+            allowed_tools: vec!["add".into()],
+        });
+        let model = MockCompletionModel::text("done");
+        let recorded = model.clone();
+        let agent = AgentBuilder::new(model)
+            .tool(MockAddTool)
+            .tool(MockSubtractTool)
+            .skills(catalog)
+            .build();
+        let runner = agent.runner("calculate").skill("math").unwrap();
+        assert_eq!(
+            runner.nested_tool_policy.allowlist.as_ref().unwrap(),
+            &["add".to_string()].into_iter().collect()
+        );
+        runner.run().await.unwrap();
+        let request = recorded.requests().into_iter().next().unwrap();
+        assert!(request.chat_history.iter().any(|message| matches!(message, Message::System { content } if content.contains("Available skills") && content.contains("Only use approved arithmetic") && content.contains("ProviderHosted"))));
+        assert_eq!(
+            request
+                .tools
+                .iter()
+                .map(|tool| tool.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["add"]
         );
     }
 }

--- a/crates/rig-core/src/agent/tool.rs
+++ b/crates/rig-core/src/agent/tool.rs
@@ -52,9 +52,14 @@ impl<M: CompletionModel + 'static> Tool for Agent<M> {
         args: Self::Args,
         extensions: &ToolCallExtensions,
     ) -> Result<Self::Output, Self::Error> {
-        self.prompt(args.prompt)
-            .tool_extensions(extensions.clone())
-            .await
+        let mut request = self.prompt(args.prompt).tool_extensions(extensions.clone());
+        if let Some(context) = extensions.get::<crate::runtime::RunContext>() {
+            let child_control = crate::runtime::RunControlHandle::for_child_context(context);
+            request.runner = request
+                .runner
+                .inherit_runtime(child_control, context.clone());
+        }
+        request.await
     }
 
     fn name(&self) -> String {
@@ -66,7 +71,40 @@ impl<M: CompletionModel + 'static> Tool for Agent<M> {
 mod tests {
     use super::*;
     use crate::agent::AgentBuilder;
+    use crate::runtime::RunContext;
     use crate::test_utils::{MockCompletionModel, MockExtensionsProbeTool, MockTurn, SessionId};
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone)]
+    struct RuntimeProbe(Arc<Mutex<Option<RunContext>>>);
+
+    impl Tool for RuntimeProbe {
+        const NAME: &'static str = "runtime_probe";
+        type Error = std::convert::Infallible;
+        type Args = serde_json::Value;
+        type Output = String;
+
+        fn description(&self) -> String {
+            "observe runtime context".into()
+        }
+        fn parameters(&self) -> serde_json::Value {
+            json!({"type": "object"})
+        }
+
+        async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
+            Ok("missing".into())
+        }
+
+        async fn call_with_extensions(
+            &self,
+            _args: Self::Args,
+            extensions: &ToolCallExtensions,
+        ) -> Result<Self::Output, Self::Error> {
+            let context = extensions.get::<RunContext>().cloned();
+            *self.0.lock().unwrap_or_else(|e| e.into_inner()) = context;
+            Ok("observed".into())
+        }
+    }
 
     /// A `ToolCallExtensions` set on the outer run propagates into a sub-agent
     /// invoked as a tool, so the inner agent's own tools observe it.
@@ -103,5 +141,35 @@ mod tests {
 
         assert_eq!(out, "outer done");
         assert_eq!(probe.observed().as_deref(), Some("session:abc-123"));
+    }
+
+    #[tokio::test]
+    async fn run_context_and_correlation_propagate_through_agent_tool() {
+        let observed = Arc::new(Mutex::new(None));
+        let inner = AgentBuilder::new(MockCompletionModel::new([
+            MockTurn::tool_call("inner-call", "runtime_probe", json!({})),
+            MockTurn::text("inner done"),
+        ]))
+        .name("researcher")
+        .tool(RuntimeProbe(observed.clone()))
+        .build();
+        let outer = AgentBuilder::new(MockCompletionModel::new([
+            MockTurn::tool_call("outer-call", "researcher", json!({"prompt": "work"})),
+            MockTurn::text("outer done"),
+        ]))
+        .tool(inner)
+        .build();
+
+        let request = outer.prompt("start").max_turns(4);
+        let control = request.control_handle();
+        assert_eq!(request.await.unwrap(), "outer done");
+        let context = observed
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+            .expect("inner tool receives RunContext");
+        assert_eq!(context.run_id(), control.run_id());
+        assert!(context.current_call_id().is_some_and(|id| !id.is_empty()));
+        assert_eq!(context.ancestry(), &["researcher", "runtime_probe"]);
     }
 }

--- a/crates/rig-core/src/client/mod.rs
+++ b/crates/rig-core/src/client/mod.rs
@@ -852,7 +852,7 @@ where
     }
 }
 
-#[cfg(all(feature = "wasm", target_arch = "wasm32"))]
+#[cfg(target_arch = "wasm32")]
 mod wasm_model_listing_compile_checks {
     use super::{ModelListingClient, Nothing};
     use crate::{

--- a/crates/rig-core/src/code_mode.rs
+++ b/crates/rig-core/src/code_mode.rs
@@ -1,0 +1,708 @@
+//! Runtime-independent code-mode execution with a safe local reference backend.
+//!
+//! # Security
+//!
+//! Allow-lists, trusted working directories, protected paths, output limits,
+//! deadlines, and mutation queues are defense-in-depth host policy. They are not
+//! an OS sandbox: do not allow shells or interpreters when untrusted arguments
+//! could encode paths or commands. Unix cancellation creates and terminates a
+//! process group; Windows uses `taskkill /T /F` when available. SSH/container
+//! adapters inherit the local transport process controls, while isolation inside
+//! the remote/container environment remains that environment's responsibility.
+
+use crate::{
+    runtime::RunContext,
+    wasm_compat::{WasmBoxedFuture, WasmCompatSend, WasmCompatSync},
+};
+use serde::{Deserialize, Serialize};
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
+#[cfg(not(target_family = "wasm"))]
+use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashSet, path::PathBuf, time::Duration};
+#[cfg(not(target_family = "wasm"))]
+use tokio::io::AsyncReadExt;
+
+/// Explicit execution limits.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ExecutionLimits {
+    pub timeout: Duration,
+    pub output_bytes: usize,
+}
+/// Request to an execution backend.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CodeRequest {
+    pub program: String,
+    pub arguments: Vec<String>,
+    pub working_directory: PathBuf,
+    pub resource: String,
+    pub mutates: bool,
+    pub limits: ExecutionLimits,
+}
+/// Reference to truncated output retained by the backend.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArtifactReference {
+    pub path: PathBuf,
+    pub original_bytes: usize,
+}
+/// Safe execution result.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CodeResult {
+    pub status: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+    pub truncated: bool,
+    pub artifact: Option<ArtifactReference>,
+}
+/// Backend error.
+#[derive(Debug, thiserror::Error)]
+pub enum CodeError {
+    #[error("permission denied: {0}")]
+    Permission(String),
+    #[error("execution cancelled")]
+    Cancelled,
+    #[error("execution timed out")]
+    Timeout,
+    #[error("backend error: {0}")]
+    Backend(String),
+}
+/// Progress observer.
+pub trait CodeProgress: WasmCompatSend + WasmCompatSync {
+    fn report(&self, message: &str);
+}
+/// Runtime/language-agnostic backend.
+pub trait CodeBackend: WasmCompatSend + WasmCompatSync {
+    fn execute<'a>(
+        &'a self,
+        request: CodeRequest,
+        context: &'a RunContext,
+        progress: &'a dyn CodeProgress,
+    ) -> WasmBoxedFuture<'a, Result<CodeResult, CodeError>>;
+}
+
+struct SilentProgress;
+impl CodeProgress for SilentProgress {
+    fn report(&self, _: &str) {}
+}
+
+/// Installable code-mode tool that delegates to any safe backend without
+/// changing the agent drive loop.
+#[derive(Clone)]
+pub struct CodeModeTool<B> {
+    backend: B,
+}
+impl<B> CodeModeTool<B> {
+    pub fn new(backend: B) -> Self {
+        Self { backend }
+    }
+}
+impl<B> crate::tool::Tool for CodeModeTool<B>
+where
+    B: CodeBackend + Clone + 'static,
+{
+    const NAME: &'static str = "code_mode";
+    type Error = CodeError;
+    type Args = CodeRequest;
+    type Output = CodeResult;
+    fn description(&self) -> String {
+        "Execute an allowlisted command in the configured safe backend".into()
+    }
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({"type":"object","required":["program","arguments","working_directory","resource","mutates","limits"]})
+    }
+    async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
+        Err(CodeError::Permission("RunContext is required".into()))
+    }
+    async fn call_with_extensions(
+        &self,
+        args: Self::Args,
+        extensions: &crate::tool::ToolCallExtensions,
+    ) -> Result<Self::Output, Self::Error> {
+        let context = extensions
+            .get::<RunContext>()
+            .ok_or_else(|| CodeError::Permission("RunContext is required".into()))?;
+        self.backend.execute(args, context, &SilentProgress).await
+    }
+}
+
+/// Hide wrapped executable tools and expose only the code-mode tool definition.
+pub fn code_mode_catalog(
+    definition: crate::completion::ToolDefinition,
+) -> Vec<crate::completion::ToolDefinition> {
+    vec![definition]
+}
+
+/// Permissions and project trust applied before execution.
+#[derive(Clone, Debug)]
+pub struct CodePermissions {
+    pub programs: HashSet<String>,
+    pub trusted_root: PathBuf,
+}
+
+/// Hermetic local process backend with allowlists, process termination,
+/// output limits, artifacts, and per-resource mutation serialization.
+#[cfg(not(target_family = "wasm"))]
+#[derive(Clone)]
+pub struct LocalCommandBackend {
+    permissions: CodePermissions,
+    artifact_directory: PathBuf,
+    protected_paths: Arc<[PathBuf]>,
+    mutations: Arc<tokio::sync::Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>>,
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl LocalCommandBackend {
+    pub fn new(permissions: CodePermissions, artifact_directory: PathBuf) -> Self {
+        Self {
+            permissions,
+            artifact_directory,
+            protected_paths: Arc::from([]),
+            mutations: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Deny command arguments that resolve to these protected paths.
+    pub fn protect_paths(mut self, paths: impl IntoIterator<Item = PathBuf>) -> Self {
+        self.protected_paths = paths.into_iter().collect::<Vec<_>>().into();
+        self
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+async fn read_bounded<R>(mut reader: R, limit: usize) -> Result<(Vec<u8>, usize), CodeError>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let mut captured = Vec::with_capacity(limit.min(8192));
+    let mut total = 0usize;
+    let mut buffer = [0u8; 8192];
+    loop {
+        let read = reader
+            .read(&mut buffer)
+            .await
+            .map_err(|error| CodeError::Backend(error.to_string()))?;
+        if read == 0 {
+            break;
+        }
+        total = total.saturating_add(read);
+        let remaining = limit.saturating_sub(captured.len());
+        if let Some(bytes) = buffer.get(..read.min(remaining)) {
+            captured.extend_from_slice(bytes);
+        }
+    }
+    Ok((captured, total))
+}
+
+#[cfg(not(target_family = "wasm"))]
+async fn terminate_process_tree(child: &mut tokio::process::Child) {
+    #[cfg(unix)]
+    if let Some(pid) = child.id() {
+        let _ = tokio::process::Command::new("kill")
+            .args(["-TERM", &format!("-{pid}")])
+            .status()
+            .await;
+        futures_timer::Delay::new(Duration::from_millis(25)).await;
+        let _ = tokio::process::Command::new("kill")
+            .args(["-KILL", &format!("-{pid}")])
+            .status()
+            .await;
+    }
+    #[cfg(windows)]
+    if let Some(pid) = child.id() {
+        // `taskkill /T` is the broadly available Windows process-tree fallback.
+        let _ = tokio::process::Command::new("taskkill")
+            .args(["/PID", &pid.to_string(), "/T", "/F"])
+            .status()
+            .await;
+    }
+    let _ = child.kill().await;
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl CodeBackend for LocalCommandBackend {
+    fn execute<'a>(
+        &'a self,
+        request: CodeRequest,
+        context: &'a RunContext,
+        progress: &'a dyn CodeProgress,
+    ) -> WasmBoxedFuture<'a, Result<CodeResult, CodeError>> {
+        Box::pin(async move {
+            if !self.permissions.programs.contains(&request.program) {
+                return Err(CodeError::Permission(format!(
+                    "program `{}` is not allowed",
+                    request.program
+                )));
+            }
+            let root = self
+                .permissions
+                .trusted_root
+                .canonicalize()
+                .map_err(|e| CodeError::Permission(e.to_string()))?;
+            let cwd = request
+                .working_directory
+                .canonicalize()
+                .map_err(|e| CodeError::Permission(e.to_string()))?;
+            if !cwd.starts_with(&root) {
+                return Err(CodeError::Permission(
+                    "working directory escapes trusted project".into(),
+                ));
+            }
+            for argument in &request.arguments {
+                let values = std::iter::once(argument.as_str())
+                    .chain(argument.split_once('=').map(|(_, value)| value));
+                for value in values {
+                    let candidate = cwd.join(value);
+                    let protected = self.protected_paths.iter().any(|protected| {
+                        let protected = protected
+                            .canonicalize()
+                            .unwrap_or_else(|_| protected.clone());
+                        candidate.canonicalize().map_or_else(
+                            |_| candidate.starts_with(&protected),
+                            |candidate| candidate.starts_with(&protected),
+                        )
+                    });
+                    if protected {
+                        return Err(CodeError::Permission(format!(
+                            "argument targets protected path `{argument}`"
+                        )));
+                    }
+                }
+            }
+            let artifact_parent = self
+                .artifact_directory
+                .parent()
+                .and_then(|parent| parent.canonicalize().ok())
+                .ok_or_else(|| {
+                    CodeError::Permission("artifact directory has no trusted parent".into())
+                })?;
+            if !artifact_parent.starts_with(&root) {
+                return Err(CodeError::Permission(
+                    "artifact directory escapes trusted project".into(),
+                ));
+            }
+            let resource_lock = if request.mutates {
+                let mut locks = self.mutations.lock().await;
+                Some(
+                    locks
+                        .entry(request.resource.clone())
+                        .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+                        .clone(),
+                )
+            } else {
+                None
+            };
+            let _mutation_guard = match resource_lock {
+                Some(lock) => {
+                    let acquire = lock.lock_owned();
+                    let stopped = context.stopped();
+                    futures::pin_mut!(acquire, stopped);
+                    match futures::future::select(acquire, stopped).await {
+                        futures::future::Either::Left((guard, _)) => {
+                            if context.should_stop() {
+                                return Err(CodeError::Cancelled);
+                            }
+                            Some(guard)
+                        }
+                        futures::future::Either::Right(_) => return Err(CodeError::Cancelled),
+                    }
+                }
+                None => None,
+            };
+            progress.report("starting process");
+            let mut command = tokio::process::Command::new(&request.program);
+            command
+                .args(&request.arguments)
+                .current_dir(cwd)
+                .kill_on_drop(true);
+            // A dedicated process group lets cancellation terminate shells and
+            // all descendants rather than only the immediate child.
+            #[cfg(unix)]
+            command.as_std_mut().process_group(0);
+            let mut child = command
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
+                .spawn()
+                .map_err(|e| CodeError::Backend(e.to_string()))?;
+            let stdout = child
+                .stdout
+                .take()
+                .ok_or_else(|| CodeError::Backend("stdout pipe missing".into()))?;
+            let stderr = child
+                .stderr
+                .take()
+                .ok_or_else(|| CodeError::Backend("stderr pipe missing".into()))?;
+            let started = std::time::Instant::now();
+            let wait = async {
+                loop {
+                    if context.should_stop() {
+                        terminate_process_tree(&mut child).await;
+                        return Err(CodeError::Cancelled);
+                    }
+                    if started.elapsed() >= request.limits.timeout {
+                        terminate_process_tree(&mut child).await;
+                        return Err(CodeError::Timeout);
+                    }
+                    if let Some(status) = child
+                        .try_wait()
+                        .map_err(|e| CodeError::Backend(e.to_string()))?
+                    {
+                        return Ok(status);
+                    }
+                    futures_timer::Delay::new(Duration::from_millis(5)).await;
+                }
+            };
+            let (status, stdout, stderr) = futures::join!(
+                wait,
+                read_bounded(stdout, request.limits.output_bytes),
+                read_bounded(stderr, request.limits.output_bytes),
+            );
+            let status = status?;
+            let (stdout, stdout_bytes) = stdout?;
+            let (stderr, stderr_bytes) = stderr?;
+            let stdout_visible = stdout
+                .get(..stdout.len().min(request.limits.output_bytes))
+                .unwrap_or(&stdout);
+            let stderr_budget = request
+                .limits
+                .output_bytes
+                .saturating_sub(stdout_visible.len());
+            let stderr_visible = stderr
+                .get(..stderr.len().min(stderr_budget))
+                .unwrap_or(&stderr);
+            let mut combined = stdout_visible.to_vec();
+            combined.extend_from_slice(stderr_visible);
+            let original_bytes = stdout_bytes.saturating_add(stderr_bytes);
+            let truncated = original_bytes > request.limits.output_bytes;
+            let artifact = if truncated {
+                tokio::fs::create_dir_all(&self.artifact_directory)
+                    .await
+                    .map_err(|e| CodeError::Backend(e.to_string()))?;
+                let path = self
+                    .artifact_directory
+                    .join(format!("rig-code-{}.log", crate::id::generate()));
+                tokio::fs::write(&path, &combined)
+                    .await
+                    .map_err(|e| CodeError::Backend(e.to_string()))?;
+                Some(ArtifactReference {
+                    path,
+                    original_bytes,
+                })
+            } else {
+                None
+            };
+            progress.report("process finished");
+            Ok(CodeResult {
+                status: status.code(),
+                stdout: String::from_utf8_lossy(stdout_visible).into(),
+                stderr: String::from_utf8_lossy(stderr_visible).into(),
+                truncated,
+                artifact,
+            })
+        })
+    }
+}
+
+/// Concrete command-configured remote/container/sandbox adapter. The configured
+/// transport executable is itself subject to the local backend's allow-list,
+/// trusted working directory, cancellation, output, and mutation controls.
+#[cfg(not(target_family = "wasm"))]
+#[derive(Clone)]
+pub struct CommandAdapterBackend {
+    local: LocalCommandBackend,
+    executable: String,
+    prefix: Vec<String>,
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl CommandAdapterBackend {
+    /// Configure an SSH adapter (`ssh <destination> -- <program> ...`).
+    pub fn ssh(
+        local: LocalCommandBackend,
+        executable: impl Into<String>,
+        destination: impl Into<String>,
+    ) -> Self {
+        Self {
+            local,
+            executable: executable.into(),
+            prefix: vec![destination.into(), "--".into()],
+        }
+    }
+    /// Configure a container adapter (`runtime exec <container> <program> ...`).
+    pub fn container(
+        local: LocalCommandBackend,
+        runtime: impl Into<String>,
+        container: impl Into<String>,
+    ) -> Self {
+        Self {
+            local,
+            executable: runtime.into(),
+            prefix: vec!["exec".into(), container.into()],
+        }
+    }
+    /// Configure a sandbox adapter whose prefix precedes the requested command.
+    pub fn sandbox(
+        local: LocalCommandBackend,
+        executable: impl Into<String>,
+        prefix: Vec<String>,
+    ) -> Self {
+        Self {
+            local,
+            executable: executable.into(),
+            prefix,
+        }
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl CodeBackend for CommandAdapterBackend {
+    fn execute<'a>(
+        &'a self,
+        request: CodeRequest,
+        context: &'a RunContext,
+        progress: &'a dyn CodeProgress,
+    ) -> WasmBoxedFuture<'a, Result<CodeResult, CodeError>> {
+        if !self.local.permissions.programs.contains(&request.program) {
+            return Box::pin(async move {
+                Err(CodeError::Permission(format!(
+                    "inner program `{}` is not allowed",
+                    request.program
+                )))
+            });
+        }
+        let mut arguments = self.prefix.clone();
+        arguments.push(request.program);
+        arguments.extend(request.arguments);
+        self.local.execute(
+            CodeRequest {
+                program: self.executable.clone(),
+                arguments,
+                ..request
+            },
+            context,
+            progress,
+        )
+    }
+}
+
+/// Backend location abstraction for hosts installing local, SSH, container, or sandbox adapters.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BackendLocation {
+    Local,
+    Ssh(String),
+    Container(String),
+    Sandbox(String),
+}
+
+#[cfg(all(test, not(target_family = "wasm")))]
+mod tests {
+    use super::*;
+    struct Progress;
+    impl CodeProgress for Progress {
+        fn report(&self, _: &str) {}
+    }
+
+    #[tokio::test]
+    async fn local_backend_enforces_allowlist_and_truncates_to_artifact() {
+        let root = std::env::temp_dir().join(format!("rig-code-test-{}", crate::id::generate()));
+        std::fs::create_dir_all(&root).unwrap();
+        let backend = LocalCommandBackend::new(
+            CodePermissions {
+                programs: ["sh".into()].into_iter().collect(),
+                trusted_root: root.clone(),
+            },
+            root.join("artifacts"),
+        );
+        let (_, context) = crate::runtime::RunControlHandle::new(None, None);
+        let result = backend
+            .execute(
+                CodeRequest {
+                    program: "sh".into(),
+                    arguments: vec!["-c".into(), "printf 123456789".into()],
+                    working_directory: root.clone(),
+                    resource: "project".into(),
+                    mutates: true,
+                    limits: ExecutionLimits {
+                        timeout: Duration::from_secs(2),
+                        output_bytes: 4,
+                    },
+                },
+                &context,
+                &Progress,
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.stdout, "1234");
+        assert!(result.truncated);
+        assert!(result.artifact.unwrap().path.is_file());
+        let denied = backend
+            .execute(
+                CodeRequest {
+                    program: "false-not-allowed".into(),
+                    arguments: vec![],
+                    working_directory: root.clone(),
+                    resource: "project".into(),
+                    mutates: false,
+                    limits: ExecutionLimits {
+                        timeout: Duration::from_secs(1),
+                        output_bytes: 10,
+                    },
+                },
+                &context,
+                &Progress,
+            )
+            .await;
+        assert!(matches!(denied, Err(CodeError::Permission(_))));
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn queued_mutation_cancels_before_resource_lock_acquisition() {
+        let root = std::env::temp_dir().join(format!("rig-code-cancel-{}", crate::id::generate()));
+        std::fs::create_dir_all(&root).unwrap();
+        let backend = LocalCommandBackend::new(
+            CodePermissions {
+                programs: ["sh".into()].into_iter().collect(),
+                trusted_root: root.clone(),
+            },
+            root.join("artifacts"),
+        );
+        let lock = Arc::new(tokio::sync::Mutex::new(()));
+        backend
+            .mutations
+            .lock()
+            .await
+            .insert("same".into(), lock.clone());
+        let guard = lock.lock_owned().await;
+        let (control, context) = crate::runtime::RunControlHandle::new(None, None);
+        let request = CodeRequest {
+            program: "sh".into(),
+            arguments: vec!["-c".into(), "printf should-not-run".into()],
+            working_directory: root.clone(),
+            resource: "same".into(),
+            mutates: true,
+            limits: ExecutionLimits {
+                timeout: Duration::from_secs(2),
+                output_bytes: 100,
+            },
+        };
+        let execution = backend.execute(request, &context, &Progress);
+        futures::pin_mut!(execution);
+        assert!(futures::poll!(&mut execution).is_pending());
+        control.cancel();
+        assert!(matches!(execution.await, Err(CodeError::Cancelled)));
+        drop(guard);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn same_resource_mutations_serialize_and_command_adapter_executes() {
+        let root = std::env::temp_dir().join(format!("rig-code-queue-{}", crate::id::generate()));
+        std::fs::create_dir_all(&root).unwrap();
+        let backend = LocalCommandBackend::new(
+            CodePermissions {
+                programs: ["sh".into(), "env".into()].into_iter().collect(),
+                trusted_root: root.clone(),
+            },
+            root.join("artifacts"),
+        );
+        let request = || CodeRequest {
+            program: "sh".into(),
+            arguments: vec!["-c".into(), "mkdir lock && sleep 0.05 && rmdir lock".into()],
+            working_directory: root.clone(),
+            resource: "same".into(),
+            mutates: true,
+            limits: ExecutionLimits {
+                timeout: Duration::from_secs(2),
+                output_bytes: 100,
+            },
+        };
+        let (_, first_context) = crate::runtime::RunControlHandle::new(None, None);
+        let (_, second_context) = crate::runtime::RunControlHandle::new(None, None);
+        let (first, second) = futures::join!(
+            backend.execute(request(), &first_context, &Progress),
+            backend.execute(request(), &second_context, &Progress),
+        );
+        assert_eq!(first.unwrap().status, Some(0));
+        assert_eq!(second.unwrap().status, Some(0));
+        let adapter = CommandAdapterBackend::sandbox(backend, "env", vec![]);
+        let result = adapter
+            .execute(
+                CodeRequest {
+                    program: "sh".into(),
+                    arguments: vec!["-c".into(), "printf adapter".into()],
+                    working_directory: root.clone(),
+                    resource: "read".into(),
+                    mutates: false,
+                    limits: ExecutionLimits {
+                        timeout: Duration::from_secs(2),
+                        output_bytes: 100,
+                    },
+                },
+                &first_context,
+                &Progress,
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.stdout, "adapter");
+        let denied = CommandAdapterBackend::sandbox(
+            LocalCommandBackend::new(
+                CodePermissions {
+                    programs: ["env".into()].into_iter().collect(),
+                    trusted_root: root.clone(),
+                },
+                root.join("artifacts"),
+            ),
+            "env",
+            vec![],
+        )
+        .execute(
+            CodeRequest {
+                program: "sh".into(),
+                arguments: vec![],
+                working_directory: root.clone(),
+                resource: "read".into(),
+                mutates: false,
+                limits: ExecutionLimits {
+                    timeout: Duration::from_secs(1),
+                    output_bytes: 100,
+                },
+            },
+            &first_context,
+            &Progress,
+        )
+        .await;
+        assert!(matches!(denied, Err(CodeError::Permission(_))));
+        let large = CommandAdapterBackend::sandbox(
+            LocalCommandBackend::new(
+                CodePermissions {
+                    programs: ["env".into(), "sh".into()].into_iter().collect(),
+                    trusted_root: root.clone(),
+                },
+                root.join("artifacts"),
+            ),
+            "env",
+            vec![],
+        )
+        .execute(
+            CodeRequest {
+                program: "sh".into(),
+                arguments: vec!["-c".into(), "yes x | head -c 200000".into()],
+                working_directory: root.clone(),
+                resource: "read".into(),
+                mutates: false,
+                limits: ExecutionLimits {
+                    timeout: Duration::from_secs(3),
+                    output_bytes: 1024,
+                },
+            },
+            &first_context,
+            &Progress,
+        )
+        .await
+        .unwrap();
+        assert_eq!(large.status, Some(0));
+        assert!(large.truncated);
+        assert_eq!(large.stdout.len(), 1024);
+        std::fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/crates/rig-core/src/completion/message.rs
+++ b/crates/rig-core/src/completion/message.rs
@@ -214,6 +214,12 @@ pub struct ToolResult {
     /// Provider-specific call ID, when distinct from `id`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub call_id: Option<String>,
+    /// Rig-generated identifier of the call this result answers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub internal_call_id: Option<String>,
+    /// Rig-generated parent identifier for nested execution.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_internal_call_id: Option<String>,
     /// One or more content items produced by the tool.
     pub content: OneOrMany<ToolResultContent>,
 }
@@ -233,6 +239,12 @@ pub struct ToolCall {
     pub id: String,
     /// Provider-specific call ID used by some APIs for tool result correlation.
     pub call_id: Option<String>,
+    /// Rig-generated call correlation identifier, never sent as a provider ID.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub internal_call_id: Option<String>,
+    /// Rig-generated parent call identifier for nested tool execution.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_internal_call_id: Option<String>,
     /// Function name and JSON arguments requested by the model.
     pub function: ToolFunction,
     /// Optional cryptographic signature for the tool call.
@@ -254,6 +266,8 @@ impl ToolCall {
         Self {
             id,
             call_id: None,
+            internal_call_id: None,
+            parent_internal_call_id: None,
             function,
             signature: None,
             additional_params: None,
@@ -262,6 +276,17 @@ impl ToolCall {
 
     pub fn with_call_id(mut self, call_id: String) -> Self {
         self.call_id = Some(call_id);
+        self
+    }
+
+    /// Attach Rig-only call correlation identifiers.
+    pub fn with_internal_call_ids(
+        mut self,
+        internal_call_id: Option<String>,
+        parent_internal_call_id: Option<String>,
+    ) -> Self {
+        self.internal_call_id = internal_call_id;
+        self.parent_internal_call_id = parent_internal_call_id;
         self
     }
 
@@ -638,6 +663,8 @@ impl Message {
             content: OneOrMany::one(UserContent::ToolResult(ToolResult {
                 id: id.into(),
                 call_id: None,
+                internal_call_id: None,
+                parent_internal_call_id: None,
                 content: OneOrMany::one(ToolResultContent::text(content)),
             })),
         }
@@ -652,6 +679,8 @@ impl Message {
             content: OneOrMany::one(UserContent::ToolResult(ToolResult {
                 id: id.into(),
                 call_id,
+                internal_call_id: None,
+                parent_internal_call_id: None,
                 content: OneOrMany::one(ToolResultContent::text(content)),
             })),
         }
@@ -794,6 +823,8 @@ impl UserContent {
         UserContent::ToolResult(ToolResult {
             id: id.into(),
             call_id: None,
+            internal_call_id: None,
+            parent_internal_call_id: None,
             content,
         })
     }
@@ -807,6 +838,8 @@ impl UserContent {
         UserContent::ToolResult(ToolResult {
             id: id.into(),
             call_id: Some(call_id),
+            internal_call_id: None,
+            parent_internal_call_id: None,
             content,
         })
     }
@@ -1336,6 +1369,8 @@ impl From<ToolResultContent> for Message {
             content: OneOrMany::one(UserContent::ToolResult(ToolResult {
                 id: String::new(),
                 call_id: None,
+                internal_call_id: None,
+                parent_internal_call_id: None,
                 content: OneOrMany::one(tool_result_content),
             })),
         }

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -155,6 +155,10 @@ pub enum PromptError {
     #[error("MemoryError: {0}")]
     MemoryError(#[from] crate::memory::MemoryError),
 
+    /// Durable session loading or persistence failed.
+    #[error("SessionError: {0}")]
+    SessionError(#[from] crate::session::SessionError),
+
     /// There was an error while using a tool
     #[error("ToolCallError: {0}")]
     ToolError(#[from] ToolSetError),
@@ -329,6 +333,31 @@ pub struct ToolDefinition {
     pub description: String,
     /// JSON Schema describing tool arguments.
     pub parameters: serde_json::Value,
+    /// Optional JSON Schema describing the model-visible tool result.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_schema: Option<serde_json::Value>,
+}
+
+impl ToolDefinition {
+    /// Construct a tool definition without an output schema.
+    pub fn new(
+        name: impl Into<String>,
+        description: impl Into<String>,
+        parameters: serde_json::Value,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            description: description.into(),
+            parameters,
+            output_schema: None,
+        }
+    }
+
+    /// Attach a model-visible output schema.
+    pub fn with_output_schema(mut self, output_schema: serde_json::Value) -> Self {
+        self.output_schema = Some(output_schema);
+        self
+    }
 }
 
 /// Provider-native tool definition.
@@ -493,6 +522,10 @@ pub struct CompletionResponse<T> {
     /// Provider-assigned message ID (e.g. OpenAI Responses API `msg_` ID).
     /// Used to pair reasoning input items with their output items in multi-turn.
     pub message_id: Option<String>,
+    /// Provider-neutral reason this completion stopped, when reported.
+    pub finish_reason: Option<crate::runtime::TerminalReason>,
+    /// Original provider finish/status value, preserved for forward compatibility.
+    pub raw_finish_reason: Option<String>,
 }
 
 /// A trait for grabbing the token usage of a completion response.
@@ -503,6 +536,16 @@ pub trait GetTokenUsage {
     /// [`Usage`]'s documented sentinel for missing provider usage metrics;
     /// response types that carry no usage return [`Usage::new`].
     fn token_usage(&self) -> crate::completion::Usage;
+
+    /// Returns a provider-neutral terminal reason when the response exposes one.
+    fn finish_reason(&self) -> Option<crate::runtime::TerminalReason> {
+        None
+    }
+
+    /// Returns the unmodified provider finish/status value when available.
+    fn raw_finish_reason(&self) -> Option<String> {
+        None
+    }
 }
 
 impl GetTokenUsage for () {
@@ -521,6 +564,14 @@ where
         } else {
             crate::completion::Usage::new()
         }
+    }
+
+    fn finish_reason(&self) -> Option<crate::runtime::TerminalReason> {
+        self.as_ref().and_then(GetTokenUsage::finish_reason)
+    }
+
+    fn raw_finish_reason(&self) -> Option<String> {
+        self.as_ref().and_then(GetTokenUsage::raw_finish_reason)
     }
 }
 

--- a/crates/rig-core/src/http_client/sse.rs
+++ b/crates/rig-core/src/http_client/sse.rs
@@ -12,9 +12,9 @@ use crate::{
 use bytes::Bytes;
 use eventsource_stream::{Event as MessageEvent, EventStreamError, Eventsource};
 use futures::Stream;
-#[cfg(not(all(feature = "wasm", target_arch = "wasm32")))]
+#[cfg(not(target_arch = "wasm32"))]
 use futures::{future::BoxFuture, stream::BoxStream};
-#[cfg(all(feature = "wasm", target_arch = "wasm32"))]
+#[cfg(target_arch = "wasm32")]
 use futures::{future::LocalBoxFuture, stream::LocalBoxStream};
 use futures_timer::Delay;
 use http::Response;
@@ -31,12 +31,12 @@ pub type BoxedStream = Pin<Box<dyn WasmCompatSendStream<InnerItem = StreamResult
 
 #[cfg(not(target_arch = "wasm32"))]
 type ResponseFuture = BoxFuture<'static, Result<Response<BoxedStream>, super::Error>>;
-#[cfg(all(feature = "wasm", target_arch = "wasm32"))]
+#[cfg(target_arch = "wasm32")]
 type ResponseFuture = LocalBoxFuture<'static, Result<Response<BoxedStream>, super::Error>>;
 
 #[cfg(not(target_arch = "wasm32"))]
 type EventStream = BoxStream<'static, Result<MessageEvent, EventStreamError<super::Error>>>;
-#[cfg(all(feature = "wasm", target_arch = "wasm32"))]
+#[cfg(target_arch = "wasm32")]
 type EventStream = LocalBoxStream<'static, Result<MessageEvent, EventStreamError<super::Error>>>;
 
 pin_project! {

--- a/crates/rig-core/src/lib.rs
+++ b/crates/rig-core/src/lib.rs
@@ -147,6 +147,7 @@ pub mod agent;
 #[cfg_attr(docsrs, doc(cfg(feature = "audio")))]
 pub mod audio_generation;
 pub mod client;
+pub mod code_mode;
 pub mod completion;
 pub mod embeddings;
 pub mod extractor;
@@ -166,8 +167,13 @@ pub mod prelude;
 pub(crate) mod provider_response;
 pub mod providers;
 pub mod rerank;
+/// Provider-independent contracts for interactive and nested execution.
+pub mod runtime;
+pub mod session;
+pub mod skills;
 
 pub mod streaming;
+pub mod subagent;
 #[cfg(any(test, feature = "test-utils"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "test-utils")))]
 pub mod test_utils;

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -254,6 +254,8 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
         };
 
         Ok(completion::CompletionResponse {
+            finish_reason: None,
+            raw_finish_reason: None,
             choice,
             usage,
             raw_response: response,
@@ -3026,6 +3028,7 @@ mod tests {
 
     fn generic_tool(name: &str) -> completion::ToolDefinition {
         completion::ToolDefinition {
+            output_schema: None,
             name: name.to_string(),
             description: format!("{name} description"),
             parameters: json!({

--- a/crates/rig-core/src/providers/anthropic/streaming.rs
+++ b/crates/rig-core/src/providers/anthropic/streaming.rs
@@ -556,7 +556,7 @@ mod tests {
     use async_stream::stream;
     use futures::StreamExt;
 
-    #[cfg(not(all(feature = "wasm", target_arch = "wasm32")))]
+    #[cfg(not(target_arch = "wasm32"))]
     fn to_stream_result(
         stream: impl futures::Stream<
             Item = Result<RawStreamingChoice<StreamingCompletionResponse>, CompletionError>,
@@ -566,7 +566,7 @@ mod tests {
         Box::pin(stream)
     }
 
-    #[cfg(all(feature = "wasm", target_arch = "wasm32"))]
+    #[cfg(target_arch = "wasm32")]
     fn to_stream_result(
         stream: impl futures::Stream<
             Item = Result<RawStreamingChoice<StreamingCompletionResponse>, CompletionError>,
@@ -587,6 +587,7 @@ mod tests {
 
         let mut tools = build_tool_definitions(
             vec![crate::completion::ToolDefinition {
+                output_schema: None,
                 name: "rig_tool".to_string(),
                 description: "Rig tool".to_string(),
                 parameters: json!({"type": "object", "properties": {}}),
@@ -737,6 +738,7 @@ mod tests {
             chat_history: OneOrMany::one(RigMessage::user("Add 2 and 3")),
             documents: vec![],
             tools: vec![crate::completion::ToolDefinition {
+                output_schema: None,
                 name: "add".to_string(),
                 description: "Add x and y".to_string(),
                 parameters: json!({
@@ -813,6 +815,7 @@ mod tests {
             resolve_top_level_cache_control(false, None, &mut additional_params).unwrap();
         let mut tools = build_tool_definitions(
             vec![crate::completion::ToolDefinition {
+                output_schema: None,
                 name: "rig_tool".to_string(),
                 description: "Rig tool".to_string(),
                 parameters: json!({"type": "object", "properties": {}}),

--- a/crates/rig-core/src/providers/cohere/completion.rs
+++ b/crates/rig-core/src/providers/cohere/completion.rs
@@ -196,6 +196,8 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             .unwrap_or_default();
 
         Ok(completion::CompletionResponse {
+            finish_reason: None,
+            raw_finish_reason: None,
             choice: model_response,
             usage,
             raw_response: response,

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -687,6 +687,8 @@ impl TryFrom<ChatCompletionResponse> for completion::CompletionResponse<ChatComp
             .unwrap_or_default();
 
         Ok(completion::CompletionResponse {
+            finish_reason: None,
+            raw_finish_reason: None,
             choice,
             usage,
             raw_response: response,
@@ -869,6 +871,8 @@ where
                         }
 
                         Ok(completion::CompletionResponse {
+                            finish_reason: None,
+                            raw_finish_reason: None,
                             choice: core.choice,
                             usage: core.usage,
                             raw_response: CopilotCompletionResponse::Chat(Box::new(response)),
@@ -939,6 +943,8 @@ where
                 }
 
                 Ok(completion::CompletionResponse {
+                    finish_reason: None,
+                    raw_finish_reason: None,
                     choice: core.choice,
                     usage: core.usage,
                     raw_response: CopilotCompletionResponse::Responses(Box::new(response)),
@@ -1213,6 +1219,8 @@ where
                             usage: final_usage,
                             reasoning_metadata,
                             reasoning_context,
+                            finish_reason: None,
+                            raw_finish_reason: None,
                         }
                     )
                 ));

--- a/crates/rig-core/src/providers/deepseek.rs
+++ b/crates/rig-core/src/providers/deepseek.rs
@@ -400,6 +400,8 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
         let usage = response.usage.token_usage();
 
         Ok(completion::CompletionResponse {
+            finish_reason: None,
+            raw_finish_reason: None,
             choice,
             usage,
             raw_response: response,
@@ -583,6 +585,7 @@ mod tests {
     fn deepseek_request_serializes_specific_tool_choice_as_chat_completions_object() {
         let request = CompletionRequestBuilder::new(MockCompletionModel::default(), "Use a tool.")
             .tool(RigToolDefinition {
+                output_schema: None,
                 name: "alpha".to_string(),
                 description: "Alpha tool".to_string(),
                 parameters: serde_json::json!({
@@ -592,6 +595,7 @@ mod tests {
                 }),
             })
             .tool(RigToolDefinition {
+                output_schema: None,
                 name: "beta".to_string(),
                 description: "Beta tool".to_string(),
                 parameters: serde_json::json!({
@@ -618,6 +622,7 @@ mod tests {
     fn deepseek_request_suppresses_required_tool_choice_when_thinking_is_not_disabled() {
         let request = CompletionRequestBuilder::new(MockCompletionModel::default(), "Use a tool.")
             .tool(RigToolDefinition {
+                output_schema: None,
                 name: "alpha".to_string(),
                 description: "Alpha tool".to_string(),
                 parameters: serde_json::json!({

--- a/crates/rig-core/src/providers/gemini/client.rs
+++ b/crates/rig-core/src/providers/gemini/client.rs
@@ -233,8 +233,10 @@ pub struct ApiErrorResponse {
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 pub enum ApiResponse<T> {
-    Ok(T),
+    // Check the error envelope first: several successful response structs use
+    // serde defaults and can otherwise accept an error body as an empty success.
     Err(ApiErrorResponse),
+    Ok(T),
 }
 
 // ================================================================

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -383,6 +383,35 @@ impl TryFrom<Vec<completion::ToolDefinition>> for Tool {
     }
 }
 
+pub(crate) fn normalized_finish_reason(
+    reason: &FinishReason,
+) -> (crate::runtime::TerminalReason, String) {
+    use crate::runtime::TerminalReason;
+    let (normalized, raw) = match reason {
+        FinishReason::Stop => (TerminalReason::Completed, "STOP"),
+        FinishReason::MaxTokens => (TerminalReason::MaxTokens, "MAX_TOKENS"),
+        FinishReason::Safety => (TerminalReason::ContentFiltered, "SAFETY"),
+        FinishReason::Recitation => (TerminalReason::ContentFiltered, "RECITATION"),
+        FinishReason::Language => (TerminalReason::ContentFiltered, "LANGUAGE"),
+        FinishReason::Blocklist => (TerminalReason::ContentFiltered, "BLOCKLIST"),
+        FinishReason::ProhibitedContent => (TerminalReason::ContentFiltered, "PROHIBITED_CONTENT"),
+        FinishReason::Spii => (TerminalReason::ContentFiltered, "SPII"),
+        FinishReason::MalformedFunctionCall => (TerminalReason::Failed, "MALFORMED_FUNCTION_CALL"),
+        FinishReason::UnexpectedToolCall => (TerminalReason::Failed, "UNEXPECTED_TOOL_CALL"),
+        FinishReason::MissingThoughtSignature => {
+            (TerminalReason::Failed, "MISSING_THOUGHT_SIGNATURE")
+        }
+        FinishReason::TooManyToolCalls => (TerminalReason::Failed, "TOO_MANY_TOOL_CALLS"),
+        FinishReason::MalformedResponse => (TerminalReason::Failed, "MALFORMED_RESPONSE"),
+        FinishReason::FinishReasonUnspecified => (
+            TerminalReason::Other("unspecified".into()),
+            "FINISH_REASON_UNSPECIFIED",
+        ),
+        FinishReason::Other => (TerminalReason::Other("other".into()), "OTHER"),
+    };
+    (normalized, raw.to_string())
+}
+
 pub(crate) fn function_call_finish_reason_error(
     reason: &FinishReason,
     finish_message: Option<&str>,
@@ -508,7 +537,15 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse<Generat
             .map(GetTokenUsage::token_usage)
             .unwrap_or_default();
 
+        let (finish_reason, raw_finish_reason) = candidate
+            .finish_reason
+            .as_ref()
+            .map(normalized_finish_reason)
+            .map_or((None, None), |(reason, raw)| (Some(reason), Some(raw)));
+
         Ok(completion::CompletionResponse {
+            finish_reason,
+            raw_finish_reason,
             choice,
             usage,
             raw_response: response,
@@ -2545,6 +2582,24 @@ mod tests {
     }
 
     #[test]
+    fn normalized_finish_reason_preserves_provider_value() {
+        assert_eq!(
+            super::normalized_finish_reason(&FinishReason::Stop),
+            (
+                crate::runtime::TerminalReason::Completed,
+                "STOP".to_string()
+            )
+        );
+        assert_eq!(
+            super::normalized_finish_reason(&FinishReason::Safety),
+            (
+                crate::runtime::TerminalReason::ContentFiltered,
+                "SAFETY".to_string()
+            )
+        );
+    }
+
+    #[test]
     fn test_tool_protocol_finish_reason_returns_response_error() {
         for (reason, finish_message) in [
             (
@@ -2690,6 +2745,8 @@ mod tests {
         let tool_call = message::ToolCall {
             id: "test_tool".to_string(),
             call_id: None,
+            internal_call_id: None,
+            parent_internal_call_id: None,
             function: message::ToolFunction {
                 name: "test_function".to_string(),
                 arguments: json!({"arg1": "value1"}),
@@ -2961,6 +3018,8 @@ mod tests {
         let tool_result = ToolResult {
             id: "test_tool".to_string(),
             call_id: None,
+            internal_call_id: None,
+            parent_internal_call_id: None,
             content: OneOrMany::many(vec![
                 ToolResultContent::Text(message::Text::new(r#"{"status": "success"}"#.to_string())),
                 ToolResultContent::Image(Image {
@@ -3088,6 +3147,8 @@ mod tests {
         let tool_result = ToolResult {
             id: "screenshot_tool".to_string(),
             call_id: None,
+            internal_call_id: None,
+            parent_internal_call_id: None,
             content: OneOrMany::one(ToolResultContent::Image(Image {
                 data: DocumentSourceKind::Url("https://example.com/image.png".to_string()),
                 media_type: Some(ImageMediaType::PNG),

--- a/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
@@ -496,6 +496,8 @@ impl TryFrom<Interaction> for completion::CompletionResponse<Interaction> {
             .unwrap_or_default();
 
         Ok(completion::CompletionResponse {
+            finish_reason: None,
+            raw_finish_reason: None,
             choice,
             usage,
             raw_response: response,
@@ -1796,6 +1798,7 @@ pub mod interactions_api_types {
                     id,
                     call_id,
                     content,
+                    ..
                 }) => {
                     let Some(call_id) = call_id else {
                         return Err(message::MessageError::ConversionError(
@@ -2575,6 +2578,8 @@ mod tests {
         let content = message::UserContent::ToolResult(message::ToolResult {
             id: "get_weather".to_string(),
             call_id: None,
+            internal_call_id: None,
+            parent_internal_call_id: None,
             content: OneOrMany::one(message::ToolResultContent::text("ok")),
         });
 

--- a/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
@@ -32,11 +32,11 @@ pub struct StreamingCompletionResponse {
     pub model_version: Option<String>,
 }
 
-#[cfg(not(all(feature = "wasm", target_arch = "wasm32")))]
+#[cfg(not(target_arch = "wasm32"))]
 pub type InteractionEventStream =
     Pin<Box<dyn Stream<Item = Result<InteractionSseEvent, CompletionError>> + Send>>;
 
-#[cfg(all(feature = "wasm", target_arch = "wasm32"))]
+#[cfg(target_arch = "wasm32")]
 pub type InteractionEventStream =
     Pin<Box<dyn Stream<Item = Result<InteractionSseEvent, CompletionError>>>>;
 

--- a/crates/rig-core/src/providers/gemini/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/streaming.rs
@@ -8,8 +8,8 @@ use super::completion::gemini_api_types::{
     ContentCandidate, FinishReason, ModalityTokenCount, Part, PartKind, TrafficType,
 };
 use super::completion::{
-    CompletionModel, create_request_body, function_call_finish_reason_error, resolve_request_model,
-    streaming_endpoint,
+    CompletionModel, create_request_body, function_call_finish_reason_error,
+    normalized_finish_reason, resolve_request_model, streaming_endpoint,
 };
 use crate::completion::message::ReasoningContent;
 use crate::completion::{CompletionError, CompletionRequest, GetTokenUsage};
@@ -85,6 +85,20 @@ pub struct StreamingCompletionResponse {
 impl GetTokenUsage for StreamingCompletionResponse {
     fn token_usage(&self) -> crate::completion::Usage {
         self.usage_metadata.token_usage()
+    }
+
+    fn finish_reason(&self) -> Option<crate::runtime::TerminalReason> {
+        self.finish_reason
+            .as_ref()
+            .map(normalized_finish_reason)
+            .map(|(reason, _)| reason)
+    }
+
+    fn raw_finish_reason(&self) -> Option<String> {
+        self.finish_reason
+            .as_ref()
+            .map(normalized_finish_reason)
+            .map(|(_, raw)| raw)
     }
 }
 

--- a/crates/rig-core/src/providers/groq.rs
+++ b/crates/rig-core/src/providers/groq.rs
@@ -372,6 +372,7 @@ mod tests {
         let request = CompletionRequestBuilder::new(MockCompletionModel::default(), "Return JSON")
             .max_tokens(64)
             .tool(crate::completion::ToolDefinition {
+                output_schema: None,
                 name: "choose_beta".to_string(),
                 description: "Choose beta".to_string(),
                 parameters: serde_json::json!({"type":"object","properties":{},"required":[]}),
@@ -424,6 +425,7 @@ mod tests {
     fn groq_prepare_request_merges_native_tools_into_compound_custom() {
         let request = CompletionRequestBuilder::new(MockCompletionModel::default(), "search")
             .tool(crate::completion::ToolDefinition {
+                output_schema: None,
                 name: "local_tool".to_string(),
                 description: "A local function tool".to_string(),
                 parameters: serde_json::json!({"type":"object","properties":{},"required":[]}),

--- a/crates/rig-core/src/providers/hyperbolic.rs
+++ b/crates/rig-core/src/providers/hyperbolic.rs
@@ -443,6 +443,7 @@ mod tests {
             "hello",
         )
         .tool(crate::completion::ToolDefinition {
+            output_schema: None,
             name: "lookup".to_string(),
             description: "Lookup".to_string(),
             parameters: serde_json::json!({"type":"object","properties":{},"required":[]}),

--- a/crates/rig-core/src/providers/mira.rs
+++ b/crates/rig-core/src/providers/mira.rs
@@ -405,6 +405,8 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
         })?;
 
         Ok(completion::CompletionResponse {
+            finish_reason: None,
+            raw_finish_reason: None,
             choice,
             usage,
             raw_response: response,

--- a/crates/rig-core/src/providers/mistral/completion.rs
+++ b/crates/rig-core/src/providers/mistral/completion.rs
@@ -256,6 +256,8 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
         let message_id = response.id.clone();
 
         Ok(completion::CompletionResponse {
+            finish_reason: None,
+            raw_finish_reason: None,
             choice,
             usage,
             raw_response: response,

--- a/crates/rig-core/src/providers/moonshot.rs
+++ b/crates/rig-core/src/providers/moonshot.rs
@@ -389,6 +389,8 @@ mod tests {
                 AssistantContent::ToolCall(ToolCall {
                     id: "call_1".to_string(),
                     call_id: None,
+                    internal_call_id: None,
+                    parent_internal_call_id: None,
                     function: ToolFunction {
                         name: "lookup".to_string(),
                         arguments: serde_json::json!({}),

--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -380,6 +380,8 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                 };
 
                 Ok(completion::CompletionResponse {
+                    finish_reason: None,
+                    raw_finish_reason: None,
                     choice,
                     usage: Usage {
                         input_tokens: prompt_tokens,
@@ -873,7 +875,15 @@ where
 pub struct ToolDefinition {
     #[serde(rename = "type")]
     pub type_field: String, // Fixed as "function"
-    pub function: completion::ToolDefinition,
+    pub function: OllamaFunctionDefinition,
+}
+
+/// Ollama's wire function shape; Rig-only output schemas are intentionally omitted.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct OllamaFunctionDefinition {
+    pub name: String,
+    pub description: String,
+    pub parameters: serde_json::Value,
 }
 
 /// Convert internal ToolDefinition (from the completion module) into Ollama's tool definition.
@@ -881,7 +891,7 @@ impl From<crate::completion::ToolDefinition> for ToolDefinition {
     fn from(tool: crate::completion::ToolDefinition) -> Self {
         ToolDefinition {
             type_field: "function".to_owned(),
-            function: completion::ToolDefinition {
+            function: OllamaFunctionDefinition {
                 name: tool.name,
                 description: tool.description,
                 parameters: tool.parameters,
@@ -1320,6 +1330,7 @@ mod tests {
     fn test_tool_definition_conversion() {
         // Internal tool definition from the completion module.
         let internal_tool = crate::completion::ToolDefinition {
+            output_schema: Some(json!({"type": "string"})),
             name: "get_current_weather".to_owned(),
             description: "Get the current weather for a location".to_owned(),
             parameters: json!({
@@ -1342,6 +1353,11 @@ mod tests {
         let ollama_tool: ToolDefinition = internal_tool.into();
         assert_eq!(ollama_tool.type_field, "function");
         assert_eq!(ollama_tool.function.name, "get_current_weather");
+        assert!(
+            serde_json::to_value(&ollama_tool).unwrap()["function"]
+                .get("output_schema")
+                .is_none()
+        );
         assert_eq!(
             ollama_tool.function.description,
             "Get the current weather for a location"

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -472,6 +472,14 @@ pub struct ToolDefinition {
     pub function: FunctionDefinition,
 }
 
+/// Native function tools and provider-hosted tool declarations share one wire array.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(untagged)]
+pub enum ChatToolDefinition {
+    Function(ToolDefinition),
+    Hosted(serde_json::Value),
+}
+
 impl From<completion::ToolDefinition> for ToolDefinition {
     fn from(tool: completion::ToolDefinition) -> Self {
         Self {
@@ -928,6 +936,8 @@ impl From<ToolCall> for message::ToolCall {
         Self {
             id: tool_call.id,
             call_id: None,
+            internal_call_id: None,
+            parent_internal_call_id: None,
             function: message::ToolFunction {
                 name: tool_call.function.name,
                 arguments: tool_call.function.arguments,
@@ -1204,6 +1214,8 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             .unwrap_or_default();
 
         Ok(completion::CompletionResponse {
+            finish_reason: None,
+            raw_finish_reason: None,
             choice,
             usage,
             raw_response: response,
@@ -1471,14 +1483,18 @@ pub trait OpenAICompatibleProvider: crate::client::Provider {
         request: CoreCompletionRequest,
         options: CompletionModelOptions,
     ) -> Result<CompletionRequest, CompletionError> {
-        CompletionRequest::try_from(OpenAIRequestParams {
+        let mut request = CompletionRequest::try_from(OpenAIRequestParams {
             model,
             request,
             strict_tools: options.strict_tools,
             tool_result_array_content: options.tool_result_array_content,
             supports_response_format: Self::SUPPORTS_RESPONSE_FORMAT,
             supports_tools: Self::SUPPORTS_TOOLS,
-        })
+        })?;
+        if Self::PROVIDER_NAME == "openai" {
+            request.merge_provider_tools();
+        }
+        Ok(request)
     }
 
     /// Adjust the typed request before serialization (e.g. rewrite the model
@@ -1586,7 +1602,7 @@ pub struct CompletionRequest {
     pub model: String,
     pub messages: Vec<Message>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub tools: Vec<ToolDefinition>,
+    pub tools: Vec<ChatToolDefinition>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_choice: Option<ToolChoice>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1595,6 +1611,19 @@ pub struct CompletionRequest {
     pub max_tokens: Option<u64>,
     #[serde(flatten)]
     pub additional_params: Option<serde_json::Value>,
+}
+
+impl CompletionRequest {
+    fn merge_provider_tools(&mut self) {
+        if let Some(params) = self.additional_params.as_mut()
+            && let Some(object) = params.as_object_mut()
+            && let Some(hosted) = object.remove("tools")
+        {
+            let hosted = hosted.as_array().cloned().unwrap_or_else(|| vec![hosted]);
+            self.tools
+                .extend(hosted.into_iter().map(ChatToolDefinition::Hosted));
+        }
+    }
 }
 
 /// Shared helper for provider `finalize_request_body` hooks whose APIs take
@@ -1802,11 +1831,11 @@ impl TryFrom<OpenAIRequestParams> for CompletionRequest {
 
         let (tools, tool_choice) = if supports_tools {
             let tool_choice = tool_choice.map(ToolChoice::try_from).transpose()?;
-            let tools: Vec<ToolDefinition> = tools
+            let tools: Vec<ChatToolDefinition> = tools
                 .into_iter()
                 .map(|tool| {
                     let def = ToolDefinition::from(tool);
-                    if strict_tools { def.with_strict() } else { def }
+                    ChatToolDefinition::Function(if strict_tools { def.with_strict() } else { def })
                 })
                 .collect();
             (tools, tool_choice)
@@ -2603,6 +2632,7 @@ mod tests {
             )),
             documents: vec![],
             tools: vec![completion::ToolDefinition {
+                output_schema: None,
                 name: "weather".to_string(),
                 description: "Get the weather".to_string(),
                 parameters: serde_json::json!({
@@ -2673,6 +2703,7 @@ mod tests {
             .expect("history should be non-empty"),
             documents: vec![],
             tools: vec![completion::ToolDefinition {
+                output_schema: None,
                 name: "weather".to_string(),
                 description: "Get the weather".to_string(),
                 parameters: serde_json::json!({
@@ -3077,6 +3108,38 @@ mod tests {
             }
             other => panic!("expected ProviderResponse, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn mixed_native_and_hosted_chat_tools_use_one_wire_key() {
+        let mut request = CompletionRequest {
+            model: "gpt".into(),
+            messages: vec![],
+            tools: vec![ChatToolDefinition::Function(ToolDefinition {
+                r#type: "function".into(),
+                function: FunctionDefinition {
+                    name: "native".into(),
+                    description: "native".into(),
+                    parameters: serde_json::json!({"type":"object"}),
+                    strict: None,
+                },
+            })],
+            tool_choice: None,
+            temperature: None,
+            max_tokens: None,
+            additional_params: Some(serde_json::json!({"tools":[{"type":"web_search"}]})),
+        };
+        request.merge_provider_tools();
+        let json = serde_json::to_value(request).unwrap();
+        assert_eq!(json["tools"].as_array().unwrap().len(), 2);
+        assert_eq!(
+            json.as_object()
+                .unwrap()
+                .keys()
+                .filter(|key| *key == "tools")
+                .count(),
+            1
+        );
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -733,6 +733,7 @@ impl From<completion::ToolDefinition> for ResponsesToolDefinition {
             name,
             parameters,
             description,
+            output_schema: _,
         } = value;
 
         Self::function(name, description, parameters)
@@ -997,6 +998,24 @@ pub enum ResponseStatus {
     Cancelled,
     Queued,
     Incomplete,
+}
+
+pub(crate) fn normalized_response_status(
+    status: &ResponseStatus,
+) -> (Option<crate::runtime::TerminalReason>, Option<String>) {
+    use crate::runtime::TerminalReason;
+    let (reason, raw) = match status {
+        ResponseStatus::Completed => (Some(TerminalReason::Completed), "completed"),
+        ResponseStatus::Cancelled => (Some(TerminalReason::Cancelled), "cancelled"),
+        ResponseStatus::Failed => (Some(TerminalReason::Failed), "failed"),
+        ResponseStatus::Incomplete => (
+            Some(TerminalReason::Other("incomplete".to_string())),
+            "incomplete",
+        ),
+        ResponseStatus::InProgress => (None, "in_progress"),
+        ResponseStatus::Queued => (None, "queued"),
+    };
+    (reason, Some(raw.to_string()))
 }
 
 /// Controls where Rig system instructions are placed in an OpenAI Responses request.
@@ -2255,7 +2274,11 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             .map(GetTokenUsage::token_usage)
             .unwrap_or_default();
 
+        let (finish_reason, raw_finish_reason) = normalized_response_status(&response.status);
+
         Ok(completion::CompletionResponse {
+            finish_reason,
+            raw_finish_reason,
             choice,
             usage,
             raw_response: response,
@@ -2671,6 +2694,40 @@ impl FromStr for UserContent {
 mod tests {
     use super::*;
     use crate::completion::CompletionRequestBuilder;
+
+    #[test]
+    fn mixed_native_and_hosted_tools_serialize_under_one_tools_key() {
+        let request = CompletionRequestBuilder::new(MockCompletionModel::text("unused"), "hi")
+            .tool(weather_tool_definition())
+            .provider_tool(completion::ProviderToolDefinition::new("web_search"))
+            .build();
+        let converted = CompletionRequest::try_from(("gpt-5".to_string(), request)).unwrap();
+        let value = serde_json::to_value(converted).unwrap();
+        let object = value.as_object().unwrap();
+        assert_eq!(
+            object.keys().filter(|key| key.as_str() == "tools").count(),
+            1
+        );
+        assert_eq!(object["tools"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn response_status_is_normalized_and_raw_value_is_preserved() {
+        assert_eq!(
+            normalized_response_status(&ResponseStatus::Completed),
+            (
+                Some(crate::runtime::TerminalReason::Completed),
+                Some("completed".to_string())
+            )
+        );
+        assert_eq!(
+            normalized_response_status(&ResponseStatus::Incomplete),
+            (
+                Some(crate::runtime::TerminalReason::Other("incomplete".into())),
+                Some("incomplete".to_string())
+            )
+        );
+    }
     use crate::message;
     use crate::test_utils::MockCompletionModel;
     use serde_json::json;
@@ -2686,6 +2743,7 @@ mod tests {
 
     fn weather_tool_definition() -> completion::ToolDefinition {
         completion::ToolDefinition {
+            output_schema: None,
             name: "get_weather".to_string(),
             description: "Get the weather".to_string(),
             parameters: json!({
@@ -3077,6 +3135,7 @@ mod tests {
         let model = ResponsesCompletionModel::new(client, "gpt-4o-mini")
             .with_strict_tools()
             .with_tool(completion::ToolDefinition {
+                output_schema: None,
                 name: "lookup".to_string(),
                 description: "Look something up".to_string(),
                 parameters: json!({

--- a/crates/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -45,6 +45,10 @@ pub struct StreamingCompletionResponse {
     /// The effective reasoning context from the terminal response event.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning_context: Option<String>,
+    /// Provider-neutral terminal status from the terminal response event.
+    pub finish_reason: Option<crate::runtime::TerminalReason>,
+    /// Raw terminal response status.
+    pub raw_finish_reason: Option<String>,
 }
 
 pub(crate) fn reasoning_choices_from_done_item(
@@ -84,6 +88,14 @@ pub(crate) fn reasoning_choices_from_done_item(
 impl GetTokenUsage for StreamingCompletionResponse {
     fn token_usage(&self) -> crate::completion::Usage {
         self.usage.token_usage()
+    }
+
+    fn finish_reason(&self) -> Option<crate::runtime::TerminalReason> {
+        self.finish_reason.clone()
+    }
+
+    fn raw_finish_reason(&self) -> Option<String> {
+        self.raw_finish_reason.clone()
     }
 }
 
@@ -223,6 +235,8 @@ struct RawChoiceAccumulator {
     reasoning_context: Option<String>,
     tool_calls: Vec<StreamingRawChoice>,
     tool_call_internal_ids: std::collections::HashMap<String, String>,
+    finish_reason: Option<crate::runtime::TerminalReason>,
+    raw_finish_reason: Option<String>,
 }
 
 impl RawChoiceAccumulator {
@@ -233,6 +247,8 @@ impl RawChoiceAccumulator {
             reasoning_context: None,
             tool_calls: Vec::new(),
             tool_call_internal_ids: std::collections::HashMap::new(),
+            finish_reason: None,
+            raw_finish_reason: None,
         }
     }
 
@@ -318,6 +334,8 @@ impl RawChoiceAccumulator {
     ) -> Result<(), CompletionError> {
         match kind {
             ResponseChunkKind::ResponseCompleted => {
+                (self.finish_reason, self.raw_finish_reason) =
+                    super::normalized_response_status(&response.status);
                 if let Some(usage) = response.usage {
                     self.final_usage = usage;
                 }
@@ -396,6 +414,8 @@ impl RawChoiceAccumulator {
                 usage: self.final_usage,
                 reasoning_metadata: self.reasoning_metadata,
                 reasoning_context: self.reasoning_context,
+                finish_reason: self.finish_reason,
+                raw_finish_reason: self.raw_finish_reason,
             },
         ));
         choices
@@ -562,6 +582,8 @@ pub(crate) async fn completion_response_from_sse_body(
     }
 
     Ok(completion::CompletionResponse {
+        finish_reason: None,
+        raw_finish_reason: None,
         usage: stream
             .response
             .as_ref()
@@ -1560,10 +1582,18 @@ mod tests {
             "response": response,
         });
 
-        let usage = final_response_from_event(event).await.usage;
-        assert_eq!(usage.input_tokens, 10);
-        assert_eq!(usage.output_tokens, 5);
-        assert_eq!(usage.total_tokens, 15);
+        let final_response = final_response_from_event(event).await;
+        assert_eq!(final_response.usage.input_tokens, 10);
+        assert_eq!(final_response.usage.output_tokens, 5);
+        assert_eq!(final_response.usage.total_tokens, 15);
+        assert_eq!(
+            final_response.finish_reason,
+            Some(crate::runtime::TerminalReason::Completed)
+        );
+        assert_eq!(
+            final_response.raw_finish_reason.as_deref(),
+            Some("completed")
+        );
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/providers/openrouter/completion.rs
+++ b/crates/rig-core/src/providers/openrouter/completion.rs
@@ -729,6 +729,8 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             .unwrap_or_default();
 
         Ok(completion::CompletionResponse {
+            finish_reason: None,
+            raw_finish_reason: None,
             choice,
             usage,
             raw_response: response,
@@ -1377,13 +1379,15 @@ impl TryFrom<OpenRouterRequestParams<'_>> for OpenrouterCompletionRequest {
             .map(crate::providers::openai::completion::ToolChoice::try_from)
             .transpose()?;
 
-        let tools: Vec<crate::providers::openai::completion::ToolDefinition> = req
+        let tools: Vec<crate::providers::openai::completion::ChatToolDefinition> = req
             .tools
             .clone()
             .into_iter()
             .map(|tool| {
                 let def = crate::providers::openai::completion::ToolDefinition::from(tool);
-                if strict_tools { def.with_strict() } else { def }
+                crate::providers::openai::completion::ChatToolDefinition::Function(
+                    if strict_tools { def.with_strict() } else { def },
+                )
             })
             .collect();
 
@@ -2855,6 +2859,8 @@ mod tests {
         let tool_call = message::ToolCall {
             id: "call_wire".to_string(),
             call_id: None,
+            internal_call_id: None,
+            parent_internal_call_id: None,
             function: message::ToolFunction {
                 name: "lookup".to_string(),
                 arguments: json!({}),
@@ -2890,6 +2896,8 @@ mod tests {
         let tool_call = message::ToolCall {
             id: "call_wire".to_string(),
             call_id: None,
+            internal_call_id: None,
+            parent_internal_call_id: None,
             function: message::ToolFunction {
                 name: "lookup".to_string(),
                 arguments: json!({}),

--- a/crates/rig-core/src/providers/perplexity.rs
+++ b/crates/rig-core/src/providers/perplexity.rs
@@ -214,6 +214,7 @@ mod tests {
             output_schema: None,
         };
         request.tools = vec![crate::completion::ToolDefinition {
+            output_schema: None,
             name: "lookup".to_string(),
             description: String::new(),
             parameters: serde_json::json!({}),
@@ -274,6 +275,7 @@ mod tests {
             "What's new today?",
         )
         .tool(crate::completion::ToolDefinition {
+            output_schema: None,
             name: "lookup".to_string(),
             description: "Lookup".to_string(),
             parameters: serde_json::json!({"type":"object","properties":{},"required":[]}),

--- a/crates/rig-core/src/providers/xai/completion.rs
+++ b/crates/rig-core/src/providers/xai/completion.rs
@@ -157,6 +157,8 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
         });
 
         Ok(completion::CompletionResponse {
+            finish_reason: None,
+            raw_finish_reason: None,
             choice,
             usage,
             raw_response: response,
@@ -365,6 +367,7 @@ mod tests {
     fn xai_request_uses_responses_tool_choice_for_specific_tool() {
         let request = CompletionRequestBuilder::new(MockCompletionModel::default(), "Use a tool.")
             .tool(ToolDefinition {
+                output_schema: None,
                 name: "alpha".to_string(),
                 description: "Alpha tool".to_string(),
                 parameters: serde_json::json!({
@@ -374,6 +377,7 @@ mod tests {
                 }),
             })
             .tool(ToolDefinition {
+                output_schema: None,
                 name: "beta".to_string(),
                 description: "Beta tool".to_string(),
                 parameters: serde_json::json!({

--- a/crates/rig-core/src/runtime.rs
+++ b/crates/rig-core/src/runtime.rs
@@ -1,0 +1,1272 @@
+//! Runtime control and context for interactive agent runs.
+//!
+//! A [`crate::runtime::RunControlHandle`] is cloneable host-side state for one run. The shared
+//! agent driver observes it only at explicit boundaries and inserts the paired
+//! [`crate::runtime::RunContext`] into every tool call's extensions.
+
+use crate::{agent::RunId, completion::Message};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::VecDeque,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+/// Cooperative cancellation shared by a run and all descendant work.
+#[derive(Clone, Debug, Default)]
+pub struct CancellationToken(Arc<AtomicBool>);
+
+impl CancellationToken {
+    /// Creates an uncancelled token.
+    pub fn new() -> Self {
+        Self::default()
+    }
+    /// Requests cancellation. Repeated requests are harmless.
+    pub fn cancel(&self) {
+        self.0.store(true, Ordering::Release);
+    }
+    /// Returns whether cancellation was requested.
+    pub fn is_cancelled(&self) -> bool {
+        self.0.load(Ordering::Acquire)
+    }
+}
+
+/// Provider-neutral terminal reason for a completion or agent run.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum TerminalReason {
+    /// A final answer completed normally.
+    #[default]
+    Completed,
+    /// Cancellation was requested.
+    Cancelled,
+    /// The run deadline elapsed.
+    DeadlineExceeded,
+    /// The configured model-turn budget was exhausted.
+    MaxTurns,
+    /// The provider's output-token limit was reached.
+    MaxTokens,
+    /// A hook or host policy terminated execution.
+    PolicyTerminated,
+    /// A provider safety policy filtered the response.
+    ContentFiltered,
+    /// The model stopped to invoke tools.
+    ToolCalls,
+    /// Execution failed.
+    Failed,
+    /// Provider-specific reason not understood by Rig.
+    Other(String),
+}
+
+/// Observable state of an interactive run.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RunStatus {
+    /// The run can make progress.
+    Running,
+    /// Cancellation has been requested while work settles.
+    Cancelling,
+    /// A checkpoint was requested and will be honored at the next safe boundary.
+    Checkpointing,
+    /// The run is paused at a safe [`AgentRun`](crate::agent::AgentRun) boundary.
+    Checkpointed,
+    /// The run has settled.
+    Terminal(TerminalReason),
+}
+
+#[derive(Debug)]
+struct ControlState {
+    status: Mutex<RunStatus>,
+    steering: Mutex<VecDeque<Message>>,
+    follow_ups: Mutex<VecDeque<Message>>,
+    checkpoint_state: Mutex<Option<String>>,
+    cancellation: CancellationToken,
+}
+
+/// Error returned when a run-control command cannot be accepted.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum RunControlError {
+    /// The run already settled.
+    #[error("run is already terminal")]
+    Terminal,
+    /// Resume was requested before the driver reached a checkpoint.
+    #[error("run has not reached a checkpoint")]
+    NotCheckpointed,
+    /// Follow-ups were requested before terminal settlement.
+    #[error("run has not settled")]
+    NotTerminal,
+}
+
+/// Cloneable control handle for exactly one agent run.
+#[derive(Clone, Debug)]
+pub struct RunControlHandle {
+    run_id: RunId,
+    state: Arc<ControlState>,
+}
+
+pub(crate) struct RunLease(RunControlHandle);
+
+impl Drop for RunLease {
+    fn drop(&mut self) {
+        self.0.finish(TerminalReason::Cancelled);
+    }
+}
+
+impl RunControlHandle {
+    /// Creates independent settlement ownership for a child while sharing the
+    /// supplied context's cancellation and deadline.
+    pub(crate) fn for_child_context(context: &RunContext) -> Self {
+        Self {
+            run_id: context.run_id.clone(),
+            state: Arc::new(ControlState {
+                status: Mutex::new(RunStatus::Running),
+                steering: Mutex::new(VecDeque::new()),
+                follow_ups: Mutex::new(VecDeque::new()),
+                checkpoint_state: Mutex::new(None),
+                cancellation: context.cancellation.clone(),
+            }),
+        }
+    }
+
+    /// Creates a handle and the context inherited by work in the run.
+    pub fn new(conversation_id: Option<String>, deadline: Option<Instant>) -> (Self, RunContext) {
+        let run_id = RunId::generate();
+        let cancellation = CancellationToken::new();
+        let state = Arc::new(ControlState {
+            status: Mutex::new(RunStatus::Running),
+            steering: Mutex::new(VecDeque::new()),
+            follow_ups: Mutex::new(VecDeque::new()),
+            checkpoint_state: Mutex::new(None),
+            cancellation: cancellation.clone(),
+        });
+        let handle = Self {
+            run_id: run_id.clone(),
+            state,
+        };
+        let context = RunContext {
+            run_id,
+            conversation_id,
+            cancellation,
+            deadline,
+            ancestry: Arc::from([]),
+            current_call_id: None,
+        };
+        (handle, context)
+    }
+
+    /// Returns the stable run identifier.
+    pub fn run_id(&self) -> &RunId {
+        &self.run_id
+    }
+
+    /// Returns a consistent status snapshot.
+    pub fn status(&self) -> RunStatus {
+        self.state
+            .status
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
+
+    /// Requests cancellation and returns false when the run was already terminal.
+    pub fn cancel(&self) -> bool {
+        let mut status = self.state.status.lock().unwrap_or_else(|e| e.into_inner());
+        if matches!(*status, RunStatus::Terminal(_)) {
+            return false;
+        }
+        self.state.cancellation.cancel();
+        *status = RunStatus::Cancelling;
+        true
+    }
+
+    /// Queues a user message for the next pre-model safe boundary.
+    pub fn steer(&self, message: impl Into<Message>) -> Result<(), RunControlError> {
+        self.enqueue(message.into(), false)
+    }
+
+    /// Queues a user message for consumption only after this run settles.
+    pub fn follow_up(&self, message: impl Into<Message>) -> Result<(), RunControlError> {
+        self.enqueue(message.into(), true)
+    }
+
+    fn enqueue(&self, message: Message, follow_up: bool) -> Result<(), RunControlError> {
+        let status = self.state.status.lock().unwrap_or_else(|e| e.into_inner());
+        if matches!(*status, RunStatus::Terminal(_)) {
+            return Err(RunControlError::Terminal);
+        }
+        let queue = if follow_up {
+            &self.state.follow_ups
+        } else {
+            &self.state.steering
+        };
+        queue
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push_back(message);
+        drop(status);
+        Ok(())
+    }
+
+    /// Requests a pause at the next safe state-machine boundary.
+    pub fn checkpoint(&self) -> Result<(), RunControlError> {
+        let mut status = self.state.status.lock().unwrap_or_else(|e| e.into_inner());
+        if matches!(*status, RunStatus::Terminal(_)) {
+            return Err(RunControlError::Terminal);
+        }
+        if matches!(*status, RunStatus::Running) {
+            *status = RunStatus::Checkpointing;
+        }
+        Ok(())
+    }
+
+    /// Resumes execution after the driver reports [`RunStatus::Checkpointed`].
+    pub fn resume(&self) -> Result<(), RunControlError> {
+        let mut status = self.state.status.lock().unwrap_or_else(|e| e.into_inner());
+        if *status != RunStatus::Checkpointed {
+            return Err(RunControlError::NotCheckpointed);
+        }
+        *status = RunStatus::Running;
+        Ok(())
+    }
+
+    /// Drains follow-ups in FIFO order after terminal settlement.
+    pub fn drain_follow_ups(&self) -> Result<Vec<Message>, RunControlError> {
+        let status = self.state.status.lock().unwrap_or_else(|e| e.into_inner());
+        if !matches!(*status, RunStatus::Terminal(_)) {
+            return Err(RunControlError::NotTerminal);
+        }
+        let messages = self
+            .state
+            .follow_ups
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .drain(..)
+            .collect();
+        drop(status);
+        Ok(messages)
+    }
+
+    pub(crate) fn drain_steering(&self) -> Vec<Message> {
+        self.state
+            .steering
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .drain(..)
+            .collect()
+    }
+
+    pub(crate) fn defer_as_follow_ups(&self, messages: Vec<Message>) {
+        self.state
+            .follow_ups
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .extend(messages);
+    }
+
+    /// Returns the serialized [`AgentRun`](crate::agent::AgentRun) captured at
+    /// the current or most recent safe checkpoint.
+    ///
+    /// It contains conversation data and follows `AgentRun`'s same-version
+    /// resume contract, so hosts must store it as sensitive data.
+    pub fn checkpoint_state(&self) -> Option<String> {
+        self.state
+            .checkpoint_state
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
+
+    pub(crate) fn checkpoint_requested(&self) -> bool {
+        self.status() == RunStatus::Checkpointing
+    }
+
+    pub(crate) fn reach_checkpoint(&self, serialized_run: String) {
+        let mut status = self.state.status.lock().unwrap_or_else(|e| e.into_inner());
+        if *status == RunStatus::Checkpointing {
+            *self
+                .state
+                .checkpoint_state
+                .lock()
+                .unwrap_or_else(|e| e.into_inner()) = Some(serialized_run);
+            *status = RunStatus::Checkpointed;
+        }
+    }
+
+    pub(crate) fn checkpoint_blocked(&self) -> bool {
+        self.status() == RunStatus::Checkpointed
+    }
+
+    pub(crate) fn lease(&self) -> RunLease {
+        RunLease(self.clone())
+    }
+
+    pub(crate) fn finish(&self, mut reason: TerminalReason) -> bool {
+        let mut status = self.state.status.lock().unwrap_or_else(|e| e.into_inner());
+        if matches!(*status, RunStatus::Terminal(_)) {
+            return false;
+        }
+        if reason == TerminalReason::Completed && self.state.cancellation.is_cancelled() {
+            reason = TerminalReason::Cancelled;
+        }
+        *status = RunStatus::Terminal(reason);
+        true
+    }
+}
+
+/// Immutable context automatically inherited by tools and nested agents.
+#[derive(Clone, Debug)]
+pub struct RunContext {
+    run_id: RunId,
+    conversation_id: Option<String>,
+    cancellation: CancellationToken,
+    deadline: Option<Instant>,
+    ancestry: Arc<[String]>,
+    current_call_id: Option<String>,
+}
+
+impl RunContext {
+    /// Returns the root run identifier.
+    pub fn run_id(&self) -> &RunId {
+        &self.run_id
+    }
+    /// Returns the conversation identifier, when configured.
+    pub fn conversation_id(&self) -> Option<&str> {
+        self.conversation_id.as_deref()
+    }
+    /// Returns the inherited cancellation token.
+    pub fn cancellation(&self) -> &CancellationToken {
+        &self.cancellation
+    }
+    /// Returns the absolute deadline.
+    pub fn deadline(&self) -> Option<Instant> {
+        self.deadline
+    }
+    /// Returns the remaining duration, saturating at zero.
+    pub fn remaining(&self) -> Option<Duration> {
+        self.deadline
+            .map(|d| d.saturating_duration_since(Instant::now()))
+    }
+    /// Returns whether cancellation or deadline requires work to stop.
+    pub fn should_stop(&self) -> bool {
+        self.cancellation.is_cancelled() || self.deadline.is_some_and(|d| Instant::now() >= d)
+    }
+    /// Returns ancestor names, oldest first.
+    pub fn ancestry(&self) -> &[String] {
+        &self.ancestry
+    }
+    /// Returns the current framework-generated call identifier.
+    pub fn current_call_id(&self) -> Option<&str> {
+        self.current_call_id.as_deref()
+    }
+
+    pub(crate) fn with_conversation(mut self, id: Option<String>) -> Self {
+        self.conversation_id = id;
+        self
+    }
+
+    pub(crate) fn with_deadline(mut self, deadline: Option<Instant>) -> Self {
+        self.deadline = deadline;
+        self
+    }
+
+    pub(crate) fn fresh_child(&self, name: String, call_id: String) -> Self {
+        let mut ancestry = self.ancestry.to_vec();
+        ancestry.push(format!("{}:{name}", self.run_id));
+        Self {
+            run_id: RunId::generate(),
+            conversation_id: self.conversation_id.clone(),
+            cancellation: self.cancellation.clone(),
+            deadline: self.deadline,
+            ancestry: ancestry.into(),
+            current_call_id: Some(call_id),
+        }
+    }
+
+    pub(crate) fn child(&self, name: String, call_id: String) -> Self {
+        let mut ancestry = self.ancestry.to_vec();
+        ancestry.push(name);
+        Self {
+            run_id: self.run_id.clone(),
+            conversation_id: self.conversation_id.clone(),
+            cancellation: self.cancellation.clone(),
+            deadline: self.deadline,
+            ancestry: ancestry.into(),
+            current_call_id: Some(call_id),
+        }
+    }
+
+    pub(crate) async fn stopped(&self) -> TerminalReason {
+        loop {
+            if self.cancellation.is_cancelled() {
+                return TerminalReason::Cancelled;
+            }
+            if self.deadline.is_some_and(|d| Instant::now() >= d) {
+                return TerminalReason::DeadlineExceeded;
+            }
+            let delay = self.remaining().map_or(Duration::from_millis(5), |left| {
+                left.min(Duration::from_millis(5))
+            });
+            futures_timer::Delay::new(delay).await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        agent::{AgentBuilder, AgentHook, Flow, HookContext, StepEvent},
+        completion::{
+            CompletionError, CompletionModel, CompletionRequest, CompletionResponse, Prompt,
+            PromptError, ProviderToolDefinition,
+        },
+        streaming::{StreamingCompletionResponse, StreamingPrompt},
+        test_utils::{MockAddTool, MockCompletionModel, MockResponse, MockStreamEvent, MockTurn},
+        tool::{
+            Tool, ToolReturn,
+            server::{
+                NestedToolPolicy, ScopedToolExecutor, ToolCatalogKind, ToolCatalogMetadata,
+                ToolServer,
+            },
+        },
+    };
+    use futures::StreamExt;
+    use std::{
+        convert::Infallible,
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
+
+    #[derive(Clone)]
+    struct PendingModel {
+        started: Arc<tokio::sync::Notify>,
+    }
+
+    impl CompletionModel for PendingModel {
+        type Response = MockResponse;
+        type StreamingResponse = MockResponse;
+        type Client = ();
+
+        fn make(_: &Self::Client, _: impl Into<String>) -> Self {
+            Self {
+                started: Arc::new(tokio::sync::Notify::new()),
+            }
+        }
+
+        async fn completion(
+            &self,
+            _request: CompletionRequest,
+        ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+            self.started.notify_one();
+            futures::future::pending().await
+        }
+
+        async fn stream(
+            &self,
+            _request: CompletionRequest,
+        ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+            self.started.notify_one();
+            futures::future::pending().await
+        }
+    }
+
+    #[derive(Clone)]
+    struct RegenerateArgsHook;
+
+    impl AgentHook<MockCompletionModel> for RegenerateArgsHook {
+        async fn on_event(
+            &self,
+            _context: &HookContext,
+            event: StepEvent<'_, MockCompletionModel>,
+        ) -> Flow {
+            if matches!(event, StepEvent::InvalidToolCall(_)) {
+                Flow::regenerate_args("regenerate the call with valid arguments")
+            } else {
+                Flow::cont()
+            }
+        }
+    }
+
+    #[derive(Clone)]
+    struct NestedHook(Arc<AtomicUsize>);
+
+    impl AgentHook<MockCompletionModel> for NestedHook {
+        async fn on_event(
+            &self,
+            _context: &HookContext,
+            event: StepEvent<'_, MockCompletionModel>,
+        ) -> Flow {
+            match event {
+                StepEvent::ToolCall {
+                    tool_name: "add",
+                    parent_internal_call_id: Some(_),
+                    ..
+                } => {
+                    self.0.fetch_add(1, Ordering::SeqCst);
+                    Flow::rewrite_args(serde_json::json!({"x": 40, "y": 2}))
+                }
+                StepEvent::ToolResult {
+                    tool_name: "add",
+                    parent_internal_call_id: Some(_),
+                    ..
+                } => {
+                    self.0.fetch_add(1, Ordering::SeqCst);
+                    Flow::rewrite_result("nested-rewritten")
+                }
+                _ => Flow::cont(),
+            }
+        }
+    }
+
+    #[derive(Clone)]
+    struct NestedCaller(Arc<Mutex<Option<String>>>);
+
+    impl Tool for NestedCaller {
+        const NAME: &'static str = "nested_caller";
+        type Error = std::io::Error;
+        type Args = serde_json::Value;
+        type Output = String;
+
+        fn description(&self) -> String {
+            "call add through scoped executor".into()
+        }
+        fn parameters(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+        fn output_schema(&self) -> Option<serde_json::Value> {
+            Some(serde_json::json!({"type": "string"}))
+        }
+        async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
+            Err(std::io::Error::other("scoped executor missing"))
+        }
+        async fn call_with_extensions(
+            &self,
+            _args: Self::Args,
+            extensions: &crate::tool::ToolCallExtensions,
+        ) -> Result<Self::Output, Self::Error> {
+            let executor = extensions
+                .get::<ScopedToolExecutor>()
+                .ok_or_else(|| std::io::Error::other("scoped executor missing"))?;
+            let nested = executor.call("add", r#"{"x":2,"y":3}"#).await;
+            assert!(nested.parent_internal_call_id.is_some());
+            let output = nested.result.model_output().to_string();
+            *self.0.lock().unwrap_or_else(|error| error.into_inner()) = Some(output.clone());
+            Ok(output)
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct ErrorTag(&'static str);
+
+    #[derive(Clone)]
+    struct SchedulingTool {
+        active: Arc<AtomicUsize>,
+        maximum: Arc<AtomicUsize>,
+    }
+
+    impl Tool for SchedulingTool {
+        const NAME: &'static str = "scheduled";
+        type Error = Infallible;
+        type Args = serde_json::Value;
+        type Output = String;
+        fn description(&self) -> String {
+            "scheduling probe".into()
+        }
+        fn parameters(&self) -> serde_json::Value {
+            serde_json::json!({"type":"object"})
+        }
+        async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
+            let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
+            self.maximum.fetch_max(active, Ordering::SeqCst);
+            futures_timer::Delay::new(Duration::from_millis(10)).await;
+            self.active.fetch_sub(1, Ordering::SeqCst);
+            Ok("ok".into())
+        }
+    }
+
+    #[derive(Clone)]
+    struct FinalTool;
+
+    impl Tool for FinalTool {
+        const NAME: &'static str = "final_tool";
+        type Error = Infallible;
+        type Args = serde_json::Value;
+        type Output = String;
+        fn description(&self) -> String {
+            "final result".into()
+        }
+        fn parameters(&self) -> serde_json::Value {
+            serde_json::json!({"type":"object"})
+        }
+        async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
+            Ok("tool-final".into())
+        }
+    }
+
+    #[derive(Clone)]
+    struct ClassifiedErrorTool;
+
+    impl Tool for ClassifiedErrorTool {
+        const NAME: &'static str = "classified_error";
+        type Error = std::io::Error;
+        type Args = serde_json::Value;
+        type Output = String;
+
+        fn description(&self) -> String {
+            "fails with metadata".into()
+        }
+        fn parameters(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+        fn classify_error(&self, error: &Self::Error) -> crate::tool::ToolFailure {
+            crate::tool::ToolFailure::provider(error.to_string())
+        }
+        fn error_extensions(&self, _error: &Self::Error) -> crate::tool::ToolResultExtensions {
+            let mut extensions = crate::tool::ToolResultExtensions::new();
+            extensions.insert(ErrorTag("classified"));
+            extensions
+        }
+        async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
+            Err(std::io::Error::other("boom"))
+        }
+    }
+
+    #[derive(Clone)]
+    struct RichTool;
+
+    impl Tool for RichTool {
+        const NAME: &'static str = "rich";
+        type Error = Infallible;
+        type Args = serde_json::Value;
+        type Output = String;
+
+        fn description(&self) -> String {
+            "rich output".into()
+        }
+        fn parameters(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+        async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
+            Ok("fallback".into())
+        }
+        async fn call_structured(
+            &self,
+            _args: Self::Args,
+            _extensions: &crate::tool::ToolCallExtensions,
+        ) -> Result<ToolReturn<Self::Output>, Self::Error> {
+            Ok(ToolReturn::success("fallback".into()).with_content(
+                crate::OneOrMany::many([
+                    crate::message::ToolResultContent::text("first"),
+                    crate::message::ToolResultContent::text("second"),
+                ])
+                .unwrap(),
+            ))
+        }
+    }
+
+    #[derive(Clone)]
+    struct RetryTool(Arc<AtomicUsize>);
+
+    impl Tool for RetryTool {
+        const NAME: &'static str = "retry";
+        type Error = std::io::Error;
+        type Args = serde_json::Value;
+        type Output = String;
+
+        fn description(&self) -> String {
+            "fails once".into()
+        }
+        fn parameters(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+        fn classify_error(&self, error: &Self::Error) -> crate::tool::ToolFailure {
+            crate::tool::ToolFailure::network(error.to_string())
+        }
+        async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
+            if self.0.fetch_add(1, Ordering::SeqCst) == 0 {
+                Err(std::io::Error::other("transient"))
+            } else {
+                Ok("recovered".into())
+            }
+        }
+    }
+
+    #[derive(Clone)]
+    struct PendingTool {
+        started: Arc<tokio::sync::Notify>,
+    }
+
+    impl Tool for PendingTool {
+        const NAME: &'static str = "pending";
+        type Error = Infallible;
+        type Args = serde_json::Value;
+        type Output = String;
+
+        fn description(&self) -> String {
+            "wait forever".into()
+        }
+        fn parameters(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+
+        async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
+            self.started.notify_one();
+            futures::future::pending().await
+        }
+    }
+
+    #[tokio::test]
+    async fn steering_is_fifo_and_identical_on_unary_and_streaming() {
+        let unary_model = MockCompletionModel::new([MockTurn::text("done")]);
+        let unary_request = AgentBuilder::new(unary_model.clone())
+            .build()
+            .prompt("original")
+            .extended_details();
+        let unary_control = unary_request.control_handle();
+        unary_control.steer("first steer").unwrap();
+        unary_control.steer("second steer").unwrap();
+        let unary = unary_request.await.unwrap();
+        assert_eq!(unary.terminal_reason(), &TerminalReason::Completed);
+        let unary_text: Vec<_> = unary_model.requests()[0]
+            .chat_history
+            .iter()
+            .filter_map(Message::rag_text)
+            .collect();
+        assert!(unary_text.ends_with(&["first steer".to_string(), "second steer".to_string(),]));
+
+        let stream_model =
+            MockCompletionModel::from_stream_turns([[MockStreamEvent::text("done")]]);
+        let stream_request = AgentBuilder::new(stream_model.clone())
+            .build()
+            .stream_prompt("original");
+        let stream_control = stream_request.control_handle();
+        stream_control.steer("first steer").unwrap();
+        stream_control.steer("second steer").unwrap();
+        let mut stream = stream_request.await;
+        while let Some(item) = stream.next().await {
+            item.unwrap();
+        }
+        let stream_text: Vec<_> = stream_model.requests()[0]
+            .chat_history
+            .iter()
+            .filter_map(Message::rag_text)
+            .collect();
+        assert!(stream_text.ends_with(&["first steer".to_string(), "second steer".to_string(),]));
+        assert_eq!(
+            stream_control.status(),
+            RunStatus::Terminal(TerminalReason::Completed)
+        );
+    }
+
+    #[tokio::test]
+    async fn regenerated_arguments_share_repair_and_turn_budgets_on_both_surfaces() {
+        let unary = AgentBuilder::new(MockCompletionModel::new([
+            MockTurn::tool_call("bad", "missing", serde_json::json!({"x": 1})),
+            MockTurn::tool_call("good", "add", serde_json::json!({"x": 2, "y": 3})),
+            MockTurn::text("done"),
+        ]))
+        .tool(MockAddTool)
+        .build()
+        .prompt("start")
+        .add_hook(RegenerateArgsHook)
+        .max_tool_repairs(1)
+        .max_turns(3)
+        .await
+        .unwrap();
+        assert_eq!(unary, "done");
+
+        let streaming = AgentBuilder::new(MockCompletionModel::from_stream_turns([
+            [MockStreamEvent::tool_call(
+                "bad",
+                "missing",
+                serde_json::json!({"x": 1}),
+            )],
+            [MockStreamEvent::tool_call(
+                "good",
+                "add",
+                serde_json::json!({"x": 2, "y": 3}),
+            )],
+            [MockStreamEvent::text("done")],
+        ]))
+        .tool(MockAddTool)
+        .build()
+        .stream_prompt("start")
+        .add_hook(RegenerateArgsHook)
+        .max_tool_repairs(1)
+        .max_turns(3);
+        let mut stream = streaming.await;
+        while let Some(item) = stream.next().await {
+            item.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn scoped_executor_inherits_context_and_dispatches_nested_tool() {
+        let model = MockCompletionModel::new([
+            MockTurn::tool_call("outer", "nested_caller", serde_json::json!({})),
+            MockTurn::text("done"),
+        ]);
+        let observed = Arc::new(Mutex::new(None));
+        let hook_events = Arc::new(AtomicUsize::new(0));
+        let agent = AgentBuilder::new(model.clone())
+            .nested_tool_policy(NestedToolPolicy {
+                allowlist: Some(["add".to_string()].into_iter().collect()),
+                ..Default::default()
+            })
+            .tool(MockAddTool)
+            .tool(NestedCaller(observed.clone()))
+            .build();
+        agent
+            .prompt("start")
+            .add_hook(NestedHook(hook_events.clone()))
+            .max_turns(2)
+            .await
+            .unwrap();
+        assert_eq!(
+            model.requests()[0]
+                .tools
+                .iter()
+                .find(|definition| definition.name == "nested_caller")
+                .unwrap()
+                .output_schema,
+            Some(serde_json::json!({"type": "string"}))
+        );
+        assert_eq!(
+            observed
+                .lock()
+                .unwrap_or_else(|error| error.into_inner())
+                .as_deref(),
+            Some("nested-rewritten")
+        );
+        assert_eq!(hook_events.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn serial_and_parallel_safe_metadata_control_batch_scheduling() {
+        async fn maximum_for(scheduling: crate::tool::server::ToolScheduling) -> usize {
+            let active = Arc::new(AtomicUsize::new(0));
+            let maximum = Arc::new(AtomicUsize::new(0));
+            let server = ToolServer::new().run();
+            server
+                .add_tool_with_metadata(
+                    SchedulingTool {
+                        active,
+                        maximum: maximum.clone(),
+                    },
+                    ToolCatalogMetadata {
+                        scheduling,
+                        ..Default::default()
+                    },
+                )
+                .await
+                .unwrap();
+            let turn = MockTurn::from_contents([
+                crate::message::AssistantContent::ToolCall(crate::message::ToolCall::new(
+                    "one".to_string(),
+                    crate::message::ToolFunction::new(
+                        "scheduled".to_string(),
+                        serde_json::json!({}),
+                    ),
+                )),
+                crate::message::AssistantContent::ToolCall(crate::message::ToolCall::new(
+                    "two".to_string(),
+                    crate::message::ToolFunction::new(
+                        "scheduled".to_string(),
+                        serde_json::json!({}),
+                    ),
+                )),
+            ])
+            .unwrap();
+            AgentBuilder::new(MockCompletionModel::new([turn, MockTurn::text("done")]))
+                .tool_server_handle(server)
+                .build()
+                .prompt("start")
+                .tool_concurrency(2)
+                .max_turns(2)
+                .await
+                .unwrap();
+            maximum.load(Ordering::SeqCst)
+        }
+        assert_eq!(
+            maximum_for(crate::tool::server::ToolScheduling::Serial).await,
+            1
+        );
+        assert_eq!(
+            maximum_for(crate::tool::server::ToolScheduling::ParallelSafe).await,
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn final_result_metadata_finishes_without_another_model_call() {
+        let server = ToolServer::new().run();
+        server
+            .add_tool_with_metadata(
+                FinalTool,
+                ToolCatalogMetadata {
+                    final_result: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        let model = MockCompletionModel::new([MockTurn::tool_call(
+            "final",
+            "final_tool",
+            serde_json::json!({}),
+        )]);
+        let output = AgentBuilder::new(model.clone())
+            .tool_server_handle(server)
+            .build()
+            .prompt("start")
+            .max_turns(2)
+            .await
+            .unwrap();
+        assert_eq!(output, "tool-final");
+        assert_eq!(model.request_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn ordinary_tool_errors_attach_classification_extensions() {
+        let server = ToolServer::new().tool(ClassifiedErrorTool).run();
+        let result = server
+            .call_tool_structured(
+                "classified_error",
+                "{}",
+                &crate::tool::ToolCallExtensions::new(),
+            )
+            .await;
+        assert!(
+            result
+                .outcome()
+                .is_error_kind(crate::tool::ToolFailureKind::Provider)
+        );
+        assert_eq!(
+            result.extensions().get::<ErrorTag>(),
+            Some(&ErrorTag("classified"))
+        );
+    }
+
+    #[tokio::test]
+    async fn explicit_rich_tool_parts_reach_model_history_without_envelope_parsing() {
+        let model = MockCompletionModel::new([
+            MockTurn::tool_call("rich-call", "rich", serde_json::json!({})),
+            MockTurn::text("done"),
+        ]);
+        AgentBuilder::new(model.clone())
+            .tool(RichTool)
+            .build()
+            .prompt("start")
+            .max_turns(2)
+            .await
+            .unwrap();
+        let has_two_parts = model.requests()[1].chat_history.iter().any(|message| {
+            if let Message::User { content } = message {
+                content.iter().any(|item| match item {
+                    crate::message::UserContent::ToolResult(result) => result.content.len() == 2,
+                    _ => false,
+                })
+            } else {
+                false
+            }
+        });
+        assert!(has_two_parts);
+    }
+
+    #[tokio::test]
+    async fn catalog_retry_budget_only_retries_classified_transient_failures() {
+        let server = ToolServer::new().run();
+        let calls = Arc::new(AtomicUsize::new(0));
+        server
+            .add_tool_with_metadata(
+                RetryTool(calls.clone()),
+                ToolCatalogMetadata {
+                    max_retries: 1,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        let result = server
+            .call_tool_structured("retry", "{}", &crate::tool::ToolCallExtensions::new())
+            .await;
+        assert!(result.outcome().is_success());
+        assert_eq!(result.model_output(), "recovered");
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn catalog_preserves_order_and_host_metadata_never_enters_schema() {
+        let server = ToolServer::new().run();
+        let mut metadata = ToolCatalogMetadata {
+            source: Some("application".into()),
+            ..Default::default()
+        };
+        metadata
+            .host
+            .insert("secret".into(), serde_json::json!(true));
+        server
+            .add_tool_with_metadata(MockAddTool, metadata)
+            .await
+            .unwrap();
+        server
+            .add_provider_tool(
+                ProviderToolDefinition::new("web_search"),
+                ToolCatalogMetadata::default(),
+            )
+            .await;
+        let catalog = server.catalog().await;
+        assert_eq!(catalog[0].kind, ToolCatalogKind::Native);
+        assert_eq!(catalog[1].kind, ToolCatalogKind::ProviderHosted);
+        let provider_schema =
+            serde_json::to_value(catalog[0].definition.as_ref().unwrap()).unwrap();
+        assert!(!provider_schema.to_string().contains("secret"));
+        server.remove_tool("add").await.unwrap();
+        assert_eq!(server.catalog().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn agent_provider_tools_are_advertised_but_not_executable() {
+        let model = MockCompletionModel::new([MockTurn::text("done")]);
+        let hosted = ProviderToolDefinition::new("web_search")
+            .with_config("search_context_size", serde_json::json!("low"));
+        let agent = AgentBuilder::new(model.clone())
+            .provider_tool(hosted)
+            .build();
+        assert!(
+            agent
+                .tool_catalog()
+                .await
+                .iter()
+                .any(|entry| entry.kind == ToolCatalogKind::ProviderHosted)
+        );
+        agent.prompt("search").await.unwrap();
+        let request = &model.requests()[0];
+        assert!(request.tools.is_empty());
+        assert_eq!(
+            request.additional_params.as_ref().unwrap()["tools"][0]["type"],
+            "web_search"
+        );
+        let result = agent
+            .tool_server_handle
+            .call_tool_structured("web_search", "{}", &crate::tool::ToolCallExtensions::new())
+            .await;
+        assert!(
+            result
+                .outcome()
+                .is_error_kind(crate::tool::ToolFailureKind::NotFound)
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_steering_is_lossless_and_run_scoped() {
+        let model = MockCompletionModel::new([MockTurn::text("done")]);
+        let request = AgentBuilder::new(model.clone()).build().prompt("original");
+        let control = request.control_handle();
+        let sends = (0..16).map(|index| {
+            let control = control.clone();
+            tokio::spawn(async move { control.steer(format!("steer-{index}")).unwrap() })
+        });
+        for send in sends {
+            send.await.unwrap();
+        }
+        request.await.unwrap();
+        let texts: std::collections::HashSet<_> = model.requests()[0]
+            .chat_history
+            .iter()
+            .filter_map(Message::rag_text)
+            .collect();
+        for index in 0..16 {
+            assert!(texts.contains(&format!("steer-{index}")));
+        }
+    }
+
+    #[tokio::test]
+    async fn checkpoint_pauses_before_model_and_resume_continues() {
+        let model = MockCompletionModel::new([MockTurn::text("done")]);
+        let request = AgentBuilder::new(model.clone())
+            .build()
+            .prompt("hello")
+            .extended_details();
+        let control = request.control_handle();
+        control.checkpoint().unwrap();
+        let task = tokio::spawn(async move { request.await });
+        for _ in 0..100 {
+            if control.status() == RunStatus::Checkpointed {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(control.status(), RunStatus::Checkpointed);
+        assert_eq!(model.request_count(), 0);
+        let checkpoint = control.checkpoint_state().expect("safe state is captured");
+        let restored: crate::agent::AgentRun = serde_json::from_str(&checkpoint).unwrap();
+        assert_eq!(restored.turn(), 0);
+        control.resume().unwrap();
+        assert_eq!(task.await.unwrap().unwrap().output(), "done");
+    }
+
+    #[tokio::test]
+    async fn deadline_cancels_pending_model_on_unary_and_streaming() {
+        for streaming in [false, true] {
+            if streaming {
+                let model =
+                    MockCompletionModel::from_stream_turns([[MockStreamEvent::text("never")]]);
+                let request = AgentBuilder::new(model)
+                    .build()
+                    .stream_prompt("hello")
+                    .deadline(Duration::ZERO);
+                let control = request.control_handle();
+                let mut stream = request.await;
+                let err = stream.next().await.unwrap().unwrap_err();
+                assert!(matches!(err, crate::agent::StreamingError::Prompt(_)));
+                assert_eq!(
+                    control.status(),
+                    RunStatus::Terminal(TerminalReason::DeadlineExceeded)
+                );
+            } else {
+                let request = AgentBuilder::new(MockCompletionModel::text("never"))
+                    .run_deadline(Duration::ZERO)
+                    .build()
+                    .prompt("hello");
+                let control = request.control_handle();
+                let err = request.await.unwrap_err();
+                assert!(matches!(err, PromptError::PromptCancelled { .. }));
+                assert_eq!(
+                    control.status(),
+                    RunStatus::Terminal(TerminalReason::DeadlineExceeded)
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn cancellation_drops_pending_model_future_on_both_surfaces() {
+        let started = Arc::new(tokio::sync::Notify::new());
+        let request = AgentBuilder::new(PendingModel {
+            started: started.clone(),
+        })
+        .build()
+        .prompt("start");
+        let control = request.control_handle();
+        let task = tokio::spawn(async move { request.await });
+        started.notified().await;
+        control.cancel();
+        assert!(matches!(
+            task.await.unwrap(),
+            Err(PromptError::PromptCancelled { .. })
+        ));
+        assert_eq!(
+            control.status(),
+            RunStatus::Terminal(TerminalReason::Cancelled)
+        );
+
+        let started = Arc::new(tokio::sync::Notify::new());
+        let request = AgentBuilder::new(PendingModel {
+            started: started.clone(),
+        })
+        .build()
+        .stream_prompt("start");
+        let control = request.control_handle();
+        let task = tokio::spawn(async move {
+            let mut stream = request.await;
+            stream.next().await
+        });
+        started.notified().await;
+        control.cancel();
+        assert!(task.await.unwrap().unwrap().is_err());
+        assert_eq!(
+            control.status(),
+            RunStatus::Terminal(TerminalReason::Cancelled)
+        );
+    }
+
+    #[tokio::test]
+    async fn cancellation_drops_pending_tool_future_on_both_surfaces() {
+        let started = Arc::new(tokio::sync::Notify::new());
+        let unary = AgentBuilder::new(MockCompletionModel::new([
+            MockTurn::tool_call("call", "pending", serde_json::json!({})),
+            MockTurn::text("unreachable"),
+        ]))
+        .tool(PendingTool {
+            started: started.clone(),
+        })
+        .build()
+        .prompt("start")
+        .max_turns(2);
+        let unary_control = unary.control_handle();
+        let unary_task = tokio::spawn(async move { unary.await });
+        started.notified().await;
+        assert!(unary_control.cancel());
+        assert!(matches!(
+            unary_task.await.unwrap(),
+            Err(PromptError::PromptCancelled { .. })
+        ));
+        assert_eq!(
+            unary_control.status(),
+            RunStatus::Terminal(TerminalReason::Cancelled)
+        );
+
+        let started = Arc::new(tokio::sync::Notify::new());
+        let streaming = AgentBuilder::new(MockCompletionModel::from_stream_turns([
+            [MockStreamEvent::tool_call(
+                "call",
+                "pending",
+                serde_json::json!({}),
+            )],
+            [MockStreamEvent::text("unreachable")],
+        ]))
+        .tool(PendingTool {
+            started: started.clone(),
+        })
+        .build()
+        .stream_prompt("start")
+        .max_turns(2);
+        let stream_control = streaming.control_handle();
+        let stream_task = tokio::spawn(async move {
+            let mut stream = streaming.await;
+            while let Some(item) = stream.next().await {
+                item?;
+            }
+            Ok::<_, crate::agent::StreamingError>(())
+        });
+        started.notified().await;
+        assert!(stream_control.cancel());
+        assert!(stream_task.await.unwrap().is_err());
+        assert_eq!(
+            stream_control.status(),
+            RunStatus::Terminal(TerminalReason::Cancelled)
+        );
+    }
+
+    #[test]
+    fn child_settlement_is_independent_while_cancellation_is_shared() {
+        let (outer, context) = RunControlHandle::new(None, None);
+        let child = RunControlHandle::for_child_context(&context);
+        assert!(child.finish(TerminalReason::Completed));
+        assert_eq!(outer.status(), RunStatus::Running);
+        outer.cancel();
+        assert!(context.cancellation().is_cancelled());
+        assert_eq!(
+            child.status(),
+            RunStatus::Terminal(TerminalReason::Completed)
+        );
+    }
+
+    #[test]
+    fn follow_ups_are_hidden_until_terminal_settlement() {
+        let (control, _) = RunControlHandle::new(None, None);
+        control.follow_up("next").unwrap();
+        assert_eq!(
+            control.drain_follow_ups(),
+            Err(RunControlError::NotTerminal)
+        );
+        control.finish(TerminalReason::Completed);
+        assert_eq!(control.drain_follow_ups().unwrap().len(), 1);
+    }
+}

--- a/crates/rig-core/src/session.rs
+++ b/crates/rig-core/src/session.rs
@@ -1,0 +1,125 @@
+//! Backend-neutral durable agent session events.
+
+use crate::{
+    completion::{Message, Usage},
+    wasm_compat::{WasmBoxedFuture, WasmCompatSend, WasmCompatSync},
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Typed durable event payload.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "data", rename_all = "snake_case")]
+pub enum SessionEventKind {
+    /// Conversation message.
+    Message(Message),
+    /// Model call metadata.
+    ModelCall {
+        model: Option<String>,
+        config: Value,
+        usage: Usage,
+    },
+    /// Tool call with ancestry.
+    ToolCall {
+        name: String,
+        arguments: Value,
+        internal_call_id: String,
+        parent_internal_call_id: Option<String>,
+    },
+    /// Model response metadata, preserving normalized/raw finish reasons.
+    ModelResponse {
+        usage: Usage,
+        finish_reason: Option<crate::runtime::TerminalReason>,
+        raw_finish_reason: Option<String>,
+    },
+    /// Tool result.
+    ToolResult {
+        outcome: String,
+        content: Value,
+        internal_call_id: String,
+        parent_internal_call_id: Option<String>,
+    },
+    /// Run lifecycle transition.
+    Lifecycle {
+        status: String,
+        detail: Option<Value>,
+    },
+    /// Serialized safe-boundary checkpoint.
+    Checkpoint { snapshot: String },
+    /// Named bookmark/checkpoint.
+    Bookmark {
+        name: String,
+        checkpoint: Option<String>,
+    },
+    /// Non-destructive compaction summary.
+    Compaction {
+        through_sequence: u64,
+        summary: String,
+    },
+    /// Interrupted run recovery marker.
+    Interrupted {
+        run_id: String,
+        checkpoint: Option<String>,
+    },
+    /// Host-defined entry.
+    Custom { kind: String, payload: Value },
+}
+
+/// Ordered event returned by a session store.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SessionEvent {
+    /// Session identifier.
+    pub session_id: String,
+    /// Branch identifier.
+    pub branch: String,
+    /// Branch-local monotonic sequence.
+    pub sequence: u64,
+    /// Parent sequence when branching or correlating.
+    pub parent_sequence: Option<u64>,
+    /// Run/call correlation identifier.
+    pub correlation_id: Option<String>,
+    /// Typed payload.
+    pub kind: SessionEventKind,
+}
+
+/// Session backend error.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum SessionError {
+    /// Backend failure.
+    #[error("session backend error: {0}")]
+    Backend(String),
+    /// A durable checkpoint could not be decoded.
+    #[error("invalid durable checkpoint: {0}")]
+    InvalidCheckpoint(String),
+    /// The latest interruption occurred at an unsafe in-flight boundary.
+    #[error("interrupted run has no safely resumable checkpoint")]
+    UnsafeRecovery,
+}
+
+/// Append-only branchable durable session store.
+pub trait SessionStore: WasmCompatSend + WasmCompatSync {
+    /// Load a branch in sequence order.
+    fn load<'a>(
+        &'a self,
+        session: &'a str,
+        branch: &'a str,
+    ) -> WasmBoxedFuture<'a, Result<Vec<SessionEvent>, SessionError>>;
+    /// Atomically append and assign sequence.
+    fn append<'a>(
+        &'a self,
+        session: &'a str,
+        branch: &'a str,
+        parent: Option<u64>,
+        correlation: Option<String>,
+        kind: SessionEventKind,
+    ) -> WasmBoxedFuture<'a, Result<SessionEvent, SessionError>>;
+    /// Create a branch from an inclusive prefix.
+    fn branch<'a>(
+        &'a self,
+        session: &'a str,
+        source: &'a str,
+        target: &'a str,
+        through: u64,
+    ) -> WasmBoxedFuture<'a, Result<(), SessionError>>;
+}

--- a/crates/rig-core/src/skills.rs
+++ b/crates/rig-core/src/skills.rs
@@ -1,0 +1,168 @@
+//! Provider-independent progressive-disclosure skills.
+
+use crate::wasm_compat::{WasmCompatSend, WasmCompatSync};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::{Arc, RwLock},
+};
+
+/// Skill provenance.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SkillProvenance {
+    BuiltIn,
+    Filesystem(PathBuf),
+    ProviderHosted(String),
+}
+
+/// Skill metadata and lazily disclosed instructions.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Skill {
+    pub name: String,
+    pub description: String,
+    pub instructions: String,
+    pub provenance: SkillProvenance,
+    pub assets: Vec<PathBuf>,
+    pub allowed_tools: Vec<String>,
+}
+
+/// Provider-independent skill lookup.
+pub trait SkillCatalog: WasmCompatSend + WasmCompatSync {
+    /// List names/descriptions without disclosing instructions.
+    fn list(&self) -> Vec<(String, String)>;
+    /// Activate and disclose one complete skill.
+    fn activate(&self, name: &str) -> Option<Skill>;
+}
+
+/// Mutable in-memory skill catalog.
+#[derive(Clone, Default)]
+pub struct InMemorySkillCatalog(Arc<RwLock<HashMap<String, Skill>>>);
+impl InMemorySkillCatalog {
+    pub fn insert(&self, skill: Skill) {
+        self.0
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(skill.name.clone(), skill);
+    }
+}
+impl SkillCatalog for InMemorySkillCatalog {
+    fn list(&self) -> Vec<(String, String)> {
+        let mut values = self
+            .0
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .values()
+            .map(|s| (s.name.clone(), s.description.clone()))
+            .collect::<Vec<_>>();
+        values.sort();
+        values
+    }
+    fn activate(&self, name: &str) -> Option<Skill> {
+        self.0
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(name)
+            .cloned()
+    }
+}
+
+/// Trusted filesystem discovery for `SKILL.md` directories.
+pub struct FilesystemSkillCatalog;
+impl FilesystemSkillCatalog {
+    /// Discover direct child `SKILL.md` files under a canonical trusted root.
+    pub fn discover(
+        root: impl AsRef<Path>,
+        trusted_root: impl AsRef<Path>,
+    ) -> std::io::Result<InMemorySkillCatalog> {
+        let trusted = trusted_root.as_ref().canonicalize()?;
+        let root = root.as_ref().canonicalize()?;
+        if !root.starts_with(&trusted) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "skill root escapes trusted project",
+            ));
+        }
+        let catalog = InMemorySkillCatalog::default();
+        for entry in std::fs::read_dir(&root)? {
+            let directory = entry?.path();
+            let path = directory.join("SKILL.md");
+            if !path.is_file() {
+                continue;
+            }
+            let canonical = path.canonicalize()?;
+            if !canonical.starts_with(&trusted) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "skill path escapes trusted project",
+                ));
+            }
+            let contents = std::fs::read_to_string(&canonical)?;
+            let mut lines = contents.lines();
+            let name = lines
+                .next()
+                .unwrap_or("skill")
+                .trim_start_matches('#')
+                .trim()
+                .to_string();
+            let description = lines.next().unwrap_or("").trim().to_string();
+            let assets = std::fs::read_dir(&directory)?
+                .filter_map(Result::ok)
+                .map(|entry| entry.path())
+                .filter(|asset| asset.file_name().is_some_and(|name| name != "SKILL.md"))
+                .collect();
+            catalog.insert(Skill {
+                name,
+                description,
+                instructions: contents,
+                provenance: SkillProvenance::Filesystem(canonical),
+                assets,
+                allowed_tools: Vec::new(),
+            });
+        }
+        Ok(catalog)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn disclosure_hides_instructions_until_activation() {
+        let catalog = InMemorySkillCatalog::default();
+        catalog.insert(Skill {
+            name: "review".into(),
+            description: "review code".into(),
+            instructions: "secret detail".into(),
+            provenance: SkillProvenance::BuiltIn,
+            assets: vec![],
+            allowed_tools: vec!["read".into()],
+        });
+        assert_eq!(
+            catalog.list(),
+            vec![("review".into(), "review code".into())]
+        );
+        assert_eq!(
+            catalog.activate("review").unwrap().instructions,
+            "secret detail"
+        );
+    }
+
+    #[test]
+    fn filesystem_discovery_respects_trusted_root() {
+        let root = std::env::temp_dir().join(format!("rig-skills-{}", crate::id::generate()));
+        let skill = root.join("review");
+        std::fs::create_dir_all(&skill).unwrap();
+        std::fs::write(
+            skill.join("SKILL.md"),
+            "# review\nReview code\nDetailed instructions",
+        )
+        .unwrap();
+        let catalog = FilesystemSkillCatalog::discover(&root, &root).unwrap();
+        assert_eq!(
+            catalog.list(),
+            vec![("review".into(), "Review code".into())]
+        );
+        assert!(FilesystemSkillCatalog::discover(&root, root.join("review")).is_err());
+        std::fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/crates/rig-core/src/streaming.rs
+++ b/crates/rig-core/src/streaming.rs
@@ -217,6 +217,8 @@ impl From<RawStreamingToolCall> for ToolCall {
         ToolCall {
             id: tool_call.id,
             call_id: tool_call.call_id,
+            internal_call_id: None,
+            parent_internal_call_id: None,
             function: ToolFunction {
                 name: tool_call.name,
                 arguments: tool_call.arguments,
@@ -227,12 +229,12 @@ impl From<RawStreamingToolCall> for ToolCall {
     }
 }
 
-#[cfg(not(all(feature = "wasm", target_arch = "wasm32")))]
+#[cfg(not(target_arch = "wasm32"))]
 /// Provider stream of raw completion chunks on native targets.
 pub type StreamingResult<R> =
     Pin<Box<dyn Stream<Item = Result<RawStreamingChoice<R>, CompletionError>> + Send>>;
 
-#[cfg(all(feature = "wasm", target_arch = "wasm32"))]
+#[cfg(target_arch = "wasm32")]
 /// Provider stream of raw completion chunks on wasm targets.
 pub type StreamingResult<R> =
     Pin<Box<dyn Stream<Item = Result<RawStreamingChoice<R>, CompletionError>>>>;
@@ -419,6 +421,8 @@ where
             // yields the provider's usage when present and the zero sentinel
             // (`Usage::new`) when the stream produced no final response.
             usage: value.response.token_usage(),
+            finish_reason: value.response.finish_reason(),
+            raw_finish_reason: value.response.raw_finish_reason(),
             raw_response: value.response,
             message_id: value.message_id,
         }
@@ -644,7 +648,7 @@ mod tests {
     use async_stream::stream;
     use tokio::time::sleep;
 
-    #[cfg(not(all(feature = "wasm", target_arch = "wasm32")))]
+    #[cfg(not(target_arch = "wasm32"))]
     fn to_stream_result(
         stream: impl futures::Stream<Item = Result<RawStreamingChoice<MockResponse>, CompletionError>>
         + Send
@@ -653,7 +657,7 @@ mod tests {
         Box::pin(stream)
     }
 
-    #[cfg(all(feature = "wasm", target_arch = "wasm32"))]
+    #[cfg(target_arch = "wasm32")]
     fn to_stream_result(
         stream: impl futures::Stream<Item = Result<RawStreamingChoice<MockResponse>, CompletionError>>
         + 'static,
@@ -1039,6 +1043,7 @@ mod tests {
 /// Describes responses from a streamed provider response which is either text, a tool call or a final usage response.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(untagged)]
+#[allow(clippy::large_enum_variant)]
 pub enum StreamedAssistantContent<R> {
     /// Text delta emitted by the assistant.
     Text(Text),

--- a/crates/rig-core/src/subagent.rs
+++ b/crates/rig-core/src/subagent.rs
@@ -1,0 +1,311 @@
+//! Bounded correlated child-agent orchestration.
+
+use crate::{
+    runtime::{RunContext, RunControlHandle},
+    wasm_compat::WasmCompatSend,
+};
+use std::{future::Future, sync::Arc};
+use tracing::Instrument;
+
+/// Whether a child inherits the parent run or starts a fresh correlated run.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ChildContextMode {
+    Inherit,
+    Fresh,
+}
+/// Child lifecycle status.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ChildStatus {
+    Queued,
+    Running,
+    Completed,
+    Cancelled,
+    Failed,
+}
+/// Typed child handoff with correlation.
+#[derive(Clone, Debug)]
+pub struct ChildHandoff<T, E = ()> {
+    pub child_run_id: String,
+    pub parent_call_id: Option<String>,
+    pub status: ChildStatus,
+    pub output: Option<T>,
+    /// Typed child failure, when status is [`ChildStatus::Failed`].
+    pub error: Option<E>,
+}
+
+/// Agent-native child failure.
+#[derive(Debug, thiserror::Error)]
+pub enum ChildAgentError {
+    #[error(transparent)]
+    Prompt(#[from] crate::completion::PromptError),
+    #[error(transparent)]
+    Session(#[from] crate::session::SessionError),
+}
+/// Progress observer for child work.
+pub trait ChildProgress:
+    crate::wasm_compat::WasmCompatSend + crate::wasm_compat::WasmCompatSync
+{
+    fn status(&self, status: ChildStatus);
+}
+
+/// Concurrency/depth bounded child executor.
+#[derive(Clone)]
+pub struct SubagentOrchestrator {
+    semaphore: Arc<tokio::sync::Semaphore>,
+    max_depth: usize,
+}
+/// History supplied to an Agent-native child run.
+#[derive(Clone, Debug, Default)]
+pub enum ChildHistory {
+    /// Start without parent transcript history.
+    #[default]
+    Fresh,
+    /// Seed the child with a selected parent transcript.
+    Inherited(Vec<crate::completion::Message>),
+}
+
+impl SubagentOrchestrator {
+    pub fn new(max_concurrency: usize, max_depth: usize) -> Self {
+        Self {
+            semaphore: Arc::new(tokio::sync::Semaphore::new(max_concurrency.max(1))),
+            max_depth,
+        }
+    }
+
+    /// Run typed child work with inherited cancellation/deadline and correlation.
+    pub async fn run_child<T, E, F, Fut>(
+        &self,
+        parent: &RunContext,
+        name: &str,
+        mode: ChildContextMode,
+        progress: &dyn ChildProgress,
+        work: F,
+    ) -> ChildHandoff<T, E>
+    where
+        T: WasmCompatSend,
+        E: WasmCompatSend,
+        F: FnOnce(RunContext) -> Fut + WasmCompatSend,
+        Fut: Future<Output = Result<T, E>> + WasmCompatSend,
+    {
+        progress.status(ChildStatus::Queued);
+        let parent_call_id = parent.current_call_id().map(str::to_owned);
+        if parent.ancestry().len() + 1 > self.max_depth || parent.should_stop() {
+            progress.status(ChildStatus::Cancelled);
+            return ChildHandoff {
+                child_run_id: parent.run_id().to_string(),
+                parent_call_id,
+                status: ChildStatus::Cancelled,
+                output: None,
+                error: None,
+            };
+        }
+        let permit = self.semaphore.acquire();
+        let stopped = parent.stopped();
+        futures::pin_mut!(permit, stopped);
+        let _permit = match futures::future::select(permit, stopped).await {
+            futures::future::Either::Left((Ok(permit), _)) => permit,
+            futures::future::Either::Left((Err(_), _)) => {
+                progress.status(ChildStatus::Failed);
+                return ChildHandoff {
+                    child_run_id: parent.run_id().to_string(),
+                    parent_call_id,
+                    status: ChildStatus::Failed,
+                    output: None,
+                    error: None,
+                };
+            }
+            futures::future::Either::Right(_) => {
+                progress.status(ChildStatus::Cancelled);
+                return ChildHandoff {
+                    child_run_id: parent.run_id().to_string(),
+                    parent_call_id,
+                    status: ChildStatus::Cancelled,
+                    output: None,
+                    error: None,
+                };
+            }
+        };
+        if parent.should_stop() {
+            progress.status(ChildStatus::Cancelled);
+            return ChildHandoff {
+                child_run_id: parent.run_id().to_string(),
+                parent_call_id,
+                status: ChildStatus::Cancelled,
+                output: None,
+                error: None,
+            };
+        }
+        let context = match mode {
+            ChildContextMode::Inherit => parent.child(name.to_string(), crate::id::generate()),
+            ChildContextMode::Fresh => parent.fresh_child(name.to_string(), crate::id::generate()),
+        };
+        let child_run_id = context.run_id().to_string();
+        progress.status(ChildStatus::Running);
+        match work(context).await {
+            Ok(output) => {
+                progress.status(ChildStatus::Completed);
+                ChildHandoff {
+                    child_run_id,
+                    parent_call_id,
+                    status: ChildStatus::Completed,
+                    output: Some(output),
+                    error: None,
+                }
+            }
+            Err(error) => {
+                progress.status(ChildStatus::Failed);
+                ChildHandoff {
+                    child_run_id,
+                    parent_call_id,
+                    status: ChildStatus::Failed,
+                    output: None,
+                    error: Some(error),
+                }
+            }
+        }
+    }
+
+    /// Run an [`Agent`](crate::agent::Agent) as a correlated child using the
+    /// same bounded scheduler and inherited cancellation/deadline.
+    pub async fn run_agent<M>(
+        &self,
+        agent: &crate::agent::Agent<M>,
+        parent: &RunContext,
+        prompt: impl Into<crate::completion::Message>,
+        history: ChildHistory,
+        mode: ChildContextMode,
+        progress: &dyn ChildProgress,
+    ) -> ChildHandoff<crate::agent::prompt_request::PromptResponse, ChildAgentError>
+    where
+        M: crate::completion::CompletionModel + 'static,
+    {
+        let prompt = prompt.into();
+        let parent_run_id = parent.run_id().to_string();
+        self.run_child(
+            parent,
+            agent.name.as_deref().unwrap_or("child"),
+            mode,
+            progress,
+            move |context| async move {
+                let child_run_id = context.run_id().to_string();
+                let span = tracing::info_span!("run_child_agent", %parent_run_id, %child_run_id);
+                async move {
+                let mut parent_sequence = None;
+                if let (Some(store), Some(session_id)) = (&agent.session_store, &agent.session_id) {
+                    parent_sequence = Some(store.append(
+                        session_id, &agent.session_branch, None, Some(parent_run_id.clone()),
+                        crate::session::SessionEventKind::Lifecycle {
+                            status: "child_started".into(),
+                            detail: Some(serde_json::json!({"parent_run_id": parent_run_id, "child_run_id": child_run_id})),
+                        },
+                    ).await?.sequence);
+                }
+                let (control, _) = RunControlHandle::new(
+                    context.conversation_id().map(str::to_owned),
+                    context.deadline(),
+                );
+                let mut runner = agent.runner(prompt).inherit_runtime(control, context);
+                if let ChildHistory::Inherited(messages) = history {
+                    runner = runner.history(messages);
+                }
+                let result = runner.run().await.map_err(ChildAgentError::from);
+                if let (Some(store), Some(session_id)) = (&agent.session_store, &agent.session_id) {
+                    store.append(
+                        session_id, &agent.session_branch, parent_sequence, Some(child_run_id.clone()),
+                        crate::session::SessionEventKind::Lifecycle {
+                            status: if result.is_ok() { "child_completed" } else { "child_failed" }.into(),
+                            detail: Some(serde_json::json!({"parent_run_id": parent_run_id, "child_run_id": child_run_id})),
+                        },
+                    ).await?;
+                }
+                result
+                }.instrument(span).await
+            },
+        )
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+    struct Progress(Mutex<Vec<ChildStatus>>);
+    impl ChildProgress for Progress {
+        fn status(&self, status: ChildStatus) {
+            self.0.lock().unwrap().push(status);
+        }
+    }
+    #[tokio::test]
+    async fn typed_child_inherits_context_and_reports_progress() {
+        let (_, context) = RunControlHandle::new(Some("conversation".into()), None);
+        let progress = Progress(Mutex::new(Vec::new()));
+        let result = SubagentOrchestrator::new(1, 2)
+            .run_child(
+                &context,
+                "child",
+                ChildContextMode::Inherit,
+                &progress,
+                |child| async move { Ok::<_, ()>((child.run_id().to_string(), 42u32)) },
+            )
+            .await;
+        assert_eq!(result.output.as_ref().map(|(_, value)| *value), Some(42));
+        assert_eq!(result.status, ChildStatus::Completed);
+        assert_eq!(
+            *progress.0.lock().unwrap(),
+            vec![
+                ChildStatus::Queued,
+                ChildStatus::Running,
+                ChildStatus::Completed
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn queued_child_cancels_before_permit_acquisition() {
+        let orchestrator = SubagentOrchestrator::new(1, 2);
+        let permit = orchestrator.semaphore.acquire().await.unwrap();
+        let (control, context) = RunControlHandle::new(None, None);
+        let progress = Progress(Mutex::new(Vec::new()));
+        let child = orchestrator.run_child(
+            &context,
+            "queued",
+            ChildContextMode::Inherit,
+            &progress,
+            |_| async { Ok::<_, ()>(42u32) },
+        );
+        futures::pin_mut!(child);
+        assert!(futures::poll!(&mut child).is_pending());
+        control.cancel();
+        let handoff = child.await;
+        assert_eq!(handoff.status, ChildStatus::Cancelled);
+        assert!(handoff.output.is_none());
+        drop(permit);
+    }
+
+    #[tokio::test]
+    async fn agent_native_child_returns_typed_handoff() {
+        let (_, context) = RunControlHandle::new(Some("conversation".into()), None);
+        let agent = crate::agent::AgentBuilder::new(crate::test_utils::MockCompletionModel::text(
+            "child answer",
+        ))
+        .build();
+        let progress = Progress(Mutex::new(Vec::new()));
+        let handoff = SubagentOrchestrator::new(1, 2)
+            .run_agent(
+                &agent,
+                &context,
+                "child prompt",
+                ChildHistory::Fresh,
+                ChildContextMode::Fresh,
+                &progress,
+            )
+            .await;
+        assert_eq!(
+            handoff.output.as_ref().map(|output| output.output.as_str()),
+            Some("child answer")
+        );
+        assert_ne!(handoff.child_run_id, context.run_id().to_string());
+        assert_eq!(handoff.status, ChildStatus::Completed);
+    }
+}

--- a/crates/rig-core/src/test_utils/completion.rs
+++ b/crates/rig-core/src/test_utils/completion.rs
@@ -56,6 +56,8 @@ struct MockTurnResponse {
     choice: OneOrMany<AssistantContent>,
     usage: Usage,
     message_id: Option<String>,
+    finish_reason: Option<crate::runtime::TerminalReason>,
+    raw_finish_reason: Option<String>,
 }
 
 impl MockTurn {
@@ -97,6 +99,8 @@ impl MockTurn {
                 choice: OneOrMany::one(content),
                 usage: Usage::new(),
                 message_id: None,
+                finish_reason: None,
+                raw_finish_reason: None,
             }),
         }
     }
@@ -110,6 +114,8 @@ impl MockTurn {
                 choice: OneOrMany::many(content)?,
                 usage: Usage::new(),
                 message_id: None,
+                finish_reason: None,
+                raw_finish_reason: None,
             }),
         })
     }
@@ -144,9 +150,24 @@ impl MockTurn {
         self
     }
 
+    /// Attach normalized and raw provider finish metadata.
+    pub fn with_finish_reason(
+        mut self,
+        finish_reason: crate::runtime::TerminalReason,
+        raw_finish_reason: impl Into<String>,
+    ) -> Self {
+        if let Ok(response) = &mut self.response {
+            response.finish_reason = Some(finish_reason);
+            response.raw_finish_reason = Some(raw_finish_reason.into());
+        }
+        self
+    }
+
     fn into_completion_response(self) -> Result<CompletionResponse<MockResponse>, CompletionError> {
         let response = self.response.map_err(MockError::into_completion_error)?;
         Ok(CompletionResponse {
+            finish_reason: response.finish_reason,
+            raw_finish_reason: response.raw_finish_reason,
             choice: response.choice,
             usage: response.usage,
             raw_response: MockResponse::with_usage(response.usage),

--- a/crates/rig-core/src/test_utils/hook.rs
+++ b/crates/rig-core/src/test_utils/hook.rs
@@ -1,0 +1,102 @@
+//! Public harness for deterministic hook-policy tests.
+
+use crate::{
+    agent::{AgentHook, Flow, HookContext, HookStack, StepEvent},
+    completion::CompletionModel,
+};
+
+/// A reusable hook stack with a stable synthetic run context.
+pub struct HookHarness<M>
+where
+    M: CompletionModel,
+{
+    context: HookContext,
+    hooks: HookStack<M>,
+}
+
+impl<M> HookHarness<M>
+where
+    M: CompletionModel,
+{
+    /// Creates an empty harness.
+    pub fn new(is_streaming: bool, agent_name: Option<String>) -> Self {
+        Self {
+            context: HookContext::with_run_id(
+                crate::agent::RunId::generate(),
+                is_streaming,
+                agent_name,
+            ),
+            hooks: HookStack::new(),
+        }
+    }
+
+    /// Appends a hook in registration order.
+    pub fn push<H>(&mut self, hook: H)
+    where
+        H: AgentHook<M> + 'static,
+    {
+        self.hooks.push(hook);
+    }
+
+    /// Returns the stable context used by every dispatch.
+    pub fn context(&self) -> &HookContext {
+        &self.context
+    }
+
+    /// Dispatches an event through normal [`HookStack`] composition.
+    pub async fn dispatch(&self, event: StepEvent<'_, M>) -> Flow {
+        self.hooks.on_event(&self.context, event).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{agent::StepEvent, test_utils::MockCompletionModel};
+
+    struct Stop;
+    impl AgentHook<MockCompletionModel> for Stop {
+        async fn on_event(
+            &self,
+            context: &HookContext,
+            event: StepEvent<'_, MockCompletionModel>,
+        ) -> Flow {
+            if let StepEvent::ToolCall {
+                internal_call_id, ..
+            } = event
+            {
+                context.call_scratchpad(internal_call_id).insert::<u32>(7);
+                Flow::terminate("blocked")
+            } else {
+                Flow::cont()
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn harness_exercises_stack_and_call_scoped_state() {
+        let mut harness = HookHarness::<MockCompletionModel>::new(false, Some("test".into()));
+        harness.push(Stop);
+        let flow = harness
+            .dispatch(StepEvent::ToolCall {
+                tool_name: "tool",
+                tool_call_id: Some("provider"),
+                internal_call_id: "internal",
+                parent_internal_call_id: None,
+                args: "{}",
+            })
+            .await;
+        assert!(matches!(flow, Flow::Terminate { .. }));
+        assert_eq!(
+            harness.context().call_scratchpad("internal").get::<u32>(),
+            Some(7)
+        );
+        assert!(
+            harness
+                .context()
+                .call_scratchpad("other")
+                .get::<u32>()
+                .is_none()
+        );
+    }
+}

--- a/crates/rig-core/src/test_utils/mod.rs
+++ b/crates/rig-core/src/test_utils/mod.rs
@@ -2,6 +2,7 @@
 
 mod completion;
 mod embeddings;
+mod hook;
 mod http;
 #[cfg(test)]
 pub(crate) mod internal_streaming_profiles;
@@ -13,6 +14,7 @@ mod tracing_isolation;
 
 pub use completion::{MockCompletionModel, MockError, MockTurn};
 pub use embeddings::{MockEmbeddingModel, MockMultiTextDocument, MockTextDocument};
+pub use hook::HookHarness;
 pub use http::{
     CapturedHttpRequest, HttpErrorStreamingClient, MockHttpResponse, MockStreamingClient,
     RecordingHttpClient, SequencedStreamingHttpClient,

--- a/crates/rig-core/src/test_utils/streaming.rs
+++ b/crates/rig-core/src/test_utils/streaming.rs
@@ -11,6 +11,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct MockResponse {
     usage: Usage,
+    finish_reason: Option<crate::runtime::TerminalReason>,
+    raw_finish_reason: Option<String>,
 }
 
 impl MockResponse {
@@ -19,12 +21,29 @@ impl MockResponse {
     pub fn new() -> Self {
         Self {
             usage: Usage::new(),
+            finish_reason: None,
+            raw_finish_reason: None,
         }
     }
 
     /// Create a mock raw response carrying token usage.
     pub fn with_usage(usage: Usage) -> Self {
-        Self { usage }
+        Self {
+            usage,
+            finish_reason: None,
+            raw_finish_reason: None,
+        }
+    }
+
+    /// Attach normalized and raw finish metadata.
+    pub fn with_finish_reason(
+        mut self,
+        finish_reason: crate::runtime::TerminalReason,
+        raw_finish_reason: impl Into<String>,
+    ) -> Self {
+        self.finish_reason = Some(finish_reason);
+        self.raw_finish_reason = Some(raw_finish_reason.into());
+        self
     }
 
     /// Create a mock raw response whose usage has only `total_tokens` set.
@@ -38,6 +57,14 @@ impl MockResponse {
 impl GetTokenUsage for MockResponse {
     fn token_usage(&self) -> Usage {
         self.usage
+    }
+
+    fn finish_reason(&self) -> Option<crate::runtime::TerminalReason> {
+        self.finish_reason.clone()
+    }
+
+    fn raw_finish_reason(&self) -> Option<String> {
+        self.raw_finish_reason.clone()
     }
 }
 

--- a/crates/rig-core/src/tool/mod.rs
+++ b/crates/rig-core/src/tool/mod.rs
@@ -154,6 +154,11 @@ pub trait Tool: Sized + WasmCompatSend + WasmCompatSync {
     /// JSON Schema for the tool arguments.
     fn parameters(&self) -> serde_json::Value;
 
+    /// Optional JSON Schema for the model-visible result.
+    fn output_schema(&self) -> Option<serde_json::Value> {
+        None
+    }
+
     /// The tool execution method.
     /// Both the arguments and return value are a String since these values are meant to
     /// be the output and input of LLM models (respectively)
@@ -210,6 +215,12 @@ pub trait Tool: Sized + WasmCompatSend + WasmCompatSync {
     /// ```
     fn classify_error(&self, error: &Self::Error) -> ToolFailure {
         ToolFailure::other(error.to_string())
+    }
+
+    /// Attach host-only metadata when classifying an ordinary [`Tool::call`]
+    /// error, without overriding [`Tool::call_structured`].
+    fn error_extensions(&self, _error: &Self::Error) -> ToolResultExtensions {
+        ToolResultExtensions::new()
     }
 
     /// Execute the tool, returning a structured [`ToolReturn`] instead of a bare
@@ -288,6 +299,16 @@ pub trait ToolDyn: WasmCompatSend + WasmCompatSync {
 
     /// JSON Schema for the tool arguments.
     fn parameters(&self) -> serde_json::Value;
+
+    /// Optional JSON Schema for the model-visible result.
+    fn output_schema(&self) -> Option<serde_json::Value> {
+        None
+    }
+
+    /// Host catalog kind retained through type erasure.
+    fn catalog_kind(&self) -> crate::tool::server::ToolCatalogKind {
+        crate::tool::server::ToolCatalogKind::Native
+    }
 
     /// Calls the tool with JSON-encoded arguments and returns model-facing text.
     fn call<'a>(&'a self, args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>>;
@@ -393,6 +414,7 @@ pub(crate) fn tool_definition_with_name(
         name: name.into(),
         description: tool.description(),
         parameters: tool.parameters(),
+        output_schema: tool.output_schema(),
     }
 }
 
@@ -407,6 +429,10 @@ impl<T: Tool> ToolDyn for T {
 
     fn parameters(&self) -> serde_json::Value {
         <Self as Tool>::parameters(self)
+    }
+
+    fn output_schema(&self) -> Option<serde_json::Value> {
+        <Self as Tool>::output_schema(self)
     }
 
     fn call<'a>(&'a self, args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
@@ -455,6 +481,7 @@ impl<T: Tool> ToolDyn for T {
                 Err(err) => {
                     let failure = self.classify_error(&err);
                     ToolExecutionResult::failed(err.to_string(), failure)
+                        .with_extensions(self.error_extensions(&err))
                 }
             }
         })
@@ -498,6 +525,13 @@ impl ToolType {
         match self {
             ToolType::Simple(tool) => tool.name(),
             ToolType::Embedding(tool) => tool.name(),
+        }
+    }
+
+    pub(crate) fn catalog_kind(&self) -> crate::tool::server::ToolCatalogKind {
+        match self {
+            ToolType::Simple(tool) => tool.catalog_kind(),
+            ToolType::Embedding(tool) => tool.catalog_kind(),
         }
     }
 

--- a/crates/rig-core/src/tool/result.rs
+++ b/crates/rig-core/src/tool/result.rs
@@ -17,7 +17,7 @@
 //! resulting [`ToolExecutionResult`] all the way through to the
 //! [`StepEvent::ToolResult`](crate::agent::StepEvent::ToolResult) hook event.
 
-use crate::tool::ToolResultExtensions;
+use crate::{OneOrMany, message::ToolResultContent, tool::ToolResultExtensions};
 use serde::Serialize;
 
 /// How a tool execution failed, as a closed set of standard kinds.
@@ -420,6 +420,7 @@ impl From<ToolReturnOutcome> for ToolOutcome {
 #[non_exhaustive]
 pub struct ToolExecutionResult {
     pub(crate) model_output: String,
+    pub(crate) content: Option<OneOrMany<ToolResultContent>>,
     pub(crate) outcome: ToolOutcome,
     pub(crate) extensions: ToolResultExtensions,
 }
@@ -435,6 +436,7 @@ impl ToolExecutionResult {
     pub(crate) fn new(model_output: impl Into<String>, outcome: ToolOutcome) -> Self {
         Self {
             model_output: model_output.into(),
+            content: None,
             outcome,
             extensions: ToolResultExtensions::new(),
         }
@@ -467,6 +469,17 @@ impl ToolExecutionResult {
     /// [`ToolOutcome` note](ToolOutcome#skipped-vs-denied).
     pub fn denied(model_output: impl Into<String>) -> Self {
         Self::new(model_output, ToolOutcome::Denied)
+    }
+
+    /// Attach explicit rich model content without a magic JSON envelope.
+    pub fn with_content(mut self, content: OneOrMany<ToolResultContent>) -> Self {
+        self.content = Some(content);
+        self
+    }
+
+    /// Rich model content, when explicitly supplied by the tool.
+    pub fn content(&self) -> Option<&OneOrMany<ToolResultContent>> {
+        self.content.as_ref()
     }
 
     /// Attach result extensions, replacing any already set.
@@ -555,6 +568,8 @@ pub struct ToolReturn<T> {
     pub outcome: ToolReturnOutcome,
     /// Metadata surfaced to hooks/tracing but never sent to the model.
     pub extensions: ToolResultExtensions,
+    /// Explicit rich model content, bypassing legacy string-envelope parsing.
+    pub content: Option<OneOrMany<ToolResultContent>>,
 }
 
 impl<T> ToolReturn<T> {
@@ -566,6 +581,7 @@ impl<T> ToolReturn<T> {
             output,
             outcome: ToolReturnOutcome::Success,
             extensions: ToolResultExtensions::new(),
+            content: None,
         }
     }
 
@@ -575,6 +591,7 @@ impl<T> ToolReturn<T> {
             output,
             outcome,
             extensions: ToolResultExtensions::new(),
+            content: None,
         }
     }
 
@@ -596,6 +613,12 @@ impl<T> ToolReturn<T> {
     /// Replace the outcome.
     pub fn with_outcome(mut self, outcome: ToolReturnOutcome) -> Self {
         self.outcome = outcome;
+        self
+    }
+
+    /// Attach explicit rich model content.
+    pub fn with_content(mut self, content: OneOrMany<ToolResultContent>) -> Self {
+        self.content = Some(content);
         self
     }
 
@@ -637,10 +660,12 @@ impl<T: Serialize> ToolReturn<T> {
             output,
             outcome,
             extensions,
+            content,
         } = self;
         match super::serialize_tool_output(&output) {
             Ok(model_output) => ToolExecutionResult {
                 model_output,
+                content,
                 outcome: outcome.into(),
                 extensions,
             },
@@ -655,6 +680,7 @@ impl<T: Serialize> ToolReturn<T> {
                 };
                 ToolExecutionResult {
                     model_output: format!("failed to serialize tool output: {err}"),
+                    content,
                     outcome,
                     extensions,
                 }
@@ -678,6 +704,20 @@ const _: fn() = || {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn explicit_rich_content_bypasses_string_envelope_parsing() {
+        let rich = OneOrMany::many([
+            ToolResultContent::text("first"),
+            ToolResultContent::text("second"),
+        ])
+        .unwrap();
+        let result = ToolReturn::success("legacy fallback".to_string())
+            .with_content(rich.clone())
+            .into_execution_result();
+        assert_eq!(result.model_output(), "legacy fallback");
+        assert_eq!(result.content(), Some(&rich));
+    }
 
     #[test]
     fn per_kind_constructors_prefill_retryable() {

--- a/crates/rig-core/src/tool/rmcp.rs
+++ b/crates/rig-core/src/tool/rmcp.rs
@@ -137,6 +137,10 @@ impl From<&rmcp::model::Tool> for ToolDefinition {
             name: val.name.to_string(),
             description: val.description.clone().unwrap_or(Cow::from("")).to_string(),
             parameters: val.schema_as_json_value(),
+            output_schema: val
+                .output_schema
+                .as_ref()
+                .map(|schema| serde_json::Value::Object((**schema).clone())),
         }
     }
 }
@@ -147,6 +151,10 @@ impl From<rmcp::model::Tool> for ToolDefinition {
             name: val.name.to_string(),
             description: val.description.clone().unwrap_or(Cow::from("")).to_string(),
             parameters: val.schema_as_json_value(),
+            output_schema: val
+                .output_schema
+                .as_ref()
+                .map(|schema| serde_json::Value::Object((**schema).clone())),
         }
     }
 }
@@ -366,6 +374,17 @@ impl ToolDyn for McpTool {
 
     fn parameters(&self) -> serde_json::Value {
         self.definition.schema_as_json_value()
+    }
+
+    fn output_schema(&self) -> Option<serde_json::Value> {
+        self.definition
+            .output_schema
+            .as_ref()
+            .map(|schema| serde_json::Value::Object((**schema).clone()))
+    }
+
+    fn catalog_kind(&self) -> crate::tool::server::ToolCatalogKind {
+        crate::tool::server::ToolCatalogKind::Mcp
     }
 
     fn call(&self, args: String) -> WasmBoxedFuture<'_, Result<String, ToolError>> {

--- a/crates/rig-core/src/tool/server.rs
+++ b/crates/rig-core/src/tool/server.rs
@@ -1,13 +1,18 @@
-use std::sync::Arc;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use tokio::sync::RwLock;
 
 use crate::{
-    completion::{CompletionError, ToolDefinition},
+    completion::{CompletionError, ProviderToolDefinition, ToolDefinition},
+    runtime::RunContext,
     tool::{
         Tool, ToolCallExtensions, ToolDyn, ToolExecutionResult, ToolFailure, ToolSet, ToolSetError,
     },
     vector_store::{VectorSearchRequest, VectorStoreError, VectorStoreIndexDyn, request::Filter},
+    wasm_compat::{WasmBoxedFuture, WasmCompatSend, WasmCompatSync},
 };
 
 /// Append `name` to the advertised static-tool list unless already present.
@@ -21,6 +26,222 @@ fn push_unique_name(names: &mut Vec<String>, name: String) {
     }
 }
 
+/// Runtime kind of an entry in the host tool catalog.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ToolCatalogKind {
+    /// A native Rig tool.
+    Native,
+    /// A tool backed by MCP.
+    Mcp,
+    /// A tool selected dynamically from an index.
+    Dynamic,
+    /// A provider-executed hosted tool.
+    ProviderHosted,
+}
+
+/// Scheduling hint enforced by hosts when composing tool batches.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum ToolScheduling {
+    /// No catalog override; preserve the runner's explicit concurrency setting.
+    #[default]
+    Unspecified,
+    /// Force serialized execution even when the runner allows concurrency.
+    Serial,
+    /// The host declares this tool safe for parallel execution.
+    ParallelSafe,
+}
+
+/// Host-side provenance and metadata for one catalog entry.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ToolCatalogMetadata {
+    /// Human-readable source or package identifier.
+    pub source: Option<String>,
+    /// Provenance identifier such as an MCP server URI.
+    pub provenance: Option<String>,
+    /// Arbitrary host-only metadata. This is never included in provider schemas.
+    pub host: serde_json::Map<String, serde_json::Value>,
+    /// Host scheduling declaration.
+    pub scheduling: ToolScheduling,
+    /// Bounded retries for failures explicitly classified retryable.
+    pub max_retries: usize,
+    /// Whether this tool semantically produces the final run result.
+    pub final_result: bool,
+}
+
+/// Ordered, introspectable catalog entry.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ToolCatalogEntry {
+    /// Catalog name or provider-hosted kind.
+    pub name: String,
+    /// Runtime kind.
+    pub kind: ToolCatalogKind,
+    /// Model-facing function schema for executable tools.
+    pub definition: Option<ToolDefinition>,
+    /// Provider-hosted declaration for provider-executed tools.
+    pub provider_definition: Option<ProviderToolDefinition>,
+    /// Metadata retained exclusively by the host.
+    pub metadata: ToolCatalogMetadata,
+}
+
+/// Restrictions for tool calls made from inside another tool.
+#[derive(Clone, Debug)]
+pub struct NestedToolPolicy {
+    /// Maximum ancestry depth after entering the child.
+    pub max_depth: usize,
+    /// Optional nested target allowlist.
+    pub allowlist: Option<HashSet<String>>,
+    /// Whether a target already present in ancestry may be entered again.
+    pub allow_recursion: bool,
+}
+
+impl Default for NestedToolPolicy {
+    fn default() -> Self {
+        Self {
+            max_depth: 8,
+            allowlist: None,
+            allow_recursion: false,
+        }
+    }
+}
+
+/// Structured result and correlation assigned to a nested dispatch.
+#[derive(Debug, Clone)]
+pub struct NestedToolResult {
+    /// Framework-generated child call ID.
+    pub internal_call_id: String,
+    /// Parent call ID inherited from the invoking tool.
+    pub parent_internal_call_id: Option<String>,
+    /// Structured tool result.
+    pub result: ToolExecutionResult,
+}
+
+pub(crate) trait ScopedToolDispatch: WasmCompatSend + WasmCompatSync {
+    #[allow(clippy::too_many_arguments)]
+    fn dispatch<'a>(
+        &'a self,
+        server: &'a ToolServerHandle,
+        extensions: ToolCallExtensions,
+        context: RunContext,
+        name: &'a str,
+        args: &'a str,
+        internal_call_id: &'a str,
+        parent_internal_call_id: Option<&'a str>,
+    ) -> WasmBoxedFuture<'a, ToolExecutionResult>;
+}
+
+/// Cloneable executor automatically supplied to tools for scoped nested calls.
+#[derive(Clone)]
+pub struct ScopedToolExecutor {
+    server: ToolServerHandle,
+    extensions: ToolCallExtensions,
+    context: RunContext,
+    policy: NestedToolPolicy,
+    dispatch: Option<Arc<dyn ScopedToolDispatch>>,
+}
+
+impl ScopedToolExecutor {
+    pub(crate) fn new(
+        server: ToolServerHandle,
+        extensions: ToolCallExtensions,
+        context: RunContext,
+        policy: NestedToolPolicy,
+        dispatch: Option<Arc<dyn ScopedToolDispatch>>,
+    ) -> Self {
+        Self {
+            server,
+            extensions,
+            context,
+            policy,
+            dispatch,
+        }
+    }
+
+    /// Dispatch a nested tool with inherited extensions and cancellation.
+    pub async fn call(&self, name: &str, args: &str) -> NestedToolResult {
+        let child_id = crate::id::generate();
+        let parent_id = self.context.current_call_id().map(str::to_owned);
+        let rejected = if self.context.should_stop() {
+            Some(ToolFailure::cancelled("parent run cancelled"))
+        } else if self.context.ancestry().len() + 1 > self.policy.max_depth {
+            Some(ToolFailure::permission_denied(
+                "nested depth limit exceeded",
+            ))
+        } else if self
+            .policy
+            .allowlist
+            .as_ref()
+            .is_some_and(|set| !set.contains(name))
+        {
+            Some(ToolFailure::permission_denied(format!(
+                "nested tool `{name}` is not allowed"
+            )))
+        } else if !self.policy.allow_recursion
+            && self
+                .context
+                .ancestry()
+                .iter()
+                .any(|ancestor| ancestor == name)
+        {
+            Some(ToolFailure::permission_denied(format!(
+                "recursive nested tool `{name}` rejected"
+            )))
+        } else {
+            None
+        };
+        if let Some(failure) = rejected {
+            return NestedToolResult {
+                internal_call_id: child_id,
+                parent_internal_call_id: parent_id,
+                result: ToolExecutionResult::failed(failure.message.clone(), failure),
+            };
+        }
+        let child = self.context.child(name.to_owned(), child_id.clone());
+        let mut extensions = self.extensions.clone();
+        extensions.insert(child.clone());
+        extensions.insert(Self::new(
+            self.server.clone(),
+            extensions.clone(),
+            child.clone(),
+            self.policy.clone(),
+            self.dispatch.clone(),
+        ));
+        let call = async {
+            if let Some(dispatch) = &self.dispatch {
+                dispatch
+                    .dispatch(
+                        &self.server,
+                        extensions,
+                        child.clone(),
+                        name,
+                        args,
+                        &child_id,
+                        parent_id.as_deref(),
+                    )
+                    .await
+            } else {
+                self.server
+                    .call_tool_structured(name, args, &extensions)
+                    .await
+            }
+        };
+        let stopped = child.stopped();
+        futures::pin_mut!(call, stopped);
+        let result = match futures::future::select(call, stopped).await {
+            futures::future::Either::Left((result, _)) => result,
+            futures::future::Either::Right((reason, _)) => ToolExecutionResult::failed(
+                format!("nested tool stopped: {reason:?}"),
+                ToolFailure::cancelled(format!("nested tool stopped: {reason:?}")),
+            ),
+        };
+        NestedToolResult {
+            internal_call_id: child_id.clone(),
+            parent_internal_call_id: parent_id.clone(),
+            result,
+        }
+    }
+}
+
 /// Shared state behind a `ToolServerHandle`.
 struct ToolServerState {
     /// Static tool names that persist until explicitly removed.
@@ -29,6 +250,8 @@ struct ToolServerState {
     dynamic_tools: Vec<(usize, Arc<dyn VectorStoreIndexDyn + Send + Sync>)>,
     /// The toolset where tools are registered and executed.
     toolset: ToolSet,
+    metadata: HashMap<String, (ToolCatalogKind, ToolCatalogMetadata)>,
+    provider_tools: Vec<(ProviderToolDefinition, ToolCatalogMetadata)>,
 }
 
 /// Builder for constructing a [`ToolServerHandle`].
@@ -39,6 +262,8 @@ pub struct ToolServer {
     static_tool_names: Vec<String>,
     dynamic_tools: Vec<(usize, Arc<dyn VectorStoreIndexDyn + Send + Sync>)>,
     toolset: ToolSet,
+    metadata: HashMap<String, (ToolCatalogKind, ToolCatalogMetadata)>,
+    provider_tools: Vec<(ProviderToolDefinition, ToolCatalogMetadata)>,
 }
 
 impl Default for ToolServer {
@@ -53,6 +278,8 @@ impl ToolServer {
             static_tool_names: Vec::new(),
             dynamic_tools: Vec::new(),
             toolset: ToolSet::default(),
+            metadata: HashMap::new(),
+            provider_tools: Vec::new(),
         }
     }
 
@@ -72,6 +299,22 @@ impl ToolServer {
         self
     }
 
+    pub(crate) fn catalog_kinds(mut self, kinds: HashMap<String, ToolCatalogKind>) -> Self {
+        for (name, kind) in kinds {
+            self.metadata
+                .insert(name, (kind, ToolCatalogMetadata::default()));
+        }
+        self
+    }
+
+    pub(crate) fn provider_tools(mut self, tools: Vec<ProviderToolDefinition>) -> Self {
+        self.provider_tools = tools
+            .into_iter()
+            .map(|tool| (tool, ToolCatalogMetadata::default()))
+            .collect();
+        self
+    }
+
     pub(crate) fn add_dynamic_tools(
         mut self,
         dyn_tools: Vec<(usize, Arc<dyn VectorStoreIndexDyn + Send + Sync>)>,
@@ -84,7 +327,10 @@ impl ToolServer {
     /// replaces the implementation (last wins) and keeps its position.
     pub fn tool(mut self, tool: impl Tool + 'static) -> Self {
         let toolname = self.toolset.add_tool(tool);
-        push_unique_name(&mut self.static_tool_names, toolname);
+        push_unique_name(&mut self.static_tool_names, toolname.clone());
+        self.metadata
+            .entry(toolname)
+            .or_insert_with(|| (ToolCatalogKind::Native, ToolCatalogMetadata::default()));
         self
     }
 
@@ -114,7 +360,11 @@ impl ToolServer {
         let toolname = self
             .toolset
             .add_tool(McpTool::from_mcp_server(tool, client).with_timeout(timeout));
-        push_unique_name(&mut self.static_tool_names, toolname);
+        push_unique_name(&mut self.static_tool_names, toolname.clone());
+        self.metadata.insert(
+            toolname,
+            (ToolCatalogKind::Mcp, ToolCatalogMetadata::default()),
+        );
         self
     }
 
@@ -127,16 +377,29 @@ impl ToolServer {
         toolset: ToolSet,
     ) -> Self {
         self.dynamic_tools.push((sample, Arc::new(dynamic_tools)));
+        for name in toolset.ordered_names() {
+            self.metadata
+                .entry(name.clone())
+                .or_insert_with(|| (ToolCatalogKind::Dynamic, ToolCatalogMetadata::default()));
+        }
         self.toolset.add_tools(toolset);
         self
     }
 
     /// Consume the builder and return a shared [`ToolServerHandle`].
     pub fn run(self) -> ToolServerHandle {
+        let mut metadata = self.metadata;
+        for name in &self.static_tool_names {
+            metadata
+                .entry(name.clone())
+                .or_insert_with(|| (ToolCatalogKind::Native, ToolCatalogMetadata::default()));
+        }
         ToolServerHandle(Arc::new(RwLock::new(ToolServerState {
             static_tool_names: self.static_tool_names,
             dynamic_tools: self.dynamic_tools,
             toolset: self.toolset,
+            metadata,
+            provider_tools: self.provider_tools,
         })))
     }
 }
@@ -154,9 +417,83 @@ impl ToolServerHandle {
     /// the implementation (last wins) and keeps its position.
     pub async fn add_tool(&self, tool: impl ToolDyn + 'static) -> Result<(), ToolServerError> {
         let mut state = self.0.write().await;
+        let kind = tool.catalog_kind();
         let toolname = state.toolset.add_tool_boxed(Box::new(tool));
-        push_unique_name(&mut state.static_tool_names, toolname);
+        push_unique_name(&mut state.static_tool_names, toolname.clone());
+        state
+            .metadata
+            .insert(toolname, (kind, ToolCatalogMetadata::default()));
         Ok(())
+    }
+
+    /// Register or replace a native tool with host-only catalog metadata.
+    pub async fn add_tool_with_metadata(
+        &self,
+        tool: impl ToolDyn + 'static,
+        metadata: ToolCatalogMetadata,
+    ) -> Result<(), ToolServerError> {
+        let mut state = self.0.write().await;
+        let kind = tool.catalog_kind();
+        let name = state.toolset.add_tool_boxed(Box::new(tool));
+        push_unique_name(&mut state.static_tool_names, name.clone());
+        state.metadata.insert(name, (kind, metadata));
+        Ok(())
+    }
+
+    /// Register a provider-hosted tool for introspection. It is never available
+    /// to [`call_tool_structured`](Self::call_tool_structured).
+    pub async fn add_provider_tool(
+        &self,
+        tool: ProviderToolDefinition,
+        metadata: ToolCatalogMetadata,
+    ) {
+        let mut state = self.0.write().await;
+        if let Some(existing) = state
+            .provider_tools
+            .iter_mut()
+            .find(|(registered, _)| registered.kind == tool.kind)
+        {
+            *existing = (tool, metadata);
+        } else {
+            state.provider_tools.push((tool, metadata));
+        }
+    }
+
+    /// Return an ordered snapshot of executable and provider-hosted entries.
+    pub async fn catalog(&self) -> Vec<ToolCatalogEntry> {
+        let state = self.0.read().await;
+        let mut entries = state
+            .toolset
+            .ordered_names()
+            .filter_map(|name| {
+                let tool = state.toolset.get(name)?;
+                let (kind, metadata) = state
+                    .metadata
+                    .get(name)
+                    .cloned()
+                    .unwrap_or((ToolCatalogKind::Dynamic, ToolCatalogMetadata::default()));
+                Some(ToolCatalogEntry {
+                    name: name.clone(),
+                    kind,
+                    definition: Some(tool.definition_with_name(name.clone())),
+                    provider_definition: None,
+                    metadata,
+                })
+            })
+            .collect::<Vec<_>>();
+        entries.extend(
+            state
+                .provider_tools
+                .iter()
+                .map(|(tool, metadata)| ToolCatalogEntry {
+                    name: tool.kind.clone(),
+                    kind: ToolCatalogKind::ProviderHosted,
+                    definition: None,
+                    provider_definition: Some(tool.clone()),
+                    metadata: metadata.clone(),
+                }),
+        );
+        entries
     }
 
     /// Merge an entire toolset into the server. Tool names from `toolset`
@@ -168,6 +505,13 @@ impl ToolServerHandle {
         let mut state = self.0.write().await;
         for name in toolset.ordered_names() {
             push_unique_name(&mut state.static_tool_names, name.clone());
+            let kind = toolset
+                .get(name)
+                .map_or(ToolCatalogKind::Native, |tool| tool.catalog_kind());
+            state
+                .metadata
+                .entry(name.clone())
+                .or_insert_with(|| (kind, ToolCatalogMetadata::default()));
         }
         state.toolset.add_tools(toolset);
         Ok(())
@@ -178,6 +522,10 @@ impl ToolServerHandle {
         let mut state = self.0.write().await;
         state.static_tool_names.retain(|x| *x != tool_name);
         state.toolset.delete_tool(tool_name);
+        state.metadata.remove(tool_name);
+        state
+            .provider_tools
+            .retain(|(tool, _)| tool.kind != tool_name);
         Ok(())
     }
 
@@ -239,9 +587,15 @@ impl ToolServerHandle {
         args: &str,
         extensions: &ToolCallExtensions,
     ) -> ToolExecutionResult {
-        let tool = {
+        let (tool, max_retries) = {
             let state = self.0.read().await;
-            state.toolset.get(tool_name).cloned()
+            (
+                state.toolset.get(tool_name).cloned(),
+                state
+                    .metadata
+                    .get(tool_name)
+                    .map_or(0, |(_, metadata)| metadata.max_retries),
+            )
         };
 
         match tool {
@@ -250,13 +604,45 @@ impl ToolServerHandle {
                     "Calling tool {tool_name} with args:\n{}",
                     serde_json::to_string_pretty(&args).unwrap_or_default()
                 );
-                tool.call_structured(args.to_string(), extensions).await
+                let mut attempt = 0;
+                loop {
+                    let result = tool.call_structured(args.to_string(), extensions).await;
+                    let retryable = result
+                        .outcome()
+                        .failure()
+                        .and_then(|failure| failure.retryable)
+                        == Some(true);
+                    if !retryable || attempt >= max_retries {
+                        break result;
+                    }
+                    attempt += 1;
+                }
             }
             None => ToolExecutionResult::failed(
                 format!("tool `{tool_name}` not found"),
                 ToolFailure::not_found(format!("no tool named `{tool_name}` is registered")),
             ),
         }
+    }
+
+    pub(crate) async fn scheduling(&self, name: &str) -> ToolScheduling {
+        self.0
+            .read()
+            .await
+            .metadata
+            .get(name)
+            .map_or(ToolScheduling::Unspecified, |(_, metadata)| {
+                metadata.scheduling.clone()
+            })
+    }
+
+    pub(crate) async fn is_final_result(&self, name: &str) -> bool {
+        self.0
+            .read()
+            .await
+            .metadata
+            .get(name)
+            .is_some_and(|(_, metadata)| metadata.final_result)
     }
 
     /// Retrieve tool definitions, optionally using a prompt to select

--- a/crates/rig-core/src/wasm_compat.rs
+++ b/crates/rig-core/src/wasm_compat.rs
@@ -3,19 +3,19 @@ use std::pin::Pin;
 
 use futures::Stream;
 
-#[cfg(not(all(feature = "wasm", target_arch = "wasm32")))]
-/// `Send` on native targets and a no-op marker on wasm32 with the `wasm` feature.
+#[cfg(not(target_arch = "wasm32"))]
+/// `Send` on native targets and a no-op marker on wasm32.
 pub trait WasmCompatSend: Send {}
-#[cfg(all(feature = "wasm", target_arch = "wasm32"))]
-/// `Send` on native targets and a no-op marker on wasm32 with the `wasm` feature.
+#[cfg(target_arch = "wasm32")]
+/// `Send` on native targets and a no-op marker on wasm32.
 pub trait WasmCompatSend {}
 
-#[cfg(not(all(feature = "wasm", target_arch = "wasm32")))]
+#[cfg(not(target_arch = "wasm32"))]
 impl<T> WasmCompatSend for T where T: Send {}
-#[cfg(all(feature = "wasm", target_arch = "wasm32"))]
+#[cfg(target_arch = "wasm32")]
 impl<T> WasmCompatSend for T {}
 
-#[cfg(not(all(feature = "wasm", target_arch = "wasm32")))]
+#[cfg(not(target_arch = "wasm32"))]
 /// Streaming response bound that includes `Send` on native targets.
 pub trait WasmCompatSendStream:
     Stream<Item = Result<Bytes, crate::http_client::Error>> + Send
@@ -23,13 +23,13 @@ pub trait WasmCompatSendStream:
     type InnerItem: Send;
 }
 
-#[cfg(all(feature = "wasm", target_arch = "wasm32"))]
-/// Streaming response bound without `Send` on wasm32 with the `wasm` feature.
+#[cfg(target_arch = "wasm32")]
+/// Streaming response bound without `Send` on wasm32.
 pub trait WasmCompatSendStream: Stream<Item = Result<Bytes, crate::http_client::Error>> {
     type InnerItem;
 }
 
-#[cfg(not(all(feature = "wasm", target_arch = "wasm32")))]
+#[cfg(not(target_arch = "wasm32"))]
 impl<T> WasmCompatSendStream for T
 where
     T: Stream<Item = Result<Bytes, crate::http_client::Error>> + Send,
@@ -37,7 +37,7 @@ where
     type InnerItem = Result<Bytes, crate::http_client::Error>;
 }
 
-#[cfg(all(feature = "wasm", target_arch = "wasm32"))]
+#[cfg(target_arch = "wasm32")]
 impl<T> WasmCompatSendStream for T
 where
     T: Stream<Item = Result<Bytes, crate::http_client::Error>>,
@@ -45,20 +45,20 @@ where
     type InnerItem = Result<Bytes, crate::http_client::Error>;
 }
 
-#[cfg(not(all(feature = "wasm", target_arch = "wasm32")))]
-/// `Sync` on native targets and a no-op marker on wasm32 with the `wasm` feature.
+#[cfg(not(target_arch = "wasm32"))]
+/// `Sync` on native targets and a no-op marker on wasm32.
 pub trait WasmCompatSync: Sync {}
-#[cfg(all(feature = "wasm", target_arch = "wasm32"))]
-/// `Sync` on native targets and a no-op marker on wasm32 with the `wasm` feature.
+#[cfg(target_arch = "wasm32")]
+/// `Sync` on native targets and a no-op marker on wasm32.
 pub trait WasmCompatSync {}
 
-#[cfg(not(all(feature = "wasm", target_arch = "wasm32")))]
+#[cfg(not(target_arch = "wasm32"))]
 impl<T> WasmCompatSync for T where T: Sync {}
-#[cfg(all(feature = "wasm", target_arch = "wasm32"))]
+#[cfg(target_arch = "wasm32")]
 impl<T> WasmCompatSync for T {}
 
-#[cfg(not(all(feature = "wasm", target_arch = "wasm32")))]
-/// Boxed future type that includes `Send`, except on wasm32 with the `wasm` feature.
+#[cfg(not(target_arch = "wasm32"))]
+/// Boxed future type that includes `Send`, except on wasm32.
 ///
 /// Gated to match [`WasmCompatSend`]/[`WasmCompatSync`] (and the streaming `Box`
 /// selection) — a `WasmBoxedFuture` returned by a `WasmCompatSend` bound (e.g.
@@ -66,8 +66,8 @@ impl<T> WasmCompatSync for T {}
 /// condition the marker relaxes it, or the two disagree on wasm.
 pub type WasmBoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
-#[cfg(all(feature = "wasm", target_arch = "wasm32"))]
-/// Boxed future type without `Send`, on wasm32 with the `wasm` feature.
+#[cfg(target_arch = "wasm32")]
+/// Boxed future type without `Send`, on wasm32.
 pub type WasmBoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
 
 /// Error returned by [`timeout`] when the future does not complete in time.
@@ -118,7 +118,7 @@ where
 #[macro_export]
 macro_rules! if_wasm {
     ($($tokens:tt)*) => {
-        #[cfg(all(feature = "wasm", target_arch = "wasm32"))]
+        #[cfg(target_arch = "wasm32")]
         $($tokens)*
 
     };
@@ -127,7 +127,7 @@ macro_rules! if_wasm {
 #[macro_export]
 macro_rules! if_not_wasm {
     ($($tokens:tt)*) => {
-        #[cfg(not(all(feature = "wasm", target_arch = "wasm32")))]
+        #[cfg(not(target_arch = "wasm32"))]
         $($tokens)*
 
     };

--- a/crates/rig-gemini-grpc/src/completion.rs
+++ b/crates/rig-gemini-grpc/src/completion.rs
@@ -489,11 +489,22 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse<Generat
             })
             .unwrap_or_default();
 
+        let raw_finish_reason = format!("{:?}", candidate.finish_reason);
+        let finish_reason = match raw_finish_reason.as_str() {
+            "Stop" => rig_core::runtime::TerminalReason::Completed,
+            "MaxTokens" => rig_core::runtime::TerminalReason::MaxTokens,
+            "Safety" | "Recitation" | "Blocklist" | "ProhibitedContent" | "Spii" => {
+                rig_core::runtime::TerminalReason::ContentFiltered
+            }
+            other => rig_core::runtime::TerminalReason::Other(other.to_string()),
+        };
         Ok(completion::CompletionResponse {
             choice,
             usage,
             raw_response: response,
             message_id: None,
+            finish_reason: Some(finish_reason),
+            raw_finish_reason: Some(raw_finish_reason),
         })
     }
 }
@@ -962,6 +973,7 @@ mod tests {
                 },
                 "required": ["city"]
             }),
+            output_schema: None,
         };
 
         let req = create_grpc_request(

--- a/crates/rig-memory/src/lib.rs
+++ b/crates/rig-memory/src/lib.rs
@@ -1584,6 +1584,8 @@ mod tests {
             content: OneOrMany::one(UserContent::ToolResult(ToolResult {
                 id: "call_1".into(),
                 call_id: None,
+                internal_call_id: None,
+                parent_internal_call_id: None,
                 content: OneOrMany::one(ToolResultContent::text("ok")),
             })),
         }

--- a/crates/rig-sqlite/Cargo.toml
+++ b/crates/rig-sqlite/Cargo.toml
@@ -23,6 +23,7 @@ tokio-rusqlite = { workspace = true, features = ["bundled"] }
 tracing = { workspace = true }
 zerocopy = { workspace = true }
 chrono = { workspace = true }
+futures = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/crates/rig-sqlite/README.md
+++ b/crates/rig-sqlite/README.md
@@ -18,6 +18,15 @@
 
 This companion crate implements a Rig vector store based on SQLite.
 
+## Durable agent memory and sessions
+
+`SqliteConversationMemory::open("agent.db")` supplies ordered, versioned,
+transactional conversation memory for `AgentBuilder::memory`.
+`SqliteSessionStore::open("agent.db")` supplies the separate append-only,
+branchable event store accepted by `AgentBuilder::session`, including typed
+messages/model/tool events, bookmarks, checkpoints, interruption recovery,
+compaction records, and JSON import/export.
+
 ## Usage
 
 Add the companion crate to your `Cargo.toml`, along with the rig-core crate:

--- a/crates/rig-sqlite/src/lib.rs
+++ b/crates/rig-sqlite/src/lib.rs
@@ -5,7 +5,11 @@
 //! document table schemas by implementing [`SqliteVectorStoreTable`].
 //!
 //! The root `rig` facade re-exports this crate as `rig::sqlite` when the
-//! `sqlite` feature is enabled.
+//! `sqlite` feature is enabled. Durable conversation and branchable event
+//! storage are available from [`memory`].
+
+pub mod memory;
+pub use memory::{SessionEntry, SqliteConversationMemory, SqliteSessionStore, StoredSessionEvent};
 
 use rig_core::embeddings::{Embedding, EmbeddingModel};
 use rig_core::vector_store::request::{FilterError, SearchFilter, VectorSearchRequest};

--- a/crates/rig-sqlite/src/memory.rs
+++ b/crates/rig-sqlite/src/memory.rs
@@ -1,0 +1,1109 @@
+//! Durable SQLite conversation memory and branchable session event storage.
+
+use rig_core::{
+    completion::Message,
+    memory::{ConversationMemory, MemoryError},
+    session::{SessionError, SessionEvent, SessionEventKind, SessionStore},
+    wasm_compat::WasmBoxedFuture,
+};
+use rusqlite::OptionalExtension;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio_rusqlite::Connection;
+
+const MESSAGE_FORMAT_VERSION: i64 = 1;
+
+fn memory_error(error: impl std::fmt::Display) -> MemoryError {
+    MemoryError::backend(std::io::Error::other(error.to_string()))
+}
+
+/// Durable ordered [`ConversationMemory`] backed by SQLite.
+#[derive(Clone)]
+pub struct SqliteConversationMemory {
+    connection: Connection,
+}
+
+impl SqliteConversationMemory {
+    /// Open a database and apply idempotent schema migrations.
+    pub async fn open(path: impl AsRef<std::path::Path>) -> Result<Self, MemoryError> {
+        let connection = Connection::open(path).await.map_err(memory_error)?;
+        Self::from_connection(connection).await
+    }
+
+    /// Use an existing connection and apply idempotent schema migrations.
+    pub async fn from_connection(connection: Connection) -> Result<Self, MemoryError> {
+        connection
+            .call(|conn| {
+                conn.execute_batch(
+                    "PRAGMA foreign_keys=ON;
+                     PRAGMA busy_timeout=5000;
+                     CREATE TABLE IF NOT EXISTS rig_memory_messages (
+                       conversation_id TEXT NOT NULL,
+                       sequence INTEGER NOT NULL,
+                       format_version INTEGER NOT NULL,
+                       message_json TEXT NOT NULL,
+                       PRIMARY KEY(conversation_id, sequence)
+                     );
+                     CREATE INDEX IF NOT EXISTS rig_memory_conversation_order
+                       ON rig_memory_messages(conversation_id, sequence);",
+                )?;
+                Ok(())
+            })
+            .await
+            .map_err(memory_error)?;
+        Ok(Self { connection })
+    }
+
+    /// Access the shared SQLite connection.
+    pub fn connection(&self) -> &Connection {
+        &self.connection
+    }
+}
+
+impl ConversationMemory for SqliteConversationMemory {
+    fn load<'a>(
+        &'a self,
+        conversation_id: &'a str,
+    ) -> WasmBoxedFuture<'a, Result<Vec<Message>, MemoryError>> {
+        let connection = self.connection.clone();
+        let conversation_id = conversation_id.to_owned();
+        Box::pin(async move {
+            connection
+                .call(move |conn| {
+                    let mut statement = conn.prepare(
+                        "SELECT format_version, message_json
+                         FROM rig_memory_messages
+                         WHERE conversation_id=?1 ORDER BY sequence ASC",
+                    )?;
+                    let rows = statement.query_map([conversation_id], |row| {
+                        Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+                    })?;
+                    let mut messages = Vec::new();
+                    for row in rows {
+                        let (version, json) = row?;
+                        if version != MESSAGE_FORMAT_VERSION {
+                            return Err(tokio_rusqlite::Error::Rusqlite(
+                                rusqlite::Error::InvalidQuery,
+                            ));
+                        }
+                        messages.push(serde_json::from_str(&json).map_err(|error| {
+                            rusqlite::Error::FromSqlConversionFailure(
+                                1,
+                                rusqlite::types::Type::Text,
+                                Box::new(error),
+                            )
+                        })?);
+                    }
+                    Ok(messages)
+                })
+                .await
+                .map_err(memory_error)
+        })
+    }
+
+    fn append<'a>(
+        &'a self,
+        conversation_id: &'a str,
+        messages: Vec<Message>,
+    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+        let connection = self.connection.clone();
+        let conversation_id = conversation_id.to_owned();
+        Box::pin(async move {
+            let encoded = messages
+                .into_iter()
+                .map(|message| serde_json::to_string(&message))
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(memory_error)?;
+            connection
+                .call(move |conn| {
+                    let transaction =
+                        conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+                    let next: i64 = transaction.query_row(
+                        "SELECT COALESCE(MAX(sequence) + 1, 0)
+                         FROM rig_memory_messages WHERE conversation_id=?1",
+                        [&conversation_id],
+                        |row| row.get(0),
+                    )?;
+                    for (offset, json) in encoded.into_iter().enumerate() {
+                        transaction.execute(
+                            "INSERT INTO rig_memory_messages
+                             (conversation_id, sequence, format_version, message_json)
+                             VALUES (?1, ?2, ?3, ?4)",
+                            rusqlite::params![
+                                conversation_id,
+                                next + offset as i64,
+                                MESSAGE_FORMAT_VERSION,
+                                json
+                            ],
+                        )?;
+                    }
+                    transaction.commit()?;
+                    Ok(())
+                })
+                .await
+                .map_err(memory_error)
+        })
+    }
+
+    fn clear<'a>(
+        &'a self,
+        conversation_id: &'a str,
+    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+        let connection = self.connection.clone();
+        let conversation_id = conversation_id.to_owned();
+        Box::pin(async move {
+            connection
+                .call(move |conn| {
+                    conn.execute(
+                        "DELETE FROM rig_memory_messages WHERE conversation_id=?1",
+                        [conversation_id],
+                    )?;
+                    Ok(())
+                })
+                .await
+                .map_err(memory_error)
+        })
+    }
+}
+
+/// Typed payload stored in a durable session event.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "data", rename_all = "snake_case")]
+pub enum SessionEntry {
+    /// A serialized conversation message.
+    Message(Message),
+    /// Model invocation metadata and usage.
+    ModelCall {
+        model: Option<String>,
+        config: Value,
+        usage: Value,
+    },
+    /// Tool invocation with parent correlation.
+    ToolCall {
+        name: String,
+        arguments: Value,
+        internal_call_id: String,
+        parent_internal_call_id: Option<String>,
+    },
+    /// Model response metadata.
+    ModelResponse {
+        usage: Value,
+        finish_reason: Option<String>,
+        raw_finish_reason: Option<String>,
+    },
+    /// Tool result payload.
+    ToolResult {
+        outcome: String,
+        content: Value,
+        internal_call_id: String,
+        parent_internal_call_id: Option<String>,
+    },
+    /// Run lifecycle transition.
+    Lifecycle {
+        status: String,
+        detail: Option<Value>,
+    },
+    /// Serialized safe-boundary checkpoint.
+    Checkpoint { snapshot: String },
+    /// Bookmark or named checkpoint.
+    Bookmark {
+        name: String,
+        checkpoint: Option<String>,
+    },
+    /// Compaction summary. Earlier events remain intact.
+    Compaction {
+        through_sequence: u64,
+        summary: String,
+    },
+    /// Application-defined event.
+    Custom { kind: String, payload: Value },
+    /// Marks an interrupted turn that may be recovered.
+    Interrupted {
+        run_id: String,
+        checkpoint: Option<String>,
+    },
+}
+
+/// Ordered event in a session branch.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StoredSessionEvent {
+    pub session_id: String,
+    pub branch: String,
+    pub sequence: u64,
+    pub parent_sequence: Option<u64>,
+    pub correlation_id: Option<String>,
+    pub entry: SessionEntry,
+}
+
+/// Durable append-only SQLite session store.
+#[derive(Clone)]
+pub struct SqliteSessionStore {
+    connection: Connection,
+}
+
+impl SqliteSessionStore {
+    /// Open a store and migrate its schema.
+    pub async fn open(path: impl AsRef<std::path::Path>) -> Result<Self, MemoryError> {
+        let connection = Connection::open(path).await.map_err(memory_error)?;
+        Self::from_connection(connection).await
+    }
+
+    /// Create a store over an existing connection.
+    pub async fn from_connection(connection: Connection) -> Result<Self, MemoryError> {
+        connection
+            .call(|conn| {
+                conn.execute_batch(
+                    "CREATE TABLE IF NOT EXISTS rig_session_events (
+                   session_id TEXT NOT NULL,
+                   branch TEXT NOT NULL,
+                   sequence INTEGER NOT NULL,
+                   parent_sequence INTEGER,
+                   correlation_id TEXT,
+                   format_version INTEGER NOT NULL,
+                   entry_json TEXT NOT NULL,
+                   PRIMARY KEY(session_id, branch, sequence)
+                 );",
+                )?;
+                Ok(())
+            })
+            .await
+            .map_err(memory_error)?;
+        Ok(Self { connection })
+    }
+
+    /// Atomically append and assign the next branch-local sequence.
+    pub async fn append(
+        &self,
+        session_id: &str,
+        branch: &str,
+        parent_sequence: Option<u64>,
+        correlation_id: Option<String>,
+        entry: SessionEntry,
+    ) -> Result<StoredSessionEvent, MemoryError> {
+        let connection = self.connection.clone();
+        let session_id = session_id.to_owned();
+        let branch = branch.to_owned();
+        let json = serde_json::to_string(&entry).map_err(memory_error)?;
+        connection
+            .call(move |conn| {
+                let tx =
+                    conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+                let sequence: i64 = tx.query_row(
+                    "SELECT COALESCE(MAX(sequence)+1,0) FROM rig_session_events
+                 WHERE session_id=?1 AND branch=?2",
+                    rusqlite::params![session_id, branch],
+                    |row| row.get(0),
+                )?;
+                tx.execute(
+                    "INSERT INTO rig_session_events VALUES (?1,?2,?3,?4,?5,1,?6)",
+                    rusqlite::params![
+                        session_id,
+                        branch,
+                        sequence,
+                        parent_sequence,
+                        correlation_id,
+                        json
+                    ],
+                )?;
+                tx.commit()?;
+                Ok(StoredSessionEvent {
+                    session_id,
+                    branch,
+                    sequence: sequence as u64,
+                    parent_sequence,
+                    correlation_id,
+                    entry,
+                })
+            })
+            .await
+            .map_err(memory_error)
+    }
+
+    /// Load a branch in sequence order.
+    pub async fn load(
+        &self,
+        session_id: &str,
+        branch: &str,
+    ) -> Result<Vec<StoredSessionEvent>, MemoryError> {
+        let connection = self.connection.clone();
+        let session_id = session_id.to_owned();
+        let branch = branch.to_owned();
+        connection
+            .call(move |conn| {
+                let mut stmt = conn.prepare(
+                "SELECT sequence,parent_sequence,correlation_id,entry_json FROM rig_session_events
+                 WHERE session_id=?1 AND branch=?2 ORDER BY sequence")?;
+                let rows = stmt.query_map(rusqlite::params![session_id, branch], |row| {
+                    let json: String = row.get(3)?;
+                    let entry = serde_json::from_str(&json).map_err(|error| {
+                        rusqlite::Error::FromSqlConversionFailure(
+                            3,
+                            rusqlite::types::Type::Text,
+                            Box::new(error),
+                        )
+                    })?;
+                    Ok(StoredSessionEvent {
+                        session_id: session_id.clone(),
+                        branch: branch.clone(),
+                        sequence: row.get::<_, i64>(0)? as u64,
+                        parent_sequence: row.get::<_, Option<i64>>(1)?.map(|v| v as u64),
+                        correlation_id: row.get(2)?,
+                        entry,
+                    })
+                })?;
+                let collected: Result<Vec<_>, rusqlite::Error> = rows.collect();
+                Ok(collected?)
+            })
+            .await
+            .map_err(memory_error)
+    }
+
+    /// Create a branch by copying an inclusive prefix while retaining parent links.
+    pub async fn branch(
+        &self,
+        session_id: &str,
+        source: &str,
+        target: &str,
+        through: u64,
+    ) -> Result<(), MemoryError> {
+        let connection = self.connection.clone();
+        let session_id = session_id.to_owned();
+        let source = source.to_owned();
+        let target = target.to_owned();
+        connection.call(move |conn| {
+            let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+            tx.execute(
+                "INSERT INTO rig_session_events
+                 SELECT session_id,?1,sequence,parent_sequence,correlation_id,format_version,entry_json
+                 FROM rig_session_events WHERE session_id=?2 AND branch=?3 AND sequence<=?4",
+                rusqlite::params![target, session_id, source, through])?;
+            tx.commit()?;
+            Ok(())
+        }).await.map_err(memory_error)
+    }
+
+    /// Export a complete branch as versioned JSON.
+    pub async fn export_json(&self, session_id: &str, branch: &str) -> Result<String, MemoryError> {
+        serde_json::to_string(&self.load(session_id, branch).await?).map_err(memory_error)
+    }
+
+    /// Import events transactionally while preserving sequences and parent links.
+    ///
+    /// Re-importing an identical event is idempotent. An occupied sequence with
+    /// different metadata or payload, or a missing parent, rejects the entire
+    /// import without writing any events.
+    pub async fn import_json(&self, json: &str) -> Result<(), MemoryError> {
+        let events: Vec<StoredSessionEvent> = serde_json::from_str(json).map_err(memory_error)?;
+        let connection = self.connection.clone();
+        connection
+            .call(move |conn| {
+                let tx =
+                    conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+                for event in events {
+                    let sequence = i64::try_from(event.sequence).map_err(|_| {
+                        rusqlite::Error::InvalidParameterName(
+                            "sequence exceeds SQLite range".into(),
+                        )
+                    })?;
+                    let parent_sequence = event
+                        .parent_sequence
+                        .map(i64::try_from)
+                        .transpose()
+                        .map_err(|_| {
+                            rusqlite::Error::InvalidParameterName(
+                                "parent sequence exceeds SQLite range".into(),
+                            )
+                        })?;
+                    let entry_json = serde_json::to_string(&event.entry).map_err(|error| {
+                        rusqlite::Error::ToSqlConversionFailure(Box::new(error))
+                    })?;
+                    let existing = tx
+                        .query_row(
+                            "SELECT parent_sequence,correlation_id,entry_json
+                             FROM rig_session_events
+                             WHERE session_id=?1 AND branch=?2 AND sequence=?3",
+                            rusqlite::params![event.session_id, event.branch, sequence],
+                            |row| {
+                                Ok((
+                                    row.get::<_, Option<i64>>(0)?,
+                                    row.get::<_, Option<String>>(1)?,
+                                    row.get::<_, String>(2)?,
+                                ))
+                            },
+                        )
+                        .optional()?;
+                    if let Some((stored_parent, stored_correlation, stored_json)) = existing {
+                        if stored_parent != parent_sequence
+                            || stored_correlation != event.correlation_id
+                            || stored_json != entry_json
+                        {
+                            return Err(rusqlite::Error::InvalidParameterName(format!(
+                                "conflicting imported event {}:{branch}:{sequence}",
+                                event.session_id,
+                                branch = event.branch,
+                            ))
+                            .into());
+                        }
+                        continue;
+                    }
+                    if let Some(parent) = parent_sequence {
+                        let parent_exists: bool = tx.query_row(
+                            "SELECT EXISTS(SELECT 1 FROM rig_session_events
+                             WHERE session_id=?1 AND branch=?2 AND sequence=?3)",
+                            rusqlite::params![event.session_id, event.branch, parent],
+                            |row| row.get(0),
+                        )?;
+                        if !parent_exists {
+                            return Err(rusqlite::Error::InvalidParameterName(format!(
+                                "missing parent {parent} for imported event {}:{branch}:{sequence}",
+                                event.session_id,
+                                branch = event.branch,
+                            ))
+                            .into());
+                        }
+                    }
+                    tx.execute(
+                        "INSERT INTO rig_session_events VALUES (?1,?2,?3,?4,?5,1,?6)",
+                        rusqlite::params![
+                            event.session_id,
+                            event.branch,
+                            sequence,
+                            parent_sequence,
+                            event.correlation_id,
+                            entry_json,
+                        ],
+                    )?;
+                }
+                tx.commit()?;
+                Ok(())
+            })
+            .await
+            .map_err(memory_error)
+    }
+}
+
+impl SessionStore for SqliteSessionStore {
+    fn load<'a>(
+        &'a self,
+        session: &'a str,
+        branch: &'a str,
+    ) -> WasmBoxedFuture<'a, Result<Vec<SessionEvent>, SessionError>> {
+        Box::pin(async move {
+            let events = SqliteSessionStore::load(self, session, branch)
+                .await
+                .map_err(|error| SessionError::Backend(error.to_string()))?;
+            events
+                .into_iter()
+                .map(|event| {
+                    let kind = serde_json::from_value(
+                        serde_json::to_value(event.entry)
+                            .map_err(|error| SessionError::Backend(error.to_string()))?,
+                    )
+                    .map_err(|error| SessionError::Backend(error.to_string()))?;
+                    Ok(SessionEvent {
+                        session_id: event.session_id,
+                        branch: event.branch,
+                        sequence: event.sequence,
+                        parent_sequence: event.parent_sequence,
+                        correlation_id: event.correlation_id,
+                        kind,
+                    })
+                })
+                .collect()
+        })
+    }
+
+    fn append<'a>(
+        &'a self,
+        session: &'a str,
+        branch: &'a str,
+        parent: Option<u64>,
+        correlation: Option<String>,
+        kind: SessionEventKind,
+    ) -> WasmBoxedFuture<'a, Result<SessionEvent, SessionError>> {
+        Box::pin(async move {
+            let entry: SessionEntry = serde_json::from_value(
+                serde_json::to_value(&kind)
+                    .map_err(|error| SessionError::Backend(error.to_string()))?,
+            )
+            .map_err(|error| SessionError::Backend(error.to_string()))?;
+            let event =
+                SqliteSessionStore::append(self, session, branch, parent, correlation, entry)
+                    .await
+                    .map_err(|error| SessionError::Backend(error.to_string()))?;
+            Ok(SessionEvent {
+                session_id: event.session_id,
+                branch: event.branch,
+                sequence: event.sequence,
+                parent_sequence: event.parent_sequence,
+                correlation_id: event.correlation_id,
+                kind,
+            })
+        })
+    }
+
+    fn branch<'a>(
+        &'a self,
+        session: &'a str,
+        source: &'a str,
+        target: &'a str,
+        through: u64,
+    ) -> WasmBoxedFuture<'a, Result<(), SessionError>> {
+        Box::pin(async move {
+            SqliteSessionStore::branch(self, session, source, target, through)
+                .await
+                .map_err(|error| SessionError::Backend(error.to_string()))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+    use rig_core::{
+        agent::AgentBuilder,
+        completion::{
+            CompletionError, CompletionModel, CompletionRequest, CompletionResponse, GetTokenUsage,
+            PromptError, Usage,
+        },
+        streaming::{RawStreamingChoice, RawStreamingToolCall, StreamingCompletionResponse},
+        tool::Tool,
+    };
+    use std::{
+        convert::Infallible,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    struct TestResponse;
+
+    impl GetTokenUsage for TestResponse {
+        fn token_usage(&self) -> Usage {
+            Usage::new()
+        }
+    }
+
+    #[derive(Clone)]
+    struct PendingModel {
+        started: Arc<tokio::sync::Notify>,
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl CompletionModel for PendingModel {
+        type Response = TestResponse;
+        type StreamingResponse = TestResponse;
+        type Client = ();
+
+        fn make(_: &Self::Client, _: impl Into<String>) -> Self {
+            Self {
+                started: Arc::new(tokio::sync::Notify::new()),
+                calls: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+
+        async fn completion(
+            &self,
+            _: CompletionRequest,
+        ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            self.started.notify_one();
+            futures::future::pending().await
+        }
+
+        async fn stream(
+            &self,
+            _: CompletionRequest,
+        ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            self.started.notify_one();
+            futures::future::pending().await
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct ToolCallModel {
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl CompletionModel for ToolCallModel {
+        type Response = TestResponse;
+        type StreamingResponse = TestResponse;
+        type Client = ();
+
+        fn make(_: &Self::Client, _: impl Into<String>) -> Self {
+            Self::default()
+        }
+
+        async fn completion(
+            &self,
+            _: CompletionRequest,
+        ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+            futures::future::pending().await
+        }
+
+        async fn stream(
+            &self,
+            _: CompletionRequest,
+        ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+            let call = self.calls.fetch_add(1, Ordering::SeqCst);
+            let choice = if call == 0 {
+                RawStreamingChoice::ToolCall(RawStreamingToolCall {
+                    id: "call".into(),
+                    internal_call_id: "internal-call".into(),
+                    call_id: None,
+                    name: "pending".into(),
+                    arguments: serde_json::json!({}),
+                    signature: None,
+                    additional_params: None,
+                })
+            } else {
+                RawStreamingChoice::Message("must not run".into())
+            };
+            Ok(StreamingCompletionResponse::stream(Box::pin(
+                futures::stream::iter([Ok(choice)]),
+            )))
+        }
+    }
+
+    #[derive(Clone)]
+    struct PendingTool {
+        started: Arc<tokio::sync::Notify>,
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl Tool for PendingTool {
+        const NAME: &'static str = "pending";
+        type Error = Infallible;
+        type Args = serde_json::Value;
+        type Output = String;
+
+        fn description(&self) -> String {
+            "wait forever".into()
+        }
+
+        fn parameters(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+
+        async fn call(&self, _: Self::Args) -> Result<Self::Output, Self::Error> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            self.started.notify_one();
+            futures::future::pending().await
+        }
+    }
+
+    fn session_path(name: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "rig-session-{name}-{}-{}.sqlite",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
+    async fn assert_unsafe_recovery<M>(agent: rig_core::agent::Agent<M>)
+    where
+        M: CompletionModel + 'static,
+    {
+        let mut reopened = agent.runner("resume").stream().await;
+        let error = match reopened.next().await {
+            Some(Err(error)) => error,
+            _ => panic!("unsafe pending work must emit one terminal error"),
+        };
+        assert!(matches!(
+            error,
+            rig_core::agent::StreamingError::Prompt(error)
+                if matches!(*error, PromptError::SessionError(SessionError::UnsafeRecovery))
+        ));
+    }
+
+    #[tokio::test]
+    async fn streaming_cancellation_persists_interrupted_before_consumer_drop() {
+        let model_path = session_path("pending-model");
+        let model_started = Arc::new(tokio::sync::Notify::new());
+        let model_calls = Arc::new(AtomicUsize::new(0));
+        let model = PendingModel {
+            started: model_started.clone(),
+            calls: model_calls.clone(),
+        };
+        let store = SqliteSessionStore::open(&model_path).await.unwrap();
+        let runner = AgentBuilder::new(model.clone())
+            .session(store, "pending-model")
+            .build()
+            .runner("start");
+        let control = runner.control_handle();
+        let request = runner.stream();
+        let task = tokio::spawn(async move {
+            let mut stream = request.await;
+            let error = loop {
+                if let Some(Err(error)) = stream.next().await {
+                    break error;
+                }
+            };
+            drop(stream);
+            error
+        });
+        model_started.notified().await;
+        assert!(control.cancel());
+        assert!(matches!(
+            task.await.unwrap(),
+            rig_core::agent::StreamingError::Prompt(_)
+        ));
+
+        let reopened = SqliteSessionStore::open(&model_path).await.unwrap();
+        let events = reopened.load("pending-model", "main").await.unwrap();
+        assert!(matches!(
+            events.last().map(|event| &event.entry),
+            Some(SessionEntry::Interrupted {
+                checkpoint: None,
+                ..
+            })
+        ));
+        assert_unsafe_recovery(
+            AgentBuilder::new(model)
+                .session(reopened, "pending-model")
+                .build(),
+        )
+        .await;
+        assert_eq!(model_calls.load(Ordering::SeqCst), 1);
+        drop(std::fs::remove_file(model_path));
+
+        let tool_path = session_path("pending-tool");
+        let tool_started = Arc::new(tokio::sync::Notify::new());
+        let tool_calls = Arc::new(AtomicUsize::new(0));
+        let store = SqliteSessionStore::open(&tool_path).await.unwrap();
+        let model = ToolCallModel::default();
+        let runner = AgentBuilder::new(model.clone())
+            .tool(PendingTool {
+                started: tool_started.clone(),
+                calls: tool_calls.clone(),
+            })
+            .session(store, "pending-tool")
+            .build()
+            .runner("start")
+            .max_turns(2);
+        let control = runner.control_handle();
+        let request = runner.stream();
+        let task = tokio::spawn(async move {
+            let mut stream = request.await;
+            let error = loop {
+                if let Some(Err(error)) = stream.next().await {
+                    break error;
+                }
+            };
+            drop(stream);
+            error
+        });
+        tool_started.notified().await;
+        assert!(control.cancel());
+        assert!(matches!(
+            task.await.unwrap(),
+            rig_core::agent::StreamingError::Prompt(_)
+        ));
+
+        let reopened = SqliteSessionStore::open(&tool_path).await.unwrap();
+        let events = reopened.load("pending-tool", "main").await.unwrap();
+        assert!(matches!(
+            events.last().map(|event| &event.entry),
+            Some(SessionEntry::Interrupted {
+                checkpoint: None,
+                ..
+            })
+        ));
+        assert_unsafe_recovery(
+            AgentBuilder::new(model)
+                .tool(PendingTool {
+                    started: tool_started,
+                    calls: tool_calls.clone(),
+                })
+                .session(reopened, "pending-tool")
+                .build(),
+        )
+        .await;
+        assert_eq!(tool_calls.load(Ordering::SeqCst), 1);
+        drop(std::fs::remove_file(tool_path));
+    }
+
+    async fn connection(name: &str) -> Connection {
+        Connection::open(format!("file:{name}?mode=memory&cache=shared"))
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn memory_orders_concurrent_appends_and_clears() {
+        let memory = SqliteConversationMemory::from_connection(connection("memory_order").await)
+            .await
+            .unwrap();
+        let writes = (0..16).map(|value| {
+            let memory = memory.clone();
+            async move {
+                memory
+                    .append("conversation", vec![Message::user(value.to_string())])
+                    .await
+                    .unwrap()
+            }
+        });
+        futures::future::join_all(writes).await;
+        let loaded = memory.load("conversation").await.unwrap();
+        assert_eq!(loaded.len(), 16);
+        memory.clear("conversation").await.unwrap();
+        assert!(memory.load("conversation").await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn file_backed_multi_connection_appends_survive_reopen_in_order() {
+        let path = std::env::temp_dir().join(format!(
+            "rig-sqlite-durable-{}-{}.db",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let first = SqliteConversationMemory::open(&path).await.unwrap();
+        let second = SqliteConversationMemory::open(&path).await.unwrap();
+        let writes = (0..24).map(|value| {
+            let memory = if value % 2 == 0 {
+                first.clone()
+            } else {
+                second.clone()
+            };
+            async move {
+                memory
+                    .append("conversation", vec![Message::user(value.to_string())])
+                    .await
+            }
+        });
+        for result in futures::future::join_all(writes).await {
+            result.unwrap();
+        }
+        drop(first);
+        drop(second);
+        let reopened = SqliteConversationMemory::open(&path).await.unwrap();
+        let loaded = reopened.load("conversation").await.unwrap();
+        assert_eq!(loaded.len(), 24);
+        drop(reopened);
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[tokio::test]
+    async fn file_backed_session_multi_connection_order_survives_reopen() {
+        let path = std::env::temp_dir().join(format!(
+            "rig-session-durable-{}-{}.db",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+        ));
+        let first = SqliteSessionStore::open(&path).await.unwrap();
+        let second = SqliteSessionStore::open(&path).await.unwrap();
+        let writes = (0..24).map(|value| {
+            let store = if value % 2 == 0 {
+                first.clone()
+            } else {
+                second.clone()
+            };
+            async move {
+                store
+                    .append(
+                        "session",
+                        "main",
+                        None,
+                        Some(format!("run-{value}")),
+                        SessionEntry::Custom {
+                            kind: "value".into(),
+                            payload: serde_json::json!(value),
+                        },
+                    )
+                    .await
+            }
+        });
+        for result in futures::future::join_all(writes).await {
+            result.unwrap();
+        }
+        drop(first);
+        drop(second);
+        let reopened = SqliteSessionStore::open(&path).await.unwrap();
+        let events = reopened.load("session", "main").await.unwrap();
+        assert_eq!(events.len(), 24);
+        assert_eq!(
+            events
+                .iter()
+                .map(|event| event.sequence)
+                .collect::<Vec<_>>(),
+            (0..24).collect::<Vec<_>>()
+        );
+        drop(reopened);
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[tokio::test]
+    async fn sessions_branch_export_and_recover_interruption() {
+        let store = SqliteSessionStore::from_connection(connection("sessions").await)
+            .await
+            .unwrap();
+        store
+            .append(
+                "s",
+                "main",
+                None,
+                Some("run".into()),
+                SessionEntry::Message(Message::user("hi")),
+            )
+            .await
+            .unwrap();
+        store
+            .append(
+                "s",
+                "main",
+                Some(0),
+                Some("run".into()),
+                SessionEntry::Interrupted {
+                    run_id: "run".into(),
+                    checkpoint: Some("state".into()),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .append(
+                "s", "main", Some(1), Some("run".into()),
+                SessionEntry::ModelResponse {
+                    usage: serde_json::json!({"input_tokens": 1, "output_tokens": 2, "total_tokens": 3}),
+                    finish_reason: Some("stop".into()), raw_finish_reason: Some("STOP".into()),
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .append(
+                "s",
+                "main",
+                Some(2),
+                Some("run".into()),
+                SessionEntry::Checkpoint {
+                    snapshot: "safe-state".into(),
+                },
+            )
+            .await
+            .unwrap();
+        store.branch("s", "main", "retry", 3).await.unwrap();
+        store
+            .append(
+                "s",
+                "retry",
+                Some(3),
+                Some("run-2".into()),
+                SessionEntry::Bookmark {
+                    name: "resumed".into(),
+                    checkpoint: None,
+                },
+            )
+            .await
+            .unwrap();
+        let exported = store.export_json("s", "retry").await.unwrap();
+        let imported = SqliteSessionStore::from_connection(connection("sessions_import").await)
+            .await
+            .unwrap();
+        imported.import_json(&exported).await.unwrap();
+        imported
+            .import_json(&exported)
+            .await
+            .expect("an identical repeated import is idempotent");
+        let loaded = imported.load("s", "retry").await.unwrap();
+        assert_eq!(loaded.len(), 5);
+        assert_eq!(
+            loaded
+                .iter()
+                .map(|event| event.sequence)
+                .collect::<Vec<_>>(),
+            vec![0, 1, 2, 3, 4]
+        );
+        assert_eq!(
+            loaded
+                .iter()
+                .map(|event| event.parent_sequence)
+                .collect::<Vec<_>>(),
+            vec![None, Some(0), Some(1), Some(2), Some(3)]
+        );
+        assert!(matches!(
+            loaded[2].entry,
+            SessionEntry::ModelResponse { .. }
+        ));
+        assert!(matches!(loaded[3].entry, SessionEntry::Checkpoint { .. }));
+
+        let mut conflicting = loaded[2].clone();
+        conflicting.correlation_id = Some("different-run".into());
+        let conflict_json = serde_json::to_string(&vec![
+            StoredSessionEvent {
+                sequence: 5,
+                parent_sequence: Some(4),
+                entry: SessionEntry::Custom {
+                    kind: "must-roll-back".into(),
+                    payload: serde_json::json!(true),
+                },
+                ..loaded[4].clone()
+            },
+            conflicting,
+        ])
+        .unwrap();
+        imported
+            .import_json(&conflict_json)
+            .await
+            .expect_err("a conflicting occupied sequence rejects the transaction");
+        assert_eq!(imported.load("s", "retry").await.unwrap(), loaded);
+        assert_eq!(store.load("s", "main").await.unwrap().len(), 4);
+    }
+
+    #[tokio::test]
+    async fn core_session_events_preserve_finish_and_rig_correlation_metadata() {
+        use rig_core::session::{SessionEventKind, SessionStore};
+        let store = SqliteSessionStore::from_connection(connection("core_metadata").await)
+            .await
+            .unwrap();
+        let call = SessionStore::append(
+            &store,
+            "s",
+            "main",
+            None,
+            Some("run".into()),
+            SessionEventKind::ToolCall {
+                name: "add".into(),
+                arguments: serde_json::json!({}),
+                internal_call_id: "rig-call".into(),
+                parent_internal_call_id: Some("rig-parent".into()),
+            },
+        )
+        .await
+        .unwrap();
+        SessionStore::append(
+            &store,
+            "s",
+            "main",
+            Some(call.sequence),
+            Some("run".into()),
+            SessionEventKind::ModelResponse {
+                usage: rig_core::completion::Usage::new(),
+                finish_reason: Some(rig_core::runtime::TerminalReason::Completed),
+                raw_finish_reason: Some("STOP_RAW".into()),
+            },
+        )
+        .await
+        .unwrap();
+        let loaded = SessionStore::load(&store, "s", "main").await.unwrap();
+        assert!(matches!(&loaded[0].kind, SessionEventKind::ToolCall {
+            internal_call_id, parent_internal_call_id: Some(parent), ..
+        } if internal_call_id == "rig-call" && parent == "rig-parent"));
+        assert!(matches!(&loaded[1].kind, SessionEventKind::ModelResponse {
+            finish_reason: Some(reason), raw_finish_reason: Some(raw), ..
+        } if *reason == rig_core::runtime::TerminalReason::Completed && raw == "STOP_RAW"));
+    }
+}

--- a/crates/rig-vertexai/src/types/completion_request.rs
+++ b/crates/rig-vertexai/src/types/completion_request.rs
@@ -345,6 +345,7 @@ mod tests {
                     "type": "object",
                     "properties": {}
                 }),
+                output_schema: None,
             }],
             ..minimal_request()
         };
@@ -376,6 +377,7 @@ mod tests {
                     "type": "object",
                     "properties": {}
                 }),
+                output_schema: None,
             }],
             ..minimal_request()
         };
@@ -407,6 +409,7 @@ mod tests {
                     "type": "object",
                     "properties": {}
                 }),
+                output_schema: None,
             }],
             ..minimal_request()
         };
@@ -440,6 +443,7 @@ mod tests {
                     "type": "object",
                     "properties": {}
                 }),
+                output_schema: None,
             }],
             ..minimal_request()
         };
@@ -532,6 +536,7 @@ mod tests {
                     },
                     "required": ["x", "y"]
                 }),
+                output_schema: None,
             }],
             ..minimal_request()
         };
@@ -564,6 +569,7 @@ mod tests {
                     "type": "object",
                     "properties": {}
                 }),
+                output_schema: None,
             }],
             ..minimal_request()
         };
@@ -595,6 +601,7 @@ mod tests {
                     "type": "object",
                     "properties": {}
                 }),
+                output_schema: None,
             }],
             ..minimal_request()
         };
@@ -635,6 +642,7 @@ mod tests {
                     },
                     "required": ["location"]
                 }),
+                output_schema: None,
             }],
             ..minimal_request()
         };

--- a/crates/rig-vertexai/src/types/completion_response.rs
+++ b/crates/rig-vertexai/src/types/completion_response.rs
@@ -137,11 +137,25 @@ impl TryFrom<VertexGenerateContentOutput> for CompletionResponse<VertexGenerateC
             })
             .unwrap_or_default();
 
+        let provider_finish_reason = candidate.finish_reason.clone();
+        let raw_finish_reason = format!("{provider_finish_reason:?}");
+        let finish_reason = match raw_finish_reason.as_str() {
+            "Stop" => rig_core::runtime::TerminalReason::Completed,
+            "MaxTokens" => rig_core::runtime::TerminalReason::MaxTokens,
+            "Safety" | "Recitation" | "Blocklist" | "ProhibitedContent" | "Spii" => {
+                rig_core::runtime::TerminalReason::ContentFiltered
+            }
+            "Unspecified" => rig_core::runtime::TerminalReason::Other("unspecified".into()),
+            other => rig_core::runtime::TerminalReason::Other(other.to_string()),
+        };
+
         Ok(CompletionResponse {
             choice,
             usage,
             raw_response: value,
             message_id: None,
+            finish_reason: Some(finish_reason),
+            raw_finish_reason: Some(raw_finish_reason),
         })
     }
 }
@@ -293,6 +307,11 @@ mod tests {
                 "Hello, world!".to_string()
             )))
         );
+        assert_eq!(
+            response.finish_reason,
+            Some(rig_core::runtime::TerminalReason::Completed)
+        );
+        assert_eq!(response.raw_finish_reason.as_deref(), Some("Stop"));
     }
 
     #[test]

--- a/crates/rig-vertexai/src/types/message.rs
+++ b/crates/rig-vertexai/src/types/message.rs
@@ -416,6 +416,8 @@ mod tests {
         let tool_result = ToolResult {
             id: "add".to_string(),
             call_id: None,
+            internal_call_id: None,
+            parent_internal_call_id: None,
             content: OneOrMany::one(ToolResultContent::Text(Text::new("8".to_string()))),
         };
 

--- a/examples/durable_coding_agent/Cargo.toml
+++ b/examples/durable_coding_agent/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "durable_coding_agent"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+rig.workspace = true
+rig-sqlite = { path = "../../crates/rig-sqlite" }
+anyhow.workspace = true
+tokio = { workspace = true, features = ["full"] }

--- a/examples/durable_coding_agent/src/main.rs
+++ b/examples/durable_coding_agent/src/main.rs
@@ -1,0 +1,64 @@
+//! Durable interactive coding-agent host composition.
+//! Security: run only inside a trusted project; the command allow-list and
+//! protected paths are host policy, not a substitute for an OS sandbox.
+
+use anyhow::Context;
+use rig::{
+    agent::Agent,
+    client::{CompletionClient, ProviderClient},
+    code_mode::{CodeModeTool, CodePermissions, LocalCommandBackend},
+    providers::openai,
+    skills::{InMemorySkillCatalog, Skill, SkillProvenance},
+};
+use rig_sqlite::{SqliteConversationMemory, SqliteSessionStore};
+use std::collections::HashSet;
+use tokio::io::{AsyncBufReadExt, BufReader};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let project = std::env::current_dir()?.canonicalize()?;
+    let state = project.join(".rig-agent.sqlite");
+    let memory = SqliteConversationMemory::open(&state).await?;
+    let sessions = SqliteSessionStore::open(&state).await?;
+    let skills = InMemorySkillCatalog::default();
+    skills.insert(Skill {
+        name: "coding".into(),
+        description: "Inspect and modify this trusted project".into(),
+        instructions: "Prefer read-only inspection; explain mutations and validate them.".into(),
+        provenance: SkillProvenance::BuiltIn,
+        assets: vec![],
+        allowed_tools: vec!["code_mode".into()],
+    });
+    let backend = LocalCommandBackend::new(
+        CodePermissions {
+            programs: HashSet::from(["git".into(), "cargo".into(), "rg".into()]),
+            trusted_root: project.clone(),
+        },
+        project.join(".rig-artifacts"),
+    )
+    .protect_paths([state.clone(), project.join(".git")]);
+    let client = openai::Client::from_env()?;
+    let agent: Agent<_> = client
+        .agent(openai::GPT_4O)
+        .preamble("You are a cautious interactive coding agent.")
+        .memory(memory)
+        .conversation("interactive-user")
+        .session(sessions, "interactive-user")
+        .skills(skills)
+        .tool(CodeModeTool::new(backend))
+        .build();
+
+    eprintln!("Durable coding agent ready. Ctrl-D to exit.");
+    let mut lines = BufReader::new(tokio::io::stdin()).lines();
+    while let Some(line) = lines.next_line().await? {
+        let response = agent
+            .runner(line)
+            .skill("coding")
+            .map_err(anyhow::Error::msg)?
+            .run()
+            .await
+            .context("agent run failed")?;
+        println!("{}", response.output);
+    }
+    Ok(())
+}

--- a/examples/openai_streaming_per_call_usage/src/main.rs
+++ b/examples/openai_streaming_per_call_usage/src/main.rs
@@ -161,7 +161,7 @@ async fn main() -> Result<()> {
     println!("\n\nfinal response: {}", response.output());
     print_usage("aggregate agent usage", response.usage());
 
-    if let Some(final_completion_call) = response.completion_calls().last().copied() {
+    if let Some(final_completion_call) = response.completion_calls().last().cloned() {
         let usage = final_completion_call.usage;
         if usage.has_values() {
             print_usage("final completion call usage", usage);

--- a/tests/common/support.rs
+++ b/tests/common/support.rs
@@ -233,6 +233,7 @@ pub(crate) fn zero_arg_tool_definition(name: &str) -> ToolDefinition {
             "properties": {},
             "required": [],
         }),
+        output_schema: None,
     }
 }
 

--- a/tests/core/reasoning_stream_stats.rs
+++ b/tests/core/reasoning_stream_stats.rs
@@ -20,6 +20,8 @@ async fn collect_stream_stats_tracks_only_final_turn_text() {
     let tool_result = ToolResult {
         id: "tool_1".to_string(),
         call_id: None,
+        internal_call_id: Some(internal_call_id.clone()),
+        parent_internal_call_id: None,
         content: OneOrMany::one(ToolResultContent::text("72F and sunny")),
     };
 

--- a/tests/providers/anthropic/cassette/empty_end_turn.rs
+++ b/tests/providers/anthropic/cassette/empty_end_turn.rs
@@ -53,6 +53,7 @@ fn notify_tool_definition() -> ToolDefinition {
             },
             "required": ["msg"]
         }),
+        output_schema: None,
     }
 }
 

--- a/tests/providers/anthropic/cassette/messages_tool_args.rs
+++ b/tests/providers/anthropic/cassette/messages_tool_args.rs
@@ -320,6 +320,7 @@ async fn unicode_arguments_streaming() {
                         },
                         "required": ["message"]
                     }),
+                    output_schema: None,
                 })
                 .build();
 

--- a/tests/providers/anthropic/cassette/prompt_caching.rs
+++ b/tests/providers/anthropic/cassette/prompt_caching.rs
@@ -268,6 +268,7 @@ fn cache_probe_tools() -> Vec<ToolDefinition> {
                 },
                 "required": ["topic"]
             }),
+            output_schema: None,
         },
         ToolDefinition {
             name: "lookup_cache_fixture".to_string(),
@@ -285,6 +286,7 @@ fn cache_probe_tools() -> Vec<ToolDefinition> {
                 },
                 "required": ["fixture"]
             }),
+            output_schema: None,
         },
     ]
 }
@@ -307,6 +309,7 @@ fn cache_probe_tools_for(label: &str) -> Vec<ToolDefinition> {
                 },
                 "required": ["topic"]
             }),
+            output_schema: None,
         },
         ToolDefinition {
             name: "lookup_cache_fixture".to_string(),
@@ -324,6 +327,7 @@ fn cache_probe_tools_for(label: &str) -> Vec<ToolDefinition> {
                 },
                 "required": ["fixture"]
             }),
+            output_schema: None,
         },
     ]
 }

--- a/tests/providers/chatgpt/cassette/codex_tool_args.rs
+++ b/tests/providers/chatgpt/cassette/codex_tool_args.rs
@@ -315,6 +315,7 @@ async fn unicode_arguments_streaming() {
                         },
                         "required": ["message"]
                     }),
+                    output_schema: None,
                 })
                 .build();
 

--- a/tests/providers/gemini/agent_run_support.rs
+++ b/tests/providers/gemini/agent_run_support.rs
@@ -40,6 +40,7 @@ fn operation_definition(name: &str, description: &str) -> ToolDefinition {
             },
             "required": ["x", "y"]
         }),
+        output_schema: None,
     }
 }
 

--- a/tests/providers/gemini/cassette/agent_run_streamed.rs
+++ b/tests/providers/gemini/cassette/agent_run_streamed.rs
@@ -29,6 +29,7 @@ use crate::support::{assert_mentions_expected_number, assert_nonempty_response};
 
 /// How one hand-driven streamed turn ended.
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 enum TurnEnd {
     /// The turn was assembled and fed to the machine.
     Finished,

--- a/tests/providers/gemini/cassette/generate_tool_args.rs
+++ b/tests/providers/gemini/cassette/generate_tool_args.rs
@@ -256,6 +256,7 @@ async fn unicode_arguments_streaming() {
                         },
                         "required": ["message"]
                     }),
+                    output_schema: None,
                 })
                 .build();
 
@@ -326,6 +327,7 @@ async fn optional_nullable_argument_omitted_when_not_requested() {
                         },
                         "required": ["name"]
                     }),
+                    output_schema: None,
                 })
                 .build();
 

--- a/tests/providers/gemini/cassette/interactions_api.rs
+++ b/tests/providers/gemini/cassette/interactions_api.rs
@@ -153,6 +153,7 @@ async fn tool_result_roundtrip() {
                     },
                     "required": ["x", "y"]
                 }),
+                output_schema: None,
             };
 
             let initial = model

--- a/tests/providers/gemini/tools_support.rs
+++ b/tests/providers/gemini/tools_support.rs
@@ -75,6 +75,7 @@ fn operation_definition(name: &str, description: &str) -> ToolDefinition {
             },
             "required": ["x", "y"]
         }),
+        output_schema: None,
     }
 }
 

--- a/tests/providers/llamacpp/typed_prompt_tools.rs
+++ b/tests/providers/llamacpp/typed_prompt_tools.rs
@@ -88,6 +88,7 @@ where
                 tool_call_id,
                 internal_call_id,
                 args,
+                ..
             } => {
                 let tool_no = self.next_tool_call();
 

--- a/tests/providers/openai/cassette/response_schema.rs
+++ b/tests/providers/openai/cassette/response_schema.rs
@@ -78,6 +78,7 @@ fn test_nested_objects() {
         name: "submit".to_string(),
         description: "Submit".to_string(),
         parameters: serde_json::to_value(schema).unwrap(),
+        output_schema: None,
     };
     let response = ResponsesToolDefinition::from(tool_def).with_strict();
 
@@ -94,6 +95,7 @@ fn test_array_items() {
         name: "submit".to_string(),
         description: "Submit".to_string(),
         parameters: serde_json::to_value(schema).unwrap(),
+        output_schema: None,
     };
     let response = ResponsesToolDefinition::from(tool_def).with_strict();
 
@@ -110,6 +112,7 @@ fn test_enum_schemas() {
         name: "submit".to_string(),
         description: "Submit".to_string(),
         parameters: serde_json::to_value(schema).unwrap(),
+        output_schema: None,
     };
     let response = ResponsesToolDefinition::from(tool_def).with_strict();
 

--- a/tests/providers/openai/cassette/responses_tool_args.rs
+++ b/tests/providers/openai/cassette/responses_tool_args.rs
@@ -315,6 +315,7 @@ async fn unicode_arguments_streaming() {
                         },
                         "required": ["message"]
                     }),
+                    output_schema: None,
                 })
                 .build();
 


### PR DESCRIPTION
## Summary

This PR delivers a broad **foundation and partial implementation** of the production interactive-agent roadmap in #2118. It does not complete the epic or every linked issue.

## Implemented scope

### Interactive runtime
- Adds run-scoped `RunControlHandle`/`RunContext` with status, cooperative cancellation, deadlines, steering, follow-ups, safe checkpoints, and resume.
- Uses the shared unary/streaming drive loop so those control semantics remain aligned across both surfaces.
- Propagates run identity, cancellation, deadlines, and call ancestry through native tools, MCP tools, nested dispatch, and child agents.
- Preserves normalized and raw terminal metadata through completions, streams, final responses, checkpoints, and session events for the provider paths covered here.

### Tool platform
- Adds hook-aware scoped nested execution with inherited extensions, parent/child internal IDs, allowlists, depth limits, recursion guards, cancellation, and telemetry.
- Adds call-scoped scratchpads, structured error extensions, a public hook test harness, bounded argument repair/retry, scheduling metadata, and final-result tools.
- Adds an ordered host-facing catalog projection for native, MCP, dynamic, and provider-hosted tools while keeping host metadata off provider wires.
- Adds `ToolDefinition::output_schema` and structured rich tool output parts while retaining string-returning tool compatibility.
- Wires provider-hosted tools through `AgentBuilder`; OpenAI request conversion merges hosted and native tools into one wire array.

### Persistence and reusable capabilities
- Adds durable SQLite `ConversationMemory` with atomic multi-connection ordering.
- Adds a backend-neutral typed, branchable session event-store API and SQLite implementation with checkpoints, interruption recovery, compaction/bookmarks, import/export, and call correlation.
- Adds a provider-independent progressive-disclosure skill catalog, trusted filesystem discovery, provenance/assets, and per-turn/nested-tool restrictions.
- Adds bounded child-agent orchestration with fresh/inherited history, shared cancellation/deadlines, typed handoffs, progress/status, and parent/session correlation.

### Coding-tool foundation
- Adds runtime-independent code-execution contracts and a hardened allowlisted local command backend with process-tree termination, bounded output capture, artifact references, protected paths, mutation queues, and command-configured SSH/container/sandbox adapters.
- Adds a runnable `durable_coding_agent` example.

## What this PR does **not** complete

The following #2118 work remains and should be handled in focused follow-ups:

- a distinct `next_turn` queue/API separate from steer and follow-up;
- run-scoped tool/toolset factories with deterministic lifecycle cleanup;
- complete normalized finish-reason mappings across every provider covered by #1886;
- the typed native/MCP host-dispatch design requested by #1906 (this PR adds catalog metadata and unified erased dispatch, not typed native dispatch);
- full Agent Skills/SKILL.md-standard frontmatter and asset-loading semantics;
- a general tool-progress event channel beyond the code/subagent interfaces;
- concrete isolation-enforcing SSH/container/sandbox implementations rather than command-configured adapters;
- a real code-mode runtime that exposes selected Rig tools as callable functions inside JavaScript, Python/Monty, Lua, or WASM. The `CodeModeTool` in this PR is an allowlisted command-execution foundation, not completion of #1439;
- the focused child-issue decomposition and migration work requested by the epic.

Accordingly, this PR **advances but does not close** #2118, #2095, #1906, #1264, #1439, or #1886.

## Breaking API migration

The implemented output-schema and correlation work adds fields to public response/tool types. `CHANGELOG.md` documents struct-literal migration and constructors/helpers. Serialized checkpoint/session fields use defaults where backward deserialization is safe.

## Validation

- `cargo test -p rig-core --all-features --lib` — 1303 passed, 8 ignored
- `cargo test -p rig-sqlite --lib` — 56 passed
- `cargo check --workspace --all-targets --all-features`
- `cargo check -p rig-core --target wasm32-unknown-unknown`
- `cargo check -p rig-core --features wasm --target wasm32-unknown-unknown`
- `cargo clippy -p rig-core --all-targets --all-features -- -D warnings`
- `cargo clippy -p rig-sqlite --lib --all-features -- -D warnings`
- `cargo doc -p rig-core -p rig-sqlite --no-deps`
- `cargo check --manifest-path examples/durable_coding_agent/Cargo.toml`
- `cargo fmt --all -- --check`
- `git diff --check`
- GitHub CI: fmt, WASM, clippy, tests, doctests, and docs all pass

Live provider and external SSH/container/sandbox execution remain environment-dependent. Windows process-tree cleanup uses the host's `taskkill /T /F`.

Supersedes the steering approach in #1858. It does not fully supersede #1886.

Closes #2116
Closes #2090
Closes #2094
Closes #1613
Closes #1890
Closes #1968
