### PR TITLE
fix(openai): Accept also null values for strict for tool calls

### DIFF
--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -641,7 +641,11 @@ pub struct ResponsesToolDefinition {
     pub parameters: serde_json::Value,
     /// Whether to use strict mode. Disabled by default; opt in with [`Self::with_strict`]
     /// or [`GenericResponsesCompletionModel::with_strict_tools`].
-    #[serde(default, skip_serializing_if = "is_false", deserialize_with = "null_to_false")]
+    #[serde(
+        default,
+        skip_serializing_if = "is_false",
+        deserialize_with = "null_to_false"
+    )]
     pub strict: bool,
     /// Tool description.
     #[serde(default, skip_serializing_if = "String::is_empty")]

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -641,7 +641,7 @@ pub struct ResponsesToolDefinition {
     pub parameters: serde_json::Value,
     /// Whether to use strict mode. Disabled by default; opt in with [`Self::with_strict`]
     /// or [`GenericResponsesCompletionModel::with_strict_tools`].
-    #[serde(default, skip_serializing_if = "is_false")]
+    #[serde(default, skip_serializing_if = "is_false", deserialize_with = "null_to_false")]
     pub strict: bool,
     /// Tool description.
     #[serde(default, skip_serializing_if = "String::is_empty")]
@@ -657,6 +657,15 @@ fn is_json_null(value: &Value) -> bool {
 
 fn is_false(value: &bool) -> bool {
     !value
+}
+
+fn null_to_false<'a, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: Deserializer<'a>,
+{
+    // First deserialize as Option<bool>, then map None -> false
+    let opt = Option::<bool>::deserialize(deserializer)?;
+    Ok(opt.unwrap_or(false))
 }
 
 impl ResponsesToolDefinition {


### PR DESCRIPTION
The OpenAI API allows the field strict for tool calls to be set to true, false or null. False is the default. Currently, rig only accepts true and false, but not null. This PR makes rig accept null as well and maps it to false.