### PR TITLE
Make agent hooks provider-independent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,7 +152,7 @@ Use `WasmCompatSend` and `WasmCompatSync` bounds.
 
 ## Agent Hook Changes
 
-Agent hooks are per-run lifecycle observers and steerers. `AgentHook<M>` exposes
+Agent hooks are per-run lifecycle observers and steerers. `AgentHook` exposes
 one method per lifecycle event, and every method receives the run-scoped
 `HookContext` (run id, turn, streaming flag, agent name, shared `Scratchpad`).
 Each method returns an event-specific action type, so unsupported combinations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- *(agent)* [**breaking**] Remove the completion-model generic from managed
+  hooks. `AgentHook<M>`, `HookStack<M>`, and their response events are now
+  provider-independent `AgentHook`, `HookStack`, `CompletionResponseEvent<'_>`,
+  and `StreamResponseFinish<'_>`. Managed response hooks receive canonical Rig
+  assistant content, usage, prompt, and message ID; direct `CompletionModel`
+  completion and streaming APIs continue exposing typed provider responses.
+
+  ```rust
+  // Before
+  impl<M: CompletionModel> AgentHook<M> for TelemetryHook { /* ... */ }
+
+  // After
+  impl AgentHook for TelemetryHook { /* ... */ }
+  ```
 - *(agent)* [**breaking**] Remove the built-in `AgentBuilder::dynamic_context`,
   `ExtractorBuilder::dynamic_context`, and internal `DynamicContextStore`
   passive-retrieval pipeline. Static builder context remains available. For
@@ -27,9 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       samples: u64,
   }
 
-  impl<M, I> AgentHook<M> for AppRetrievalHook<I>
+  impl<I> AgentHook for AppRetrievalHook<I>
   where
-      M: CompletionModel,
       I: VectorStoreIndexDyn,
   {
       async fn on_completion_call(

--- a/crates/rig-bedrock/examples/rag_with_bedrock.rs
+++ b/crates/rig-bedrock/examples/rag_with_bedrock.rs
@@ -9,7 +9,7 @@ use rig_core::agent::{
 use rig_core::client::{CompletionClient, EmbeddingsClient, ProviderClient};
 use rig_core::{
     Embed,
-    completion::{CompletionModel, Document, Message, Prompt},
+    completion::{Document, Message, Prompt},
     embeddings::EmbeddingsBuilder,
     message::UserContent,
     vector_store::{
@@ -35,9 +35,8 @@ struct DictionaryRag<I> {
     samples: u64,
 }
 
-impl<M, I> AgentHook<M> for DictionaryRag<I>
+impl<I> AgentHook for DictionaryRag<I>
 where
-    M: CompletionModel,
     I: VectorStoreIndexDyn,
 {
     async fn on_completion_call(

--- a/crates/rig-core/CHANGELOG.md
+++ b/crates/rig-core/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- *(agent)* [**breaking**] Remove the completion-model generic from managed
+  hooks. `AgentHook<M>` becomes `AgentHook`, `HookStack<M>` becomes `HookStack`,
+  and completion/stream response events now expose canonical Rig assistant
+  content, usage, prompt, and message ID instead of typed provider payloads.
+  Direct `CompletionModel` completion and streaming APIs remain the source of
+  typed provider responses.
+
+  ```rust
+  // Before
+  impl<M: CompletionModel> AgentHook<M> for TelemetryHook { /* ... */ }
+
+  // After
+  impl AgentHook for TelemetryHook { /* ... */ }
+  ```
 - *(agent)* [**breaking**] Remove `AgentBuilder::dynamic_context`,
   `ExtractorBuilder::dynamic_context`, and the internal `DynamicContextStore`
   passive-retrieval pipeline. Static builder context remains available. Rig no
@@ -25,9 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       samples: u64,
   }
 
-  impl<M, I> AgentHook<M> for AppRetrievalHook<I>
+  impl<I> AgentHook for AppRetrievalHook<I>
   where
-      M: CompletionModel,
       I: VectorStoreIndexDyn,
   {
       async fn on_completion_call(

--- a/crates/rig-core/src/agent/builder.rs
+++ b/crates/rig-core/src/agent/builder.rs
@@ -123,7 +123,7 @@ where
     /// Tool configuration state (typestate pattern)
     tool_state: ToolState,
     /// Default hook stack applied to every prompt request from the built agent.
-    hooks: HookStack<M>,
+    hooks: HookStack,
     /// Optional JSON Schema for structured output
     output_schema: Option<schemars::Schema>,
     /// How `output_schema` is enforced (tool vs native vs prompted; see #1928)
@@ -281,7 +281,7 @@ where
     /// [`hook`](crate::agent::hook) module docs.
     pub fn add_hook<H>(mut self, hook: H) -> Self
     where
-        H: AgentHook<M> + 'static,
+        H: AgentHook + 'static,
     {
         self.hooks.push(hook);
         self
@@ -736,7 +736,7 @@ mod tests {
     #[derive(Clone)]
     struct BuilderHook;
 
-    impl AgentHook<MockCompletionModel> for BuilderHook {}
+    impl AgentHook for BuilderHook {}
 
     #[test]
     fn hook_can_be_set_after_tool_configuration() {

--- a/crates/rig-core/src/agent/completion.rs
+++ b/crates/rig-core/src/agent/completion.rs
@@ -587,7 +587,7 @@ where
     pub(crate) default_max_turns: Option<usize>,
     /// Default hook stack applied to every prompt request and runner created
     /// from this agent. Empty by default.
-    pub(crate) hooks: HookStack<M>,
+    pub(crate) hooks: HookStack,
     /// Optional JSON Schema for structured output. When set, providers that support
     /// native structured outputs will constrain the model's response to match this schema.
     pub(crate) output_schema: Option<schemars::Schema>,

--- a/crates/rig-core/src/agent/hook.rs
+++ b/crates/rig-core/src/agent/hook.rs
@@ -22,6 +22,20 @@
 //! Blocking and streaming agents share the same request, tool-call, and
 //! tool-result resolution path. Streaming adds delta-specific observations, but
 //! shared lifecycle actions have identical semantics on both surfaces.
+//!
+//! Hooks are provider-independent. [`CompletionResponse`] and
+//! [`StreamResponseFinish`] expose canonical Rig messages, usage, and message
+//! identifiers; provider-specific response types remain available through the
+//! direct [`CompletionModel`](crate::completion::CompletionModel) APIs.
+//!
+//! ```rust
+//! # use rig_core::agent::AgentHook;
+//! struct TelemetryHook;
+//!
+//! // No model type parameter is needed, so one hook can be reused with every
+//! // completion-model implementation.
+//! impl AgentHook for TelemetryHook {}
+//! ```
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -30,7 +44,7 @@ use std::{future::Future, sync::Arc};
 use crate::tool::extensions::TypeMap;
 use crate::{
     OneOrMany,
-    completion::{CompletionModel, Document, Usage},
+    completion::{Document, Usage},
     json_utils,
     message::{AssistantContent, Message, ToolChoice},
     tool::{ToolContext, ToolOutput, ToolResult},
@@ -301,19 +315,17 @@ pub struct CompletionCall<'a> {
     pub turn: usize,
 }
 
-/// Non-streaming completion response event.
-pub struct CompletionResponse<'a, M: CompletionModel> {
+/// Canonical non-streaming completion response event.
+#[derive(Clone, Copy)]
+pub struct CompletionResponse<'a> {
     /// Prompt sent for this turn.
     pub prompt: &'a Message,
-    /// Normalized response and raw provider payload.
-    pub response: &'a crate::completion::CompletionResponse<M::Response>,
-}
-
-impl<M: CompletionModel> Copy for CompletionResponse<'_, M> {}
-impl<M: CompletionModel> Clone for CompletionResponse<'_, M> {
-    fn clone(&self) -> Self {
-        *self
-    }
+    /// Canonical assistant content returned for this turn.
+    pub content: &'a OneOrMany<AssistantContent>,
+    /// Usage reported for this turn.
+    pub usage: Usage,
+    /// Provider-assigned message ID, when available.
+    pub message_id: Option<&'a str>,
 }
 
 /// Medium-neutral accepted model-turn event.
@@ -384,19 +396,17 @@ pub struct ToolCallDelta<'a> {
     pub delta: &'a str,
 }
 
-/// Streaming response-finish event.
-pub struct StreamResponseFinish<'a, M: CompletionModel> {
+/// Canonical streaming response-finish event.
+#[derive(Clone, Copy)]
+pub struct StreamResponseFinish<'a> {
     /// Prompt sent for this turn.
     pub prompt: &'a Message,
-    /// Provider's final streaming response.
-    pub response: &'a M::StreamingResponse,
-}
-
-impl<M: CompletionModel> Copy for StreamResponseFinish<'_, M> {}
-impl<M: CompletionModel> Clone for StreamResponseFinish<'_, M> {
-    fn clone(&self) -> Self {
-        *self
-    }
+    /// Canonical assistant content aggregated for this turn.
+    pub content: &'a OneOrMany<AssistantContent>,
+    /// Usage reported for this turn.
+    pub usage: Usage,
+    /// Provider-assigned message ID, when available.
+    pub message_id: Option<&'a str>,
 }
 
 /// Hook event kind used only as an observation performance hint.
@@ -767,10 +777,7 @@ impl ObservationAction {
 }
 
 /// Per-run lifecycle observer and steerer.
-pub trait AgentHook<M>: WasmCompatSend + WasmCompatSync
-where
-    M: CompletionModel,
-{
+pub trait AgentHook: WasmCompatSend + WasmCompatSync {
     /// Runs before a completion request is sent.
     ///
     /// Return a per-turn patch, continue without one, or stop the run. Patches
@@ -789,7 +796,7 @@ where
     fn on_completion_response(
         &self,
         _ctx: &HookContext,
-        _event: CompletionResponse<'_, M>,
+        _event: CompletionResponse<'_>,
     ) -> impl Future<Output = ObservationAction> + WasmCompatSend {
         async { ObservationAction::Continue }
     }
@@ -869,13 +876,13 @@ where
         async { ObservationAction::Continue }
     }
 
-    /// Observes the provider's final streaming response.
+    /// Observes the canonical final streaming response.
     ///
     /// The default action continues the run.
     fn on_stream_response_finish(
         &self,
         _ctx: &HookContext,
-        _event: StreamResponseFinish<'_, M>,
+        _event: StreamResponseFinish<'_>,
     ) -> impl Future<Output = ObservationAction> + WasmCompatSend {
         async { ObservationAction::Continue }
     }
@@ -886,135 +893,98 @@ where
     }
 }
 
-impl<M: CompletionModel> AgentHook<M> for () {
+impl AgentHook for () {
     fn observes(&self, _kind: StepEventKind) -> bool {
         false
     }
 }
 
-trait DynAgentHook<M>: WasmCompatSend + WasmCompatSync
-where
-    M: CompletionModel,
-{
+trait DynAgentHook: WasmCompatSend + WasmCompatSync {
     fn completion_call<'a>(
         &'a self,
         ctx: &'a HookContext,
         event: CompletionCall<'a>,
-    ) -> WasmBoxedFuture<'a, CompletionCallAction>
-    where
-        M: 'a;
+    ) -> WasmBoxedFuture<'a, CompletionCallAction>;
     fn completion_response<'a>(
         &'a self,
         ctx: &'a HookContext,
-        event: CompletionResponse<'a, M>,
-    ) -> WasmBoxedFuture<'a, ObservationAction>
-    where
-        M: 'a;
+        event: CompletionResponse<'a>,
+    ) -> WasmBoxedFuture<'a, ObservationAction>;
     fn model_turn_finished<'a>(
         &'a self,
         ctx: &'a HookContext,
         event: ModelTurnFinished<'a>,
-    ) -> WasmBoxedFuture<'a, ObservationAction>
-    where
-        M: 'a;
+    ) -> WasmBoxedFuture<'a, ObservationAction>;
     fn invalid_tool_call<'a>(
         &'a self,
         ctx: &'a HookContext,
         event: &'a InvalidToolCallContext,
-    ) -> WasmBoxedFuture<'a, Option<InvalidToolCallAction>>
-    where
-        M: 'a;
+    ) -> WasmBoxedFuture<'a, Option<InvalidToolCallAction>>;
     fn tool_call<'a>(
         &'a self,
         ctx: &'a HookContext,
         event: ToolCall<'a>,
-    ) -> WasmBoxedFuture<'a, (ToolCallAction, Option<serde_json::Value>)>
-    where
-        M: 'a;
+    ) -> WasmBoxedFuture<'a, (ToolCallAction, Option<serde_json::Value>)>;
     fn tool_result<'a>(
         &'a self,
         ctx: &'a HookContext,
         event: ToolResultEvent<'a>,
-    ) -> WasmBoxedFuture<'a, ToolResultAction>
-    where
-        M: 'a;
+    ) -> WasmBoxedFuture<'a, ToolResultAction>;
     fn text_delta<'a>(
         &'a self,
         ctx: &'a HookContext,
         event: TextDelta<'a>,
-    ) -> WasmBoxedFuture<'a, ObservationAction>
-    where
-        M: 'a;
+    ) -> WasmBoxedFuture<'a, ObservationAction>;
     fn tool_call_delta<'a>(
         &'a self,
         ctx: &'a HookContext,
         event: ToolCallDelta<'a>,
-    ) -> WasmBoxedFuture<'a, ObservationAction>
-    where
-        M: 'a;
+    ) -> WasmBoxedFuture<'a, ObservationAction>;
     fn stream_response_finish<'a>(
         &'a self,
         ctx: &'a HookContext,
-        event: StreamResponseFinish<'a, M>,
-    ) -> WasmBoxedFuture<'a, ObservationAction>
-    where
-        M: 'a;
+        event: StreamResponseFinish<'a>,
+    ) -> WasmBoxedFuture<'a, ObservationAction>;
     fn observes(&self, kind: StepEventKind) -> bool;
 }
 
-impl<M, H> DynAgentHook<M> for H
+impl<H> DynAgentHook for H
 where
-    M: CompletionModel,
-    H: AgentHook<M>,
+    H: AgentHook,
 {
     fn completion_call<'a>(
         &'a self,
         ctx: &'a HookContext,
         event: CompletionCall<'a>,
-    ) -> WasmBoxedFuture<'a, CompletionCallAction>
-    where
-        M: 'a,
-    {
+    ) -> WasmBoxedFuture<'a, CompletionCallAction> {
         Box::pin(self.on_completion_call(ctx, event))
     }
     fn completion_response<'a>(
         &'a self,
         ctx: &'a HookContext,
-        event: CompletionResponse<'a, M>,
-    ) -> WasmBoxedFuture<'a, ObservationAction>
-    where
-        M: 'a,
-    {
+        event: CompletionResponse<'a>,
+    ) -> WasmBoxedFuture<'a, ObservationAction> {
         Box::pin(self.on_completion_response(ctx, event))
     }
     fn model_turn_finished<'a>(
         &'a self,
         ctx: &'a HookContext,
         event: ModelTurnFinished<'a>,
-    ) -> WasmBoxedFuture<'a, ObservationAction>
-    where
-        M: 'a,
-    {
+    ) -> WasmBoxedFuture<'a, ObservationAction> {
         Box::pin(self.on_model_turn_finished(ctx, event))
     }
     fn invalid_tool_call<'a>(
         &'a self,
         ctx: &'a HookContext,
         event: &'a InvalidToolCallContext,
-    ) -> WasmBoxedFuture<'a, Option<InvalidToolCallAction>>
-    where
-        M: 'a,
-    {
+    ) -> WasmBoxedFuture<'a, Option<InvalidToolCallAction>> {
         Box::pin(self.on_invalid_tool_call(ctx, event))
     }
     fn tool_call<'a>(
         &'a self,
         ctx: &'a HookContext,
         event: ToolCall<'a>,
-    ) -> WasmBoxedFuture<'a, (ToolCallAction, Option<serde_json::Value>)>
-    where
-        M: 'a,
-    {
+    ) -> WasmBoxedFuture<'a, (ToolCallAction, Option<serde_json::Value>)> {
         Box::pin(async move {
             // Only `on_tool_call` is public dispatch. A nested `HookStack`
             // records terminal-path rewrite state into this private frame.
@@ -1027,40 +997,28 @@ where
         &'a self,
         ctx: &'a HookContext,
         event: ToolResultEvent<'a>,
-    ) -> WasmBoxedFuture<'a, ToolResultAction>
-    where
-        M: 'a,
-    {
+    ) -> WasmBoxedFuture<'a, ToolResultAction> {
         Box::pin(self.on_tool_result(ctx, event))
     }
     fn text_delta<'a>(
         &'a self,
         ctx: &'a HookContext,
         event: TextDelta<'a>,
-    ) -> WasmBoxedFuture<'a, ObservationAction>
-    where
-        M: 'a,
-    {
+    ) -> WasmBoxedFuture<'a, ObservationAction> {
         Box::pin(self.on_text_delta(ctx, event))
     }
     fn tool_call_delta<'a>(
         &'a self,
         ctx: &'a HookContext,
         event: ToolCallDelta<'a>,
-    ) -> WasmBoxedFuture<'a, ObservationAction>
-    where
-        M: 'a,
-    {
+    ) -> WasmBoxedFuture<'a, ObservationAction> {
         Box::pin(self.on_tool_call_delta(ctx, event))
     }
     fn stream_response_finish<'a>(
         &'a self,
         ctx: &'a HookContext,
-        event: StreamResponseFinish<'a, M>,
-    ) -> WasmBoxedFuture<'a, ObservationAction>
-    where
-        M: 'a,
-    {
+        event: StreamResponseFinish<'a>,
+    ) -> WasmBoxedFuture<'a, ObservationAction> {
         Box::pin(self.on_stream_response_finish(ctx, event))
     }
     fn observes(&self, kind: StepEventKind) -> bool {
@@ -1069,23 +1027,12 @@ where
 }
 
 /// Ordered composable hook stack.
-pub struct HookStack<M: CompletionModel> {
-    hooks: Vec<Arc<dyn DynAgentHook<M>>>,
+#[derive(Clone, Default)]
+pub struct HookStack {
+    hooks: Vec<Arc<dyn DynAgentHook>>,
 }
 
-impl<M: CompletionModel> Clone for HookStack<M> {
-    fn clone(&self) -> Self {
-        Self {
-            hooks: self.hooks.clone(),
-        }
-    }
-}
-impl<M: CompletionModel> Default for HookStack<M> {
-    fn default() -> Self {
-        Self { hooks: Vec::new() }
-    }
-}
-impl<M: CompletionModel> std::fmt::Debug for HookStack<M> {
+impl std::fmt::Debug for HookStack {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("HookStack")
             .field("len", &self.hooks.len())
@@ -1093,21 +1040,21 @@ impl<M: CompletionModel> std::fmt::Debug for HookStack<M> {
     }
 }
 
-impl<M: CompletionModel> HookStack<M> {
+impl HookStack {
     /// Creates an empty hook stack.
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Creates a hook stack containing `hook`.
-    pub fn with<H: AgentHook<M> + 'static>(hook: H) -> Self {
+    pub fn with<H: AgentHook + 'static>(hook: H) -> Self {
         let mut stack = Self::new();
         stack.push(hook);
         stack
     }
 
     /// Appends a hook to the end of the stack's registration order.
-    pub fn push<H: AgentHook<M> + 'static>(&mut self, hook: H) {
+    pub fn push<H: AgentHook + 'static>(&mut self, hook: H) {
         self.hooks.push(Arc::new(hook));
     }
 
@@ -1164,7 +1111,7 @@ where
     ObservationAction::Continue
 }
 
-impl<M: CompletionModel> AgentHook<M> for HookStack<M> {
+impl AgentHook for HookStack {
     async fn on_completion_call(
         &self,
         ctx: &HookContext,
@@ -1189,7 +1136,7 @@ impl<M: CompletionModel> AgentHook<M> for HookStack<M> {
     async fn on_completion_response(
         &self,
         ctx: &HookContext,
-        event: CompletionResponse<'_, M>,
+        event: CompletionResponse<'_>,
     ) -> ObservationAction {
         let mut actions = Vec::new();
         for hook in &self.hooks {
@@ -1281,7 +1228,7 @@ impl<M: CompletionModel> AgentHook<M> for HookStack<M> {
     async fn on_stream_response_finish(
         &self,
         ctx: &HookContext,
-        event: StreamResponseFinish<'_, M>,
+        event: StreamResponseFinish<'_>,
     ) -> ObservationAction {
         for hook in &self.hooks {
             let action = hook.stream_response_finish(ctx, event).await;
@@ -1299,13 +1246,10 @@ impl<M: CompletionModel> AgentHook<M> for HookStack<M> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        test_utils::MockCompletionModel,
-        tool::{ToolErrorKind, ToolExecutionError},
-    };
+    use crate::tool::{ToolErrorKind, ToolExecutionError};
 
     struct Patcher(f64);
-    impl AgentHook<MockCompletionModel> for Patcher {
+    impl AgentHook for Patcher {
         async fn on_completion_call(
             &self,
             _ctx: &HookContext,
@@ -1346,7 +1290,7 @@ mod tests {
         replacement: serde_json::Value,
     }
 
-    impl AgentHook<MockCompletionModel> for CallRewriter {
+    impl AgentHook for CallRewriter {
         async fn on_tool_call(&self, _ctx: &HookContext, event: ToolCall<'_>) -> ToolCallAction {
             self.seen.lock().unwrap().push(event.args.to_string());
             ToolCallAction::rewrite(self.replacement.clone())
@@ -1393,7 +1337,7 @@ mod tests {
         replacement: String,
     }
 
-    impl AgentHook<MockCompletionModel> for ResultRewriter {
+    impl AgentHook for ResultRewriter {
         async fn on_tool_result(
             &self,
             _ctx: &HookContext,
@@ -1466,7 +1410,7 @@ mod tests {
         calls: Arc<AtomicUsize>,
     }
 
-    impl AgentHook<MockCompletionModel> for StopThenCount {
+    impl AgentHook for StopThenCount {
         async fn on_tool_result(
             &self,
             _ctx: &HookContext,
@@ -1522,10 +1466,7 @@ mod migrated_tests {
     };
 
     use super::*;
-    use crate::test_utils::MockCompletionModel;
     use serde_json::{Value, json};
-
-    type M = MockCompletionModel;
 
     fn ctx() -> HookContext {
         HookContext::new(false, Some("test-agent".to_string()))
@@ -1536,7 +1477,7 @@ mod migrated_tests {
         log: Arc<Mutex<Vec<u32>>>,
         stop: bool,
     }
-    impl AgentHook<M> for ToolRecorder {
+    impl AgentHook for ToolRecorder {
         async fn on_tool_call(&self, _ctx: &HookContext, _event: ToolCall<'_>) -> ToolCallAction {
             self.log.lock().expect("log").push(self.label);
             if self.stop {
@@ -1552,7 +1493,7 @@ mod migrated_tests {
         log: Arc<Mutex<Vec<u32>>>,
         stop: bool,
     }
-    impl AgentHook<M> for ObservationRecorder {
+    impl AgentHook for ObservationRecorder {
         async fn on_text_delta(
             &self,
             _ctx: &HookContext,
@@ -1568,7 +1509,7 @@ mod migrated_tests {
     }
 
     struct ObservesOnly(StepEventKind);
-    impl AgentHook<M> for ObservesOnly {
+    impl AgentHook for ObservesOnly {
         fn observes(&self, kind: StepEventKind) -> bool {
             kind == self.0
         }
@@ -1578,7 +1519,7 @@ mod migrated_tests {
         action: InvalidToolCallAction,
         calls: Arc<AtomicUsize>,
     }
-    impl AgentHook<M> for InvalidResponder {
+    impl AgentHook for InvalidResponder {
         async fn on_invalid_tool_call(
             &self,
             _ctx: &HookContext,
@@ -1595,7 +1536,7 @@ mod migrated_tests {
         patch: RequestPatch,
         stop: bool,
     }
-    impl AgentHook<M> for Patcher {
+    impl AgentHook for Patcher {
         async fn on_completion_call(
             &self,
             _ctx: &HookContext,
@@ -1644,7 +1585,7 @@ mod migrated_tests {
     #[tokio::test]
     async fn runs_hooks_in_registration_order_and_consults_all_on_continue() {
         let log = Arc::new(Mutex::new(Vec::new()));
-        let mut stack = HookStack::<M>::with(ToolRecorder {
+        let mut stack = HookStack::with(ToolRecorder {
             label: 1,
             log: log.clone(),
             stop: false,
@@ -1664,7 +1605,7 @@ mod migrated_tests {
     #[tokio::test]
     async fn first_stop_short_circuits_on_chained_tool_call() {
         let log = Arc::new(Mutex::new(Vec::new()));
-        let mut stack = HookStack::<M>::with(ToolRecorder {
+        let mut stack = HookStack::with(ToolRecorder {
             label: 1,
             log: log.clone(),
             stop: true,
@@ -1684,7 +1625,7 @@ mod migrated_tests {
     #[tokio::test]
     async fn first_stop_short_circuits_observation() {
         let log = Arc::new(Mutex::new(Vec::new()));
-        let mut stack = HookStack::<M>::with(ObservationRecorder {
+        let mut stack = HookStack::with(ObservationRecorder {
             label: 1,
             log: log.clone(),
             stop: true,
@@ -1713,7 +1654,7 @@ mod migrated_tests {
     async fn explicit_fail_short_circuits_later_invalid_tool_hooks() {
         let fail_calls = Arc::new(AtomicUsize::new(0));
         let retry_calls = Arc::new(AtomicUsize::new(0));
-        let mut stack = HookStack::<M>::with(InvalidResponder {
+        let mut stack = HookStack::with(InvalidResponder {
             action: InvalidToolCallAction::fail(),
             calls: fail_calls.clone(),
         });
@@ -1734,7 +1675,7 @@ mod migrated_tests {
     #[tokio::test]
     async fn no_invalid_tool_decision_defers_to_later_hooks() {
         let retry_calls = Arc::new(AtomicUsize::new(0));
-        let mut stack = HookStack::<M>::with(());
+        let mut stack = HookStack::with(());
         stack.push(InvalidResponder {
             action: InvalidToolCallAction::retry("try another tool"),
             calls: retry_calls.clone(),
@@ -1754,7 +1695,7 @@ mod migrated_tests {
     #[tokio::test]
     async fn completion_patches_accumulate_and_stop_discards_prior_patch() {
         let log = Arc::new(Mutex::new(Vec::new()));
-        let mut stack = HookStack::<M>::with(Patcher {
+        let mut stack = HookStack::with(Patcher {
             label: 1,
             log: log.clone(),
             patch: RequestPatch::new().temperature(0.1),
@@ -1777,7 +1718,7 @@ mod migrated_tests {
             other => panic!("expected patch, got {other:?}"),
         }
         assert_eq!(*log.lock().unwrap(), vec![1, 2]);
-        let mut stopped = HookStack::<M>::with(Patcher {
+        let mut stopped = HookStack::with(Patcher {
             label: 3,
             log: log.clone(),
             patch: RequestPatch::new(),
@@ -1801,7 +1742,7 @@ mod migrated_tests {
     #[tokio::test]
     async fn nested_stack_composes_patches() {
         let log = Arc::new(Mutex::new(Vec::new()));
-        let mut inner = HookStack::<M>::with(Patcher {
+        let mut inner = HookStack::with(Patcher {
             label: 1,
             log: log.clone(),
             patch: RequestPatch::new().temperature(0.2),
@@ -1813,7 +1754,7 @@ mod migrated_tests {
             patch: RequestPatch::new().max_tokens(128),
             stop: false,
         });
-        let mut outer = HookStack::<M>::with(inner);
+        let mut outer = HookStack::with(inner);
         outer.push(Patcher {
             label: 3,
             log: log.clone(),
@@ -1836,17 +1777,17 @@ mod migrated_tests {
 
     #[test]
     fn stack_observes_is_the_or_of_members() {
-        let mut stack = HookStack::<M>::with(ObservesOnly(StepEventKind::ToolCall));
+        let mut stack = HookStack::with(ObservesOnly(StepEventKind::ToolCall));
         stack.push(ObservesOnly(StepEventKind::ToolResult));
-        assert!(<HookStack<M> as AgentHook<M>>::observes(
+        assert!(<HookStack as AgentHook>::observes(
             &stack,
             StepEventKind::ToolCall
         ));
-        assert!(<HookStack<M> as AgentHook<M>>::observes(
+        assert!(<HookStack as AgentHook>::observes(
             &stack,
             StepEventKind::ToolResult
         ));
-        assert!(!<HookStack<M> as AgentHook<M>>::observes(
+        assert!(!<HookStack as AgentHook>::observes(
             &stack,
             StepEventKind::TextDelta
         ));
@@ -1854,9 +1795,9 @@ mod migrated_tests {
 
     #[test]
     fn empty_stack_observes_nothing() {
-        let empty = HookStack::<M>::new();
+        let empty = HookStack::new();
         assert!(empty.is_empty());
-        assert!(!<HookStack<M> as AgentHook<M>>::observes(
+        assert!(!<HookStack as AgentHook>::observes(
             &empty,
             StepEventKind::ToolCall
         ));
@@ -1875,7 +1816,7 @@ mod migrated_tests {
             StepEventKind::ToolCallDelta,
             StepEventKind::StreamResponseFinish,
         ] {
-            assert!(!<() as AgentHook<M>>::observes(&(), kind));
+            assert!(!<() as AgentHook>::observes(&(), kind));
         }
     }
 
@@ -1970,26 +1911,26 @@ mod migrated_tests {
     }
 
     struct RewriteHook(Value);
-    impl AgentHook<M> for RewriteHook {
+    impl AgentHook for RewriteHook {
         async fn on_tool_call(&self, _: &HookContext, _: ToolCall<'_>) -> ToolCallAction {
             ToolCallAction::rewrite(self.0.clone())
         }
     }
     struct SkipHook;
-    impl AgentHook<M> for SkipHook {
+    impl AgentHook for SkipHook {
         async fn on_tool_call(&self, _: &HookContext, _: ToolCall<'_>) -> ToolCallAction {
             ToolCallAction::skip("denied")
         }
     }
     struct StopHook;
-    impl AgentHook<M> for StopHook {
+    impl AgentHook for StopHook {
         async fn on_tool_call(&self, _: &HookContext, _: ToolCall<'_>) -> ToolCallAction {
             ToolCallAction::stop("stop")
         }
     }
     #[derive(Clone, Default)]
     struct ArgsSpy(Arc<Mutex<Vec<String>>>);
-    impl AgentHook<M> for ArgsSpy {
+    impl AgentHook for ArgsSpy {
         async fn on_tool_call(&self, _: &HookContext, event: ToolCall<'_>) -> ToolCallAction {
             self.0.lock().unwrap().push(event.args.into());
             ToolCallAction::run()
@@ -1997,7 +1938,7 @@ mod migrated_tests {
     }
 
     struct OnToolCallOnly(Arc<AtomicUsize>);
-    impl AgentHook<M> for OnToolCallOnly {
+    impl AgentHook for OnToolCallOnly {
         async fn on_tool_call(&self, _: &HookContext, _: ToolCall<'_>) -> ToolCallAction {
             self.0.fetch_add(1, Ordering::Relaxed);
             ToolCallAction::skip("called")
@@ -2005,7 +1946,7 @@ mod migrated_tests {
     }
 
     struct YieldingRewriteFromCallId;
-    impl AgentHook<M> for YieldingRewriteFromCallId {
+    impl AgentHook for YieldingRewriteFromCallId {
         async fn on_tool_call(&self, _: &HookContext, event: ToolCall<'_>) -> ToolCallAction {
             tokio::task::yield_now().await;
             ToolCallAction::rewrite(json!({"call_id": event.internal_call_id}))
@@ -2013,21 +1954,21 @@ mod migrated_tests {
     }
 
     struct YieldingSkip;
-    impl AgentHook<M> for YieldingSkip {
+    impl AgentHook for YieldingSkip {
         async fn on_tool_call(&self, _: &HookContext, _: ToolCall<'_>) -> ToolCallAction {
             tokio::task::yield_now().await;
             ToolCallAction::skip("denied")
         }
     }
 
-    async fn resolve(stack: &HookStack<M>) -> (ToolCallAction, Option<Value>) {
+    async fn resolve(stack: &HookStack) -> (ToolCallAction, Option<Value>) {
         stack.resolve_tool_call(&ctx(), tool_call_event()).await
     }
 
     #[tokio::test]
     async fn erased_dispatch_uses_the_public_on_tool_call_method() {
         let calls = Arc::new(AtomicUsize::new(0));
-        let stack = HookStack::<M>::with(OnToolCallOnly(calls.clone()));
+        let stack = HookStack::with(OnToolCallOnly(calls.clone()));
 
         let (action, salvaged) = resolve(&stack).await;
 
@@ -2040,7 +1981,7 @@ mod migrated_tests {
     async fn string_rewrite_is_json_encoded_for_later_hook_in_same_stack() {
         let spy = ArgsSpy::default();
         let replacement = Value::String("sanitized".into());
-        let mut stack = HookStack::<M>::new();
+        let mut stack = HookStack::new();
         stack.push(RewriteHook(replacement.clone()));
         stack.push(spy.clone());
 
@@ -2058,8 +1999,8 @@ mod migrated_tests {
     async fn string_rewrite_is_json_encoded_for_hook_in_nested_stack() {
         let spy = ArgsSpy::default();
         let replacement = Value::String("sanitized".into());
-        let inner = HookStack::<M>::with(spy.clone());
-        let mut outer = HookStack::<M>::new();
+        let inner = HookStack::with(spy.clone());
+        let mut outer = HookStack::new();
         outer.push(RewriteHook(replacement.clone()));
         outer.push(inner);
 
@@ -2075,10 +2016,10 @@ mod migrated_tests {
 
     #[tokio::test]
     async fn nested_rewrite_then_skip_preserves_rewrite() {
-        let mut inner = HookStack::<M>::new();
+        let mut inner = HookStack::new();
         inner.push(RewriteHook(json!({"x":41})));
         inner.push(SkipHook);
-        let mut outer = HookStack::<M>::new();
+        let mut outer = HookStack::new();
         outer.push(inner);
         let (action, salvaged) = resolve(&outer).await;
         assert!(matches!(action, ToolCallAction::Skip(_)));
@@ -2087,10 +2028,10 @@ mod migrated_tests {
 
     #[tokio::test]
     async fn nested_rewrite_then_stop_preserves_rewrite() {
-        let mut inner = HookStack::<M>::new();
+        let mut inner = HookStack::new();
         inner.push(RewriteHook(json!({"x":41})));
         inner.push(StopHook);
-        let mut outer = HookStack::<M>::new();
+        let mut outer = HookStack::new();
         outer.push(inner);
         let (action, salvaged) = resolve(&outer).await;
         assert!(matches!(action, ToolCallAction::Stop(_)));
@@ -2099,15 +2040,15 @@ mod migrated_tests {
 
     #[tokio::test]
     async fn deeply_nested_terminal_action_preserves_the_last_rewrite() {
-        let mut inner = HookStack::<M>::new();
+        let mut inner = HookStack::new();
         inner.push(RewriteHook(json!({"x":3})));
         inner.push(SkipHook);
 
-        let mut middle = HookStack::<M>::new();
+        let mut middle = HookStack::new();
         middle.push(RewriteHook(json!({"x":2})));
         middle.push(inner);
 
-        let mut outer = HookStack::<M>::new();
+        let mut outer = HookStack::new();
         outer.push(RewriteHook(json!({"x":1})));
         outer.push(middle);
 
@@ -2119,10 +2060,10 @@ mod migrated_tests {
 
     #[tokio::test]
     async fn concurrent_nested_resolutions_keep_rewrites_isolated_by_call() {
-        let mut inner = HookStack::<M>::new();
+        let mut inner = HookStack::new();
         inner.push(YieldingRewriteFromCallId);
         inner.push(YieldingSkip);
-        let outer = HookStack::<M>::with(inner);
+        let outer = HookStack::with(inner);
         let context = ctx();
 
         let first = outer.resolve_tool_call(
@@ -2151,10 +2092,10 @@ mod migrated_tests {
     #[tokio::test]
     async fn outer_rewrite_threads_into_nested_stack() {
         let spy = ArgsSpy::default();
-        let mut inner = HookStack::<M>::new();
+        let mut inner = HookStack::new();
         inner.push(spy.clone());
         inner.push(SkipHook);
-        let mut outer = HookStack::<M>::new();
+        let mut outer = HookStack::new();
         outer.push(RewriteHook(json!({"x":1})));
         outer.push(inner);
         let (action, salvaged) = resolve(&outer).await;
@@ -2168,7 +2109,7 @@ mod migrated_tests {
 
     #[tokio::test]
     async fn nested_proceeding_rewrite_surfaces_as_rewrite_action() {
-        let mut proceed = HookStack::<M>::new();
+        let mut proceed = HookStack::new();
         proceed.push(RewriteHook(json!({"x":5})));
         let (action, salvaged) = resolve(&proceed).await;
         assert_eq!(action, ToolCallAction::rewrite(json!({"x":5})));

--- a/crates/rig-core/src/agent/mod.rs
+++ b/crates/rig-core/src/agent/mod.rs
@@ -52,13 +52,16 @@
 //! retrieves documents, and injects them with [`RequestPatch::extra_context`].
 //! Active RAG instead exposes a vector index or custom retriever as a tool so the
 //! model decides when and how to search.
+//! Agent hooks are provider-independent and receive canonical Rig lifecycle
+//! data. Use direct [`CompletionModel`](crate::completion::CompletionModel)
+//! requests when provider-specific raw responses are required.
 //!
 //! Passive RAG agent example
 //! ```no_run
 //! use rig_core::{
 //!     agent::{AgentHook, CompletionCallAction, CompletionCallEvent, HookContext, RequestPatch},
 //!     client::{CompletionClient, EmbeddingsClient, ProviderClient},
-//!     completion::{CompletionModel, Document, Message, Prompt},
+//!     completion::{Document, Message, Prompt},
 //!     embeddings::EmbeddingsBuilder,
 //!     message::UserContent,
 //!     providers::openai,
@@ -71,9 +74,8 @@
 //!
 //! struct DictionaryRag<I>(I);
 //!
-//! impl<M, I> AgentHook<M> for DictionaryRag<I>
+//! impl<I> AgentHook for DictionaryRag<I>
 //! where
-//!     M: CompletionModel,
 //!     I: VectorStoreIndexDyn,
 //! {
 //!     async fn on_completion_call(

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -263,7 +263,7 @@ where
     /// [`hook`](crate::agent::hook) module docs.
     pub fn add_hook<H>(mut self, hook: H) -> Self
     where
-        H: AgentHook<M> + 'static,
+        H: AgentHook + 'static,
     {
         self.runner = self.runner.add_hook(hook);
         self
@@ -772,7 +772,7 @@ where
     /// already carries).
     pub fn add_hook<H>(mut self, hook: H) -> Self
     where
-        H: AgentHook<M> + 'static,
+        H: AgentHook + 'static,
     {
         self.inner = self.inner.add_hook(hook);
         self
@@ -941,11 +941,11 @@ mod tests {
     #[derive(Clone)]
     struct PanicOnUnknownToolHook;
 
-    impl AgentHook<MockCompletionModel> for PanicOnUnknownToolHook {
+    impl AgentHook for PanicOnUnknownToolHook {
         async fn on_completion_response(
             &self,
             _ctx: &HookContext,
-            _event: CompletionResponseEvent<'_, MockCompletionModel>,
+            _event: CompletionResponseEvent<'_>,
         ) -> ObservationAction {
             panic!("unknown tool response should fail before response hooks run")
         }
@@ -961,7 +961,7 @@ mod tests {
     #[derive(Clone)]
     struct PanicOnToolCallHook;
 
-    impl AgentHook<MockCompletionModel> for PanicOnToolCallHook {
+    impl AgentHook for PanicOnToolCallHook {
         async fn on_tool_call(
             &self,
             _ctx: &HookContext,
@@ -974,7 +974,7 @@ mod tests {
     #[derive(Clone)]
     struct SkipDefaultApiAndPanicOnToolCallHook;
 
-    impl AgentHook<MockCompletionModel> for SkipDefaultApiAndPanicOnToolCallHook {
+    impl AgentHook for SkipDefaultApiAndPanicOnToolCallHook {
         async fn on_invalid_tool_call(
             &self,
             ctx: &HookContext,
@@ -994,7 +994,7 @@ mod tests {
     #[derive(Clone)]
     struct RepairDefaultApiHook;
 
-    impl AgentHook<MockCompletionModel> for RepairDefaultApiHook {
+    impl AgentHook for RepairDefaultApiHook {
         async fn on_invalid_tool_call(
             &self,
             _ctx: &HookContext,
@@ -1008,7 +1008,7 @@ mod tests {
     #[derive(Clone)]
     struct RepairToSubtractHook;
 
-    impl AgentHook<MockCompletionModel> for RepairToSubtractHook {
+    impl AgentHook for RepairToSubtractHook {
         async fn on_invalid_tool_call(
             &self,
             _ctx: &HookContext,
@@ -1021,7 +1021,7 @@ mod tests {
     #[derive(Clone)]
     struct RetryDefaultApiHook;
 
-    impl AgentHook<MockCompletionModel> for RetryDefaultApiHook {
+    impl AgentHook for RetryDefaultApiHook {
         async fn on_invalid_tool_call(
             &self,
             _ctx: &HookContext,
@@ -1037,7 +1037,7 @@ mod tests {
     #[derive(Clone)]
     struct SkipDefaultApiHook;
 
-    impl AgentHook<MockCompletionModel> for SkipDefaultApiHook {
+    impl AgentHook for SkipDefaultApiHook {
         async fn on_invalid_tool_call(
             &self,
             _ctx: &HookContext,
@@ -1061,7 +1061,7 @@ mod tests {
         }
     }
 
-    impl AgentHook<MockCompletionModel> for RecordingInvalidToolCallHook {
+    impl AgentHook for RecordingInvalidToolCallHook {
         async fn on_invalid_tool_call(
             &self,
             _ctx: &HookContext,

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -331,7 +331,7 @@ where
     /// [`hook`](crate::agent::hook) module docs.
     pub fn add_hook<H>(mut self, hook: H) -> Self
     where
-        H: AgentHook<M> + 'static,
+        H: AgentHook + 'static,
     {
         self.runner = self.runner.add_hook(hook);
         self
@@ -986,8 +986,8 @@ pub(crate) struct StreamingTurnSource {
 }
 
 impl StreamingTurnSource {
-    pub(crate) fn new<M: CompletionModel>(
-        hooks: &HookStack<M>,
+    pub(crate) fn new(
+        hooks: &HookStack,
         agent_name: String,
         created_agent_span: bool,
         record_telemetry_content: bool,
@@ -1182,9 +1182,10 @@ where
                             }
 
                             if emit_final
-                                && let Some(StreamedAssistantContent::Final(final_resp)) =
+                                && let Some(StreamedAssistantContent::Final(_)) =
                                     item_slot.as_ref()
                             {
+                                let canonical_content = stream.accumulated_choice();
                                 if !turn_recovered
                                     && let Some(reason) = observe_action(
                                         runner
@@ -1193,7 +1194,9 @@ where
                                                 hook_ctx,
                                                 StreamResponseFinish {
                                                     prompt: &current_prompt,
-                                                    response: final_resp,
+                                                    content: &canonical_content,
+                                                    usage,
+                                                    message_id: stream.message_id.as_deref(),
                                                 },
                                             )
                                             .await,
@@ -1599,7 +1602,7 @@ mod migrated_tests {
 
     struct StopAgentStreamingBeforeCompletion;
 
-    impl AgentHook<MockCompletionModel> for StopAgentStreamingBeforeCompletion {
+    impl AgentHook for StopAgentStreamingBeforeCompletion {
         async fn on_completion_call(
             &self,
             _ctx: &HookContext,
@@ -1999,7 +2002,7 @@ mod migrated_tests {
     #[derive(Clone)]
     struct PanicOnUnknownToolHook;
 
-    impl AgentHook<MockCompletionModel> for PanicOnUnknownToolHook {
+    impl AgentHook for PanicOnUnknownToolHook {
         async fn on_tool_call_delta(
             &self,
             _: &HookContext,
@@ -2013,7 +2016,7 @@ mod migrated_tests {
         async fn on_stream_response_finish(
             &self,
             _: &HookContext,
-            _: StreamResponseFinish<'_, MockCompletionModel>,
+            _: StreamResponseFinish<'_>,
         ) -> ObservationAction {
             panic!("unknown tool call should fail before stream finish hooks run")
         }
@@ -3141,11 +3144,11 @@ mod migrated_tests {
     #[derive(Clone)]
     struct TerminateOnStreamFinish;
 
-    impl AgentHook<MockCompletionModel> for TerminateOnStreamFinish {
+    impl AgentHook for TerminateOnStreamFinish {
         async fn on_stream_response_finish(
             &self,
             _ctx: &HookContext,
-            event: StreamResponseFinish<'_, MockCompletionModel>,
+            event: StreamResponseFinish<'_>,
         ) -> ObservationAction {
             match event {
                 StreamResponseFinish { .. } => {
@@ -3161,7 +3164,7 @@ mod migrated_tests {
     #[derive(Clone)]
     struct RepairDefaultApiHook;
 
-    impl AgentHook<MockCompletionModel> for RepairDefaultApiHook {
+    impl AgentHook for RepairDefaultApiHook {
         async fn on_invalid_tool_call(
             &self,
             _ctx: &HookContext,
@@ -3180,7 +3183,7 @@ mod migrated_tests {
     #[derive(Clone)]
     struct RetryDefaultApiHook;
 
-    impl AgentHook<MockCompletionModel> for RetryDefaultApiHook {
+    impl AgentHook for RetryDefaultApiHook {
         async fn on_invalid_tool_call(
             &self,
             _ctx: &HookContext,
@@ -3202,7 +3205,7 @@ mod migrated_tests {
     #[derive(Clone)]
     struct SkipDefaultApiHook;
 
-    impl AgentHook<MockCompletionModel> for SkipDefaultApiHook {
+    impl AgentHook for SkipDefaultApiHook {
         async fn on_invalid_tool_call(
             &self,
             _ctx: &HookContext,
@@ -3232,7 +3235,7 @@ mod migrated_tests {
         }
     }
 
-    impl AgentHook<MockCompletionModel> for RecordingInvalidToolCallHook {
+    impl AgentHook for RecordingInvalidToolCallHook {
         async fn on_invalid_tool_call(
             &self,
             _ctx: &HookContext,
@@ -3265,7 +3268,7 @@ mod migrated_tests {
         }
     }
 
-    impl AgentHook<MockCompletionModel> for RecordingToolCallDeltaHook {
+    impl AgentHook for RecordingToolCallDeltaHook {
         async fn on_tool_call_delta(
             &self,
             _ctx: &HookContext,
@@ -3309,7 +3312,7 @@ mod migrated_tests {
         }
     }
 
-    impl AgentHook<MockCompletionModel> for RecordingTextDeltaHook {
+    impl AgentHook for RecordingTextDeltaHook {
         async fn on_text_delta(
             &self,
             _ctx: &HookContext,
@@ -3334,7 +3337,7 @@ mod migrated_tests {
         text: RecordingTextDeltaHook,
     }
 
-    impl AgentHook<MockCompletionModel> for RecordingTextAndSkipInvalidToolHook {
+    impl AgentHook for RecordingTextAndSkipInvalidToolHook {
         async fn on_text_delta(
             &self,
             ctx: &HookContext,
@@ -3356,7 +3359,7 @@ mod migrated_tests {
         text: RecordingTextDeltaHook,
     }
 
-    impl AgentHook<MockCompletionModel> for RecordingTextAndRetryInvalidToolHook {
+    impl AgentHook for RecordingTextAndRetryInvalidToolHook {
         async fn on_text_delta(
             &self,
             ctx: &HookContext,
@@ -3378,7 +3381,7 @@ mod migrated_tests {
         delta: RecordingToolCallDeltaHook,
     }
 
-    impl AgentHook<MockCompletionModel> for RecordingDeltaAndRetryInvalidToolHook {
+    impl AgentHook for RecordingDeltaAndRetryInvalidToolHook {
         async fn on_tool_call_delta(
             &self,
             ctx: &HookContext,
@@ -3400,7 +3403,7 @@ mod migrated_tests {
         delta: RecordingToolCallDeltaHook,
     }
 
-    impl AgentHook<MockCompletionModel> for RecordingDeltaAndSkipInvalidToolHook {
+    impl AgentHook for RecordingDeltaAndSkipInvalidToolHook {
         async fn on_tool_call_delta(
             &self,
             ctx: &HookContext,
@@ -3431,7 +3434,7 @@ mod migrated_tests {
         }
     }
 
-    impl AgentHook<MockCompletionModel> for TerminatingToolCallDeltaHook {
+    impl AgentHook for TerminatingToolCallDeltaHook {
         async fn on_tool_call_delta(
             &self,
             _ctx: &HookContext,

--- a/crates/rig-core/src/agent/runner.rs
+++ b/crates/rig-core/src/agent/runner.rs
@@ -203,7 +203,7 @@ where
     pub(crate) concurrency: usize,
     pub(crate) memory: Option<Arc<dyn ConversationMemory>>,
     pub(crate) conversation_id: Option<String>,
-    pub(crate) hooks: HookStack<M>,
+    pub(crate) hooks: HookStack,
     pub(crate) error_usage: Option<Arc<Mutex<Usage>>>,
 }
 
@@ -252,7 +252,7 @@ where
     /// [`hook`](crate::agent::hook) module docs.
     pub fn add_hook<H>(mut self, hook: H) -> Self
     where
-        H: AgentHook<M> + 'static,
+        H: AgentHook + 'static,
     {
         self.hooks.push(hook);
         self
@@ -561,16 +561,13 @@ pub(crate) enum CompletionCallOutcome {
 }
 
 /// Fire the event-specific completion-call hook for a turn.
-pub(crate) async fn resolve_completion_call<M>(
-    hooks: &HookStack<M>,
+pub(crate) async fn resolve_completion_call(
+    hooks: &HookStack,
     ctx: &HookContext,
     prompt: &Message,
     history: &[Message],
     turn: usize,
-) -> CompletionCallOutcome
-where
-    M: CompletionModel,
-{
+) -> CompletionCallOutcome {
     match completion_call_decision(
         hooks
             .on_completion_call(
@@ -962,8 +959,8 @@ where
                         }
 
                         if !response_hook_suppressed {
-                            // The medium-specific raw response event fires first,
-                            // then the normalized per-turn event. Both are
+                            // The completion-response lifecycle event fires first,
+                            // then the accepted per-turn event. Both are
                             // observe-only and suppressed for recovered turns.
                             if let Some(reason) = observe_action(
                                 runner
@@ -972,7 +969,9 @@ where
                                         hook_ctx,
                                         CompletionResponseEvent {
                                             prompt: &current_prompt,
-                                            response: &resp,
+                                            content: &resp.choice,
+                                            usage: resp.usage,
+                                            message_id: resp.message_id.as_deref(),
                                         },
                                     )
                                     .await,
@@ -1146,10 +1145,18 @@ mod tests {
     use serde_json::json;
 
     use crate::{
-        agent::{AgentBuilder, AgentHook, HookContext, ToolResultAction, ToolResultEvent},
-        completion::{CompletionModel, Document},
-        message::ToolChoice,
-        test_utils::{MockCompletionModel, MockStreamEvent, MockTurn},
+        OneOrMany,
+        agent::{
+            AgentBuilder, AgentHook, CompletionResponseEvent, HookContext, ObservationAction,
+            StreamResponseFinish, ToolResultAction, ToolResultEvent,
+        },
+        completion::{
+            CompletionError, CompletionModel, CompletionRequest, CompletionResponse, Document,
+            Message, Usage,
+        },
+        message::{AssistantContent, ToolChoice},
+        streaming::StreamingCompletionResponse,
+        test_utils::{MockCompletionModel, MockResponse, MockStreamEvent, MockTurn},
         tool::{Tool, ToolContext, ToolErrorKind, ToolExecutionError},
     };
 
@@ -1209,7 +1216,7 @@ mod tests {
     #[derive(Clone, Default)]
     struct SnapshotResults(Arc<Mutex<Vec<usize>>>);
 
-    impl<M: CompletionModel> AgentHook<M> for SnapshotResults {
+    impl AgentHook for SnapshotResults {
         async fn on_tool_result(
             &self,
             _ctx: &HookContext,
@@ -1252,7 +1259,7 @@ mod tests {
     #[derive(Clone, Default)]
     struct Results(Arc<Mutex<Vec<(ToolErrorKind, String, String)>>>);
 
-    impl<M: CompletionModel> AgentHook<M> for Results {
+    impl AgentHook for Results {
         async fn on_tool_result(
             &self,
             _ctx: &HookContext,
@@ -1271,6 +1278,131 @@ mod tests {
             }
             ToolResultAction::rewrite("rewritten for model")
         }
+    }
+
+    #[derive(Clone)]
+    struct AlternateMockCompletionModel(MockCompletionModel);
+
+    impl CompletionModel for AlternateMockCompletionModel {
+        type Response = MockResponse;
+        type StreamingResponse = MockResponse;
+        type Client = ();
+
+        fn make(_: &Self::Client, _: impl Into<String>) -> Self {
+            Self(MockCompletionModel::default())
+        }
+
+        async fn completion(
+            &self,
+            request: CompletionRequest,
+        ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+            self.0.completion(request).await
+        }
+
+        async fn stream(
+            &self,
+            request: CompletionRequest,
+        ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+            self.0.stream(request).await
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct CanonicalResponseSnapshot {
+        prompt: Message,
+        content: OneOrMany<AssistantContent>,
+        usage: Usage,
+        message_id: Option<String>,
+    }
+
+    #[derive(Clone, Default)]
+    struct CanonicalResponseHook {
+        blocking: Arc<Mutex<Option<CanonicalResponseSnapshot>>>,
+        streaming: Arc<Mutex<Option<CanonicalResponseSnapshot>>>,
+    }
+
+    impl AgentHook for CanonicalResponseHook {
+        async fn on_completion_response(
+            &self,
+            _ctx: &HookContext,
+            event: CompletionResponseEvent<'_>,
+        ) -> ObservationAction {
+            *self.blocking.lock().expect("blocking response") = Some(CanonicalResponseSnapshot {
+                prompt: event.prompt.clone(),
+                content: event.content.clone(),
+                usage: event.usage,
+                message_id: event.message_id.map(str::to_owned),
+            });
+            ObservationAction::continue_run()
+        }
+
+        async fn on_stream_response_finish(
+            &self,
+            _ctx: &HookContext,
+            event: StreamResponseFinish<'_>,
+        ) -> ObservationAction {
+            *self.streaming.lock().expect("streaming response") = Some(CanonicalResponseSnapshot {
+                prompt: event.prompt.clone(),
+                content: event.content.clone(),
+                usage: event.usage,
+                message_id: event.message_id.map(str::to_owned),
+            });
+            ObservationAction::continue_run()
+        }
+    }
+
+    #[tokio::test]
+    async fn one_provider_independent_hook_observes_equivalent_canonical_responses() {
+        let usage = Usage {
+            input_tokens: 7,
+            output_tokens: 3,
+            total_tokens: 10,
+            ..Usage::new()
+        };
+        let hook = CanonicalResponseHook::default();
+
+        AgentBuilder::new(MockCompletionModel::from_turns([MockTurn::text(
+            "same output",
+        )
+        .with_usage(usage)
+        .with_message_id("shared-message-id")]))
+        .add_hook(hook.clone())
+        .build()
+        .runner("same prompt")
+        .run()
+        .await
+        .expect("blocking run");
+
+        let streaming_model =
+            AlternateMockCompletionModel(MockCompletionModel::from_stream_turns([[
+                MockStreamEvent::message_id("shared-message-id"),
+                MockStreamEvent::text("same output"),
+                MockStreamEvent::final_response(usage),
+            ]]));
+        let mut stream = AgentBuilder::new(streaming_model)
+            .add_hook(hook.clone())
+            .build()
+            .runner("same prompt")
+            .stream()
+            .await;
+        while let Some(item) = stream.next().await {
+            item.expect("stream item");
+        }
+
+        let expected = CanonicalResponseSnapshot {
+            prompt: Message::user("same prompt"),
+            content: OneOrMany::one(AssistantContent::text("same output")),
+            usage,
+            message_id: Some("shared-message-id".to_string()),
+        };
+        assert_eq!(
+            hook.blocking.lock().expect("blocking response").clone(),
+            Some(expected.clone())
+        );
+        assert_eq!(
+            hook.streaming.lock().expect("streaming response").clone(),
+            Some(expected)
+        );
     }
 
     #[test]
@@ -1432,10 +1564,7 @@ mod tests {
         #[derive(Clone)]
         struct CountCompletionCalls(Arc<AtomicUsize>);
 
-        impl<M> AgentHook<M> for CountCompletionCalls
-        where
-            M: CompletionModel,
-        {
+        impl AgentHook for CountCompletionCalls {
             async fn on_completion_call(
                 &self,
                 _ctx: &HookContext,
@@ -1669,7 +1798,7 @@ mod migrated_tests {
         }
     }
 
-    impl<M: CompletionModel> AgentHook<M> for RecordingHook {
+    impl AgentHook for RecordingHook {
         async fn on_completion_call(
             &self,
             _: &HookContext,
@@ -1681,7 +1810,7 @@ mod migrated_tests {
         async fn on_completion_response(
             &self,
             _: &HookContext,
-            _: crate::agent::hook::CompletionResponse<'_, M>,
+            _: crate::agent::hook::CompletionResponse<'_>,
         ) -> ObservationAction {
             self.record(StepEventKind::CompletionResponse);
             ObservationAction::continue_run()
@@ -1733,7 +1862,7 @@ mod migrated_tests {
         async fn on_stream_response_finish(
             &self,
             _: &HookContext,
-            _: StreamResponseFinish<'_, M>,
+            _: StreamResponseFinish<'_>,
         ) -> ObservationAction {
             self.record(StepEventKind::StreamResponseFinish);
             ObservationAction::continue_run()
@@ -1929,7 +2058,6 @@ mod migrated_tests {
             AgentBuilder, AgentHook, HookContext, HookStack, ToolCall, ToolCallAction,
             ToolResultAction, ToolResultEvent,
         };
-        use crate::completion::CompletionModel;
         use crate::test_utils::{
             MockAddTool, MockCompletionModel, MockDeniedTool, MockFailingTool,
             MockHandledFailureTool, MockMetadataTool, MockRequestId, MockStreamEvent, MockTurn,
@@ -1967,7 +2095,7 @@ mod migrated_tests {
             }
         }
 
-        impl<M: CompletionModel> AgentHook<M> for OutcomeHook {
+        impl AgentHook for OutcomeHook {
             async fn on_tool_result(
                 &self,
                 _ctx: &HookContext,
@@ -2044,7 +2172,7 @@ mod migrated_tests {
             struct TimeoutCount(usize);
 
             struct TimeoutTerminator;
-            impl<M: CompletionModel> AgentHook<M> for TimeoutTerminator {
+            impl AgentHook for TimeoutTerminator {
                 async fn on_tool_result(
                     &self,
                     ctx: &HookContext,
@@ -2102,7 +2230,7 @@ mod migrated_tests {
             let status: Arc<Mutex<Option<u16>>> = Arc::new(Mutex::new(None));
 
             struct StatusProbe(Arc<Mutex<Option<u16>>>);
-            impl<M: CompletionModel> AgentHook<M> for StatusProbe {
+            impl AgentHook for StatusProbe {
                 async fn on_tool_result(
                     &self,
                     _ctx: &HookContext,
@@ -2162,7 +2290,7 @@ mod migrated_tests {
         #[tokio::test]
         async fn flow_skip_produces_skipped_outcome() {
             struct SkipHook;
-            impl<M: CompletionModel> AgentHook<M> for SkipHook {
+            impl AgentHook for SkipHook {
                 async fn on_tool_call(
                     &self,
                     _ctx: &HookContext,
@@ -2246,7 +2374,7 @@ mod migrated_tests {
         async fn rewrite_args_then_skip_reports_rewritten_args() {
             // Rewrites the tool args, replacing whatever the model emitted.
             struct RewriteHook;
-            impl<M: CompletionModel> AgentHook<M> for RewriteHook {
+            impl AgentHook for RewriteHook {
                 async fn on_tool_call(
                     &self,
                     _ctx: &HookContext,
@@ -2261,7 +2389,7 @@ mod migrated_tests {
             }
             // Skips *after* the rewrite (registered second).
             struct SkipHook;
-            impl<M: CompletionModel> AgentHook<M> for SkipHook {
+            impl AgentHook for SkipHook {
                 async fn on_tool_call(
                     &self,
                     _ctx: &HookContext,
@@ -2280,7 +2408,7 @@ mod migrated_tests {
                 args: Arc<Mutex<Option<String>>>,
                 outcome: Arc<Mutex<Option<String>>>,
             }
-            impl<M: CompletionModel> AgentHook<M> for ArgsProbe {
+            impl AgentHook for ArgsProbe {
                 async fn on_tool_result(
                     &self,
                     _ctx: &HookContext,
@@ -2364,7 +2492,7 @@ mod migrated_tests {
         #[tokio::test]
         async fn nested_hook_stack_rewrite_then_skip_reports_rewritten_args() {
             struct RewriteHook;
-            impl<M: CompletionModel> AgentHook<M> for RewriteHook {
+            impl AgentHook for RewriteHook {
                 async fn on_tool_call(
                     &self,
                     _ctx: &HookContext,
@@ -2378,7 +2506,7 @@ mod migrated_tests {
                 }
             }
             struct SkipHook;
-            impl<M: CompletionModel> AgentHook<M> for SkipHook {
+            impl AgentHook for SkipHook {
                 async fn on_tool_call(
                     &self,
                     _ctx: &HookContext,
@@ -2396,7 +2524,7 @@ mod migrated_tests {
                 args: Arc<Mutex<Option<String>>>,
                 outcome: Arc<Mutex<Option<String>>>,
             }
-            impl<M: CompletionModel> AgentHook<M> for ArgsProbe {
+            impl AgentHook for ArgsProbe {
                 async fn on_tool_result(
                     &self,
                     _ctx: &HookContext,
@@ -2414,8 +2542,8 @@ mod migrated_tests {
             }
 
             // The rewrite + skip live inside a *nested* stack added as one hook.
-            fn nested_stack() -> HookStack<MockCompletionModel> {
-                let mut nested = HookStack::<MockCompletionModel>::new();
+            fn nested_stack() -> HookStack {
+                let mut nested = HookStack::new();
                 nested.push(RewriteHook);
                 nested.push(SkipHook);
                 nested
@@ -2500,7 +2628,7 @@ mod migrated_tests {
                 seen: Arc<Mutex<Option<String>>>,
                 model_output: Arc<Mutex<Option<String>>>,
             }
-            impl<M: CompletionModel> AgentHook<M> for MetadataProbe {
+            impl AgentHook for MetadataProbe {
                 async fn on_tool_result(
                     &self,
                     _ctx: &HookContext,
@@ -2587,7 +2715,7 @@ mod migrated_tests {
         #[tokio::test]
         async fn rewrite_result_does_not_mask_the_structured_outcome() {
             struct Redact;
-            impl<M: CompletionModel> AgentHook<M> for Redact {
+            impl AgentHook for Redact {
                 async fn on_tool_result(
                     &self,
                     _ctx: &HookContext,
@@ -3035,7 +3163,7 @@ mod migrated_tests {
 
         /// Redacts every tool result before the model sees it.
         struct RedactResultHook;
-        impl<M: crate::completion::CompletionModel> crate::agent::AgentHook<M> for RedactResultHook {
+        impl crate::agent::AgentHook for RedactResultHook {
             async fn on_tool_result(
                 &self,
                 _ctx: &HookContext,
@@ -3051,7 +3179,7 @@ mod migrated_tests {
 
         /// Stops the run after observing a completed tool result.
         struct StopOnResultHook;
-        impl<M: crate::completion::CompletionModel> crate::agent::AgentHook<M> for StopOnResultHook {
+        impl crate::agent::AgentHook for StopOnResultHook {
             async fn on_tool_result(
                 &self,
                 _ctx: &HookContext,
@@ -3675,7 +3803,7 @@ mod migrated_tests {
     struct TerminateAfterSiblingStartedHook {
         sibling_started: Arc<tokio::sync::Notify>,
     }
-    impl<M: CompletionModel> AgentHook<M> for TerminateAfterSiblingStartedHook {
+    impl AgentHook for TerminateAfterSiblingStartedHook {
         async fn on_tool_result(
             &self,
             _ctx: &HookContext,
@@ -3826,7 +3954,7 @@ mod migrated_tests {
         gate: Arc<tokio::sync::Notify>,
     }
 
-    impl<M: CompletionModel> AgentHook<M> for OrderedTerminateHook {
+    impl AgentHook for OrderedTerminateHook {
         async fn on_tool_call(&self, _ctx: &HookContext, event: ToolCall<'_>) -> ToolCallAction {
             if let ToolCall { args, .. } = event {
                 let x = serde_json::from_str::<serde_json::Value>(args)
@@ -3940,7 +4068,7 @@ mod migrated_tests {
     /// Terminates the run from the `ToolCall` event of the first tool only
     /// (`x == 1`), letting any later tool through.
     struct TerminateOnFirstToolHook;
-    impl<M: CompletionModel> AgentHook<M> for TerminateOnFirstToolHook {
+    impl AgentHook for TerminateOnFirstToolHook {
         async fn on_tool_call(&self, _ctx: &HookContext, event: ToolCall<'_>) -> ToolCallAction {
             if let ToolCall { args, .. } = event
                 && serde_json::from_str::<serde_json::Value>(args)
@@ -4081,7 +4209,7 @@ mod migrated_tests {
     struct TerminateOnArgZeroAfterSiblingHook {
         sibling_started: Arc<tokio::sync::Notify>,
     }
-    impl<M: CompletionModel> AgentHook<M> for TerminateOnArgZeroAfterSiblingHook {
+    impl AgentHook for TerminateOnArgZeroAfterSiblingHook {
         async fn on_tool_call(&self, _ctx: &HookContext, event: ToolCall<'_>) -> ToolCallAction {
             if let ToolCall { args, .. } = event
                 && serde_json::from_str::<serde_json::Value>(args)
@@ -4199,7 +4327,7 @@ mod migrated_tests {
     struct TerminateAfterSiblingDoneHook {
         a_done: Arc<tokio::sync::Notify>,
     }
-    impl<M: CompletionModel> AgentHook<M> for TerminateAfterSiblingDoneHook {
+    impl AgentHook for TerminateAfterSiblingDoneHook {
         async fn on_tool_call(&self, _ctx: &HookContext, event: ToolCall<'_>) -> ToolCallAction {
             if let ToolCall { args, .. } = event
                 && serde_json::from_str::<serde_json::Value>(args)
@@ -4347,7 +4475,7 @@ mod migrated_tests {
     #[tokio::test]
     async fn stream_hook_skip_surfaces_result_without_execution_commit() {
         struct SkipHook;
-        impl<M: CompletionModel> AgentHook<M> for SkipHook {
+        impl AgentHook for SkipHook {
             async fn on_tool_call(
                 &self,
                 _ctx: &HookContext,
@@ -4423,7 +4551,7 @@ mod migrated_tests {
     #[tokio::test]
     async fn required_with_empty_active_tools_errors_locally_without_provider_call() {
         struct EmptyActiveToolsHook;
-        impl<M: CompletionModel> AgentHook<M> for EmptyActiveToolsHook {
+        impl AgentHook for EmptyActiveToolsHook {
             async fn on_completion_call(
                 &self,
                 _ctx: &HookContext,
@@ -4471,7 +4599,7 @@ mod migrated_tests {
     #[tokio::test]
     async fn specific_naming_filtered_out_tool_errors_locally_without_provider_call() {
         struct FilterToAddHook;
-        impl<M: CompletionModel> AgentHook<M> for FilterToAddHook {
+        impl AgentHook for FilterToAddHook {
             async fn on_completion_call(
                 &self,
                 _ctx: &HookContext,
@@ -4572,7 +4700,7 @@ mod migrated_tests {
         other_calls: Arc<AtomicU32>,
     }
 
-    impl<M: CompletionModel> AgentHook<M> for ToolOnlyHook {
+    impl AgentHook for ToolOnlyHook {
         async fn on_text_delta(&self, _: &HookContext, _: TextDelta<'_>) -> ObservationAction {
             self.text_delta_calls.fetch_add(1, SeqCst);
             ObservationAction::continue_run()
@@ -4624,7 +4752,7 @@ mod migrated_tests {
     /// event as `Continue`.
     struct TerminateOn(StepEventKind);
 
-    impl<M: CompletionModel> AgentHook<M> for TerminateOn {
+    impl AgentHook for TerminateOn {
         async fn on_completion_call(
             &self,
             _: &HookContext,
@@ -4769,7 +4897,7 @@ mod migrated_tests {
     /// Renames an invalid tool call to a known tool; observes everything else.
     struct RepairInvalidToHook(&'static str);
 
-    impl<M: CompletionModel> AgentHook<M> for RepairInvalidToHook {
+    impl AgentHook for RepairInvalidToHook {
         async fn on_invalid_tool_call(
             &self,
             _ctx: &HookContext,
@@ -4789,7 +4917,7 @@ mod migrated_tests {
         args: Arc<Mutex<Vec<Option<String>>>>,
     }
 
-    impl<M: CompletionModel> AgentHook<M> for CaptureAndRepairInvalidHook {
+    impl AgentHook for CaptureAndRepairInvalidHook {
         async fn on_invalid_tool_call(
             &self,
             _ctx: &HookContext,
@@ -5216,7 +5344,7 @@ mod migrated_tests {
     /// everything else.
     struct SkipInvalidHook(&'static str);
 
-    impl<M: CompletionModel> AgentHook<M> for SkipInvalidHook {
+    impl AgentHook for SkipInvalidHook {
         async fn on_invalid_tool_call(
             &self,
             _ctx: &HookContext,
@@ -5463,7 +5591,7 @@ mod migrated_tests {
     /// Skips a *valid* tool call before execution; observes everything else.
     struct SkipToolCallHook(&'static str);
 
-    impl<M: CompletionModel> AgentHook<M> for SkipToolCallHook {
+    impl AgentHook for SkipToolCallHook {
         async fn on_tool_call(&self, _ctx: &HookContext, event: ToolCall<'_>) -> ToolCallAction {
             if let ToolCall { .. } = event {
                 ToolCallAction::skip(self.0)
@@ -5562,7 +5690,7 @@ mod migrated_tests {
     /// model emitted.
     struct RewriteToolArgsHook(serde_json::Value);
 
-    impl<M: CompletionModel> AgentHook<M> for RewriteToolArgsHook {
+    impl AgentHook for RewriteToolArgsHook {
         async fn on_tool_call(&self, _ctx: &HookContext, event: ToolCall<'_>) -> ToolCallAction {
             if let ToolCall { .. } = event {
                 ToolCallAction::rewrite(self.0.clone())
@@ -6038,7 +6166,7 @@ mod migrated_tests {
     /// actual output.
     struct RewriteToolResultHook(&'static str);
 
-    impl<M: CompletionModel> AgentHook<M> for RewriteToolResultHook {
+    impl AgentHook for RewriteToolResultHook {
         async fn on_tool_result(
             &self,
             _ctx: &HookContext,
@@ -6185,7 +6313,7 @@ mod migrated_tests {
     /// advertised tools to an allow-list, and injects a passthrough param.
     struct PatchRequestHook;
 
-    impl<M: CompletionModel> AgentHook<M> for PatchRequestHook {
+    impl AgentHook for PatchRequestHook {
         async fn on_completion_call(
             &self,
             _ctx: &HookContext,
@@ -6329,7 +6457,7 @@ mod migrated_tests {
         text: &'static str,
     }
 
-    impl<M: CompletionModel> AgentHook<M> for ExtraContextHook {
+    impl AgentHook for ExtraContextHook {
         async fn on_completion_call(
             &self,
             _ctx: &HookContext,
@@ -6349,7 +6477,7 @@ mod migrated_tests {
     /// per-turn, non-sticky behavior).
     struct ExtraContextTurnOneHook;
 
-    impl<M: CompletionModel> AgentHook<M> for ExtraContextTurnOneHook {
+    impl AgentHook for ExtraContextTurnOneHook {
         async fn on_completion_call(
             &self,
             _ctx: &HookContext,
@@ -6370,9 +6498,8 @@ mod migrated_tests {
         index: I,
     }
 
-    impl<M, I> AgentHook<M> for RetrievalHook<I>
+    impl<I> AgentHook for RetrievalHook<I>
     where
-        M: CompletionModel,
         I: VectorStoreIndexDyn,
     {
         async fn on_completion_call(
@@ -6752,7 +6879,7 @@ mod migrated_tests {
         const SENTINEL: &str = "COMPACTED-HISTORY-SENTINEL";
 
         struct HistoryOverrideHook;
-        impl<M: CompletionModel> AgentHook<M> for HistoryOverrideHook {
+        impl AgentHook for HistoryOverrideHook {
             async fn on_completion_call(
                 &self,
                 _ctx: &HookContext,
@@ -6878,7 +7005,7 @@ mod migrated_tests {
         kinds: Arc<Mutex<Option<Vec<&'static str>>>>,
     }
 
-    impl<M: CompletionModel> AgentHook<M> for CaptureFirstTurnContent {
+    impl AgentHook for CaptureFirstTurnContent {
         async fn on_model_turn_finished(
             &self,
             _ctx: &HookContext,
@@ -6950,7 +7077,7 @@ mod migrated_tests {
             key: &'static str,
             value: i64,
         }
-        impl<M: CompletionModel> AgentHook<M> for SetArg {
+        impl AgentHook for SetArg {
             async fn on_tool_call(
                 &self,
                 _ctx: &HookContext,
@@ -6969,7 +7096,7 @@ mod migrated_tests {
 
         /// Wraps the tool result in `label(...)`.
         struct WrapResult(&'static str);
-        impl<M: CompletionModel> AgentHook<M> for WrapResult {
+        impl AgentHook for WrapResult {
             async fn on_tool_result(
                 &self,
                 _ctx: &HookContext,
@@ -7117,7 +7244,7 @@ mod migrated_tests {
         second_turn_patch: Option<RequestPatch>,
     }
 
-    impl<M: CompletionModel> AgentHook<M> for RegisterLateFinalResultTool {
+    impl AgentHook for RegisterLateFinalResultTool {
         async fn on_model_turn_finished(
             &self,
             ctx: &HookContext,
@@ -7459,7 +7586,7 @@ mod migrated_tests {
     /// `final_result` tool.
     struct ActiveToolsAddOnly;
 
-    impl<M: CompletionModel> AgentHook<M> for ActiveToolsAddOnly {
+    impl AgentHook for ActiveToolsAddOnly {
         async fn on_completion_call(
             &self,
             _ctx: &HookContext,
@@ -7542,7 +7669,7 @@ mod migrated_tests {
         saw_output_tool_call: Arc<Mutex<bool>>,
     }
 
-    impl<M: CompletionModel> AgentHook<M> for CaptureOutputToolInModelTurn {
+    impl AgentHook for CaptureOutputToolInModelTurn {
         async fn on_model_turn_finished(
             &self,
             _ctx: &HookContext,
@@ -7701,7 +7828,7 @@ mod migrated_tests {
         }
     }
 
-    impl<M: CompletionModel> AgentHook<M> for HumanApprovalHook {
+    impl AgentHook for HumanApprovalHook {
         async fn on_tool_call(&self, _ctx: &HookContext, event: ToolCall<'_>) -> ToolCallAction {
             let ToolCall {
                 tool_name, args, ..
@@ -7948,7 +8075,7 @@ mod migrated_tests {
         }
     }
 
-    impl<M: CompletionModel> AgentHook<M> for PolicyHook {
+    impl AgentHook for PolicyHook {
         async fn on_tool_call(&self, _ctx: &HookContext, event: ToolCall<'_>) -> ToolCallAction {
             let ToolCall { tool_name, .. } = event else {
                 return ToolCallAction::run();

--- a/crates/rig-core/src/extractor.rs
+++ b/crates/rig-core/src/extractor.rs
@@ -28,6 +28,11 @@
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! Extractors execute through the managed [`AgentRunner`](crate::agent::AgentRunner)
+//! lifecycle. Hooks registered with [`ExtractorBuilder::add_hook`] are
+//! provider-independent and receive canonical Rig response content, usage, and
+//! message identifiers.
 
 use std::marker::PhantomData;
 
@@ -316,7 +321,7 @@ where
     /// Add a lifecycle hook to every extraction attempt.
     pub fn add_hook<H>(mut self, hook: H) -> Self
     where
-        H: AgentHook<M> + 'static,
+        H: AgentHook + 'static,
     {
         self.agent_builder = self.agent_builder.add_hook(hook);
         self
@@ -335,13 +340,14 @@ where
 #[cfg(test)]
 mod tests {
     use std::sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
     };
 
     use serde_json::json;
 
     use super::*;
+    use crate::OneOrMany;
     use crate::agent::{
         CompletionCallAction, CompletionResponseEvent, HookContext, ObservationAction, RequestPatch,
     };
@@ -386,10 +392,34 @@ mod tests {
         invalid_tool_calls: Arc<AtomicUsize>,
     }
 
-    impl<M> AgentHook<M> for LifecycleCounts
-    where
-        M: CompletionModel,
-    {
+    #[derive(Clone)]
+    struct ExtractorResponseSnapshot {
+        prompt: Message,
+        content: OneOrMany<AssistantContent>,
+        usage: Usage,
+        message_id: Option<String>,
+    }
+
+    #[derive(Clone, Default)]
+    struct ExtractorResponseCapture(Arc<Mutex<Option<ExtractorResponseSnapshot>>>);
+
+    impl AgentHook for ExtractorResponseCapture {
+        async fn on_completion_response(
+            &self,
+            _ctx: &HookContext,
+            event: CompletionResponseEvent<'_>,
+        ) -> ObservationAction {
+            *self.0.lock().expect("extractor response capture") = Some(ExtractorResponseSnapshot {
+                prompt: event.prompt.clone(),
+                content: event.content.clone(),
+                usage: event.usage,
+                message_id: event.message_id.map(str::to_owned),
+            });
+            ObservationAction::continue_run()
+        }
+    }
+
+    impl AgentHook for LifecycleCounts {
         async fn on_completion_call(
             &self,
             _ctx: &HookContext,
@@ -402,7 +432,7 @@ mod tests {
         async fn on_completion_response(
             &self,
             _ctx: &HookContext,
-            _event: CompletionResponseEvent<'_, M>,
+            _event: CompletionResponseEvent<'_>,
         ) -> ObservationAction {
             self.completion_responses.fetch_add(1, Ordering::SeqCst);
             ObservationAction::Continue
@@ -429,10 +459,7 @@ mod tests {
 
     struct StopBeforeCompletion;
 
-    impl<M> AgentHook<M> for StopBeforeCompletion
-    where
-        M: CompletionModel,
-    {
+    impl AgentHook for StopBeforeCompletion {
         async fn on_completion_call(
             &self,
             _ctx: &HookContext,
@@ -444,10 +471,7 @@ mod tests {
 
     struct ExtractorRetrievalHook;
 
-    impl<M> AgentHook<M> for ExtractorRetrievalHook
-    where
-        M: CompletionModel,
-    {
+    impl AgentHook for ExtractorRetrievalHook {
         async fn on_completion_call(
             &self,
             _ctx: &HookContext,
@@ -473,14 +497,11 @@ mod tests {
         calls: Arc<AtomicUsize>,
     }
 
-    impl<M> AgentHook<M> for StopFirstBilledResponse
-    where
-        M: CompletionModel,
-    {
+    impl AgentHook for StopFirstBilledResponse {
         async fn on_completion_response(
             &self,
             _ctx: &HookContext,
-            _event: CompletionResponseEvent<'_, M>,
+            _event: CompletionResponseEvent<'_>,
         ) -> ObservationAction {
             if matches!(self.phase, StopFirstBilledResponseAt::CompletionResponse)
                 && self.calls.fetch_add(1, Ordering::SeqCst) == 0
@@ -508,10 +529,7 @@ mod tests {
 
     struct StopOnInvalidToolCall;
 
-    impl<M> AgentHook<M> for StopOnInvalidToolCall
-    where
-        M: CompletionModel,
-    {
+    impl AgentHook for StopOnInvalidToolCall {
         async fn on_invalid_tool_call(
             &self,
             _ctx: &HookContext,
@@ -525,10 +543,7 @@ mod tests {
 
     struct RepairUnexpectedAsSubmit;
 
-    impl<M> AgentHook<M> for RepairUnexpectedAsSubmit
-    where
-        M: CompletionModel,
-    {
+    impl AgentHook for RepairUnexpectedAsSubmit {
         async fn on_invalid_tool_call(
             &self,
             _ctx: &HookContext,
@@ -542,10 +557,7 @@ mod tests {
 
     struct SkipUnexpected;
 
-    impl<M> AgentHook<M> for SkipUnexpected
-    where
-        M: CompletionModel,
-    {
+    impl AgentHook for SkipUnexpected {
         async fn on_invalid_tool_call(
             &self,
             _ctx: &HookContext,
@@ -614,6 +626,35 @@ mod tests {
                 if reason == "extractor stopped"
         ));
         assert_eq!(model.request_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn extractor_hook_receives_canonical_completion_response() {
+        let capture = ExtractorResponseCapture::default();
+        let response =
+            ExtractorBuilder::<_, Person>::new(MockCompletionModel::new([submit_turn("John")
+                .with_usage(usage(9))
+                .with_message_id("extractor-message-id")]))
+            .add_hook(capture.clone())
+            .build()
+            .extract("John")
+            .await
+            .expect("extraction should succeed");
+
+        assert_eq!(response.name, "John");
+        let snapshot = capture
+            .0
+            .lock()
+            .expect("extractor response capture")
+            .clone()
+            .expect("completion response event");
+        assert!(matches!(snapshot.prompt, Message::User { .. }));
+        assert!(matches!(
+            snapshot.content.first(),
+            AssistantContent::ToolCall(call) if call.function.name == SUBMIT_TOOL_NAME
+        ));
+        assert_eq!(snapshot.usage, usage(9));
+        assert_eq!(snapshot.message_id.as_deref(), Some("extractor-message-id"));
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/streaming.rs
+++ b/crates/rig-core/src/streaming.rs
@@ -281,6 +281,16 @@ where
         }
     }
 
+    /// Snapshot the canonical assistant content accumulated so far.
+    ///
+    /// Managed response-finish hooks run when the provider's final-response
+    /// item arrives, before the next poll observes end-of-stream and publishes
+    /// the same items through [`Self::choice`].
+    pub(crate) fn accumulated_choice(&self) -> OneOrMany<AssistantContent> {
+        OneOrMany::from_iter_optional(self.assistant_items.clone())
+            .unwrap_or_else(|| self.choice.clone())
+    }
+
     /// Cancel the stream and immediately drop the provider's inner stream.
     /// Cancellation is surfaced as normal stream termination.
     pub fn cancel(&mut self) {

--- a/crates/rig-core/src/test_utils/model_conformance.rs
+++ b/crates/rig-core/src/test_utils/model_conformance.rs
@@ -534,10 +534,7 @@ struct RewriteArgument {
     value: serde_json::Value,
 }
 
-impl<M> AgentHook<M> for RewriteArgument
-where
-    M: CompletionModel,
-{
+impl AgentHook for RewriteArgument {
     async fn on_tool_call(&self, _ctx: &HookContext, event: ToolCallEvent<'_>) -> ToolCallAction {
         if event.tool_name != CountingAdd::NAME {
             return ToolCallAction::run();
@@ -556,10 +553,7 @@ where
 #[derive(Clone, Default)]
 struct ObserveArguments(Arc<Mutex<Vec<serde_json::Value>>>);
 
-impl<M> AgentHook<M> for ObserveArguments
-where
-    M: CompletionModel,
-{
+impl AgentHook for ObserveArguments {
     async fn on_tool_call(&self, _ctx: &HookContext, event: ToolCallEvent<'_>) -> ToolCallAction {
         let value = serde_json::from_str(event.args)
             .unwrap_or_else(|_| serde_json::Value::String(event.args.to_string()));
@@ -571,10 +565,7 @@ where
 #[derive(Clone)]
 struct ReplaceResult(&'static str);
 
-impl<M> AgentHook<M> for ReplaceResult
-where
-    M: CompletionModel,
-{
+impl AgentHook for ReplaceResult {
     async fn on_tool_result(
         &self,
         _ctx: &HookContext,
@@ -591,10 +582,7 @@ where
 #[derive(Clone)]
 struct WrapResult;
 
-impl<M> AgentHook<M> for WrapResult
-where
-    M: CompletionModel,
-{
+impl AgentHook for WrapResult {
     async fn on_tool_result(
         &self,
         _ctx: &HookContext,
@@ -611,10 +599,7 @@ where
 #[derive(Clone)]
 struct FirstTurnPatch(RequestPatch);
 
-impl<M> AgentHook<M> for FirstTurnPatch
-where
-    M: CompletionModel,
-{
+impl AgentHook for FirstTurnPatch {
     async fn on_completion_call(
         &self,
         ctx: &HookContext,
@@ -631,10 +616,7 @@ where
 #[derive(Clone)]
 struct StopAfterResult(&'static str);
 
-impl<M> AgentHook<M> for StopAfterResult
-where
-    M: CompletionModel,
-{
+impl AgentHook for StopAfterResult {
     async fn on_tool_result(
         &self,
         _ctx: &HookContext,
@@ -1411,19 +1393,16 @@ where
     #[derive(Clone)]
     struct CaptureTurn(Arc<Mutex<Option<ModelTurn>>>);
 
-    impl<M> AgentHook<M> for CaptureTurn
-    where
-        M: CompletionModel,
-    {
+    impl AgentHook for CaptureTurn {
         async fn on_completion_response(
             &self,
             _ctx: &HookContext,
-            event: CompletionResponseEvent<'_, M>,
+            event: CompletionResponseEvent<'_>,
         ) -> ObservationAction {
             *lock_recover(&self.0) = Some(ModelTurn::new(
-                event.response.message_id.clone(),
-                event.response.choice.clone(),
-                event.response.usage,
+                event.message_id.map(str::to_owned),
+                event.content.clone(),
+                event.usage,
                 BTreeSet::new(),
                 BTreeSet::new(),
             ));

--- a/crates/rig-lancedb/examples/vector_search_local_ann_agent.rs
+++ b/crates/rig-lancedb/examples/vector_search_local_ann_agent.rs
@@ -4,7 +4,7 @@ use rig_core::agent::{
     AgentHook, CompletionCallAction, CompletionCallEvent, HookContext, RequestPatch,
 };
 use rig_core::client::{EmbeddingsClient, ProviderClient};
-use rig_core::completion::{CompletionModel, Document, Message, Prompt};
+use rig_core::completion::{Document, Message, Prompt};
 use rig_core::message::UserContent;
 use rig_core::prelude::CompletionClient;
 use rig_core::providers::openai;
@@ -23,9 +23,8 @@ struct LanceDbRag<I> {
     samples: u64,
 }
 
-impl<M, I> AgentHook<M> for LanceDbRag<I>
+impl<I> AgentHook for LanceDbRag<I>
 where
-    M: CompletionModel,
     I: VectorStoreIndexDyn,
 {
     async fn on_completion_call(

--- a/examples/agent_run_stepping/src/main.rs
+++ b/examples/agent_run_stepping/src/main.rs
@@ -81,7 +81,7 @@ impl Tool for Add {
 
 struct ToolLoggerHook;
 
-impl<M: CompletionModel> AgentHook<M> for ToolLoggerHook {
+impl AgentHook for ToolLoggerHook {
     async fn on_tool_call(&self, _ctx: &HookContext, event: ToolCallEvent<'_>) -> ToolCallAction {
         println!("[hook] tool call: {}({})", event.tool_name, event.args);
         ToolCallAction::run()

--- a/examples/agent_with_approval_policy/src/main.rs
+++ b/examples/agent_with_approval_policy/src/main.rs
@@ -22,7 +22,7 @@ use std::collections::HashSet;
 use anyhow::Result;
 use rig::agent::{AgentHook, HookContext, ToolCall as ToolCallEvent, ToolCallAction};
 use rig::client::{CompletionClient, ProviderClient};
-use rig::completion::{CompletionModel, Prompt};
+use rig::completion::Prompt;
 use rig::providers::openai;
 use rig::tool::Tool;
 use serde::Deserialize;
@@ -118,7 +118,7 @@ struct ApprovalPolicy {
     max_auto_transfer: u64,
 }
 
-impl<M: CompletionModel> AgentHook<M> for ApprovalPolicy {
+impl AgentHook for ApprovalPolicy {
     async fn on_tool_call(&self, _ctx: &HookContext, event: ToolCallEvent<'_>) -> ToolCallAction {
         let tool_name = event.tool_name;
         if self.auto_approve.contains(tool_name) {

--- a/examples/agent_with_human_in_the_loop/src/main.rs
+++ b/examples/agent_with_human_in_the_loop/src/main.rs
@@ -23,7 +23,7 @@
 use anyhow::Result;
 use rig::agent::{AgentHook, HookContext, ToolCall as ToolCallEvent, ToolCallAction};
 use rig::client::{CompletionClient, ProviderClient};
-use rig::completion::{CompletionModel, Prompt};
+use rig::completion::Prompt;
 use rig::providers::openai;
 use rig::tool::Tool;
 use serde::Deserialize;
@@ -157,7 +157,7 @@ async fn ask(prompt: &str) -> Option<String> {
 /// tool itself.
 struct ApprovalHook;
 
-impl<M: CompletionModel> AgentHook<M> for ApprovalHook {
+impl AgentHook for ApprovalHook {
     async fn on_tool_call(&self, _ctx: &HookContext, event: ToolCallEvent<'_>) -> ToolCallAction {
         let tool_name = event.tool_name;
         let args = event.args;

--- a/examples/force_tool_first_turn/src/main.rs
+++ b/examples/force_tool_first_turn/src/main.rs
@@ -23,7 +23,7 @@
 use anyhow::Result;
 use rig::agent::{AgentHook, CompletionCallAction, CompletionCallEvent, HookContext, RequestPatch};
 use rig::client::{CompletionClient, ProviderClient};
-use rig::completion::{CompletionModel, Prompt, PromptError};
+use rig::completion::{Prompt, PromptError};
 use rig::message::ToolChoice;
 use rig::providers::openai;
 use rig::tool::Tool;
@@ -88,10 +88,7 @@ impl Tool for Add {
 #[derive(Clone)]
 struct ForceToolEveryTurn;
 
-impl<M> AgentHook<M> for ForceToolEveryTurn
-where
-    M: CompletionModel,
-{
+impl AgentHook for ForceToolEveryTurn {
     async fn on_completion_call(
         &self,
         _ctx: &HookContext,
@@ -108,10 +105,7 @@ where
 #[derive(Clone)]
 struct ForceToolOnFirstTurn;
 
-impl<M> AgentHook<M> for ForceToolOnFirstTurn
-where
-    M: CompletionModel,
-{
+impl AgentHook for ForceToolOnFirstTurn {
     async fn on_completion_call(
         &self,
         ctx: &HookContext,

--- a/examples/gemini_default_api_recovery/src/main.rs
+++ b/examples/gemini_default_api_recovery/src/main.rs
@@ -10,7 +10,6 @@ use rig::agent::{
     PromptResponse, StreamingResult,
 };
 use rig::client::{CompletionClient, ProviderClient};
-use rig::completion::CompletionModel;
 use rig::message::ToolResultContent;
 use rig::providers::gemini::{
     self,
@@ -149,10 +148,7 @@ impl DefaultApiRepairHook {
     }
 }
 
-impl<M> AgentHook<M> for DefaultApiRepairHook
-where
-    M: CompletionModel,
-{
+impl AgentHook for DefaultApiRepairHook {
     async fn on_invalid_tool_call(
         &self,
         _ctx: &HookContext,

--- a/examples/gemini_extractor_with_rag/src/main.rs
+++ b/examples/gemini_extractor_with_rag/src/main.rs
@@ -45,9 +45,8 @@ struct QuestionnaireRag<I> {
     samples: u64,
 }
 
-impl<M, I> AgentHook<M> for QuestionnaireRag<I>
+impl<I> AgentHook for QuestionnaireRag<I>
 where
-    M: CompletionModel,
     I: VectorStoreIndexDyn,
 {
     async fn on_completion_call(

--- a/examples/pdf_agent/src/main.rs
+++ b/examples/pdf_agent/src/main.rs
@@ -27,9 +27,8 @@ struct PdfRag<I> {
     samples: u64,
 }
 
-impl<M, I> AgentHook<M> for PdfRag<I>
+impl<I> AgentHook for PdfRag<I>
 where
-    M: CompletionModel,
     I: VectorStoreIndexDyn,
 {
     async fn on_completion_call(

--- a/examples/rag/src/main.rs
+++ b/examples/rag/src/main.rs
@@ -28,9 +28,8 @@ struct DictionaryRag<I> {
     samples: u64,
 }
 
-impl<M, I> AgentHook<M> for DictionaryRag<I>
+impl<I> AgentHook for DictionaryRag<I>
 where
-    M: CompletionModel,
     I: VectorStoreIndexDyn,
 {
     async fn on_completion_call(

--- a/examples/rag_ollama/src/main.rs
+++ b/examples/rag_ollama/src/main.rs
@@ -27,9 +27,8 @@ struct DictionaryRag<I> {
     samples: u64,
 }
 
-impl<M, I> AgentHook<M> for DictionaryRag<I>
+impl<I> AgentHook for DictionaryRag<I>
 where
-    M: CompletionModel,
     I: VectorStoreIndexDyn,
 {
     async fn on_completion_call(

--- a/examples/request_hook/src/main.rs
+++ b/examples/request_hook/src/main.rs
@@ -26,7 +26,7 @@ use rig::agent::{
     ObservationAction, RequestPatch,
 };
 use rig::client::{CompletionClient, ProviderClient};
-use rig::completion::{CompletionModel, CompletionResponse, Document, Message, Prompt};
+use rig::completion::{Document, Message, Prompt};
 use rig::message::UserContent;
 use rig::providers::openai;
 
@@ -37,10 +37,7 @@ use rig::providers::openai;
 #[derive(Clone)]
 struct LoggingHook;
 
-impl<M> AgentHook<M> for LoggingHook
-where
-    M: CompletionModel,
-{
+impl AgentHook for LoggingHook {
     async fn on_completion_call(
         &self,
         ctx: &HookContext,
@@ -70,13 +67,14 @@ where
     async fn on_completion_response(
         &self,
         ctx: &HookContext,
-        event: CompletionResponseEvent<'_, M>,
+        event: CompletionResponseEvent<'_>,
     ) -> ObservationAction {
-        let response: &CompletionResponse<M::Response> = event.response;
         println!(
-            "[run {}] received response: {:?}",
+            "[run {}] received response {:?} with usage {:?} and message id {:?}",
             ctx.run_id(),
-            response.choice
+            event.content,
+            event.usage,
+            event.message_id,
         );
         ObservationAction::continue_run()
     }
@@ -89,10 +87,7 @@ where
 #[derive(Clone)]
 struct ContextHook;
 
-impl<M> AgentHook<M> for ContextHook
-where
-    M: CompletionModel,
-{
+impl AgentHook for ContextHook {
     async fn on_completion_call(
         &self,
         _ctx: &HookContext,
@@ -115,10 +110,7 @@ where
 #[derive(Clone)]
 struct SamplingHook;
 
-impl<M> AgentHook<M> for SamplingHook
-where
-    M: CompletionModel,
-{
+impl AgentHook for SamplingHook {
     async fn on_completion_call(
         &self,
         _ctx: &HookContext,
@@ -138,10 +130,7 @@ struct TurnCount(usize);
 #[derive(Clone)]
 struct TurnCounterHook;
 
-impl<M> AgentHook<M> for TurnCounterHook
-where
-    M: CompletionModel,
-{
+impl AgentHook for TurnCounterHook {
     async fn on_completion_call(
         &self,
         ctx: &HookContext,

--- a/examples/tool_result_outcomes/src/main.rs
+++ b/examples/tool_result_outcomes/src/main.rs
@@ -37,7 +37,7 @@ use rig::agent::{
     ToolResultAction, ToolResultEvent,
 };
 use rig::client::{CompletionClient, ProviderClient};
-use rig::completion::{CompletionModel, Prompt};
+use rig::completion::Prompt;
 use rig::message::ToolChoice;
 use rig::providers::openai;
 use rig::tool::{Tool, ToolContext, ToolErrorKind, ToolExecutionError, ToolResult};
@@ -155,10 +155,7 @@ fn system_probe_patch(turn: usize) -> Option<RequestPatch> {
     })
 }
 
-impl<M> AgentHook<M> for ForceSystemProbeOnFirstTurn
-where
-    M: CompletionModel,
-{
+impl AgentHook for ForceSystemProbeOnFirstTurn {
     async fn on_completion_call(
         &self,
         _ctx: &HookContext,
@@ -206,10 +203,7 @@ fn failure_record(
     })
 }
 
-impl<M> AgentHook<M> for FailureRecorder
-where
-    M: CompletionModel,
-{
+impl AgentHook for FailureRecorder {
     async fn on_tool_result(
         &self,
         ctx: &HookContext,
@@ -277,10 +271,7 @@ fn policy_action(ledger: Option<&FailureLedger>, internal_call_id: &str) -> Tool
 
 struct FatalFailurePolicy;
 
-impl<M> AgentHook<M> for FatalFailurePolicy
-where
-    M: CompletionModel,
-{
+impl AgentHook for FatalFailurePolicy {
     async fn on_tool_result(
         &self,
         ctx: &HookContext,

--- a/tests/integrations/lancedb/mod.rs
+++ b/tests/integrations/lancedb/mod.rs
@@ -14,7 +14,7 @@ use rig::agent::{AgentHook, CompletionCallAction, CompletionCallEvent, HookConte
 use rig::lancedb::{LanceDbVectorIndex, SearchParams};
 use rig::{
     client::EmbeddingsClient,
-    completion::{CompletionModel, Document, Message, Prompt},
+    completion::{Document, Message, Prompt},
     embeddings::{EmbeddingModel, EmbeddingsBuilder},
     message::UserContent,
     prelude::CompletionClient,
@@ -30,9 +30,8 @@ struct LanceDbRag<I> {
     samples: u64,
 }
 
-impl<M, I> AgentHook<M> for LanceDbRag<I>
+impl<I> AgentHook for LanceDbRag<I>
 where
-    M: CompletionModel,
     I: rig::vector_store::VectorStoreIndexDyn,
 {
     async fn on_completion_call(

--- a/tests/providers/anthropic/cassette/request_override.rs
+++ b/tests/providers/anthropic/cassette/request_override.rs
@@ -14,7 +14,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rig::agent::{AgentHook, CompletionCallAction, CompletionCallEvent, RequestPatch};
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, Prompt};
+use rig::completion::Prompt;
 use rig::message::ToolChoice;
 use rig::providers::anthropic;
 use rig::streaming::StreamingPrompt;
@@ -118,7 +118,7 @@ impl Tool for GetTime {
 /// override is per-turn and non-sticky), so the model can answer with text.
 struct ForceWeatherOnlyOnFirstTurn;
 
-impl<M: CompletionModel> AgentHook<M> for ForceWeatherOnlyOnFirstTurn {
+impl AgentHook for ForceWeatherOnlyOnFirstTurn {
     async fn on_completion_call(
         &self,
         _ctx: &rig::agent::HookContext,

--- a/tests/providers/anthropic/cassette/tool_call_rewrite_args.rs
+++ b/tests/providers/anthropic/cassette/tool_call_rewrite_args.rs
@@ -12,7 +12,7 @@ use std::sync::{Arc, Mutex};
 
 use rig::agent::{AgentHook, ToolCall as ToolCallEvent, ToolCallAction};
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, Prompt};
+use rig::completion::Prompt;
 use rig::providers::anthropic;
 use rig::streaming::StreamingPrompt;
 use rig::test_utils::validate_rewritten_arguments;
@@ -109,7 +109,7 @@ impl Tool for GetWeather {
 /// returns the rewritten object via [`ToolCallAction::rewrite`].
 struct PinUnitsToCelsius;
 
-impl<M: CompletionModel> AgentHook<M> for PinUnitsToCelsius {
+impl AgentHook for PinUnitsToCelsius {
     async fn on_tool_call(
         &self,
         _ctx: &rig::agent::HookContext,

--- a/tests/providers/anthropic/cassette/tool_result_rewrite.rs
+++ b/tests/providers/anthropic/cassette/tool_result_rewrite.rs
@@ -12,7 +12,7 @@ use std::sync::{Arc, Mutex};
 
 use rig::agent::{AgentHook, ToolResultAction, ToolResultEvent};
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, Prompt};
+use rig::completion::Prompt;
 use rig::providers::anthropic;
 use rig::streaming::StreamingPrompt;
 use rig::test_utils::validate_result_redaction;
@@ -113,7 +113,7 @@ fn redact_ssn(record: &str) -> String {
 /// use case `ToolResultAction::Rewrite` exists for.
 struct RedactSsnFromResult;
 
-impl<M: CompletionModel> AgentHook<M> for RedactSsnFromResult {
+impl AgentHook for RedactSsnFromResult {
     async fn on_tool_result(
         &self,
         _ctx: &rig::agent::HookContext,

--- a/tests/providers/chatgpt/permission_control.rs
+++ b/tests/providers/chatgpt/permission_control.rs
@@ -6,7 +6,7 @@ use rig::agent::{
     stream_to_stdout,
 };
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, Prompt};
+use rig::completion::Prompt;
 use rig::streaming::StreamingPrompt;
 use rig::tool::Tool;
 use serde::{Deserialize, Serialize};
@@ -119,7 +119,7 @@ struct PermissionHook {
     last_result: Arc<Mutex<Option<String>>>,
 }
 
-impl<M: CompletionModel> AgentHook<M> for PermissionHook {
+impl AgentHook for PermissionHook {
     async fn on_tool_call(
         &self,
         _ctx: &rig::agent::HookContext,

--- a/tests/providers/chatgpt/request_hook.rs
+++ b/tests/providers/chatgpt/request_hook.rs
@@ -9,7 +9,7 @@ use rig::agent::{
     ObservationAction,
 };
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, Message, Prompt};
+use rig::completion::{Message, Prompt};
 use rig::message::UserContent;
 
 use crate::chatgpt::{LIVE_MODEL, live_client};
@@ -24,10 +24,7 @@ struct SessionIdHook<'a> {
     seen_response: Arc<Mutex<Option<String>>>,
 }
 
-impl<'a, M> AgentHook<M> for SessionIdHook<'a>
-where
-    M: CompletionModel,
-{
+impl<'a> AgentHook for SessionIdHook<'a> {
     async fn on_completion_call(
         &self,
         _ctx: &rig::agent::HookContext,
@@ -57,12 +54,12 @@ where
     async fn on_completion_response(
         &self,
         _ctx: &rig::agent::HookContext,
-        event: CompletionResponseEvent<'_, M>,
+        event: CompletionResponseEvent<'_>,
     ) -> ObservationAction {
         self.response_calls.fetch_add(1, Ordering::SeqCst);
         match self.seen_response.lock() {
             Ok(mut seen_response) => {
-                *seen_response = Some(format!("{:?}", event.response.choice));
+                *seen_response = Some(format!("{:?}", event.content));
                 ObservationAction::continue_run()
             }
             Err(_) => ObservationAction::stop("response hook state unavailable"),

--- a/tests/providers/copilot/permission_control.rs
+++ b/tests/providers/copilot/permission_control.rs
@@ -6,7 +6,7 @@ use rig::agent::{
     stream_to_stdout,
 };
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, Prompt};
+use rig::completion::Prompt;
 use rig::streaming::StreamingPrompt;
 use rig::tool::Tool;
 use serde::{Deserialize, Serialize};
@@ -119,7 +119,7 @@ struct PermissionHook {
     last_result: Arc<Mutex<Option<String>>>,
 }
 
-impl<M: CompletionModel> AgentHook<M> for PermissionHook {
+impl AgentHook for PermissionHook {
     async fn on_tool_call(
         &self,
         _ctx: &rig::agent::HookContext,

--- a/tests/providers/copilot/request_hook.rs
+++ b/tests/providers/copilot/request_hook.rs
@@ -9,7 +9,7 @@ use rig::agent::{
     ObservationAction,
 };
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, Message, Prompt};
+use rig::completion::{Message, Prompt};
 use rig::message::UserContent;
 
 use crate::copilot::{LIVE_MODEL, with_copilot_cassette_result};
@@ -24,10 +24,7 @@ struct SessionIdHook<'a> {
     seen_response: Arc<Mutex<Option<String>>>,
 }
 
-impl<'a, M> AgentHook<M> for SessionIdHook<'a>
-where
-    M: CompletionModel,
-{
+impl<'a> AgentHook for SessionIdHook<'a> {
     async fn on_completion_call(
         &self,
         _ctx: &rig::agent::HookContext,
@@ -57,12 +54,12 @@ where
     async fn on_completion_response(
         &self,
         _ctx: &rig::agent::HookContext,
-        event: CompletionResponseEvent<'_, M>,
+        event: CompletionResponseEvent<'_>,
     ) -> ObservationAction {
         self.response_calls.fetch_add(1, Ordering::SeqCst);
         match self.seen_response.lock() {
             Ok(mut seen_response) => {
-                *seen_response = Some(format!("{:?}", event.response.choice));
+                *seen_response = Some(format!("{:?}", event.content));
                 ObservationAction::continue_run()
             }
             Err(_) => ObservationAction::stop("response hook state unavailable"),

--- a/tests/providers/deepseek/permission_control.rs
+++ b/tests/providers/deepseek/permission_control.rs
@@ -6,7 +6,7 @@ use rig::agent::{
     stream_to_stdout,
 };
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, Prompt};
+use rig::completion::Prompt;
 use rig::providers::deepseek;
 use rig::streaming::StreamingPrompt;
 use rig::tool::Tool;
@@ -135,7 +135,7 @@ struct PermissionHook {
     last_result: Arc<Mutex<Option<String>>>,
 }
 
-impl<M: CompletionModel> AgentHook<M> for PermissionHook {
+impl AgentHook for PermissionHook {
     async fn on_tool_call(
         &self,
         _ctx: &rig::agent::HookContext,

--- a/tests/providers/deepseek/request_hook.rs
+++ b/tests/providers/deepseek/request_hook.rs
@@ -9,7 +9,7 @@ use rig::agent::{
     ObservationAction,
 };
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, Message, Prompt};
+use rig::completion::{Message, Prompt};
 use rig::message::UserContent;
 use rig::providers::deepseek;
 
@@ -25,10 +25,7 @@ struct SessionIdHook<'a> {
     seen_response: Arc<Mutex<Option<String>>>,
 }
 
-impl<'a, M> AgentHook<M> for SessionIdHook<'a>
-where
-    M: CompletionModel,
-{
+impl<'a> AgentHook for SessionIdHook<'a> {
     async fn on_completion_call(
         &self,
         _ctx: &rig::agent::HookContext,
@@ -58,12 +55,12 @@ where
     async fn on_completion_response(
         &self,
         _ctx: &rig::agent::HookContext,
-        event: CompletionResponseEvent<'_, M>,
+        event: CompletionResponseEvent<'_>,
     ) -> ObservationAction {
         self.response_calls.fetch_add(1, Ordering::SeqCst);
         match self.seen_response.lock() {
             Ok(mut seen_response) => {
-                *seen_response = Some(format!("{:?}", event.response.choice));
+                *seen_response = Some(format!("{:?}", event.content));
                 ObservationAction::continue_run()
             }
             Err(_) => ObservationAction::stop("response hook state unavailable"),

--- a/tests/providers/doubleword/cassette/request_hook.rs
+++ b/tests/providers/doubleword/cassette/request_hook.rs
@@ -8,7 +8,7 @@ use rig::agent::{
     ObservationAction,
 };
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, Message, Prompt};
+use rig::completion::{Message, Prompt};
 use rig::message::UserContent;
 
 use super::super::{DEFAULT_MODEL, support::with_doubleword_cassette};
@@ -21,10 +21,7 @@ struct ObservingHook {
     seen_prompt: Arc<Mutex<Option<String>>>,
 }
 
-impl<M> AgentHook<M> for ObservingHook
-where
-    M: CompletionModel,
-{
+impl AgentHook for ObservingHook {
     async fn on_completion_call(
         &self,
         _ctx: &rig::agent::HookContext,
@@ -49,7 +46,7 @@ where
     async fn on_completion_response(
         &self,
         _ctx: &rig::agent::HookContext,
-        _event: CompletionResponseEvent<'_, M>,
+        _event: CompletionResponseEvent<'_>,
     ) -> ObservationAction {
         self.response_calls.fetch_add(1, Ordering::SeqCst);
         ObservationAction::continue_run()

--- a/tests/providers/gemini/cassette/agent_run_streamed.rs
+++ b/tests/providers/gemini/cassette/agent_run_streamed.rs
@@ -521,7 +521,7 @@ async fn builtin_streaming_max_turns_error_carries_pending_message() {
 #[derive(Clone)]
 struct CancelOnToolCall;
 
-impl AgentHook<gemini::completion::CompletionModel> for CancelOnToolCall {
+impl AgentHook for CancelOnToolCall {
     async fn on_tool_call(
         &self,
         _ctx: &rig::agent::HookContext,

--- a/tests/providers/gemini/cassette/hook_stress.rs
+++ b/tests/providers/gemini/cassette/hook_stress.rs
@@ -38,8 +38,6 @@ use super::super::support::with_gemini_cassette;
 use super::super::tools_support::{CountingAdd, CountingSubtract, SkipToolHook, ToolEventRecorder};
 use crate::support::assert_nonempty_response;
 
-type GeminiModel = gemini::completion::CompletionModel;
-
 /// Preamble that forces tool use and a dependent two-step chain so the model
 /// takes at least two turns (compute A, then use A to compute B).
 const CHAIN_PREAMBLE: &str = "You are a calculator assistant. You MUST use the provided tools for \
@@ -114,7 +112,7 @@ impl LifecycleRecorder {
             });
     }
 }
-impl AgentHook<GeminiModel> for LifecycleRecorder {
+impl AgentHook for LifecycleRecorder {
     async fn on_completion_call(
         &self,
         ctx: &HookContext,
@@ -126,7 +124,7 @@ impl AgentHook<GeminiModel> for LifecycleRecorder {
     async fn on_completion_response(
         &self,
         ctx: &HookContext,
-        _event: CompletionResponseEvent<'_, GeminiModel>,
+        _event: CompletionResponseEvent<'_>,
     ) -> ObservationAction {
         self.record(ctx, "CompletionResponse");
         ObservationAction::continue_run()
@@ -170,7 +168,7 @@ impl ScratchpadReader {
     }
 }
 
-impl AgentHook<GeminiModel> for ScratchpadReader {
+impl AgentHook for ScratchpadReader {
     async fn on_model_turn_finished(
         &self,
         ctx: &HookContext,
@@ -195,7 +193,7 @@ struct InjectContextAndNarrowTools {
     allow: &'static [&'static str],
 }
 
-impl AgentHook<GeminiModel> for InjectContextAndNarrowTools {
+impl AgentHook for InjectContextAndNarrowTools {
     async fn on_completion_call(
         &self,
         _ctx: &HookContext,
@@ -223,7 +221,7 @@ struct ForceArgs {
     args: serde_json::Value,
 }
 
-impl AgentHook<GeminiModel> for ForceArgs {
+impl AgentHook for ForceArgs {
     async fn on_tool_call(&self, _ctx: &HookContext, event: ToolCallEvent<'_>) -> ToolCallAction {
         if event.tool_name == self.tool_name {
             ToolCallAction::rewrite(self.args.clone())
@@ -240,7 +238,7 @@ struct RedactResult {
     marker: &'static str,
 }
 
-impl AgentHook<GeminiModel> for RedactResult {
+impl AgentHook for RedactResult {
     async fn on_tool_result(
         &self,
         _ctx: &HookContext,
@@ -763,7 +761,7 @@ async fn skip_in_multi_tool_workflow_leaves_tool_unexecuted_blocking() {
 // Compile-time proof the fixtures implement the hook trait for the Gemini model.
 #[allow(unused)]
 fn assert_hook_impls() {
-    fn requires_hook<H: AgentHook<GeminiModel>>(_hook: H) {}
+    fn requires_hook<H: AgentHook>(_hook: H) {}
     requires_hook(LifecycleRecorder::default());
     requires_hook(ScratchpadReader::default());
     requires_hook(InjectContextAndNarrowTools {

--- a/tests/providers/gemini/cassette/tool_hooks.rs
+++ b/tests/providers/gemini/cassette/tool_hooks.rs
@@ -169,7 +169,7 @@ async fn hooks_observe_every_tool_call_and_result() {
 // builder code.
 #[allow(unused)]
 fn assert_hook_impls() {
-    fn requires_hook<H: AgentHook<gemini::completion::CompletionModel>>(_hook: H) {}
+    fn requires_hook<H: AgentHook>(_hook: H) {}
     requires_hook(ToolEventRecorder::default());
     requires_hook(SkipToolHook {
         tool_name: "add",

--- a/tests/providers/gemini/hook_stress_support.rs
+++ b/tests/providers/gemini/hook_stress_support.rs
@@ -18,7 +18,7 @@ use rig::agent::{
     StreamResponseFinish, TextDelta, ToolCall as ToolCallEvent, ToolCallAction, ToolCallDelta,
     ToolResultAction, ToolResultEvent,
 };
-use rig::completion::{CompletionModel, Document};
+use rig::completion::Document;
 use rig::tool::Tool;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -190,7 +190,7 @@ impl EventTap {
     }
 }
 
-impl<M: CompletionModel> AgentHook<M> for EventTap {
+impl AgentHook for EventTap {
     async fn on_completion_call(
         &self,
         ctx: &HookContext,
@@ -202,7 +202,7 @@ impl<M: CompletionModel> AgentHook<M> for EventTap {
     async fn on_completion_response(
         &self,
         ctx: &HookContext,
-        _event: CompletionResponseEvent<'_, M>,
+        _event: CompletionResponseEvent<'_>,
     ) -> ObservationAction {
         self.record(ctx, "CompletionResponse");
         ObservationAction::continue_run()
@@ -260,7 +260,7 @@ impl<M: CompletionModel> AgentHook<M> for EventTap {
     async fn on_stream_response_finish(
         &self,
         ctx: &HookContext,
-        _event: StreamResponseFinish<'_, M>,
+        _event: StreamResponseFinish<'_>,
     ) -> ObservationAction {
         self.record(ctx, "StreamResponseFinish");
         ObservationAction::continue_run()
@@ -281,7 +281,7 @@ impl ScratchpadReader {
     }
 }
 
-impl<M: CompletionModel> AgentHook<M> for ScratchpadReader {
+impl AgentHook for ScratchpadReader {
     async fn on_model_turn_finished(
         &self,
         ctx: &HookContext,
@@ -307,7 +307,7 @@ impl<M: CompletionModel> AgentHook<M> for ScratchpadReader {
 #[derive(Clone)]
 pub(crate) struct ApplyPatch(pub(crate) RequestPatch);
 
-impl<M: CompletionModel> AgentHook<M> for ApplyPatch {
+impl AgentHook for ApplyPatch {
     async fn on_completion_call(
         &self,
         _ctx: &HookContext,
@@ -324,7 +324,7 @@ impl<M: CompletionModel> AgentHook<M> for ApplyPatch {
 #[derive(Clone)]
 pub(crate) struct FirstTurnPatch(pub(crate) RequestPatch);
 
-impl<M: CompletionModel> AgentHook<M> for FirstTurnPatch {
+impl AgentHook for FirstTurnPatch {
     async fn on_completion_call(
         &self,
         ctx: &HookContext,
@@ -356,7 +356,7 @@ pub(crate) struct SetArg {
     pub(crate) value: serde_json::Value,
 }
 
-impl<M: CompletionModel> AgentHook<M> for SetArg {
+impl AgentHook for SetArg {
     async fn on_tool_call(&self, _ctx: &HookContext, event: ToolCallEvent<'_>) -> ToolCallAction {
         if event.tool_name == self.tool {
             let mut parsed: serde_json::Value =
@@ -390,7 +390,7 @@ pub(crate) struct RewriteToolResult {
     pub(crate) rewrite: ResultRewrite,
 }
 
-impl<M: CompletionModel> AgentHook<M> for RewriteToolResult {
+impl AgentHook for RewriteToolResult {
     async fn on_tool_result(
         &self,
         _ctx: &HookContext,
@@ -417,7 +417,7 @@ pub(crate) struct TerminateOnResult {
     pub(crate) reason: &'static str,
 }
 
-impl<M: CompletionModel> AgentHook<M> for TerminateOnResult {
+impl AgentHook for TerminateOnResult {
     async fn on_tool_result(
         &self,
         _ctx: &HookContext,

--- a/tests/providers/gemini/tools_support.rs
+++ b/tests/providers/gemini/tools_support.rs
@@ -27,7 +27,7 @@ use rig::OneOrMany;
 use rig::agent::{
     AgentHook, ToolCall as ToolCallEvent, ToolCallAction, ToolResultAction, ToolResultEvent,
 };
-use rig::completion::{CompletionModel, ToolDefinition};
+use rig::completion::ToolDefinition;
 use rig::message::{ImageMediaType, ToolResultContent};
 use rig::tool::server::ToolServerHandle;
 use rig::tool::{Tool, ToolEmbedding, ToolOutput};
@@ -417,10 +417,7 @@ impl ToolEventRecorder {
     }
 }
 
-impl<M> AgentHook<M> for ToolEventRecorder
-where
-    M: CompletionModel,
-{
+impl AgentHook for ToolEventRecorder {
     async fn on_tool_call(
         &self,
         _ctx: &rig::agent::HookContext,
@@ -457,10 +454,7 @@ pub(crate) struct SkipToolHook {
     pub(crate) reason: &'static str,
 }
 
-impl<M> AgentHook<M> for SkipToolHook
-where
-    M: CompletionModel,
-{
+impl AgentHook for SkipToolHook {
     async fn on_tool_call(
         &self,
         _ctx: &rig::agent::HookContext,
@@ -481,10 +475,7 @@ pub(crate) struct TerminateOnToolHook {
     pub(crate) reason: &'static str,
 }
 
-impl<M> AgentHook<M> for TerminateOnToolHook
-where
-    M: CompletionModel,
-{
+impl AgentHook for TerminateOnToolHook {
     async fn on_tool_call(
         &self,
         _ctx: &rig::agent::HookContext,
@@ -506,10 +497,7 @@ pub(crate) struct RemoveToolBeforeExecutionHook {
     pub(crate) tool_name: &'static str,
 }
 
-impl<M> AgentHook<M> for RemoveToolBeforeExecutionHook
-where
-    M: CompletionModel,
-{
+impl AgentHook for RemoveToolBeforeExecutionHook {
     async fn on_tool_call(
         &self,
         _ctx: &rig::agent::HookContext,

--- a/tests/providers/groq/permission_control.rs
+++ b/tests/providers/groq/permission_control.rs
@@ -6,7 +6,7 @@ use rig::agent::{
     stream_to_stdout,
 };
 use rig::client::{CompletionClient, ProviderClient};
-use rig::completion::{CompletionModel, Prompt};
+use rig::completion::Prompt;
 use rig::providers::groq;
 use rig::streaming::StreamingPrompt;
 use rig::tool::Tool;
@@ -123,7 +123,7 @@ struct PermissionHook {
     last_result: Arc<Mutex<Option<String>>>,
 }
 
-impl<M: CompletionModel> AgentHook<M> for PermissionHook {
+impl AgentHook for PermissionHook {
     async fn on_tool_call(
         &self,
         _ctx: &rig::agent::HookContext,

--- a/tests/providers/groq/request_hook.rs
+++ b/tests/providers/groq/request_hook.rs
@@ -9,7 +9,7 @@ use rig::agent::{
     ObservationAction,
 };
 use rig::client::{CompletionClient, ProviderClient};
-use rig::completion::{CompletionModel, Message, Prompt};
+use rig::completion::{Message, Prompt};
 use rig::message::UserContent;
 use rig::providers::groq;
 
@@ -26,10 +26,7 @@ struct SessionIdHook<'a> {
     seen_response: Arc<Mutex<Option<String>>>,
 }
 
-impl<'a, M> AgentHook<M> for SessionIdHook<'a>
-where
-    M: CompletionModel,
-{
+impl<'a> AgentHook for SessionIdHook<'a> {
     async fn on_completion_call(
         &self,
         _ctx: &rig::agent::HookContext,
@@ -59,12 +56,12 @@ where
     async fn on_completion_response(
         &self,
         _ctx: &rig::agent::HookContext,
-        event: CompletionResponseEvent<'_, M>,
+        event: CompletionResponseEvent<'_>,
     ) -> ObservationAction {
         self.response_calls.fetch_add(1, Ordering::SeqCst);
         match self.seen_response.lock() {
             Ok(mut seen_response) => {
-                *seen_response = Some(format!("{:?}", event.response.choice));
+                *seen_response = Some(format!("{:?}", event.content));
                 ObservationAction::continue_run()
             }
             Err(_) => ObservationAction::stop("response hook state unavailable"),

--- a/tests/providers/llamacpp/permission_control.rs
+++ b/tests/providers/llamacpp/permission_control.rs
@@ -3,7 +3,7 @@ use rig::agent::{
     AgentHook, ToolCall as ToolCallEvent, ToolCallAction, ToolResultAction, ToolResultEvent,
 };
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, Prompt};
+use rig::completion::Prompt;
 use rig::streaming::StreamingPrompt;
 use rig::tool::Tool;
 use serde::{Deserialize, Serialize};
@@ -117,7 +117,7 @@ struct PermissionHook {
     last_result: Arc<Mutex<Option<String>>>,
 }
 
-impl<M: CompletionModel> AgentHook<M> for PermissionHook {
+impl AgentHook for PermissionHook {
     async fn on_tool_call(
         &self,
         _ctx: &rig::agent::HookContext,

--- a/tests/providers/llamacpp/request_hook.rs
+++ b/tests/providers/llamacpp/request_hook.rs
@@ -9,7 +9,7 @@ use rig::agent::{
     ObservationAction,
 };
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, Message, Prompt};
+use rig::completion::{Message, Prompt};
 use rig::message::UserContent;
 
 use crate::support::assert_nonempty_response;
@@ -25,10 +25,7 @@ struct SessionIdHook<'a> {
     seen_response: Arc<Mutex<Option<String>>>,
 }
 
-impl<'a, M> AgentHook<M> for SessionIdHook<'a>
-where
-    M: CompletionModel,
-{
+impl<'a> AgentHook for SessionIdHook<'a> {
     async fn on_completion_call(
         &self,
         _ctx: &rig::agent::HookContext,
@@ -58,12 +55,12 @@ where
     async fn on_completion_response(
         &self,
         _ctx: &rig::agent::HookContext,
-        event: CompletionResponseEvent<'_, M>,
+        event: CompletionResponseEvent<'_>,
     ) -> ObservationAction {
         self.response_calls.fetch_add(1, Ordering::SeqCst);
         match self.seen_response.lock() {
             Ok(mut seen_response) => {
-                *seen_response = Some(format!("{:?}", event.response.choice));
+                *seen_response = Some(format!("{:?}", event.content));
                 ObservationAction::continue_run()
             }
             Err(_) => ObservationAction::stop("response hook state unavailable"),

--- a/tests/providers/llamacpp/typed_prompt_tools.rs
+++ b/tests/providers/llamacpp/typed_prompt_tools.rs
@@ -12,7 +12,7 @@ use rig::agent::{
     ToolResultEvent,
 };
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, TypedPrompt};
+use rig::completion::TypedPrompt;
 use rig::tool::Tool;
 
 use super::support;
@@ -59,11 +59,7 @@ impl StepLogger {
     }
 }
 
-impl<M> AgentHook<M> for StepLogger
-where
-    M: CompletionModel,
-    M::Response: Serialize,
-{
+impl AgentHook for StepLogger {
     async fn on_completion_call(
         &self,
         _ctx: &rig::agent::HookContext,
@@ -79,13 +75,13 @@ where
     async fn on_completion_response(
         &self,
         _ctx: &rig::agent::HookContext,
-        event: CompletionResponseEvent<'_, M>,
+        event: CompletionResponseEvent<'_>,
     ) -> ObservationAction {
         let call_no = self.current_completion_call();
-        println!("\n=== completion response #{call_no}: normalized choice ===");
-        println!("{}", pretty_json(&event.response.choice));
-        println!("\n=== completion response #{call_no}: raw provider payload ===");
-        println!("{}", pretty_json(&event.response.raw_response));
+        println!("\n=== completion response #{call_no}: canonical content ===");
+        println!("{}", pretty_json(event.content));
+        println!("usage: {:?}", event.usage);
+        println!("message_id: {:?}", event.message_id);
         ObservationAction::continue_run()
     }
 

--- a/tests/providers/llamafile/permission_control.rs
+++ b/tests/providers/llamafile/permission_control.rs
@@ -6,7 +6,7 @@ use rig::agent::{
     stream_to_stdout,
 };
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, Prompt, PromptError};
+use rig::completion::{Prompt, PromptError};
 use rig::streaming::StreamingPrompt;
 use rig::tool::Tool;
 use serde::{Deserialize, Serialize};
@@ -140,7 +140,7 @@ fn should_skip_retry_capability(
         || response.contains("read_file_tail")
 }
 
-impl<M: CompletionModel> AgentHook<M> for PermissionHook {
+impl AgentHook for PermissionHook {
     async fn on_tool_call(
         &self,
         _ctx: &rig::agent::HookContext,

--- a/tests/providers/llamafile/request_hook.rs
+++ b/tests/providers/llamafile/request_hook.rs
@@ -9,7 +9,7 @@ use rig::agent::{
     ObservationAction,
 };
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, Message, Prompt};
+use rig::completion::{Message, Prompt};
 use rig::message::UserContent;
 
 use crate::support::assert_nonempty_response;
@@ -25,10 +25,7 @@ struct SessionIdHook<'a> {
     seen_response: Arc<Mutex<Option<String>>>,
 }
 
-impl<'a, M> AgentHook<M> for SessionIdHook<'a>
-where
-    M: CompletionModel,
-{
+impl<'a> AgentHook for SessionIdHook<'a> {
     async fn on_completion_call(
         &self,
         _ctx: &rig::agent::HookContext,
@@ -58,12 +55,12 @@ where
     async fn on_completion_response(
         &self,
         _ctx: &rig::agent::HookContext,
-        event: CompletionResponseEvent<'_, M>,
+        event: CompletionResponseEvent<'_>,
     ) -> ObservationAction {
         self.response_calls.fetch_add(1, Ordering::SeqCst);
         match self.seen_response.lock() {
             Ok(mut seen_response) => {
-                *seen_response = Some(format!("{:?}", event.response.choice));
+                *seen_response = Some(format!("{:?}", event.content));
                 ObservationAction::continue_run()
             }
             Err(_) => ObservationAction::stop("response hook state unavailable"),

--- a/tests/providers/mistral/permission_control.rs
+++ b/tests/providers/mistral/permission_control.rs
@@ -6,7 +6,7 @@ use rig::agent::{
     stream_to_stdout,
 };
 use rig::client::{CompletionClient, ProviderClient};
-use rig::completion::{CompletionModel, Prompt};
+use rig::completion::Prompt;
 use rig::providers::mistral;
 use rig::streaming::StreamingPrompt;
 use rig::tool::Tool;
@@ -121,7 +121,7 @@ struct PermissionHook {
     last_result: Arc<Mutex<Option<String>>>,
 }
 
-impl<M: CompletionModel> AgentHook<M> for PermissionHook {
+impl AgentHook for PermissionHook {
     async fn on_tool_call(
         &self,
         _ctx: &rig::agent::HookContext,

--- a/tests/providers/mistral/request_hook.rs
+++ b/tests/providers/mistral/request_hook.rs
@@ -9,7 +9,7 @@ use rig::agent::{
     ObservationAction,
 };
 use rig::client::{CompletionClient, ProviderClient};
-use rig::completion::{CompletionModel, Message, Prompt};
+use rig::completion::{Message, Prompt};
 use rig::message::UserContent;
 use rig::providers::mistral;
 
@@ -26,10 +26,7 @@ struct SessionIdHook<'a> {
     seen_response: Arc<Mutex<Option<String>>>,
 }
 
-impl<'a, M> AgentHook<M> for SessionIdHook<'a>
-where
-    M: CompletionModel,
-{
+impl<'a> AgentHook for SessionIdHook<'a> {
     async fn on_completion_call(
         &self,
         _ctx: &rig::agent::HookContext,
@@ -59,12 +56,12 @@ where
     async fn on_completion_response(
         &self,
         _ctx: &rig::agent::HookContext,
-        event: CompletionResponseEvent<'_, M>,
+        event: CompletionResponseEvent<'_>,
     ) -> ObservationAction {
         self.response_calls.fetch_add(1, Ordering::SeqCst);
         match self.seen_response.lock() {
             Ok(mut seen_response) => {
-                *seen_response = Some(format!("{:?}", event.response.choice));
+                *seen_response = Some(format!("{:?}", event.content));
                 ObservationAction::continue_run()
             }
             Err(_) => ObservationAction::stop("response hook state unavailable"),

--- a/tests/providers/openai/cassette/permission_control.rs
+++ b/tests/providers/openai/cassette/permission_control.rs
@@ -4,7 +4,7 @@ use rig::agent::{
     stream_to_stdout,
 };
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, Prompt};
+use rig::completion::Prompt;
 use rig::providers;
 use rig::streaming::StreamingPrompt;
 use rig::tool::Tool;
@@ -138,7 +138,7 @@ struct PermissionHook {
     last_result: Arc<Mutex<Option<String>>>,
 }
 
-impl<M: CompletionModel> AgentHook<M> for PermissionHook {
+impl AgentHook for PermissionHook {
     async fn on_tool_call(
         &self,
         _ctx: &rig::agent::HookContext,

--- a/tests/providers/openai/cassette/request_hook.rs
+++ b/tests/providers/openai/cassette/request_hook.rs
@@ -9,7 +9,7 @@ use rig::agent::{
     ObservationAction,
 };
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, Message, Prompt};
+use rig::completion::{Message, Prompt};
 use rig::message::UserContent;
 use rig::providers::openai;
 
@@ -25,10 +25,7 @@ struct SessionIdHook<'a> {
     seen_response: Arc<Mutex<Option<String>>>,
 }
 
-impl<'a, M> AgentHook<M> for SessionIdHook<'a>
-where
-    M: CompletionModel,
-{
+impl<'a> AgentHook for SessionIdHook<'a> {
     async fn on_completion_call(
         &self,
         _ctx: &rig::agent::HookContext,
@@ -58,12 +55,12 @@ where
     async fn on_completion_response(
         &self,
         _ctx: &rig::agent::HookContext,
-        event: CompletionResponseEvent<'_, M>,
+        event: CompletionResponseEvent<'_>,
     ) -> ObservationAction {
         self.response_calls.fetch_add(1, Ordering::SeqCst);
         match self.seen_response.lock() {
             Ok(mut seen_response) => {
-                *seen_response = Some(format!("{:?}", event.response.choice));
+                *seen_response = Some(format!("{:?}", event.content));
                 ObservationAction::continue_run()
             }
             Err(_) => ObservationAction::stop("response hook state unavailable"),

--- a/tests/providers/openrouter/cassette/permission_control.rs
+++ b/tests/providers/openrouter/cassette/permission_control.rs
@@ -6,7 +6,7 @@ use rig::agent::{
     stream_to_stdout,
 };
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, Prompt};
+use rig::completion::Prompt;
 use rig::streaming::StreamingPrompt;
 use rig::tool::Tool;
 use serde::{Deserialize, Serialize};
@@ -140,7 +140,7 @@ struct PermissionHook {
     last_result: Arc<Mutex<Option<String>>>,
 }
 
-impl<M: CompletionModel> AgentHook<M> for PermissionHook {
+impl AgentHook for PermissionHook {
     async fn on_tool_call(
         &self,
         _ctx: &rig::agent::HookContext,

--- a/tests/providers/openrouter/cassette/request_hook.rs
+++ b/tests/providers/openrouter/cassette/request_hook.rs
@@ -9,7 +9,7 @@ use rig::agent::{
     ObservationAction,
 };
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, Message, Prompt};
+use rig::completion::{Message, Prompt};
 use rig::message::UserContent;
 
 use crate::support::assert_nonempty_response;
@@ -25,10 +25,7 @@ struct SessionIdHook<'a> {
     seen_response: Arc<Mutex<Option<String>>>,
 }
 
-impl<'a, M> AgentHook<M> for SessionIdHook<'a>
-where
-    M: CompletionModel,
-{
+impl<'a> AgentHook for SessionIdHook<'a> {
     async fn on_completion_call(
         &self,
         _ctx: &rig::agent::HookContext,
@@ -58,12 +55,12 @@ where
     async fn on_completion_response(
         &self,
         _ctx: &rig::agent::HookContext,
-        event: CompletionResponseEvent<'_, M>,
+        event: CompletionResponseEvent<'_>,
     ) -> ObservationAction {
         self.response_calls.fetch_add(1, Ordering::SeqCst);
         match self.seen_response.lock() {
             Ok(mut seen_response) => {
-                *seen_response = Some(format!("{:?}", event.response.choice));
+                *seen_response = Some(format!("{:?}", event.content));
                 ObservationAction::continue_run()
             }
             Err(_) => ObservationAction::stop("response hook state unavailable"),

--- a/tests/providers/xai/permission_control.rs
+++ b/tests/providers/xai/permission_control.rs
@@ -6,7 +6,7 @@ use rig::agent::{
     stream_to_stdout,
 };
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, Prompt};
+use rig::completion::Prompt;
 use rig::providers::xai;
 use rig::streaming::StreamingPrompt;
 use rig::tool::Tool;
@@ -142,7 +142,7 @@ struct PermissionHook {
     last_result: Arc<Mutex<Option<String>>>,
 }
 
-impl<M: CompletionModel> AgentHook<M> for PermissionHook {
+impl AgentHook for PermissionHook {
     async fn on_tool_call(
         &self,
         _ctx: &rig::agent::HookContext,

--- a/tests/providers/xai/request_hook.rs
+++ b/tests/providers/xai/request_hook.rs
@@ -9,7 +9,7 @@ use rig::agent::{
     ObservationAction,
 };
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, Message, Prompt};
+use rig::completion::{Message, Prompt};
 use rig::message::UserContent;
 use rig::providers::xai;
 
@@ -25,10 +25,7 @@ struct SessionIdHook<'a> {
     seen_response: Arc<Mutex<Option<String>>>,
 }
 
-impl<'a, M> AgentHook<M> for SessionIdHook<'a>
-where
-    M: CompletionModel,
-{
+impl<'a> AgentHook for SessionIdHook<'a> {
     async fn on_completion_call(
         &self,
         _ctx: &rig::agent::HookContext,
@@ -58,12 +55,12 @@ where
     async fn on_completion_response(
         &self,
         _ctx: &rig::agent::HookContext,
-        event: CompletionResponseEvent<'_, M>,
+        event: CompletionResponseEvent<'_>,
     ) -> ObservationAction {
         self.response_calls.fetch_add(1, Ordering::SeqCst);
         match self.seen_response.lock() {
             Ok(mut seen_response) => {
-                *seen_response = Some(format!("{:?}", event.response.choice));
+                *seen_response = Some(format!("{:?}", event.content));
                 ObservationAction::continue_run()
             }
             Err(_) => ObservationAction::stop("response hook state unavailable"),


### PR DESCRIPTION
## Description

Make Rig's managed agent hook system provider-independent by removing the completion-model generic from `AgentHook`, its erased dispatch layer, `HookStack`, and managed response events.

Managed completion and streaming hooks now receive canonical Rig prompt, assistant content, usage, and message ID data. Typed provider responses remain available through direct `CompletionModel` completion and streaming APIs, and managed stream consumers retain their existing typed final-response items.

This also migrates agent, runner, prompt-request, extractor, example, conformance, and provider cassette hook implementations. The streaming finish path snapshots normalized assistant content when the provider final-response item arrives so blocking and streaming hooks observe equivalent canonical responses.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Documentation update

## Testing

- [x] `cargo test -p rig-core agent::hook -- --nocapture`
- [x] `cargo test -p rig-core agent::runner -- --nocapture`
- [x] `cargo test -p rig-core extractor -- --nocapture`
- [x] Gemini hook-stress cassette tests
- [x] OpenAI and Doubleword request-hook cassette tests
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test`
- [x] `cargo doc --workspace --no-deps`
- [x] `cargo check -p rig-core --features wasm --target wasm32-unknown-unknown`

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented the code where lifecycle timing needs explanation
- [x] I have made corresponding documentation and changelog changes
- [x] My changes generate no new warnings
- [x] I have added regression tests for the API and lifecycle behavior
- [x] New and existing tests pass locally

## Notes

An independent full-diff review found no validated P0, P1, or P2 findings. The only remaining generic hook spellings are deliberate before/after migration snippets and historical changelog entries.