### PR TITLE
feat: add MongoDB driver handshake metadata

### DIFF
--- a/crates/rig-mongodb/examples/vector_search_mongodb.rs
+++ b/crates/rig-mongodb/examples/vector_search_mongodb.rs
@@ -1,7 +1,6 @@
 use mongodb::{
     Client as MongoClient, Collection,
     bson::{self, doc},
-    options::ClientOptions,
 };
 use rig_core::{
     client::ProviderClient, providers::openai, vector_store::request::VectorSearchRequest,
@@ -55,7 +54,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Initialize MongoDB client
     let mongodb_connection_string = env::var("MONGODB_CONNECTION_STRING")?;
-    let options = ClientOptions::parse(mongodb_connection_string).await?;
+    let options = rig_mongodb::client_options(&mongodb_connection_string).await?;
 
     let mongodb_client = MongoClient::with_options(options)?;
 

--- a/crates/rig-mongodb/src/lib.rs
+++ b/crates/rig-mongodb/src/lib.rs
@@ -8,6 +8,7 @@
 
 use futures::StreamExt;
 use mongodb::bson::{self, Bson, Document, doc, to_bson};
+use mongodb::options::{ClientOptions, DriverInfo};
 
 use rig_core::{
     Embed, OneOrMany,
@@ -19,6 +20,31 @@ use rig_core::{
     wasm_compat::WasmBoxedFuture,
 };
 use serde::{Deserialize, Serialize};
+
+const DRIVER_NAME: &str = "rig-mongodb";
+
+/// Returns [`ClientOptions`] pre-configured with `rig-mongodb` driver metadata.
+///
+/// Use this to construct your [`mongodb::Client`] so that MongoDB server-side
+/// telemetry can identify traffic from Rig applications:
+///
+/// ```no_run
+/// # async fn example() -> Result<(), mongodb::error::Error> {
+/// let options = rig_mongodb::client_options("mongodb://localhost:27017").await?;
+/// let client = mongodb::Client::with_options(options)?;
+/// # Ok(())
+/// # }
+/// ```
+pub async fn client_options(uri: &str) -> Result<ClientOptions, mongodb::error::Error> {
+    let mut options = ClientOptions::parse(uri).await?;
+    options.driver_info = Some(
+        DriverInfo::builder()
+            .name(DRIVER_NAME)
+            .version(env!("CARGO_PKG_VERSION").to_string())
+            .build(),
+    );
+    Ok(options)
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -539,5 +565,28 @@ where
             .map_err(mongodb_to_rig_error)?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn client_options_sets_driver_info() {
+        let options = client_options("mongodb://localhost:27017")
+            .await
+            .expect("client_options should parse URI");
+        let info = options.driver_info.expect("driver_info should be set");
+        assert_eq!(info.name, DRIVER_NAME);
+        assert!(
+            info.version.is_some(),
+            "driver version should be set from CARGO_PKG_VERSION"
+        );
+    }
+
+    #[test]
+    fn driver_name_is_not_empty() {
+        assert!(!DRIVER_NAME.is_empty());
     }
 }


### PR DESCRIPTION
Adds a `rig_mongodb::client_options()` helper that returns `ClientOptions` pre-configured with MongoDB `DriverInfo`, allowing the MongoDB server to identify traffic from Rig applications in server-side telemetry, Atlas dashboards, and `db.currentOp()`.

## What changes

`rig-mongodb` receives a pre-built `mongodb::Collection` from callers, so it has no hook point to inject metadata at construction time. The Rust driver has no post-construction API equivalent, so the right approach is a public factory helper:

```rust
// Before
let options = ClientOptions::parse(uri).await?;
let client = Client::with_options(options)?;

// After
let options = rig_mongodb::client_options(uri).await?;
let client = Client::with_options(options)?;
```

The helper sets `driver_info` with name `"rig-mongodb"` and the crate's version (read at compile time via `env!("CARGO_PKG_VERSION")`). The existing example in `examples/vector_search_mongodb.rs` is updated to use the helper.

## How it appears in the logs

The handshake document visible in `mongod` diagnostic logs and `db.currentOp()` will include a `driver` field alongside the base `mongodb` Rust driver info:

```json
{
  "driver": {
    "name": "mongodb|rig-mongodb",
    "version": "3.7.0|0.40.0"
  }
}
```

See the [MongoDB handshake specification](https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.md) for details.

## Testing

Added two unit tests in `src/lib.rs`:
- `client_options_sets_driver_info` — confirms `driver_info.name` equals `"rig-mongodb"` and version is present
- `driver_name_is_not_empty` — guards against accidental empty-string name

```
cargo test -p rig-mongodb  # 4 tests pass
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes