### PR TITLE
Remove hardcoded dynamic context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- *(agent)* [**breaking**] Remove the hardcoded `AgentBuilder::dynamic_context` and `ExtractorBuilder::dynamic_context` passive-RAG pipeline. Static context remains configured on the builder; per-turn retrieval is now an application policy implemented with a completion-call hook. Vector-store traits, retrieval-backed tools, and vector indexes exposed as active tools are unchanged.
+
+  Migration example:
+
+  ```rust
+  // Before: Rig chose the query, queried the index on every model turn, and
+  // inserted the results through hidden Agent state.
+  let agent = client
+      .agent(model)
+      .dynamic_context(3, index)
+      .build();
+
+  // After: the application owns query selection, retrieval, serialization,
+  // failure policy, and turn policy in an ordinary hook.
+  impl<M: CompletionModel> AgentHook<M> for MyRetrievalHook {
+      async fn on_completion_call(
+          &self,
+          _ctx: &HookContext,
+          event: CompletionCallEvent<'_>,
+      ) -> CompletionCallAction {
+          let documents = match self.retrieve(event.prompt, event.history).await {
+              Ok(documents) => documents,
+              Err(error) => return CompletionCallAction::stop(error.to_string()),
+          };
+          CompletionCallAction::patch(
+              RequestPatch::new().extra_context(documents)
+          )
+      }
+  }
+
+  let agent = client
+      .agent(model)
+      .add_hook(MyRetrievalHook::new(index, 3))
+      .build();
+  ```
+
+  This is not a Rig-provided `MyRetrievalHook`: applications define it for their own vector store and retrieval policy. Passive RAG uses `RequestPatch::extra_context`; active RAG exposes a vector index or custom retriever as a tool. Extractors run through `AgentRunner`, so the same application-defined hooks can be registered with `ExtractorBuilder::add_hook`.
+
 - *(agent)* [**breaking**] Make `AgentRunner` the only execution path for configured agents: remove the raw `Completion` and `StreamingCompletion` traits and their `Agent` implementations, make agent execution state private, add runner-backed per-request overrides, and route `Extractor` through the full hook lifecycle. Raw hook-free requests remain available explicitly through `CompletionModel`.
   - For managed agent execution, replace `agent.completion(prompt, history).await?.send().await?` with `agent.runner(prompt).history(history).max_turns(3).run().await?`, choosing a turn budget large enough for tool follow-ups.
   - For managed streaming execution, replace `agent.stream_completion(prompt, history).await?.stream().await?` with `agent.runner(prompt).history(history).max_turns(3).stream().await`.

--- a/crates/rig-bedrock/examples/rag_with_bedrock.rs
+++ b/crates/rig-bedrock/examples/rag_with_bedrock.rs
@@ -4,9 +4,15 @@ use rig_bedrock::client::Client;
 use rig_bedrock::completion::AMAZON_NOVA_LITE;
 use rig_bedrock::embedding::AMAZON_TITAN_EMBED_TEXT_V2_0;
 use rig_core::client::{CompletionClient, EmbeddingsClient, ProviderClient};
+use rig_core::message::UserContent;
 use rig_core::{
-    Embed, completion::Prompt, embeddings::EmbeddingsBuilder,
-    vector_store::in_memory_store::InMemoryVectorStore,
+    Embed,
+    agent::{AgentHook, CompletionCallAction, CompletionCallEvent, HookContext, RequestPatch},
+    completion::{CompletionModel, Document, Message, Prompt},
+    embeddings::EmbeddingsBuilder,
+    vector_store::{
+        VectorStoreIndexDyn, in_memory_store::InMemoryVectorStore, request::VectorSearchRequest,
+    },
 };
 use serde::Serialize;
 use tracing::info;
@@ -20,6 +26,56 @@ struct WordDefinition {
     word: String,
     #[embed]
     definitions: Vec<String>,
+}
+
+struct RetrieveContext<I> {
+    index: I,
+}
+
+fn message_text(message: &Message) -> Option<String> {
+    let Message::User { content } = message else {
+        return None;
+    };
+    content.iter().find_map(|part| match part {
+        UserContent::Text(text) => Some(text.text.clone()),
+        _ => None,
+    })
+}
+
+impl<M, I> AgentHook<M> for RetrieveContext<I>
+where
+    M: CompletionModel,
+    I: VectorStoreIndexDyn,
+{
+    async fn on_completion_call(
+        &self,
+        _ctx: &HookContext,
+        event: CompletionCallEvent<'_>,
+    ) -> CompletionCallAction {
+        let query = message_text(event.prompt)
+            .or_else(|| event.history.iter().rev().find_map(message_text));
+        let Some(query) = query else {
+            return CompletionCallAction::continue_run();
+        };
+
+        let request = VectorSearchRequest::builder()
+            .query(query)
+            .samples(1)
+            .build();
+        match VectorStoreIndexDyn::top_n(&self.index, request).await {
+            Ok(results) => {
+                let documents = results.into_iter().map(|(_, id, value)| Document {
+                    id,
+                    text: value.to_string(),
+                    additional_props: Default::default(),
+                });
+                CompletionCallAction::patch(RequestPatch::new().extra_context(documents))
+            }
+            Err(error) => CompletionCallAction::stop(format!(
+                "failed to retrieve context before model request: {error}"
+            )),
+        }
+    }
 }
 
 #[tokio::main]
@@ -74,7 +130,7 @@ async fn main() -> Result<(), anyhow::Error> {
             You are a dictionary assistant here to assist the user in understanding the meaning of words.
             You will find additional non-standard word definitions that could be useful below.
         ")
-        .dynamic_context(1, index)
+        .add_hook(RetrieveContext { index })
         .build();
 
     // Prompt the agent and print the response

--- a/crates/rig-core/CHANGELOG.md
+++ b/crates/rig-core/CHANGELOG.md
@@ -9,6 +9,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- *(agent)* [**breaking**] Remove the hardcoded `AgentBuilder::dynamic_context` and `ExtractorBuilder::dynamic_context` passive-RAG pipeline. Static context remains configured on the builder; per-turn retrieval is now an application policy implemented with a completion-call hook. Vector-store traits, retrieval-backed tools, and vector indexes exposed as active tools are unchanged.
+
+  Migration example:
+
+  ```rust
+  // Before: Rig chose the query, queried the index on every model turn, and
+  // inserted the results through hidden Agent state.
+  let agent = client
+      .agent(model)
+      .dynamic_context(3, index)
+      .build();
+
+  // After: the application owns query selection, retrieval, serialization,
+  // failure policy, and turn policy in an ordinary hook.
+  impl<M: CompletionModel> AgentHook<M> for MyRetrievalHook {
+      async fn on_completion_call(
+          &self,
+          _ctx: &HookContext,
+          event: CompletionCallEvent<'_>,
+      ) -> CompletionCallAction {
+          let documents = match self.retrieve(event.prompt, event.history).await {
+              Ok(documents) => documents,
+              Err(error) => return CompletionCallAction::stop(error.to_string()),
+          };
+          CompletionCallAction::patch(
+              RequestPatch::new().extra_context(documents)
+          )
+      }
+  }
+
+  let agent = client
+      .agent(model)
+      .add_hook(MyRetrievalHook::new(index, 3))
+      .build();
+  ```
+
+  This is not a Rig-provided `MyRetrievalHook`: applications define it for their own vector store and retrieval policy. Passive RAG uses `RequestPatch::extra_context`; active RAG exposes a vector index or custom retriever as a tool. Extractors run through `AgentRunner`, so the same application-defined hooks can be registered with `ExtractorBuilder::add_hook`.
+
 - *(agent)* [**breaking**] Make `AgentRunner` the only execution path for configured agents: remove the raw `Completion` and `StreamingCompletion` traits and their `Agent` implementations, make agent execution state private, add runner-backed per-request overrides, and route `Extractor` through the full hook lifecycle. Raw hook-free requests remain available explicitly through `CompletionModel`.
 
   Migration examples:

--- a/crates/rig-core/src/agent/builder.rs
+++ b/crates/rig-core/src/agent/builder.rs
@@ -114,8 +114,6 @@ where
     record_telemetry_content: bool,
     /// Maximum number of tokens for the completion
     max_tokens: Option<u64>,
-    /// List of vector store, with the sample number
-    dynamic_context: Vec<(usize, Arc<dyn VectorStoreIndexDyn + Send + Sync>)>,
     /// Temperature of the model
     temperature: Option<f64>,
     /// Whether or not the underlying LLM should be forced to use a tool before providing a response.
@@ -177,18 +175,6 @@ where
             text: doc.into(),
             additional_props: HashMap::new(),
         });
-        self
-    }
-
-    /// Add some dynamic context to the agent. On each prompt, `sample` documents from the
-    /// dynamic context will be inserted in the request.
-    pub fn dynamic_context(
-        mut self,
-        sample: usize,
-        dynamic_context: impl VectorStoreIndexDyn + Send + Sync + 'static,
-    ) -> Self {
-        self.dynamic_context
-            .push((sample, Arc::new(dynamic_context)));
         self
     }
 
@@ -318,7 +304,6 @@ where
             max_tokens: None,
             additional_params: None,
             record_telemetry_content: false,
-            dynamic_context: vec![],
             tool_choice: None,
             default_max_turns: None,
             tool_state: NoToolConfig,
@@ -353,7 +338,6 @@ where
             additional_params: self.additional_params,
             record_telemetry_content: self.record_telemetry_content,
             max_tokens: self.max_tokens,
-            dynamic_context: self.dynamic_context,
             temperature: self.temperature,
             tool_choice: self.tool_choice,
             default_max_turns: self.default_max_turns,
@@ -385,7 +369,6 @@ where
             additional_params: self.additional_params,
             record_telemetry_content: self.record_telemetry_content,
             max_tokens: self.max_tokens,
-            dynamic_context: self.dynamic_context,
             temperature: self.temperature,
             tool_choice: self.tool_choice,
             default_max_turns: self.default_max_turns,
@@ -422,7 +405,6 @@ where
             additional_params: self.additional_params,
             record_telemetry_content: self.record_telemetry_content,
             max_tokens: self.max_tokens,
-            dynamic_context: self.dynamic_context,
             temperature: self.temperature,
             tool_choice: self.tool_choice,
             default_max_turns: self.default_max_turns,
@@ -521,7 +503,6 @@ where
             additional_params: self.additional_params,
             record_telemetry_content: self.record_telemetry_content,
             max_tokens: self.max_tokens,
-            dynamic_context: self.dynamic_context,
             temperature: self.temperature,
             tool_choice: self.tool_choice,
             default_max_turns: self.default_max_turns,
@@ -563,7 +544,6 @@ where
             additional_params: self.additional_params,
             record_telemetry_content: self.record_telemetry_content,
             max_tokens: self.max_tokens,
-            dynamic_context: self.dynamic_context,
             temperature: self.temperature,
             tool_choice: self.tool_choice,
             default_max_turns: self.default_max_turns,
@@ -596,7 +576,6 @@ where
             additional_params: self.additional_params,
             record_telemetry_content: self.record_telemetry_content,
             tool_choice: self.tool_choice,
-            dynamic_context: Arc::new(self.dynamic_context),
             tool_server_handle,
             default_max_turns: self.default_max_turns,
             hooks: self.hooks,
@@ -625,7 +604,6 @@ where
             additional_params: self.additional_params,
             record_telemetry_content: self.record_telemetry_content,
             tool_choice: self.tool_choice,
-            dynamic_context: Arc::new(self.dynamic_context),
             tool_server_handle: self.tool_state.handle,
             default_max_turns: self.default_max_turns,
             hooks: self.hooks,
@@ -739,7 +717,6 @@ where
             additional_params: self.additional_params,
             record_telemetry_content: self.record_telemetry_content,
             tool_choice: self.tool_choice,
-            dynamic_context: Arc::new(self.dynamic_context),
             tool_server_handle,
             default_max_turns: self.default_max_turns,
             hooks: self.hooks,

--- a/crates/rig-core/src/agent/completion.rs
+++ b/crates/rig-core/src/agent/completion.rs
@@ -12,22 +12,11 @@ use crate::{
     message::ToolChoice,
     streaming::{StreamingChat, StreamingPrompt},
     tool::server::{ToolRegistrySnapshot, ToolServerError, ToolServerHandle},
-    vector_store::{VectorStoreError, request::VectorSearchRequest},
     wasm_compat::WasmCompatSend,
 };
-use std::{
-    collections::{BTreeSet, HashMap},
-    sync::Arc,
-};
+use std::{collections::BTreeSet, sync::Arc};
 
 use super::UNKNOWN_AGENT_NAME;
-
-pub type DynamicContextStore = Arc<
-    Vec<(
-        usize,
-        Arc<dyn crate::vector_store::VectorStoreIndexDyn + Send + Sync>,
-    )>,
->;
 
 /// A prepared completion request plus the executable Rig tool names advertised
 /// to the provider for this turn.
@@ -239,7 +228,6 @@ pub(crate) async fn build_prepared_completion_request<M: CompletionModel>(
     record_telemetry_content: bool,
     tool_choice: Option<&ToolChoice>,
     tool_server_handle: &ToolServerHandle,
-    dynamic_context: &DynamicContextStore,
     output_schema: Option<&schemars::Schema>,
     output_mode: &OutputMode,
     committed_output_tool: Option<&str>,
@@ -286,71 +274,13 @@ pub(crate) async fn build_prepared_completion_request<M: CompletionModel>(
             .find_map(|message| message.rag_text())
     });
 
-    // Fetch dynamic (RAG) documents and the real executable tool set first, so we
-    // can resolve the output mode (which depends on whether tools exist) before
-    // building the preamble and request.
-    let (mut tool_snapshot, fetched_context): (ToolRegistrySnapshot, Vec<Document>) =
-        match &rag_text {
-            Some(text) => {
-                let search_futures = dynamic_context.iter().map(|(num_sample, index)| {
-                    let text = text.clone();
-                    let num_sample = *num_sample;
-                    let index = index.clone();
-
-                    async move {
-                        let req = VectorSearchRequest::builder()
-                            .query(text)
-                            .samples(num_sample as u64)
-                            .build();
-
-                        let docs = index
-                            .top_n(req)
-                            .await?
-                            .into_iter()
-                            .map(|(_, id, doc)| {
-                                let text = serde_json::to_string_pretty(&doc)
-                                    .unwrap_or_else(|_| doc.to_string());
-
-                                Document {
-                                    id,
-                                    text,
-                                    additional_props: HashMap::new(),
-                                }
-                            })
-                            .collect::<Vec<_>>();
-
-                        Ok::<_, VectorStoreError>(docs)
-                    }
-                });
-
-                let fetched_context: Vec<Document> = futures::future::try_join_all(search_futures)
-                    .await
-                    .map_err(|e| CompletionError::RequestError(Box::new(e)))?
-                    .into_iter()
-                    .flatten()
-                    .collect();
-
-                let tool_snapshot = tool_server_handle
-                    .snapshot_tool_defs(Some(text.to_string()))
-                    .await
-                    .map_err(|_| {
-                        CompletionError::RequestError("Failed to get tool definitions".into())
-                    })?;
-
-                (tool_snapshot, fetched_context)
-            }
-            None => {
-                let tool_snapshot =
-                    tool_server_handle
-                        .snapshot_tool_defs(None)
-                        .await
-                        .map_err(|_| {
-                            CompletionError::RequestError("Failed to get tool definitions".into())
-                        })?;
-
-                (tool_snapshot, Vec::new())
-            }
-        };
+    // Dynamic tools still use the current prompt to select definitions. Passive
+    // retrieval belongs in application-defined `CompletionCall` hooks, which
+    // inject per-turn documents through `RequestPatch::extra_context`.
+    let mut tool_snapshot = tool_server_handle
+        .snapshot_tool_defs(rag_text)
+        .await
+        .map_err(|_| CompletionError::RequestError("Failed to get tool definitions".into()))?;
 
     // When a per-turn `active_tools` allow-list is present, capture the full tool
     // set BEFORE filtering: the synthetic output-tool name must avoid colliding
@@ -550,13 +480,8 @@ pub(crate) async fn build_prepared_completion_request<M: CompletionModel>(
         .documents(static_context.to_vec())
         .tools(tooldefs);
 
-    if !fetched_context.is_empty() {
-        completion_request = completion_request.documents(fetched_context);
-    }
-
-    // Hook-supplied extra context documents (passive RAG) are appended last, so
-    // document order is static → dynamic (vector-store) → hook extras, with the
-    // extras in the hooks' registration order (they were merged in that order).
+    // Hook-supplied context documents are appended after static context, with
+    // extras in hook registration order (they were merged in that order).
     // Per-turn and non-sticky: the next turn re-resolves from the baseline.
     if let Some(patch) = request_patch
         && !patch.extra_context.is_empty()
@@ -658,8 +583,6 @@ where
     /// backend storage and query costs.
     pub(crate) record_telemetry_content: bool,
     pub(crate) tool_server_handle: ToolServerHandle,
-    /// List of vector store, with the sample number
-    pub(crate) dynamic_context: DynamicContextStore,
     /// Whether or not the underlying LLM should be forced to use a tool before providing a response.
     pub(crate) tool_choice: Option<ToolChoice>,
     /// Default total model-call budget, including the initial call and every

--- a/crates/rig-core/src/agent/mod.rs
+++ b/crates/rig-core/src/agent/mod.rs
@@ -1,12 +1,13 @@
 //! This module contains the implementation of the [Agent] struct and its builder.
 //!
 //! The [Agent] struct represents an LLM agent, which combines an LLM model with a preamble (system prompt),
-//! a set of context documents, and a set of tools. Note: both context documents and tools can be either
-//! static (i.e.: they are always provided) or dynamic (i.e.: they are RAGged at prompt-time).
+//! a set of static context documents, and a set of tools. Applications can add
+//! per-turn context with a completion-call hook, while tools can be selected by
+//! retrieval at prompt time.
 //!
 //! The [Agent] struct is highly configurable, allowing the user to define anything from
-//! a simple bot with a specific system prompt to a complex RAG system with a set of dynamic
-//! context documents and tools.
+//! a simple bot with a specific system prompt to a complex RAG system with
+//! application-defined retrieval policy.
 //!
 //! The [Agent] struct implements the runner-backed [crate::completion::Prompt],
 //! [crate::completion::TypedPrompt], and [crate::completion::Chat] traits. All
@@ -49,15 +50,64 @@
 //! # }
 //! ```
 //!
-//! RAG Agent example
+//! # Retrieval-augmented generation
+//!
+//! Passive RAG is an application-defined [`AgentHook`] that retrieves context
+//! during [`CompletionCallEvent`] and returns a [`RequestPatch`] with
+//! [`RequestPatch::extra_context`]. Active RAG instead exposes a vector index
+//! or custom retriever as a tool so the model chooses whether and when to
+//! search. Rig does not impose query, filtering, reranking, caching, failure,
+//! or per-turn policies for passive retrieval.
+//!
+//! Passive RAG example
 //! ```no_run
 //! use rig_core::{
 //!     client::{CompletionClient, EmbeddingsClient, ProviderClient},
-//!     completion::Prompt,
+//!     agent::{AgentHook, CompletionCallAction, CompletionCallEvent, HookContext, RequestPatch},
+//!     completion::{CompletionModel, Document, Message, Prompt},
 //!     embeddings::EmbeddingsBuilder,
+//!     message::UserContent,
 //!     providers::openai,
-//!     vector_store::in_memory_store::InMemoryVectorStore,
+//!     vector_store::{VectorStoreIndexDyn, in_memory_store::InMemoryVectorStore, request::VectorSearchRequest},
 //! };
+//!
+//! struct RetrieveContext<I>(I);
+//!
+//! fn message_text(message: &Message) -> Option<String> {
+//!     let Message::User { content } = message else { return None };
+//!     content.iter().find_map(|part| match part {
+//!         UserContent::Text(text) => Some(text.text.clone()),
+//!         _ => None,
+//!     })
+//! }
+//!
+//! impl<M, I> AgentHook<M> for RetrieveContext<I>
+//! where
+//!     M: CompletionModel,
+//!     I: VectorStoreIndexDyn,
+//! {
+//!     async fn on_completion_call(
+//!         &self,
+//!         _ctx: &HookContext,
+//!         event: CompletionCallEvent<'_>,
+//!     ) -> CompletionCallAction {
+//!         let Some(query) = message_text(event.prompt) else {
+//!             return CompletionCallAction::continue_run();
+//!         };
+//!         let request = VectorSearchRequest::builder().query(query).samples(1).build();
+//!         match VectorStoreIndexDyn::top_n(&self.0, request).await {
+//!             Ok(results) => {
+//!                 let documents = results.into_iter().map(|(_, id, value)| Document {
+//!                     id,
+//!                     text: value.to_string(),
+//!                     additional_props: Default::default(),
+//!                 });
+//!                 CompletionCallAction::patch(RequestPatch::new().extra_context(documents))
+//!             }
+//!             Err(error) => CompletionCallAction::stop(format!("context retrieval failed: {error}")),
+//!         }
+//!     }
+//! }
 //!
 //! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
 //! // Initialize OpenAI client
@@ -88,7 +138,7 @@
 //!         You are a dictionary assistant here to assist the user in understanding the meaning of words.
 //!         You will find additional non-standard word definitions that could be useful below.
 //!     ")
-//!     .dynamic_context(1, index)
+//!     .add_hook(RetrieveContext(index))
 //!     .build();
 //!
 //! // Prompt the agent and print the response

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -542,7 +542,6 @@ where
                         runner.record_telemetry_content,
                         runner.tool_choice.as_ref(),
                         &runner.tool_server_handle,
-                        &runner.dynamic_context,
                         runner.output_schema.as_ref(),
                         &runner.output_mode,
                         committed_output_tool.as_deref(),

--- a/crates/rig-core/src/agent/runner.rs
+++ b/crates/rig-core/src/agent/runner.rs
@@ -34,7 +34,7 @@ use futures::StreamExt;
 use tracing::{Instrument, info_span, span::Id};
 
 use super::{
-    completion::{Agent, DynamicContextStore, PreparedCompletionRequest},
+    completion::{Agent, PreparedCompletionRequest},
     hook::{
         AgentHook, CompletionCall, CompletionCallAction,
         CompletionResponse as CompletionResponseEvent, HookContext, HookStack,
@@ -193,7 +193,6 @@ where
     pub(crate) tool_server_handle: ToolServerHandle,
     /// Typed context cloned freshly for every tool dispatch.
     pub(crate) tool_context: ToolContext,
-    pub(crate) dynamic_context: DynamicContextStore,
     pub(crate) tool_choice: Option<ToolChoice>,
     pub(crate) output_schema: Option<schemars::Schema>,
     pub(crate) output_mode: OutputMode,
@@ -230,7 +229,6 @@ where
             record_telemetry_content: agent.record_telemetry_content,
             tool_server_handle: agent.tool_server_handle.clone(),
             tool_context: ToolContext::new(),
-            dynamic_context: agent.dynamic_context.clone(),
             tool_choice: agent.tool_choice.clone(),
             output_schema: agent.output_schema.clone(),
             output_mode: agent.output_mode.clone(),
@@ -6364,11 +6362,70 @@ mod migrated_tests {
         }
     }
 
+    /// Models an application retrieval policy that fails before it can produce
+    /// context. The hook owns that failure policy and stops the run explicitly.
+    struct FailingRetrievalHook;
+
+    impl<M: CompletionModel> AgentHook<M> for FailingRetrievalHook {
+        async fn on_completion_call(
+            &self,
+            _ctx: &HookContext,
+            _event: CompletionCallEvent<'_>,
+        ) -> CompletionCallAction {
+            let retrieval: Result<Vec<crate::completion::Document>, &str> =
+                Err("vector store unavailable");
+            match retrieval {
+                Ok(documents) => {
+                    CompletionCallAction::patch(RequestPatch::new().extra_context(documents))
+                }
+                Err(error) => CompletionCallAction::stop(format!("retrieval failed: {error}")),
+            }
+        }
+    }
+
     fn one_text_stream_turn(text: &'static str) -> Vec<MockStreamEvent> {
         vec![
             MockStreamEvent::text(text),
             MockStreamEvent::final_response_with_total_tokens(0),
         ]
+    }
+
+    #[tokio::test]
+    async fn application_retrieval_failure_stops_before_provider_io_on_both_surfaces() {
+        let blocking_model = MockCompletionModel::from_turns([MockTurn::text("unreachable")]);
+        let blocking_probe = blocking_model.clone();
+        let error = AgentBuilder::new(blocking_model)
+            .add_hook(FailingRetrievalHook)
+            .build()
+            .runner("go")
+            .run()
+            .await
+            .expect_err("retrieval failure should cancel the run");
+        assert!(error.to_string().contains("vector store unavailable"));
+        assert!(
+            blocking_probe.requests().is_empty(),
+            "blocking retrieval failure must prevent provider IO"
+        );
+
+        let streaming_model =
+            MockCompletionModel::from_stream_turns([one_text_stream_turn("unreachable")]);
+        let streaming_probe = streaming_model.clone();
+        let mut stream = AgentBuilder::new(streaming_model)
+            .add_hook(FailingRetrievalHook)
+            .build()
+            .runner("go")
+            .stream()
+            .await;
+        let error = stream
+            .next()
+            .await
+            .expect("stream should report cancellation")
+            .expect_err("retrieval failure should cancel the stream");
+        assert!(error.to_string().contains("vector store unavailable"));
+        assert!(
+            streaming_probe.requests().is_empty(),
+            "streaming retrieval failure must prevent provider IO"
+        );
     }
 
     /// A single hook's `extra_context` document appears in the completion request,
@@ -6865,6 +6922,73 @@ mod migrated_tests {
                 Ok(vec![(1.0, "final_result".to_string())])
             }
         }
+    }
+
+    struct QueryRecordingToolIndex {
+        queries: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl VectorStoreIndex for QueryRecordingToolIndex {
+        type Filter = Filter<serde_json::Value>;
+
+        async fn top_n<T: for<'a> Deserialize<'a> + WasmCompatSend>(
+            &self,
+            _request: VectorSearchRequest,
+        ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {
+            Ok(Vec::new())
+        }
+
+        async fn top_n_ids(
+            &self,
+            request: VectorSearchRequest,
+        ) -> Result<Vec<(f64, String)>, VectorStoreError> {
+            self.queries
+                .lock()
+                .expect("query recorder lock")
+                .push(request.query().to_string());
+            Ok(vec![(1.0, "add".to_string())])
+        }
+    }
+
+    #[tokio::test]
+    async fn retrieved_tools_keep_current_prompt_and_history_fallback_query_behavior() {
+        async fn run_with(
+            queries: Arc<Mutex<Vec<String>>>,
+            prompt: Message,
+            history: Vec<Message>,
+        ) {
+            AgentBuilder::new(MockCompletionModel::from_turns([MockTurn::text("done")]))
+                .retrieved_tools(
+                    1,
+                    QueryRecordingToolIndex { queries },
+                    ToolSet::from_tools(vec![MockAddTool]),
+                )
+                .build()
+                .runner(prompt)
+                .history(history)
+                .run()
+                .await
+                .expect("retrieved-tool agent run should succeed");
+        }
+
+        let queries = Arc::new(Mutex::new(Vec::new()));
+        run_with(
+            queries.clone(),
+            Message::from("current prompt query"),
+            vec![Message::from("older history query")],
+        )
+        .await;
+        run_with(
+            queries.clone(),
+            Message::system("current message has no retrieval text"),
+            vec![Message::from("history fallback query")],
+        )
+        .await;
+
+        assert_eq!(
+            *queries.lock().expect("query recorder lock"),
+            vec!["current prompt query", "history fallback query"]
+        );
     }
 
     /// Registers a real `final_result` tool after the first model turn, once the

--- a/crates/rig-core/src/extractor.rs
+++ b/crates/rig-core/src/extractor.rs
@@ -38,7 +38,6 @@ use crate::{
     agent::{Agent, AgentBuilder, AgentHook, OutputMode},
     completion::{CompletionError, CompletionModel, PromptError, Usage},
     message::{Message, ToolChoice},
-    vector_store::VectorStoreIndexDyn,
     wasm_compat::{WasmCompatSend, WasmCompatSync},
 };
 
@@ -331,19 +330,6 @@ where
             retries: self.retries.unwrap_or(0),
         }
     }
-
-    /// Add dynamic context (RAG) to the extractor.
-    ///
-    /// On each prompt, `sample` documents will be retrieved from the index based on the RAG text
-    /// and inserted in the request.
-    pub fn dynamic_context(
-        mut self,
-        sample: usize,
-        dynamic_context: impl VectorStoreIndexDyn + Send + Sync + 'static,
-    ) -> Self {
-        self.agent_builder = self.agent_builder.dynamic_context(sample, dynamic_context);
-        self
-    }
 }
 
 #[cfg(test)]
@@ -451,6 +437,27 @@ mod tests {
             _event: crate::agent::CompletionCallEvent<'_>,
         ) -> crate::agent::CompletionCallAction {
             crate::agent::CompletionCallAction::stop("extractor stopped")
+        }
+    }
+
+    struct RetrievalContextHook;
+
+    impl<M> AgentHook<M> for RetrievalContextHook
+    where
+        M: CompletionModel,
+    {
+        async fn on_completion_call(
+            &self,
+            _ctx: &HookContext,
+            _event: crate::agent::CompletionCallEvent<'_>,
+        ) -> crate::agent::CompletionCallAction {
+            crate::agent::CompletionCallAction::patch(crate::agent::RequestPatch::new().context(
+                crate::completion::Document {
+                    id: "retrieved-question".to_string(),
+                    text: "application-provided retrieval context".to_string(),
+                    additional_props: Default::default(),
+                },
+            ))
         }
     }
 
@@ -566,6 +573,26 @@ mod tests {
         assert_eq!(counts.completion_calls.load(Ordering::SeqCst), 1);
         assert_eq!(counts.completion_responses.load(Ordering::SeqCst), 1);
         assert_eq!(counts.model_turns.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn extractor_accepts_application_defined_retrieval_context_hook() {
+        let model = MockCompletionModel::new([submit_turn("John")]);
+        let probe = model.clone();
+        let response = ExtractorBuilder::<_, Person>::new(model)
+            .add_hook(RetrievalContextHook)
+            .build()
+            .extract("John")
+            .await
+            .expect("extraction should succeed with hook-provided context");
+
+        assert_eq!(response.name, "John");
+        let requests = probe.requests();
+        let request = requests.first().expect("extractor provider request");
+        assert!(request.documents.iter().any(|document| {
+            document.id == "retrieved-question"
+                && document.text == "application-provided retrieval context"
+        }));
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/memory.rs
+++ b/crates/rig-core/src/memory.rs
@@ -2,7 +2,7 @@
 //!
 //! Memory differs from existing agent context features:
 //! - [`crate::agent::AgentBuilder::context`]: static documents always included in prompts.
-//! - [`crate::agent::AgentBuilder::dynamic_context`]: RAG documents fetched from a vector store.
+//! - [`crate::agent::AgentHook`]: per-run policies such as passive retrieval and context injection.
 //! - [`crate::agent::prompt_request::PromptRequest::history`]: caller-managed message history.
 //! - **Memory** (this module): Rig-managed history loaded and saved automatically per
 //!   conversation id.

--- a/crates/rig-core/src/vector_store/mod.rs
+++ b/crates/rig-core/src/vector_store/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! - [`VectorStoreIndex`]: Query a vector store for similar documents.
 //! - [`InsertDocuments`]: Insert documents and their embeddings.
-//! - [`VectorStoreIndexDyn`]: Type-erased version for dynamic contexts.
+//! - [`VectorStoreIndexDyn`]: Type-erased access for runtime retrieval workflows.
 //!
 //! Use [`VectorSearchRequest`] to build queries. See [`request`] for filtering.
 //!
@@ -259,4 +259,57 @@ pub enum IndexStrategy {
         /// Number of hyperplanes to use for LSH.
         num_hyperplanes: usize,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tool::ToolContext;
+
+    struct ActiveRetrievalIndex;
+
+    impl VectorStoreIndex for ActiveRetrievalIndex {
+        type Filter = Filter<serde_json::Value>;
+
+        async fn top_n<T: for<'a> Deserialize<'a> + WasmCompatSend>(
+            &self,
+            request: VectorSearchRequest<Self::Filter>,
+        ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {
+            let document = serde_json::from_value(json!({
+                "answer": format!("result for {}", request.query())
+            }))?;
+            Ok(vec![(0.9, "doc-1".to_string(), document)])
+        }
+
+        async fn top_n_ids(
+            &self,
+            _request: VectorSearchRequest<Self::Filter>,
+        ) -> Result<Vec<(f64, String)>, VectorStoreError> {
+            Ok(vec![(0.9, "doc-1".to_string())])
+        }
+    }
+
+    #[tokio::test]
+    async fn vector_store_index_remains_available_as_an_active_retrieval_tool() {
+        let request = VectorSearchRequest::builder()
+            .query("the question")
+            .samples(1)
+            .build();
+        let output = <ActiveRetrievalIndex as Tool>::call(
+            &ActiveRetrievalIndex,
+            &mut ToolContext::new(),
+            request,
+        )
+        .await
+        .expect("vector index should remain callable as a tool");
+
+        assert_eq!(output.len(), 1);
+        let result = output.first().expect("one active retrieval result");
+        assert_eq!(result.score, 0.9);
+        assert_eq!(result.id, "doc-1");
+        assert_eq!(
+            result.document,
+            json!({ "answer": "result for the question" })
+        );
+    }
 }

--- a/crates/rig-lancedb/examples/vector_search_local_ann_agent.rs
+++ b/crates/rig-lancedb/examples/vector_search_local_ann_agent.rs
@@ -2,16 +2,71 @@ use fixture::{Word, as_record_batch, words};
 use lancedb::index::vector::IvfPqIndexBuilder;
 use rig_core::client::{EmbeddingsClient, ProviderClient};
 use rig_core::completion::Prompt;
+use rig_core::message::UserContent;
 use rig_core::prelude::CompletionClient;
 use rig_core::providers::openai;
 use rig_core::{
+    agent::{AgentHook, CompletionCallAction, CompletionCallEvent, HookContext, RequestPatch},
+    completion::{CompletionModel, Document, Message},
     embeddings::{EmbeddingModel, EmbeddingsBuilder},
     providers::openai::Client,
+    vector_store::{VectorStoreIndexDyn, request::VectorSearchRequest},
 };
 use rig_lancedb::{LanceDbVectorIndex, SearchParams};
 
 #[path = "./fixtures/lib.rs"]
 mod fixture;
+
+struct RetrieveContext<I> {
+    index: I,
+    samples: u64,
+}
+
+fn message_text(message: &Message) -> Option<String> {
+    let Message::User { content } = message else {
+        return None;
+    };
+    content.iter().find_map(|part| match part {
+        UserContent::Text(text) => Some(text.text.clone()),
+        _ => None,
+    })
+}
+
+impl<M, I> AgentHook<M> for RetrieveContext<I>
+where
+    M: CompletionModel,
+    I: VectorStoreIndexDyn,
+{
+    async fn on_completion_call(
+        &self,
+        _ctx: &HookContext,
+        event: CompletionCallEvent<'_>,
+    ) -> CompletionCallAction {
+        let query = message_text(event.prompt)
+            .or_else(|| event.history.iter().rev().find_map(message_text));
+        let Some(query) = query else {
+            return CompletionCallAction::continue_run();
+        };
+
+        let request = VectorSearchRequest::builder()
+            .query(query)
+            .samples(self.samples)
+            .build();
+        match VectorStoreIndexDyn::top_n(&self.index, request).await {
+            Ok(results) => {
+                let documents = results.into_iter().map(|(_, id, value)| Document {
+                    id,
+                    text: value.to_string(),
+                    additional_props: Default::default(),
+                });
+                CompletionCallAction::patch(RequestPatch::new().extra_context(documents))
+            }
+            Err(error) => CompletionCallAction::stop(format!(
+                "failed to retrieve context before model request: {error}"
+            )),
+        }
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
@@ -71,7 +126,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let search_params = SearchParams::default();
     let vector_store_index = LanceDbVectorIndex::new(table, model, "id", search_params).await?;
 
-    // Build RAG agent with dynamic context
+    // Build a RAG agent with application-defined retrieval policy.
     // Use OpenAI-compatible API interface to build agent
     let agent = openai_client
         .completion_model(openai::GPT_4O)
@@ -79,7 +134,10 @@ async fn main() -> Result<(), anyhow::Error> {
         .into_agent_builder()
         .temperature(0.5)
         .preamble("You are a helpful AI assistant.")
-        .dynamic_context(top_k, vector_store_index)
+        .add_hook(RetrieveContext {
+            index: vector_store_index,
+            samples: top_k as u64,
+        })
         .build();
 
     let query = "My boss says I zindle too much, what does that mean?";

--- a/crates/rig-surrealdb/src/lib.rs
+++ b/crates/rig-surrealdb/src/lib.rs
@@ -493,7 +493,7 @@ mod tests {
 
     #[allow(clippy::panic)]
     #[tokio::test]
-    async fn surreal_vector_store_supports_dynamic_context_filters() {
+    async fn surreal_vector_store_supports_type_erased_filters() {
         fn assert_dyn<T: VectorStoreIndexDyn + Send + Sync + 'static>(_: T) {}
 
         let surreal = match Surreal::new::<Mem>(()).await {

--- a/examples/README.md
+++ b/examples/README.md
@@ -43,7 +43,7 @@ Most examples expect provider API keys in the environment (e.g. `OPENAI_API_KEY`
 | `force_tool_first_turn` | Demonstrates a per-turn `RequestPatch` footgun and its fix: forcing `tool_choice = Required` on *every* turn loops until `max_turns`, so an `AgentHook` gates the patch on `ctx.turn() == 1` to force the tool only up front. |
 | `gemini_deep_research` | See source. |
 | `gemini_default_api_recovery` | Demonstrates recovering from Gemini emitting a legacy `default_api` tool name. |
-| `gemini_extractor_with_rag` | See source. |
+| `gemini_extractor_with_rag` | Uses an application-defined completion-call hook to retrieve questionnaire context for an extractor. |
 | `gemini_nanobanana_image_generation` | See source. |
 | `gemini_stream_kill_token_count` | Live Gemini example: obtaining a token-count estimate when a streaming |
 | `gemini_video_understanding` | Demonstrates Gemini video understanding with provider-specific request parameters. |
@@ -55,11 +55,11 @@ Most examples expect provider API keys in the environment (e.g. `OPENAI_API_KEY`
 | `openai_agent_completions_api_otel` | This example shows how you can use OpenAI's Completions API. |
 | `openai_streaming_per_call_usage` | Shows how to inspect per-completion-call usage in an agent stream. |
 | `openai_streaming_with_tools_otel` | See source. |
-| `pdf_agent` | See source. |
-| `rag_dynamic_tools_multi_turn` | See source. |
-| `rag_dynamic_tools` | See source. |
-| `rag_ollama` | See source. |
-| `rag` | See source. |
+| `pdf_agent` | Uses an application-defined completion-call hook to retrieve PDF chunks for passive RAG. |
+| `rag_dynamic_tools_multi_turn` | Demonstrates active multi-turn RAG through retrieval-backed tools. |
+| `rag_dynamic_tools` | Demonstrates active RAG through retrieval-backed tools. |
+| `rag_ollama` | Implements passive RAG as an application-defined completion-call hook using Ollama. |
+| `rag` | Implements passive RAG as an application-defined completion-call hook using OpenAI. |
 | `reasoning_loop` | See source. |
 | `request_hook` | Demonstrates observing prompt/response/tool lifecycle events by stacking two `AgentHook`s with `add_hook`. |
 | `reqwest_middleware` | Demonstrates supplying a custom reqwest client with retry middleware. |

--- a/examples/gemini_extractor_with_rag/src/main.rs
+++ b/examples/gemini_extractor_with_rag/src/main.rs
@@ -1,8 +1,15 @@
+use rig::message::UserContent;
 use rig::prelude::*;
 use rig::providers::gemini;
 use rig::providers::gemini::client::Client;
 use rig::{
-    Embed, embeddings::EmbeddingsBuilder, vector_store::in_memory_store::InMemoryVectorStore,
+    Embed,
+    agent::{AgentHook, CompletionCallAction, CompletionCallEvent, HookContext, RequestPatch},
+    completion::{CompletionModel, Document, Message},
+    embeddings::EmbeddingsBuilder,
+    vector_store::{
+        VectorStoreIndexDyn, in_memory_store::InMemoryVectorStore, request::VectorSearchRequest,
+    },
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -33,6 +40,56 @@ struct Answer {
 struct QuestionnaireResponses {
     /// The list of responses to the questionnaire
     responses: Vec<Answer>,
+}
+
+struct RetrieveQuestions<I> {
+    index: I,
+}
+
+fn message_text(message: &Message) -> Option<String> {
+    let Message::User { content } = message else {
+        return None;
+    };
+    content.iter().find_map(|part| match part {
+        UserContent::Text(text) => Some(text.text.clone()),
+        _ => None,
+    })
+}
+
+impl<M, I> AgentHook<M> for RetrieveQuestions<I>
+where
+    M: CompletionModel,
+    I: VectorStoreIndexDyn,
+{
+    async fn on_completion_call(
+        &self,
+        _ctx: &HookContext,
+        event: CompletionCallEvent<'_>,
+    ) -> CompletionCallAction {
+        let query = message_text(event.prompt)
+            .or_else(|| event.history.iter().rev().find_map(message_text));
+        let Some(query) = query else {
+            return CompletionCallAction::continue_run();
+        };
+
+        let request = VectorSearchRequest::builder()
+            .query(query)
+            .samples(3)
+            .build();
+        match VectorStoreIndexDyn::top_n(&self.index, request).await {
+            Ok(results) => {
+                let documents = results.into_iter().map(|(_, id, value)| Document {
+                    id,
+                    text: value.to_string(),
+                    additional_props: Default::default(),
+                });
+                CompletionCallAction::patch(RequestPatch::new().extra_context(documents))
+            }
+            Err(error) => CompletionCallAction::stop(format!(
+                "failed to retrieve questionnaire context before extraction: {error}"
+            )),
+        }
+    }
 }
 
 const APPLICANT_INFO: &str = r#"
@@ -100,7 +157,7 @@ async fn main() -> Result<(), anyhow::Error> {
             You are provided with the questions and based on the information available, you must answer the questions with the right format.
             Use the answer ID field to map the answer to the right question ID. Answer as much as possible without inventing information.
             ")
-        .dynamic_context(3, index) // Samples should match the number of questions
+        .add_hook(RetrieveQuestions { index })
         .build();
 
     // Prompt the agent and print the response

--- a/examples/pdf_agent/src/main.rs
+++ b/examples/pdf_agent/src/main.rs
@@ -1,11 +1,18 @@
 use anyhow::{Context, Result};
 use rig::client::Nothing;
 use rig::integrations::cli_chatbot::ChatBotBuilder;
+use rig::message::UserContent;
 use rig::prelude::*;
 use rig::providers::ollama;
 use rig::{
-    Embed, embeddings::EmbeddingsBuilder, loaders::PdfFileLoader,
-    vector_store::in_memory_store::InMemoryVectorStore,
+    Embed,
+    agent::{AgentHook, CompletionCallAction, CompletionCallEvent, HookContext, RequestPatch},
+    completion::{CompletionModel, Document as ContextDocument, Message},
+    embeddings::EmbeddingsBuilder,
+    loaders::PdfFileLoader,
+    vector_store::{
+        VectorStoreIndexDyn, in_memory_store::InMemoryVectorStore, request::VectorSearchRequest,
+    },
 };
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -15,6 +22,56 @@ struct Document {
     id: String,
     #[embed]
     content: String,
+}
+
+struct RetrievePdfContext<I> {
+    index: I,
+}
+
+fn message_text(message: &Message) -> Option<String> {
+    let Message::User { content } = message else {
+        return None;
+    };
+    content.iter().find_map(|part| match part {
+        UserContent::Text(text) => Some(text.text.clone()),
+        _ => None,
+    })
+}
+
+impl<M, I> AgentHook<M> for RetrievePdfContext<I>
+where
+    M: CompletionModel,
+    I: VectorStoreIndexDyn,
+{
+    async fn on_completion_call(
+        &self,
+        _ctx: &HookContext,
+        event: CompletionCallEvent<'_>,
+    ) -> CompletionCallAction {
+        let query = message_text(event.prompt)
+            .or_else(|| event.history.iter().rev().find_map(message_text));
+        let Some(query) = query else {
+            return CompletionCallAction::continue_run();
+        };
+
+        let request = VectorSearchRequest::builder()
+            .query(query)
+            .samples(1)
+            .build();
+        match VectorStoreIndexDyn::top_n(&self.index, request).await {
+            Ok(results) => {
+                let documents = results.into_iter().map(|(_, id, value)| ContextDocument {
+                    id,
+                    text: value.to_string(),
+                    additional_props: Default::default(),
+                });
+                CompletionCallAction::patch(RequestPatch::new().extra_context(documents))
+            }
+            Err(error) => CompletionCallAction::stop(format!(
+                "failed to retrieve PDF context before model request: {error}"
+            )),
+        }
+    }
 }
 
 fn load_pdf(path: PathBuf) -> Result<Vec<String>> {
@@ -94,7 +151,7 @@ async fn main() -> Result<()> {
     let rag_agent = client
         .agent("deepseek-r1")
         .preamble("You are a helpful assistant that answers questions based on the provided document context. When answering questions, try to synthesize information from multiple chunks if they're related.")
-        .dynamic_context(1, index)
+        .add_hook(RetrievePdfContext { index })
         .build();
 
     println!("Starting CLI chatbot...");

--- a/examples/rag/src/main.rs
+++ b/examples/rag/src/main.rs
@@ -1,8 +1,15 @@
+use rig::message::UserContent;
 use rig::prelude::*;
 use rig::providers::openai::client::Client;
 use rig::{
-    Embed, completion::Prompt, embeddings::EmbeddingsBuilder, providers::openai,
-    vector_store::in_memory_store::InMemoryVectorStore,
+    Embed,
+    agent::{AgentHook, CompletionCallAction, CompletionCallEvent, HookContext, RequestPatch},
+    completion::{CompletionModel, Document, Message, Prompt},
+    embeddings::EmbeddingsBuilder,
+    providers::openai,
+    vector_store::{
+        VectorStoreIndexDyn, in_memory_store::InMemoryVectorStore, request::VectorSearchRequest,
+    },
 };
 use serde::Serialize;
 use std::vec;
@@ -16,6 +23,57 @@ struct WordDefinition {
     word: String,
     #[embed]
     definitions: Vec<String>,
+}
+
+struct RetrieveContext<I> {
+    index: I,
+    samples: u64,
+}
+
+fn message_text(message: &Message) -> Option<String> {
+    let Message::User { content } = message else {
+        return None;
+    };
+    content.iter().find_map(|part| match part {
+        UserContent::Text(text) => Some(text.text.clone()),
+        _ => None,
+    })
+}
+
+impl<M, I> AgentHook<M> for RetrieveContext<I>
+where
+    M: CompletionModel,
+    I: VectorStoreIndexDyn,
+{
+    async fn on_completion_call(
+        &self,
+        _ctx: &HookContext,
+        event: CompletionCallEvent<'_>,
+    ) -> CompletionCallAction {
+        let query = message_text(event.prompt)
+            .or_else(|| event.history.iter().rev().find_map(message_text));
+        let Some(query) = query else {
+            return CompletionCallAction::continue_run();
+        };
+
+        let request = VectorSearchRequest::builder()
+            .query(query)
+            .samples(self.samples)
+            .build();
+        match VectorStoreIndexDyn::top_n(&self.index, request).await {
+            Ok(results) => {
+                let documents = results.into_iter().map(|(_, id, value)| Document {
+                    id,
+                    text: value.to_string(),
+                    additional_props: Default::default(),
+                });
+                CompletionCallAction::patch(RequestPatch::new().extra_context(documents))
+            }
+            Err(error) => CompletionCallAction::stop(format!(
+                "failed to retrieve context before model request: {error}"
+            )),
+        }
+    }
 }
 
 #[tokio::main]
@@ -70,7 +128,7 @@ async fn main() -> Result<(), anyhow::Error> {
             You are a dictionary assistant here to assist the user in understanding the meaning of words.
             You will find additional non-standard word definitions that could be useful below.
         ")
-        .dynamic_context(1, index)
+        .add_hook(RetrieveContext { index, samples: 1 })
         .build();
 
     // Prompt the agent and print the response

--- a/examples/rag_ollama/src/main.rs
+++ b/examples/rag_ollama/src/main.rs
@@ -1,8 +1,15 @@
 use rig::client::Nothing;
+use rig::message::UserContent;
 use rig::prelude::*;
 use rig::{
-    Embed, completion::Prompt, embeddings::EmbeddingsBuilder, providers::ollama::Client,
-    vector_store::in_memory_store::InMemoryVectorStore,
+    Embed,
+    agent::{AgentHook, CompletionCallAction, CompletionCallEvent, HookContext, RequestPatch},
+    completion::{CompletionModel, Document, Message, Prompt},
+    embeddings::EmbeddingsBuilder,
+    providers::ollama::Client,
+    vector_store::{
+        VectorStoreIndexDyn, in_memory_store::InMemoryVectorStore, request::VectorSearchRequest,
+    },
 };
 use serde::Serialize;
 
@@ -15,6 +22,57 @@ struct WordDefinition {
     word: String,
     #[embed]
     definitions: Vec<String>,
+}
+
+struct RetrieveContext<I> {
+    index: I,
+    samples: u64,
+}
+
+fn message_text(message: &Message) -> Option<String> {
+    let Message::User { content } = message else {
+        return None;
+    };
+    content.iter().find_map(|part| match part {
+        UserContent::Text(text) => Some(text.text.clone()),
+        _ => None,
+    })
+}
+
+impl<M, I> AgentHook<M> for RetrieveContext<I>
+where
+    M: CompletionModel,
+    I: VectorStoreIndexDyn,
+{
+    async fn on_completion_call(
+        &self,
+        _ctx: &HookContext,
+        event: CompletionCallEvent<'_>,
+    ) -> CompletionCallAction {
+        let query = message_text(event.prompt)
+            .or_else(|| event.history.iter().rev().find_map(message_text));
+        let Some(query) = query else {
+            return CompletionCallAction::continue_run();
+        };
+
+        let request = VectorSearchRequest::builder()
+            .query(query)
+            .samples(self.samples)
+            .build();
+        match VectorStoreIndexDyn::top_n(&self.index, request).await {
+            Ok(results) => {
+                let documents = results.into_iter().map(|(_, id, value)| Document {
+                    id,
+                    text: value.to_string(),
+                    additional_props: Default::default(),
+                });
+                CompletionCallAction::patch(RequestPatch::new().extra_context(documents))
+            }
+            Err(error) => CompletionCallAction::stop(format!(
+                "failed to retrieve context before model request: {error}"
+            )),
+        }
+    }
 }
 
 #[tokio::main]
@@ -70,7 +128,7 @@ async fn main() -> Result<(), anyhow::Error> {
             You are a dictionary assistant here to assist the user in understanding the meaning of words.
             You will find additional non-standard word definitions that could be useful below.
         ")
-        .dynamic_context(1, index)
+        .add_hook(RetrieveContext { index, samples: 1 })
         .build();
 
     // Prompt the agent and print the response

--- a/tests/core/mod.rs
+++ b/tests/core/mod.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "derive")]
 mod embed_macro;
 mod loaders;
+mod passive_retrieval_surface;
 mod prompt_response_messages;
 mod provider_layout;
 mod reasoning_stream_stats;

--- a/tests/core/passive_retrieval_surface.rs
+++ b/tests/core/passive_retrieval_surface.rs
@@ -1,0 +1,46 @@
+use std::path::{Path, PathBuf};
+
+fn scan_live_sources(path: &Path, violations: &mut Vec<PathBuf>) {
+    if path
+        .file_name()
+        .is_some_and(|name| matches!(name.to_str(), Some(".git" | "target" | "CHANGELOG.md")))
+    {
+        return;
+    }
+
+    if path.is_dir() {
+        for entry in std::fs::read_dir(path).expect("read repository source directory") {
+            scan_live_sources(&entry.expect("read source entry").path(), violations);
+        }
+        return;
+    }
+
+    let Some(extension) = path.extension().and_then(|extension| extension.to_str()) else {
+        return;
+    };
+    if !matches!(extension, "rs" | "md" | "toml") {
+        return;
+    }
+
+    let source = std::fs::read_to_string(path).expect("read UTF-8 repository source");
+    let removed_names = [
+        concat!("dynamic_", "context"),
+        concat!("DynamicContext", "Store"),
+    ];
+    if removed_names.iter().any(|name| source.contains(name)) {
+        violations.push(path.to_path_buf());
+    }
+}
+
+#[test]
+fn removed_passive_retrieval_api_does_not_reappear_in_live_sources() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let mut violations = Vec::new();
+    scan_live_sources(root, &mut violations);
+
+    assert!(
+        violations.is_empty(),
+        "the removed hardcoded passive-retrieval API reappeared outside historical changelogs: \
+         {violations:#?}"
+    );
+}

--- a/tests/integrations/lancedb/mod.rs
+++ b/tests/integrations/lancedb/mod.rs
@@ -11,17 +11,70 @@ use serde_json::json;
 use fixture::{Word, as_record_batch, words};
 use lancedb::index::vector::IvfPqIndexBuilder;
 use rig::lancedb::{LanceDbVectorIndex, SearchParams};
+use rig::message::UserContent;
 use rig::{
+    agent::{AgentHook, CompletionCallAction, CompletionCallEvent, HookContext, RequestPatch},
     client::EmbeddingsClient,
-    completion::Prompt,
+    completion::{CompletionModel, Document, Message, Prompt},
     embeddings::{EmbeddingModel, EmbeddingsBuilder},
     prelude::CompletionClient,
     providers::openai,
-    vector_store::{VectorStoreIndex, request::VectorSearchRequest},
+    vector_store::{VectorStoreIndex, VectorStoreIndexDyn, request::VectorSearchRequest},
 };
 
 #[path = "./fixtures/lib.rs"]
 mod fixture;
+
+struct RetrieveContext<I> {
+    index: I,
+    samples: u64,
+}
+
+fn message_text(message: &Message) -> Option<String> {
+    let Message::User { content } = message else {
+        return None;
+    };
+    content.iter().find_map(|part| match part {
+        UserContent::Text(text) => Some(text.text.clone()),
+        _ => None,
+    })
+}
+
+impl<M, I> AgentHook<M> for RetrieveContext<I>
+where
+    M: CompletionModel,
+    I: VectorStoreIndexDyn,
+{
+    async fn on_completion_call(
+        &self,
+        _ctx: &HookContext,
+        event: CompletionCallEvent<'_>,
+    ) -> CompletionCallAction {
+        let query = message_text(event.prompt)
+            .or_else(|| event.history.iter().rev().find_map(message_text));
+        let Some(query) = query else {
+            return CompletionCallAction::continue_run();
+        };
+
+        let request = VectorSearchRequest::builder()
+            .query(query)
+            .samples(self.samples)
+            .build();
+        match VectorStoreIndexDyn::top_n(&self.index, request).await {
+            Ok(results) => {
+                let documents = results.into_iter().map(|(_, id, value)| Document {
+                    id,
+                    text: value.to_string(),
+                    additional_props: Default::default(),
+                });
+                CompletionCallAction::patch(RequestPatch::new().extra_context(documents))
+            }
+            Err(error) => CompletionCallAction::stop(format!(
+                "failed to retrieve context before model request: {error}"
+            )),
+        }
+    }
+}
 
 #[tokio::test]
 async fn vector_search_test() {
@@ -186,8 +239,7 @@ async fn vector_search_test() {
         .build();
 
     // Query the index
-    let results = vector_store_index
-        .top_n::<serde_json::Value>(req)
+    let results = VectorStoreIndex::top_n::<serde_json::Value>(&vector_store_index, req)
         .await
         .unwrap();
 
@@ -206,7 +258,7 @@ async fn vector_search_test() {
 }
 
 #[tokio::test]
-async fn agent_with_dynamic_context_test() {
+async fn agent_with_retrieval_hook_test() {
     // Setup mock openai API
     let server = httpmock::MockServer::start();
 
@@ -393,12 +445,15 @@ async fn agent_with_dynamic_context_test() {
         .await
         .unwrap();
 
-    // Build RAG agent with dynamic context
+    // Build a RAG agent with application-defined retrieval policy.
     let agent = openai_client
         .completion_model(openai::GPT_4O)
         .completions_api()
         .into_agent_builder()
-        .dynamic_context(top_k, vector_store_index)
+        .add_hook(RetrieveContext {
+            index: vector_store_index,
+            samples: top_k as u64,
+        })
         .build();
 
     let query = "My boss says I zindle too much, what does that mean?";


### PR DESCRIPTION
## Summary

- remove the hardcoded `dynamic_context` API, state, and vector-retrieval path from agents and extractors
- migrate passive-RAG examples to small application-owned completion-call hooks while preserving active vector-store tools and dynamic-tool query behavior
- document the passive-hook and active-tool approaches, including the breaking migration, and add focused regression coverage

## Why

Passive retrieval is policy: applications need to decide how to select a query, retrieve documents, transform results, handle failures, and compose context. Keeping that policy hardcoded in agent request construction bypassed the hook system and made the agent lifecycle less explicit. Completion-call hooks now provide the sole extension point for passive retrieval, with no compatibility helper or built-in retrieval hook.

## User impact

This is intentionally breaking. Calls to `.dynamic_context(...)` must be replaced with an application-defined `AgentHook::on_completion_call` implementation that queries the desired index and returns `CompletionCallAction::patch(RequestPatch::new().extra_context(...))`. Retrieval failures can stop the run before provider I/O. Users who prefer model-directed retrieval can continue exposing a vector index or custom retriever as a tool.

## Verification

- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo doc --workspace --no-deps`
- migrated example checks for `rag`, `rag_ollama`, `pdf_agent`, `gemini_extractor_with_rag`, Rig Bedrock, and Rig LanceDB
- targeted blocking/streaming hook, extractor, dynamic-tool, vector-store-tool, removal-guard, and LanceDB integration tests
- fresh independent full-diff review, followed by a clean post-fix review

Workspace documentation succeeds with pre-existing unrelated broken/private intra-doc-link warnings in the Doubleword and Neo4j crates.
