### PR TITLE
fix(openai): omit filename for URL-backed PDFs in Responses API requests

### DIFF
--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -487,11 +487,13 @@ impl TryFrom<crate::completion::Message> for Vec<InputItem> {
                             media_type: Some(DocumentMediaType::PDF),
                             ..
                         }) => {
-                            let (file_data, file_url) = match data {
-                                DocumentSourceKind::Base64(data) => {
-                                    (Some(format!("data:application/pdf;base64,{data}")), None)
-                                }
-                                DocumentSourceKind::Url(url) => (None, Some(url)),
+                            let (file_data, file_url, filename) = match data {
+                                DocumentSourceKind::Base64(data) => (
+                                    Some(format!("data:application/pdf;base64,{data}")),
+                                    None,
+                                    Some("document.pdf".to_string()),
+                                ),
+                                DocumentSourceKind::Url(url) => (None, Some(url), None),
                                 DocumentSourceKind::Raw(_) => {
                                     return Err(CompletionError::RequestError(
                                         "Raw file data not supported, encode as base64 first"
@@ -512,7 +514,7 @@ impl TryFrom<crate::completion::Message> for Vec<InputItem> {
                                         file_id: None,
                                         file_data,
                                         file_url,
-                                        filename: Some("document.pdf".to_string()),
+                                        filename,
                                     }),
                                     name: None,
                                 }),
@@ -4874,5 +4876,143 @@ mod tests {
                 serde_json::from_value(item.clone()).expect("should decode to Unknown");
             assert_eq!(output, Output::Unknown(item));
         }
+    }
+
+    // Regression tests for issue #1429: `file_url` and `filename` are mutually
+    // exclusive on OpenAI's Responses API (400 `mutually_exclusive_parameters`),
+    // so URL-backed PDFs must not carry the hardcoded `filename`. PR #1432
+    // fixed the `TryFrom<message::Message> for Vec<Message>` conversion; these
+    // tests also cover the `TryFrom<crate::completion::Message> for
+    // Vec<InputItem>` path that `CompletionModel::completion()` requests
+    // actually go through.
+    //
+    // See <https://platform.openai.com/docs/guides/pdf-files> for the
+    // `input_file` content part and its `file_url` / `file_data` / `file_id`
+    // input variants.
+
+    const PDF_URL: &str = "https://example.com/resume.pdf";
+
+    fn url_pdf_message() -> message::Message {
+        message::Message::User {
+            content: OneOrMany::one(message::UserContent::document_url(
+                PDF_URL,
+                Some(message::DocumentMediaType::PDF),
+            )),
+        }
+    }
+
+    /// Recursively collect every JSON object with `"type": "input_file"`.
+    fn find_input_files(value: &serde_json::Value, out: &mut Vec<serde_json::Value>) {
+        match value {
+            serde_json::Value::Object(map) => {
+                if map.get("type").and_then(|t| t.as_str()) == Some("input_file") {
+                    out.push(value.clone());
+                }
+                map.values().for_each(|v| find_input_files(v, out));
+            }
+            serde_json::Value::Array(items) => {
+                items.iter().for_each(|v| find_input_files(v, out));
+            }
+            _ => {}
+        }
+    }
+
+    fn sole_input_file(value: &serde_json::Value) -> serde_json::Value {
+        let mut found = Vec::new();
+        find_input_files(value, &mut found);
+        assert_eq!(
+            found.len(),
+            1,
+            "expected exactly one input_file item in {value:#}"
+        );
+        found.pop().unwrap()
+    }
+
+    fn assert_url_only_input_file(input_file: &serde_json::Value) {
+        assert_eq!(
+            input_file.get("file_url").and_then(|v| v.as_str()),
+            Some(PDF_URL),
+            "URL PDF should carry file_url: {input_file:#}"
+        );
+        assert_eq!(
+            input_file.get("filename"),
+            None,
+            "filename must be absent for URL PDFs (issue #1429): {input_file:#}"
+        );
+        assert_eq!(
+            input_file.get("file_data"),
+            None,
+            "file_data must be absent for URL PDFs: {input_file:#}"
+        );
+    }
+
+    #[test]
+    fn url_pdf_via_input_item_path_omits_filename() {
+        let items = Vec::<InputItem>::try_from(url_pdf_message())
+            .expect("URL PDF should convert to input items");
+        let json = serde_json::to_value(&items).expect("input items should serialize");
+        assert_url_only_input_file(&sole_input_file(&json));
+    }
+
+    #[test]
+    fn url_pdf_in_full_completion_request_omits_filename() {
+        let core_request = crate::completion::CompletionRequest {
+            model: None,
+            preamble: None,
+            chat_history: OneOrMany::one(url_pdf_message()),
+            documents: Vec::new(),
+            tools: Vec::new(),
+            temperature: None,
+            max_tokens: None,
+            tool_choice: None,
+            additional_params: None,
+            output_schema: None,
+            record_telemetry_content: false,
+        };
+
+        let request = CompletionRequest::try_from(("gpt-4o".to_string(), core_request))
+            .expect("request should convert");
+        let json = serde_json::to_value(&request).expect("request should serialize");
+        assert_url_only_input_file(&sole_input_file(&json));
+    }
+
+    #[test]
+    fn url_pdf_via_vec_message_path_omits_filename() {
+        let messages = Vec::<Message>::try_from(url_pdf_message())
+            .expect("URL PDF should convert to messages");
+        let json = serde_json::to_value(&messages).expect("messages should serialize");
+        assert_url_only_input_file(&sole_input_file(&json));
+    }
+
+    #[test]
+    fn base64_pdf_via_input_item_path_keeps_filename() {
+        let input = message::Message::User {
+            content: OneOrMany::one(message::UserContent::Document(message::Document {
+                data: DocumentSourceKind::base64("dGVzdA=="),
+                media_type: Some(message::DocumentMediaType::PDF),
+                additional_params: None,
+            })),
+        };
+
+        let items =
+            Vec::<InputItem>::try_from(input).expect("base64 PDF should convert to input items");
+        let json = serde_json::to_value(&items).expect("input items should serialize");
+        let input_file = sole_input_file(&json);
+
+        assert_eq!(
+            input_file.get("file_data").and_then(|v| v.as_str()),
+            Some("data:application/pdf;base64,dGVzdA=="),
+            "base64 PDF should carry file_data: {input_file:#}"
+        );
+        assert_eq!(
+            input_file.get("filename").and_then(|v| v.as_str()),
+            Some("document.pdf"),
+            "base64 PDF should keep the default filename: {input_file:#}"
+        );
+        assert_eq!(
+            input_file.get("file_url"),
+            None,
+            "base64 PDF should not carry file_url: {input_file:#}"
+        );
     }
 }

--- a/tests/cassettes/openai/url_pdf_document/url_pdf_document_prompt.yaml
+++ b/tests/cassettes/openai/url_pdf_document/url_pdf_document_prompt.yaml
@@ -1,0 +1,16 @@
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"input":[{"content":[{"file_url":"https://bitcoin.org/bitcoin.pdf","type":"input_file"}],"role":"user","type":"message"},{"content":[{"text":"What is the title of this paper? Answer in one short sentence.","type":"input_text"}],"role":"user","type":"message"}],"instructions":"You are a helpful assistant that analyzes documents.","model":"gpt-4o","temperature":0.0}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"background":false,"billing":{"payer":"developer"},"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"You are a helpful assistant that analyzes documents.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-4o-2024-08-06","moderation":null,"object":"response","output":[{"content":[{"annotations":[],"logprobs":[],"text":"The title of the paper is \"Bitcoin: A Peer-to-Peer Electronic Cash System.\"","type":"output_text"}],"id":"msg_REDACTED_1","role":"assistant","status":"completed","type":"message"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","status":"completed","store":true,"temperature":0.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":6454,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":19,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":6473},"user":null}'

--- a/tests/providers/openai/cassette/url_pdf_document.rs
+++ b/tests/providers/openai/cassette/url_pdf_document.rs
@@ -1,0 +1,49 @@
+//! Cassette-backed OpenAI Responses coverage for URL-backed PDF documents.
+//!
+//! Regression coverage for sending a `DocumentSourceKind::Url` PDF through
+//! `CompletionModel::completion()`: the request must carry `file_url` without
+//! the hardcoded `filename`, which the Responses API rejects alongside a URL
+//! with 400 `mutually_exclusive_parameters`.
+//! See <https://platform.openai.com/docs/guides/pdf-files>.
+
+use rig::OneOrMany;
+use rig::client::AgentClientExt;
+use rig::completion::Prompt;
+use rig::message::{DocumentMediaType, Message, UserContent};
+use rig::providers::openai;
+
+use super::super::support::with_openai_cassette;
+use crate::support::{assert_contains_any_case_insensitive, assert_nonempty_response};
+
+const PDF_URL: &str = "https://bitcoin.org/bitcoin.pdf";
+
+#[tokio::test]
+async fn url_pdf_document_prompt() {
+    with_openai_cassette(
+        "url_pdf_document/url_pdf_document_prompt",
+        |client| async move {
+            let agent = client
+                .agent(openai::GPT_4O)
+                .preamble("You are a helpful assistant that analyzes documents.")
+                .temperature(0.0)
+                .build();
+
+            let response = agent
+                .prompt(Message::User {
+                    content: OneOrMany::many(vec![
+                        UserContent::document_url(PDF_URL, Some(DocumentMediaType::PDF)),
+                        UserContent::text(
+                            "What is the title of this paper? Answer in one short sentence.",
+                        ),
+                    ])
+                    .expect("content should be non-empty"),
+                })
+                .await
+                .expect("URL PDF document prompt should succeed");
+
+            assert_nonempty_response(&response);
+            assert_contains_any_case_insensitive(&response, &["bitcoin"]);
+        },
+    )
+    .await;
+}

--- a/tests/providers/openai/mod.rs
+++ b/tests/providers/openai/mod.rs
@@ -28,6 +28,7 @@ mod cassette {
     mod streaming_tools;
     mod structured_output;
     mod typed_prompt_tools;
+    mod url_pdf_document;
     mod vllm;
 }
 


### PR DESCRIPTION
Fixes #2164

## Problem

Two conversions in `responses_api/mod.rs` produce `input_file` content parts. #1432 (closing #1429) fixed `TryFrom<message::Message> for Vec<Message>`, but requests built by `CompletionModel::completion()` go through `TryFrom<crate::completion::Message> for Vec<InputItem>`, whose PDF arm still set `filename: Some("document.pdf")` unconditionally — including alongside `file_url`, which the API rejects with 400 `mutually_exclusive_parameters` ([file inputs docs](https://platform.openai.com/docs/guides/pdf-files)).

## Implementation

`filename` is now produced by the same `match` as `file_data`/`file_url`: `Some("document.pdf")` for base64 documents, `None` for URLs — mirroring what #1432 did in the parallel conversion. No public API changes.

## Testing

- Unit tests pin the serialized `input_file` JSON for URL PDFs on all three paths (`Vec<InputItem>`, the full wire request via `TryFrom<(String, CompletionRequest)>`, and `Vec<Message>`), plus base64 PDFs keeping their filename.
- New cassette test `url_pdf_document_prompt` **recorded** against the live API (recording fails with the 400 before this fix); full OpenAI cassette suite replays green.
- `cargo clippy --all-features --all-targets` and `cargo fmt -- --check` clean.

Related: #1429, #1432
