### PR TITLE
feat(core)!: add explicit JSON tool-result content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- *(message)* [**breaking**] Add explicit JSON tool-result content with lossless provider conversion.
+
 ### Changed
 
 - *(core)* [**breaking**] Mark `PromptError`, `StructuredOutputError`, `ToolError`, `ToolSetError`, and `VectorStoreError` as non-exhaustive, requiring downstream match expressions to include a wildcard arm. Conversation memory load failures now surface as the typed `PromptError::MemoryError` variant instead of `CompletionError::RequestError`.

--- a/crates/rig-bedrock/CHANGELOG.md
+++ b/crates/rig-bedrock/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+
+- Preserve structured tool-result JSON through Bedrock's native JSON content blocks.
+
 ## [0.40.0](https://github.com/0xPlaygrounds/rig/compare/rig-bedrock-v0.39.0...rig-bedrock-v0.40.0) - 2026-07-10
 
 ### Added

--- a/crates/rig-bedrock/src/types/json.rs
+++ b/crates/rig-bedrock/src/types/json.rs
@@ -44,11 +44,10 @@ impl From<Value> for AwsDocument {
             Value::Null => AwsDocument(Document::Null),
             Value::Bool(b) => AwsDocument(Document::Bool(b)),
             Value::Number(num) => {
-                if let Some(i) = num.as_i64() {
-                    match i > 0 {
-                        true => AwsDocument(Document::Number(Number::PosInt(i as u64))),
-                        false => AwsDocument(Document::Number(Number::NegInt(i))),
-                    }
+                if let Some(u) = num.as_u64() {
+                    AwsDocument(Document::Number(Number::PosInt(u)))
+                } else if let Some(i) = num.as_i64() {
+                    AwsDocument(Document::Number(Number::NegInt(i)))
                 } else if let Some(f) = num.as_f64() {
                     AwsDocument(Document::Number(Number::Float(f)))
                 } else {
@@ -113,6 +112,17 @@ mod tests {
         let value: Value = serde_json::from_str(json).unwrap();
         let document: AwsDocument = value.into();
         println!("{document:?}");
+    }
+
+    #[test]
+    fn unsigned_json_number_round_trips_without_precision_loss() {
+        let value = Value::from(u64::MAX);
+        let document: AwsDocument = value.clone().into();
+
+        assert_eq!(document.0, Document::Number(Number::PosInt(u64::MAX)));
+
+        let roundtrip: Value = document.into();
+        assert_eq!(roundtrip, value);
     }
 
     #[test]

--- a/crates/rig-bedrock/src/types/tool.rs
+++ b/crates/rig-bedrock/src/types/tool.rs
@@ -22,6 +22,9 @@ impl TryFrom<RigToolResultContent> for aws_bedrock::ToolResultContentBlock {
                 let image = RigImage(image).try_into()?;
                 Ok(aws_bedrock::ToolResultContentBlock::Image(image))
             }
+            ToolResultContent::Json { value } => Ok(aws_bedrock::ToolResultContentBlock::Json(
+                AwsDocument::from(value).0,
+            )),
         }
     }
 }
@@ -37,9 +40,7 @@ impl TryFrom<aws_bedrock::ToolResultContentBlock> for RigToolResultContent {
             }
             aws_bedrock::ToolResultContentBlock::Json(document) => {
                 let json: Value = AwsDocument(document).into();
-                Ok(RigToolResultContent(ToolResultContent::Text(Text::new(
-                    json.to_string(),
-                ))))
+                Ok(RigToolResultContent(ToolResultContent::json(json)))
             }
             aws_bedrock::ToolResultContentBlock::Text(text) => Ok(RigToolResultContent(
                 ToolResultContent::Text(Text::new(text)),
@@ -86,6 +87,34 @@ mod tests {
         let aws_tool: Result<aws_bedrock::ToolResultContentBlock, _> = tool.try_into();
         assert!(aws_tool.is_ok());
         assert!(aws_tool.unwrap().is_image())
+    }
+
+    #[test]
+    fn rig_tool_json_round_trips_through_native_aws_json() {
+        let values = [
+            serde_json::Value::Null,
+            serde_json::json!(true),
+            serde_json::json!(-42),
+            serde_json::json!("structured string"),
+            serde_json::json!([1, false, null]),
+            serde_json::json!({ "answer": 42 }),
+        ];
+
+        for value in values {
+            let aws_tool: aws_bedrock::ToolResultContentBlock =
+                RigToolResultContent(ToolResultContent::json(value.clone()))
+                    .try_into()
+                    .expect("Rig JSON should convert to a Bedrock tool result");
+            assert!(
+                aws_tool.is_json(),
+                "explicit JSON must use Bedrock's native JSON block"
+            );
+
+            let roundtrip: RigToolResultContent = aws_tool
+                .try_into()
+                .expect("Bedrock JSON should convert back to Rig JSON");
+            assert_eq!(roundtrip.0, ToolResultContent::json(value));
+        }
     }
 
     #[test]

--- a/crates/rig-core/CHANGELOG.md
+++ b/crates/rig-core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- *(message)* [**breaking**] Add explicit JSON tool-result content with lossless provider conversion.
+
 ### Changed
 
 - *(core)* [**breaking**] Mark `PromptError`, `StructuredOutputError`, `ToolError`, `ToolSetError`, and `VectorStoreError` as non-exhaustive, requiring downstream match expressions to include a wildcard arm. Conversation memory load failures now surface as the typed `PromptError::MemoryError` variant instead of `CompletionError::RequestError`.

--- a/crates/rig-core/src/completion/message.rs
+++ b/crates/rig-core/src/completion/message.rs
@@ -15,8 +15,8 @@ use super::CompletionError;
 /// Messages are role-tagged and may contain one or many content items, including
 /// text, images, audio, documents, tool calls, and tool results. Provider modules
 /// are responsible for translating these generic messages into provider-native
-/// request bodies. That conversion may be lossy when a provider does not support
-/// a particular content type.
+/// request bodies. Tool-result adapters preserve typed content and ordering or
+/// return [`MessageError::ConversionError`] when the provider cannot represent it.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(tag = "role", rename_all = "lowercase")]
 pub enum Message {
@@ -214,16 +214,28 @@ pub struct ToolResult {
     /// Provider-specific call ID, when distinct from `id`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub call_id: Option<String>,
-    /// One or more content items produced by the tool.
+    /// One or more ordered content items produced by the tool.
     pub content: OneOrMany<ToolResultContent>,
 }
 
-/// Describes the content of a tool result, which can be text or an image.
+/// Describes one typed item in a tool result.
+///
+/// Text is always literal and must not be reparsed by provider adapters to infer
+/// structured data. JSON remains structured inside Rig and is converted only at
+/// the provider boundary, while images remain explicitly typed. The order of
+/// mixed content items is significant.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum ToolResultContent {
+    /// Literal text, even when the contents resemble JSON.
     Text(Text),
+    /// An explicitly typed image.
     Image(Image),
+    /// Explicit structured JSON.
+    Json {
+        /// The structured value.
+        value: serde_json::Value,
+    },
 }
 
 /// Describes a tool call with an id and function to call, generally produced by a provider.
@@ -876,6 +888,11 @@ impl ToolResultContent {
         ToolResultContent::Text(text.into().into())
     }
 
+    /// Helper constructor for explicit structured JSON tool-result content.
+    pub fn json(value: serde_json::Value) -> Self {
+        ToolResultContent::Json { value }
+    }
+
     /// Helper constructor to make tool result images from a base64-encoded string.
     pub fn image_base64(
         data: impl Into<String>,
@@ -918,14 +935,16 @@ impl ToolResultContent {
         })
     }
 
-    /// Parse a tool output string into appropriate ToolResultContent(s).
+    /// Parse a legacy string tool output into appropriate content items.
     ///
     /// Supports three formats:
     /// 1. Simple text: Any string → `OneOrMany::one(Text)`
     /// 2. Image JSON: `{"type": "image", "data": "...", "mimeType": "..."}` → `OneOrMany::one(Image)`
     /// 3. Hybrid JSON: `{"response": {...}, "parts": [...]}` → `OneOrMany::many([Text, Image, ...])`
     ///
-    /// If JSON parsing fails, treats the entire string as text.
+    /// If JSON parsing fails, treats the entire string as text. Explicitly typed
+    /// JSON should instead be constructed with [`Self::json`]; provider adapters
+    /// never use this heuristic to reinterpret [`Self::Text`].
     pub fn from_tool_output(output: impl Into<String>) -> OneOrMany<ToolResultContent> {
         let output_str = output.into();
 
@@ -1373,7 +1392,13 @@ impl From<MessageError> for CompletionError {
 
 #[cfg(test)]
 mod tests {
-    use super::{Message, Reasoning, ReasoningContent};
+    use serde_json::json;
+
+    use crate::OneOrMany;
+
+    use super::{
+        ImageMediaType, Message, Reasoning, ReasoningContent, ToolResult, ToolResultContent,
+    };
 
     #[test]
     fn reasoning_constructors_and_accessors_work() {
@@ -1435,5 +1460,100 @@ mod tests {
         let json = serde_json::to_string(&message).expect("serialize");
         let roundtrip: Message = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(roundtrip, message);
+    }
+
+    #[test]
+    fn tool_result_json_values_serde_roundtrip_losslessly() {
+        let values = [
+            serde_json::Value::Null,
+            json!(true),
+            json!(42),
+            json!("hello"),
+            json!(["alpha", 2, false, null]),
+            json!({ "nested": { "value": 3 }, "items": [1, 2] }),
+        ];
+
+        for value in values {
+            let content = ToolResultContent::json(value.clone());
+            let encoded = serde_json::to_value(&content).expect("serialize JSON content");
+            assert_eq!(encoded["type"], "json");
+            assert_eq!(encoded["value"], value);
+
+            let roundtrip: ToolResultContent =
+                serde_json::from_value(encoded).expect("deserialize JSON content");
+            assert_eq!(roundtrip, content);
+        }
+    }
+
+    #[test]
+    fn literal_text_and_explicit_json_strings_remain_distinct() {
+        let literal = ToolResultContent::text(r#"{"answer":42}"#);
+        let structured = ToolResultContent::json(json!(r#"{"answer":42}"#));
+
+        assert!(matches!(literal, ToolResultContent::Text(_)));
+        assert!(matches!(structured, ToolResultContent::Json { .. }));
+        assert_ne!(
+            serde_json::to_value(literal).expect("serialize literal text"),
+            serde_json::to_value(structured).expect("serialize explicit JSON")
+        );
+    }
+
+    #[test]
+    fn legacy_tool_output_parser_keeps_generic_json_as_literal_text() {
+        let parsed = ToolResultContent::from_tool_output(r#"{"answer":42}"#);
+
+        assert!(matches!(
+            parsed.first(),
+            ToolResultContent::Text(text) if text.text == r#"{"answer":42}"#
+        ));
+    }
+
+    #[test]
+    fn mixed_tool_result_content_serde_preserves_order_and_types() {
+        let content = OneOrMany::many(vec![
+            ToolResultContent::text("before"),
+            ToolResultContent::json(json!({ "status": "ok" })),
+            ToolResultContent::image_url(
+                "https://example.com/result.png",
+                Some(ImageMediaType::PNG),
+                None,
+            ),
+            ToolResultContent::text("after"),
+        ])
+        .expect("non-empty mixed content");
+        let result = ToolResult {
+            id: "call-1".to_string(),
+            call_id: Some("provider-call-1".to_string()),
+            content,
+        };
+
+        let encoded = serde_json::to_string(&result).expect("serialize mixed result");
+        let roundtrip: ToolResult =
+            serde_json::from_str(&encoded).expect("deserialize mixed result");
+
+        assert_eq!(roundtrip.id, result.id);
+        assert_eq!(roundtrip.call_id, result.call_id);
+        let items = roundtrip.content.iter().collect::<Vec<_>>();
+        assert!(matches!(
+            items[0],
+            ToolResultContent::Text(text) if text.text == "before"
+        ));
+        assert!(matches!(
+            items[1],
+            ToolResultContent::Json { value } if value == &json!({ "status": "ok" })
+        ));
+        assert!(matches!(
+            items[2],
+            ToolResultContent::Image(image)
+                if matches!(
+                    &image.data,
+                    super::DocumentSourceKind::Url(url)
+                        if url == "https://example.com/result.png"
+                )
+        ));
+        assert!(matches!(
+            items[3],
+            ToolResultContent::Text(text) if text.text == "after"
+        ));
     }
 }

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -1185,23 +1185,32 @@ impl TryFrom<message::Message> for Message {
                             message::ToolResultContent::Text(message::Text { text, .. }) => {
                                 Ok(ToolResultContent::Text { text })
                             }
-                            message::ToolResultContent::Image(image) => {
-                                let DocumentSourceKind::Base64(data) = image.data else {
-                                    return Err(MessageError::ConversionError(
-                                        "Only base64 strings can be used with the Anthropic API"
-                                            .to_string(),
-                                    ));
-                                };
-                                let media_type =
-                                    image.media_type.ok_or(MessageError::ConversionError(
-                                        "Image media type is required".to_owned(),
-                                    ))?;
-                                Ok(ToolResultContent::Image {
-                                    source: ImageSource::Base64 {
-                                        data,
-                                        media_type: media_type.try_into()?,
-                                    },
+                            message::ToolResultContent::Json { value } => {
+                                Ok(ToolResultContent::Text {
+                                    text: value.to_string(),
                                 })
+                            }
+                            message::ToolResultContent::Image(image) => {
+                                let source = match image.data {
+                                    DocumentSourceKind::Base64(data) => {
+                                        let media_type = image.media_type.ok_or(
+                                            MessageError::ConversionError(
+                                                "Image media type is required".to_owned(),
+                                            ),
+                                        )?;
+                                        ImageSource::Base64 {
+                                            data,
+                                            media_type: media_type.try_into()?,
+                                        }
+                                    }
+                                    DocumentSourceKind::Url(url) => ImageSource::Url { url },
+                                    data => {
+                                        return Err(MessageError::ConversionError(format!(
+                                            "Unsupported Anthropic tool-result image source: {data:?}"
+                                        )));
+                                    }
+                                };
+                                Ok(ToolResultContent::Image { source })
                             }
                         })?,
                         is_error: None,
@@ -5037,6 +5046,47 @@ mod tests {
         assert_eq!(image_content["source"]["type"], "base64");
         assert_eq!(image_content["source"]["media_type"], "image/png");
         assert_eq!(image_content["source"]["data"], "iVBORw0KGgo...");
+    }
+
+    #[test]
+    fn tool_result_json_is_deliberately_serialized_and_url_images_stay_typed() {
+        let input = message::Message::User {
+            content: OneOrMany::one(message::UserContent::ToolResult(message::ToolResult {
+                id: "toolu_123".into(),
+                call_id: None,
+                content: OneOrMany::many(vec![
+                    message::ToolResultContent::text(r#"{"literal":true}"#),
+                    message::ToolResultContent::json(json!({ "structured": true })),
+                    message::ToolResultContent::image_url(
+                        "https://example.com/result.png",
+                        Some(message::ImageMediaType::PNG),
+                        None,
+                    ),
+                ])
+                .expect("mixed tool result is non-empty"),
+            })),
+        };
+
+        let converted = Message::try_from(input).expect("tool result should convert");
+        let Content::ToolResult { content, .. } = converted.content.first() else {
+            panic!("expected Anthropic tool result");
+        };
+        let items = content.iter().collect::<Vec<_>>();
+
+        assert!(matches!(
+            items[0],
+            ToolResultContent::Text { text } if text == r#"{"literal":true}"#
+        ));
+        assert!(matches!(
+            items[1],
+            ToolResultContent::Text { text } if text == r#"{"structured":true}"#
+        ));
+        assert!(matches!(
+            items[2],
+            ToolResultContent::Image {
+                source: ImageSource::Url { url }
+            } if url == "https://example.com/result.png"
+        ));
     }
 
     // -------------------------------------------------------------------

--- a/crates/rig-core/src/providers/cohere/completion.rs
+++ b/crates/rig-core/src/providers/cohere/completion.rs
@@ -389,9 +389,16 @@ impl TryFrom<message::Message> for Vec<Message> {
                             message::ToolResultContent::Text(text) => {
                                 Ok(ToolResultContent::Text { text: text.text })
                             }
-                            _ => Err(message::MessageError::ConversionError(
-                                "Only text tool result content is supported by Cohere".to_owned(),
-                            )),
+                            message::ToolResultContent::Json { value } => {
+                                Ok(ToolResultContent::Text {
+                                    text: value.to_string(),
+                                })
+                            }
+                            message::ToolResultContent::Image(_) => {
+                                Err(message::MessageError::ConversionError(
+                                    "Cohere does not support images in tool results".to_owned(),
+                                ))
+                            }
                         })?,
                     }),
                     _ => Err(message::MessageError::ConversionError(
@@ -507,10 +514,10 @@ impl TryFrom<Message> for message::Message {
                     Ok(match content {
                         ToolResultContent::Text { text } => message::ToolResultContent::text(text),
                         ToolResultContent::Document { document } => {
-                            message::ToolResultContent::text(
-                                serde_json::to_string(&document.data).map_err(|e| {
+                            message::ToolResultContent::json(
+                                serde_json::to_value(document.data).map_err(|e| {
                                     message::MessageError::ConversionError(
-                                        format!("Failed to convert tool result document content into text: {e}"),
+                                        format!("Failed to convert tool result document content into JSON: {e}"),
                                     )
                                 })?,
                             )
@@ -807,6 +814,76 @@ mod tests {
 
         let completion_message: completion::Message = message.clone().try_into().unwrap();
         let _converted_back: Vec<Message> = completion_message.try_into().unwrap();
+    }
+
+    #[test]
+    fn tool_result_json_is_serialized_only_at_coheres_text_boundary() {
+        let values = [
+            serde_json::Value::Null,
+            serde_json::json!(true),
+            serde_json::json!(42),
+            serde_json::json!("structured string"),
+            serde_json::json!([1, false]),
+            serde_json::json!({ "answer": 42 }),
+        ];
+        let mut rig_content = vec![message::ToolResultContent::text(r#"{"literal":true}"#)];
+        rig_content.extend(values.iter().cloned().map(message::ToolResultContent::json));
+        let input = message::Message::User {
+            content: OneOrMany::one(message::UserContent::ToolResult(message::ToolResult {
+                id: "call-1".into(),
+                call_id: None,
+                content: OneOrMany::many(rig_content).expect("tool result is non-empty"),
+            })),
+        };
+
+        let converted = Vec::<Message>::try_from(input).expect("tool result should convert");
+        let [Message::Tool { content, .. }] = converted.as_slice() else {
+            panic!("expected one Cohere tool message");
+        };
+        let text = content
+            .iter()
+            .map(|content| match content {
+                ToolResultContent::Text { text } => text.as_str(),
+                ToolResultContent::Document { .. } => panic!("outbound JSON must use text"),
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(text[0], r#"{"literal":true}"#);
+        for (actual, value) in text[1..].iter().zip(values) {
+            assert_eq!(*actual, value.to_string());
+        }
+    }
+
+    #[test]
+    fn native_cohere_tool_documents_convert_to_explicit_json() {
+        let data = std::collections::HashMap::from([
+            ("answer".to_string(), serde_json::json!(42)),
+            ("ok".to_string(), serde_json::json!(true)),
+        ]);
+        let provider = Message::Tool {
+            tool_call_id: "call-1".into(),
+            content: OneOrMany::one(ToolResultContent::Document {
+                document: Document {
+                    id: "doc-1".into(),
+                    data: data.clone(),
+                },
+            }),
+        };
+
+        let converted = message::Message::try_from(provider).expect("document should convert");
+        let message::Message::User { content } = converted else {
+            panic!("expected Rig user message");
+        };
+        let message::UserContent::ToolResult(result) = content.first() else {
+            panic!("expected Rig tool result");
+        };
+
+        assert_eq!(
+            result.content.first(),
+            message::ToolResultContent::json(
+                serde_json::to_value(data).expect("map is serializable")
+            )
+        );
     }
 
     #[test]

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -802,6 +802,36 @@ pub mod gemini_api_types {
         }
     }
 
+    fn contains_reserved_media_ref(value: &Value) -> bool {
+        match value {
+            Value::Object(object) => {
+                (object.len() == 1 && object.contains_key("$ref"))
+                    || object.values().any(contains_reserved_media_ref)
+            }
+            Value::Array(values) => values.iter().any(contains_reserved_media_ref),
+            _ => false,
+        }
+    }
+
+    fn gemini_tool_result_image_mime_type(
+        media_type: Option<&ImageMediaType>,
+    ) -> Result<&'static str, MessageError> {
+        let media_type = media_type.ok_or_else(|| {
+            MessageError::ConversionError(
+                "Image media type is required for Gemini tool results".to_string(),
+            )
+        })?;
+
+        match media_type {
+            ImageMediaType::JPEG | ImageMediaType::PNG | ImageMediaType::WEBP => {
+                Ok(media_type.to_mime_type())
+            }
+            _ => Err(MessageError::ConversionError(format!(
+                "Unsupported image media type {media_type:?} for Gemini tool results; supported types are JPEG, PNG, and WEBP"
+            ))),
+        }
+    }
+
     impl TryFrom<message::UserContent> for Part {
         type Error = message::MessageError;
 
@@ -814,41 +844,47 @@ pub mod gemini_api_types {
                     additional_params: None,
                 }),
                 message::UserContent::ToolResult(message::ToolResult { id, content, .. }) => {
-                    let mut response_json: Option<serde_json::Value> = None;
+                    let has_image = content
+                        .iter()
+                        .any(|item| matches!(item, message::ToolResultContent::Image(_)));
+                    let has_non_image = content
+                        .iter()
+                        .any(|item| !matches!(item, message::ToolResultContent::Image(_)));
+                    if has_image && has_non_image {
+                        return Err(message::MessageError::ConversionError(
+                            "Gemini generateContent cannot preserve the order of mixed image and text/JSON tool-result content without unsupported `$ref` media references; return only images or only text/JSON"
+                                .to_string(),
+                        ));
+                    }
+
+                    for item in content.iter() {
+                        if let message::ToolResultContent::Json { value } = item
+                            && contains_reserved_media_ref(value)
+                        {
+                            return Err(message::MessageError::ConversionError(
+                                "Gemini reserves single-key `$ref` objects in function responses for multimodal part references; explicit JSON tool results cannot contain that shape"
+                                    .to_string(),
+                            ));
+                        }
+                    }
+
+                    let mut response_values = Vec::new();
                     let mut parts: Vec<FunctionResponsePart> = Vec::new();
 
                     for item in content.iter() {
                         match item {
                             message::ToolResultContent::Text(text) => {
-                                let result: serde_json::Value =
-                                    serde_json::from_str(&text.text).unwrap_or_else(|error| {
-                                        tracing::trace!(
-                                            ?error,
-                                            "Tool result is not a valid JSON, treat it as normal string"
-                                        );
-                                        json!(&text.text)
-                                    });
-
-                                response_json = Some(match response_json {
-                                    Some(mut existing) => {
-                                        if let serde_json::Value::Object(ref mut map) = existing {
-                                            map.insert("text".to_string(), result);
-                                        }
-                                        existing
-                                    }
-                                    None => json!({ "result": result }),
-                                });
+                                response_values.push(json!(&text.text));
+                            }
+                            message::ToolResultContent::Json { value } => {
+                                response_values.push(value.clone());
                             }
                             message::ToolResultContent::Image(image) => {
                                 let part = match &image.data {
                                     DocumentSourceKind::Base64(b64) => {
-                                        let mime_type = image
-                                            .media_type
-                                            .as_ref()
-                                            .ok_or(message::MessageError::ConversionError(
-                                                "Image media type is required for Gemini tool results".to_string(),
-                                            ))?
-                                            .to_mime_type();
+                                        let mime_type = gemini_tool_result_image_mime_type(
+                                            image.media_type.as_ref(),
+                                        )?;
 
                                         FunctionResponsePart {
                                             inline_data: Some(FunctionResponseInlineData {
@@ -859,19 +895,11 @@ pub mod gemini_api_types {
                                             file_data: None,
                                         }
                                     }
-                                    DocumentSourceKind::Url(url) => {
-                                        let mime_type = image
-                                            .media_type
-                                            .as_ref()
-                                            .map(|mt| mt.to_mime_type().to_string());
-
-                                        FunctionResponsePart {
-                                            inline_data: None,
-                                            file_data: Some(FileData {
-                                                mime_type,
-                                                file_uri: url.clone(),
-                                            }),
-                                        }
+                                    DocumentSourceKind::Url(_) => {
+                                        return Err(message::MessageError::ConversionError(
+                                            "Gemini tool result images must use base64 inline data; URL-backed images are not supported"
+                                                .to_string(),
+                                        ));
                                     }
                                     _ => {
                                         return Err(message::MessageError::ConversionError(
@@ -884,6 +912,17 @@ pub mod gemini_api_types {
                             }
                         }
                     }
+
+                    let response_json = if response_values.is_empty() {
+                        None
+                    } else {
+                        let result = if response_values.len() == 1 {
+                            response_values.remove(0)
+                        } else {
+                            serde_json::Value::Array(response_values)
+                        };
+                        Some(json!({ "result": result }))
+                    };
 
                     Ok(Part {
                         thought: Some(false),
@@ -2165,7 +2204,7 @@ mod tests {
     use crate::{
         message,
         providers::gemini::completion::gemini_api_types::{
-            CitationMetadata, ContentCandidate, FinishReason, FunctionCall,
+            CitationMetadata, ContentCandidate, FinishReason, FunctionCall, FunctionResponse,
             GenerateContentResponse, LogprobsResult, ModalityTokenCount, Schema, TopCandidate,
             UsageMetadata, flatten_schema, tool_parameters_to_schema,
         },
@@ -2173,6 +2212,23 @@ mod tests {
 
     use super::*;
     use serde_json::json;
+
+    fn convert_tool_result(
+        content: OneOrMany<message::ToolResultContent>,
+    ) -> Result<FunctionResponse, message::MessageError> {
+        let part = Part::try_from(message::UserContent::ToolResult(message::ToolResult {
+            id: "test_tool".to_string(),
+            call_id: None,
+            content,
+        }))?;
+
+        match part.part {
+            PartKind::FunctionResponse(response) => Ok(response),
+            other => Err(message::MessageError::ConversionError(format!(
+                "expected function response, got {other:?}"
+            ))),
+        }
+    }
 
     #[test]
     fn test_usage_metadata_deserializes_without_total_token_count() {
@@ -2950,64 +3006,122 @@ mod tests {
     }
 
     #[test]
-    fn test_tool_result_with_image_content() {
-        // Test that a ToolResult with image content converts correctly to Gemini's Part format
-        use crate::OneOrMany;
-        use crate::message::{
-            DocumentSourceKind, Image, ImageMediaType, ToolResult, ToolResultContent,
-        };
+    fn tool_result_text_is_literal_and_explicit_json_keeps_its_type() {
+        let response = convert_tool_result(
+            OneOrMany::many(vec![
+                message::ToolResultContent::text(r#"{"literal":true}"#),
+                message::ToolResultContent::json(json!({"structured": true})),
+                message::ToolResultContent::json(json!("json string")),
+            ])
+            .expect("tool result should be non-empty"),
+        )
+        .expect("typed tool result should convert");
 
-        // Create a tool result with both text and image content
-        let tool_result = ToolResult {
-            id: "test_tool".to_string(),
-            call_id: None,
-            content: OneOrMany::many(vec![
-                ToolResultContent::Text(message::Text::new(r#"{"status": "success"}"#.to_string())),
-                ToolResultContent::Image(Image {
-                    data: DocumentSourceKind::Base64("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==".to_string()),
-                    media_type: Some(ImageMediaType::PNG),
-                    detail: None,
-                    additional_params: None,
-                }),
-            ]).expect("Should create OneOrMany with multiple items"),
-        };
+        assert_eq!(
+            response.response,
+            Some(json!({
+                "result": [
+                    r#"{"literal":true}"#,
+                    {"structured": true},
+                    "json string"
+                ]
+            }))
+        );
+        assert!(response.parts.is_none());
+    }
 
-        let user_content = message::UserContent::ToolResult(tool_result);
-        let msg = message::Message::User {
-            content: OneOrMany::one(user_content),
-        };
+    #[test]
+    fn tool_result_supports_every_explicit_json_value_type() {
+        let values = vec![
+            json!(null),
+            json!(true),
+            json!(42),
+            json!("value"),
+            json!([1, 2]),
+            json!({"status": "ok"}),
+        ];
 
-        // Convert to Gemini Content
-        let content: Content = msg.try_into().expect("Should convert to Gemini Content");
-        assert_eq!(content.role, Some(Role::User));
-        assert_eq!(content.parts.len(), 1);
+        for value in values {
+            let response = convert_tool_result(OneOrMany::one(message::ToolResultContent::json(
+                value.clone(),
+            )))
+            .unwrap_or_else(|error| panic!("{value} should convert: {error}"));
 
-        // Verify the part is a FunctionResponse with both response and parts
-        if let Some(Part {
-            part: PartKind::FunctionResponse(function_response),
-            ..
-        }) = content.parts.first()
-        {
-            assert_eq!(function_response.name, "test_tool");
-
-            // Check that response JSON is present
-            assert!(function_response.response.is_some());
-            let response = function_response.response.as_ref().unwrap();
-            assert!(response.get("result").is_some());
-
-            // Check that parts with image data are present
-            assert!(function_response.parts.is_some());
-            let parts = function_response.parts.as_ref().unwrap();
-            assert_eq!(parts.len(), 1);
-
-            let image_part = &parts[0];
-            assert!(image_part.inline_data.is_some());
-            let inline_data = image_part.inline_data.as_ref().unwrap();
-            assert_eq!(inline_data.mime_type, "image/png");
-            assert!(!inline_data.data.is_empty());
-        } else {
-            panic!("Expected FunctionResponse part");
+            assert_eq!(response.response, Some(json!({"result": value})));
         }
+    }
+
+    #[test]
+    fn mixed_images_and_text_or_json_return_an_actionable_error() {
+        let error = convert_tool_result(
+            OneOrMany::many(vec![
+                message::ToolResultContent::image_base64(
+                    "first-image",
+                    Some(message::ImageMediaType::PNG),
+                    None,
+                ),
+                message::ToolResultContent::text("middle"),
+                message::ToolResultContent::json(json!({"status": "ok"})),
+                message::ToolResultContent::image_base64(
+                    "second-image",
+                    Some(message::ImageMediaType::JPEG),
+                    None,
+                ),
+            ])
+            .expect("tool result should be non-empty"),
+        )
+        .expect_err("Gemini cannot preserve mixed rich-content ordering");
+
+        assert!(format!("{error}").contains("cannot preserve the order"));
+    }
+
+    #[test]
+    fn image_only_tool_results_preserve_native_part_order() {
+        let response = convert_tool_result(
+            OneOrMany::many(vec![
+                message::ToolResultContent::image_base64(
+                    "first-image",
+                    Some(message::ImageMediaType::PNG),
+                    None,
+                ),
+                message::ToolResultContent::image_base64(
+                    "second-image",
+                    Some(message::ImageMediaType::WEBP),
+                    None,
+                ),
+            ])
+            .expect("tool result should be non-empty"),
+        )
+        .expect("inline images should convert");
+
+        assert!(response.response.is_none());
+        let parts = response.parts.expect("image parts should be present");
+        assert_eq!(parts.len(), 2);
+        let first = parts[0]
+            .inline_data
+            .as_ref()
+            .expect("first image should be inline");
+        assert_eq!(first.mime_type, "image/png");
+        assert_eq!(first.data, "first-image");
+        assert!(first.display_name.is_none());
+
+        let second = parts[1]
+            .inline_data
+            .as_ref()
+            .expect("second image should be inline");
+        assert_eq!(second.mime_type, "image/webp");
+        assert_eq!(second.data, "second-image");
+        assert!(second.display_name.is_none());
+    }
+
+    #[test]
+    fn tool_result_rejects_reserved_multimodal_ref_objects_in_explicit_json() {
+        let error = convert_tool_result(OneOrMany::one(message::ToolResultContent::json(json!({
+            "existing": {"$ref": "tool_result_image_0"}
+        }))))
+        .expect_err("reserved media references cannot be represented as ordinary JSON");
+
+        assert!(format!("{error}").contains("single-key `$ref` objects"));
     }
 
     #[test]
@@ -3078,53 +3192,27 @@ mod tests {
     }
 
     #[test]
-    fn test_tool_result_with_url_image() {
-        // Test that a ToolResult with a URL-based image converts to file_data
-        use crate::OneOrMany;
-        use crate::message::{
-            DocumentSourceKind, Image, ImageMediaType, ToolResult, ToolResultContent,
-        };
+    fn tool_result_rejects_url_images() {
+        let error = convert_tool_result(OneOrMany::one(message::ToolResultContent::image_url(
+            "https://example.com/image.png",
+            Some(message::ImageMediaType::PNG),
+            None,
+        )))
+        .expect_err("URL-backed tool-result images should be rejected");
 
-        let tool_result = ToolResult {
-            id: "screenshot_tool".to_string(),
-            call_id: None,
-            content: OneOrMany::one(ToolResultContent::Image(Image {
-                data: DocumentSourceKind::Url("https://example.com/image.png".to_string()),
-                media_type: Some(ImageMediaType::PNG),
-                detail: None,
-                additional_params: None,
-            })),
-        };
+        assert!(format!("{error}").contains("must use base64 inline data"));
+    }
 
-        let user_content = message::UserContent::ToolResult(tool_result);
-        let msg = message::Message::User {
-            content: OneOrMany::one(user_content),
-        };
+    #[test]
+    fn tool_result_rejects_unsupported_image_media_types() {
+        let error = convert_tool_result(OneOrMany::one(message::ToolResultContent::image_base64(
+            "image-data",
+            Some(message::ImageMediaType::GIF),
+            None,
+        )))
+        .expect_err("unsupported image media types should be rejected");
 
-        let content: Content = msg.try_into().expect("Should convert to Gemini Content");
-        assert_eq!(content.role, Some(Role::User));
-        assert_eq!(content.parts.len(), 1);
-
-        if let Some(Part {
-            part: PartKind::FunctionResponse(function_response),
-            ..
-        }) = content.parts.first()
-        {
-            assert_eq!(function_response.name, "screenshot_tool");
-
-            // URL images should have parts with file_data
-            assert!(function_response.parts.is_some());
-            let parts = function_response.parts.as_ref().unwrap();
-            assert_eq!(parts.len(), 1);
-
-            let image_part = &parts[0];
-            assert!(image_part.file_data.is_some());
-            let file_data = image_part.file_data.as_ref().unwrap();
-            assert_eq!(file_data.file_uri, "https://example.com/image.png");
-            assert_eq!(file_data.mime_type.as_ref().unwrap(), "image/png");
-        } else {
-            panic!("Expected FunctionResponse part");
-        }
+        assert!(format!("{error}").contains("supported types are JPEG, PNG, and WEBP"));
     }
 
     #[test]

--- a/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
@@ -634,7 +634,7 @@ pub mod interactions_api_types {
     use crate::telemetry::ProviderResponseExt;
     use base64::{Engine, prelude::BASE64_STANDARD};
     use serde::{Deserialize, Serialize};
-    use serde_json::{Value, json};
+    use serde_json::Value;
 
     // =================================================================
     // Request / Response Types
@@ -1781,6 +1781,53 @@ pub mod interactions_api_types {
         FileSearchResult(FileSearchResultContent),
     }
 
+    fn rich_function_result_block(
+        content: message::ToolResultContent,
+    ) -> Result<Value, message::MessageError> {
+        let content = match content {
+            message::ToolResultContent::Text(text) => Content::Text(TextContent {
+                text: text.text,
+                annotations: None,
+            }),
+            message::ToolResultContent::Json { .. } => {
+                return Err(message::MessageError::ConversionError(
+                    "Gemini Interactions cannot represent explicit JSON inside mixed tool-result content without coercing it to text; send a JSON string or object as the only result item"
+                        .to_string(),
+                ));
+            }
+            message::ToolResultContent::Image(message::Image {
+                data, media_type, ..
+            }) => {
+                let media_type = media_type.ok_or_else(|| {
+                    message::MessageError::ConversionError(
+                        "Image media type is required for Gemini Interactions tool results"
+                            .to_string(),
+                    )
+                })?;
+                if matches!(&media_type, message::ImageMediaType::SVG) {
+                    return Err(message::MessageError::ConversionError(
+                        "Gemini Interactions does not support SVG images in tool results; use PNG, JPEG, WEBP, HEIC, HEIF, or GIF"
+                            .to_string(),
+                    ));
+                }
+                let (data, uri) = split_data_uri(data)?;
+
+                Content::Image(ImageContent {
+                    data,
+                    uri,
+                    mime_type: Some(media_type.to_mime_type().to_string()),
+                    resolution: None,
+                })
+            }
+        };
+
+        serde_json::to_value(content).map_err(|err| {
+            message::MessageError::ConversionError(format!(
+                "Failed to serialize Gemini Interactions tool result content: {err}"
+            ))
+        })
+    }
+
     impl TryFrom<message::UserContent> for Content {
         type Error = message::MessageError;
 
@@ -1803,18 +1850,37 @@ pub mod interactions_api_types {
                         ));
                     };
 
-                    let content = content.first();
+                    let mut contents = content.into_iter().collect::<Vec<_>>();
+                    let result = if contents.len() == 1 {
+                        let content = contents.pop().ok_or_else(|| {
+                            message::MessageError::ConversionError(
+                                "Tool result content must not be empty".to_string(),
+                            )
+                        })?;
 
-                    let message::ToolResultContent::Text(text) = content else {
-                        return Err(message::MessageError::ConversionError(
-                            "Tool result content must be text".to_string(),
-                        ));
+                        match content {
+                            message::ToolResultContent::Text(text) => Value::String(text.text),
+                            message::ToolResultContent::Json { value } => match value {
+                                value @ (Value::String(_) | Value::Object(_)) => value,
+                                _ => {
+                                    return Err(message::MessageError::ConversionError(
+                                        "Gemini Interactions function results support explicit JSON only when it is a string or object; null, booleans, numbers, and arrays cannot be represented losslessly"
+                                            .to_string(),
+                                    ));
+                                }
+                            },
+                            rich_content => {
+                                Value::Array(vec![rich_function_result_block(rich_content)?])
+                            }
+                        }
+                    } else {
+                        Value::Array(
+                            contents
+                                .into_iter()
+                                .map(rich_function_result_block)
+                                .collect::<Result<Vec<_>, _>>()?,
+                        )
                     };
-
-                    let result: Value = serde_json::from_str(&text.text).unwrap_or_else(|error| {
-                        tracing::trace!(?error, "Tool result is not valid JSON; sending as string");
-                        json!(text.text)
-                    });
 
                     Ok(Self::FunctionResult(FunctionResultContent {
                         name: Some(id),
@@ -2521,6 +2587,27 @@ mod tests {
     use crate::message::{self, ToolChoice as MessageToolChoice};
     use serde_json::json;
 
+    fn convert_tool_result(
+        content: OneOrMany<message::ToolResultContent>,
+    ) -> Result<Value, message::MessageError> {
+        let converted = Content::try_from(message::UserContent::ToolResult(message::ToolResult {
+            id: "test_tool".to_string(),
+            call_id: Some("call-1".to_string()),
+            content,
+        }))?;
+
+        match converted {
+            Content::FunctionResult(result) => result.result.ok_or_else(|| {
+                message::MessageError::ConversionError(
+                    "Gemini Interactions omitted the function result".to_string(),
+                )
+            }),
+            other => Err(message::MessageError::ConversionError(format!(
+                "expected function result, got {other:?}"
+            ))),
+        }
+    }
+
     #[test]
     fn test_create_request_body_simple() {
         let prompt = Message::User {
@@ -2580,6 +2667,135 @@ mod tests {
 
         let err = Content::try_from(content).expect_err("should require call_id");
         assert!(format!("{err}").contains("call_id"));
+    }
+
+    #[test]
+    fn tool_result_singletons_preserve_literal_text_and_supported_json_types() {
+        let cases = vec![
+            (
+                "literal JSON-looking text",
+                message::ToolResultContent::text(r#"{"literal":true}"#),
+                json!(r#"{"literal":true}"#),
+            ),
+            (
+                "JSON string",
+                message::ToolResultContent::json(json!("structured string")),
+                json!("structured string"),
+            ),
+            (
+                "JSON object",
+                message::ToolResultContent::json(json!({"status": "ok"})),
+                json!({"status": "ok"}),
+            ),
+        ];
+
+        for (label, content, expected) in cases {
+            let result = convert_tool_result(OneOrMany::one(content))
+                .unwrap_or_else(|error| panic!("{label} should convert: {error}"));
+            assert_eq!(result, expected, "{label}");
+        }
+    }
+
+    #[test]
+    fn tool_result_rejects_explicit_json_shapes_the_api_cannot_represent() {
+        let values = vec![json!(null), json!(true), json!(42), json!([1, 2])];
+
+        for value in values {
+            let error = convert_tool_result(OneOrMany::one(message::ToolResultContent::json(
+                value.clone(),
+            )))
+            .unwrap_err();
+            assert!(
+                format!("{error}").contains("only when it is a string or object"),
+                "unexpected error for {value}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn tool_result_rejects_explicit_json_inside_mixed_rich_content() {
+        let error = convert_tool_result(
+            OneOrMany::many(vec![
+                message::ToolResultContent::text("before"),
+                message::ToolResultContent::json(json!({"status": "ok"})),
+            ])
+            .expect("tool result should be non-empty"),
+        )
+        .expect_err("mixed explicit JSON cannot be represented losslessly");
+
+        assert!(format!("{error}").contains("without coercing it to text"));
+    }
+
+    #[test]
+    fn tool_result_images_and_text_serialize_as_ordered_tagged_content() {
+        let result = convert_tool_result(
+            OneOrMany::many(vec![
+                message::ToolResultContent::image_base64(
+                    "first-image",
+                    Some(message::ImageMediaType::PNG),
+                    None,
+                ),
+                message::ToolResultContent::text("middle"),
+                message::ToolResultContent::image_url(
+                    "https://example.com/second.jpg",
+                    Some(message::ImageMediaType::JPEG),
+                    None,
+                ),
+            ])
+            .expect("tool result should be non-empty"),
+        )
+        .expect("rich content should convert");
+
+        assert_eq!(
+            result,
+            json!([
+                {
+                    "type": "image",
+                    "data": "first-image",
+                    "mime_type": "image/png"
+                },
+                {
+                    "type": "text",
+                    "text": "middle"
+                },
+                {
+                    "type": "image",
+                    "uri": "https://example.com/second.jpg",
+                    "mime_type": "image/jpeg"
+                }
+            ])
+        );
+    }
+
+    #[test]
+    fn image_only_tool_result_uses_the_tagged_content_array() {
+        let result = convert_tool_result(OneOrMany::one(message::ToolResultContent::image_base64(
+            "image-data",
+            Some(message::ImageMediaType::WEBP),
+            None,
+        )))
+        .expect("image should convert");
+
+        assert_eq!(
+            result,
+            json!([{
+                "type": "image",
+                "data": "image-data",
+                "mime_type": "image/webp"
+            }])
+        );
+    }
+
+    #[test]
+    fn tool_result_rejects_unsupported_svg_images() {
+        let error = convert_tool_result(OneOrMany::one(message::ToolResultContent::image_base64(
+            "image-data",
+            Some(message::ImageMediaType::SVG),
+            None,
+        )))
+        .expect_err("Gemini Interactions does not accept SVG image content");
+
+        assert!(format!("{error}").contains("does not support SVG"));
     }
 
     #[test]

--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -963,81 +963,83 @@ impl TryFrom<crate::message::Message> for Vec<Message> {
                 name: None,
             }]),
             InternalMessage::User { content, .. } => {
-                let (tool_results, other_content): (Vec<_>, Vec<_>) =
-                    content.into_iter().partition(|content| {
-                        matches!(content, crate::message::UserContent::ToolResult(_))
-                    });
+                let flush_user_content =
+                    |messages: &mut Vec<Message>,
+                     texts: &mut Vec<String>,
+                     images: &mut Vec<String>| {
+                        if texts.is_empty() && images.is_empty() {
+                            return;
+                        }
 
-                if !tool_results.is_empty() {
-                    tool_results
-                        .into_iter()
-                        .map(|content| match content {
-                            crate::message::UserContent::ToolResult(
-                                crate::message::ToolResult { id, content, .. },
-                            ) => {
-                                // Ollama expects a single string for tool results, so we concatenate
-                                let content_string = content
-                                    .into_iter()
-                                    .map(|content| match content {
-                                        crate::message::ToolResultContent::Text(text) => text.text,
-                                        _ => "[Non-text content]".to_string(),
-                                    })
-                                    .collect::<Vec<_>>()
-                                    .join("\n");
+                        messages.push(Message::User {
+                            content: std::mem::take(texts).join(" "),
+                            images: if images.is_empty() {
+                                None
+                            } else {
+                                Some(std::mem::take(images))
+                            },
+                            name: None,
+                        });
+                    };
 
-                                Ok::<_, crate::message::MessageError>(Message::ToolResult {
-                                    name: id,
-                                    content: content_string,
+                let mut messages = Vec::new();
+                let mut texts = Vec::new();
+                let mut images = Vec::new();
+
+                for content in content {
+                    match content {
+                        crate::message::UserContent::ToolResult(crate::message::ToolResult {
+                            id,
+                            content,
+                            ..
+                        }) => {
+                            flush_user_content(&mut messages, &mut texts, &mut images);
+
+                            // Ollama expects a single string for tool results, so concatenate
+                            // provider-terminal text and compact JSON in canonical item order.
+                            let content = content
+                                .into_iter()
+                                .map(|content| match content {
+                                    crate::message::ToolResultContent::Text(text) => Ok(text.text),
+                                    crate::message::ToolResultContent::Json { value } => {
+                                        Ok(value.to_string())
+                                    }
+                                    crate::message::ToolResultContent::Image(_) => {
+                                        Err(crate::message::MessageError::ConversionError(
+                                            "Ollama does not support images in tool results".into(),
+                                        ))
+                                    }
                                 })
-                            }
-                            _ => Err(crate::message::MessageError::ConversionError(
-                                "expected tool result content while converting Ollama input".into(),
-                            )),
-                        })
-                        .collect::<Result<Vec<_>, _>>()
-                } else {
-                    // Ollama requires separate text content and images array
-                    let (texts, images) = other_content.into_iter().fold(
-                        (Vec::new(), Vec::new()),
-                        |(mut texts, mut images), content| {
-                            match content {
-                                crate::message::UserContent::Text(crate::message::Text {
-                                    text,
-                                    ..
-                                }) => texts.push(text),
-                                crate::message::UserContent::Image(crate::message::Image {
-                                    data: DocumentSourceKind::Base64(data),
-                                    ..
-                                }) => images.push(data),
-                                crate::message::UserContent::Document(
-                                    crate::message::Document {
-                                        data:
-                                            DocumentSourceKind::Base64(data)
-                                            | DocumentSourceKind::String(data),
-                                        ..
-                                    },
-                                ) => texts.push(data),
-                                _ => {} // Audio not supported by Ollama
-                            }
-                            (texts, images)
-                        },
-                    );
-
-                    Ok(vec![Message::User {
-                        content: texts.join(" "),
-                        images: if images.is_empty() {
-                            None
-                        } else {
-                            Some(
-                                images
-                                    .into_iter()
-                                    .map(|x| x.to_string())
-                                    .collect::<Vec<String>>(),
-                            )
-                        },
-                        name: None,
-                    }])
+                                .collect::<Result<Vec<_>, _>>()?
+                                .join("\n");
+                            messages.push(Message::ToolResult { name: id, content });
+                        }
+                        crate::message::UserContent::Text(crate::message::Text {
+                            text, ..
+                        }) => texts.push(text),
+                        crate::message::UserContent::Image(crate::message::Image {
+                            data: DocumentSourceKind::Base64(data),
+                            ..
+                        }) => images.push(data),
+                        crate::message::UserContent::Document(crate::message::Document {
+                            data:
+                                DocumentSourceKind::Base64(data) | DocumentSourceKind::String(data),
+                            ..
+                        }) => texts.push(data),
+                        _ => {} // Audio and unsupported source kinds are not accepted by Ollama.
+                    }
                 }
+
+                flush_user_content(&mut messages, &mut texts, &mut images);
+                if messages.is_empty() {
+                    messages.push(Message::User {
+                        content: String::new(),
+                        images: None,
+                        name: None,
+                    });
+                }
+
+                Ok(messages)
             }
             InternalMessage::Assistant { content, .. } => {
                 let mut thinking: Option<String> = None;
@@ -1243,6 +1245,64 @@ pub struct ImageUrl {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn mixed_user_content_preserves_order_around_tool_results() {
+        let user = crate::message::Message::User {
+            content: OneOrMany::many(vec![
+                crate::message::UserContent::text("before"),
+                crate::message::UserContent::tool_result(
+                    "tool-name",
+                    OneOrMany::many(vec![
+                        crate::message::ToolResultContent::text("literal"),
+                        crate::message::ToolResultContent::json(json!({"status": "ok"})),
+                    ])
+                    .expect("tool result should be non-empty"),
+                ),
+                crate::message::UserContent::text("after"),
+            ])
+            .expect("user content should be non-empty"),
+        };
+
+        let converted = Vec::<Message>::try_from(user).expect("history should convert");
+        assert_eq!(
+            converted,
+            vec![
+                Message::User {
+                    content: "before".to_string(),
+                    images: None,
+                    name: None,
+                },
+                Message::ToolResult {
+                    name: "tool-name".to_string(),
+                    content: "literal\n{\"status\":\"ok\"}".to_string(),
+                },
+                Message::User {
+                    content: "after".to_string(),
+                    images: None,
+                    name: None,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn tool_result_images_are_rejected_instead_of_replaced_with_placeholder_text() {
+        let user = crate::message::Message::User {
+            content: OneOrMany::one(crate::message::UserContent::tool_result(
+                "tool-name",
+                OneOrMany::one(crate::message::ToolResultContent::image_base64(
+                    "image-data",
+                    Some(crate::message::ImageMediaType::PNG),
+                    None,
+                )),
+            )),
+        };
+
+        let error =
+            Vec::<Message>::try_from(user).expect_err("Ollama tool results cannot contain images");
+        assert!(format!("{error}").contains("does not support images"));
+    }
 
     // Test deserialization and conversion for the /api/chat endpoint.
     #[tokio::test]

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -608,6 +608,7 @@ impl TryFrom<message::ToolResult> for Message {
             .map(|content| {
                 match content {
                 message::ToolResultContent::Text(message::Text { text, .. }) => Ok(text),
+                message::ToolResultContent::Json { value } => Ok(value.to_string()),
                 message::ToolResultContent::Image(_) => Err(message::MessageError::ConversionError(
                     "OpenAI does not support images in tool results. Tool results must be text."
                         .into(),
@@ -802,39 +803,46 @@ impl TryFrom<OneOrMany<message::UserContent>> for Vec<Message> {
     type Error = message::MessageError;
 
     fn try_from(value: OneOrMany<message::UserContent>) -> Result<Self, Self::Error> {
-        let (tool_results, other_content): (Vec<_>, Vec<_>) = value
-            .into_iter()
-            .partition(|content| matches!(content, message::UserContent::ToolResult(_)));
+        let flush_user_content = |messages: &mut Vec<Message>, content: &mut Vec<UserContent>| {
+            if content.is_empty() {
+                return Ok(());
+            }
 
-        // If there are messages with both tool results and user content, openai will only
-        //  handle tool results. It's unlikely that there will be both.
-        if !tool_results.is_empty() {
-            tool_results
-                .into_iter()
-                .map(|content| match content {
-                    message::UserContent::ToolResult(tool_result) => tool_result.try_into(),
-                    _ => Err(message::MessageError::ConversionError(
-                        "expected tool result content while converting OpenAI input".into(),
-                    )),
-                })
-                .collect::<Result<Vec<_>, _>>()
-        } else {
-            let other_content: Vec<UserContent> = other_content
-                .into_iter()
-                .map(|content| content.try_into())
-                .collect::<Result<Vec<_>, _>>()?;
-
-            let other_content = OneOrMany::many(other_content).map_err(|_| {
+            let content = OneOrMany::many(std::mem::take(content)).map_err(|_| {
                 message::MessageError::ConversionError(
                     "OpenAI user message did not contain any non-tool content".into(),
                 )
             })?;
-
-            Ok(vec![Message::User {
-                content: other_content,
+            messages.push(Message::User {
+                content,
                 name: None,
-            }])
+            });
+
+            Ok::<_, message::MessageError>(())
+        };
+
+        let mut messages = Vec::new();
+        let mut user_content = Vec::new();
+
+        for content in value {
+            match content {
+                message::UserContent::ToolResult(tool_result) => {
+                    flush_user_content(&mut messages, &mut user_content)?;
+                    messages.push(tool_result.try_into()?);
+                }
+                content => user_content.push(content.try_into()?),
+            }
         }
+
+        flush_user_content(&mut messages, &mut user_content)?;
+
+        if messages.is_empty() {
+            return Err(message::MessageError::ConversionError(
+                "OpenAI user message did not contain any provider-compatible content".into(),
+            ));
+        }
+
+        Ok(messages)
     }
 }
 
@@ -2059,6 +2067,142 @@ mod tests {
             text: text.to_string(),
             additional_props: HashMap::new(),
         }
+    }
+
+    #[test]
+    fn tool_result_text_stays_literal_and_json_is_stringified_at_the_wire_boundary() {
+        let cases = vec![
+            (
+                "literal JSON-looking text",
+                message::ToolResultContent::text(r#"{"status":"ok"}"#),
+                r#"{"status":"ok"}"#,
+            ),
+            (
+                "JSON string",
+                message::ToolResultContent::json(serde_json::json!("ok")),
+                r#""ok""#,
+            ),
+            (
+                "JSON null",
+                message::ToolResultContent::json(serde_json::Value::Null),
+                "null",
+            ),
+            (
+                "JSON boolean",
+                message::ToolResultContent::json(serde_json::json!(true)),
+                "true",
+            ),
+            (
+                "JSON number",
+                message::ToolResultContent::json(serde_json::json!(42)),
+                "42",
+            ),
+            (
+                "JSON array",
+                message::ToolResultContent::json(serde_json::json!([1, 2])),
+                "[1,2]",
+            ),
+            (
+                "JSON object",
+                message::ToolResultContent::json(serde_json::json!({"status": "ok"})),
+                r#"{"status":"ok"}"#,
+            ),
+        ];
+
+        for (label, content, expected) in cases {
+            let converted = Message::try_from(message::ToolResult {
+                id: "rig-id".to_string(),
+                call_id: Some("provider-call-id".to_string()),
+                content: OneOrMany::one(content),
+            })
+            .unwrap_or_else(|error| panic!("{label} should convert: {error}"));
+
+            assert_eq!(
+                converted,
+                Message::ToolResult {
+                    tool_call_id: "provider-call-id".to_string(),
+                    content: ToolResultContentValue::String(expected.to_string()),
+                },
+                "{label}"
+            );
+        }
+    }
+
+    #[test]
+    fn tool_result_mixed_content_keeps_item_order_when_flattened_to_text() {
+        let converted = Message::try_from(message::ToolResult {
+            id: "call-1".to_string(),
+            call_id: None,
+            content: OneOrMany::many(vec![
+                message::ToolResultContent::text("before"),
+                message::ToolResultContent::json(serde_json::json!({"status": "ok"})),
+                message::ToolResultContent::text("after"),
+            ])
+            .expect("tool result should be non-empty"),
+        })
+        .expect("mixed text and JSON should convert");
+
+        assert_eq!(
+            converted,
+            Message::ToolResult {
+                tool_call_id: "call-1".to_string(),
+                content: ToolResultContentValue::String(
+                    "before\n{\"status\":\"ok\"}\nafter".to_string(),
+                ),
+            }
+        );
+    }
+
+    #[test]
+    fn tool_result_images_are_rejected_instead_of_silently_dropped() {
+        let error = Message::try_from(message::ToolResult {
+            id: "call-1".to_string(),
+            call_id: None,
+            content: OneOrMany::one(message::ToolResultContent::image_base64(
+                "AA==",
+                Some(message::ImageMediaType::PNG),
+                None,
+            )),
+        })
+        .expect_err("OpenAI Chat tool results cannot contain images");
+
+        assert!(format!("{error}").contains("does not support images"));
+    }
+
+    #[test]
+    fn mixed_user_content_preserves_order_around_tool_results() {
+        let user = message::Message::User {
+            content: OneOrMany::many(vec![
+                message::UserContent::text("before"),
+                message::UserContent::tool_result(
+                    "call-1",
+                    OneOrMany::one(message::ToolResultContent::json(serde_json::json!({
+                        "status": "ok"
+                    }))),
+                ),
+                message::UserContent::text("after"),
+            ])
+            .expect("user content should be non-empty"),
+        };
+
+        let converted: Vec<Message> = user.try_into().expect("history should convert");
+        assert_eq!(converted.len(), 3);
+
+        assert!(matches!(
+            &converted[0],
+            Message::User { content, .. }
+                if matches!(content.first(), UserContent::Text { text } if text == "before")
+        ));
+        assert!(matches!(
+            &converted[1],
+            Message::ToolResult { tool_call_id, content: ToolResultContentValue::String(text) }
+                if tool_call_id == "call-1" && text == r#"{"status":"ok"}"#
+        ));
+        assert!(matches!(
+            &converted[2],
+            Message::User { content, .. }
+                if matches!(content.first(), UserContent::Text { text } if text == "after")
+        ));
     }
 
     #[test]

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -277,9 +277,116 @@ pub struct ToolResult {
     /// The call ID of a tool (this should be linked to the call ID for a tool call, otherwise an error will be received)
     call_id: String,
     /// The result of a tool call.
-    output: String,
+    output: ToolResultOutput,
     /// The status of a tool call (if used in a completion request, this should always be Completed)
     status: ToolStatus,
+}
+
+/// Output accepted by an OpenAI Responses function-call result.
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[serde(untagged)]
+pub enum ToolResultOutput {
+    /// A single text or deliberately serialized JSON result.
+    String(String),
+    /// Ordered text and image result blocks.
+    Content(Vec<ToolResultOutputContent>),
+}
+
+/// A typed content block in an OpenAI Responses function-call result.
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ToolResultOutputContent {
+    /// Literal text content.
+    InputText { text: String },
+    /// Image content backed by either a URL/data URL or a provider file ID.
+    InputImage {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        image_url: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        file_id: Option<String>,
+        #[serde(default)]
+        detail: ImageDetail,
+    },
+}
+
+fn responses_tool_result_image(
+    image: message::Image,
+) -> Result<ToolResultOutputContent, MessageError> {
+    let message::Image {
+        data,
+        media_type,
+        detail,
+        ..
+    } = image;
+
+    let (image_url, file_id) = match data {
+        DocumentSourceKind::Url(url) => (Some(url), None),
+        DocumentSourceKind::Base64(data) => {
+            let media_type = media_type.ok_or_else(|| {
+                MessageError::ConversionError(
+                    "OpenAI Responses API tool-result images encoded as base64 require a media type"
+                        .into(),
+                )
+            })?;
+            (
+                Some(format!("data:{};base64,{data}", media_type.to_mime_type())),
+                None,
+            )
+        }
+        DocumentSourceKind::FileId(file_id) => (None, Some(file_id)),
+        DocumentSourceKind::Raw(_) => {
+            return Err(MessageError::ConversionError(
+                "OpenAI Responses API tool-result images cannot use raw bytes; encode the image as base64 first"
+                    .into(),
+            ));
+        }
+        DocumentSourceKind::String(_) | DocumentSourceKind::Unknown => {
+            return Err(MessageError::ConversionError(
+                "OpenAI Responses API tool-result images require a URL, base64 data, or file ID"
+                    .into(),
+            ));
+        }
+    };
+
+    Ok(ToolResultOutputContent::InputImage {
+        image_url,
+        file_id,
+        detail: detail.unwrap_or_default(),
+    })
+}
+
+fn responses_tool_result_output(
+    content: OneOrMany<message::ToolResultContent>,
+) -> Result<ToolResultOutput, MessageError> {
+    let content = content.into_iter().collect::<Vec<_>>();
+
+    if let [content] = content.as_slice() {
+        return match content {
+            message::ToolResultContent::Text(Text { text, .. }) => {
+                Ok(ToolResultOutput::String(text.clone()))
+            }
+            message::ToolResultContent::Json { value } => {
+                Ok(ToolResultOutput::String(value.to_string()))
+            }
+            message::ToolResultContent::Image(image) => Ok(ToolResultOutput::Content(vec![
+                responses_tool_result_image(image.clone())?,
+            ])),
+        };
+    }
+
+    content
+        .into_iter()
+        .map(|content| match content {
+            message::ToolResultContent::Text(Text { text, .. }) => {
+                Ok(ToolResultOutputContent::InputText { text })
+            }
+            message::ToolResultContent::Json { value } => Ok(ToolResultOutputContent::InputText {
+                text: value.to_string(),
+            }),
+            message::ToolResultContent::Image(image) => responses_tool_result_image(image),
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(ToolResultOutput::Content)
 }
 
 impl From<Message> for InputItem {
@@ -359,26 +466,14 @@ impl TryFrom<crate::completion::Message> for Vec<InputItem> {
                                 ..
                             },
                         ) => {
-                            for tool_result_content in tool_content {
-                                let crate::completion::message::ToolResultContent::Text(Text {
-                                    text,
-                                    ..
-                                }) = tool_result_content
-                                else {
-                                    return Err(CompletionError::ProviderError(
-                                        "The OpenAI Responses API only supports text tool results"
-                                            .to_string(),
-                                    ));
-                                };
-                                items.push(InputItem {
-                                    role: None,
-                                    input: InputContent::FunctionCallOutput(ToolResult {
-                                        call_id: require_call_id(call_id.clone(), "Tool result")?,
-                                        output: text,
-                                        status: ToolStatus::Completed,
-                                    }),
-                                });
-                            }
+                            items.push(InputItem {
+                                role: None,
+                                input: InputContent::FunctionCallOutput(ToolResult {
+                                    call_id: require_call_id(call_id, "Tool result")?,
+                                    output: responses_tool_result_output(tool_content)?,
+                                    status: ToolStatus::Completed,
+                                }),
+                            });
                         }
                         crate::message::UserContent::Document(Document {
                             data: DocumentSourceKind::FileId(file_id),
@@ -2298,7 +2393,7 @@ pub enum Message {
     #[serde(rename = "tool")]
     ToolResult {
         tool_call_id: String,
-        output: String,
+        output: ToolResultOutput,
     },
 }
 
@@ -2402,8 +2497,138 @@ pub enum UserContent {
     #[serde(rename = "tool")]
     ToolResult {
         tool_call_id: String,
-        output: String,
+        output: ToolResultOutput,
     },
+}
+
+fn flush_responses_user_content(
+    messages: &mut Vec<Message>,
+    pending: &mut Vec<UserContent>,
+) -> Result<(), MessageError> {
+    if pending.is_empty() {
+        return Ok(());
+    }
+
+    let content = OneOrMany::many(std::mem::take(pending)).map_err(|_| {
+        MessageError::ConversionError(
+            "User message did not contain OpenAI Responses-compatible content".to_string(),
+        )
+    })?;
+    messages.push(Message::User {
+        content,
+        name: None,
+    });
+    Ok(())
+}
+
+fn responses_user_content(content: message::UserContent) -> Result<UserContent, MessageError> {
+    match content {
+        message::UserContent::Text(message::Text { text, .. }) => {
+            Ok(UserContent::InputText { text })
+        }
+        message::UserContent::Image(message::Image {
+            data,
+            detail,
+            media_type,
+            ..
+        }) => {
+            let url = match data {
+                DocumentSourceKind::Base64(data) => {
+                    let media_type = media_type
+                        .map(|media_type| media_type.to_mime_type().to_string())
+                        .unwrap_or_default();
+                    format!("data:{media_type};base64,{data}")
+                }
+                DocumentSourceKind::Url(url) => url,
+                DocumentSourceKind::Raw(_) => {
+                    return Err(MessageError::ConversionError(
+                        "Raw files not supported, encode as base64 first".into(),
+                    ));
+                }
+                doc => {
+                    return Err(MessageError::ConversionError(format!(
+                        "Unsupported document type: {doc}"
+                    )));
+                }
+            };
+
+            Ok(UserContent::InputImage {
+                image_url: url,
+                detail: detail.unwrap_or_default(),
+            })
+        }
+        message::UserContent::Document(message::Document {
+            data: DocumentSourceKind::FileId(file_id),
+            ..
+        }) => Ok(UserContent::InputFile {
+            file_id: Some(file_id),
+            file_url: None,
+            file_data: None,
+            filename: None,
+        }),
+        message::UserContent::Document(message::Document {
+            media_type: Some(DocumentMediaType::PDF),
+            data,
+            ..
+        }) => {
+            let (file_data, file_url, filename) = match data {
+                DocumentSourceKind::Base64(data) => (
+                    Some(format!("data:application/pdf;base64,{data}")),
+                    None,
+                    Some("document.pdf".to_string()),
+                ),
+                DocumentSourceKind::Url(url) => (None, Some(url), None),
+                DocumentSourceKind::Raw(_) => {
+                    return Err(MessageError::ConversionError(
+                        "Raw files not supported, encode as base64 first".into(),
+                    ));
+                }
+                doc => {
+                    return Err(MessageError::ConversionError(format!(
+                        "Unsupported document type: {doc}"
+                    )));
+                }
+            };
+
+            Ok(UserContent::InputFile {
+                file_id: None,
+                file_url,
+                file_data,
+                filename,
+            })
+        }
+        message::UserContent::Document(message::Document {
+            data: DocumentSourceKind::Base64(text),
+            ..
+        }) => Ok(UserContent::InputText { text }),
+        message::UserContent::Audio(message::Audio {
+            data: DocumentSourceKind::Base64(data),
+            media_type,
+            ..
+        }) => Ok(UserContent::Audio {
+            input_audio: InputAudio {
+                data,
+                format: media_type.unwrap_or(AudioMediaType::MP3),
+            },
+        }),
+        message::UserContent::Audio(_) => Err(MessageError::ConversionError(
+            "Audio must be base64 encoded data".into(),
+        )),
+        _ => Err(MessageError::ConversionError(
+            "Unsupported user content for OpenAI Responses API".into(),
+        )),
+    }
+}
+
+fn responses_tool_result(tool_result: message::ToolResult) -> Result<Message, MessageError> {
+    Ok(Message::ToolResult {
+        tool_call_id: tool_result.call_id.ok_or_else(|| {
+            MessageError::ConversionError(
+                "Tool result `call_id` is required for OpenAI Responses API".into(),
+            )
+        })?,
+        output: responses_tool_result_output(tool_result.content)?,
+    })
 }
 
 impl TryFrom<message::Message> for Vec<Message> {
@@ -2416,164 +2641,21 @@ impl TryFrom<message::Message> for Vec<Message> {
                 name: None,
             }]),
             message::Message::User { content } => {
-                let (tool_results, other_content): (Vec<_>, Vec<_>) = content
-                    .into_iter()
-                    .partition(|content| matches!(content, message::UserContent::ToolResult(_)));
+                let mut messages = Vec::new();
+                let mut pending = Vec::new();
 
-                // If there are messages with both tool results and user content, openai will only
-                //  handle tool results. It's unlikely that there will be both.
-                if !tool_results.is_empty() {
-                    tool_results
-                        .into_iter()
-                        .map(|content| match content {
-                            message::UserContent::ToolResult(message::ToolResult {
-                                call_id,
-                                content,
-                                ..
-                            }) => Ok::<_, message::MessageError>(Message::ToolResult {
-                                tool_call_id: call_id.ok_or_else(|| {
-                                    MessageError::ConversionError(
-                                        "Tool result `call_id` is required for OpenAI Responses API"
-                                            .into(),
-                                    )
-                                })?,
-                                output: {
-                                    let res = content.first();
-                                    match res {
-                                        completion::message::ToolResultContent::Text(Text {
-                                            text,
-                                            ..
-                                        }) => text,
-                                        _ => return  Err(MessageError::ConversionError("This API only currently supports text tool results".into()))
-                                    }
-                                },
-                            }),
-                            _ => Err(MessageError::ConversionError(
-                                "expected tool result content while converting Responses API input"
-                                    .into(),
-                            )),
-                        })
-                        .collect::<Result<Vec<_>, _>>()
-                } else {
-                    let other_content = other_content
-                        .into_iter()
-                        .map(|content| match content {
-                            message::UserContent::Text(message::Text { text, .. }) => {
-                                Ok(UserContent::InputText { text })
-                            }
-                            message::UserContent::Image(message::Image {
-                                data,
-                                detail,
-                                media_type,
-                                ..
-                            }) => {
-                                let url = match data {
-                                    DocumentSourceKind::Base64(data) => {
-                                        let media_type = if let Some(media_type) = media_type {
-                                            media_type.to_mime_type().to_string()
-                                        } else {
-                                            String::new()
-                                        };
-                                        format!("data:{media_type};base64,{data}")
-                                    }
-                                    DocumentSourceKind::Url(url) => url,
-                                    DocumentSourceKind::Raw(_) => {
-                                        return Err(MessageError::ConversionError(
-                                            "Raw files not supported, encode as base64 first"
-                                                .into(),
-                                        ));
-                                    }
-                                    doc => {
-                                        return Err(MessageError::ConversionError(format!(
-                                            "Unsupported document type: {doc}"
-                                        )));
-                                    }
-                                };
-
-                                Ok(UserContent::InputImage {
-                                    image_url: url,
-                                    detail: detail.unwrap_or_default(),
-                                })
-                            }
-                            message::UserContent::Document(message::Document {
-                                data: DocumentSourceKind::FileId(file_id),
-                                ..
-                            }) => Ok(UserContent::InputFile {
-                                file_id: Some(file_id),
-                                file_url: None,
-                                file_data: None,
-                                filename: None,
-                            }),
-                            message::UserContent::Document(message::Document {
-                                media_type: Some(DocumentMediaType::PDF),
-                                data,
-                                ..
-                            }) => {
-                                let (file_data, file_url, filename) = match data {
-                                    DocumentSourceKind::Base64(data) => (
-                                        Some(format!("data:application/pdf;base64,{data}")),
-                                        None,
-                                        Some("document.pdf".to_string()),
-                                    ),
-                                    DocumentSourceKind::Url(url) => (None, Some(url), None),
-                                    DocumentSourceKind::Raw(_) => {
-                                        return Err(MessageError::ConversionError(
-                                            "Raw files not supported, encode as base64 first"
-                                                .into(),
-                                        ));
-                                    }
-                                    doc => {
-                                        return Err(MessageError::ConversionError(format!(
-                                            "Unsupported document type: {doc}"
-                                        )));
-                                    }
-                                };
-
-                                Ok(UserContent::InputFile {
-                                    file_id: None,
-                                    file_url,
-                                    file_data,
-                                    filename,
-                                })
-                            }
-                            message::UserContent::Document(message::Document {
-                                data: DocumentSourceKind::Base64(text),
-                                ..
-                            }) => Ok(UserContent::InputText { text }),
-                            message::UserContent::Audio(message::Audio {
-                                data: DocumentSourceKind::Base64(data),
-                                media_type,
-                                ..
-                            }) => Ok(UserContent::Audio {
-                                input_audio: InputAudio {
-                                    data,
-                                    format: match media_type {
-                                        Some(media_type) => media_type,
-                                        None => AudioMediaType::MP3,
-                                    },
-                                },
-                            }),
-                            message::UserContent::Audio(_) => Err(MessageError::ConversionError(
-                                "Audio must be base64 encoded data".into(),
-                            )),
-                            _ => Err(MessageError::ConversionError(
-                                "Unsupported user content for OpenAI Responses API".into(),
-                            )),
-                        })
-                        .collect::<Result<Vec<_>, _>>()?;
-
-                    let other_content = OneOrMany::many(other_content).map_err(|_| {
-                        MessageError::ConversionError(
-                            "User message did not contain OpenAI Responses-compatible content"
-                                .to_string(),
-                        )
-                    })?;
-
-                    Ok(vec![Message::User {
-                        content: other_content,
-                        name: None,
-                    }])
+                for content in content {
+                    match content {
+                        message::UserContent::ToolResult(tool_result) => {
+                            flush_responses_user_content(&mut messages, &mut pending)?;
+                            messages.push(responses_tool_result(tool_result)?);
+                        }
+                        content => pending.push(responses_user_content(content)?),
+                    }
                 }
+
+                flush_responses_user_content(&mut messages, &mut pending)?;
+                Ok(messages)
             }
             message::Message::Assistant {
                 content,
@@ -2712,6 +2794,189 @@ mod tests {
             additional_params: None,
             output_schema: None,
         }
+    }
+
+    fn rig_tool_result(content: OneOrMany<message::ToolResultContent>) -> message::Message {
+        message::Message::User {
+            content: OneOrMany::one(message::UserContent::ToolResult(message::ToolResult {
+                id: "result-id".to_string(),
+                call_id: Some("call-id".to_string()),
+                content,
+            })),
+        }
+    }
+
+    fn converted_tool_result_outputs(
+        content: OneOrMany<message::ToolResultContent>,
+    ) -> (ToolResultOutput, ToolResultOutput) {
+        let input = rig_tool_result(content);
+
+        let messages = Vec::<Message>::try_from(input.clone()).expect("message conversion");
+        let [
+            Message::ToolResult {
+                output: message_output,
+                ..
+            },
+        ] = messages.as_slice()
+        else {
+            panic!("expected one tool-result message");
+        };
+
+        let items = Vec::<InputItem>::try_from(input).expect("input-item conversion");
+        let [
+            InputItem {
+                input:
+                    InputContent::FunctionCallOutput(ToolResult {
+                        output: item_output,
+                        ..
+                    }),
+                ..
+            },
+        ] = items.as_slice()
+        else {
+            panic!("expected one function-call output item");
+        };
+
+        (message_output.clone(), item_output.clone())
+    }
+
+    #[test]
+    fn responses_tool_result_json_values_serialize_only_at_the_wire_boundary() {
+        for value in [
+            Value::Null,
+            json!(true),
+            json!(42),
+            json!("structured string"),
+            json!([1, "two", false]),
+            json!({ "status": "ok" }),
+        ] {
+            let expected = ToolResultOutput::String(value.to_string());
+            let outputs = converted_tool_result_outputs(OneOrMany::one(
+                message::ToolResultContent::json(value),
+            ));
+
+            assert_eq!(outputs, (expected.clone(), expected));
+        }
+    }
+
+    #[test]
+    fn responses_tool_result_literal_text_is_not_reparsed_as_json() {
+        let literal = converted_tool_result_outputs(OneOrMany::one(
+            message::ToolResultContent::text("structured string"),
+        ));
+        let structured = converted_tool_result_outputs(OneOrMany::one(
+            message::ToolResultContent::json(json!("structured string")),
+        ));
+
+        assert_eq!(
+            literal,
+            (
+                ToolResultOutput::String("structured string".into()),
+                ToolResultOutput::String("structured string".into())
+            )
+        );
+        assert_eq!(
+            structured,
+            (
+                ToolResultOutput::String(r#""structured string""#.into()),
+                ToolResultOutput::String(r#""structured string""#.into())
+            )
+        );
+    }
+
+    #[test]
+    fn responses_tool_result_mixed_blocks_preserve_order_and_image_type() {
+        let content = OneOrMany::many(vec![
+            message::ToolResultContent::text("before"),
+            message::ToolResultContent::json(json!({ "status": "ok" })),
+            message::ToolResultContent::image_base64(
+                "aW1hZ2U=",
+                Some(message::ImageMediaType::PNG),
+                Some(message::ImageDetail::High),
+            ),
+            message::ToolResultContent::text("after"),
+        ])
+        .expect("mixed result is non-empty");
+        let expected = ToolResultOutput::Content(vec![
+            ToolResultOutputContent::InputText {
+                text: "before".into(),
+            },
+            ToolResultOutputContent::InputText {
+                text: r#"{"status":"ok"}"#.into(),
+            },
+            ToolResultOutputContent::InputImage {
+                image_url: Some("data:image/png;base64,aW1hZ2U=".into()),
+                file_id: None,
+                detail: ImageDetail::High,
+            },
+            ToolResultOutputContent::InputText {
+                text: "after".into(),
+            },
+        ]);
+
+        let outputs = converted_tool_result_outputs(content);
+        assert_eq!(outputs, (expected.clone(), expected));
+    }
+
+    #[test]
+    fn responses_tool_result_image_only_uses_native_content_array() {
+        let expected = ToolResultOutput::Content(vec![ToolResultOutputContent::InputImage {
+            image_url: Some("https://example.com/result.png".into()),
+            file_id: None,
+            detail: ImageDetail::Auto,
+        }]);
+        let outputs =
+            converted_tool_result_outputs(OneOrMany::one(message::ToolResultContent::image_url(
+                "https://example.com/result.png",
+                Some(message::ImageMediaType::PNG),
+                None,
+            )));
+
+        assert_eq!(outputs, (expected.clone(), expected));
+    }
+
+    #[test]
+    fn responses_tool_result_rejects_unrepresentable_images() {
+        for content in [
+            message::ToolResultContent::image_base64("aW1hZ2U=", None, None),
+            message::ToolResultContent::image_raw(
+                vec![1, 2, 3],
+                Some(message::ImageMediaType::PNG),
+                None,
+            ),
+        ] {
+            let input = rig_tool_result(OneOrMany::one(content));
+            assert!(Vec::<Message>::try_from(input.clone()).is_err());
+            assert!(Vec::<InputItem>::try_from(input).is_err());
+        }
+    }
+
+    #[test]
+    fn responses_mixed_user_content_preserves_order_around_tool_results() {
+        let input = message::Message::User {
+            content: OneOrMany::many(vec![
+                message::UserContent::text("before"),
+                message::UserContent::tool_result_with_call_id(
+                    "result-id",
+                    "call-id".to_string(),
+                    OneOrMany::one(message::ToolResultContent::text("tool output")),
+                ),
+                message::UserContent::text("after"),
+            ])
+            .expect("mixed content is non-empty"),
+        };
+
+        let messages = Vec::<Message>::try_from(input).expect("message conversion");
+        assert!(matches!(
+            messages.as_slice(),
+            [
+                Message::User { content: before, .. },
+                Message::ToolResult { tool_call_id, .. },
+                Message::User { content: after, .. },
+            ] if matches!(before.first(), UserContent::InputText { text } if text == "before")
+                && tool_call_id == "call-id"
+                && matches!(after.first(), UserContent::InputText { text } if text == "after")
+        ));
     }
 
     #[test]

--- a/crates/rig-core/src/providers/openrouter/completion.rs
+++ b/crates/rig-core/src/providers/openrouter/completion.rs
@@ -1012,17 +1012,32 @@ fn document_filename(media_type: Option<&DocumentMediaType>) -> Option<String> {
 fn user_contents_to_messages(
     value: OneOrMany<message::UserContent>,
 ) -> Result<Vec<Message>, message::MessageError> {
-    let (tool_results, other_content): (Vec<_>, Vec<_>) = value
-        .into_iter()
-        .partition(|content| matches!(content, message::UserContent::ToolResult(_)));
+    let flush_user_content = |messages: &mut Vec<Message>, content: &mut Vec<UserContent>| {
+        if content.is_empty() {
+            return Ok(());
+        }
 
-    // If there are messages with both tool results and user content, we handle
-    // tool results first. It's unlikely that there will be both.
-    if !tool_results.is_empty() {
-        tool_results
-            .into_iter()
-            .map(|content| match content {
-                message::UserContent::ToolResult(tool_result) => Ok(Message::ToolResult {
+        let content = OneOrMany::many(std::mem::take(content)).map_err(|_| {
+            message::MessageError::ConversionError(
+                "OpenRouter user message did not contain any non-tool content".into(),
+            )
+        })?;
+        messages.push(Message::User {
+            content,
+            name: None,
+        });
+
+        Ok::<_, message::MessageError>(())
+    };
+
+    let mut messages = Vec::new();
+    let mut user_content = Vec::new();
+
+    for content in value {
+        match content {
+            message::UserContent::ToolResult(tool_result) => {
+                flush_user_content(&mut messages, &mut user_content)?;
+                messages.push(Message::ToolResult {
                     // Prefer the provider-issued call id, matching the
                     // assistant echo (shared From<message::ToolCall>).
                     tool_call_id: tool_result.call_id.unwrap_or(tool_result.id),
@@ -1033,37 +1048,25 @@ fn user_contents_to_messages(
                             .map(|c| match c {
                                 message::ToolResultContent::Text(message::Text {
                                     text, ..
-                                }) => text,
+                                }) => Ok(text),
+                                message::ToolResultContent::Json { value } => Ok(value.to_string()),
                                 message::ToolResultContent::Image(_) => {
-                                    "[Image content not supported in tool results]".to_string()
+                                    Err(message::MessageError::ConversionError(
+                                        "OpenRouter does not support images in tool results".into(),
+                                    ))
                                 }
                             })
-                            .collect::<Vec<_>>()
+                            .collect::<Result<Vec<_>, _>>()?
                             .join("\n"),
                     ),
-                }),
-                _ => Err(message::MessageError::ConversionError(
-                    "expected tool result content while converting OpenRouter input".into(),
-                )),
-            })
-            .collect::<Result<Vec<_>, _>>()
-    } else {
-        let user_content: Vec<UserContent> = other_content
-            .into_iter()
-            .map(user_content_to_openai)
-            .collect::<Result<Vec<_>, _>>()?;
-
-        let content = OneOrMany::many(user_content).map_err(|_| {
-            message::MessageError::ConversionError(
-                "OpenRouter user message did not contain any non-tool content".into(),
-            )
-        })?;
-
-        Ok(vec![Message::User {
-            content,
-            name: None,
-        }])
+                });
+            }
+            content => user_content.push(user_content_to_openai(content)?),
+        }
     }
+
+    flush_user_content(&mut messages, &mut user_content)?;
+    Ok(messages)
 }
 
 // ================================================================
@@ -1520,6 +1523,65 @@ mod tests {
     use super::*;
     use crate::message::{AudioMediaType, ImageDetail, VideoMediaType};
     use serde_json::json;
+
+    #[test]
+    fn mixed_user_content_preserves_order_around_tool_results() {
+        let user = message::Message::User {
+            content: OneOrMany::many(vec![
+                message::UserContent::text("before"),
+                message::UserContent::tool_result_with_call_id(
+                    "rig-id",
+                    "provider-call-id".to_string(),
+                    OneOrMany::many(vec![
+                        message::ToolResultContent::text("literal"),
+                        message::ToolResultContent::json(json!({"status": "ok"})),
+                    ])
+                    .expect("tool result should be non-empty"),
+                ),
+                message::UserContent::text("after"),
+            ])
+            .expect("user content should be non-empty"),
+        };
+
+        let converted = messages_from_rig_message(user).expect("history should convert");
+        assert_eq!(converted.len(), 3);
+        assert!(matches!(
+            &converted[0],
+            Message::User { content, .. }
+                if matches!(content.first(), UserContent::Text { text } if text == "before")
+        ));
+        assert!(matches!(
+            &converted[1],
+            Message::ToolResult {
+                tool_call_id,
+                content: openai::completion::ToolResultContentValue::String(text),
+            } if tool_call_id == "provider-call-id"
+                && text == "literal\n{\"status\":\"ok\"}"
+        ));
+        assert!(matches!(
+            &converted[2],
+            Message::User { content, .. }
+                if matches!(content.first(), UserContent::Text { text } if text == "after")
+        ));
+    }
+
+    #[test]
+    fn tool_result_images_are_rejected_instead_of_replaced_with_placeholder_text() {
+        let user = message::Message::User {
+            content: OneOrMany::one(message::UserContent::tool_result(
+                "call-1",
+                OneOrMany::one(message::ToolResultContent::image_base64(
+                    "image-data",
+                    Some(message::ImageMediaType::PNG),
+                    None,
+                )),
+            )),
+        };
+
+        let error = messages_from_rig_message(user)
+            .expect_err("OpenRouter tool results cannot contain images");
+        assert!(format!("{error}").contains("does not support images"));
+    }
 
     #[test]
     fn test_openrouter_request_uses_request_model_override() {

--- a/crates/rig-core/src/providers/xai/api.rs
+++ b/crates/rig-core/src/providers/xai/api.rs
@@ -246,7 +246,9 @@ impl TryFrom<RigMessage> for Vec<Message> {
                                     items.push(Message::user_with_content(msg_items));
                                 }
                             } else if !text_parts.is_empty() {
-                                items.push(Message::user(text_parts.join("\n")));
+                                items.push(Message::user(
+                                    std::mem::take(&mut text_parts).join("\n"),
+                                ));
                             }
                             has_images = false;
 
@@ -254,12 +256,17 @@ impl TryFrom<RigMessage> for Vec<Message> {
                             let output = tr
                                 .content
                                 .into_iter()
-                                .map(|tc| match tc {
-                                    ToolResultContent::Text(t) => Ok(t.text),
-                                    ToolResultContent::Image(_) => {
-                                        Err(CompletionError::RequestError(
-                                            "xAI does not support images in tool results".into(),
-                                        ))
+                                .map(|tc| -> Result<String, CompletionError> {
+                                    match tc {
+                                        ToolResultContent::Text(t) => Ok(t.text),
+                                        ToolResultContent::Json { value } => Ok(value.to_string()),
+                                        ToolResultContent::Image(_) => {
+                                            Err(crate::message::MessageError::ConversionError(
+                                                "xAI does not support images in tool results"
+                                                    .into(),
+                                            )
+                                            .into())
+                                        }
                                     }
                                 })
                                 .collect::<Result<Vec<_>, _>>()?
@@ -394,7 +401,10 @@ mod tests {
     use super::Message;
     use crate::OneOrMany;
     use crate::completion::CompletionError;
-    use crate::message::{AssistantContent, Message as RigMessage, Reasoning, ReasoningContent};
+    use crate::message::{
+        AssistantContent, Message as RigMessage, Reasoning, ReasoningContent, ToolResultContent,
+        UserContent,
+    };
     use crate::providers::openai::responses_api::ReasoningSummary;
 
     #[test]
@@ -539,6 +549,76 @@ mod tests {
                     .to_string()
                     .contains("Tool result `call_id` is required")
         ));
+    }
+
+    #[test]
+    fn user_content_preserves_order_around_tool_results_without_replaying_flushed_text() {
+        let message = RigMessage::User {
+            content: OneOrMany::many(vec![
+                UserContent::text("before"),
+                UserContent::tool_result_with_call_id(
+                    "rig-id",
+                    "call-1".to_string(),
+                    OneOrMany::many(vec![
+                        ToolResultContent::text("literal"),
+                        ToolResultContent::json(serde_json::json!({"status": "ok"})),
+                    ])
+                    .expect("tool result should be non-empty"),
+                ),
+                UserContent::text("after"),
+            ])
+            .expect("user content should be non-empty"),
+        };
+
+        let converted = Vec::<Message>::try_from(message).expect("history should convert");
+        let serialized = serde_json::to_value(converted).expect("messages should serialize");
+        assert_eq!(
+            serialized,
+            serde_json::json!([
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": "before"
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call-1",
+                    "output": "literal\n{\"status\":\"ok\"}"
+                },
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": "after"
+                }
+            ])
+        );
+    }
+
+    #[test]
+    fn user_tool_result_images_fail_with_a_message_conversion_error() {
+        let message = RigMessage::User {
+            content: OneOrMany::one(UserContent::tool_result_with_call_id(
+                "rig-id",
+                "call-1".to_string(),
+                OneOrMany::one(ToolResultContent::image_base64(
+                    "image-data",
+                    Some(crate::message::ImageMediaType::PNG),
+                    None,
+                )),
+            )),
+        };
+
+        let error =
+            Vec::<Message>::try_from(message).expect_err("xAI tool results cannot contain images");
+        match error {
+            CompletionError::RequestError(source) => {
+                let message_error = source
+                    .downcast_ref::<crate::message::MessageError>()
+                    .expect("request error should preserve MessageError");
+                assert!(format!("{message_error}").contains("does not support images"));
+            }
+            other => panic!("expected request error, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/rig-gemini-grpc/CHANGELOG.md
+++ b/crates/rig-gemini-grpc/CHANGELOG.md
@@ -3,7 +3,15 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).## [0.2.6](https://github.com/0xPlaygrounds/rig/compare/rig-gemini-grpc-v0.2.5...rig-gemini-grpc-v0.2.6) - 2026-05-13
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Preserve ordered text and structured JSON tool results in native protobuf values.
+
+## [0.2.6](https://github.com/0xPlaygrounds/rig/compare/rig-gemini-grpc-v0.2.5...rig-gemini-grpc-v0.2.6) - 2026-05-13
 
 ### Fixed
 

--- a/crates/rig-gemini-grpc/src/completion.rs
+++ b/crates/rig-gemini-grpc/src/completion.rs
@@ -253,20 +253,32 @@ fn rig_user_content_to_grpc_part(
             part_metadata: None,
         }),
         message::UserContent::ToolResult(result) => {
-            let response_text = match &result.content.first() {
-                message::ToolResultContent::Text(t) => t.text.clone(),
-                message::ToolResultContent::Image(_) => {
-                    return Err(CompletionError::RequestError(
-                        "Tool result content must be text".into(),
-                    ));
+            let mut result_values = result
+                .content
+                .into_iter()
+                .map(|content| match content {
+                    message::ToolResultContent::Text(text) => Ok(proto::Value {
+                        kind: Some(proto::value::Kind::StringValue(text.text)),
+                    }),
+                    message::ToolResultContent::Json { value } => json_to_prost_value(value),
+                    message::ToolResultContent::Image(_) => Err(message_conversion_error(
+                        "Gemini gRPC does not support images in tool results; return text or JSON instead",
+                    )),
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
+            let result_value = if result_values.len() == 1 {
+                result_values.remove(0)
+            } else {
+                proto::Value {
+                    kind: Some(proto::value::Kind::ListValue(proto::ListValue {
+                        values: result_values,
+                    })),
                 }
             };
-
-            let result_value: serde_json::Value = serde_json::from_str(&response_text)
-                .unwrap_or_else(|_| serde_json::json!(response_text));
-
-            let response_struct =
-                json_to_prost_struct(serde_json::json!({ "result": result_value }))?;
+            let response_struct = proto::Struct {
+                fields: [("result".to_string(), result_value)].into_iter().collect(),
+            };
 
             Ok(proto::Part {
                 data: Some(proto::part::Data::FunctionResponse(
@@ -599,20 +611,21 @@ fn encode_optional_base64(bytes: &[u8]) -> Option<String> {
 
 fn json_to_prost_struct(value: serde_json::Value) -> Result<proto::Struct, CompletionError> {
     match value {
-        serde_json::Value::Object(map) => Ok(proto::Struct {
-            fields: map
+        serde_json::Value::Object(map) => {
+            let fields = map
                 .into_iter()
-                .map(|(k, v)| (k, json_to_prost_value(v)))
-                .collect(),
-        }),
+                .map(|(key, value)| json_to_prost_value(value).map(|value| (key, value)))
+                .collect::<Result<_, _>>()?;
+            Ok(proto::Struct { fields })
+        }
         _ => Err(CompletionError::RequestError(
             "Expected a JSON object for google.protobuf.Struct".into(),
         )),
     }
 }
 
-fn json_to_prost_value(value: serde_json::Value) -> proto::Value {
-    match value {
+fn json_to_prost_value(value: serde_json::Value) -> Result<proto::Value, CompletionError> {
+    let value = match value {
         serde_json::Value::Null => proto::Value {
             kind: Some(proto::value::Kind::NullValue(
                 proto::NullValue::NullValue as i32,
@@ -622,27 +635,57 @@ fn json_to_prost_value(value: serde_json::Value) -> proto::Value {
             kind: Some(proto::value::Kind::BoolValue(b)),
         },
         serde_json::Value::Number(n) => proto::Value {
-            kind: Some(proto::value::Kind::NumberValue(
-                n.as_f64().unwrap_or_default(),
-            )),
+            kind: Some(proto::value::Kind::NumberValue(json_number_to_f64(n)?)),
         },
         serde_json::Value::String(s) => proto::Value {
             kind: Some(proto::value::Kind::StringValue(s)),
         },
         serde_json::Value::Array(items) => proto::Value {
             kind: Some(proto::value::Kind::ListValue(proto::ListValue {
-                values: items.into_iter().map(json_to_prost_value).collect(),
+                values: items
+                    .into_iter()
+                    .map(json_to_prost_value)
+                    .collect::<Result<_, _>>()?,
             })),
         },
         serde_json::Value::Object(map) => proto::Value {
             kind: Some(proto::value::Kind::StructValue(proto::Struct {
                 fields: map
                     .into_iter()
-                    .map(|(k, v)| (k, json_to_prost_value(v)))
-                    .collect(),
+                    .map(|(key, value)| json_to_prost_value(value).map(|value| (key, value)))
+                    .collect::<Result<_, _>>()?,
             })),
         },
+    };
+    Ok(value)
+}
+
+fn json_number_to_f64(number: serde_json::Number) -> Result<f64, CompletionError> {
+    let converted = number.as_f64().ok_or_else(|| {
+        message_conversion_error(format!(
+            "Gemini gRPC cannot represent JSON number `{number}` as f64"
+        ))
+    })?;
+
+    let exact = if let Some(integer) = number.as_i64() {
+        converted as i128 == i128::from(integer)
+    } else if let Some(integer) = number.as_u64() {
+        converted as u128 == u128::from(integer)
+    } else {
+        serde_json::Number::from_f64(converted).as_ref() == Some(&number)
+    };
+
+    if exact {
+        Ok(converted)
+    } else {
+        Err(message_conversion_error(format!(
+            "Gemini gRPC cannot represent JSON number `{number}` as f64 without precision loss"
+        )))
     }
+}
+
+fn message_conversion_error(message: impl Into<String>) -> CompletionError {
+    message::MessageError::ConversionError(message.into()).into()
 }
 
 fn prost_struct_to_json(st: &proto::Struct) -> serde_json::Value {
@@ -721,6 +764,41 @@ fn json_type_to_proto_type(t: &str) -> proto::Type {
 mod tests {
     use super::*;
 
+    fn grpc_tool_result(
+        content: OneOrMany<message::ToolResultContent>,
+    ) -> Result<proto::FunctionResponse, CompletionError> {
+        let part =
+            rig_user_content_to_grpc_part(message::UserContent::ToolResult(message::ToolResult {
+                id: "lookup".to_string(),
+                call_id: Some("call-1".to_string()),
+                content,
+            }))?;
+
+        match part.data {
+            Some(proto::part::Data::FunctionResponse(response)) => Ok(response),
+            other => Err(CompletionError::ResponseError(format!(
+                "expected function response, got {other:?}"
+            ))),
+        }
+    }
+
+    fn grpc_tool_result_value(response: &proto::FunctionResponse) -> serde_json::Value {
+        let response = response.response.as_ref().expect("response struct");
+        prost_value_to_json(response.fields.get("result").expect("result field"))
+    }
+
+    fn conversion_error_message(error: CompletionError) -> String {
+        let CompletionError::RequestError(source) = error else {
+            panic!("expected request error wrapping MessageError, got {error:?}");
+        };
+        let error = source
+            .downcast_ref::<message::MessageError>()
+            .expect("request error should preserve MessageError");
+        match error {
+            message::MessageError::ConversionError(message) => message.clone(),
+        }
+    }
+
     // ============================================================
     // rpc_error — pins the from_provider_body usage on the RPC error path
     // ============================================================
@@ -768,6 +846,82 @@ mod tests {
             decode_base64_bytes("data:text/plain;base64,Zm9v"),
             Ok(bytes) if bytes == b"foo".to_vec()
         ));
+    }
+
+    #[test]
+    fn tool_result_singletons_preserve_literal_text_and_native_json() {
+        let literal = grpc_tool_result(OneOrMany::one(message::ToolResultContent::text(
+            r#"{"status":"literal"}"#,
+        )))
+        .expect("literal text should convert");
+        assert_eq!(
+            grpc_tool_result_value(&literal),
+            serde_json::json!(r#"{"status":"literal"}"#)
+        );
+
+        let structured_value = serde_json::json!({
+            "status": "structured",
+            "items": [true, null]
+        });
+        let structured = grpc_tool_result(OneOrMany::one(message::ToolResultContent::json(
+            structured_value.clone(),
+        )))
+        .expect("structured JSON should convert");
+        assert_eq!(grpc_tool_result_value(&structured), structured_value);
+    }
+
+    #[test]
+    fn tool_result_multiple_items_preserve_order_in_a_native_list() {
+        let response = grpc_tool_result(
+            OneOrMany::many([
+                message::ToolResultContent::text("first"),
+                message::ToolResultContent::json(serde_json::json!("second")),
+                message::ToolResultContent::json(serde_json::json!({ "position": 3 })),
+            ])
+            .expect("non-empty tool result"),
+        )
+        .expect("ordered result should convert");
+
+        assert_eq!(
+            grpc_tool_result_value(&response),
+            serde_json::json!(["first", "second", { "position": 3.0 }])
+        );
+    }
+
+    #[test]
+    fn tool_result_images_return_conversion_errors() {
+        let error = grpc_tool_result(OneOrMany::one(message::ToolResultContent::image_base64(
+            "image-data",
+            Some(message::ImageMediaType::PNG),
+            None,
+        )))
+        .expect_err("images cannot be represented by Gemini gRPC function responses");
+
+        assert!(conversion_error_message(error).contains("does not support images"));
+    }
+
+    #[test]
+    fn tool_result_rejects_json_numbers_that_f64_would_round() {
+        let exactly_representable = 9_007_199_254_740_992_u64;
+        let response = grpc_tool_result(OneOrMany::one(message::ToolResultContent::json(
+            serde_json::json!(exactly_representable),
+        )))
+        .expect("exact f64 integer should convert");
+        assert_eq!(
+            grpc_tool_result_value(&response),
+            serde_json::json!(exactly_representable as f64)
+        );
+
+        let rounded_by_f64 = 9_007_199_254_740_993_u64;
+        let error = grpc_tool_result(OneOrMany::one(message::ToolResultContent::json(
+            serde_json::json!({
+                "nested": [rounded_by_f64]
+            }),
+        )))
+        .expect_err("lossy integers must not be rounded at the provider boundary");
+        let message = conversion_error_message(error);
+        assert!(message.contains(&rounded_by_f64.to_string()));
+        assert!(message.contains("precision loss"));
     }
 
     // ============================================================

--- a/crates/rig-memory/CHANGELOG.md
+++ b/crates/rig-memory/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+
+- Count compact structured JSON bytes when estimating tool-result tokens.
+
 ## [0.38.1](https://github.com/0xPlaygrounds/rig/compare/rig-memory-v0.1.2...rig-memory-v0.38.1) - 2026-06-02
 
 ### Other

--- a/crates/rig-memory/src/lib.rs
+++ b/crates/rig-memory/src/lib.rs
@@ -369,6 +369,9 @@ impl HeuristicTokenCounter {
                     rig_core::message::ToolResultContent::Text(t) => {
                         self.bytes_to_tokens(t.text.len())
                     }
+                    rig_core::message::ToolResultContent::Json { value } => {
+                        self.bytes_to_tokens(value.to_string().len())
+                    }
                     rig_core::message::ToolResultContent::Image(_) => self.per_attachment_tokens,
                 })
                 .sum(),
@@ -1698,6 +1701,23 @@ mod tests {
         let counter = HeuristicTokenCounter::default();
         let cost = counter.count(&tool_call_msg());
         assert!(cost > 0);
+    }
+
+    #[test]
+    fn heuristic_counter_charges_compact_json_bytes_for_tool_results() {
+        let value = serde_json::json!({
+            "answer": [true, null, "structured value"],
+        });
+        let message = Message::User {
+            content: OneOrMany::one(UserContent::ToolResult(ToolResult {
+                id: "call_1".into(),
+                call_id: None,
+                content: OneOrMany::one(ToolResultContent::json(value.clone())),
+            })),
+        };
+        let counter = HeuristicTokenCounter::new(1.0, 0, usize::MAX);
+
+        assert_eq!(counter.count(&message), value.to_string().len());
     }
 
     #[test]

--- a/crates/rig-vertexai/CHANGELOG.md
+++ b/crates/rig-vertexai/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed
+
+- Preserve ordered text and structured JSON tool results in native function responses.
+
 ## [0.40.0](https://github.com/0xPlaygrounds/rig/compare/rig-vertexai-v0.39.0...rig-vertexai-v0.40.0) - 2026-07-10
 
 ### Added

--- a/crates/rig-vertexai/src/types/message.rs
+++ b/crates/rig-vertexai/src/types/message.rs
@@ -25,23 +25,22 @@ impl TryFrom<RigMessage> for vertexai::model::Content {
                             Ok(vertexai::model::Part::new().set_text(text))
                         }
                         UserContent::ToolResult(tool_result) => {
-                            // vertexai tool calling response takes in a serde_json::Map. For now we bundle all
-                            // outputs into a single key and the value will either be a Value or Array depending on num outputs
-                            let outputs: Vec<serde_json::Value> = tool_result
+                            // Vertex AI accepts native JSON under `output`. Keep a singleton
+                            // scalar/object as-is and use an array only when preserving the
+                            // order of multiple Rig content blocks.
+                            let outputs = tool_result
                                 .content
-                                .iter()
+                                .into_iter()
                                 .map(|content| match content {
                                     ToolResultContent::Text(Text { text, .. }) => {
-                                        serde_json::Value::String(text.clone())
+                                        Ok(serde_json::Value::String(text))
                                     }
-                                    ToolResultContent::Image(_) => {
-                                        tracing::warn!("Tool call result contains image, which is not supported at this time");
-                                        serde_json::Value::String(
-                                            "Image result (not serialized)".to_string(),
-                                        )
-                                    }
+                                    ToolResultContent::Json { value } => Ok(value),
+                                    ToolResultContent::Image(_) => Err(message_conversion_error(
+                                        "Vertex AI does not support images in tool results; return text or JSON instead",
+                                    )),
                                 })
-                                .collect();
+                                .collect::<Result<Vec<_>, CompletionError>>()?;
 
                             let output_value = match outputs.as_slice() {
                                 [single] => single.clone(),
@@ -143,6 +142,10 @@ impl TryFrom<RigMessage> for vertexai::model::Content {
     }
 }
 
+fn message_conversion_error(message: impl Into<String>) -> CompletionError {
+    rig_core::message::MessageError::ConversionError(message.into()).into()
+}
+
 fn vertex_assistant_image_part(image: Image) -> Result<vertexai::model::Part, CompletionError> {
     let media_type = image.media_type.ok_or_else(|| {
         CompletionError::RequestError(
@@ -188,6 +191,37 @@ mod tests {
     use rig_core::OneOrMany;
     use rig_core::completion::CompletionResponse;
     use rig_core::message::{Message, Text, ToolResult, ToolResultContent};
+
+    fn vertex_tool_result(
+        content: OneOrMany<ToolResultContent>,
+    ) -> Result<vertexai::model::Content, CompletionError> {
+        RigMessage(Message::User {
+            content: OneOrMany::one(UserContent::ToolResult(ToolResult {
+                id: "lookup".to_string(),
+                call_id: None,
+                content,
+            })),
+        })
+        .try_into()
+    }
+
+    fn function_response(content: &vertexai::model::Content) -> &vertexai::model::FunctionResponse {
+        content.parts[0]
+            .function_response()
+            .expect("function response part")
+    }
+
+    fn conversion_error_message(error: CompletionError) -> String {
+        let CompletionError::RequestError(source) = error else {
+            panic!("expected request error wrapping MessageError, got {error:?}");
+        };
+        let error = source
+            .downcast_ref::<rig_core::message::MessageError>()
+            .expect("request error should preserve MessageError");
+        match error {
+            rig_core::message::MessageError::ConversionError(message) => message.clone(),
+        }
+    }
 
     #[test]
     fn test_user_text_message_conversion() {
@@ -413,27 +447,74 @@ mod tests {
 
     #[test]
     fn test_user_tool_result_message_conversion() {
-        let tool_result = ToolResult {
-            id: "add".to_string(),
-            call_id: None,
-            content: OneOrMany::one(ToolResultContent::Text(Text::new("8".to_string()))),
-        };
-
-        let message = Message::User {
-            content: OneOrMany::one(rig_core::message::UserContent::ToolResult(tool_result)),
-        };
-
-        let rig_message = RigMessage(message);
-        let vertex_content: Result<vertexai::model::Content, _> = rig_message.try_into();
-
-        assert!(vertex_content.is_ok());
-        let content = vertex_content.unwrap();
+        let content =
+            vertex_tool_result(OneOrMany::one(ToolResultContent::text(r#"{"answer":8}"#)))
+                .expect("literal text tool result should convert");
         assert_eq!(content.role.as_str(), "user");
         assert_eq!(content.parts.len(), 1);
 
-        let function_response = content.parts[0].function_response();
-        assert!(function_response.is_some());
-        let function_response = function_response.unwrap();
-        assert_eq!(function_response.name.as_str(), "add");
+        let function_response = function_response(&content);
+        assert_eq!(function_response.name.as_str(), "lookup");
+        assert_eq!(
+            function_response
+                .response
+                .as_ref()
+                .expect("response")
+                .get("output"),
+            Some(&serde_json::json!(r#"{"answer":8}"#))
+        );
+    }
+
+    #[test]
+    fn test_user_tool_result_preserves_native_json_singleton() {
+        let value = serde_json::json!({
+            "answer": 8,
+            "metadata": { "exact": true }
+        });
+        let content = vertex_tool_result(OneOrMany::one(ToolResultContent::json(value.clone())))
+            .expect("structured JSON tool result should convert");
+
+        assert_eq!(
+            function_response(&content)
+                .response
+                .as_ref()
+                .expect("response")
+                .get("output"),
+            Some(&value)
+        );
+    }
+
+    #[test]
+    fn test_user_tool_result_preserves_text_json_order() {
+        let content = vertex_tool_result(
+            OneOrMany::many([
+                ToolResultContent::text("before"),
+                ToolResultContent::json(serde_json::json!({ "step": 2 })),
+                ToolResultContent::text("after"),
+            ])
+            .expect("non-empty tool result"),
+        )
+        .expect("ordered mixed tool result should convert");
+
+        assert_eq!(
+            function_response(&content)
+                .response
+                .as_ref()
+                .expect("response")
+                .get("output"),
+            Some(&serde_json::json!(["before", { "step": 2 }, "after"]))
+        );
+    }
+
+    #[test]
+    fn test_user_tool_result_images_return_conversion_errors() {
+        let error = vertex_tool_result(OneOrMany::one(ToolResultContent::image_base64(
+            "image-data",
+            Some(ImageMediaType::PNG),
+            None,
+        )))
+        .expect_err("Vertex AI tool results cannot represent images");
+
+        assert!(conversion_error_message(error).contains("does not support images"));
     }
 }

--- a/tests/cassettes/gemini/streaming_multimodal_tool_results/streaming_history_preserves_hybrid_tool_result_image_parts.yaml
+++ b/tests/cassettes/gemini/streaming_multimodal_tool_results/streaming_history_preserves_hybrid_tool_result_image_parts.yaml
@@ -17,25 +17,4 @@ then:
   header:
   - name: content-type
     value: text/event-stream
-  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"args\":{},\"id\":\"eydqag09\",\"name\":\"render_reference_image\"},\"thoughtSignature\":\"signature_REDACTED_1\"}],\"role\":\"model\"},\"index\":0}],\"modelVersion\":\"gemini-3-flash-preview\",\"responseId\":\"id_REDACTED_1\",\"usageMetadata\":{\"candidatesTokenCount\":12,\"promptTokenCount\":90,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":90}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":56,\"totalTokenCount\":158}}\r\n\r\ndata: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"\"}],\"role\":\"model\"},\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-3-flash-preview\",\"responseId\":\"id_REDACTED_1\",\"usageMetadata\":{\"candidatesTokenCount\":12,\"promptTokenCount\":90,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":90}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":56,\"totalTokenCount\":158}}\r\n\r\n"
----
-when:
-  path: /v1beta/models/gemini-3-flash-preview:streamGenerateContent
-  method: POST
-  query_param:
-  - name: alt
-    value: sse
-  - name: key
-    value: '[REDACTED]'
-  header:
-  - name: accept
-    value: text/event-stream
-  - name: content-type
-    value: application/json
-  body: '{"contents":[{"parts":[{"text":"Use the tool once, then answer with the dominant color in the returned image.","thought":false}],"role":"user"},{"parts":[{"functionCall":{"args":{},"name":"render_reference_image"},"thought":false,"thoughtSignature":"signature_REDACTED_1"}],"role":"model"},{"parts":[{"functionResponse":{"name":"render_reference_image","parts":[{"inlineData":{"data":"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==","mimeType":"image/png"}}],"response":{"result":{"instruction":"Use the image part to answer the user''s question."}}},"thought":false}],"role":"user"}],"generationConfig":{"maxOutputTokens":4096,"temperature":1.0},"safetySettings":null,"systemInstruction":{"parts":[{"text":"You are a precise assistant. Call `render_reference_image` exactly once before answering. After the tool result arrives, do not call any more tools. Answer in one short sentence.","thought":false}],"role":"model"},"toolConfig":null,"tools":[{"codeExecution":null,"functionDeclarations":[{"description":"Return a reference image the assistant must inspect before answering.","name":"render_reference_image","parameters":{"properties":{},"required":[],"type":"object"}}]}]}'
-then:
-  status: 200
-  header:
-  - name: content-type
-    value: text/event-stream
-  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"The dominant color in the image is red.\"}],\"role\":\"model\"},\"index\":0}],\"modelVersion\":\"gemini-3-flash-preview\",\"responseId\":\"id_REDACTED_2\",\"usageMetadata\":{\"candidatesTokenCount\":9,\"promptTokenCount\":131,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":131}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":14,\"totalTokenCount\":154}}\r\n\r\ndata: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"\",\"thoughtSignature\":\"signature_REDACTED_2\"}],\"role\":\"model\"},\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-3-flash-preview\",\"responseId\":\"id_REDACTED_2\",\"usageMetadata\":{\"candidatesTokenCount\":9,\"promptTokenCount\":1276,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":187},{\"modality\":\"IMAGE\",\"tokenCount\":1089}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":14,\"totalTokenCount\":1299}}\r\n\r\n"
+  body: "data: {\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{\"args\":{},\"id\":\"4briv2fb\",\"name\":\"render_reference_image\"},\"thoughtSignature\":\"signature_REDACTED_1\"}],\"role\":\"model\"},\"index\":0}],\"modelVersion\":\"gemini-3-flash-preview\",\"responseId\":\"id_REDACTED_1\",\"usageMetadata\":{\"candidatesTokenCount\":12,\"promptTokenCount\":90,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":90}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":58,\"totalTokenCount\":160}}\r\n\r\ndata: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"\"}],\"role\":\"model\"},\"finishReason\":\"STOP\",\"index\":0}],\"modelVersion\":\"gemini-3-flash-preview\",\"responseId\":\"id_REDACTED_1\",\"usageMetadata\":{\"candidatesTokenCount\":12,\"promptTokenCount\":90,\"promptTokensDetails\":[{\"modality\":\"TEXT\",\"tokenCount\":90}],\"serviceTier\":\"standard\",\"thoughtsTokenCount\":58,\"totalTokenCount\":160}}\r\n\r\n"

--- a/tests/providers/gemini/cassette/streaming_multimodal_tool_results.rs
+++ b/tests/providers/gemini/cassette/streaming_multimodal_tool_results.rs
@@ -1,20 +1,16 @@
-//! Gemini streaming regression for multimodal tool results in chat history.
+//! Gemini streaming regressions for multimodal tool results in chat history.
 
 use futures::StreamExt;
 use rig::agent::MultiTurnStreamItem;
 use rig::client::CompletionClient;
-use rig::message::{
-    AssistantContent, DocumentSourceKind, ImageMediaType, Message, ToolResultContent, UserContent,
-};
+use rig::message::{DocumentSourceKind, ImageMediaType, Message, ToolResultContent};
 use rig::providers::gemini;
 use rig::providers::gemini::completion::gemini_api_types::{
     AdditionalParameters, GenerationConfig,
 };
-use rig::streaming::StreamingPrompt;
+use rig::streaming::{StreamedUserContent, StreamingPrompt};
 use rig::tool::Tool;
 use serde_json::json;
-
-use crate::support::assert_nonempty_response;
 
 const RED_PIXEL_PNG_BASE64: &str = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==";
 const MULTIMODAL_FUNCTION_RESPONSE_MODEL: &str = gemini::completion::GEMINI_3_FLASH_PREVIEW;
@@ -67,7 +63,7 @@ impl Tool for HybridImageTool {
 }
 
 #[tokio::test]
-async fn streaming_history_preserves_hybrid_tool_result_image_parts() {
+async fn streaming_history_rejects_lossy_hybrid_tool_result_conversion() {
     super::super::support::with_gemini_cassette("streaming_multimodal_tool_results/streaming_history_preserves_hybrid_tool_result_image_parts", |client| async move {
     let agent = client
         .agent(MULTIMODAL_FUNCTION_RESPONSE_MODEL)
@@ -89,49 +85,30 @@ async fn streaming_history_preserves_hybrid_tool_result_image_parts() {
         .max_turns(4)
         .await;
 
-    let mut final_response = None;
-    let mut final_history = None;
+    let mut streamed_tool_result = None;
+    let mut conversion_error = None;
 
     while let Some(item) = stream.next().await {
-        match item.expect("streaming prompt should succeed") {
-            MultiTurnStreamItem::FinalResponse(response) => {
-                final_response = Some(response.output().to_owned());
-                final_history = response.messages().map(|history| history.to_vec());
+        match item {
+            Ok(MultiTurnStreamItem::StreamUserItem(StreamedUserContent::ToolResult {
+                tool_result,
+                ..
+            })) => streamed_tool_result = Some(tool_result),
+            Ok(_) => {}
+            Err(error) => {
+                conversion_error = Some(error);
                 break;
             }
-            MultiTurnStreamItem::StreamAssistantItem(_)
-            | MultiTurnStreamItem::StreamUserItem(_) => {}
-            _ => {}
         }
     }
 
-    let final_response = final_response.expect("stream should yield a final response");
-    assert_nonempty_response(&final_response);
-
-    let history = final_history.expect("final response should include updated history");
+    let error = conversion_error.expect("mixed tool-result conversion should stop the stream");
     assert!(
-        history.iter().any(|message| matches!(
-            message,
-            Message::Assistant { content, .. }
-                if content.iter().any(|item| matches!(
-                    item,
-                    AssistantContent::ToolCall(tool_call)
-                        if tool_call.function.name == HybridImageTool::NAME
-                ))
-        )),
-        "history should retain the assistant tool call: {history:#?}"
+        error.to_string().contains("cannot preserve the order"),
+        "unexpected conversion error: {error:?}"
     );
 
-    let tool_result = history
-        .iter()
-        .find_map(|message| match message {
-            Message::User { content } => content.iter().find_map(|item| match item {
-                UserContent::ToolResult(tool_result) => Some(tool_result),
-                _ => None,
-            }),
-            _ => None,
-        })
-        .expect("history should retain the tool result user message");
+    let tool_result = streamed_tool_result.expect("the executed tool result should be streamed");
 
     assert_eq!(
         tool_result.content.len(),
@@ -162,6 +139,9 @@ async fn streaming_history_preserves_hybrid_tool_result_image_parts() {
                     matches!(image.data, DocumentSourceKind::Base64(ref data) if data == RED_PIXEL_PNG_BASE64),
                     "tool result image should preserve the base64 image payload: {image:?}"
                 );
+            }
+            ToolResultContent::Json { value } => {
+                panic!("hybrid image fixture unexpectedly produced JSON content: {value}")
             }
         }
     }


### PR DESCRIPTION
## What

- Add `ToolResultContent::Json { value: serde_json::Value }` and `ToolResultContent::json` with serde, documentation, and message-layer regression coverage for every JSON shape.
- Keep JSON-looking `Text` literal, preserve explicit JSON until the provider boundary, and retain ordered typed content wherever the wire format can represent it.
- Use native structured result fields for Bedrock, Gemini, Gemini gRPC, and Vertex AI; deliberately compact-serialize JSON only for string-only protocols.
- Return `MessageError::ConversionError` when conversion would lose semantics, including unsupported Gemini Interactions JSON shapes and generateContent mixed image/non-image results.
- Update OpenAI Responses native image blocks, all other provider adapters, companion crates, memory accounting, changelogs, and a targeted Gemini cassette.

## Why

Structured tool outputs previously crossed Rig as strings, so provider adapters could not reliably distinguish literal JSON-looking text from explicit JSON and sometimes guessed intent by reparsing text. The new transcript variant makes that intent stable and keeps unsupported conversions explicit.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p rig-core --all-features --lib` (1,305 passed, 8 ignored)
- `cargo test -p rig-bedrock -p rig-memory -p rig-gemini-grpc -p rig-vertexai --lib` (228 passed)
- Targeted Gemini cassette recorded against the live API, then replayed successfully
- Gemini cassette safety checks (2 passed)

Fixes #2137
