### PR TITLE
Remove built-in agent dynamic context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,16 +13,82 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- *(agent)* [**breaking**] Remove the built-in `AgentBuilder::dynamic_context` and
-  `ExtractorBuilder::dynamic_context` passive-retrieval APIs. Applications now own
-  retrieval query selection, formatting, and failure policy in an `AgentHook`; a
-  retrieval failure can return `CompletionCallAction::stop` before provider I/O.
-  Replace `.dynamic_context(samples, index)` with a local hook that queries the
-  index during `on_completion_call` and returns
-  `CompletionCallAction::patch(RequestPatch::new().extra_context(documents))`, then
-  register it with `.add_hook(MyRetrievalHook { index, samples })`. Use an index's
-  blanket `Tool` implementation (or a custom tool) instead when the model should
-  actively decide whether to retrieve.
+- *(agent)* [**breaking**] Remove the built-in `AgentBuilder::dynamic_context`,
+  `ExtractorBuilder::dynamic_context`, and internal `DynamicContextStore`
+  passive-retrieval pipeline. Static builder context remains available. For
+  passive RAG, applications now own query selection, retrieval, filtering,
+  reranking, formatting, caching, failure handling, and per-turn policy in a
+  local `AgentHook`:
+
+  ```rust
+  // Application code: Rig does not provide AppRetrievalHook.
+  struct AppRetrievalHook<I> {
+      index: I,
+      samples: u64,
+  }
+
+  impl<M, I> AgentHook<M> for AppRetrievalHook<I>
+  where
+      M: CompletionModel,
+      I: VectorStoreIndexDyn,
+  {
+      async fn on_completion_call(
+          &self,
+          _ctx: &HookContext,
+          event: CompletionCallEvent<'_>,
+      ) -> CompletionCallAction {
+          let message_text = |message: &Message| match message {
+              Message::User { content } => content.iter().find_map(|part| match part {
+                  UserContent::Text(text) => Some(text.text.clone()),
+                  _ => None,
+              }),
+              _ => None,
+          };
+          let Some(query) = message_text(event.prompt)
+              .or_else(|| event.history.iter().rev().find_map(message_text))
+          else {
+              return CompletionCallAction::continue_run();
+          };
+
+          let request = VectorSearchRequest::builder()
+              .query(query)
+              .samples(self.samples)
+              .build();
+          match self.index.top_n(request).await {
+              Ok(results) => {
+                  let documents = results.into_iter().map(|(_, id, value)| Document {
+                      id,
+                      text: serde_json::to_string_pretty(&value)
+                          .unwrap_or_else(|_| value.to_string()),
+                      additional_props: Default::default(),
+                  });
+                  CompletionCallAction::patch(
+                      RequestPatch::new().extra_context(documents),
+                  )
+              }
+              Err(error) => CompletionCallAction::stop(
+                  format!("application retrieval failed: {error}"),
+              ),
+          }
+      }
+  }
+
+  // Before
+  let agent = client.agent(model).dynamic_context(3, index).build();
+
+  // After
+  let agent = client
+      .agent(model)
+      .add_hook(AppRetrievalHook { index, samples: 3 })
+      .build();
+  ```
+
+  Returning `CompletionCallAction::stop(...)` prevents provider I/O for that
+  turn. The same hook-aware `AgentRunner` lifecycle is used by blocking,
+  streaming, and extractor execution; register the local hook with
+  `ExtractorBuilder::add_hook` for extraction. For active RAG, expose a vector
+  index through its blanket `Tool` implementation or provide a custom retriever
+  tool so the model decides whether and when to retrieve.
 - *(agent)* [**breaking**] Make `AgentRunner` the only execution path for configured agents: remove the raw `Completion` and `StreamingCompletion` traits and their `Agent` implementations, make agent execution state private, add runner-backed per-request overrides, and route `Extractor` through the full hook lifecycle. Raw hook-free requests remain available explicitly through `CompletionModel`.
   - For managed agent execution, replace `agent.completion(prompt, history).await?.send().await?` with `agent.runner(prompt).history(history).max_turns(3).run().await?`, choosing a turn budget large enough for tool follow-ups.
   - For managed streaming execution, replace `agent.stream_completion(prompt, history).await?.stream().await?` with `agent.runner(prompt).history(history).max_turns(3).stream().await`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- *(agent)* [**breaking**] Remove the built-in `AgentBuilder::dynamic_context` and
+  `ExtractorBuilder::dynamic_context` passive-retrieval APIs. Applications now own
+  retrieval query selection, formatting, and failure policy in an `AgentHook`; a
+  retrieval failure can return `CompletionCallAction::stop` before provider I/O.
+  Replace `.dynamic_context(samples, index)` with a local hook that queries the
+  index during `on_completion_call` and returns
+  `CompletionCallAction::patch(RequestPatch::new().extra_context(documents))`, then
+  register it with `.add_hook(MyRetrievalHook { index, samples })`. Use an index's
+  blanket `Tool` implementation (or a custom tool) instead when the model should
+  actively decide whether to retrieve.
 - *(agent)* [**breaking**] Make `AgentRunner` the only execution path for configured agents: remove the raw `Completion` and `StreamingCompletion` traits and their `Agent` implementations, make agent execution state private, add runner-backed per-request overrides, and route `Extractor` through the full hook lifecycle. Raw hook-free requests remain available explicitly through `CompletionModel`.
   - For managed agent execution, replace `agent.completion(prompt, history).await?.send().await?` with `agent.runner(prompt).history(history).max_turns(3).run().await?`, choosing a turn budget large enough for tool follow-ups.
   - For managed streaming execution, replace `agent.stream_completion(prompt, history).await?.stream().await?` with `agent.runner(prompt).history(history).max_turns(3).stream().await`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4379,6 +4379,7 @@ dependencies = [
  "rig",
  "schemars 1.2.1",
  "serde",
+ "serde_json",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -8293,6 +8294,7 @@ dependencies = [
  "anyhow",
  "rig",
  "serde",
+ "serde_json",
  "tokio",
 ]
 
@@ -9108,6 +9110,7 @@ dependencies = [
  "anyhow",
  "rig",
  "serde",
+ "serde_json",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -9148,6 +9151,7 @@ dependencies = [
  "anyhow",
  "rig",
  "serde",
+ "serde_json",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/crates/rig-bedrock/examples/rag_with_bedrock.rs
+++ b/crates/rig-bedrock/examples/rag_with_bedrock.rs
@@ -32,7 +32,7 @@ struct WordDefinition {
 
 struct DictionaryRag<I> {
     index: I,
-    samples: usize,
+    samples: u64,
 }
 
 impl<M, I> AgentHook<M> for DictionaryRag<I>
@@ -60,7 +60,7 @@ where
 
         let request = VectorSearchRequest::builder()
             .query(query)
-            .samples(self.samples as u64)
+            .samples(self.samples)
             .build();
         match self.index.top_n(request).await {
             Ok(results) => CompletionCallAction::patch(RequestPatch::new().extra_context(

--- a/crates/rig-bedrock/examples/rag_with_bedrock.rs
+++ b/crates/rig-bedrock/examples/rag_with_bedrock.rs
@@ -3,10 +3,18 @@ use std::vec;
 use rig_bedrock::client::Client;
 use rig_bedrock::completion::AMAZON_NOVA_LITE;
 use rig_bedrock::embedding::AMAZON_TITAN_EMBED_TEXT_V2_0;
+use rig_core::agent::{
+    AgentHook, CompletionCallAction, CompletionCallEvent, HookContext, RequestPatch,
+};
 use rig_core::client::{CompletionClient, EmbeddingsClient, ProviderClient};
 use rig_core::{
-    Embed, completion::Prompt, embeddings::EmbeddingsBuilder,
-    vector_store::in_memory_store::InMemoryVectorStore,
+    Embed,
+    completion::{CompletionModel, Document, Message, Prompt},
+    embeddings::EmbeddingsBuilder,
+    message::UserContent,
+    vector_store::{
+        VectorStoreIndexDyn, in_memory_store::InMemoryVectorStore, request::VectorSearchRequest,
+    },
 };
 use serde::Serialize;
 use tracing::info;
@@ -20,6 +28,54 @@ struct WordDefinition {
     word: String,
     #[embed]
     definitions: Vec<String>,
+}
+
+struct DictionaryRag<I> {
+    index: I,
+    samples: usize,
+}
+
+impl<M, I> AgentHook<M> for DictionaryRag<I>
+where
+    M: CompletionModel,
+    I: VectorStoreIndexDyn,
+{
+    async fn on_completion_call(
+        &self,
+        _ctx: &HookContext,
+        event: CompletionCallEvent<'_>,
+    ) -> CompletionCallAction {
+        let message_text = |message: &Message| match message {
+            Message::User { content } => content.iter().find_map(|item| match item {
+                UserContent::Text(text) => Some(text.text.clone()),
+                _ => None,
+            }),
+            _ => None,
+        };
+        let Some(query) = message_text(event.prompt)
+            .or_else(|| event.history.iter().rev().find_map(message_text))
+        else {
+            return CompletionCallAction::continue_run();
+        };
+
+        let request = VectorSearchRequest::builder()
+            .query(query)
+            .samples(self.samples as u64)
+            .build();
+        match self.index.top_n(request).await {
+            Ok(results) => CompletionCallAction::patch(RequestPatch::new().extra_context(
+                results.into_iter().map(|(_, id, value)| Document {
+                    id,
+                    text:
+                        serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string()),
+                    additional_props: Default::default(),
+                }),
+            )),
+            Err(error) => {
+                CompletionCallAction::stop(format!("dictionary retrieval failed: {error}"))
+            }
+        }
+    }
 }
 
 #[tokio::main]
@@ -74,7 +130,7 @@ async fn main() -> Result<(), anyhow::Error> {
             You are a dictionary assistant here to assist the user in understanding the meaning of words.
             You will find additional non-standard word definitions that could be useful below.
         ")
-        .dynamic_context(1, index)
+        .add_hook(DictionaryRag { index, samples: 1 })
         .build();
 
     // Prompt the agent and print the response

--- a/crates/rig-core/CHANGELOG.md
+++ b/crates/rig-core/CHANGELOG.md
@@ -9,6 +9,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- *(agent)* [**breaking**] Remove `AgentBuilder::dynamic_context`,
+  `ExtractorBuilder::dynamic_context`, and the internal `DynamicContextStore`.
+  Passive RAG is now explicit application policy implemented with an `AgentHook`;
+  active, model-directed RAG remains available through the blanket vector-index
+  `Tool` implementation or a custom tool.
+
+  Migration pattern:
+
+  ```rust
+  // Before: Rig selected the prompt text, queried the index, and formatted context.
+  let agent = client
+      .agent(model)
+      .dynamic_context(3, index)
+      .build();
+
+  // After: define a local AgentHook whose on_completion_call implementation:
+  // 1. selects a query from event.prompt and event.history,
+  // 2. calls index.top_n(VectorSearchRequest::builder() ...),
+  // 3. converts matches into completion::Document values, and
+  // 4. returns a patch, or stops before provider I/O if retrieval fails.
+  let agent = client
+      .agent(model)
+      .add_hook(MyRetrievalHook { index, samples: 3 })
+      .build();
+
+  // Successful retrieval:
+  CompletionCallAction::patch(
+      RequestPatch::new().extra_context(documents),
+  )
+
+  // Retrieval failure:
+  CompletionCallAction::stop(format!("retrieval failed: {error}"))
+  ```
+
+  The hook path is shared by `AgentRunner::run` and `AgentRunner::stream`, and is
+  also used by `Extractor`, so one retrieval policy has the same behavior on all
+  managed execution surfaces. Multiple hook context patches append in registration
+  order after static agent context.
 - *(agent)* [**breaking**] Make `AgentRunner` the only execution path for configured agents: remove the raw `Completion` and `StreamingCompletion` traits and their `Agent` implementations, make agent execution state private, add runner-backed per-request overrides, and route `Extractor` through the full hook lifecycle. Raw hook-free requests remain available explicitly through `CompletionModel`.
 
   Migration examples:

--- a/crates/rig-core/CHANGELOG.md
+++ b/crates/rig-core/CHANGELOG.md
@@ -10,43 +10,86 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - *(agent)* [**breaking**] Remove `AgentBuilder::dynamic_context`,
-  `ExtractorBuilder::dynamic_context`, and the internal `DynamicContextStore`.
-  Passive RAG is now explicit application policy implemented with an `AgentHook`;
-  active, model-directed RAG remains available through the blanket vector-index
-  `Tool` implementation or a custom tool.
+  `ExtractorBuilder::dynamic_context`, and the internal `DynamicContextStore`
+  passive-retrieval pipeline. Static builder context remains available. Rig no
+  longer imposes passive-retrieval query selection, retrieval, filtering,
+  reranking, formatting, caching, failure handling, or per-turn policy; those
+  decisions belong in an application-defined `AgentHook`.
 
-  Migration pattern:
+  Migration example:
 
   ```rust
-  // Before: Rig selected the prompt text, queried the index, and formatted context.
+  // Application code: Rig does not provide AppRetrievalHook.
+  struct AppRetrievalHook<I> {
+      index: I,
+      samples: u64,
+  }
+
+  impl<M, I> AgentHook<M> for AppRetrievalHook<I>
+  where
+      M: CompletionModel,
+      I: VectorStoreIndexDyn,
+  {
+      async fn on_completion_call(
+          &self,
+          _ctx: &HookContext,
+          event: CompletionCallEvent<'_>,
+      ) -> CompletionCallAction {
+          let message_text = |message: &Message| match message {
+              Message::User { content } => content.iter().find_map(|part| match part {
+                  UserContent::Text(text) => Some(text.text.clone()),
+                  _ => None,
+              }),
+              _ => None,
+          };
+          let Some(query) = message_text(event.prompt)
+              .or_else(|| event.history.iter().rev().find_map(message_text))
+          else {
+              return CompletionCallAction::continue_run();
+          };
+
+          let request = VectorSearchRequest::builder()
+              .query(query)
+              .samples(self.samples)
+              .build();
+          match self.index.top_n(request).await {
+              Ok(results) => {
+                  let documents = results.into_iter().map(|(_, id, value)| Document {
+                      id,
+                      text: serde_json::to_string_pretty(&value)
+                          .unwrap_or_else(|_| value.to_string()),
+                      additional_props: Default::default(),
+                  });
+                  CompletionCallAction::patch(
+                      RequestPatch::new().extra_context(documents),
+                  )
+              }
+              Err(error) => CompletionCallAction::stop(
+                  format!("application retrieval failed: {error}"),
+              ),
+          }
+      }
+  }
+
+  // Before
+  let agent = client.agent(model).dynamic_context(3, index).build();
+
+  // After
   let agent = client
       .agent(model)
-      .dynamic_context(3, index)
+      .add_hook(AppRetrievalHook { index, samples: 3 })
       .build();
-
-  // After: define a local AgentHook whose on_completion_call implementation:
-  // 1. selects a query from event.prompt and event.history,
-  // 2. calls index.top_n(VectorSearchRequest::builder() ...),
-  // 3. converts matches into completion::Document values, and
-  // 4. returns a patch, or stops before provider I/O if retrieval fails.
-  let agent = client
-      .agent(model)
-      .add_hook(MyRetrievalHook { index, samples: 3 })
-      .build();
-
-  // Successful retrieval:
-  CompletionCallAction::patch(
-      RequestPatch::new().extra_context(documents),
-  )
-
-  // Retrieval failure:
-  CompletionCallAction::stop(format!("retrieval failed: {error}"))
   ```
 
-  The hook path is shared by `AgentRunner::run` and `AgentRunner::stream`, and is
-  also used by `Extractor`, so one retrieval policy has the same behavior on all
-  managed execution surfaces. Multiple hook context patches append in registration
-  order after static agent context.
+  `CompletionCallAction::patch(RequestPatch::new().extra_context(documents))`
+  appends application-retrieved documents after static context. Returning
+  `CompletionCallAction::stop(...)` on retrieval failure prevents provider I/O
+  for that turn. The same hook-aware `AgentRunner` lifecycle powers blocking,
+  streaming, and extractor execution; register the local hook with
+  `ExtractorBuilder::add_hook` for extraction. Multiple hook context patches
+  append in registration order. For active RAG, expose an index through its
+  blanket `Tool` implementation or provide a custom retriever tool so the model
+  decides whether and when to retrieve.
 - *(agent)* [**breaking**] Make `AgentRunner` the only execution path for configured agents: remove the raw `Completion` and `StreamingCompletion` traits and their `Agent` implementations, make agent execution state private, add runner-backed per-request overrides, and route `Extractor` through the full hook lifecycle. Raw hook-free requests remain available explicitly through `CompletionModel`.
 
   Migration examples:

--- a/crates/rig-core/src/agent/builder.rs
+++ b/crates/rig-core/src/agent/builder.rs
@@ -114,8 +114,6 @@ where
     record_telemetry_content: bool,
     /// Maximum number of tokens for the completion
     max_tokens: Option<u64>,
-    /// List of vector store, with the sample number
-    dynamic_context: Vec<(usize, Arc<dyn VectorStoreIndexDyn + Send + Sync>)>,
     /// Temperature of the model
     temperature: Option<f64>,
     /// Whether or not the underlying LLM should be forced to use a tool before providing a response.
@@ -177,18 +175,6 @@ where
             text: doc.into(),
             additional_props: HashMap::new(),
         });
-        self
-    }
-
-    /// Add some dynamic context to the agent. On each prompt, `sample` documents from the
-    /// dynamic context will be inserted in the request.
-    pub fn dynamic_context(
-        mut self,
-        sample: usize,
-        dynamic_context: impl VectorStoreIndexDyn + Send + Sync + 'static,
-    ) -> Self {
-        self.dynamic_context
-            .push((sample, Arc::new(dynamic_context)));
         self
     }
 
@@ -318,7 +304,6 @@ where
             max_tokens: None,
             additional_params: None,
             record_telemetry_content: false,
-            dynamic_context: vec![],
             tool_choice: None,
             default_max_turns: None,
             tool_state: NoToolConfig,
@@ -353,7 +338,6 @@ where
             additional_params: self.additional_params,
             record_telemetry_content: self.record_telemetry_content,
             max_tokens: self.max_tokens,
-            dynamic_context: self.dynamic_context,
             temperature: self.temperature,
             tool_choice: self.tool_choice,
             default_max_turns: self.default_max_turns,
@@ -385,7 +369,6 @@ where
             additional_params: self.additional_params,
             record_telemetry_content: self.record_telemetry_content,
             max_tokens: self.max_tokens,
-            dynamic_context: self.dynamic_context,
             temperature: self.temperature,
             tool_choice: self.tool_choice,
             default_max_turns: self.default_max_turns,
@@ -422,7 +405,6 @@ where
             additional_params: self.additional_params,
             record_telemetry_content: self.record_telemetry_content,
             max_tokens: self.max_tokens,
-            dynamic_context: self.dynamic_context,
             temperature: self.temperature,
             tool_choice: self.tool_choice,
             default_max_turns: self.default_max_turns,
@@ -521,7 +503,6 @@ where
             additional_params: self.additional_params,
             record_telemetry_content: self.record_telemetry_content,
             max_tokens: self.max_tokens,
-            dynamic_context: self.dynamic_context,
             temperature: self.temperature,
             tool_choice: self.tool_choice,
             default_max_turns: self.default_max_turns,
@@ -563,7 +544,6 @@ where
             additional_params: self.additional_params,
             record_telemetry_content: self.record_telemetry_content,
             max_tokens: self.max_tokens,
-            dynamic_context: self.dynamic_context,
             temperature: self.temperature,
             tool_choice: self.tool_choice,
             default_max_turns: self.default_max_turns,
@@ -596,7 +576,6 @@ where
             additional_params: self.additional_params,
             record_telemetry_content: self.record_telemetry_content,
             tool_choice: self.tool_choice,
-            dynamic_context: Arc::new(self.dynamic_context),
             tool_server_handle,
             default_max_turns: self.default_max_turns,
             hooks: self.hooks,
@@ -625,7 +604,6 @@ where
             additional_params: self.additional_params,
             record_telemetry_content: self.record_telemetry_content,
             tool_choice: self.tool_choice,
-            dynamic_context: Arc::new(self.dynamic_context),
             tool_server_handle: self.tool_state.handle,
             default_max_turns: self.default_max_turns,
             hooks: self.hooks,
@@ -739,7 +717,6 @@ where
             additional_params: self.additional_params,
             record_telemetry_content: self.record_telemetry_content,
             tool_choice: self.tool_choice,
-            dynamic_context: Arc::new(self.dynamic_context),
             tool_server_handle,
             default_max_turns: self.default_max_turns,
             hooks: self.hooks,

--- a/crates/rig-core/src/agent/completion.rs
+++ b/crates/rig-core/src/agent/completion.rs
@@ -12,22 +12,11 @@ use crate::{
     message::ToolChoice,
     streaming::{StreamingChat, StreamingPrompt},
     tool::server::{ToolRegistrySnapshot, ToolServerError, ToolServerHandle},
-    vector_store::{VectorStoreError, request::VectorSearchRequest},
     wasm_compat::WasmCompatSend,
 };
-use std::{
-    collections::{BTreeSet, HashMap},
-    sync::Arc,
-};
+use std::{collections::BTreeSet, sync::Arc};
 
 use super::UNKNOWN_AGENT_NAME;
-
-pub type DynamicContextStore = Arc<
-    Vec<(
-        usize,
-        Arc<dyn crate::vector_store::VectorStoreIndexDyn + Send + Sync>,
-    )>,
->;
 
 /// A prepared completion request plus the executable Rig tool names advertised
 /// to the provider for this turn.
@@ -239,7 +228,6 @@ pub(crate) async fn build_prepared_completion_request<M: CompletionModel>(
     record_telemetry_content: bool,
     tool_choice: Option<&ToolChoice>,
     tool_server_handle: &ToolServerHandle,
-    dynamic_context: &DynamicContextStore,
     output_schema: Option<&schemars::Schema>,
     output_mode: &OutputMode,
     committed_output_tool: Option<&str>,
@@ -277,80 +265,19 @@ pub(crate) async fn build_prepared_completion_request<M: CompletionModel>(
     };
     let active_tools = request_patch.and_then(|o| o.active_tools.as_deref());
 
-    // Find the latest message in the chat history that contains RAG text
-    let rag_text = prompt.rag_text();
-    let rag_text = rag_text.or_else(|| {
+    // Retrieved tools keep their existing query-selection behavior: prefer the
+    // current prompt's RAG text, then the latest matching history message.
+    let retrieval_query = prompt.rag_text().or_else(|| {
         chat_history
             .iter()
             .rev()
             .find_map(|message| message.rag_text())
     });
 
-    // Fetch dynamic (RAG) documents and the real executable tool set first, so we
-    // can resolve the output mode (which depends on whether tools exist) before
-    // building the preamble and request.
-    let (mut tool_snapshot, fetched_context): (ToolRegistrySnapshot, Vec<Document>) =
-        match &rag_text {
-            Some(text) => {
-                let search_futures = dynamic_context.iter().map(|(num_sample, index)| {
-                    let text = text.clone();
-                    let num_sample = *num_sample;
-                    let index = index.clone();
-
-                    async move {
-                        let req = VectorSearchRequest::builder()
-                            .query(text)
-                            .samples(num_sample as u64)
-                            .build();
-
-                        let docs = index
-                            .top_n(req)
-                            .await?
-                            .into_iter()
-                            .map(|(_, id, doc)| {
-                                let text = serde_json::to_string_pretty(&doc)
-                                    .unwrap_or_else(|_| doc.to_string());
-
-                                Document {
-                                    id,
-                                    text,
-                                    additional_props: HashMap::new(),
-                                }
-                            })
-                            .collect::<Vec<_>>();
-
-                        Ok::<_, VectorStoreError>(docs)
-                    }
-                });
-
-                let fetched_context: Vec<Document> = futures::future::try_join_all(search_futures)
-                    .await
-                    .map_err(|e| CompletionError::RequestError(Box::new(e)))?
-                    .into_iter()
-                    .flatten()
-                    .collect();
-
-                let tool_snapshot = tool_server_handle
-                    .snapshot_tool_defs(Some(text.to_string()))
-                    .await
-                    .map_err(|_| {
-                        CompletionError::RequestError("Failed to get tool definitions".into())
-                    })?;
-
-                (tool_snapshot, fetched_context)
-            }
-            None => {
-                let tool_snapshot =
-                    tool_server_handle
-                        .snapshot_tool_defs(None)
-                        .await
-                        .map_err(|_| {
-                            CompletionError::RequestError("Failed to get tool definitions".into())
-                        })?;
-
-                (tool_snapshot, Vec::new())
-            }
-        };
+    let mut tool_snapshot = tool_server_handle
+        .snapshot_tool_defs(retrieval_query)
+        .await
+        .map_err(|_| CompletionError::RequestError("Failed to get tool definitions".into()))?;
 
     // When a per-turn `active_tools` allow-list is present, capture the full tool
     // set BEFORE filtering: the synthetic output-tool name must avoid colliding
@@ -550,13 +477,8 @@ pub(crate) async fn build_prepared_completion_request<M: CompletionModel>(
         .documents(static_context.to_vec())
         .tools(tooldefs);
 
-    if !fetched_context.is_empty() {
-        completion_request = completion_request.documents(fetched_context);
-    }
-
-    // Hook-supplied extra context documents (passive RAG) are appended last, so
-    // document order is static → dynamic (vector-store) → hook extras, with the
-    // extras in the hooks' registration order (they were merged in that order).
+    // Hook-supplied extra context documents (passive RAG) follow static context,
+    // with extras in hook registration order (they were merged in that order).
     // Per-turn and non-sticky: the next turn re-resolves from the baseline.
     if let Some(patch) = request_patch
         && !patch.extra_context.is_empty()
@@ -658,8 +580,6 @@ where
     /// backend storage and query costs.
     pub(crate) record_telemetry_content: bool,
     pub(crate) tool_server_handle: ToolServerHandle,
-    /// List of vector store, with the sample number
-    pub(crate) dynamic_context: DynamicContextStore,
     /// Whether or not the underlying LLM should be forced to use a tool before providing a response.
     pub(crate) tool_choice: Option<ToolChoice>,
     /// Default total model-call budget, including the initial call and every

--- a/crates/rig-core/src/agent/mod.rs
+++ b/crates/rig-core/src/agent/mod.rs
@@ -1,12 +1,11 @@
 //! This module contains the implementation of the [Agent] struct and its builder.
 //!
 //! The [Agent] struct represents an LLM agent, which combines an LLM model with a preamble (system prompt),
-//! a set of context documents, and a set of tools. Note: both context documents and tools can be either
-//! static (i.e.: they are always provided) or dynamic (i.e.: they are RAGged at prompt-time).
+//! a set of static context documents, and a set of tools. Tools can be always
+//! available or selected from a retrieval index at prompt time.
 //!
 //! The [Agent] struct is highly configurable, allowing the user to define anything from
-//! a simple bot with a specific system prompt to a complex RAG system with a set of dynamic
-//! context documents and tools.
+//! a simple bot with a specific system prompt to a complex RAG system.
 //!
 //! The [Agent] struct implements the runner-backed [crate::completion::Prompt],
 //! [crate::completion::TypedPrompt], and [crate::completion::Chat] traits. All
@@ -49,15 +48,66 @@
 //! # }
 //! ```
 //!
-//! RAG Agent example
+//! Passive RAG is application-defined: a completion-call hook chooses the query,
+//! retrieves documents, and injects them with [`RequestPatch::extra_context`].
+//! Active RAG instead exposes a vector index or custom retriever as a tool so the
+//! model decides when and how to search.
+//!
+//! Passive RAG agent example
 //! ```no_run
 //! use rig_core::{
+//!     agent::{AgentHook, CompletionCallAction, CompletionCallEvent, HookContext, RequestPatch},
 //!     client::{CompletionClient, EmbeddingsClient, ProviderClient},
-//!     completion::Prompt,
+//!     completion::{CompletionModel, Document, Message, Prompt},
 //!     embeddings::EmbeddingsBuilder,
+//!     message::UserContent,
 //!     providers::openai,
-//!     vector_store::in_memory_store::InMemoryVectorStore,
+//!     vector_store::{
+//!         VectorStoreIndexDyn,
+//!         in_memory_store::InMemoryVectorStore,
+//!         request::VectorSearchRequest,
+//!     },
 //! };
+//!
+//! struct DictionaryRag<I>(I);
+//!
+//! impl<M, I> AgentHook<M> for DictionaryRag<I>
+//! where
+//!     M: CompletionModel,
+//!     I: VectorStoreIndexDyn,
+//! {
+//!     async fn on_completion_call(
+//!         &self,
+//!         _ctx: &HookContext,
+//!         event: CompletionCallEvent<'_>,
+//!     ) -> CompletionCallAction {
+//!         let message_text = |message: &Message| match message {
+//!             Message::User { content } => content.iter().find_map(|item| match item {
+//!                 UserContent::Text(text) => Some(text.text.clone()),
+//!                 _ => None,
+//!             }),
+//!             _ => None,
+//!         };
+//!         let Some(query) = message_text(event.prompt)
+//!             .or_else(|| event.history.iter().rev().find_map(message_text))
+//!         else {
+//!             return CompletionCallAction::continue_run();
+//!         };
+//!
+//!         let request = VectorSearchRequest::builder().query(query).samples(1).build();
+//!         match self.0.top_n(request).await {
+//!             Ok(results) => CompletionCallAction::patch(RequestPatch::new().extra_context(
+//!                 results.into_iter().map(|(_, id, value)| Document {
+//!                     id,
+//!                     text: serde_json::to_string_pretty(&value)
+//!                         .unwrap_or_else(|_| value.to_string()),
+//!                     additional_props: Default::default(),
+//!                 }),
+//!             )),
+//!             Err(error) => CompletionCallAction::stop(format!("retrieval failed: {error}")),
+//!         }
+//!     }
+//! }
 //!
 //! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
 //! // Initialize OpenAI client
@@ -88,7 +138,7 @@
 //!         You are a dictionary assistant here to assist the user in understanding the meaning of words.
 //!         You will find additional non-standard word definitions that could be useful below.
 //!     ")
-//!     .dynamic_context(1, index)
+//!     .add_hook(DictionaryRag(index))
 //!     .build();
 //!
 //! // Prompt the agent and print the response

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -542,7 +542,6 @@ where
                         runner.record_telemetry_content,
                         runner.tool_choice.as_ref(),
                         &runner.tool_server_handle,
-                        &runner.dynamic_context,
                         runner.output_schema.as_ref(),
                         &runner.output_mode,
                         committed_output_tool.as_deref(),

--- a/crates/rig-core/src/agent/runner.rs
+++ b/crates/rig-core/src/agent/runner.rs
@@ -34,7 +34,7 @@ use futures::StreamExt;
 use tracing::{Instrument, info_span, span::Id};
 
 use super::{
-    completion::{Agent, DynamicContextStore, PreparedCompletionRequest},
+    completion::{Agent, PreparedCompletionRequest},
     hook::{
         AgentHook, CompletionCall, CompletionCallAction,
         CompletionResponse as CompletionResponseEvent, HookContext, HookStack,
@@ -193,7 +193,6 @@ where
     pub(crate) tool_server_handle: ToolServerHandle,
     /// Typed context cloned freshly for every tool dispatch.
     pub(crate) tool_context: ToolContext,
-    pub(crate) dynamic_context: DynamicContextStore,
     pub(crate) tool_choice: Option<ToolChoice>,
     pub(crate) output_schema: Option<schemars::Schema>,
     pub(crate) output_mode: OutputMode,
@@ -230,7 +229,6 @@ where
             record_telemetry_content: agent.record_telemetry_content,
             tool_server_handle: agent.tool_server_handle.clone(),
             tool_context: ToolContext::new(),
-            dynamic_context: agent.dynamic_context.clone(),
             tool_choice: agent.tool_choice.clone(),
             output_schema: agent.output_schema.clone(),
             output_mode: agent.output_mode.clone(),
@@ -1593,11 +1591,14 @@ mod migrated_tests {
     use serde_json::json;
     use tokio::sync::Notify;
 
+    use crate::OneOrMany;
     use crate::agent::AgentBuilder;
     use crate::agent::hook::{AgentHook, HookContext, RequestPatch, StepEventKind};
     use crate::agent::prompt_request::streaming::{MultiTurnStreamItem, StreamingError};
     use crate::agent::run::OutputMode;
-    use crate::completion::{CompletionError, CompletionModel, Message, Prompt, PromptError};
+    use crate::completion::{
+        CompletionError, CompletionModel, Document, Message, Prompt, PromptError,
+    };
     use crate::message::{
         AssistantContent, ToolCall as MessageToolCall, ToolChoice, ToolFunction, UserContent,
     };
@@ -1611,7 +1612,8 @@ mod migrated_tests {
         server::{ToolServer, ToolServerHandle},
     };
     use crate::vector_store::{
-        VectorSearchRequest, VectorStoreError, VectorStoreIndex, request::Filter,
+        VectorSearchRequest, VectorStoreError, VectorStoreIndex, VectorStoreIndexDyn,
+        request::Filter,
     };
     use crate::wasm_compat::WasmCompatSend;
 
@@ -6364,6 +6366,96 @@ mod migrated_tests {
         }
     }
 
+    struct RetrievalHook<I> {
+        index: I,
+    }
+
+    impl<M, I> AgentHook<M> for RetrievalHook<I>
+    where
+        M: CompletionModel,
+        I: VectorStoreIndexDyn,
+    {
+        async fn on_completion_call(
+            &self,
+            _ctx: &HookContext,
+            event: CompletionCallEvent<'_>,
+        ) -> CompletionCallAction {
+            let Message::User { content } = event.prompt else {
+                return CompletionCallAction::continue_run();
+            };
+            let Some(query) = content.iter().find_map(|item| match item {
+                UserContent::Text(text) => Some(text.text.clone()),
+                _ => None,
+            }) else {
+                return CompletionCallAction::continue_run();
+            };
+            let request = VectorSearchRequest::builder()
+                .query(query)
+                .samples(1)
+                .build();
+            match self.index.top_n(request).await {
+                Ok(results) => CompletionCallAction::patch(RequestPatch::new().extra_context(
+                    results.into_iter().map(|(_, id, value)| Document {
+                        id,
+                        text: value.to_string(),
+                        additional_props: Default::default(),
+                    }),
+                )),
+                Err(error) => CompletionCallAction::stop(format!("retrieval failed: {error}")),
+            }
+        }
+    }
+
+    struct FailingContextIndex;
+
+    impl VectorStoreIndex for FailingContextIndex {
+        type Filter = Filter<serde_json::Value>;
+
+        async fn top_n<T: for<'a> Deserialize<'a> + WasmCompatSend>(
+            &self,
+            _req: VectorSearchRequest,
+        ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {
+            Err(VectorStoreError::BuilderError(
+                "context index unavailable".to_string(),
+            ))
+        }
+
+        async fn top_n_ids(
+            &self,
+            _req: VectorSearchRequest,
+        ) -> Result<Vec<(f64, String)>, VectorStoreError> {
+            Err(VectorStoreError::BuilderError(
+                "context index unavailable".to_string(),
+            ))
+        }
+    }
+
+    struct QueryRecordingToolIndex {
+        queries: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl VectorStoreIndex for QueryRecordingToolIndex {
+        type Filter = Filter<serde_json::Value>;
+
+        async fn top_n<T: for<'a> Deserialize<'a> + WasmCompatSend>(
+            &self,
+            _req: VectorSearchRequest,
+        ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {
+            Ok(Vec::new())
+        }
+
+        async fn top_n_ids(
+            &self,
+            req: VectorSearchRequest,
+        ) -> Result<Vec<(f64, String)>, VectorStoreError> {
+            self.queries
+                .lock()
+                .expect("query recorder lock")
+                .push(req.query().to_string());
+            Ok(vec![(1.0, MockAddTool::NAME.to_string())])
+        }
+    }
+
     fn one_text_stream_turn(text: &'static str) -> Vec<MockStreamEvent> {
         vec![
             MockStreamEvent::text(text),
@@ -6455,6 +6547,154 @@ mod migrated_tests {
             ids,
             vec!["first", "second"],
             "hook extras append in registration order"
+        );
+    }
+
+    #[tokio::test]
+    async fn retrieval_failure_stops_before_provider_io_on_both_surfaces() {
+        let blocking_model = MockCompletionModel::from_turns([MockTurn::text("unused")]);
+        let blocking_probe = blocking_model.clone();
+        let error = AgentBuilder::new(blocking_model)
+            .add_hook(RetrievalHook {
+                index: FailingContextIndex,
+            })
+            .build()
+            .runner("retrieve this")
+            .run()
+            .await
+            .expect_err("failed retrieval should stop the run");
+        assert!(matches!(
+            error,
+            PromptError::PromptCancelled { reason, .. }
+                if reason.contains("context index unavailable")
+        ));
+        assert_eq!(blocking_probe.request_count(), 0);
+
+        let streaming_model =
+            MockCompletionModel::from_stream_turns([one_text_stream_turn("unused")]);
+        let streaming_probe = streaming_model.clone();
+        let mut stream = AgentBuilder::new(streaming_model)
+            .add_hook(RetrievalHook {
+                index: FailingContextIndex,
+            })
+            .build()
+            .runner("retrieve this")
+            .stream()
+            .await;
+        let error = stream
+            .next()
+            .await
+            .expect("stream should report retrieval failure")
+            .expect_err("failed retrieval should stop the stream");
+        assert!(matches!(
+            error,
+            StreamingError::Prompt(prompt_error)
+                if matches!(
+                    prompt_error.as_ref(),
+                    PromptError::PromptCancelled { reason, .. }
+                        if reason.contains("context index unavailable")
+                )
+        ));
+        assert_eq!(streaming_probe.request_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn retrieved_tool_query_selection_is_unchanged_on_both_surfaces() {
+        let queries = Arc::new(Mutex::new(Vec::new()));
+        AgentBuilder::new(MockCompletionModel::from_turns([MockTurn::text("done")]))
+            .retrieved_tools(
+                1,
+                QueryRecordingToolIndex {
+                    queries: queries.clone(),
+                },
+                ToolSet::from_tools(vec![MockAddTool]),
+            )
+            .build()
+            .runner("blocking retrieval query")
+            .history(vec![Message::user("blocking history query")])
+            .run()
+            .await
+            .expect("blocking run should succeed");
+
+        AgentBuilder::new(MockCompletionModel::from_turns([MockTurn::text("done")]))
+            .retrieved_tools(
+                1,
+                QueryRecordingToolIndex {
+                    queries: queries.clone(),
+                },
+                ToolSet::from_tools(vec![MockAddTool]),
+            )
+            .build()
+            .runner(Message::User {
+                content: OneOrMany::one(UserContent::image_url(
+                    "https://example.com/blocking.png",
+                    None,
+                    None,
+                )),
+            })
+            .history(vec![
+                Message::user("older blocking history query"),
+                Message::user("latest blocking history query"),
+            ])
+            .run()
+            .await
+            .expect("blocking history fallback should succeed");
+
+        let mut stream = AgentBuilder::new(MockCompletionModel::from_stream_turns([
+            one_text_stream_turn("done"),
+        ]))
+        .retrieved_tools(
+            1,
+            QueryRecordingToolIndex {
+                queries: queries.clone(),
+            },
+            ToolSet::from_tools(vec![MockAddTool]),
+        )
+        .build()
+        .runner("streaming retrieval query")
+        .history(vec![Message::user("streaming history query")])
+        .stream()
+        .await;
+        while let Some(item) = stream.next().await {
+            item.expect("stream item should succeed");
+        }
+
+        let mut stream = AgentBuilder::new(MockCompletionModel::from_stream_turns([
+            one_text_stream_turn("done"),
+        ]))
+        .retrieved_tools(
+            1,
+            QueryRecordingToolIndex {
+                queries: queries.clone(),
+            },
+            ToolSet::from_tools(vec![MockAddTool]),
+        )
+        .build()
+        .runner(Message::User {
+            content: OneOrMany::one(UserContent::image_url(
+                "https://example.com/streaming.png",
+                None,
+                None,
+            )),
+        })
+        .history(vec![
+            Message::user("older streaming history query"),
+            Message::user("latest streaming history query"),
+        ])
+        .stream()
+        .await;
+        while let Some(item) = stream.next().await {
+            item.expect("stream item should succeed");
+        }
+
+        assert_eq!(
+            *queries.lock().expect("query recorder lock"),
+            vec![
+                "blocking retrieval query",
+                "latest blocking history query",
+                "streaming retrieval query",
+                "latest streaming history query",
+            ]
         );
     }
 

--- a/crates/rig-core/src/extractor.rs
+++ b/crates/rig-core/src/extractor.rs
@@ -38,7 +38,6 @@ use crate::{
     agent::{Agent, AgentBuilder, AgentHook, OutputMode},
     completion::{CompletionError, CompletionModel, PromptError, Usage},
     message::{Message, ToolChoice},
-    vector_store::VectorStoreIndexDyn,
     wasm_compat::{WasmCompatSend, WasmCompatSync},
 };
 
@@ -331,19 +330,6 @@ where
             retries: self.retries.unwrap_or(0),
         }
     }
-
-    /// Add dynamic context (RAG) to the extractor.
-    ///
-    /// On each prompt, `sample` documents will be retrieved from the index based on the RAG text
-    /// and inserted in the request.
-    pub fn dynamic_context(
-        mut self,
-        sample: usize,
-        dynamic_context: impl VectorStoreIndexDyn + Send + Sync + 'static,
-    ) -> Self {
-        self.agent_builder = self.agent_builder.dynamic_context(sample, dynamic_context);
-        self
-    }
 }
 
 #[cfg(test)]
@@ -356,7 +342,9 @@ mod tests {
     use serde_json::json;
 
     use super::*;
-    use crate::agent::{CompletionResponseEvent, HookContext, ObservationAction};
+    use crate::agent::{
+        CompletionCallAction, CompletionResponseEvent, HookContext, ObservationAction, RequestPatch,
+    };
     use crate::message::{AssistantContent, ToolCall, ToolFunction};
     use crate::test_utils::{MockCompletionModel, MockTurn};
 
@@ -451,6 +439,25 @@ mod tests {
             _event: crate::agent::CompletionCallEvent<'_>,
         ) -> crate::agent::CompletionCallAction {
             crate::agent::CompletionCallAction::stop("extractor stopped")
+        }
+    }
+
+    struct ExtractorRetrievalHook;
+
+    impl<M> AgentHook<M> for ExtractorRetrievalHook
+    where
+        M: CompletionModel,
+    {
+        async fn on_completion_call(
+            &self,
+            _ctx: &HookContext,
+            _event: crate::agent::CompletionCallEvent<'_>,
+        ) -> CompletionCallAction {
+            CompletionCallAction::patch(RequestPatch::new().context(crate::completion::Document {
+                id: "application-retrieval".to_string(),
+                text: "retrieved extractor context".to_string(),
+                additional_props: Default::default(),
+            }))
         }
     }
 
@@ -566,6 +573,28 @@ mod tests {
         assert_eq!(counts.completion_calls.load(Ordering::SeqCst), 1);
         assert_eq!(counts.completion_responses.load(Ordering::SeqCst), 1);
         assert_eq!(counts.model_turns.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn extractor_accepts_application_defined_retrieval_hook() {
+        let model = MockCompletionModel::new([submit_turn("John")]);
+        let probe = model.clone();
+        let response = ExtractorBuilder::<_, Person>::new(model)
+            .add_hook(ExtractorRetrievalHook)
+            .build()
+            .extract("John")
+            .await
+            .expect("extraction should succeed");
+
+        assert_eq!(response.name, "John");
+        let requests = probe.requests();
+        let request = requests.first().expect("one extractor request");
+        assert!(
+            request
+                .documents
+                .iter()
+                .any(|document| document.id == "application-retrieval")
+        );
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/extractor.rs
+++ b/crates/rig-core/src/extractor.rs
@@ -593,7 +593,8 @@ mod tests {
             request
                 .documents
                 .iter()
-                .any(|document| document.id == "application-retrieval")
+                .any(|document| document.id == "application-retrieval"
+                    && document.text == "retrieved extractor context")
         );
     }
 

--- a/crates/rig-core/src/lib.rs
+++ b/crates/rig-core/src/lib.rs
@@ -69,8 +69,15 @@
 //! Rig provides a common interface for working with vector stores and indexes. Specifically, the library
 //! provides the [VectorStoreIndex](crate::vector_store::VectorStoreIndex)
 //! trait, which can be implemented to define vector stores and indices respectively.
-//! Those can then be used as the knowledge base for a RAG enabled [Agent](crate::agent::Agent), or
-//! as a source of context documents in a custom architecture that use multiple LLMs or agents.
+//! There are two complementary ways to use an index with an [Agent](crate::agent::Agent):
+//! - For passive RAG, implement an [`AgentHook`](crate::agent::AgentHook) that queries the index
+//!   in `on_completion_call` and returns a
+//!   [`RequestPatch::extra_context`](crate::agent::RequestPatch::extra_context). This keeps
+//!   query selection, document formatting, and retrieval failure policy in application code.
+//! - For active RAG, expose the index through its blanket [`Tool`](crate::tool::Tool)
+//!   implementation, or through a custom tool, so the model decides when and how to retrieve.
+//!
+//! Indexes can also serve custom architectures that use multiple LLMs or agents.
 //!
 //! ## Conversation memory
 //! Rig can transparently load and persist per-conversation history through the

--- a/crates/rig-core/src/memory.rs
+++ b/crates/rig-core/src/memory.rs
@@ -2,7 +2,7 @@
 //!
 //! Memory differs from existing agent context features:
 //! - [`crate::agent::AgentBuilder::context`]: static documents always included in prompts.
-//! - [`crate::agent::AgentBuilder::dynamic_context`]: RAG documents fetched from a vector store.
+//! - [`crate::agent::RequestPatch::extra_context`]: per-turn documents supplied by application hooks.
 //! - [`crate::agent::prompt_request::PromptRequest::history`]: caller-managed message history.
 //! - **Memory** (this module): Rig-managed history loaded and saved automatically per
 //!   conversation id.

--- a/crates/rig-core/src/vector_store/mod.rs
+++ b/crates/rig-core/src/vector_store/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! - [`VectorStoreIndex`]: Query a vector store for similar documents.
 //! - [`InsertDocuments`]: Insert documents and their embeddings.
-//! - [`VectorStoreIndexDyn`]: Type-erased version for dynamic contexts.
+//! - [`VectorStoreIndexDyn`]: Type-erased vector queries for runtime-defined retrieval policies.
 //!
 //! Use [`VectorSearchRequest`] to build queries. See [`request`] for filtering.
 //!
@@ -242,6 +242,51 @@ where
                 document,
             })
             .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tool::ToolContext;
+    use crate::vector_store::request::Filter;
+
+    struct TestIndex;
+
+    impl VectorStoreIndex for TestIndex {
+        type Filter = Filter<serde_json::Value>;
+
+        async fn top_n<T: for<'a> Deserialize<'a> + WasmCompatSend>(
+            &self,
+            _req: VectorSearchRequest,
+        ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {
+            let document = serde_json::from_value(json!({ "answer": 42 }))?;
+            Ok(vec![(0.9, "doc-1".to_string(), document)])
+        }
+
+        async fn top_n_ids(
+            &self,
+            _req: VectorSearchRequest,
+        ) -> Result<Vec<(f64, String)>, VectorStoreError> {
+            Ok(vec![(0.9, "doc-1".to_string())])
+        }
+    }
+
+    #[tokio::test]
+    async fn vector_store_index_remains_a_tool() {
+        let request = VectorSearchRequest::builder()
+            .query("answer")
+            .samples(1)
+            .build();
+        let output = <TestIndex as Tool>::call(&TestIndex, &mut ToolContext::new(), request)
+            .await
+            .expect("vector tool call should succeed");
+
+        assert_eq!(<TestIndex as Tool>::NAME, "search_vector_store");
+        assert_eq!(output.len(), 1);
+        let result = output.first().expect("one vector result");
+        assert_eq!(result.id, "doc-1");
+        assert_eq!(result.document, json!({ "answer": 42 }));
     }
 }
 

--- a/crates/rig-core/src/vector_store/mod.rs
+++ b/crates/rig-core/src/vector_store/mod.rs
@@ -245,51 +245,6 @@ where
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::tool::ToolContext;
-    use crate::vector_store::request::Filter;
-
-    struct TestIndex;
-
-    impl VectorStoreIndex for TestIndex {
-        type Filter = Filter<serde_json::Value>;
-
-        async fn top_n<T: for<'a> Deserialize<'a> + WasmCompatSend>(
-            &self,
-            _req: VectorSearchRequest,
-        ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {
-            let document = serde_json::from_value(json!({ "answer": 42 }))?;
-            Ok(vec![(0.9, "doc-1".to_string(), document)])
-        }
-
-        async fn top_n_ids(
-            &self,
-            _req: VectorSearchRequest,
-        ) -> Result<Vec<(f64, String)>, VectorStoreError> {
-            Ok(vec![(0.9, "doc-1".to_string())])
-        }
-    }
-
-    #[tokio::test]
-    async fn vector_store_index_remains_a_tool() {
-        let request = VectorSearchRequest::builder()
-            .query("answer")
-            .samples(1)
-            .build();
-        let output = <TestIndex as Tool>::call(&TestIndex, &mut ToolContext::new(), request)
-            .await
-            .expect("vector tool call should succeed");
-
-        assert_eq!(<TestIndex as Tool>::NAME, "search_vector_store");
-        assert_eq!(output.len(), 1);
-        let result = output.first().expect("one vector result");
-        assert_eq!(result.id, "doc-1");
-        assert_eq!(result.document, json!({ "answer": 42 }));
-    }
-}
-
 /// Index strategy for the super::InMemoryVectorStore
 #[derive(Clone, Debug, Default)]
 pub enum IndexStrategy {
@@ -304,4 +259,66 @@ pub enum IndexStrategy {
         /// Number of hyperplanes to use for LSH.
         num_hyperplanes: usize,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+    use crate::tool::ToolContext;
+    use crate::vector_store::request::Filter;
+
+    struct TestIndex {
+        queries: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl VectorStoreIndex for TestIndex {
+        type Filter = Filter<serde_json::Value>;
+
+        async fn top_n<T: for<'a> Deserialize<'a> + WasmCompatSend>(
+            &self,
+            req: VectorSearchRequest,
+        ) -> Result<Vec<(f64, String, T)>, VectorStoreError> {
+            self.queries
+                .lock()
+                .expect("query recorder lock")
+                .push(req.query().to_string());
+            let document = serde_json::from_value(json!({ "answer": 42 }))?;
+            Ok(vec![(0.9, "doc-1".to_string(), document)])
+        }
+
+        async fn top_n_ids(
+            &self,
+            _req: VectorSearchRequest,
+        ) -> Result<Vec<(f64, String)>, VectorStoreError> {
+            Ok(vec![(0.9, "doc-1".to_string())])
+        }
+    }
+
+    #[tokio::test]
+    async fn vector_store_index_remains_a_tool() {
+        let queries = Arc::new(Mutex::new(Vec::new()));
+        let index = TestIndex {
+            queries: queries.clone(),
+        };
+        let request = VectorSearchRequest::builder()
+            .query("answer")
+            .samples(1)
+            .build();
+        let output = <TestIndex as Tool>::call(&index, &mut ToolContext::new(), request)
+            .await
+            .expect("vector tool call should succeed");
+
+        assert_eq!(<TestIndex as Tool>::NAME, "search_vector_store");
+        assert_eq!(
+            *queries.lock().expect("query recorder lock"),
+            vec!["answer"]
+        );
+        assert_eq!(output.len(), 1);
+        let result = output.first().expect("one vector result");
+        assert_eq!(result.score, 0.9);
+        assert_eq!(result.id, "doc-1");
+        assert_eq!(result.document, json!({ "answer": 42 }));
+    }
 }

--- a/crates/rig-lancedb/examples/vector_search_local_ann_agent.rs
+++ b/crates/rig-lancedb/examples/vector_search_local_ann_agent.rs
@@ -1,17 +1,68 @@
 use fixture::{Word, as_record_batch, words};
 use lancedb::index::vector::IvfPqIndexBuilder;
+use rig_core::agent::{
+    AgentHook, CompletionCallAction, CompletionCallEvent, HookContext, RequestPatch,
+};
 use rig_core::client::{EmbeddingsClient, ProviderClient};
-use rig_core::completion::Prompt;
+use rig_core::completion::{CompletionModel, Document, Message, Prompt};
+use rig_core::message::UserContent;
 use rig_core::prelude::CompletionClient;
 use rig_core::providers::openai;
 use rig_core::{
     embeddings::{EmbeddingModel, EmbeddingsBuilder},
     providers::openai::Client,
+    vector_store::{VectorStoreIndexDyn, request::VectorSearchRequest},
 };
 use rig_lancedb::{LanceDbVectorIndex, SearchParams};
 
 #[path = "./fixtures/lib.rs"]
 mod fixture;
+
+struct LanceDbRag<I> {
+    index: I,
+    samples: usize,
+}
+
+impl<M, I> AgentHook<M> for LanceDbRag<I>
+where
+    M: CompletionModel,
+    I: VectorStoreIndexDyn,
+{
+    async fn on_completion_call(
+        &self,
+        _ctx: &HookContext,
+        event: CompletionCallEvent<'_>,
+    ) -> CompletionCallAction {
+        let message_text = |message: &Message| match message {
+            Message::User { content } => content.iter().find_map(|item| match item {
+                UserContent::Text(text) => Some(text.text.clone()),
+                _ => None,
+            }),
+            _ => None,
+        };
+        let Some(query) = message_text(event.prompt)
+            .or_else(|| event.history.iter().rev().find_map(message_text))
+        else {
+            return CompletionCallAction::continue_run();
+        };
+
+        let request = VectorSearchRequest::builder()
+            .query(query)
+            .samples(self.samples as u64)
+            .build();
+        match self.index.top_n(request).await {
+            Ok(results) => CompletionCallAction::patch(RequestPatch::new().extra_context(
+                results.into_iter().map(|(_, id, value)| Document {
+                    id,
+                    text:
+                        serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string()),
+                    additional_props: Default::default(),
+                }),
+            )),
+            Err(error) => CompletionCallAction::stop(format!("LanceDB retrieval failed: {error}")),
+        }
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
@@ -71,7 +122,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let search_params = SearchParams::default();
     let vector_store_index = LanceDbVectorIndex::new(table, model, "id", search_params).await?;
 
-    // Build RAG agent with dynamic context
+    // Build a passive-RAG agent with application-defined retrieval policy.
     // Use OpenAI-compatible API interface to build agent
     let agent = openai_client
         .completion_model(openai::GPT_4O)
@@ -79,7 +130,10 @@ async fn main() -> Result<(), anyhow::Error> {
         .into_agent_builder()
         .temperature(0.5)
         .preamble("You are a helpful AI assistant.")
-        .dynamic_context(top_k, vector_store_index)
+        .add_hook(LanceDbRag {
+            index: vector_store_index,
+            samples: top_k,
+        })
         .build();
 
     let query = "My boss says I zindle too much, what does that mean?";

--- a/crates/rig-lancedb/examples/vector_search_local_ann_agent.rs
+++ b/crates/rig-lancedb/examples/vector_search_local_ann_agent.rs
@@ -20,7 +20,7 @@ mod fixture;
 
 struct LanceDbRag<I> {
     index: I,
-    samples: usize,
+    samples: u64,
 }
 
 impl<M, I> AgentHook<M> for LanceDbRag<I>
@@ -48,7 +48,7 @@ where
 
         let request = VectorSearchRequest::builder()
             .query(query)
-            .samples(self.samples as u64)
+            .samples(self.samples)
             .build();
         match self.index.top_n(request).await {
             Ok(results) => CompletionCallAction::patch(RequestPatch::new().extra_context(
@@ -132,7 +132,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .preamble("You are a helpful AI assistant.")
         .add_hook(LanceDbRag {
             index: vector_store_index,
-            samples: top_k,
+            samples: top_k as u64,
         })
         .build();
 

--- a/crates/rig-surrealdb/src/lib.rs
+++ b/crates/rig-surrealdb/src/lib.rs
@@ -493,7 +493,7 @@ mod tests {
 
     #[allow(clippy::panic)]
     #[tokio::test]
-    async fn surreal_vector_store_supports_dynamic_context_filters() {
+    async fn surreal_vector_store_supports_type_erased_queries() {
         fn assert_dyn<T: VectorStoreIndexDyn + Send + Sync + 'static>(_: T) {}
 
         let surreal = match Surreal::new::<Mem>(()).await {

--- a/examples/gemini_extractor_with_rag/Cargo.toml
+++ b/examples/gemini_extractor_with_rag/Cargo.toml
@@ -12,6 +12,7 @@ rig = { workspace = true, features = ["derive"] }
 anyhow = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/examples/gemini_extractor_with_rag/src/main.rs
+++ b/examples/gemini_extractor_with_rag/src/main.rs
@@ -42,7 +42,7 @@ struct QuestionnaireResponses {
 
 struct QuestionnaireRag<I> {
     index: I,
-    samples: usize,
+    samples: u64,
 }
 
 impl<M, I> AgentHook<M> for QuestionnaireRag<I>
@@ -70,7 +70,7 @@ where
 
         let request = VectorSearchRequest::builder()
             .query(query)
-            .samples(self.samples as u64)
+            .samples(self.samples)
             .build();
         match self.index.top_n(request).await {
             Ok(results) => CompletionCallAction::patch(RequestPatch::new().extra_context(

--- a/examples/gemini_extractor_with_rag/src/main.rs
+++ b/examples/gemini_extractor_with_rag/src/main.rs
@@ -2,7 +2,12 @@ use rig::prelude::*;
 use rig::providers::gemini;
 use rig::providers::gemini::client::Client;
 use rig::{
-    Embed, embeddings::EmbeddingsBuilder, vector_store::in_memory_store::InMemoryVectorStore,
+    Embed,
+    agent::{AgentHook, CompletionCallAction, CompletionCallEvent, HookContext, RequestPatch},
+    completion::{Document, Message},
+    embeddings::EmbeddingsBuilder,
+    message::UserContent,
+    vector_store::{VectorStoreIndexDyn, in_memory_store::InMemoryVectorStore},
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -33,6 +38,52 @@ struct Answer {
 struct QuestionnaireResponses {
     /// The list of responses to the questionnaire
     responses: Vec<Answer>,
+}
+
+struct QuestionnaireRag<I> {
+    index: I,
+    samples: usize,
+}
+
+impl<M, I> AgentHook<M> for QuestionnaireRag<I>
+where
+    M: CompletionModel,
+    I: VectorStoreIndexDyn,
+{
+    async fn on_completion_call(
+        &self,
+        _ctx: &HookContext,
+        event: CompletionCallEvent<'_>,
+    ) -> CompletionCallAction {
+        let message_text = |message: &Message| match message {
+            Message::User { content } => content.iter().find_map(|item| match item {
+                UserContent::Text(text) => Some(text.text.clone()),
+                _ => None,
+            }),
+            _ => None,
+        };
+        let Some(query) = message_text(event.prompt)
+            .or_else(|| event.history.iter().rev().find_map(message_text))
+        else {
+            return CompletionCallAction::continue_run();
+        };
+
+        let request = VectorSearchRequest::builder()
+            .query(query)
+            .samples(self.samples as u64)
+            .build();
+        match self.index.top_n(request).await {
+            Ok(results) => CompletionCallAction::patch(RequestPatch::new().extra_context(
+                results.into_iter().map(|(_, id, value)| Document {
+                    id,
+                    text:
+                        serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string()),
+                    additional_props: Default::default(),
+                }),
+            )),
+            Err(error) => CompletionCallAction::stop(format!("question retrieval failed: {error}")),
+        }
+    }
 }
 
 const APPLICANT_INFO: &str = r#"
@@ -100,7 +151,8 @@ async fn main() -> Result<(), anyhow::Error> {
             You are provided with the questions and based on the information available, you must answer the questions with the right format.
             Use the answer ID field to map the answer to the right question ID. Answer as much as possible without inventing information.
             ")
-        .dynamic_context(3, index) // Samples should match the number of questions
+        // Samples should match the number of questions.
+        .add_hook(QuestionnaireRag { index, samples: 3 })
         .build();
 
     // Prompt the agent and print the response

--- a/examples/pdf_agent/Cargo.toml
+++ b/examples/pdf_agent/Cargo.toml
@@ -11,4 +11,5 @@ workspace = true
 rig = { workspace = true, features = ["derive", "pdf"] }
 anyhow = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/examples/pdf_agent/src/main.rs
+++ b/examples/pdf_agent/src/main.rs
@@ -24,7 +24,7 @@ struct Document {
 
 struct PdfRag<I> {
     index: I,
-    samples: usize,
+    samples: u64,
 }
 
 impl<M, I> AgentHook<M> for PdfRag<I>
@@ -52,7 +52,7 @@ where
 
         let request = VectorSearchRequest::builder()
             .query(query)
-            .samples(self.samples as u64)
+            .samples(self.samples)
             .build();
         match self.index.top_n(request).await {
             Ok(results) => CompletionCallAction::patch(RequestPatch::new().extra_context(

--- a/examples/pdf_agent/src/main.rs
+++ b/examples/pdf_agent/src/main.rs
@@ -4,8 +4,13 @@ use rig::integrations::cli_chatbot::ChatBotBuilder;
 use rig::prelude::*;
 use rig::providers::ollama;
 use rig::{
-    Embed, embeddings::EmbeddingsBuilder, loaders::PdfFileLoader,
-    vector_store::in_memory_store::InMemoryVectorStore,
+    Embed,
+    agent::{AgentHook, CompletionCallAction, CompletionCallEvent, HookContext, RequestPatch},
+    completion::{Document as ContextDocument, Message},
+    embeddings::EmbeddingsBuilder,
+    loaders::PdfFileLoader,
+    message::UserContent,
+    vector_store::{VectorStoreIndexDyn, in_memory_store::InMemoryVectorStore},
 };
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -15,6 +20,52 @@ struct Document {
     id: String,
     #[embed]
     content: String,
+}
+
+struct PdfRag<I> {
+    index: I,
+    samples: usize,
+}
+
+impl<M, I> AgentHook<M> for PdfRag<I>
+where
+    M: CompletionModel,
+    I: VectorStoreIndexDyn,
+{
+    async fn on_completion_call(
+        &self,
+        _ctx: &HookContext,
+        event: CompletionCallEvent<'_>,
+    ) -> CompletionCallAction {
+        let message_text = |message: &Message| match message {
+            Message::User { content } => content.iter().find_map(|item| match item {
+                UserContent::Text(text) => Some(text.text.clone()),
+                _ => None,
+            }),
+            _ => None,
+        };
+        let Some(query) = message_text(event.prompt)
+            .or_else(|| event.history.iter().rev().find_map(message_text))
+        else {
+            return CompletionCallAction::continue_run();
+        };
+
+        let request = VectorSearchRequest::builder()
+            .query(query)
+            .samples(self.samples as u64)
+            .build();
+        match self.index.top_n(request).await {
+            Ok(results) => CompletionCallAction::patch(RequestPatch::new().extra_context(
+                results.into_iter().map(|(_, id, value)| ContextDocument {
+                    id,
+                    text:
+                        serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string()),
+                    additional_props: Default::default(),
+                }),
+            )),
+            Err(error) => CompletionCallAction::stop(format!("PDF retrieval failed: {error}")),
+        }
+    }
 }
 
 fn load_pdf(path: PathBuf) -> Result<Vec<String>> {
@@ -94,7 +145,7 @@ async fn main() -> Result<()> {
     let rag_agent = client
         .agent("deepseek-r1")
         .preamble("You are a helpful assistant that answers questions based on the provided document context. When answering questions, try to synthesize information from multiple chunks if they're related.")
-        .dynamic_context(1, index)
+        .add_hook(PdfRag { index, samples: 1 })
         .build();
 
     println!("Starting CLI chatbot...");

--- a/examples/rag/Cargo.toml
+++ b/examples/rag/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 rig = { workspace = true, features = ["derive"] }
 anyhow = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/examples/rag/src/main.rs
+++ b/examples/rag/src/main.rs
@@ -1,8 +1,13 @@
 use rig::prelude::*;
 use rig::providers::openai::client::Client;
 use rig::{
-    Embed, completion::Prompt, embeddings::EmbeddingsBuilder, providers::openai,
-    vector_store::in_memory_store::InMemoryVectorStore,
+    Embed,
+    agent::{AgentHook, CompletionCallAction, CompletionCallEvent, HookContext, RequestPatch},
+    completion::{Document, Message, Prompt},
+    embeddings::EmbeddingsBuilder,
+    message::UserContent,
+    providers::openai,
+    vector_store::{VectorStoreIndexDyn, in_memory_store::InMemoryVectorStore},
 };
 use serde::Serialize;
 use std::vec;
@@ -16,6 +21,54 @@ struct WordDefinition {
     word: String,
     #[embed]
     definitions: Vec<String>,
+}
+
+struct DictionaryRag<I> {
+    index: I,
+    samples: usize,
+}
+
+impl<M, I> AgentHook<M> for DictionaryRag<I>
+where
+    M: CompletionModel,
+    I: VectorStoreIndexDyn,
+{
+    async fn on_completion_call(
+        &self,
+        _ctx: &HookContext,
+        event: CompletionCallEvent<'_>,
+    ) -> CompletionCallAction {
+        let message_text = |message: &Message| match message {
+            Message::User { content } => content.iter().find_map(|item| match item {
+                UserContent::Text(text) => Some(text.text.clone()),
+                _ => None,
+            }),
+            _ => None,
+        };
+        let Some(query) = message_text(event.prompt)
+            .or_else(|| event.history.iter().rev().find_map(message_text))
+        else {
+            return CompletionCallAction::continue_run();
+        };
+
+        let request = VectorSearchRequest::builder()
+            .query(query)
+            .samples(self.samples as u64)
+            .build();
+        match self.index.top_n(request).await {
+            Ok(results) => CompletionCallAction::patch(RequestPatch::new().extra_context(
+                results.into_iter().map(|(_, id, value)| Document {
+                    id,
+                    text:
+                        serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string()),
+                    additional_props: Default::default(),
+                }),
+            )),
+            Err(error) => {
+                CompletionCallAction::stop(format!("dictionary retrieval failed: {error}"))
+            }
+        }
+    }
 }
 
 #[tokio::main]
@@ -70,7 +123,7 @@ async fn main() -> Result<(), anyhow::Error> {
             You are a dictionary assistant here to assist the user in understanding the meaning of words.
             You will find additional non-standard word definitions that could be useful below.
         ")
-        .dynamic_context(1, index)
+        .add_hook(DictionaryRag { index, samples: 1 })
         .build();
 
     // Prompt the agent and print the response

--- a/examples/rag/src/main.rs
+++ b/examples/rag/src/main.rs
@@ -25,7 +25,7 @@ struct WordDefinition {
 
 struct DictionaryRag<I> {
     index: I,
-    samples: usize,
+    samples: u64,
 }
 
 impl<M, I> AgentHook<M> for DictionaryRag<I>
@@ -53,7 +53,7 @@ where
 
         let request = VectorSearchRequest::builder()
             .query(query)
-            .samples(self.samples as u64)
+            .samples(self.samples)
             .build();
         match self.index.top_n(request).await {
             Ok(results) => CompletionCallAction::patch(RequestPatch::new().extra_context(

--- a/examples/rag_ollama/Cargo.toml
+++ b/examples/rag_ollama/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 rig = { workspace = true, features = ["derive"] }
 anyhow = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/examples/rag_ollama/src/main.rs
+++ b/examples/rag_ollama/src/main.rs
@@ -1,8 +1,13 @@
 use rig::client::Nothing;
 use rig::prelude::*;
 use rig::{
-    Embed, completion::Prompt, embeddings::EmbeddingsBuilder, providers::ollama::Client,
-    vector_store::in_memory_store::InMemoryVectorStore,
+    Embed,
+    agent::{AgentHook, CompletionCallAction, CompletionCallEvent, HookContext, RequestPatch},
+    completion::{Document, Message, Prompt},
+    embeddings::EmbeddingsBuilder,
+    message::UserContent,
+    providers::ollama::Client,
+    vector_store::{VectorStoreIndexDyn, in_memory_store::InMemoryVectorStore},
 };
 use serde::Serialize;
 
@@ -15,6 +20,54 @@ struct WordDefinition {
     word: String,
     #[embed]
     definitions: Vec<String>,
+}
+
+struct DictionaryRag<I> {
+    index: I,
+    samples: usize,
+}
+
+impl<M, I> AgentHook<M> for DictionaryRag<I>
+where
+    M: CompletionModel,
+    I: VectorStoreIndexDyn,
+{
+    async fn on_completion_call(
+        &self,
+        _ctx: &HookContext,
+        event: CompletionCallEvent<'_>,
+    ) -> CompletionCallAction {
+        let message_text = |message: &Message| match message {
+            Message::User { content } => content.iter().find_map(|item| match item {
+                UserContent::Text(text) => Some(text.text.clone()),
+                _ => None,
+            }),
+            _ => None,
+        };
+        let Some(query) = message_text(event.prompt)
+            .or_else(|| event.history.iter().rev().find_map(message_text))
+        else {
+            return CompletionCallAction::continue_run();
+        };
+
+        let request = VectorSearchRequest::builder()
+            .query(query)
+            .samples(self.samples as u64)
+            .build();
+        match self.index.top_n(request).await {
+            Ok(results) => CompletionCallAction::patch(RequestPatch::new().extra_context(
+                results.into_iter().map(|(_, id, value)| Document {
+                    id,
+                    text:
+                        serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string()),
+                    additional_props: Default::default(),
+                }),
+            )),
+            Err(error) => {
+                CompletionCallAction::stop(format!("dictionary retrieval failed: {error}"))
+            }
+        }
+    }
 }
 
 #[tokio::main]
@@ -70,7 +123,7 @@ async fn main() -> Result<(), anyhow::Error> {
             You are a dictionary assistant here to assist the user in understanding the meaning of words.
             You will find additional non-standard word definitions that could be useful below.
         ")
-        .dynamic_context(1, index)
+        .add_hook(DictionaryRag { index, samples: 1 })
         .build();
 
     // Prompt the agent and print the response

--- a/examples/rag_ollama/src/main.rs
+++ b/examples/rag_ollama/src/main.rs
@@ -24,7 +24,7 @@ struct WordDefinition {
 
 struct DictionaryRag<I> {
     index: I,
-    samples: usize,
+    samples: u64,
 }
 
 impl<M, I> AgentHook<M> for DictionaryRag<I>
@@ -52,7 +52,7 @@ where
 
         let request = VectorSearchRequest::builder()
             .query(query)
-            .samples(self.samples as u64)
+            .samples(self.samples)
             .build();
         match self.index.top_n(request).await {
             Ok(results) => CompletionCallAction::patch(RequestPatch::new().extra_context(

--- a/tests/core/mod.rs
+++ b/tests/core/mod.rs
@@ -4,5 +4,6 @@ mod loaders;
 mod prompt_response_messages;
 mod provider_layout;
 mod reasoning_stream_stats;
+mod removed_passive_context_api;
 #[cfg(feature = "derive")]
 mod tool_macro;

--- a/tests/core/removed_passive_context_api.rs
+++ b/tests/core/removed_passive_context_api.rs
@@ -1,0 +1,48 @@
+//! Guards the removal of the former built-in passive retrieval API.
+
+use std::{fs, path::Path};
+
+fn source_files(root: &Path, files: &mut Vec<std::path::PathBuf>) {
+    for entry in fs::read_dir(root).expect("repository source directory should be readable") {
+        let path = entry.expect("repository entry should be readable").path();
+        if path.is_dir() {
+            source_files(&path, files);
+            continue;
+        }
+
+        if path.file_name().and_then(|name| name.to_str()) == Some("CHANGELOG.md") {
+            continue;
+        }
+
+        if matches!(
+            path.extension().and_then(|extension| extension.to_str()),
+            Some("rs" | "md" | "toml" | "yml" | "yaml")
+        ) {
+            files.push(path);
+        }
+    }
+}
+
+#[test]
+fn removed_passive_context_builder_api_stays_absent() {
+    let repository = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let mut files = Vec::new();
+    for directory in ["crates", "examples", "src", "tests"] {
+        source_files(&repository.join(directory), &mut files);
+    }
+    files.extend([repository.join("Cargo.toml"), repository.join("README.md")]);
+
+    let removed_name = ["dynamic", "context"].join("_");
+    let references = files
+        .into_iter()
+        .filter_map(|path| {
+            let contents = fs::read_to_string(&path).ok()?;
+            contents.contains(&removed_name).then_some(path)
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        references.is_empty(),
+        "the removed passive retrieval API is still referenced in {references:#?}"
+    );
+}

--- a/tests/core/removed_passive_context_api.rs
+++ b/tests/core/removed_passive_context_api.rs
@@ -1,16 +1,28 @@
 //! Guards the removal of the former built-in passive retrieval API.
 
-use std::{fs, path::Path};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
-fn source_files(root: &Path, files: &mut Vec<std::path::PathBuf>) {
+fn is_ignored(path: &Path) -> bool {
+    path.file_name()
+        .is_some_and(|name| matches!(name.to_str(), Some(".git" | "target" | "CHANGELOG.md")))
+}
+
+fn source_files(root: &Path, files: &mut Vec<PathBuf>) {
+    if is_ignored(root) || !root.exists() {
+        return;
+    }
+
     for entry in fs::read_dir(root).expect("repository source directory should be readable") {
         let path = entry.expect("repository entry should be readable").path();
-        if path.is_dir() {
-            source_files(&path, files);
+        if is_ignored(&path) {
             continue;
         }
 
-        if path.file_name().and_then(|name| name.to_str()) == Some("CHANGELOG.md") {
+        if path.is_dir() {
+            source_files(&path, files);
             continue;
         }
 
@@ -27,17 +39,28 @@ fn source_files(root: &Path, files: &mut Vec<std::path::PathBuf>) {
 fn removed_passive_context_builder_api_stays_absent() {
     let repository = Path::new(env!("CARGO_MANIFEST_DIR"));
     let mut files = Vec::new();
-    for directory in ["crates", "examples", "src", "tests"] {
+    for directory in ["crates", "examples", "src", "tests", ".github"] {
         source_files(&repository.join(directory), &mut files);
     }
-    files.extend([repository.join("Cargo.toml"), repository.join("README.md")]);
+    for file in ["Cargo.toml", "README.md", "AGENTS.md", "CONTRIBUTING.md"] {
+        let path = repository.join(file);
+        if path.exists() {
+            files.push(path);
+        }
+    }
 
-    let removed_name = ["dynamic", "context"].join("_");
+    let removed_names = [
+        ["dynamic", "context"].join("_"),
+        ["Dynamic", "Context", "Store"].concat(),
+    ];
     let references = files
         .into_iter()
         .filter_map(|path| {
             let contents = fs::read_to_string(&path).ok()?;
-            contents.contains(&removed_name).then_some(path)
+            removed_names
+                .iter()
+                .any(|removed_name| contents.contains(removed_name))
+                .then_some(path)
         })
         .collect::<Vec<_>>();
 

--- a/tests/integrations/lancedb/mod.rs
+++ b/tests/integrations/lancedb/mod.rs
@@ -27,7 +27,7 @@ mod fixture;
 
 struct LanceDbRag<I> {
     index: I,
-    samples: usize,
+    samples: u64,
 }
 
 impl<M, I> AgentHook<M> for LanceDbRag<I>
@@ -55,7 +55,7 @@ where
 
         let request = VectorSearchRequest::builder()
             .query(query)
-            .samples(self.samples as u64)
+            .samples(self.samples)
             .build();
         match rig::vector_store::VectorStoreIndexDyn::top_n(&self.index, request).await {
             Ok(results) => CompletionCallAction::patch(RequestPatch::new().extra_context(
@@ -448,7 +448,7 @@ async fn agent_with_application_defined_context_test() {
         .into_agent_builder()
         .add_hook(LanceDbRag {
             index: vector_store_index,
-            samples: top_k,
+            samples: top_k as u64,
         })
         .build();
 

--- a/tests/integrations/lancedb/mod.rs
+++ b/tests/integrations/lancedb/mod.rs
@@ -10,11 +10,13 @@ use serde_json::json;
 
 use fixture::{Word, as_record_batch, words};
 use lancedb::index::vector::IvfPqIndexBuilder;
+use rig::agent::{AgentHook, CompletionCallAction, CompletionCallEvent, HookContext, RequestPatch};
 use rig::lancedb::{LanceDbVectorIndex, SearchParams};
 use rig::{
     client::EmbeddingsClient,
-    completion::Prompt,
+    completion::{CompletionModel, Document, Message, Prompt},
     embeddings::{EmbeddingModel, EmbeddingsBuilder},
+    message::UserContent,
     prelude::CompletionClient,
     providers::openai,
     vector_store::{VectorStoreIndex, request::VectorSearchRequest},
@@ -22,6 +24,52 @@ use rig::{
 
 #[path = "./fixtures/lib.rs"]
 mod fixture;
+
+struct LanceDbRag<I> {
+    index: I,
+    samples: usize,
+}
+
+impl<M, I> AgentHook<M> for LanceDbRag<I>
+where
+    M: CompletionModel,
+    I: rig::vector_store::VectorStoreIndexDyn,
+{
+    async fn on_completion_call(
+        &self,
+        _ctx: &HookContext,
+        event: CompletionCallEvent<'_>,
+    ) -> CompletionCallAction {
+        let message_text = |message: &Message| match message {
+            Message::User { content } => content.iter().find_map(|item| match item {
+                UserContent::Text(text) => Some(text.text.clone()),
+                _ => None,
+            }),
+            _ => None,
+        };
+        let Some(query) = message_text(event.prompt)
+            .or_else(|| event.history.iter().rev().find_map(message_text))
+        else {
+            return CompletionCallAction::continue_run();
+        };
+
+        let request = VectorSearchRequest::builder()
+            .query(query)
+            .samples(self.samples as u64)
+            .build();
+        match rig::vector_store::VectorStoreIndexDyn::top_n(&self.index, request).await {
+            Ok(results) => CompletionCallAction::patch(RequestPatch::new().extra_context(
+                results.into_iter().map(|(_, id, value)| Document {
+                    id,
+                    text:
+                        serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string()),
+                    additional_props: Default::default(),
+                }),
+            )),
+            Err(error) => CompletionCallAction::stop(format!("LanceDB retrieval failed: {error}")),
+        }
+    }
+}
 
 #[tokio::test]
 async fn vector_search_test() {
@@ -206,7 +254,7 @@ async fn vector_search_test() {
 }
 
 #[tokio::test]
-async fn agent_with_dynamic_context_test() {
+async fn agent_with_application_defined_context_test() {
     // Setup mock openai API
     let server = httpmock::MockServer::start();
 
@@ -393,12 +441,15 @@ async fn agent_with_dynamic_context_test() {
         .await
         .unwrap();
 
-    // Build RAG agent with dynamic context
+    // Build passive RAG with an application-defined retrieval hook.
     let agent = openai_client
         .completion_model(openai::GPT_4O)
         .completions_api()
         .into_agent_builder()
-        .dynamic_context(top_k, vector_store_index)
+        .add_hook(LanceDbRag {
+            index: vector_store_index,
+            samples: top_k,
+        })
         .build();
 
     let query = "My boss says I zindle too much, what does that mean?";


### PR DESCRIPTION
## What changed

- remove `AgentBuilder::dynamic_context`, `ExtractorBuilder::dynamic_context`, `DynamicContextStore`, and all runner/request plumbing
- migrate passive-RAG examples to small application-owned `AgentHook::on_completion_call` implementations
- preserve retrieved-tool query selection and the vector-index `Tool` implementation
- document passive hook-based RAG versus active tool-based RAG
- add regression coverage for blocking/streaming hook context, retrieval failure, extractor hooks, query selection, vector tools, and source-tree API removal

## Why

Hardcoded passive retrieval embedded application policy in agent request construction. Hooks already provide the correct per-turn policy boundary and behave consistently across blocking, streaming, and extractor execution.

## Impact

This is a breaking API removal. Callers should replace `.dynamic_context(samples, index)` with a local completion-call hook that queries the index and patches `RequestPatch::extra_context`. Retrieval failures can stop the run before provider I/O. Model-directed retrieval remains available by exposing a vector index or custom retriever as a tool.

## Root cause

The original dynamic-context feature coupled vector retrieval, query selection, document formatting, and error policy to the core completion builder. Removing that special path leaves one managed execution lifecycle and makes retrieval policy explicit.

## Verification

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo doc --workspace --no-deps`
- `cargo check -p rig-core --target wasm32-unknown-unknown --features wasm`
- targeted migrated-example checks and independent full-diff review

External-service-backed examples were compiled but not executed.