### PR TITLE
fix(openai): accept nullable strict tool definitions

### DIFF
--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -641,7 +641,11 @@ pub struct ResponsesToolDefinition {
     pub parameters: serde_json::Value,
     /// Whether to use strict mode. Disabled by default; opt in with [`Self::with_strict`]
     /// or [`GenericResponsesCompletionModel::with_strict_tools`].
-    #[serde(default, skip_serializing_if = "is_false", deserialize_with = "null_to_false")]
+    #[serde(
+        default,
+        skip_serializing_if = "is_false",
+        deserialize_with = "null_to_false"
+    )]
     pub strict: bool,
     /// Tool description.
     #[serde(default, skip_serializing_if = "String::is_empty")]

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -641,7 +641,7 @@ pub struct ResponsesToolDefinition {
     pub parameters: serde_json::Value,
     /// Whether to use strict mode. Disabled by default; opt in with [`Self::with_strict`]
     /// or [`GenericResponsesCompletionModel::with_strict_tools`].
-    #[serde(default, skip_serializing_if = "is_false")]
+    #[serde(default, skip_serializing_if = "is_false", deserialize_with = "null_to_false")]
     pub strict: bool,
     /// Tool description.
     #[serde(default, skip_serializing_if = "String::is_empty")]
@@ -657,6 +657,15 @@ fn is_json_null(value: &Value) -> bool {
 
 fn is_false(value: &bool) -> bool {
     !value
+}
+
+fn null_to_false<'a, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: Deserializer<'a>,
+{
+    // First deserialize as Option<bool>, then map None -> false
+    let opt = Option::<bool>::deserialize(deserializer)?;
+    Ok(opt.unwrap_or(false))
 }
 
 impl ResponsesToolDefinition {

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -644,7 +644,7 @@ pub struct ResponsesToolDefinition {
     #[serde(
         default,
         skip_serializing_if = "is_false",
-        deserialize_with = "null_to_false"
+        deserialize_with = "json_utils::null_or_default"
     )]
     pub strict: bool,
     /// Tool description.
@@ -661,15 +661,6 @@ fn is_json_null(value: &Value) -> bool {
 
 fn is_false(value: &bool) -> bool {
     !value
-}
-
-fn null_to_false<'a, D>(deserializer: D) -> Result<bool, D::Error>
-where
-    D: Deserializer<'a>,
-{
-    // First deserialize as Option<bool>, then map None -> false
-    let opt = Option::<bool>::deserialize(deserializer)?;
-    Ok(opt.unwrap_or(false))
 }
 
 impl ResponsesToolDefinition {
@@ -2643,6 +2634,53 @@ mod tests {
 
         let serialized = serde_json::to_value(tool).expect("tool should serialize");
         assert!(serialized.get("strict").is_none());
+    }
+
+    #[test]
+    fn responses_tool_definitions_accept_nullable_strict() {
+        let cases = [
+            (
+                json!({
+                    "type": "function",
+                    "name": "get_weather",
+                    "parameters": {}
+                }),
+                false,
+            ),
+            (
+                json!({
+                    "type": "function",
+                    "name": "get_weather",
+                    "parameters": {},
+                    "strict": null
+                }),
+                false,
+            ),
+            (
+                json!({
+                    "type": "function",
+                    "name": "get_weather",
+                    "parameters": {},
+                    "strict": false
+                }),
+                false,
+            ),
+            (
+                json!({
+                    "type": "function",
+                    "name": "get_weather",
+                    "parameters": {},
+                    "strict": true
+                }),
+                true,
+            ),
+        ];
+
+        for (value, expected) in cases {
+            let tool: ResponsesToolDefinition =
+                serde_json::from_value(value).expect("tool definition should deserialize");
+            assert_eq!(tool.strict, expected);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- preserves both original commits from #2162 unchanged
- accepts `strict: null` in OpenAI Responses tool definitions and maps it to `false`
- reuses the existing `json_utils::null_or_default` deserializer
- adds regression coverage for omitted, `null`, `false`, and `true` values

## Why

OpenAI-compatible Responses payloads may return `strict: null`. Deserializing that field directly as `bool` rejects the response. #2162 fixes the behavior; this follow-up keeps its complete commit history while addressing the review findings about duplicated deserialization logic and missing regression coverage.

## Impact

Omitted and null `strict` values deserialize as `false`. Explicit `false` and `true` remain unchanged, invalid non-boolean values still fail normal serde validation, and false values remain omitted during serialization.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p rig-core responses_`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -- --test-threads=1`
- focused all-features OpenAI cassette rerun in serial mode
- independent full-diff review and final committed-stack audit: no findings

This is a history-preserving successor to #2162: commits `24d69222` and `90cb8fa1` are unchanged ancestors, followed by one findings-fix commit.