### PR TITLE
fix(gemini): preserve image generation error envelopes

### DIFF
--- a/crates/rig-core/src/providers/gemini/client.rs
+++ b/crates/rig-core/src/providers/gemini/client.rs
@@ -233,8 +233,10 @@ pub struct ApiErrorResponse {
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 pub enum ApiResponse<T> {
-    Ok(T),
+    // Untagged variants are tried in order, and some Gemini success responses
+    // contain only defaulted or optional fields that also accept error objects.
     Err(ApiErrorResponse),
+    Ok(T),
 }
 
 // ================================================================

--- a/crates/rig-core/src/providers/gemini/client.rs
+++ b/crates/rig-core/src/providers/gemini/client.rs
@@ -226,6 +226,14 @@ impl<H> InteractionsClient<H> {
 /// Error response payload returned by Gemini.
 #[derive(Debug, Deserialize)]
 pub struct ApiErrorResponse {
+    /// Structured error details.
+    pub error: ApiError,
+}
+
+/// Error details returned in a Gemini API error response.
+#[derive(Debug, Deserialize)]
+pub struct ApiError {
+    /// Human-readable description of the error.
     pub message: String,
 }
 
@@ -233,8 +241,8 @@ pub struct ApiErrorResponse {
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 pub enum ApiResponse<T> {
-    // Untagged variants are tried in order, and some Gemini success responses
-    // contain only defaulted or optional fields that also accept error objects.
+    // Untagged variants are tried in order, and some Gemini success response
+    // types contain only defaulted or optional fields that accept error objects.
     Err(ApiErrorResponse),
     Ok(T),
 }
@@ -246,6 +254,45 @@ pub enum ApiResponse<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn api_response_detects_nested_error_before_permissive_success() {
+        #[derive(Debug, Deserialize)]
+        struct PermissiveResponse {
+            #[serde(default)]
+            candidates: Vec<serde_json::Value>,
+        }
+
+        let response: ApiResponse<PermissiveResponse> = serde_json::from_str(
+            r#"{"error":{"code":503,"message":"boom","status":"UNAVAILABLE"}}"#,
+        )
+        .expect("nested Gemini error should deserialize");
+
+        match response {
+            ApiResponse::Err(err) => assert_eq!(err.error.message, "boom"),
+            ApiResponse::Ok(response) => panic!(
+                "expected nested error, got success with {} candidates",
+                response.candidates.len()
+            ),
+        }
+    }
+
+    #[test]
+    fn api_response_allows_top_level_message_in_success() {
+        #[derive(Debug, Deserialize)]
+        struct MessageResponse {
+            message: String,
+        }
+
+        let response: ApiResponse<MessageResponse> =
+            serde_json::from_str(r#"{"message":"success"}"#)
+                .expect("success response should deserialize");
+
+        match response {
+            ApiResponse::Ok(response) => assert_eq!(response.message, "success"),
+            ApiResponse::Err(err) => panic!("expected success, got error: {err:?}"),
+        }
+    }
 
     #[test]
     fn test_client_initialization() {

--- a/crates/rig-core/src/providers/gemini/embedding.rs
+++ b/crates/rig-core/src/providers/gemini/embedding.rs
@@ -115,11 +115,8 @@ where
         let status = response.status();
         let body = response.into_body().await?;
 
-        // A non-success status may carry an error body that does not match the
-        // `ApiResponse` shape (Gemini nests its error under `error`, with no
-        // top-level `message`), so preserve it verbatim before trying to
-        // deserialize the success envelope — otherwise it would surface as a
-        // `JsonError` and the provider_response_* helpers would lose it.
+        // Preserve non-success bodies before deserialization because providers
+        // may return empty, non-JSON, or otherwise unexpected error payloads.
         if !status.is_success() {
             return Err(EmbeddingError::from_http_response(
                 status,
@@ -145,7 +142,7 @@ where
                 Ok(docs)
             }
             ApiResponse::Err(err) => {
-                tracing::warn!(message = %err.message, "provider returned an error response");
+                tracing::warn!(message = %err.error.message, "provider returned an error response");
                 Err(EmbeddingError::from_http_response(
                     status,
                     String::from_utf8_lossy(&body),
@@ -238,10 +235,8 @@ mod tests {
         use crate::embeddings::EmbeddingModel as _;
         use crate::test_utils::RecordingHttpClient;
 
-        // A realistic Gemini error body: the error is nested under `error` with no
-        // top-level `message`, so it does NOT match the `ApiResponse` envelope. The
-        // non-success status guard must preserve it verbatim (otherwise it would
-        // surface as a `JsonError`).
+        // The non-success status guard preserves the raw provider body without
+        // depending on its envelope shape.
         let body =
             r#"{"error":{"code":503,"message":"service unavailable","status":"UNAVAILABLE"}}"#;
         let http_client =
@@ -272,10 +267,8 @@ mod tests {
         use crate::embeddings::EmbeddingModel as _;
         use crate::test_utils::RecordingHttpClient;
 
-        // 200 OK whose body deserializes to `ApiResponse::Err` (requires a top-level
-        // `message`; absence of `embeddings` keeps it off the success variant).
-        let body =
-            r#"{"message":"boom","error":{"code":503,"message":"boom","status":"UNAVAILABLE"}}"#;
+        // 200 OK carrying Gemini's standard nested error envelope.
+        let body = r#"{"error":{"code":503,"message":"boom","status":"UNAVAILABLE"}}"#;
         let http_client = RecordingHttpClient::new(body); // 200 OK
         let client = Client::builder()
             .api_key("test-key")

--- a/crates/rig-core/src/providers/gemini/image_generation.rs
+++ b/crates/rig-core/src/providers/gemini/image_generation.rs
@@ -84,7 +84,7 @@ where
         match serde_json::from_str::<ApiResponse<GenerateContentResponse>>(&text)? {
             ApiResponse::Ok(response) => response.try_into(),
             ApiResponse::Err(err) => {
-                tracing::warn!(message = %err.message, "provider returned an error response");
+                tracing::warn!(message = %err.error.message, "provider returned an error response");
                 Err(ImageGenerationError::from_http_response(status, text))
             }
         }
@@ -358,6 +358,21 @@ mod tests {
         assert!(err.to_string().contains("did not include image data"));
     }
 
+    #[test]
+    fn api_response_parsing_keeps_blocked_prompt_as_success() {
+        let response: ApiResponse<GenerateContentResponse> = serde_json::from_value(json!({
+            "promptFeedback": {
+                "blockReason": "SAFETY"
+            }
+        }))
+        .expect("blocked prompt response should deserialize");
+
+        match response {
+            ApiResponse::Ok(response) => assert!(response.candidates.is_empty()),
+            ApiResponse::Err(err) => panic!("expected success envelope, got error: {err:?}"),
+        }
+    }
+
     #[tokio::test]
     async fn image_generation_non_success_preserves_status_and_body() {
         use crate::client::image_generation::ImageGenerationClient;
@@ -393,11 +408,10 @@ mod tests {
         use crate::image_generation::ImageGenerationModel as _;
         use crate::test_utils::RecordingHttpClient;
 
-        // 200 OK whose body deserializes to `ApiResponse::Err`. The error variant
-        // must be tried first because all identifying fields in
+        // 200 OK carrying Gemini's standard nested error envelope. The error
+        // variant must be tried first because all identifying fields in
         // `GenerateContentResponse` can be omitted.
-        let body =
-            r#"{"message":"boom","error":{"code":503,"message":"boom","status":"UNAVAILABLE"}}"#;
+        let body = r#"{"error":{"code":503,"message":"boom","status":"UNAVAILABLE"}}"#;
         let http_client = RecordingHttpClient::new(body); // 200 OK
         let client = Client::builder()
             .api_key("test-key")

--- a/crates/rig-core/src/providers/gemini/image_generation.rs
+++ b/crates/rig-core/src/providers/gemini/image_generation.rs
@@ -393,9 +393,9 @@ mod tests {
         use crate::image_generation::ImageGenerationModel as _;
         use crate::test_utils::RecordingHttpClient;
 
-        // 200 OK whose body deserializes to `ApiResponse::Err` (Gemini `ApiErrorResponse`
-        // requires a top-level `message` field; the absence of `candidates`/`response_id`
-        // prevents it from matching the success `GenerateContentResponse` variant).
+        // 200 OK whose body deserializes to `ApiResponse::Err`. The error variant
+        // must be tried first because all identifying fields in
+        // `GenerateContentResponse` can be omitted.
         let body =
             r#"{"message":"boom","error":{"code":503,"message":"boom","status":"UNAVAILABLE"}}"#;
         let http_client = RecordingHttpClient::new(body); // 200 OK


### PR DESCRIPTION
## Summary

- prioritize Gemini's standard nested `error` envelope before permissive success payloads during untagged deserialization
- preserve the original HTTP status and raw body for 2xx image-generation and embedding error envelopes
- keep sparse blocked-prompt responses and ordinary top-level `message` payloads on the success path

## Root cause

`GenerateContentResponse` now defaults omitted `response_id` and `candidates` fields, while its remaining fields are optional. Because serde tries untagged enum variants in declaration order, a Gemini error object was accepted by `ApiResponse::Ok` as an empty success response before `ApiResponse::Err` was considered. Image extraction then returned a generic missing-image `ResponseError`, losing the provider status and body.

The error model now matches Gemini's standard `{"error":{"message":...}}` structure. Trying that explicit nested shape first resolves the ambiguity without removing support for legitimate blocked-prompt responses that omit proto-default fields or treating unrelated top-level `message` fields as errors.

## Impact

Gemini image-generation and embedding error envelopes returned with a 2xx status surface through `ProviderResponse`, retaining the provider-authored body and HTTP status for callers.

## Validation

- `cargo test -p rig-core --all-features providers::gemini:: -- --nocapture` (90 passed, 1 ignored)
- `cargo test -p rig-core --lib --all-features` (1,266 passed, 8 ignored)
- `cargo clippy -p rig-core --all-targets --all-features`
- `cargo fmt --all -- --check`
- `git diff --check`