### PR TITLE
Add model turn terminal metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,14 +170,31 @@ Composition through `HookStack` remains event-dependent:
   `Repair`, `Skip`, or `Stop`).
 - **Observe-only events** return `ObservationAction` (`Continue` or `Stop`).
 
+`ModelTurnPrepared` is the single managed model-response event. It receives the
+accepted canonical content, usage, optional message ID, and optional canonical
+terminal metadata after invalid-tool resolution, but before tools execute or a
+final response is produced. It fires with identical semantics for blocking and
+streaming text, reasoning-only, and tool-only turns. A stop must prevent the
+state transition, tool execution, buffered streaming final item, and final
+response. Recovered, retried, and abandoned turns retain their existing hook
+suppression while every successfully received provider call remains present in
+completion-call accounting.
+
+Provider terminal reasons are normalized into `CompletionTerminalMetadata`;
+preserve an exact provider reason string when available, use `Unknown` for a
+supplied but unrecognized value, and use `None` only when no value was supplied.
+Keep raw provider response types on direct `CompletionModel` APIs rather than
+exposing them through managed hooks.
+
 Register observe-only hooks before steering hooks because stop actions
 short-circuit. Nested `HookStack`s must preserve merge and chaining semantics.
 `RequestPatch` remains per-turn and non-sticky; its documented merge rules are
 append `extra_context`, shallow-merge `additional_params`, intersect
 `active_tools`, and last-writer-wins scalars/history with a warning.
 
-Every hook semantic must behave identically on streaming and non-streaming
-surfaces (`AgentRunner::stream` and `AgentRunner::run` share `drive_agent`).
+Every managed hook semantic must behave identically on streaming and
+non-streaming surfaces (`AgentRunner::stream` and `AgentRunner::run` share
+`drive_agent`).
 
 ## Style
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- *(agent)* [**breaking**] Managed agent hooks are now provider-independent.
-  `AgentHook`, `HookStack`, and the internal erased-hook interface no longer
-  carry a completion-model type parameter. `CompletionResponseEvent` and
-  `StreamResponseFinish` now expose canonical Rig content, usage, prompt, and
-  message ID fields instead of typed provider responses. Direct
-  `CompletionModel` completion and streaming APIs continue to return their
-  typed raw provider responses.
+- *(agent, completion)* [**breaking**] Replace the overlapping managed
+  `CompletionResponse`, `StreamResponseFinish`, and `ModelTurnFinished` hook
+  events with one provider- and medium-independent `ModelTurnPrepared` event.
+  It observes the accepted canonical model content, usage, optional message ID,
+  and optional terminal metadata after invalid-tool resolution and before state
+  advancement, buffered streaming output, tool execution, or a final response.
+  Blocking and streaming text, reasoning-only, and tool-only turns now have the
+  same exactly-once lifecycle semantics. `AgentHook`, `HookStack`, and the
+  erased-hook interface remain non-generic, so one hook instance can attach to
+  models from different providers. Direct `CompletionModel` APIs continue to
+  expose typed raw provider responses.
 
   ```rust
   // Before
@@ -28,6 +32,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   // After
   impl AgentHook for TelemetryHook { /* ... */ }
   ```
+
+- *(completion, providers)* [**breaking**] Replace `GetTokenUsage` with
+  `GetCompletionMetadata` and add canonical `CompletionFinishReason` /
+  `CompletionTerminalMetadata` to blocking responses, collected streams,
+  agent `ModelTurn`s, and every billed `CompletionCall`. Provider finish
+  reasons are normalized for OpenAI-compatible chat and Responses, Anthropic,
+  Cohere, Gemini, Ollama, xAI, Bedrock, Vertex AI, Gemini gRPC, and Candle while
+  preserving exact raw values. Missing reasons remain `None`, supplied unknown
+  values remain `Unknown`, and provider error frames remain errors.
 
 - *(agent)* [**breaking**] Remove the built-in `AgentBuilder::dynamic_context`,
   `ExtractorBuilder::dynamic_context`, and internal `DynamicContextStore`

--- a/crates/rig-bedrock/src/lib.rs
+++ b/crates/rig-bedrock/src/lib.rs
@@ -23,4 +23,5 @@ pub mod completion;
 pub mod embedding;
 pub mod image;
 pub mod streaming;
+pub(crate) mod terminal_metadata;
 pub mod types;

--- a/crates/rig-bedrock/src/streaming.rs
+++ b/crates/rig-bedrock/src/streaming.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use async_stream::stream;
 use aws_sdk_bedrockruntime::types as aws_bedrock;
-use rig_core::completion::GetTokenUsage;
+use rig_core::completion::{CompletionTerminalMetadata, GetCompletionMetadata};
 use rig_core::streaming::StreamingCompletionResponse;
 use rig_core::telemetry::{CompletionOperation, CompletionSpanBuilder, SpanCombinator};
 use rig_core::{
@@ -19,6 +19,8 @@ use tracing_futures::Instrument;
 #[derive(Clone, Deserialize, Serialize)]
 pub struct BedrockStreamingResponse {
     pub usage: Option<BedrockUsage>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal_metadata: Option<CompletionTerminalMetadata>,
 }
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -32,7 +34,7 @@ pub struct BedrockUsage {
     pub cache_write_input_tokens: Option<i32>,
 }
 
-impl GetTokenUsage for BedrockStreamingResponse {
+impl GetCompletionMetadata for BedrockStreamingResponse {
     fn token_usage(&self) -> rig_core::completion::Usage {
         self.usage
             .as_ref()
@@ -47,6 +49,16 @@ impl GetTokenUsage for BedrockStreamingResponse {
             })
             .unwrap_or_default()
     }
+
+    fn terminal_metadata(&self) -> Option<CompletionTerminalMetadata> {
+        self.terminal_metadata.clone()
+    }
+}
+
+fn terminal_metadata_from_stop_reason(
+    reason: &aws_bedrock::StopReason,
+) -> CompletionTerminalMetadata {
+    crate::terminal_metadata::from_stop_reason(reason.as_str())
 }
 
 #[derive(Default)]
@@ -137,6 +149,7 @@ impl CompletionModel {
             let span = tracing::Span::current();
             let mut current_tool_call: Option<ToolCallState> = None;
             let mut current_reasoning: Option<ReasoningState> = None;
+            let mut terminal_metadata: Option<CompletionTerminalMetadata> = None;
             let mut stream = response.stream;
             loop {
                 let output = match stream.recv().await {
@@ -228,6 +241,9 @@ impl CompletionModel {
                             }
                     },
                     aws_bedrock::ConverseStreamOutput::MessageStop(message_stop_event) => {
+                        terminal_metadata = Some(terminal_metadata_from_stop_reason(
+                            &message_stop_event.stop_reason,
+                        ));
                         match message_stop_event.stop_reason {
                             aws_bedrock::StopReason::ToolUse => {
                                 if let Some(tool_call) = current_tool_call.take() {
@@ -245,27 +261,31 @@ impl CompletionModel {
                                     yield Err(CompletionError::ProviderError("Failed to call tool".into()))
                                 }
                             }
-                            aws_bedrock::StopReason::MaxTokens => {
-                                yield Err(CompletionError::ProviderError("Exceeded max tokens".into()))
+                            aws_bedrock::StopReason::MalformedModelOutput
+                            | aws_bedrock::StopReason::MalformedToolUse => {
+                                yield Err(CompletionError::ProviderError(format!(
+                                    "Bedrock stopped with {}",
+                                    message_stop_event.stop_reason.as_str()
+                                )));
+                                return;
                             }
                             _ => {}
                         }
                     },
                     aws_bedrock::ConverseStreamOutput::Metadata(metadata_event) => {
                         // Extract usage information from metadata
-                        if let Some(usage) = metadata_event.usage {
-                            let final_response = BedrockStreamingResponse {
-                                usage: Some(BedrockUsage {
+                        let final_response = BedrockStreamingResponse {
+                            usage: metadata_event.usage.map(|usage| BedrockUsage {
                                     input_tokens: usage.input_tokens,
                                     output_tokens: usage.output_tokens,
                                     total_tokens: usage.total_tokens,
                                     cache_read_input_tokens: usage.cache_read_input_tokens,
                                     cache_write_input_tokens: usage.cache_write_input_tokens,
                                 }),
-                            };
-                            span.record_token_usage(&final_response);
-                            yield Ok(RawStreamingChoice::FinalResponse(final_response));
-                        }
+                            terminal_metadata: terminal_metadata.clone(),
+                        };
+                        span.record_token_usage(&final_response);
+                        yield Ok(RawStreamingChoice::FinalResponse(final_response));
                     },
                     _ => {}
                 }
@@ -279,6 +299,7 @@ impl CompletionModel {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rig_core::completion::CompletionFinishReason;
 
     #[test]
     fn test_bedrock_usage_creation() {
@@ -305,6 +326,7 @@ mod tests {
                 cache_read_input_tokens: Some(40),
                 cache_write_input_tokens: Some(10),
             }),
+            terminal_metadata: None,
         };
 
         assert_eq!(
@@ -323,7 +345,10 @@ mod tests {
 
     #[test]
     fn test_bedrock_streaming_response_without_usage() {
-        let response = BedrockStreamingResponse { usage: None };
+        let response = BedrockStreamingResponse {
+            usage: None,
+            terminal_metadata: None,
+        };
 
         // Zero-valued usage is rig's documented sentinel for "the provider
         // reported no usage metrics".
@@ -332,7 +357,42 @@ mod tests {
     }
 
     #[test]
-    fn test_get_token_usage_trait() {
+    fn bedrock_stop_reason_normalization_covers_terminal_categories() {
+        for (reason, expected) in [
+            (
+                aws_bedrock::StopReason::EndTurn,
+                CompletionFinishReason::Stop,
+            ),
+            (
+                aws_bedrock::StopReason::MaxTokens,
+                CompletionFinishReason::Length,
+            ),
+            (
+                aws_bedrock::StopReason::ModelContextWindowExceeded,
+                CompletionFinishReason::Length,
+            ),
+            (
+                aws_bedrock::StopReason::ToolUse,
+                CompletionFinishReason::ToolCalls,
+            ),
+            (
+                aws_bedrock::StopReason::ContentFiltered,
+                CompletionFinishReason::ContentFilter,
+            ),
+        ] {
+            let metadata = terminal_metadata_from_stop_reason(&reason);
+            assert_eq!(metadata.reason(), expected);
+            assert_eq!(metadata.raw_reason(), Some(reason.as_str()));
+        }
+
+        let unknown = aws_bedrock::StopReason::from("future_stop_reason");
+        let metadata = terminal_metadata_from_stop_reason(&unknown);
+        assert_eq!(metadata.reason(), CompletionFinishReason::Unknown);
+        assert_eq!(metadata.raw_reason(), Some("future_stop_reason"));
+    }
+
+    #[test]
+    fn test_get_completion_metadata_trait() {
         let response = BedrockStreamingResponse {
             usage: Some(BedrockUsage {
                 input_tokens: 448,
@@ -341,9 +401,10 @@ mod tests {
                 cache_read_input_tokens: Some(80),
                 cache_write_input_tokens: Some(20),
             }),
+            terminal_metadata: None,
         };
 
-        // Test that GetTokenUsage trait is properly implemented
+        // Test that GetCompletionMetadata trait is properly implemented
         assert_eq!(
             response.token_usage(),
             rig_core::completion::Usage {
@@ -399,6 +460,7 @@ mod tests {
                 cache_read_input_tokens: Some(30),
                 cache_write_input_tokens: Some(15),
             }),
+            terminal_metadata: None,
         };
 
         // Test serialization

--- a/crates/rig-bedrock/src/terminal_metadata.rs
+++ b/crates/rig-bedrock/src/terminal_metadata.rs
@@ -1,0 +1,13 @@
+use rig_core::completion::{CompletionFinishReason, CompletionTerminalMetadata};
+
+pub(crate) fn from_stop_reason(raw_reason: &str) -> CompletionTerminalMetadata {
+    let reason = match raw_reason {
+        "content_filtered" | "guardrail_intervened" => CompletionFinishReason::ContentFilter,
+        "end_turn" | "stop_sequence" => CompletionFinishReason::Stop,
+        "max_tokens" | "model_context_window_exceeded" => CompletionFinishReason::Length,
+        "tool_use" => CompletionFinishReason::ToolCalls,
+        _ => CompletionFinishReason::Unknown,
+    };
+
+    CompletionTerminalMetadata::new(reason).with_raw_reason(raw_reason)
+}

--- a/crates/rig-bedrock/src/types/assistant_content.rs
+++ b/crates/rig-bedrock/src/types/assistant_content.rs
@@ -12,7 +12,7 @@ use super::{
     converse_output::{ContentBlock, InternalConverseOutput, TokenUsage},
     json::AwsDocument,
 };
-use rig_core::completion::{self, GetTokenUsage};
+use rig_core::completion::{self, CompletionTerminalMetadata, GetCompletionMetadata};
 use rig_core::telemetry::ProviderResponseExt;
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -75,10 +75,20 @@ impl ProviderResponseExt for AwsConverseOutput {
     }
 }
 
-impl GetTokenUsage for AwsConverseOutput {
+impl GetCompletionMetadata for AwsConverseOutput {
     fn token_usage(&self) -> completion::Usage {
         self.get_usage().unwrap_or_default()
     }
+
+    fn terminal_metadata(&self) -> Option<CompletionTerminalMetadata> {
+        Some(terminal_metadata_from_stop_reason(&self.0.stop_reason))
+    }
+}
+
+fn terminal_metadata_from_stop_reason(
+    reason: &super::converse_output::StopReason,
+) -> CompletionTerminalMetadata {
+    crate::terminal_metadata::from_stop_reason(reason.as_raw_reason())
 }
 
 impl TryFrom<AwsConverseOutput> for completion::CompletionResponse<AwsConverseOutput> {
@@ -109,12 +119,14 @@ impl TryFrom<AwsConverseOutput> for completion::CompletionResponse<AwsConverseOu
         }?;
 
         let usage = value.0.usage().map(normalize_usage).unwrap_or_default();
+        let terminal_metadata = Some(terminal_metadata_from_stop_reason(&value.0.stop_reason));
 
         Ok(completion::CompletionResponse {
             choice,
             usage,
             raw_response: value,
             message_id: None,
+            terminal_metadata,
         })
     }
 }
@@ -246,11 +258,11 @@ mod tests {
         errors::TypeConversionError, json::AwsDocument,
     };
 
-    use super::AwsConverseOutput;
+    use super::{AwsConverseOutput, terminal_metadata_from_stop_reason};
     use aws_sdk_bedrockruntime::types as aws_bedrock;
     use rig_core::{
         OneOrMany, completion,
-        completion::GetTokenUsage,
+        completion::GetCompletionMetadata,
         message::{AssistantContent, ReasoningContent},
         telemetry::ProviderResponseExt,
     };
@@ -375,6 +387,36 @@ mod tests {
             completion.choice,
             OneOrMany::one(AssistantContent::Text("txt".into()))
         );
+        let metadata = completion
+            .terminal_metadata
+            .expect("Bedrock stop reason should be normalized");
+        assert_eq!(metadata.reason(), completion::CompletionFinishReason::Stop);
+        assert_eq!(metadata.raw_reason(), Some("end_turn"));
+    }
+
+    #[test]
+    fn bedrock_internal_terminal_metadata_preserves_limits_and_unknown_values() {
+        use super::super::converse_output::{StopReason, UnknownVariantValue};
+
+        let context_limit =
+            terminal_metadata_from_stop_reason(&StopReason::ModelContextWindowExceeded);
+        assert_eq!(
+            context_limit.reason(),
+            completion::CompletionFinishReason::Length
+        );
+        assert_eq!(
+            context_limit.raw_reason(),
+            Some("model_context_window_exceeded")
+        );
+
+        let unknown = terminal_metadata_from_stop_reason(&StopReason::Unknown(
+            UnknownVariantValue("future_stop_reason".to_string()),
+        ));
+        assert_eq!(
+            unknown.reason(),
+            completion::CompletionFinishReason::Unknown
+        );
+        assert_eq!(unknown.raw_reason(), Some("future_stop_reason"));
     }
 
     #[test]

--- a/crates/rig-bedrock/src/types/converse_output.rs
+++ b/crates/rig-bedrock/src/types/converse_output.rs
@@ -73,9 +73,25 @@ pub enum StopReason {
     EndTurn,
     GuardrailIntervened,
     MaxTokens,
+    ModelContextWindowExceeded,
     StopSequence,
     ToolUse,
     Unknown(UnknownVariantValue),
+}
+
+impl StopReason {
+    pub(crate) fn as_raw_reason(&self) -> &str {
+        match self {
+            Self::ContentFiltered => "content_filtered",
+            Self::EndTurn => "end_turn",
+            Self::GuardrailIntervened => "guardrail_intervened",
+            Self::MaxTokens => "max_tokens",
+            Self::ModelContextWindowExceeded => "model_context_window_exceeded",
+            Self::StopSequence => "stop_sequence",
+            Self::ToolUse => "tool_use",
+            Self::Unknown(value) => &value.0,
+        }
+    }
 }
 
 /// Opaque struct used as inner data for the `Unknown` variant defined in enums in
@@ -721,10 +737,20 @@ impl TryFrom<aws_sdk_bedrockruntime::types::StopReason> for StopReason {
                 Ok(StopReason::GuardrailIntervened)
             }
             aws_sdk_bedrockruntime::types::StopReason::MaxTokens => Ok(StopReason::MaxTokens),
+            aws_sdk_bedrockruntime::types::StopReason::ModelContextWindowExceeded => {
+                Ok(StopReason::ModelContextWindowExceeded)
+            }
             aws_sdk_bedrockruntime::types::StopReason::StopSequence => Ok(StopReason::StopSequence),
             aws_sdk_bedrockruntime::types::StopReason::ToolUse => Ok(StopReason::ToolUse),
-            invalid => Err(TypeConversionError::new(&format!(
-                "Unknown variant for StopReason: {invalid:?}"
+            invalid @ (aws_sdk_bedrockruntime::types::StopReason::MalformedModelOutput
+            | aws_sdk_bedrockruntime::types::StopReason::MalformedToolUse) => {
+                Err(TypeConversionError::new(&format!(
+                    "Bedrock stopped with malformed output: {}",
+                    invalid.as_str()
+                )))
+            }
+            other => Ok(StopReason::Unknown(UnknownVariantValue(
+                other.as_str().to_owned(),
             ))),
         }
     }

--- a/crates/rig-candle/src/lib.rs
+++ b/crates/rig-candle/src/lib.rs
@@ -83,8 +83,8 @@ use candle_transformers::utils::apply_repeat_penalty;
 use futures::Stream;
 use rig_core::OneOrMany;
 use rig_core::completion::{
-    AssistantContent, CompletionError, CompletionModel, CompletionRequest, CompletionResponse,
-    GetTokenUsage, Usage,
+    AssistantContent, CompletionError, CompletionFinishReason, CompletionModel, CompletionRequest,
+    CompletionResponse, CompletionTerminalMetadata, GetCompletionMetadata, Usage,
 };
 #[cfg(test)]
 use rig_core::message::{Message, UserContent};
@@ -466,7 +466,7 @@ pub struct CandleCompletionResponse {
     pub tokens_per_second: Option<f64>,
 }
 
-impl GetTokenUsage for CandleCompletionResponse {
+impl GetCompletionMetadata for CandleCompletionResponse {
     fn token_usage(&self) -> Usage {
         Usage {
             input_tokens: self.prompt_tokens,
@@ -474,6 +474,14 @@ impl GetTokenUsage for CandleCompletionResponse {
             total_tokens: self.prompt_tokens.saturating_add(self.generated_tokens),
             ..Usage::new()
         }
+    }
+
+    fn terminal_metadata(&self) -> Option<CompletionTerminalMetadata> {
+        let (reason, raw_reason) = match self.finish_reason {
+            FinishReason::Eos => (CompletionFinishReason::Stop, "eos"),
+            FinishReason::MaxTokens => (CompletionFinishReason::Length, "max_tokens"),
+        };
+        Some(CompletionTerminalMetadata::new(reason).with_raw_reason(raw_reason))
     }
 }
 
@@ -2675,11 +2683,13 @@ fn infer(
         CandleError::Inference("output protocol produced no assistant content".to_string())
     })?;
     let usage = raw_response.token_usage();
+    let terminal_metadata = raw_response.terminal_metadata();
     Ok(CompletionResponse {
         choice,
         usage,
         raw_response,
         message_id: None,
+        terminal_metadata,
     })
 }
 
@@ -4284,6 +4294,11 @@ mod tests {
         assert_eq!(usage.input_tokens, 5);
         assert_eq!(usage.output_tokens, 2);
         assert_eq!(usage.total_tokens, 7);
+        let metadata = response
+            .terminal_metadata()
+            .expect("local generation always has a finish reason");
+        assert_eq!(metadata.reason(), CompletionFinishReason::Stop);
+        assert_eq!(metadata.raw_reason(), Some("eos"));
         assert_eq!(response.finish_reason, FinishReason::Eos);
         assert_eq!(response.text, "done");
         assert_eq!(response.requested_max_tokens, 4);

--- a/crates/rig-core/CHANGELOG.md
+++ b/crates/rig-core/CHANGELOG.md
@@ -9,13 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- *(agent)* [**breaking**] Remove the completion-model parameter from
-  `AgentHook`, `HookStack`, and the erased hook interface. Managed response
-  hooks now receive canonical Rig lifecycle fields (`prompt`, `content`,
-  `usage`, and `message_id`) through non-generic `CompletionResponse` and
-  `StreamResponseFinish` events. This lets one concrete hook attach to agents
-  backed by different providers. Typed raw provider responses remain available
-  from direct `CompletionModel` completion and streaming APIs.
+- *(agent, completion)* [**breaking**] Replace the overlapping managed
+  `CompletionResponse`, `StreamResponseFinish`, and `ModelTurnFinished` hook
+  events with one provider- and medium-independent `ModelTurnPrepared` event.
+  It observes the accepted canonical model content, usage, optional message ID,
+  and optional terminal metadata after invalid-tool resolution and before state
+  advancement, buffered streaming output, tool execution, or a final response.
+  Blocking and streaming text, reasoning-only, and tool-only turns now have the
+  same exactly-once lifecycle semantics. `AgentHook`, `HookStack`, and the
+  erased-hook interface remain non-generic, so one hook instance can attach to
+  models from different providers. Direct `CompletionModel` APIs continue to
+  expose typed raw provider responses.
 
   ```rust
   // Before
@@ -24,6 +28,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   // After
   impl AgentHook for TelemetryHook { /* ... */ }
   ```
+
+- *(completion, providers)* [**breaking**] Replace `GetTokenUsage` with
+  `GetCompletionMetadata` and add canonical `CompletionFinishReason` /
+  `CompletionTerminalMetadata` to blocking responses, collected streams,
+  agent `ModelTurn`s, and every billed `CompletionCall`. Provider finish
+  reasons are normalized for OpenAI-compatible chat and Responses, Anthropic,
+  Cohere, Gemini, Ollama, and xAI while preserving exact raw values. Missing
+  reasons remain `None`, supplied unknown values remain `Unknown`, and provider
+  error frames remain errors. Companion crates extend the same contract for
+  Bedrock, Vertex AI, Gemini gRPC, and Candle.
 
 - *(agent)* [**breaking**] Remove `AgentBuilder::dynamic_context`,
   `ExtractorBuilder::dynamic_context`, and the internal `DynamicContextStore`

--- a/crates/rig-core/src/agent/completion.rs
+++ b/crates/rig-core/src/agent/completion.rs
@@ -5,8 +5,8 @@ use super::runner::AgentRunner;
 use crate::{
     agent::prompt_request::streaming::StreamingPromptRequest,
     completion::{
-        Chat, CompletionError, CompletionModel, CompletionRequestBuilder, Document, GetTokenUsage,
-        Message, Prompt, PromptError, ToolDefinition, TypedPrompt,
+        Chat, CompletionError, CompletionModel, CompletionRequestBuilder, Document,
+        GetCompletionMetadata, Message, Prompt, PromptError, ToolDefinition, TypedPrompt,
     },
     json_utils,
     message::ToolChoice,
@@ -698,7 +698,7 @@ where
 impl<M> StreamingPrompt<M, M::StreamingResponse> for Agent<M>
 where
     M: CompletionModel + 'static,
-    M::StreamingResponse: GetTokenUsage,
+    M::StreamingResponse: GetCompletionMetadata,
 {
     fn stream_prompt(
         &self,
@@ -711,7 +711,7 @@ where
 impl<M> StreamingChat<M, M::StreamingResponse> for Agent<M>
 where
     M: CompletionModel + 'static,
-    M::StreamingResponse: GetTokenUsage,
+    M::StreamingResponse: GetCompletionMetadata,
 {
     fn stream_chat<I, T>(
         &self,

--- a/crates/rig-core/src/agent/hook.rs
+++ b/crates/rig-core/src/agent/hook.rs
@@ -4,9 +4,9 @@
 //! method and one action type per event. Unsupported combinations are therefore
 //! rejected by the compiler instead of being interpreted at runtime.
 //! Hooks are independent of the agent's [`CompletionModel`](crate::completion::CompletionModel):
-//! managed response events carry canonical Rig messages, content, usage, and
-//! message IDs. Use the direct completion or streaming APIs when a hook-like
-//! integration needs the provider's typed raw response.
+//! managed response events carry canonical Rig messages, content, usage,
+//! message IDs, and terminal metadata. Use the direct completion or streaming
+//! APIs when a hook-like integration needs the provider's typed raw response.
 //!
 //! Hooks run in registration order through [`HookStack`]. Completion-call
 //! [`RequestPatch`] values accumulate and merge; tool-call argument rewrites and
@@ -29,26 +29,50 @@
 //!
 //! # Example
 //!
-//! ```
+//! ```no_run
 //! use rig_core::agent::{
-//!     AgentHook, CompletionResponseEvent, HookContext, ObservationAction,
+//!     AgentHook, HookContext, ModelTurnPrepared, ObservationAction,
 //! };
+//! use rig_core::client::{CompletionClient, ProviderClient};
+//! use rig_core::providers::{anthropic, openai};
 //!
+//! #[derive(Clone)]
 //! struct ResponseLogger;
 //!
 //! impl AgentHook for ResponseLogger {
-//!     async fn on_completion_response(
+//!     async fn on_model_turn_prepared(
 //!         &self,
 //!         _ctx: &HookContext,
-//!         event: CompletionResponseEvent<'_>,
+//!         event: ModelTurnPrepared<'_>,
 //!     ) -> ObservationAction {
 //!         println!(
-//!             "message {:?}: {:?} ({:?})",
-//!             event.message_id, event.content, event.usage
+//!             "turn {} message {:?}: {:?} ({:?}); finish={:?}",
+//!             event.turn,
+//!             event.message_id,
+//!             event.content,
+//!             event.usage,
+//!             event.terminal_metadata.map(|metadata| (
+//!                 metadata.reason(),
+//!                 metadata.raw_reason(),
+//!             )),
 //!         );
 //!         ObservationAction::continue_run()
 //!     }
 //! }
+//!
+//! # fn build_agents() -> Result<(), Box<dyn std::error::Error>> {
+//! let hook = ResponseLogger;
+//! let openai_agent = openai::Client::from_env()?
+//!     .agent(openai::GPT_5_2)
+//!     .add_hook(hook.clone())
+//!     .build();
+//! let anthropic_agent = anthropic::Client::from_env()?
+//!     .agent(anthropic::completion::CLAUDE_SONNET_4_6)
+//!     .add_hook(hook)
+//!     .build();
+//! # let _ = (openai_agent, anthropic_agent);
+//! # Ok(())
+//! # }
 //! ```
 
 use std::collections::HashMap;
@@ -58,7 +82,7 @@ use std::{future::Future, sync::Arc};
 use crate::tool::extensions::TypeMap;
 use crate::{
     OneOrMany,
-    completion::{Document, Usage},
+    completion::{CompletionTerminalMetadata, Document, Usage},
     json_utils,
     message::{AssistantContent, Message, ToolChoice},
     tool::{ToolContext, ToolOutput, ToolResult},
@@ -329,28 +353,22 @@ pub struct CompletionCall<'a> {
     pub turn: usize,
 }
 
-/// Canonical non-streaming completion response event.
+/// Canonical accepted model turn, prepared for the agent state machine.
 #[derive(Clone, Copy)]
-pub struct CompletionResponse<'a> {
-    /// Prompt sent for this turn.
+pub struct ModelTurnPrepared<'a> {
+    /// One-based model-call index.
+    pub turn: usize,
+    /// Prompt sent for this model call.
     pub prompt: &'a Message,
-    /// Canonical assistant content returned for this turn.
+    /// Canonical accepted model-emitted content passed to the next agent-state
+    /// transition.
     pub content: &'a OneOrMany<AssistantContent>,
-    /// Usage reported for this turn.
+    /// Usage reported for this completion call.
     pub usage: Usage,
     /// Provider-assigned message ID, when available.
     pub message_id: Option<&'a str>,
-}
-
-/// Medium-neutral accepted model-turn event.
-#[derive(Clone, Copy)]
-pub struct ModelTurnFinished<'a> {
-    /// One-based model-call index.
-    pub turn: usize,
-    /// Canonical committed assistant content.
-    pub content: &'a OneOrMany<AssistantContent>,
-    /// Usage reported for the turn.
-    pub usage: Usage,
+    /// Canonical provider terminal metadata, when available.
+    pub terminal_metadata: Option<&'a CompletionTerminalMetadata>,
 }
 
 /// Pre-execution tool event.
@@ -410,32 +428,17 @@ pub struct ToolCallDelta<'a> {
     pub delta: &'a str,
 }
 
-/// Canonical streaming response-finish event.
-#[derive(Clone, Copy)]
-pub struct StreamResponseFinish<'a> {
-    /// Prompt sent for this turn.
-    pub prompt: &'a Message,
-    /// Canonical assistant content aggregated for this turn.
-    pub content: &'a OneOrMany<AssistantContent>,
-    /// Usage reported for this turn.
-    pub usage: Usage,
-    /// Provider-assigned message ID, when available.
-    pub message_id: Option<&'a str>,
-}
-
 /// Hook event kind used only as an observation performance hint.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum StepEventKind {
     CompletionCall,
-    CompletionResponse,
-    ModelTurnFinished,
+    ModelTurnPrepared,
     InvalidToolCall,
     ToolCall,
     ToolResult,
     TextDelta,
     ToolCallDelta,
-    StreamResponseFinish,
 }
 
 /// A non-sticky patch applied only to the current turn's completion request.
@@ -804,24 +807,14 @@ pub trait AgentHook: WasmCompatSend + WasmCompatSync {
         async { CompletionCallAction::Continue }
     }
 
-    /// Observes a completed model response.
+    /// Observes an accepted model turn after validation and recovery, but
+    /// before tools execute or a final response is produced.
     ///
     /// The default action continues the run.
-    fn on_completion_response(
+    fn on_model_turn_prepared(
         &self,
         _ctx: &HookContext,
-        _event: CompletionResponse<'_>,
-    ) -> impl Future<Output = ObservationAction> + WasmCompatSend {
-        async { ObservationAction::Continue }
-    }
-
-    /// Observes the content and usage produced at the end of a model turn.
-    ///
-    /// The default action continues the run.
-    fn on_model_turn_finished(
-        &self,
-        _ctx: &HookContext,
-        _event: ModelTurnFinished<'_>,
+        _event: ModelTurnPrepared<'_>,
     ) -> impl Future<Output = ObservationAction> + WasmCompatSend {
         async { ObservationAction::Continue }
     }
@@ -890,17 +883,6 @@ pub trait AgentHook: WasmCompatSend + WasmCompatSync {
         async { ObservationAction::Continue }
     }
 
-    /// Observes a completed streaming response in canonical Rig form.
-    ///
-    /// The default action continues the run.
-    fn on_stream_response_finish(
-        &self,
-        _ctx: &HookContext,
-        _event: StreamResponseFinish<'_>,
-    ) -> impl Future<Output = ObservationAction> + WasmCompatSend {
-        async { ObservationAction::Continue }
-    }
-
     /// Observation interest hint, primarily for high-frequency deltas.
     fn observes(&self, _kind: StepEventKind) -> bool {
         true
@@ -919,15 +901,10 @@ trait DynAgentHook: WasmCompatSend + WasmCompatSync {
         ctx: &'a HookContext,
         event: CompletionCall<'a>,
     ) -> WasmBoxedFuture<'a, CompletionCallAction>;
-    fn completion_response<'a>(
+    fn model_turn_prepared<'a>(
         &'a self,
         ctx: &'a HookContext,
-        event: CompletionResponse<'a>,
-    ) -> WasmBoxedFuture<'a, ObservationAction>;
-    fn model_turn_finished<'a>(
-        &'a self,
-        ctx: &'a HookContext,
-        event: ModelTurnFinished<'a>,
+        event: ModelTurnPrepared<'a>,
     ) -> WasmBoxedFuture<'a, ObservationAction>;
     fn invalid_tool_call<'a>(
         &'a self,
@@ -954,11 +931,6 @@ trait DynAgentHook: WasmCompatSend + WasmCompatSync {
         ctx: &'a HookContext,
         event: ToolCallDelta<'a>,
     ) -> WasmBoxedFuture<'a, ObservationAction>;
-    fn stream_response_finish<'a>(
-        &'a self,
-        ctx: &'a HookContext,
-        event: StreamResponseFinish<'a>,
-    ) -> WasmBoxedFuture<'a, ObservationAction>;
     fn observes(&self, kind: StepEventKind) -> bool;
 }
 
@@ -973,19 +945,12 @@ where
     ) -> WasmBoxedFuture<'a, CompletionCallAction> {
         Box::pin(self.on_completion_call(ctx, event))
     }
-    fn completion_response<'a>(
+    fn model_turn_prepared<'a>(
         &'a self,
         ctx: &'a HookContext,
-        event: CompletionResponse<'a>,
+        event: ModelTurnPrepared<'a>,
     ) -> WasmBoxedFuture<'a, ObservationAction> {
-        Box::pin(self.on_completion_response(ctx, event))
-    }
-    fn model_turn_finished<'a>(
-        &'a self,
-        ctx: &'a HookContext,
-        event: ModelTurnFinished<'a>,
-    ) -> WasmBoxedFuture<'a, ObservationAction> {
-        Box::pin(self.on_model_turn_finished(ctx, event))
+        Box::pin(self.on_model_turn_prepared(ctx, event))
     }
     fn invalid_tool_call<'a>(
         &'a self,
@@ -1027,13 +992,6 @@ where
         event: ToolCallDelta<'a>,
     ) -> WasmBoxedFuture<'a, ObservationAction> {
         Box::pin(self.on_tool_call_delta(ctx, event))
-    }
-    fn stream_response_finish<'a>(
-        &'a self,
-        ctx: &'a HookContext,
-        event: StreamResponseFinish<'a>,
-    ) -> WasmBoxedFuture<'a, ObservationAction> {
-        Box::pin(self.on_stream_response_finish(ctx, event))
     }
     fn observes(&self, kind: StepEventKind) -> bool {
         AgentHook::observes(self, kind)
@@ -1113,18 +1071,6 @@ impl HookStack {
     }
 }
 
-async fn first_stop<I>(futures: I) -> ObservationAction
-where
-    I: IntoIterator<Item = ObservationAction>,
-{
-    for action in futures {
-        if !matches!(action, ObservationAction::Continue) {
-            return action;
-        }
-    }
-    ObservationAction::Continue
-}
-
 impl AgentHook for HookStack {
     async fn on_completion_call(
         &self,
@@ -1147,29 +1093,13 @@ impl AgentHook for HookStack {
         }
     }
 
-    async fn on_completion_response(
+    async fn on_model_turn_prepared(
         &self,
         ctx: &HookContext,
-        event: CompletionResponse<'_>,
-    ) -> ObservationAction {
-        let mut actions = Vec::new();
-        for hook in &self.hooks {
-            let action = hook.completion_response(ctx, event).await;
-            let stop = !matches!(action, ObservationAction::Continue);
-            actions.push(action);
-            if stop {
-                break;
-            }
-        }
-        first_stop(actions).await
-    }
-    async fn on_model_turn_finished(
-        &self,
-        ctx: &HookContext,
-        event: ModelTurnFinished<'_>,
+        event: ModelTurnPrepared<'_>,
     ) -> ObservationAction {
         for hook in &self.hooks {
-            let action = hook.model_turn_finished(ctx, event).await;
+            let action = hook.model_turn_prepared(ctx, event).await;
             if !matches!(action, ObservationAction::Continue) {
                 return action;
             }
@@ -1233,19 +1163,6 @@ impl AgentHook for HookStack {
     ) -> ObservationAction {
         for hook in &self.hooks {
             let action = hook.tool_call_delta(ctx, event).await;
-            if !matches!(action, ObservationAction::Continue) {
-                return action;
-            }
-        }
-        ObservationAction::Continue
-    }
-    async fn on_stream_response_finish(
-        &self,
-        ctx: &HookContext,
-        event: StreamResponseFinish<'_>,
-    ) -> ObservationAction {
-        for hook in &self.hooks {
-            let action = hook.stream_response_finish(ctx, event).await;
             if !matches!(action, ObservationAction::Continue) {
                 return action;
             }
@@ -1520,6 +1437,19 @@ mod migrated_tests {
                 ObservationAction::continue_run()
             }
         }
+
+        async fn on_model_turn_prepared(
+            &self,
+            _ctx: &HookContext,
+            _event: ModelTurnPrepared<'_>,
+        ) -> ObservationAction {
+            self.log.lock().expect("log").push(self.label);
+            if self.stop {
+                ObservationAction::stop("stop")
+            } else {
+                ObservationAction::continue_run()
+            }
+        }
     }
 
     struct ObservesOnly(StepEventKind);
@@ -1649,13 +1579,19 @@ mod migrated_tests {
             log: log.clone(),
             stop: false,
         });
+        let prompt = Message::user("hi");
+        let content = OneOrMany::one(AssistantContent::text("done"));
         assert!(matches!(
             stack
-                .on_text_delta(
+                .on_model_turn_prepared(
                     &ctx(),
-                    TextDelta {
-                        delta: "hi",
-                        aggregated: "hi"
+                    ModelTurnPrepared {
+                        turn: 1,
+                        prompt: &prompt,
+                        content: &content,
+                        usage: Usage::new(),
+                        message_id: None,
+                        terminal_metadata: None,
                     }
                 )
                 .await,
@@ -1821,14 +1757,12 @@ mod migrated_tests {
     fn unit_hook_observes_no_event_kind() {
         for kind in [
             StepEventKind::CompletionCall,
-            StepEventKind::CompletionResponse,
-            StepEventKind::ModelTurnFinished,
+            StepEventKind::ModelTurnPrepared,
             StepEventKind::InvalidToolCall,
             StepEventKind::ToolCall,
             StepEventKind::ToolResult,
             StepEventKind::TextDelta,
             StepEventKind::ToolCallDelta,
-            StepEventKind::StreamResponseFinish,
         ] {
             assert!(!<() as AgentHook>::observes(&(), kind));
         }

--- a/crates/rig-core/src/agent/mod.rs
+++ b/crates/rig-core/src/agent/mod.rs
@@ -162,10 +162,10 @@ pub use builder::{AgentBuilder, NoToolConfig, WithBuilderTools, WithToolServerHa
 pub use completion::Agent;
 pub use hook::CompletionCall as CompletionCallEvent;
 pub use hook::{
-    AgentHook, CompletionCallAction, CompletionResponse as CompletionResponseEvent, HookContext,
-    HookStack, InvalidToolCallAction, InvalidToolCallContext, ModelTurnFinished, ObservationAction,
-    RequestPatch, RunId, Scratchpad, StepEventKind, StreamResponseFinish, TextDelta, ToolCall,
-    ToolCallAction, ToolCallDelta, ToolResultAction, ToolResultEvent,
+    AgentHook, CompletionCallAction, HookContext, HookStack, InvalidToolCallAction,
+    InvalidToolCallContext, ModelTurnPrepared, ObservationAction, RequestPatch, RunId, Scratchpad,
+    StepEventKind, TextDelta, ToolCall, ToolCallAction, ToolCallDelta, ToolResultAction,
+    ToolResultEvent,
 };
 pub use prompt_request::streaming::{
     MultiTurnStreamItem, StreamingError, StreamingPromptRequest, StreamingResult, stream_to_stdout,

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -3,7 +3,7 @@ pub mod streaming;
 use super::{Agent, hook::AgentHook, run::OutputMode, runner::AgentRunner};
 use crate::{
     OneOrMany,
-    completion::{CompletionModel, Message, PromptError, Usage},
+    completion::{CompletionModel, CompletionTerminalMetadata, Message, PromptError, Usage},
     message::{AssistantContent, ToolResultContent, UserContent},
     tool::{ToolContext, ToolOutput},
     wasm_compat::{WasmBoxedFuture, WasmCompatSend},
@@ -310,7 +310,7 @@ where
 }
 
 /// Details for one successfully completed completion request made by an agent run.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct CompletionCall {
     /// Zero-based index of the completion request within this agent run.
@@ -322,12 +322,30 @@ pub struct CompletionCall {
     /// from "unreported".
     #[serde(default, deserialize_with = "usage_null_as_default")]
     pub usage: Usage,
+    /// Canonical provider terminal metadata for this completion request.
+    ///
+    /// `None` means the provider supplied no terminal reason.
+    #[serde(default)]
+    pub terminal_metadata: Option<CompletionTerminalMetadata>,
 }
 
 impl CompletionCall {
     /// Create details for one completion request in an agent run.
     pub fn new(call_index: usize, usage: Usage) -> Self {
-        Self { call_index, usage }
+        Self {
+            call_index,
+            usage,
+            terminal_metadata: None,
+        }
+    }
+
+    /// Attach canonical provider terminal metadata to this completion call.
+    pub fn with_terminal_metadata(
+        mut self,
+        terminal_metadata: Option<CompletionTerminalMetadata>,
+    ) -> Self {
+        self.terminal_metadata = terminal_metadata;
+        self
     }
 }
 
@@ -873,14 +891,14 @@ mod tests {
         agent::{
             AgentBuilder,
             hook::{
-                AgentHook, CompletionResponse as CompletionResponseEvent, HookContext,
-                InvalidToolCallAction, InvalidToolCallContext, ObservationAction,
-                ToolCall as ToolCallEvent, ToolCallAction,
+                AgentHook, HookContext, InvalidToolCallAction, InvalidToolCallContext,
+                ModelTurnPrepared, ObservationAction, ToolCall as ToolCallEvent, ToolCallAction,
             },
         },
         completion::{
-            AssistantContent, CompletionError, CompletionRequest, Message, Prompt, PromptError,
-            StructuredOutputError, TypedPrompt, Usage,
+            AssistantContent, CompletionError, CompletionFinishReason, CompletionRequest,
+            CompletionTerminalMetadata, Message, Prompt, PromptError, StructuredOutputError,
+            TypedPrompt, Usage,
         },
         message::{Text, ToolCall, ToolChoice, ToolFunction, UserContent},
         test_utils::{
@@ -942,12 +960,12 @@ mod tests {
     struct PanicOnUnknownToolHook;
 
     impl AgentHook for PanicOnUnknownToolHook {
-        async fn on_completion_response(
+        async fn on_model_turn_prepared(
             &self,
             _ctx: &HookContext,
-            _event: CompletionResponseEvent<'_>,
+            _event: ModelTurnPrepared<'_>,
         ) -> ObservationAction {
-            panic!("unknown tool response should fail before response hooks run")
+            panic!("unknown tool response should fail before prepared-turn hooks run")
         }
         async fn on_tool_call(
             &self,
@@ -1167,6 +1185,7 @@ mod tests {
             Some(&json!([
                 {
                     "call_index": 0,
+                    "terminal_metadata": null,
                     "usage": {
                         "input_tokens": 0,
                         "output_tokens": 0,
@@ -1179,6 +1198,7 @@ mod tests {
                 },
                 {
                     "call_index": 1,
+                    "terminal_metadata": null,
                     "usage": {
                         "input_tokens": 3,
                         "output_tokens": 4,
@@ -1330,6 +1350,17 @@ mod tests {
             round.completion_calls(),
             &[CompletionCall::new(0, usage(1, 2))]
         );
+    }
+
+    #[test]
+    fn completion_call_missing_terminal_metadata_defaults_to_none() {
+        let call: CompletionCall = serde_json::from_value(serde_json::json!({
+            "call_index": 3,
+            "usage": Usage::new()
+        }))
+        .expect("deserialize legacy completion call");
+
+        assert_eq!(call.terminal_metadata, None);
     }
 
     #[tokio::test]
@@ -2272,6 +2303,10 @@ mod tests {
 
     #[tokio::test]
     async fn prompt_request_stops_cleanly_on_empty_terminal_turn() {
+        let first_metadata = CompletionTerminalMetadata::new(CompletionFinishReason::ToolCalls)
+            .with_raw_reason("tool_calls");
+        let second_metadata =
+            CompletionTerminalMetadata::new(CompletionFinishReason::Stop).with_raw_reason("stop");
         let first_call_usage = Usage {
             input_tokens: 1,
             output_tokens: 1,
@@ -2293,8 +2328,11 @@ mod tests {
         let model = MockCompletionModel::new([
             MockTurn::tool_call("tool_call_1", "add", json!({"x": 1, "y": 2}))
                 .with_call_id("call_1")
-                .with_usage(first_call_usage),
-            MockTurn::text("").with_usage(second_call_usage),
+                .with_usage(first_call_usage)
+                .with_terminal_metadata(first_metadata.clone()),
+            MockTurn::text("")
+                .with_usage(second_call_usage)
+                .with_terminal_metadata(second_metadata.clone()),
         ]);
         let agent = AgentBuilder::new(model).tool(MockAddTool).build();
 
@@ -2321,8 +2359,10 @@ mod tests {
         assert_eq!(
             response.completion_calls(),
             &[
-                CompletionCall::new(0, first_call_usage),
+                CompletionCall::new(0, first_call_usage)
+                    .with_terminal_metadata(Some(first_metadata)),
                 CompletionCall::new(1, second_call_usage)
+                    .with_terminal_metadata(Some(second_metadata))
             ]
         );
 

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -2,8 +2,8 @@ use crate::{
     OneOrMany,
     agent::completion::{PreparedCompletionRequest, build_prepared_completion_request},
     agent::hook::{
-        AgentHook, HookContext, HookStack, InvalidToolCallAction, ModelTurnFinished, StepEventKind,
-        StreamResponseFinish, TextDelta, ToolCallDelta,
+        AgentHook, HookContext, HookStack, InvalidToolCallAction, ModelTurnPrepared, StepEventKind,
+        TextDelta, ToolCallDelta,
     },
     agent::prompt_request::{assistant_text_from_choice, is_empty_assistant_turn},
     agent::run::{
@@ -15,7 +15,7 @@ use crate::{
         build_chat_span, new_execute_tool_span, observe_action, resolve_completion_call,
         run_single_tool,
     },
-    completion::GetTokenUsage,
+    completion::GetCompletionMetadata,
     message::{AssistantContent, UserContent},
     streaming::{StreamedAssistantContent, StreamedUserContent, ToolCallDeltaContent},
     tool::{ToolContext, server::ToolRegistrySnapshot},
@@ -173,23 +173,29 @@ impl<R> MultiTurnStreamItem<R> {
 
 /// Drain a provider stream abandoned by invalid tool-call recovery so the
 /// reported usage for the recovered completion call is not lost.
-async fn drain_stream_usage<R>(
+async fn drain_stream_metadata<R>(
     stream: &mut crate::streaming::StreamingCompletionResponse<R>,
-) -> Result<crate::completion::Usage, StreamingError>
+) -> Result<
+    (
+        crate::completion::Usage,
+        Option<crate::completion::CompletionTerminalMetadata>,
+    ),
+    StreamingError,
+>
 where
-    R: Clone + Unpin + GetTokenUsage,
+    R: Clone + Unpin + GetCompletionMetadata,
 {
     while let Some(content) = stream.next().await {
         match content {
             Ok(StreamedAssistantContent::Final(final_resp)) => {
-                return Ok(final_resp.token_usage());
+                return Ok((final_resp.token_usage(), final_resp.terminal_metadata()));
             }
             Ok(_) => {}
             Err(err) => return Err(err.into()),
         }
     }
 
-    Ok(crate::completion::Usage::new())
+    Ok((crate::completion::Usage::new(), None))
 }
 
 pub(crate) fn record_usage_on_span(span: &tracing::Span, usage: crate::completion::Usage) {
@@ -282,7 +288,7 @@ where
 impl<M> StreamingPromptRequest<M>
 where
     M: CompletionModel + 'static,
-    <M as CompletionModel>::StreamingResponse: WasmCompatSend + GetTokenUsage,
+    <M as CompletionModel>::StreamingResponse: WasmCompatSend + GetCompletionMetadata,
 {
     /// Create a new `StreamingPromptRequest` from an agent, including its
     /// default hooks.
@@ -1008,7 +1014,7 @@ impl StreamingTurnSource {
 impl<M> TurnSource<M> for StreamingTurnSource
 where
     M: CompletionModel,
-    <M as CompletionModel>::StreamingResponse: WasmCompatSend + GetTokenUsage,
+    <M as CompletionModel>::StreamingResponse: WasmCompatSend + GetCompletionMetadata,
 {
     type Raw = M::StreamingResponse;
 
@@ -1043,9 +1049,10 @@ where
                     return;
                 }
             };
-            // Captured from each completion-call emission so the normalized
-            // `ModelTurnFinished` event carries the turn's usage.
+            // Captured from each completion-call emission so the prepared-turn
+            // event carries the provider's final canonical metadata.
             let mut last_usage = crate::completion::Usage::new();
+            let mut last_terminal_metadata = None;
 
             let mut assembler = StreamedTurnAssembler::new(
                 prepared.executable_tool_names.clone(),
@@ -1055,9 +1062,9 @@ where
             let mut turn_abandoned = false;
             let mut provider_final_seen = false;
             let mut pending_final = None;
-            // Mirrors the blocking driver's `response_hook_suppressed`: a turn
+            // Mirrors the blocking driver's `prepared_hook_suppressed`: a turn
             // whose invalid tool call was repaired is a recovered turn, so its
-            // response-finish hook is suppressed.
+            // prepared-turn hook is suppressed.
             let mut turn_recovered = false;
 
             // Emit the turn's single `CompletionCall` exactly once, recording its
@@ -1068,14 +1075,16 @@ where
             // Returns the item to yield (`Some` the first time, `None` after), or
             // the terminal error to surface.
             macro_rules! emit_completion_call {
-                ($usage:expr) => {{
+                ($usage:expr, $terminal_metadata:expr) => {{
                     let usage = $usage;
+                    let terminal_metadata = $terminal_metadata;
                     last_usage = usage;
+                    last_terminal_metadata = terminal_metadata.clone();
                     if !completion_call_emitted {
                         if usage.has_values() {
                             record_usage_on_span(&chat_span, usage);
                         }
-                        match run.record_streamed_completion_call(usage) {
+                        match run.record_streamed_completion_call(usage, terminal_metadata) {
                             Ok(call) => {
                                 completion_call_emitted = true;
                                 Ok(Some(MultiTurnStreamItem::CompletionCall(call)))
@@ -1181,8 +1190,12 @@ where
                                 },
                             ));
                         }
-                        StreamedTurnEvent::Completed { usage, emit_final } => {
-                            match emit_completion_call!(usage) {
+                        StreamedTurnEvent::Completed {
+                            usage,
+                            terminal_metadata,
+                            emit_final,
+                        } => {
+                            match emit_completion_call!(usage, terminal_metadata) {
                                 Ok(Some(item)) => yield Ok(item),
                                 Ok(None) => {}
                                 Err(err) => {
@@ -1231,7 +1244,7 @@ where
                                 StreamedResolution::Repaired { .. } => {
                                     // Replayed deltas flow through the same event
                                     // handling above; the turn is now recovered, so
-                                    // its response-finish hook is suppressed.
+                                    // its prepared-turn hook is suppressed.
                                     turn_recovered = true;
                                     events.extend(assembler.resolve_pending_invalid(&resolution));
                                 }
@@ -1245,14 +1258,14 @@ where
                                         yield Err(err.into());
                                         return;
                                     }
-                                    let drained_usage = match drain_stream_usage(&mut stream).await {
-                                        Ok(usage) => usage,
+                                    let (drained_usage, drained_terminal_metadata) = match drain_stream_metadata(&mut stream).await {
+                                        Ok(metadata) => metadata,
                                         Err(err) => {
                                             yield Err(err);
                                             return;
                                         }
                                     };
-                                    match emit_completion_call!(drained_usage) {
+                                    match emit_completion_call!(drained_usage, drained_terminal_metadata) {
                                         Ok(Some(item)) => yield Ok(item),
                                         Ok(None) => {}
                                         Err(err) => {
@@ -1291,7 +1304,10 @@ where
             // inline (not `emit_completion_call!`) so it doesn't emit a dead
             // `completion_call_emitted = true` write.
             if !completion_call_emitted {
-                match run.record_streamed_completion_call(crate::completion::Usage::new()) {
+                match run.record_streamed_completion_call(
+                    crate::completion::Usage::new(),
+                    None,
+                ) {
                     Ok(call) => yield Ok(MultiTurnStreamItem::CompletionCall(call)),
                     Err(err) => {
                         yield Err(Box::new(err).into());
@@ -1302,18 +1318,19 @@ where
 
             let final_turn_content = stream.choice.clone();
             let streamed_turn = assembler.finish(stream.message_id.clone(), &final_turn_content);
-            if pending_final.is_some()
-                && !turn_recovered
+            if !turn_recovered
                 && let Some(reason) = observe_action(
                     runner
                         .hooks
-                        .on_stream_response_finish(
+                        .on_model_turn_prepared(
                             hook_ctx,
-                            StreamResponseFinish {
+                            ModelTurnPrepared {
+                                turn: hook_ctx.turn(),
                                 prompt: &current_prompt,
                                 content: &streamed_turn.choice,
                                 usage: last_usage,
                                 message_id: streamed_turn.message_id.as_deref(),
+                                terminal_metadata: last_terminal_metadata.as_ref(),
                             },
                         )
                         .await,
@@ -1328,10 +1345,8 @@ where
             self.last_message_id = streamed_turn.message_id.clone();
             // The canonical (committed) assistant content: `finish` normalizes
             // reasoning/text/tool ordering, so this can differ from the raw
-            // `stream.choice` aggregate. `ModelTurnFinished` — the normalized
-            // per-turn event — carries this, matching what is recorded into run
-            // history; the raw `stream.choice` is kept in `last_final_choice` for
-            // the raw/final streaming behavior.
+            // `stream.choice` aggregate. The prepared hook saw this same value;
+            // the raw aggregate is kept for direct streaming final behavior.
             let canonical_choice = streamed_turn.choice.clone();
             if let Err(err) = run.streamed_turn(streamed_turn) {
                 yield Err(Box::new(err).into());
@@ -1350,29 +1365,6 @@ where
                 &canonical_choice,
                 runner.record_telemetry_content,
             );
-
-            // Normalized per-turn event, fired once the turn is committed on the
-            // streaming surface — including tool-only / reasoning-only turns that
-            // fire no `StreamResponseFinish`. Suppressed for recovered turns,
-            // mirroring the blocking surface's `Continue` arm.
-            if !turn_recovered
-                && let Some(reason) = observe_action(
-                    runner
-                        .hooks
-                        .on_model_turn_finished(
-                            hook_ctx,
-                            ModelTurnFinished {
-                                turn: hook_ctx.turn(),
-                                content: &canonical_choice,
-                                usage: last_usage,
-                            },
-                        )
-                        .await,
-                )
-            {
-                yield Err(StreamingError::Prompt(Box::new(run.cancel_error(reason))));
-                return;
-            }
 
             self.last_final_choice = final_turn_content;
         })
@@ -1443,7 +1435,7 @@ where
 impl<M> AgentRunner<M>
 where
     M: CompletionModel + 'static,
-    <M as CompletionModel>::StreamingResponse: WasmCompatSend + GetTokenUsage,
+    <M as CompletionModel>::StreamingResponse: WasmCompatSend + GetCompletionMetadata,
 {
     /// Drive the agent loop, streaming assistant content, tool activity, and a
     /// final response. Hooks fire at every observable point, including streamed
@@ -1577,7 +1569,7 @@ pub async fn stream_to_stdout<R>(
 #[allow(irrefutable_let_patterns, unreachable_patterns)]
 mod migrated_tests {
     use crate::agent::{
-        InvalidToolCallAction, InvalidToolCallContext, ObservationAction, StreamResponseFinish,
+        InvalidToolCallAction, InvalidToolCallContext, ModelTurnPrepared, ObservationAction,
         TextDelta, ToolCall, ToolCallAction, ToolCallDelta,
     };
 
@@ -1588,7 +1580,10 @@ mod migrated_tests {
     use crate::agent::run::streamed::merge_reasoning_blocks;
     use crate::client::ProviderClient;
     use crate::client::completion::CompletionClient;
-    use crate::completion::{CompletionRequest, Prompt, PromptError, ToolDefinition, Usage};
+    use crate::completion::{
+        CompletionFinishReason, CompletionRequest, CompletionTerminalMetadata, Prompt, PromptError,
+        ToolDefinition, Usage,
+    };
     use crate::message::{
         AssistantContent, DocumentSourceKind, ImageMediaType, Message, ReasoningContent,
         ToolChoice, ToolResultContent, UserContent,
@@ -2025,12 +2020,12 @@ mod migrated_tests {
         async fn on_tool_call(&self, _: &HookContext, _: ToolCall<'_>) -> ToolCallAction {
             panic!("unknown tool call should fail before tool hooks run")
         }
-        async fn on_stream_response_finish(
+        async fn on_model_turn_prepared(
             &self,
             _: &HookContext,
-            _: StreamResponseFinish<'_>,
+            _: ModelTurnPrepared<'_>,
         ) -> ObservationAction {
-            panic!("unknown tool call should fail before stream finish hooks run")
+            panic!("unknown tool call should fail before prepared-turn hooks run")
         }
     }
 
@@ -2987,6 +2982,7 @@ mod migrated_tests {
             serde_json::json!({
                 "type": "completionCall",
                 "call_index": 2,
+                "terminal_metadata": null,
                 "usage": {
                     "input_tokens": 3,
                     "output_tokens": 4,
@@ -3019,6 +3015,7 @@ mod migrated_tests {
             serde_json::json!({
                 "type": "completionCall",
                 "call_index": 3,
+                "terminal_metadata": null,
                 "usage": {
                     "input_tokens": 0,
                     "output_tokens": 0,
@@ -3071,6 +3068,7 @@ mod migrated_tests {
             Some(&serde_json::json!([
                 {
                     "call_index": 0,
+                    "terminal_metadata": null,
                     "usage": {
                         "input_tokens": 0,
                         "output_tokens": 0,
@@ -3083,6 +3081,7 @@ mod migrated_tests {
                 },
                 {
                     "call_index": 1,
+                    "terminal_metadata": null,
                     "usage": {
                         "input_tokens": 3,
                         "output_tokens": 4,
@@ -3154,18 +3153,16 @@ mod migrated_tests {
     }
 
     #[derive(Clone)]
-    struct TerminateOnStreamFinish;
+    struct TerminateOnPreparedTurn;
 
-    impl AgentHook for TerminateOnStreamFinish {
-        async fn on_stream_response_finish(
+    impl AgentHook for TerminateOnPreparedTurn {
+        async fn on_model_turn_prepared(
             &self,
             _ctx: &HookContext,
-            event: StreamResponseFinish<'_>,
+            event: ModelTurnPrepared<'_>,
         ) -> ObservationAction {
             match event {
-                StreamResponseFinish { .. } => {
-                    ObservationAction::stop("stop after completion call")
-                }
+                ModelTurnPrepared { .. } => ObservationAction::stop("stop after completion call"),
                 _ => ObservationAction::continue_run(),
             }
         }
@@ -3925,6 +3922,14 @@ mod migrated_tests {
     #[tokio::test]
     async fn invalid_tool_call_hook_retries_mixed_streaming_turn_without_executing_valid_call() {
         let add_calls = Arc::new(AtomicU32::new(0));
+        let first_metadata = CompletionTerminalMetadata::new(CompletionFinishReason::Unknown)
+            .with_raw_reason("abandoned_turn_reason");
+        let second_metadata =
+            CompletionTerminalMetadata::new(CompletionFinishReason::Stop).with_raw_reason("stop");
+        let mut first_usage = Usage::new();
+        first_usage.total_tokens = 4;
+        let mut second_usage = Usage::new();
+        second_usage.total_tokens = 6;
         let model = MockCompletionModel::from_stream_turns([
             vec![
                 MockStreamEvent::text("checking "),
@@ -3940,11 +3945,14 @@ mod migrated_tests {
                     serde_json::json!({"x": 4, "y": 5}),
                 )
                 .with_call_id("call_2"),
-                MockStreamEvent::final_response_with_total_tokens(4),
+                MockStreamEvent::final_response_with_metadata(first_usage, first_metadata.clone()),
             ],
             vec![
                 MockStreamEvent::text("retried"),
-                MockStreamEvent::final_response_with_total_tokens(6),
+                MockStreamEvent::final_response_with_metadata(
+                    second_usage,
+                    second_metadata.clone(),
+                ),
             ],
         ]);
         let recorded = model.clone();
@@ -3984,13 +3992,9 @@ mod migrated_tests {
 
         assert_eq!(final_response_text.as_deref(), Some("retried"));
         assert_eq!(add_calls.load(Ordering::SeqCst), 0);
-        let mut first_usage = Usage::new();
-        first_usage.total_tokens = 4;
-        let mut second_usage = Usage::new();
-        second_usage.total_tokens = 6;
         let expected_completion_calls = vec![
-            CompletionCall::new(0, first_usage),
-            CompletionCall::new(1, second_usage),
+            CompletionCall::new(0, first_usage).with_terminal_metadata(Some(first_metadata)),
+            CompletionCall::new(1, second_usage).with_terminal_metadata(Some(second_metadata)),
         ];
         assert_eq!(completion_call_events, expected_completion_calls);
         assert_eq!(final_completion_calls, expected_completion_calls);
@@ -4809,7 +4813,7 @@ mod migrated_tests {
     }
 
     #[tokio::test]
-    async fn completed_unknown_tool_call_after_text_fails_before_finish_hook_or_later_emit() {
+    async fn completed_unknown_tool_call_after_text_fails_before_prepared_hook_or_later_emit() {
         let add_calls = Arc::new(AtomicU32::new(0));
         let model = MockCompletionModel::from_stream_turns([
             vec![
@@ -5880,6 +5884,10 @@ mod migrated_tests {
     async fn stream_prompt_exposes_completion_calls() {
         let first_call_usage = usage(10, 2);
         let second_call_usage = usage(25, 5);
+        let first_metadata = CompletionTerminalMetadata::new(CompletionFinishReason::ToolCalls)
+            .with_raw_reason("tool_calls");
+        let second_metadata =
+            CompletionTerminalMetadata::new(CompletionFinishReason::Stop).with_raw_reason("stop");
         let model = MockCompletionModel::from_stream_turns([
             vec![
                 MockStreamEvent::tool_call(
@@ -5888,11 +5896,17 @@ mod migrated_tests {
                     serde_json::json!({"x": 1, "y": 2}),
                 )
                 .with_call_id("call_1"),
-                MockStreamEvent::final_response(first_call_usage),
+                MockStreamEvent::final_response_with_metadata(
+                    first_call_usage,
+                    first_metadata.clone(),
+                ),
             ],
             vec![
                 MockStreamEvent::text("done"),
-                MockStreamEvent::final_response(second_call_usage),
+                MockStreamEvent::final_response_with_metadata(
+                    second_call_usage,
+                    second_metadata.clone(),
+                ),
             ],
         ]);
         let agent = AgentBuilder::new(model).tool(MockAddTool).build();
@@ -5923,8 +5937,10 @@ mod migrated_tests {
         assert_eq!(
             completion_calls_events,
             vec![
-                CompletionCall::new(0, first_call_usage),
+                CompletionCall::new(0, first_call_usage)
+                    .with_terminal_metadata(Some(first_metadata.clone())),
                 CompletionCall::new(1, second_call_usage)
+                    .with_terminal_metadata(Some(second_metadata.clone()))
             ]
         );
 
@@ -5944,8 +5960,10 @@ mod migrated_tests {
         assert_eq!(
             final_response.completion_calls(),
             &[
-                CompletionCall::new(0, first_call_usage),
+                CompletionCall::new(0, first_call_usage)
+                    .with_terminal_metadata(Some(first_metadata)),
                 CompletionCall::new(1, second_call_usage)
+                    .with_terminal_metadata(Some(second_metadata))
             ]
         );
     }
@@ -5993,7 +6011,7 @@ mod migrated_tests {
     }
 
     #[tokio::test]
-    async fn stream_prompt_emits_completion_call_before_finish_hook_termination() {
+    async fn stream_prompt_emits_completion_call_before_prepared_hook_termination() {
         let call_usage = usage(10, 2);
         let model = MockCompletionModel::from_stream_turns([[
             MockStreamEvent::text("done"),
@@ -6003,7 +6021,7 @@ mod migrated_tests {
 
         let mut stream = agent
             .stream_prompt("say done")
-            .add_hook(TerminateOnStreamFinish)
+            .add_hook(TerminateOnPreparedTurn)
             .await;
         let mut completion_calls = Vec::new();
         let mut saw_error = false;

--- a/crates/rig-core/src/agent/run/mod.rs
+++ b/crates/rig-core/src/agent/run/mod.rs
@@ -77,7 +77,7 @@ use crate::{
         assistant_text_from_choice, build_full_history, build_history_for_request,
         invalid_tool_retry_user_message, is_empty_assistant_turn, tool_result_message,
     },
-    completion::{Message, PromptError, Usage},
+    completion::{CompletionTerminalMetadata, Message, PromptError, Usage},
     json_utils,
     message::{AssistantContent, ToolCall, ToolChoice, ToolResult, ToolResultContent, UserContent},
 };
@@ -166,6 +166,9 @@ pub struct ModelTurn {
     pub choice: OneOrMany<AssistantContent>,
     /// Token usage reported by the provider for this completion request.
     pub usage: Usage,
+    /// Canonical provider terminal metadata for this completion request.
+    #[serde(default)]
+    pub terminal_metadata: Option<CompletionTerminalMetadata>,
     /// Executable Rig tools advertised to the provider for this turn.
     pub executable_tool_names: BTreeSet<String>,
     /// Tools allowed by the active [`ToolChoice`] for this turn.
@@ -186,9 +189,19 @@ impl ModelTurn {
             message_id,
             choice,
             usage,
+            terminal_metadata: None,
             executable_tool_names,
             allowed_tool_names,
         }
+    }
+
+    /// Attach canonical provider terminal metadata to this model turn.
+    pub fn with_terminal_metadata(
+        mut self,
+        terminal_metadata: Option<CompletionTerminalMetadata>,
+    ) -> Self {
+        self.terminal_metadata = terminal_metadata;
+        self
     }
 }
 
@@ -199,16 +212,16 @@ impl ModelTurn {
 /// variant is a breaking change by design.
 #[derive(Debug)]
 pub enum ModelTurnOutcome {
-    /// The turn was accepted. Unless `response_hook_suppressed` is set, the
-    /// driver should run its completion-response hook now, then call
+    /// The turn was accepted. Unless `prepared_hook_suppressed` is set, the
+    /// driver should run its prepared-turn hook now, then call
     /// [`AgentRun::next_step`].
     ///
-    /// `response_hook_suppressed` is set when invalid tool-call recovery
+    /// `prepared_hook_suppressed` is set when invalid tool-call recovery
     /// (repair or skip) modified the turn, matching the agent loop's behavior
-    /// of not invoking `on_completion_response` for recovered turns.
+    /// of not invoking `on_model_turn_prepared` for recovered turns.
     Continue {
-        /// Whether the driver should suppress its completion-response hook.
-        response_hook_suppressed: bool,
+        /// Whether the driver should suppress its prepared-turn hook.
+        prepared_hook_suppressed: bool,
     },
     /// The model emitted a tool call that is unknown or disallowed for this
     /// turn. The driver must decide how to recover (typically by asking its
@@ -801,7 +814,7 @@ impl AgentRun {
             ));
         }
 
-        self.record_completion_call(turn.usage);
+        self.record_completion_call(turn.usage, turn.terminal_metadata);
 
         let items: Vec<AssistantContent> = turn.choice.iter().cloned().collect();
         let has_tool_calls = items
@@ -830,10 +843,15 @@ impl AgentRun {
     /// ingestion paths. Callers own the once-per-turn `streamed_completion_call_recorded`
     /// guard/flag; this helper never touches it, so it cannot be mistaken for
     /// "a completion call happened" and re-introduce a double count.
-    fn record_completion_call(&mut self, usage: Usage) -> CompletionCall {
-        let call = CompletionCall::new(self.completion_call_index, usage);
+    fn record_completion_call(
+        &mut self,
+        usage: Usage,
+        terminal_metadata: Option<CompletionTerminalMetadata>,
+    ) -> CompletionCall {
+        let call = CompletionCall::new(self.completion_call_index, usage)
+            .with_terminal_metadata(terminal_metadata);
         self.completion_call_index += 1;
-        self.completion_calls.push(call);
+        self.completion_calls.push(call.clone());
         self.usage += usage;
         call
     }
@@ -1163,7 +1181,7 @@ impl AgentRun {
 
         self.finalize_turn(message_id, items, has_tool_calls, skipped, Vec::new());
         Ok(ModelTurnOutcome::Continue {
-            response_hook_suppressed: recovered,
+            prepared_hook_suppressed: recovered,
         })
     }
 
@@ -1183,6 +1201,7 @@ impl AgentRun {
     pub fn record_streamed_completion_call(
         &mut self,
         usage: Usage,
+        terminal_metadata: Option<CompletionTerminalMetadata>,
     ) -> Result<CompletionCall, PromptError> {
         let recordable = matches!(self.state, RunState::AwaitingModel)
             || (matches!(self.state, RunState::PreparingRequest) && self.rollback_pending);
@@ -1198,7 +1217,7 @@ impl AgentRun {
         }
         self.streamed_completion_call_recorded = true;
 
-        Ok(self.record_completion_call(usage))
+        Ok(self.record_completion_call(usage, terminal_metadata))
     }
 
     /// The recovery-hook context for an invalid tool call surfaced
@@ -1361,7 +1380,7 @@ impl AgentRun {
             // `Usage::new()` is the additive identity for `Usage`'s `AddAssign`,
             // so routing the no-usage fallback through `record_completion_call`
             // leaves the run total unchanged while unifying the accounting.
-            self.record_completion_call(Usage::new());
+            self.record_completion_call(Usage::new(), None);
             self.streamed_completion_call_recorded = true;
         }
 
@@ -1518,8 +1537,8 @@ mod tests {
     fn expect_continue(outcome: ModelTurnOutcome) -> bool {
         match outcome {
             ModelTurnOutcome::Continue {
-                response_hook_suppressed,
-            } => response_hook_suppressed,
+                prepared_hook_suppressed,
+            } => prepared_hook_suppressed,
             outcome => panic!("expected Continue, got {outcome:?}"),
         }
     }
@@ -1839,7 +1858,7 @@ mod tests {
     }
 
     #[test]
-    fn invalid_tool_call_repair_renames_and_suppresses_response_hook() {
+    fn invalid_tool_call_repair_renames_and_suppresses_prepared_hook() {
         let mut run = AgentRun::new("call something").max_turns(2);
 
         expect_call_model(&mut run);
@@ -1976,7 +1995,7 @@ mod tests {
     fn model_response_rejected_after_streamed_completion_call_record() {
         let mut run = AgentRun::new("hello");
         expect_call_model(&mut run);
-        run.record_streamed_completion_call(Usage::new())
+        run.record_streamed_completion_call(Usage::new(), None)
             .expect("record should succeed");
 
         let err = run

--- a/crates/rig-core/src/agent/run/streamed.rs
+++ b/crates/rig-core/src/agent/run/streamed.rs
@@ -40,7 +40,9 @@ use serde::{Deserialize, Serialize};
 use crate::{
     OneOrMany,
     agent::prompt_request::{TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER, tool_result_message},
-    completion::{CompletionError, GetTokenUsage, Message, Usage},
+    completion::{
+        CompletionError, CompletionTerminalMetadata, GetCompletionMetadata, Message, Usage,
+    },
     json_utils,
     message::{AssistantContent, Reasoning, ToolCall, ToolFunction, ToolResult},
     streaming::{StreamedAssistantContent, ToolCallDeltaContent},
@@ -280,6 +282,8 @@ pub enum StreamedTurnEvent {
         /// Provider-reported usage for this call. Zero-valued usage means the
         /// provider reported no usage metrics.
         usage: Usage,
+        /// Canonical provider terminal metadata for this call, when supplied.
+        terminal_metadata: Option<CompletionTerminalMetadata>,
         /// Whether the ingested final item should be forwarded to the
         /// consumer (set when the turn streamed text).
         emit_final: bool,
@@ -387,7 +391,7 @@ impl StreamedTurnAssembler {
         item: &StreamedAssistantContent<R>,
     ) -> Result<Vec<StreamedTurnEvent>, CompletionError>
     where
-        R: Clone + Unpin + GetTokenUsage,
+        R: Clone + Unpin + GetCompletionMetadata,
     {
         if self.pending_invalid.is_some() {
             return Err(CompletionError::ResponseError(
@@ -499,9 +503,14 @@ impl StreamedTurnAssembler {
                 }
 
                 let usage = final_response.token_usage();
+                let terminal_metadata = final_response.terminal_metadata();
                 let emit_final = self.saw_text;
                 self.saw_text = false;
-                Ok(vec![StreamedTurnEvent::Completed { usage, emit_final }])
+                Ok(vec![StreamedTurnEvent::Completed {
+                    usage,
+                    terminal_metadata,
+                    emit_final,
+                }])
             }
             StreamedAssistantContent::Unknown(_) => {
                 // Unmodeled provider item (e.g. a hosted-tool result): forward it
@@ -875,7 +884,7 @@ mod tests {
             total_tokens: 12,
             ..Usage::new()
         };
-        run.record_streamed_completion_call(usage)
+        run.record_streamed_completion_call(usage, None)
             .expect("record should succeed");
         let final_choice = OneOrMany::one(AssistantContent::ToolCall(tool_call("tc_1", "add")));
         run.streamed_turn(asm.finish(Some("msg_1".to_string()), &final_choice))
@@ -897,7 +906,7 @@ mod tests {
             panic!("expected CallModel");
         };
         let asm = assembler();
-        run.record_streamed_completion_call(Usage::new())
+        run.record_streamed_completion_call(Usage::new(), None)
             .expect("record should succeed");
         let final_choice = OneOrMany::one(AssistantContent::text("done"));
         run.streamed_turn(asm.finish(None, &final_choice))
@@ -958,7 +967,7 @@ mod tests {
         asm.resolve_pending_invalid(&resolution);
 
         // Usage from the drained stream is recorded after the rollback.
-        run.record_streamed_completion_call(Usage::new())
+        run.record_streamed_completion_call(Usage::new(), None)
             .expect("record after rollback should succeed");
 
         // The rollback appended the partial assistant turn and feedback.
@@ -1029,7 +1038,7 @@ mod tests {
                 skipped_tool_result: None
             }
         ));
-        run.record_streamed_completion_call(Usage::new())
+        run.record_streamed_completion_call(Usage::new(), None)
             .expect("completion call should be recorded");
         assert_eq!(run.completion_calls().len(), 1);
 
@@ -1142,13 +1151,13 @@ mod tests {
         // even though the machine is in its initial PreparingRequest state.
         let mut run = AgentRun::new("hello");
         let err = run
-            .record_streamed_completion_call(Usage::new())
+            .record_streamed_completion_call(Usage::new(), None)
             .expect_err("recording before any model call must be rejected");
         assert!(matches!(err, PromptError::PromptCancelled { .. }));
 
         // The run stays drivable.
         run.next_step().expect("next_step should still succeed");
-        run.record_streamed_completion_call(Usage::new())
+        run.record_streamed_completion_call(Usage::new(), None)
             .expect("recording during a pending model call succeeds");
     }
 
@@ -1168,7 +1177,7 @@ mod tests {
             internal_call_id: "internal_b".to_string(),
         })
         .expect("ingest should succeed");
-        run.record_streamed_completion_call(Usage::new())
+        run.record_streamed_completion_call(Usage::new(), None)
             .expect("record should succeed");
 
         let final_choice = OneOrMany::many(vec![
@@ -1212,10 +1221,10 @@ mod tests {
         let mut run = AgentRun::new("hello");
         run.next_step().expect("next_step");
 
-        run.record_streamed_completion_call(Usage::new())
+        run.record_streamed_completion_call(Usage::new(), None)
             .expect("first record succeeds");
         let err = run
-            .record_streamed_completion_call(Usage::new())
+            .record_streamed_completion_call(Usage::new(), None)
             .expect_err("second record for the same turn must be rejected");
         assert!(matches!(err, PromptError::PromptCancelled { .. }));
         assert_eq!(run.completion_calls().len(), 1);
@@ -1229,7 +1238,7 @@ mod tests {
         let mut asm = assembler();
         asm.ingest(&tool_call_item("tc_1", "add"))
             .expect("ingest should succeed");
-        run.record_streamed_completion_call(Usage::new())
+        run.record_streamed_completion_call(Usage::new(), None)
             .expect("record should succeed");
         let final_choice = OneOrMany::one(AssistantContent::ToolCall(tool_call("tc_1", "add")));
         run.streamed_turn(asm.finish(None, &final_choice))

--- a/crates/rig-core/src/agent/runner.rs
+++ b/crates/rig-core/src/agent/runner.rs
@@ -36,9 +36,8 @@ use tracing::{Instrument, info_span, span::Id};
 use super::{
     completion::{Agent, PreparedCompletionRequest},
     hook::{
-        AgentHook, CompletionCall, CompletionCallAction,
-        CompletionResponse as CompletionResponseEvent, HookContext, HookStack,
-        InvalidToolCallAction, ModelTurnFinished, ObservationAction, RequestPatch,
+        AgentHook, CompletionCall, CompletionCallAction, HookContext, HookStack,
+        InvalidToolCallAction, ModelTurnPrepared, ObservationAction, RequestPatch,
         ToolCall as ToolCallEvent, ToolCallAction, ToolResultAction, ToolResultEvent,
     },
     prompt_request::{
@@ -915,7 +914,7 @@ where
                 resp.usage,
                 prepared.executable_tool_names,
                 prepared.allowed_tool_names,
-            )) {
+            ).with_terminal_metadata(resp.terminal_metadata.clone())) {
                 Ok(outcome) => outcome,
                 Err(err) => {
                     yield Err(Box::new(err).into());
@@ -950,7 +949,7 @@ where
                     }
                     ModelTurnOutcome::TurnRetried => break,
                     ModelTurnOutcome::Continue {
-                        response_hook_suppressed,
+                        prepared_hook_suppressed,
                     } => {
                         if runner.record_telemetry_content
                             && let Some(choice) = run.accepted_turn_choice()
@@ -958,41 +957,27 @@ where
                             crate::telemetry::record_model_output(&chat_span, &choice, true);
                         }
 
-                        if !response_hook_suppressed {
-                            // The response-finish event fires first, then the
-                            // normalized per-turn event. Both carry canonical
-                            // Rig data, are observe-only, and are suppressed for
-                            // recovered turns.
-                            if let Some(reason) = observe_action(
-                                runner
-                                    .hooks
-                                    .on_completion_response(
-                                        hook_ctx,
-                                        CompletionResponseEvent {
-                                            prompt: &current_prompt,
-                                            content: &resp.choice,
-                                            usage: resp.usage,
-                                            message_id: resp.message_id.as_deref(),
-                                        },
-                                    )
-                                    .await,
-                            ) {
-                                yield Err(StreamingError::Prompt(Box::new(run.cancel_error(reason))));
+                        if !prepared_hook_suppressed {
+                            let Some(accepted_content) = run.accepted_turn_choice() else {
+                                yield Err(StreamingError::Prompt(Box::new(run.cancel_error(
+                                    "accepted model turn did not retain canonical content",
+                                ))));
                                 return;
-                            }
-                            if let Some(reason) = observe_action(
-                                runner
-                                    .hooks
-                                    .on_model_turn_finished(
-                                        hook_ctx,
-                                        ModelTurnFinished {
-                                            turn: hook_ctx.turn(),
-                                            content: &resp.choice,
-                                            usage: resp.usage,
-                                        },
-                                    )
-                                    .await,
-                            ) {
+                            };
+                            if let Some(reason) = observe_action(runner
+                                .hooks
+                                .on_model_turn_prepared(
+                                    hook_ctx,
+                                    ModelTurnPrepared {
+                                        turn: hook_ctx.turn(),
+                                        prompt: &current_prompt,
+                                        content: &accepted_content,
+                                        usage: resp.usage,
+                                        message_id: resp.message_id.as_deref(),
+                                        terminal_metadata: resp.terminal_metadata.as_ref(),
+                                    },
+                                )
+                                .await) {
                                 yield Err(StreamingError::Prompt(Box::new(run.cancel_error(reason))));
                                 return;
                             }
@@ -1574,8 +1559,8 @@ mod tests {
 mod migrated_tests {
     use crate::agent::{
         CompletionCallAction, CompletionCallEvent, InvalidToolCallAction, InvalidToolCallContext,
-        ModelTurnFinished, ObservationAction, StreamResponseFinish, TextDelta, ToolCall,
-        ToolCallAction, ToolCallDelta, ToolResultAction, ToolResultEvent,
+        ModelTurnPrepared, ObservationAction, TextDelta, ToolCall, ToolCallAction, ToolCallDelta,
+        ToolResultAction, ToolResultEvent,
     };
 
     use std::sync::{
@@ -1594,7 +1579,8 @@ mod migrated_tests {
     use crate::agent::prompt_request::streaming::{MultiTurnStreamItem, StreamingError};
     use crate::agent::run::OutputMode;
     use crate::completion::{
-        CompletionError, CompletionModel, Document, Message, Prompt, PromptError, Usage,
+        CompletionError, CompletionFinishReason, CompletionModel, CompletionTerminalMetadata,
+        Document, Message, Prompt, PromptError, Usage,
     };
     use crate::message::{
         AssistantContent, ToolCall as MessageToolCall, ToolChoice, ToolFunction, UserContent,
@@ -1624,8 +1610,7 @@ mod migrated_tests {
 
     impl RecordingHook {
         /// Event kinds that should be identical across streaming and
-        /// non-streaming (excludes the medium-specific delta / response-finish
-        /// events).
+        /// non-streaming (excluding streaming-only deltas).
         fn shared_events(&self) -> Vec<StepEventKind> {
             self.events
                 .lock()
@@ -1636,6 +1621,7 @@ mod migrated_tests {
                     matches!(
                         kind,
                         StepEventKind::CompletionCall
+                            | StepEventKind::ModelTurnPrepared
                             | StepEventKind::ToolCall
                             | StepEventKind::ToolResult
                             | StepEventKind::InvalidToolCall
@@ -1648,8 +1634,7 @@ mod migrated_tests {
             self.tool_results.lock().expect("results lock").clone()
         }
 
-        /// Count of a single event kind across the whole run, including the
-        /// medium-specific response-finish events that `shared_events` excludes.
+        /// Count of a single event kind across the whole run.
         fn count(&self, kind: StepEventKind) -> usize {
             self.events
                 .lock()
@@ -1675,20 +1660,12 @@ mod migrated_tests {
             self.record(StepEventKind::CompletionCall);
             CompletionCallAction::continue_run()
         }
-        async fn on_completion_response(
+        async fn on_model_turn_prepared(
             &self,
             _: &HookContext,
-            _: crate::agent::hook::CompletionResponse<'_>,
+            _: ModelTurnPrepared<'_>,
         ) -> ObservationAction {
-            self.record(StepEventKind::CompletionResponse);
-            ObservationAction::continue_run()
-        }
-        async fn on_model_turn_finished(
-            &self,
-            _: &HookContext,
-            _: ModelTurnFinished<'_>,
-        ) -> ObservationAction {
-            self.record(StepEventKind::ModelTurnFinished);
+            self.record(StepEventKind::ModelTurnPrepared);
             ObservationAction::continue_run()
         }
         async fn on_invalid_tool_call(
@@ -1727,14 +1704,6 @@ mod migrated_tests {
             self.record(StepEventKind::ToolCallDelta);
             ObservationAction::continue_run()
         }
-        async fn on_stream_response_finish(
-            &self,
-            _: &HookContext,
-            _: StreamResponseFinish<'_>,
-        ) -> ObservationAction {
-            self.record(StepEventKind::StreamResponseFinish);
-            ObservationAction::continue_run()
-        }
     }
 
     #[derive(Clone, Debug, PartialEq)]
@@ -1743,71 +1712,41 @@ mod migrated_tests {
         content: OneOrMany<AssistantContent>,
         usage: Usage,
         message_id: Option<String>,
+        terminal_metadata: Option<CompletionTerminalMetadata>,
     }
 
     #[derive(Clone, Default)]
     struct CanonicalResponseHook {
-        blocking: Arc<Mutex<Vec<CanonicalResponseSnapshot>>>,
-        streaming: Arc<Mutex<Vec<CanonicalResponseSnapshot>>>,
-        committed: Arc<Mutex<Vec<OneOrMany<AssistantContent>>>>,
+        snapshots: Arc<Mutex<Vec<CanonicalResponseSnapshot>>>,
     }
 
     impl AgentHook for CanonicalResponseHook {
-        async fn on_completion_response(
+        async fn on_model_turn_prepared(
             &self,
             _ctx: &HookContext,
-            event: crate::agent::hook::CompletionResponse<'_>,
+            event: crate::agent::hook::ModelTurnPrepared<'_>,
         ) -> ObservationAction {
-            self.blocking
+            self.snapshots
                 .lock()
-                .expect("blocking snapshots")
+                .expect("prepared snapshots")
                 .push(CanonicalResponseSnapshot {
                     prompt: event.prompt.clone(),
                     content: event.content.clone(),
                     usage: event.usage,
                     message_id: event.message_id.map(str::to_owned),
+                    terminal_metadata: event.terminal_metadata.cloned(),
                 });
-            ObservationAction::continue_run()
-        }
-
-        async fn on_stream_response_finish(
-            &self,
-            _ctx: &HookContext,
-            event: StreamResponseFinish<'_>,
-        ) -> ObservationAction {
-            self.streaming
-                .lock()
-                .expect("streaming snapshots")
-                .push(CanonicalResponseSnapshot {
-                    prompt: event.prompt.clone(),
-                    content: event.content.clone(),
-                    usage: event.usage,
-                    message_id: event.message_id.map(str::to_owned),
-                });
-            ObservationAction::continue_run()
-        }
-
-        async fn on_model_turn_finished(
-            &self,
-            _ctx: &HookContext,
-            event: ModelTurnFinished<'_>,
-        ) -> ObservationAction {
-            self.committed
-                .lock()
-                .expect("committed snapshots")
-                .push(event.content.clone());
             ObservationAction::continue_run()
         }
     }
 
     #[derive(Clone, Default)]
-    struct FinishLifecycleHook {
+    struct PreparedLifecycleHook {
         snapshots: Arc<Mutex<Vec<CanonicalResponseSnapshot>>>,
-        model_turns: Arc<AtomicU32>,
         stop: Arc<AtomicBool>,
     }
 
-    impl FinishLifecycleHook {
+    impl PreparedLifecycleHook {
         fn stopping() -> Self {
             let hook = Self::default();
             hook.stop.store(true, SeqCst);
@@ -1815,11 +1754,11 @@ mod migrated_tests {
         }
     }
 
-    impl AgentHook for FinishLifecycleHook {
-        async fn on_stream_response_finish(
+    impl AgentHook for PreparedLifecycleHook {
+        async fn on_model_turn_prepared(
             &self,
             _ctx: &HookContext,
-            event: StreamResponseFinish<'_>,
+            event: ModelTurnPrepared<'_>,
         ) -> ObservationAction {
             self.snapshots
                 .lock()
@@ -1829,21 +1768,13 @@ mod migrated_tests {
                     content: event.content.clone(),
                     usage: event.usage,
                     message_id: event.message_id.map(str::to_owned),
+                    terminal_metadata: event.terminal_metadata.cloned(),
                 });
             if self.stop.load(SeqCst) {
                 ObservationAction::stop("stop at stream EOF")
             } else {
                 ObservationAction::continue_run()
             }
-        }
-
-        async fn on_model_turn_finished(
-            &self,
-            _ctx: &HookContext,
-            _event: ModelTurnFinished<'_>,
-        ) -> ObservationAction {
-            self.model_turns.fetch_add(1, SeqCst);
-            ObservationAction::continue_run()
         }
     }
 
@@ -1856,15 +1787,21 @@ mod migrated_tests {
         }
     }
 
+    fn canonical_terminal_metadata() -> CompletionTerminalMetadata {
+        CompletionTerminalMetadata::new(CompletionFinishReason::Length)
+            .with_raw_reason("provider_limit")
+    }
+
     #[tokio::test]
-    async fn blocking_completion_response_hook_receives_canonical_fields() {
+    async fn blocking_model_turn_prepared_receives_canonical_fields() {
         let hook = CanonicalResponseHook::default();
         let prompt = Message::user("canonical prompt");
         AgentBuilder::new(MockCompletionModel::new([MockTurn::text(
             "canonical response",
         )
         .with_usage(canonical_usage())
-        .with_message_id("msg-canonical")]))
+        .with_message_id("msg-canonical")
+        .with_terminal_metadata(canonical_terminal_metadata())]))
         .add_hook(hook.clone())
         .build()
         .runner(prompt.clone())
@@ -1873,25 +1810,27 @@ mod migrated_tests {
         .expect("blocking response");
 
         assert_eq!(
-            *hook.blocking.lock().expect("blocking snapshots"),
+            *hook.snapshots.lock().expect("blocking snapshots"),
             [CanonicalResponseSnapshot {
                 prompt,
                 content: OneOrMany::one(AssistantContent::text("canonical response")),
                 usage: canonical_usage(),
                 message_id: Some("msg-canonical".to_string()),
+                terminal_metadata: Some(canonical_terminal_metadata()),
             }]
         );
     }
 
     #[tokio::test]
-    async fn streaming_response_finish_matches_blocking_canonical_fields() {
+    async fn streaming_model_turn_prepared_matches_blocking_canonical_fields() {
         let prompt = Message::user("canonical prompt");
         let blocking_hook = CanonicalResponseHook::default();
         AgentBuilder::new(MockCompletionModel::new([MockTurn::text(
             "canonical response",
         )
         .with_usage(canonical_usage())
-        .with_message_id("msg-canonical")]))
+        .with_message_id("msg-canonical")
+        .with_terminal_metadata(canonical_terminal_metadata())]))
         .add_hook(blocking_hook.clone())
         .build()
         .runner(prompt.clone())
@@ -1902,7 +1841,10 @@ mod migrated_tests {
         let streaming_hook = CanonicalResponseHook::default();
         let mut stream = AgentBuilder::new(MockCompletionModel::from_stream_turns([[
             MockStreamEvent::text("canonical response"),
-            MockStreamEvent::final_response(canonical_usage()),
+            MockStreamEvent::final_response_with_metadata(
+                canonical_usage(),
+                canonical_terminal_metadata(),
+            ),
             MockStreamEvent::message_id("msg-canonical"),
         ]]))
         .add_hook(streaming_hook.clone())
@@ -1915,12 +1857,12 @@ mod migrated_tests {
         }
 
         let blocking = blocking_hook
-            .blocking
+            .snapshots
             .lock()
             .expect("blocking snapshots")
             .clone();
         let streaming = streaming_hook
-            .streaming
+            .snapshots
             .lock()
             .expect("streaming snapshots")
             .clone();
@@ -1930,8 +1872,8 @@ mod migrated_tests {
     }
 
     #[tokio::test]
-    async fn streaming_response_finish_without_provider_message_id_reports_none() {
-        let hook = FinishLifecycleHook::default();
+    async fn streaming_model_turn_prepared_without_provider_message_id_reports_none() {
+        let hook = PreparedLifecycleHook::default();
         let mut stream = AgentBuilder::new(MockCompletionModel::from_stream_turns([[
             MockStreamEvent::text("canonical response"),
             MockStreamEvent::final_response(canonical_usage()),
@@ -1951,8 +1893,8 @@ mod migrated_tests {
     }
 
     #[tokio::test]
-    async fn streaming_response_finish_runs_before_buffered_final_is_exposed() {
-        let hook = FinishLifecycleHook::default();
+    async fn streaming_model_turn_prepared_runs_before_buffered_final_is_exposed() {
+        let hook = PreparedLifecycleHook::default();
         let mut stream = AgentBuilder::new(MockCompletionModel::from_stream_turns([[
             MockStreamEvent::text("canonical response"),
             MockStreamEvent::final_response(canonical_usage()),
@@ -1973,28 +1915,27 @@ mod migrated_tests {
                 let snapshots = hook.snapshots.lock().expect("finish snapshots");
                 assert_eq!(snapshots.len(), 1, "hook must run before final exposure");
                 assert_eq!(snapshots[0].message_id.as_deref(), Some("msg-after-final"));
-                assert_eq!(
-                    hook.model_turns.load(SeqCst),
-                    0,
-                    "the turn must remain uncommitted while the final item is yielded"
-                );
             }
         }
 
         assert_eq!(provider_finals, 1);
         assert_eq!(hook.snapshots.lock().expect("finish snapshots").len(), 1);
-        assert_eq!(hook.model_turns.load(SeqCst), 1);
     }
 
     #[tokio::test]
-    async fn streaming_response_finish_stop_suppresses_final_and_turn_commit() {
-        let hook = FinishLifecycleHook::stopping();
+    async fn streaming_model_turn_prepared_stop_suppresses_final_and_turn_commit() {
+        let hook = PreparedLifecycleHook::stopping();
+        let tool_calls = Arc::new(AtomicU32::new(0));
         let prompt = Message::user("canonical prompt");
-        let mut stream = AgentBuilder::new(MockCompletionModel::from_stream_turns([[
+        let mut stream = AgentBuilder::new(MockCompletionModel::from_stream_turns([vec![
             MockStreamEvent::text("canonical response"),
+            MockStreamEvent::tool_call("tc1", "add", json!({"x": 2, "y": 3})),
             MockStreamEvent::final_response(canonical_usage()),
             MockStreamEvent::message_id("msg-after-final"),
         ]]))
+        .tool(CountingAddTool {
+            calls: tool_calls.clone(),
+        })
         .add_hook(hook.clone())
         .build()
         .runner(prompt.clone())
@@ -2020,7 +1961,11 @@ mod migrated_tests {
             "the cancelled run must not produce a response"
         );
         assert_eq!(hook.snapshots.lock().expect("finish snapshots").len(), 1);
-        assert_eq!(hook.model_turns.load(SeqCst), 0);
+        assert_eq!(
+            tool_calls.load(SeqCst),
+            0,
+            "tools must not execute after stop"
+        );
         assert!(matches!(
             error,
             Some(StreamingError::Prompt(error))
@@ -2033,8 +1978,8 @@ mod migrated_tests {
     }
 
     #[tokio::test]
-    async fn provider_error_after_final_suppresses_finish_hook_and_buffered_final() {
-        let hook = FinishLifecycleHook::default();
+    async fn provider_error_after_final_suppresses_prepared_hook_and_buffered_final() {
+        let hook = PreparedLifecycleHook::default();
         let mut stream = AgentBuilder::new(MockCompletionModel::from_stream_turns([[
             MockStreamEvent::text("canonical response"),
             MockStreamEvent::final_response(canonical_usage()),
@@ -2059,7 +2004,6 @@ mod migrated_tests {
 
         assert!(!saw_provider_final, "the buffered final must remain hidden");
         assert!(hook.snapshots.lock().expect("finish snapshots").is_empty());
-        assert_eq!(hook.model_turns.load(SeqCst), 0);
         assert!(matches!(
             error,
             Some(StreamingError::Completion(CompletionError::ProviderError(message)))
@@ -2088,7 +2032,7 @@ mod migrated_tests {
         ];
 
         for (case, visible_item) in cases {
-            let hook = FinishLifecycleHook::default();
+            let hook = PreparedLifecycleHook::default();
             let mut stream = AgentBuilder::new(MockCompletionModel::from_stream_turns([vec![
                 MockStreamEvent::text("canonical response"),
                 MockStreamEvent::final_response(canonical_usage()),
@@ -2117,9 +2061,8 @@ mod migrated_tests {
             );
             assert!(
                 hook.snapshots.lock().expect("finish snapshots").is_empty(),
-                "{case}: finish hook must not run"
+                "{case}: prepared hook must not run"
             );
-            assert_eq!(hook.model_turns.load(SeqCst), 0, "{case}");
             assert!(
                 matches!(
                     error,
@@ -2133,7 +2076,7 @@ mod migrated_tests {
 
     #[tokio::test]
     async fn visible_item_after_non_emittable_final_is_rejected() {
-        let hook = FinishLifecycleHook::default();
+        let hook = PreparedLifecycleHook::default();
         let mut stream = AgentBuilder::new(MockCompletionModel::from_stream_turns([[
             MockStreamEvent::reasoning("think"),
             MockStreamEvent::final_response(canonical_usage()),
@@ -2152,7 +2095,6 @@ mod migrated_tests {
         }
 
         assert!(hook.snapshots.lock().expect("finish snapshots").is_empty());
-        assert_eq!(hook.model_turns.load(SeqCst), 0);
         assert!(matches!(
             error,
             Some(StreamingError::Completion(CompletionError::ResponseError(message)))
@@ -2161,7 +2103,7 @@ mod migrated_tests {
     }
 
     #[tokio::test]
-    async fn streaming_response_finish_normalizes_interleaved_content() {
+    async fn streaming_model_turn_prepared_normalizes_interleaved_content() {
         let hook = CanonicalResponseHook::default();
         let mut stream = AgentBuilder::new(MockCompletionModel::from_stream_turns([
             vec![
@@ -2186,8 +2128,7 @@ mod migrated_tests {
             item.expect("stream item");
         }
 
-        let snapshots = hook.streaming.lock().expect("streaming snapshots");
-        let committed = hook.committed.lock().expect("committed snapshots");
+        let snapshots = hook.snapshots.lock().expect("streaming snapshots");
         let kinds = snapshots[0]
             .content
             .iter()
@@ -2199,10 +2140,6 @@ mod migrated_tests {
             })
             .collect::<Vec<_>>();
         assert_eq!(kinds, ["reasoning", "text", "tool_call"]);
-        assert_eq!(
-            snapshots[0].content, committed[0],
-            "finish hook and committed turn must share one canonical choice"
-        );
     }
 
     fn blocking_model() -> MockCompletionModel {
@@ -2348,8 +2285,8 @@ mod migrated_tests {
         assert_eq!(blocking.output, "the answer is 5");
         assert_eq!(final_response.output(), blocking.output);
 
-        // Same medium-independent hook event sequence (model call, tool call,
-        // tool result, second model call).
+        // Same medium-independent hook event sequence (model call, accepted
+        // turn, tool call/result, second model call, accepted final turn).
         assert_eq!(
             blocking_hook.shared_events(),
             streaming_hook.shared_events()
@@ -2358,9 +2295,11 @@ mod migrated_tests {
             blocking_hook.shared_events(),
             vec![
                 StepEventKind::CompletionCall,
+                StepEventKind::ModelTurnPrepared,
                 StepEventKind::ToolCall,
                 StepEventKind::ToolResult,
                 StepEventKind::CompletionCall,
+                StepEventKind::ModelTurnPrepared,
             ]
         );
 
@@ -5100,6 +5039,17 @@ mod migrated_tests {
                 CompletionCallAction::continue_run()
             }
         }
+        async fn on_model_turn_prepared(
+            &self,
+            _: &HookContext,
+            _: ModelTurnPrepared<'_>,
+        ) -> ObservationAction {
+            if self.0 == StepEventKind::ModelTurnPrepared {
+                ObservationAction::stop("stop here")
+            } else {
+                ObservationAction::continue_run()
+            }
+        }
         async fn on_tool_call(&self, _: &HookContext, _: ToolCall<'_>) -> ToolCallAction {
             if self.0 == StepEventKind::ToolCall {
                 ToolCallAction::stop("stop here")
@@ -5127,6 +5077,7 @@ mod migrated_tests {
     async fn run_terminates_from_each_shared_event() {
         for kind in [
             StepEventKind::CompletionCall,
+            StepEventKind::ModelTurnPrepared,
             StepEventKind::ToolCall,
             StepEventKind::ToolResult,
         ] {
@@ -5147,12 +5098,12 @@ mod migrated_tests {
     }
 
     /// The same fail-closed termination holds for the streaming driver across the
-    /// shared events it fires (it surfaces `StreamResponseFinish` instead of
-    /// `CompletionResponse`): each yields a stream error and no final response.
+    /// shared events it fires: each yields a stream error and no final response.
     #[tokio::test]
     async fn stream_terminates_from_each_shared_event() {
         for kind in [
             StepEventKind::CompletionCall,
+            StepEventKind::ModelTurnPrepared,
             StepEventKind::ToolCall,
             StepEventKind::ToolResult,
         ] {
@@ -5222,9 +5173,11 @@ mod migrated_tests {
             a_block.shared_events(),
             vec![
                 StepEventKind::CompletionCall,
+                StepEventKind::ModelTurnPrepared,
                 StepEventKind::ToolCall,
                 StepEventKind::ToolResult,
                 StepEventKind::CompletionCall,
+                StepEventKind::ModelTurnPrepared,
             ]
         );
         assert_eq!(blocking.output, "the answer is 5");
@@ -5780,16 +5733,12 @@ mod migrated_tests {
     }
 
     /// A turn that streams *text and* an invalid tool call, then is repaired, is
-    /// a recovered turn: its response-finish hook must be suppressed on BOTH
-    /// drivers — `CompletionResponse` under `run()`, `StreamResponseFinish` under
-    /// `stream()`. The shared-events parity harness deliberately excludes these
-    /// medium-specific events, so this asymmetry needs a dedicated assertion (it
-    /// is the exact event the harness cannot see).
+    /// a recovered turn: its prepared-turn hook must be suppressed on both
+    /// drivers.
     #[tokio::test]
-    async fn recovered_turn_suppresses_response_finish_hook_on_both_drivers() {
+    async fn recovered_turn_suppresses_model_turn_prepared_on_both_drivers() {
         // Turn 1 emits text then an invalid tool call (repaired to "add"); turn 2
-        // is a plain final-text turn whose response event DOES fire on both
-        // drivers — so a correct run sees exactly one response-finish event.
+        // is a plain final-text turn whose prepared event fires on both drivers.
         let blocking_model = MockCompletionModel::from_turns([
             MockTurn::from_contents([
                 AssistantContent::text("let me compute that"),
@@ -5839,48 +5788,22 @@ mod migrated_tests {
         // Recovery still reaches the same final answer.
         assert_eq!(blocking.output, "the answer is 5");
 
-        // Blocking: the recovered turn 1 suppresses `CompletionResponse`; only the
-        // plain turn 2 fires it.
+        // The recovered turn 1 is suppressed; only the accepted turn 2 fires.
         assert_eq!(
-            blocking_hook.count(StepEventKind::CompletionResponse),
+            streaming_hook.count(StepEventKind::ModelTurnPrepared),
             1,
-            "the recovered turn must not fire CompletionResponse"
-        );
-        // Streaming: the recovered turn 1 must likewise suppress
-        // `StreamResponseFinish` (without the fix this is 2).
-        assert_eq!(
-            streaming_hook.count(StepEventKind::StreamResponseFinish),
-            1,
-            "the recovered turn must not fire StreamResponseFinish"
-        );
-        // Stated as parity: the count of un-suppressed response-finish events is
-        // the same across drivers.
-        assert_eq!(
-            blocking_hook.count(StepEventKind::CompletionResponse),
-            streaming_hook.count(StepEventKind::StreamResponseFinish),
-        );
-
-        // The normalized per-turn `ModelTurnFinished` is suppressed on the
-        // recovered turn 1 on BOTH surfaces too (its own guard, separate from the
-        // medium-specific response-finish guards above), so only the accepted turn
-        // 2 fires it — count is 1, not 2, on each driver. Without the suppression
-        // this would be 2, and a per-turn accounting hook would double-count the
-        // recovered turn.
-        assert_eq!(
-            blocking_hook.count(StepEventKind::ModelTurnFinished),
-            1,
-            "the recovered turn must not fire ModelTurnFinished"
+            "the recovered turn must not fire ModelTurnPrepared"
         );
         assert_eq!(
-            streaming_hook.count(StepEventKind::ModelTurnFinished),
+            blocking_hook.count(StepEventKind::ModelTurnPrepared),
             1,
-            "the recovered turn must not fire ModelTurnFinished on the streaming surface either"
+            "the recovered turn must not fire ModelTurnPrepared"
         );
         // Parity: the normalized per-turn event fires the same number of times on
         // both drivers even when a turn is recovered.
         assert_eq!(
-            blocking_hook.count(StepEventKind::ModelTurnFinished),
-            streaming_hook.count(StepEventKind::ModelTurnFinished),
+            blocking_hook.count(StepEventKind::ModelTurnPrepared),
+            streaming_hook.count(StepEventKind::ModelTurnPrepared),
         );
     }
 
@@ -6792,7 +6715,7 @@ mod migrated_tests {
         assert_request(&streaming_requests[0]);
     }
 
-    // --- Hook system v2: extra_context, history view, ModelTurnFinished, chained rewrites ---
+    // --- Hook system v2: extra_context, history view, ModelTurnPrepared, chained rewrites ---
 
     fn hook_doc(id: &str, text: &str) -> crate::completion::Document {
         crate::completion::Document {
@@ -7303,10 +7226,10 @@ mod migrated_tests {
         );
     }
 
-    /// `ModelTurnFinished` fires exactly once per accepted turn on both surfaces,
-    /// including a streamed tool-only turn that fires no `StreamResponseFinish`.
+    /// `ModelTurnPrepared` fires exactly once per accepted turn on both surfaces,
+    /// including streamed tool-only turns.
     #[tokio::test]
-    async fn model_turn_finished_fires_once_per_accepted_turn_including_tool_only() {
+    async fn model_turn_prepared_fires_once_per_accepted_turn_including_tool_only() {
         let blocking_hook = RecordingHook::default();
         AgentBuilder::new(blocking_model())
             .tool(MockAddTool)
@@ -7318,9 +7241,9 @@ mod migrated_tests {
             .await
             .expect("blocking run should succeed");
         assert_eq!(
-            blocking_hook.count(StepEventKind::ModelTurnFinished),
+            blocking_hook.count(StepEventKind::ModelTurnPrepared),
             2,
-            "one ModelTurnFinished per accepted turn (tool turn + text turn)"
+            "one ModelTurnPrepared per accepted turn (tool turn + text turn)"
         );
 
         let streaming_hook = RecordingHook::default();
@@ -7336,28 +7259,36 @@ mod migrated_tests {
             let _ = item.map_err(|err| panic!("stream item errored: {err}"));
         }
         assert_eq!(
-            streaming_hook.count(StepEventKind::ModelTurnFinished),
+            streaming_hook.count(StepEventKind::ModelTurnPrepared),
             2,
-            "ModelTurnFinished fires once per turn on the streaming surface too"
-        );
-        // The tool-only first turn streams no assistant text, so only the second
-        // (text) turn fires StreamResponseFinish — proving ModelTurnFinished
-        // covers the gap.
-        assert_eq!(
-            streaming_hook.count(StepEventKind::StreamResponseFinish),
-            1,
-            "the tool-only turn fires no StreamResponseFinish"
+            "ModelTurnPrepared fires once per turn on the streaming surface too"
         );
     }
 
     #[tokio::test]
-    async fn reasoning_only_turn_does_not_gain_stream_response_finish() {
-        let hook = RecordingHook::default();
+    async fn reasoning_only_turn_fires_model_turn_prepared_once_on_both_surfaces() {
+        let blocking_hook = RecordingHook::default();
+        AgentBuilder::new(MockCompletionModel::from_turns([MockTurn::from_content(
+            AssistantContent::reasoning("think"),
+        )]))
+        .add_hook(blocking_hook.clone())
+        .build()
+        .runner("reason")
+        .run()
+        .await
+        .expect("reasoning-only blocking turn should finish");
+        assert_eq!(
+            blocking_hook.count(StepEventKind::ModelTurnPrepared),
+            1,
+            "the accepted blocking reasoning-only turn fires ModelTurnPrepared"
+        );
+
+        let streaming_hook = RecordingHook::default();
         let mut stream = AgentBuilder::new(MockCompletionModel::from_stream_turns([[
             MockStreamEvent::reasoning("think"),
             MockStreamEvent::final_response_with_total_tokens(0),
         ]]))
-        .add_hook(hook.clone())
+        .add_hook(streaming_hook.clone())
         .build()
         .runner("reason")
         .stream()
@@ -7367,30 +7298,25 @@ mod migrated_tests {
         }
 
         assert_eq!(
-            hook.count(StepEventKind::StreamResponseFinish),
-            0,
-            "reasoning-only turns must not fire StreamResponseFinish"
-        );
-        assert_eq!(
-            hook.count(StepEventKind::ModelTurnFinished),
+            streaming_hook.count(StepEventKind::ModelTurnPrepared),
             1,
-            "the accepted reasoning-only turn still fires ModelTurnFinished"
+            "the accepted streaming reasoning-only turn fires ModelTurnPrepared"
         );
     }
 
-    /// Records the content kinds of the first turn's `ModelTurnFinished`.
+    /// Records the content kinds of the first turn's `ModelTurnPrepared`.
     #[derive(Clone, Default)]
     struct CaptureFirstTurnContent {
         kinds: Arc<Mutex<Option<Vec<&'static str>>>>,
     }
 
     impl AgentHook for CaptureFirstTurnContent {
-        async fn on_model_turn_finished(
+        async fn on_model_turn_prepared(
             &self,
             _ctx: &HookContext,
-            event: ModelTurnFinished<'_>,
+            event: ModelTurnPrepared<'_>,
         ) -> ObservationAction {
-            if let ModelTurnFinished { turn, content, .. } = event
+            if let ModelTurnPrepared { turn, content, .. } = event
                 && turn == 1
             {
                 let kinds = content
@@ -7408,14 +7334,14 @@ mod migrated_tests {
         }
     }
 
-    /// On the streaming surface, `ModelTurnFinished.content` carries the
+    /// On the streaming surface, `ModelTurnPrepared.content` carries the
     /// **canonical** committed content from `StreamedTurn::finish` (reasoning →
     /// text → tool calls), not the raw `stream.choice` aggregate. The turn streams
     /// reasoning, then a tool call, then text (a non-canonical emission order), so
     /// a raw-choice implementation would surface `reasoning, tool_call, text` —
     /// the canonical event instead reports `reasoning, text, tool_call`.
     #[tokio::test]
-    async fn streaming_model_turn_finished_carries_canonical_committed_content() {
+    async fn streaming_model_turn_prepared_carries_canonical_committed_content() {
         let model = MockCompletionModel::from_stream_turns([
             vec![
                 MockStreamEvent::reasoning("think"),
@@ -7442,7 +7368,7 @@ mod migrated_tests {
         assert_eq!(
             hook.kinds.lock().expect("kinds").clone(),
             Some(vec!["reasoning", "text", "tool_call"]),
-            "ModelTurnFinished carries the canonical reasoning->text->tool ordering \
+            "ModelTurnPrepared carries the canonical reasoning->text->tool ordering \
              from StreamedTurn::finish, not the raw stream.choice emission order"
         );
     }
@@ -7624,10 +7550,10 @@ mod migrated_tests {
     }
 
     impl AgentHook for RegisterLateFinalResultTool {
-        async fn on_model_turn_finished(
+        async fn on_model_turn_prepared(
             &self,
             ctx: &HookContext,
-            _event: ModelTurnFinished<'_>,
+            _event: ModelTurnPrepared<'_>,
         ) -> ObservationAction {
             if ctx.turn() == 1 {
                 self.handle.add_tool(FinalResultTool).await;
@@ -8041,7 +7967,7 @@ mod migrated_tests {
         );
     }
 
-    /// Captures whether any `ModelTurnFinished.content` carried a tool call named
+    /// Captures whether any `ModelTurnPrepared.content` carried a tool call named
     /// `final_result` — the model-emitted structured-output output-tool call.
     #[derive(Clone, Default)]
     struct CaptureOutputToolInModelTurn {
@@ -8049,12 +7975,12 @@ mod migrated_tests {
     }
 
     impl AgentHook for CaptureOutputToolInModelTurn {
-        async fn on_model_turn_finished(
+        async fn on_model_turn_prepared(
             &self,
             _ctx: &HookContext,
-            event: ModelTurnFinished<'_>,
+            event: ModelTurnPrepared<'_>,
         ) -> ObservationAction {
-            if let ModelTurnFinished { content, .. } = event
+            if let ModelTurnPrepared { content, .. } = event
                 && content.iter().any(|c| {
                     matches!(c, AssistantContent::ToolCall(tc) if tc.function.name == "final_result")
                 })
@@ -8065,13 +7991,13 @@ mod migrated_tests {
         }
     }
 
-    /// `ModelTurnFinished.content` carries the **model-emitted** content — including
+    /// `ModelTurnPrepared.content` carries the **model-emitted** content — including
     /// a structured-output Tool-mode output-tool call — on both surfaces, even though
     /// the run persists that turn as assistant text (the structured output) with the
     /// tool call dropped. Guards the documented `content` contract: it is the model's
     /// committed turn content, not the finalized/persisted content, in Tool mode.
     #[tokio::test]
-    async fn model_turn_finished_content_carries_output_tool_call_in_tool_mode() {
+    async fn model_turn_prepared_content_carries_output_tool_call_in_tool_mode() {
         // Blocking surface.
         let hook = CaptureOutputToolInModelTurn::default();
         let response = AgentBuilder::new(MockCompletionModel::from_turns([MockTurn::tool_call(
@@ -8090,7 +8016,7 @@ mod migrated_tests {
         .expect("run should finalize via the output tool");
         assert!(
             *hook.saw_output_tool_call.lock().expect("lock"),
-            "ModelTurnFinished.content must carry the model-emitted output-tool call (blocking)"
+            "ModelTurnPrepared.content must carry the model-emitted output-tool call (blocking)"
         );
         assert!(
             response.output.contains("done"),
@@ -8115,7 +8041,7 @@ mod migrated_tests {
         while stream.next().await.is_some() {}
         assert!(
             *s_hook.saw_output_tool_call.lock().expect("lock"),
-            "ModelTurnFinished.content must carry the model-emitted output-tool call (streaming)"
+            "ModelTurnPrepared.content must carry the model-emitted output-tool call (streaming)"
         );
     }
 

--- a/crates/rig-core/src/completion/mod.rs
+++ b/crates/rig-core/src/completion/mod.rs
@@ -12,6 +12,9 @@
 //! Agent execution always goes through [`AgentRunner`](crate::agent::AgentRunner),
 //! including the high-level traits above. Call [`CompletionModel::completion`]
 //! directly only when intentionally making a raw, hook-free provider request.
+//! Direct blocking responses and fully collected streams expose normalized
+//! [`CompletionTerminalMetadata`] alongside the provider's typed raw response;
+//! managed agent hooks receive only canonical Rig data.
 //!
 //! `CompletionRequest` is Rig's canonical request representation. Provider modules
 //! translate it into provider-specific request bodies and convert responses back into

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -459,27 +459,97 @@ pub struct CompletionResponse<T> {
     /// Provider-assigned message ID (e.g. OpenAI Responses API `msg_` ID).
     /// Used to pair reasoning input items with their output items in multi-turn.
     pub message_id: Option<String>,
+    /// Canonical metadata describing why the provider ended the completion.
+    ///
+    /// `None` means the provider did not supply a terminal reason. The typed
+    /// provider response remains available in [`Self::raw_response`] for direct
+    /// provider-specific inspection.
+    pub terminal_metadata: Option<CompletionTerminalMetadata>,
 }
 
-/// A trait for grabbing the token usage of a completion response.
+/// Canonical reason a provider ended a successful completion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum CompletionFinishReason {
+    /// The model completed normally, reached an end-turn condition, or matched
+    /// a configured stop sequence.
+    Stop,
+    /// The provider stopped at a token, output, or context limit.
+    Length,
+    /// The provider declared the completion finished because it emitted tool
+    /// calls or tool use.
+    ToolCalls,
+    /// The provider stopped or blocked output for safety or content filtering.
+    ContentFilter,
+    /// The provider supplied a terminal reason Rig does not recognize.
+    Unknown,
+}
+
+/// Canonical metadata describing why a provider ended a successful completion.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct CompletionTerminalMetadata {
+    /// Provider-independent terminal category.
+    pub reason: CompletionFinishReason,
+    /// Exact provider reason string, when the provider supplied one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub raw_reason: Option<String>,
+}
+
+impl CompletionTerminalMetadata {
+    /// Create terminal metadata with no provider-specific reason string.
+    pub fn new(reason: CompletionFinishReason) -> Self {
+        Self {
+            reason,
+            raw_reason: None,
+        }
+    }
+
+    /// Attach the exact reason string supplied by the provider.
+    pub fn with_raw_reason(mut self, raw_reason: impl Into<String>) -> Self {
+        self.raw_reason = Some(raw_reason.into());
+        self
+    }
+
+    /// Return the provider-independent terminal category.
+    pub fn reason(&self) -> CompletionFinishReason {
+        self.reason
+    }
+
+    /// Return the exact provider reason string, when available.
+    pub fn raw_reason(&self) -> Option<&str> {
+        self.raw_reason.as_deref()
+    }
+}
+
+/// Extracts canonical metadata from a provider's final completion response.
 ///
-/// Primarily designed for streamed completion responses in streamed multi-turn, as otherwise it would be impossible to do.
-pub trait GetTokenUsage {
+/// This is primarily used by streamed completions, whose usage and terminal
+/// reason are only available after the provider yields its final response.
+pub trait GetCompletionMetadata {
     /// Returns token usage for this response. Zero-valued usage is
     /// [`Usage`]'s documented sentinel for missing provider usage metrics;
     /// response types that carry no usage return [`Usage::new`].
     fn token_usage(&self) -> crate::completion::Usage;
+
+    /// Returns normalized terminal metadata when the provider supplied a
+    /// terminal reason. Missing terminal reasons remain `None`.
+    fn terminal_metadata(&self) -> Option<CompletionTerminalMetadata> {
+        None
+    }
 }
 
-impl GetTokenUsage for () {
+impl GetCompletionMetadata for () {
     fn token_usage(&self) -> crate::completion::Usage {
         crate::completion::Usage::new()
     }
 }
 
-impl<T> GetTokenUsage for Option<T>
+impl<T> GetCompletionMetadata for Option<T>
 where
-    T: GetTokenUsage,
+    T: GetCompletionMetadata,
 {
     fn token_usage(&self) -> crate::completion::Usage {
         if let Some(usage) = self {
@@ -487,6 +557,11 @@ where
         } else {
             crate::completion::Usage::new()
         }
+    }
+
+    fn terminal_metadata(&self) -> Option<CompletionTerminalMetadata> {
+        self.as_ref()
+            .and_then(GetCompletionMetadata::terminal_metadata)
     }
 }
 
@@ -583,7 +658,7 @@ pub trait CompletionModel: Clone + WasmCompatSend + WasmCompatSync {
         + WasmCompatSync
         + Serialize
         + DeserializeOwned
-        + GetTokenUsage;
+        + GetCompletionMetadata;
 
     /// Provider client type used to construct this model.
     type Client;
@@ -1115,10 +1190,10 @@ impl<M: CompletionModel> CompletionRequestBuilder<M> {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn usage_has_values_reflects_the_zero_sentinel() {
-        use super::Usage;
-
         assert!(!Usage::new().has_values());
 
         let mut usage = Usage::new();
@@ -1126,8 +1201,65 @@ mod tests {
         assert!(usage.has_values());
     }
 
-    use super::*;
     use crate::test_utils::MockCompletionModel;
+
+    #[test]
+    fn terminal_metadata_serde_preserves_canonical_and_raw_reasons() {
+        let metadata = CompletionTerminalMetadata::new(CompletionFinishReason::Unknown)
+            .with_raw_reason("provider_future_reason");
+
+        let value = serde_json::to_value(&metadata).expect("serialize terminal metadata");
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "reason": "unknown",
+                "rawReason": "provider_future_reason"
+            })
+        );
+        let roundtrip: CompletionTerminalMetadata =
+            serde_json::from_value(value).expect("deserialize terminal metadata");
+        assert_eq!(roundtrip, metadata);
+
+        let without_raw = CompletionTerminalMetadata::new(CompletionFinishReason::Stop);
+        let value = serde_json::to_value(without_raw).expect("serialize without raw reason");
+        assert_eq!(value, serde_json::json!({"reason": "stop"}));
+    }
+
+    #[test]
+    fn optional_completion_metadata_delegates_provider_override() {
+        #[derive(Clone)]
+        struct ProviderMetadata;
+
+        impl GetCompletionMetadata for ProviderMetadata {
+            fn token_usage(&self) -> Usage {
+                Usage {
+                    total_tokens: 7,
+                    ..Usage::new()
+                }
+            }
+
+            fn terminal_metadata(&self) -> Option<CompletionTerminalMetadata> {
+                Some(
+                    CompletionTerminalMetadata::new(CompletionFinishReason::Length)
+                        .with_raw_reason("limit"),
+                )
+            }
+        }
+
+        let present = Some(ProviderMetadata);
+        assert_eq!(present.token_usage().total_tokens, 7);
+        assert_eq!(
+            present.terminal_metadata(),
+            Some(
+                CompletionTerminalMetadata::new(CompletionFinishReason::Length)
+                    .with_raw_reason("limit")
+            )
+        );
+
+        let missing: Option<ProviderMetadata> = None;
+        assert_eq!(missing.token_usage(), Usage::new());
+        assert_eq!(missing.terminal_metadata(), None);
+    }
 
     #[test]
     fn completion_request_content_telemetry_is_opt_in_and_not_serialized() {

--- a/crates/rig-core/src/extractor.rs
+++ b/crates/rig-core/src/extractor.rs
@@ -315,7 +315,7 @@ where
 
     /// Add a provider-independent lifecycle hook to every extraction attempt.
     ///
-    /// Completion-response hooks receive canonical Rig content, usage, prompt,
+    /// Prepared-turn hooks receive canonical Rig content, usage, prompt,
     /// and message ID fields, just like hooks attached directly to an agent.
     pub fn add_hook<H>(mut self, hook: H) -> Self
     where
@@ -346,7 +346,7 @@ mod tests {
 
     use super::*;
     use crate::agent::{
-        CompletionCallAction, CompletionResponseEvent, HookContext, ObservationAction, RequestPatch,
+        CompletionCallAction, HookContext, ModelTurnPrepared, ObservationAction, RequestPatch,
     };
     use crate::message::{AssistantContent, ToolCall, ToolFunction};
     use crate::test_utils::{MockCompletionModel, MockTurn};
@@ -384,8 +384,7 @@ mod tests {
     #[derive(Clone, Default)]
     struct LifecycleCounts {
         completion_calls: Arc<AtomicUsize>,
-        completion_responses: Arc<AtomicUsize>,
-        model_turns: Arc<AtomicUsize>,
+        prepared_turns: Arc<AtomicUsize>,
         invalid_tool_calls: Arc<AtomicUsize>,
     }
 
@@ -399,21 +398,12 @@ mod tests {
             crate::agent::CompletionCallAction::Continue
         }
 
-        async fn on_completion_response(
+        async fn on_model_turn_prepared(
             &self,
             _ctx: &HookContext,
-            _event: CompletionResponseEvent<'_>,
+            _event: ModelTurnPrepared<'_>,
         ) -> ObservationAction {
-            self.completion_responses.fetch_add(1, Ordering::SeqCst);
-            ObservationAction::Continue
-        }
-
-        async fn on_model_turn_finished(
-            &self,
-            _ctx: &HookContext,
-            _event: crate::agent::ModelTurnFinished<'_>,
-        ) -> ObservationAction {
-            self.model_turns.fetch_add(1, Ordering::SeqCst);
+            self.prepared_turns.fetch_add(1, Ordering::SeqCst);
             ObservationAction::Continue
         }
 
@@ -435,10 +425,10 @@ mod tests {
     }
 
     impl AgentHook for ExtractorResponseCapture {
-        async fn on_completion_response(
+        async fn on_model_turn_prepared(
             &self,
             _ctx: &HookContext,
-            event: CompletionResponseEvent<'_>,
+            event: ModelTurnPrepared<'_>,
         ) -> ObservationAction {
             *self.snapshot.lock().expect("extractor response snapshot") = Some((
                 event.prompt.clone(),
@@ -478,42 +468,19 @@ mod tests {
         }
     }
 
-    #[derive(Clone, Copy)]
-    enum StopFirstBilledResponseAt {
-        CompletionResponse,
-        ModelTurnFinished,
-    }
-
     #[derive(Clone)]
     struct StopFirstBilledResponse {
-        phase: StopFirstBilledResponseAt,
         calls: Arc<AtomicUsize>,
     }
 
     impl AgentHook for StopFirstBilledResponse {
-        async fn on_completion_response(
+        async fn on_model_turn_prepared(
             &self,
             _ctx: &HookContext,
-            _event: CompletionResponseEvent<'_>,
+            _event: ModelTurnPrepared<'_>,
         ) -> ObservationAction {
-            if matches!(self.phase, StopFirstBilledResponseAt::CompletionResponse)
-                && self.calls.fetch_add(1, Ordering::SeqCst) == 0
-            {
+            if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
                 ObservationAction::stop("stop first billed response")
-            } else {
-                ObservationAction::continue_run()
-            }
-        }
-
-        async fn on_model_turn_finished(
-            &self,
-            _ctx: &HookContext,
-            _event: crate::agent::ModelTurnFinished<'_>,
-        ) -> ObservationAction {
-            if matches!(self.phase, StopFirstBilledResponseAt::ModelTurnFinished)
-                && self.calls.fetch_add(1, Ordering::SeqCst) == 0
-            {
-                ObservationAction::stop("stop first billed model turn")
             } else {
                 ObservationAction::continue_run()
             }
@@ -576,8 +543,7 @@ mod tests {
         assert_eq!(response.name, "John");
         assert_eq!(model.request_count(), 1);
         assert_eq!(counts.completion_calls.load(Ordering::SeqCst), 1);
-        assert_eq!(counts.completion_responses.load(Ordering::SeqCst), 1);
-        assert_eq!(counts.model_turns.load(Ordering::SeqCst), 1);
+        assert_eq!(counts.prepared_turns.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]
@@ -674,7 +640,7 @@ mod tests {
         assert_eq!(response.usage.total_tokens, 15);
     }
 
-    async fn assert_billed_hook_termination_usage(phase: StopFirstBilledResponseAt) {
+    async fn assert_billed_hook_termination_usage() {
         let model = MockCompletionModel::new([
             submit_turn("ignored").with_usage(usage(10)),
             submit_turn("John").with_usage(usage(5)),
@@ -682,7 +648,6 @@ mod tests {
         let response = ExtractorBuilder::<_, Person>::new(model)
             .retries(1)
             .add_hook(StopFirstBilledResponse {
-                phase,
                 calls: Arc::new(AtomicUsize::new(0)),
             })
             .build()
@@ -695,13 +660,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn completion_response_hook_termination_preserves_billed_usage() {
-        assert_billed_hook_termination_usage(StopFirstBilledResponseAt::CompletionResponse).await;
-    }
-
-    #[tokio::test]
-    async fn model_turn_finished_hook_termination_preserves_billed_usage() {
-        assert_billed_hook_termination_usage(StopFirstBilledResponseAt::ModelTurnFinished).await;
+    async fn model_turn_prepared_hook_termination_preserves_billed_usage() {
+        assert_billed_hook_termination_usage().await;
     }
 
     #[tokio::test]
@@ -739,8 +699,7 @@ mod tests {
         assert_eq!(response.data.name, "John");
         assert_eq!(response.usage.total_tokens, 15);
         assert_eq!(counts.invalid_tool_calls.load(Ordering::SeqCst), 1);
-        assert_eq!(counts.completion_responses.load(Ordering::SeqCst), 2);
-        assert_eq!(counts.model_turns.load(Ordering::SeqCst), 2);
+        assert_eq!(counts.prepared_turns.load(Ordering::SeqCst), 2);
     }
 
     #[tokio::test]
@@ -816,6 +775,36 @@ mod tests {
 
         assert_eq!(response.data.name, "John");
         assert_eq!(response.usage.total_tokens, 7);
+    }
+
+    #[tokio::test]
+    async fn prepared_hook_receives_extractor_content_after_invalid_siblings_are_removed() {
+        let capture = ExtractorResponseCapture::default();
+        let turn = MockTurn::from_contents([
+            tool_call("unknown", "unexpected", json!({})),
+            tool_call("submit", SUBMIT_TOOL_NAME, json!({ "name": "John" })),
+        ])
+        .expect("two tool calls");
+
+        let response = ExtractorBuilder::<_, Person>::new(MockCompletionModel::new([turn]))
+            .add_hook(capture.clone())
+            .build()
+            .extract("John")
+            .await
+            .expect("submit should remain authoritative");
+        assert_eq!(response.name, "John");
+
+        let (_, content, _, _) = capture
+            .snapshot
+            .lock()
+            .expect("extractor response snapshot")
+            .clone()
+            .expect("prepared hook should fire");
+        assert!(matches!(
+            content.as_slice(),
+            [AssistantContent::ToolCall(tool_call)]
+                if tool_call.function.name == SUBMIT_TOOL_NAME
+        ));
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/providers/anthropic/completion.rs
+++ b/crates/rig-core/src/providers/anthropic/completion.rs
@@ -5,7 +5,7 @@ use crate::providers::anthropic::streaming::StreamingCompletionResponse;
 use crate::{
     OneOrMany,
     client::Provider,
-    completion::{self, CompletionError, GetTokenUsage},
+    completion::{self, CompletionError, GetCompletionMetadata},
     http_client::HttpClientExt,
     message::{self, DocumentMediaType, DocumentSourceKind, MessageError, MimeType, Reasoning},
     one_or_many::string_or_one_or_many,
@@ -130,7 +130,7 @@ impl std::fmt::Display for Usage {
     }
 }
 
-impl GetTokenUsage for Usage {
+impl GetCompletionMetadata for Usage {
     fn token_usage(&self) -> crate::completion::Usage {
         let mut usage = crate::completion::Usage::new();
 
@@ -218,6 +218,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
     type Error = CompletionError;
 
     fn try_from(response: CompletionResponse) -> Result<Self, Self::Error> {
+        let terminal_metadata = terminal_metadata_from_stop_reason(response.stop_reason.as_deref());
         let content = response
             .content
             .iter()
@@ -258,8 +259,25 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             usage,
             raw_response: response,
             message_id: None,
+            terminal_metadata,
         })
     }
+}
+
+pub(crate) fn terminal_metadata_from_stop_reason(
+    raw_reason: Option<&str>,
+) -> Option<completion::CompletionTerminalMetadata> {
+    let raw_reason = raw_reason?;
+    let reason = match raw_reason {
+        "end_turn" | "stop_sequence" => completion::CompletionFinishReason::Stop,
+        "max_tokens" | "model_context_window_exceeded" => {
+            completion::CompletionFinishReason::Length
+        }
+        "tool_use" => completion::CompletionFinishReason::ToolCalls,
+        "refusal" => completion::CompletionFinishReason::ContentFilter,
+        _ => completion::CompletionFinishReason::Unknown,
+    };
+    Some(completion::CompletionTerminalMetadata::new(reason).with_raw_reason(raw_reason))
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
@@ -2595,6 +2613,30 @@ mod tests {
     use super::*;
     use serde_json::json;
     use serde_path_to_error::deserialize;
+
+    #[test]
+    fn stop_reason_normalization_preserves_raw_values() {
+        use crate::completion::CompletionFinishReason;
+
+        for (raw, expected) in [
+            ("end_turn", CompletionFinishReason::Stop),
+            ("stop_sequence", CompletionFinishReason::Stop),
+            ("max_tokens", CompletionFinishReason::Length),
+            (
+                "model_context_window_exceeded",
+                CompletionFinishReason::Length,
+            ),
+            ("tool_use", CompletionFinishReason::ToolCalls),
+            ("refusal", CompletionFinishReason::ContentFilter),
+            ("pause_turn", CompletionFinishReason::Unknown),
+        ] {
+            let metadata = terminal_metadata_from_stop_reason(Some(raw))
+                .expect("supplied reason should produce metadata");
+            assert_eq!(metadata.reason(), expected);
+            assert_eq!(metadata.raw_reason(), Some(raw));
+        }
+        assert_eq!(terminal_metadata_from_stop_reason(None), None);
+    }
 
     #[test]
     fn current_model_default_max_tokens_match_anthropic_limits() {

--- a/crates/rig-core/src/providers/anthropic/streaming.rs
+++ b/crates/rig-core/src/providers/anthropic/streaming.rs
@@ -9,7 +9,7 @@ use super::completion::{
     AnthropicCompatibleProvider, AnthropicCompletionRequest, AnthropicRequestParams, CacheTtl,
     Content, GenericCompletionModel, Usage,
 };
-use crate::completion::{CompletionError, CompletionRequest, GetTokenUsage};
+use crate::completion::{CompletionError, CompletionRequest, GetCompletionMetadata};
 use crate::http_client::sse::{Event, GenericEventSource};
 use crate::http_client::{self, HttpClientExt};
 use crate::message::ReasoningContent;
@@ -156,7 +156,7 @@ pub struct PartialUsage {
     pub cache_read_input_tokens: Option<u64>,
 }
 
-impl GetTokenUsage for PartialUsage {
+impl GetCompletionMetadata for PartialUsage {
     fn token_usage(&self) -> crate::completion::Usage {
         let mut usage = crate::completion::Usage::new();
 
@@ -196,9 +196,12 @@ struct ThinkingState {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StreamingCompletionResponse {
     pub usage: PartialUsage,
+    /// Exact Anthropic stop reason from the terminal message delta.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stop_reason: Option<String>,
 }
 
-impl GetTokenUsage for StreamingCompletionResponse {
+impl GetCompletionMetadata for StreamingCompletionResponse {
     fn token_usage(&self) -> crate::completion::Usage {
         let mut usage = crate::completion::Usage::new();
         usage.input_tokens = self.usage.input_tokens.unwrap_or(0) as u64;
@@ -211,6 +214,10 @@ impl GetTokenUsage for StreamingCompletionResponse {
             + usage.output_tokens;
 
         usage
+    }
+
+    fn terminal_metadata(&self) -> Option<crate::completion::CompletionTerminalMetadata> {
+        super::completion::terminal_metadata_from_stop_reason(self.stop_reason.as_deref())
     }
 }
 
@@ -283,6 +290,7 @@ where
             let mut sse_stream = Box::pin(stream);
             let mut input_tokens = 0;
             let mut final_usage = None;
+            let mut final_stop_reason = None;
 
             let mut text_content = String::new();
 
@@ -303,6 +311,7 @@ where
                                     },
                                     StreamingEvent::MessageDelta { delta, usage } => {
                                         if delta.stop_reason.is_some() {
+                                            final_stop_reason = delta.stop_reason.clone();
                                             // cache_creation_input_tokens and cache_read_input_tokens
                                             // are cumulative totals on message_delta.usage per the
                                             // Anthropic streaming API spec — use them directly.
@@ -354,7 +363,8 @@ where
             sse_stream.close();
 
             yield Ok(RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
-                usage: final_usage.unwrap_or_default()
+                usage: final_usage.unwrap_or_default(),
+                stop_reason: final_stop_reason,
             }))
         }.instrument(span));
 
@@ -1619,6 +1629,7 @@ mod tests {
 
             yield Ok(RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
                 usage: PartialUsage::default(),
+                stop_reason: None,
             }));
         };
 
@@ -1764,6 +1775,7 @@ mod tests {
 
             yield Ok(RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
                 usage: PartialUsage::default(),
+                stop_reason: None,
             }));
         };
 

--- a/crates/rig-core/src/providers/azure.rs
+++ b/crates/rig-core/src/providers/azure.rs
@@ -29,7 +29,7 @@ use crate::client::{
     self, ApiKey, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
     ProviderClient,
 };
-use crate::completion::GetTokenUsage;
+use crate::completion::GetCompletionMetadata;
 use crate::http_client::multipart::Part;
 use crate::http_client::{self, HttpClientExt, MultipartForm, bearer_auth_header};
 use crate::transcription::TranscriptionError;
@@ -374,7 +374,7 @@ pub struct Usage {
     pub total_tokens: usize,
 }
 
-impl GetTokenUsage for Usage {
+impl GetCompletionMetadata for Usage {
     fn token_usage(&self) -> crate::completion::Usage {
         let mut usage = crate::completion::Usage::new();
 

--- a/crates/rig-core/src/providers/cohere/completion.rs
+++ b/crates/rig-core/src/providers/cohere/completion.rs
@@ -1,6 +1,6 @@
 use crate::{
     OneOrMany,
-    completion::{self, CompletionError, GetTokenUsage},
+    completion::{self, CompletionError, GetCompletionMetadata},
     http_client::{self, HttpClientExt},
     json_utils,
     message::{self, Reasoning, ToolChoice},
@@ -85,14 +85,71 @@ impl crate::telemetry::ProviderResponseExt for CompletionResponse {
     }
 }
 
-#[derive(Debug, Deserialize, PartialEq, Eq, Clone, Serialize)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum FinishReason {
     MaxTokens,
     StopSequence,
     Complete,
     Error,
     ToolCall,
+    /// A provider value introduced after this Rig version.
+    Unknown(String),
+}
+
+impl FinishReason {
+    pub(crate) fn as_raw_reason(&self) -> &str {
+        match self {
+            Self::MaxTokens => "MAX_TOKENS",
+            Self::StopSequence => "STOP_SEQUENCE",
+            Self::Complete => "COMPLETE",
+            Self::Error => "ERROR",
+            Self::ToolCall => "TOOL_CALL",
+            Self::Unknown(reason) => reason,
+        }
+    }
+}
+
+impl Serialize for FinishReason {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_raw_reason())
+    }
+}
+
+impl<'de> Deserialize<'de> for FinishReason {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(match String::deserialize(deserializer)?.as_str() {
+            "MAX_TOKENS" => Self::MaxTokens,
+            "STOP_SEQUENCE" => Self::StopSequence,
+            "COMPLETE" => Self::Complete,
+            "ERROR" => Self::Error,
+            "TOOL_CALL" => Self::ToolCall,
+            reason => Self::Unknown(reason.to_owned()),
+        })
+    }
+}
+
+pub(crate) fn terminal_metadata_from_finish_reason(
+    finish_reason: &FinishReason,
+) -> Option<completion::CompletionTerminalMetadata> {
+    let reason = match finish_reason {
+        FinishReason::MaxTokens => completion::CompletionFinishReason::Length,
+        FinishReason::StopSequence | FinishReason::Complete => {
+            completion::CompletionFinishReason::Stop
+        }
+        FinishReason::ToolCall => completion::CompletionFinishReason::ToolCalls,
+        FinishReason::Error => return None,
+        FinishReason::Unknown(_) => completion::CompletionFinishReason::Unknown,
+    };
+    Some(
+        completion::CompletionTerminalMetadata::new(reason)
+            .with_raw_reason(finish_reason.as_raw_reason()),
+    )
 }
 
 #[derive(Debug, Deserialize, Clone, Serialize)]
@@ -103,7 +160,7 @@ pub struct Usage {
     pub tokens: Option<Tokens>,
 }
 
-impl GetTokenUsage for Usage {
+impl GetCompletionMetadata for Usage {
     fn token_usage(&self) -> crate::completion::Usage {
         let mut usage = crate::completion::Usage::new();
 
@@ -141,6 +198,15 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
     type Error = CompletionError;
 
     fn try_from(response: CompletionResponse) -> Result<Self, Self::Error> {
+        if matches!(response.finish_reason, FinishReason::Error) {
+            return Err(match serde_json::to_string(&response) {
+                Ok(body) => CompletionError::from_provider_body(body),
+                Err(error) => CompletionError::ProviderError(format!(
+                    "Cohere completion ended with finish reason ERROR; failed to preserve response: {error}"
+                )),
+            });
+        }
+        let terminal_metadata = terminal_metadata_from_finish_reason(&response.finish_reason);
         let (content, _, tool_calls) = response.message()?;
 
         let model_response = if !tool_calls.is_empty() {
@@ -200,6 +266,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             usage,
             raw_response: response,
             message_id: None,
+            terminal_metadata,
         })
     }
 }
@@ -714,6 +781,58 @@ where
 mod tests {
     use super::*;
     use serde_path_to_error::deserialize;
+
+    #[test]
+    fn finish_reason_normalization_matches_cohere_categories() {
+        use crate::completion::CompletionFinishReason;
+
+        for (raw, expected) in [
+            (FinishReason::MaxTokens, CompletionFinishReason::Length),
+            (FinishReason::StopSequence, CompletionFinishReason::Stop),
+            (FinishReason::Complete, CompletionFinishReason::Stop),
+            (FinishReason::ToolCall, CompletionFinishReason::ToolCalls),
+        ] {
+            let metadata = terminal_metadata_from_finish_reason(&raw)
+                .expect("successful reason should produce metadata");
+            assert_eq!(metadata.reason(), expected);
+            assert_eq!(metadata.raw_reason(), Some(raw.as_raw_reason()));
+        }
+        assert_eq!(
+            terminal_metadata_from_finish_reason(&FinishReason::Error),
+            None
+        );
+
+        let raw: FinishReason = serde_json::from_str(r#""FUTURE_REASON""#)
+            .expect("unknown provider reasons should deserialize");
+        let metadata = terminal_metadata_from_finish_reason(&raw)
+            .expect("an unknown supplied reason should produce metadata");
+        assert_eq!(metadata.reason(), CompletionFinishReason::Unknown);
+        assert_eq!(metadata.raw_reason(), Some("FUTURE_REASON"));
+        assert_eq!(
+            serde_json::to_string(&raw).expect("unknown reason should serialize"),
+            r#""FUTURE_REASON""#
+        );
+    }
+
+    #[test]
+    fn error_finish_reason_preserves_provider_response() {
+        let response: CompletionResponse = serde_json::from_value(serde_json::json!({
+            "id": "cohere-error",
+            "message": { "role": "assistant", "content": [] },
+            "finish_reason": "ERROR"
+        }))
+        .expect("error response should deserialize");
+
+        let error = completion::CompletionResponse::try_from(response)
+            .expect_err("ERROR finish reason must remain a provider error");
+        assert_eq!(error.provider_response_status(), None);
+        let preserved = error
+            .provider_response_json()
+            .expect("preserved response should be JSON")
+            .expect("provider response should be present");
+        assert_eq!(preserved["finish_reason"], "ERROR");
+        assert_eq!(preserved["id"], "cohere-error");
+    }
 
     #[test]
     fn test_deserialize_completion_response() {

--- a/crates/rig-core/src/providers/cohere/streaming.rs
+++ b/crates/rig-core/src/providers/cohere/streaming.rs
@@ -1,8 +1,8 @@
-use crate::completion::{CompletionError, CompletionRequest, GetTokenUsage};
+use crate::completion::{CompletionError, CompletionRequest, GetCompletionMetadata};
 use crate::http_client::HttpClientExt;
 use crate::http_client::sse::{Event, GenericEventSource};
 use crate::providers::cohere::CompletionModel;
-use crate::providers::cohere::completion::{CohereCompletionRequest, Usage};
+use crate::providers::cohere::completion::{CohereCompletionRequest, FinishReason, Usage};
 use crate::streaming::{RawStreamingChoice, RawStreamingToolCall, ToolCallDeltaContent};
 use crate::telemetry::{CompletionOperation, CompletionSpanBuilder, SpanCombinator};
 use crate::{json_utils, streaming};
@@ -56,15 +56,18 @@ struct Delta {
 
 #[derive(Debug, Deserialize)]
 struct MessageEndDelta {
+    finish_reason: Option<FinishReason>,
     usage: Option<Usage>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct StreamingCompletionResponse {
     pub usage: Option<Usage>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub finish_reason: Option<FinishReason>,
 }
 
-impl GetTokenUsage for StreamingCompletionResponse {
+impl GetCompletionMetadata for StreamingCompletionResponse {
     fn token_usage(&self) -> crate::completion::Usage {
         let tokens = self
             .usage
@@ -86,6 +89,16 @@ impl GetTokenUsage for StreamingCompletionResponse {
 
         usage
     }
+
+    fn terminal_metadata(&self) -> Option<crate::completion::CompletionTerminalMetadata> {
+        self.finish_reason
+            .as_ref()
+            .and_then(super::completion::terminal_metadata_from_finish_reason)
+    }
+}
+
+fn provider_error_from_stream_event(data: &str) -> CompletionError {
+    CompletionError::from_provider_body(data.to_owned())
 }
 
 impl<T> CompletionModel<T>
@@ -136,6 +149,8 @@ where
         let stream = stream! {
             let mut current_tool_call: Option<(String, String, String, String)> = None;
             let mut final_usage = None;
+            let mut final_finish_reason = None;
+            let mut stream_failed = false;
 
             while let Some(event_result) = event_source.next().await {
                 match event_result {
@@ -168,9 +183,15 @@ where
                             },
 
                             StreamingEvent::MessageEnd { delta: Some(delta) } => {
+                                if matches!(delta.finish_reason.as_ref(), Some(FinishReason::Error)) {
+                                    stream_failed = true;
+                                    yield Err(provider_error_from_stream_event(data_str));
+                                    break;
+                                }
                                 let span = tracing::Span::current();
                                 span.record_token_usage(&delta.usage);
                                 final_usage = Some(delta.usage.clone());
+                                final_finish_reason = delta.finish_reason.clone();
                                 break;
                             },
 
@@ -237,8 +258,13 @@ where
             // Ensure event source is closed when stream ends
             event_source.close();
 
+            if stream_failed {
+                return;
+            }
+
             yield Ok(RawStreamingChoice::FinalResponse(StreamingCompletionResponse {
-                usage: final_usage.unwrap_or_default()
+                usage: final_usage.unwrap_or_default(),
+                finish_reason: final_finish_reason,
             }))
         }.instrument(span);
 
@@ -252,6 +278,19 @@ where
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn error_finish_reason_preserves_raw_stream_event() {
+        let raw = r#"{"type":"message-end","delta":{"finish_reason":"ERROR","usage":null}}"#;
+        let error = provider_error_from_stream_event(raw);
+
+        assert_eq!(error.provider_response_status(), None);
+        let preserved = error
+            .provider_response_json()
+            .expect("preserved event should be JSON")
+            .expect("provider event should be present");
+        assert_eq!(preserved["delta"]["finish_reason"], "ERROR");
+    }
 
     #[test]
     fn test_message_content_delta_deserialization() {

--- a/crates/rig-core/src/providers/copilot/mod.rs
+++ b/crates/rig-core/src/providers/copilot/mod.rs
@@ -26,7 +26,7 @@ use crate::client::{
     self, ApiKey, Capabilities, Capable, DebugExt, ModelLister, Nothing, Provider, ProviderBuilder,
     ProviderClient, Transport,
 };
-use crate::completion::{self, CompletionError, GetTokenUsage};
+use crate::completion::{self, CompletionError, GetCompletionMetadata};
 use crate::embeddings::{self, EmbeddingError};
 use crate::http_client::{self, HttpClientExt};
 use crate::model::{Model, ModelList, ModelListingError};
@@ -582,11 +582,18 @@ pub enum CopilotStreamingResponse {
     Responses(responses_api::streaming::StreamingCompletionResponse),
 }
 
-impl GetTokenUsage for CopilotStreamingResponse {
+impl GetCompletionMetadata for CopilotStreamingResponse {
     fn token_usage(&self) -> completion::Usage {
         match self {
             Self::Chat(response) => response.token_usage(),
             Self::Responses(response) => response.token_usage(),
+        }
+    }
+
+    fn terminal_metadata(&self) -> Option<completion::CompletionTerminalMetadata> {
+        match self {
+            Self::Chat(response) => response.terminal_metadata(),
+            Self::Responses(response) => response.terminal_metadata(),
         }
     }
 }
@@ -621,6 +628,9 @@ impl TryFrom<ChatCompletionResponse> for completion::CompletionResponse<ChatComp
         let choice = response.choices.first().ok_or_else(|| {
             CompletionError::ResponseError("Response contained no choices".to_owned())
         })?;
+        let terminal_metadata = openai::completion::terminal_metadata_from_finish_reason(
+            choice.finish_reason.as_deref(),
+        );
 
         let content = match &choice.message {
             openai::completion::Message::Assistant {
@@ -685,12 +695,12 @@ impl TryFrom<ChatCompletionResponse> for completion::CompletionResponse<ChatComp
                 reasoning_tokens: 0,
             })
             .unwrap_or_default();
-
         Ok(completion::CompletionResponse {
             choice,
             usage,
             raw_response: response,
             message_id: None,
+            terminal_metadata,
         })
     }
 }
@@ -874,6 +884,7 @@ where
                             usage: core.usage,
                             raw_response: CopilotCompletionResponse::Chat(Box::new(response)),
                             message_id: core.message_id,
+                            terminal_metadata: core.terminal_metadata,
                         })
                     }
                     ChatApiResponse::Err(err) => {
@@ -945,6 +956,7 @@ where
                     usage: core.usage,
                     raw_response: CopilotCompletionResponse::Responses(Box::new(response)),
                     message_id: core.message_id,
+                    terminal_metadata: core.terminal_metadata,
                 })
             } else {
                 let body = http_client::text(response).await?;
@@ -1034,6 +1046,7 @@ where
                 let mut final_usage = responses_api::ResponsesUsage::new();
                 let mut reasoning_metadata = None;
                 let mut reasoning_context = None;
+                let mut final_terminal_metadata = None;
                 let mut tool_calls: Vec<streaming::RawStreamingChoice<CopilotStreamingResponse>> = Vec::new();
                 let mut tool_call_internal_ids: HashMap<String, String> = HashMap::new();
                 let span = tracing::Span::current();
@@ -1139,7 +1152,10 @@ where
                             if let responses_api::streaming::StreamingCompletionChunk::Response(chunk) = data {
                                 let responses_api::streaming::ResponseChunk { kind, response, .. } = *chunk;
                                 match kind {
-                                    responses_api::streaming::ResponseChunkKind::ResponseCompleted => {
+                                    responses_api::streaming::ResponseChunkKind::ResponseCompleted
+                                    | responses_api::streaming::ResponseChunkKind::ResponseIncomplete => {
+                                        final_terminal_metadata =
+                                            responses_api::terminal_metadata_from_response(&response);
                                         span.record("gen_ai.response.id", response.id.as_str());
                                         span.record("gen_ai.response.model", response.model.as_str());
                                         if let Some(usage) = response.usage {
@@ -1152,8 +1168,7 @@ where
                                             reasoning_context = response.reasoning_context;
                                         }
                                     }
-                                    responses_api::streaming::ResponseChunkKind::ResponseFailed
-                                    | responses_api::streaming::ResponseChunkKind::ResponseIncomplete => {
+                                    responses_api::streaming::ResponseChunkKind::ResponseFailed => {
                                         terminated_with_error = true;
                                         // Deliberate two-tier behaviour matching the OpenAI Responses
                                         // SSE path: when the provider supplies an error object we
@@ -1217,6 +1232,7 @@ where
                             usage: final_usage,
                             reasoning_metadata,
                             reasoning_context,
+                            terminal_metadata: final_terminal_metadata,
                         }
                     )
                 ));
@@ -1603,6 +1619,16 @@ impl CompatibleStreamProfile for CopilotChatCompatibleProfile {
                     } else {
                         CompatibleFinishReason::Other
                     },
+                    terminal_metadata: choice.finish_reason.as_ref().and_then(|reason| {
+                        let raw_reason = match reason {
+                            ChatFinishReason::ToolCalls => "tool_calls",
+                            ChatFinishReason::Stop => "stop",
+                            ChatFinishReason::ContentFilter => "content_filter",
+                            ChatFinishReason::Length => "length",
+                            ChatFinishReason::Other(reason) => reason.as_str(),
+                        };
+                        openai::completion::terminal_metadata_from_finish_reason(Some(raw_reason))
+                    }),
                     text: choice.delta.content.clone(),
                     reasoning: choice.delta.reasoning_content.clone(),
                     tool_calls: openai_chat_completions_compatible::tool_call_chunks(
@@ -1614,9 +1640,14 @@ impl CompatibleStreamProfile for CopilotChatCompatibleProfile {
         ))
     }
 
-    fn build_final_response(&self, usage: Self::Usage) -> Self::FinalResponse {
+    fn build_final_response(
+        &self,
+        usage: Self::Usage,
+        terminal_metadata: Option<completion::CompletionTerminalMetadata>,
+    ) -> Self::FinalResponse {
         CopilotStreamingResponse::Chat(openai::completion::streaming::StreamingCompletionResponse {
             usage,
+            terminal_metadata,
         })
     }
 
@@ -2207,6 +2238,58 @@ mod tests {
         }
 
         panic!("responses stream should yield a final response");
+    }
+
+    #[tokio::test]
+    async fn responses_stream_preserves_incomplete_terminal_metadata() {
+        let incomplete = serde_json::json!({
+            "type": "response.incomplete",
+            "sequence_number": 1,
+            "response": {
+                "id": "resp_123",
+                "object": "response",
+                "created_at": 1700000000,
+                "status": "incomplete",
+                "error": null,
+                "incomplete_details": { "reason": "max_output_tokens" },
+                "instructions": null,
+                "max_output_tokens": 1,
+                "model": "gpt-5.3-codex",
+                "usage": null,
+                "output": [],
+                "tools": []
+            }
+        });
+        let http_client = MockStreamingClient {
+            sse_bytes: sse_bytes_from_json_events(&[incomplete]),
+        };
+        let client = Client::builder()
+            .api_key("copilot-token")
+            .http_client(http_client)
+            .build()
+            .expect("build client");
+        let model = client.completion_model("gpt-5.3-codex");
+        let request = model.completion_request("hello").build();
+        let mut stream = model.stream(request).await.expect("stream should start");
+
+        while let Some(item) = stream.next().await {
+            if let StreamedAssistantContent::Final(super::CopilotStreamingResponse::Responses(
+                response,
+            )) = item.expect("incomplete stream should retain its partial completion")
+            {
+                let metadata = response
+                    .terminal_metadata
+                    .expect("incomplete reason should be normalized");
+                assert_eq!(
+                    metadata.reason(),
+                    crate::completion::CompletionFinishReason::Length
+                );
+                assert_eq!(metadata.raw_reason(), Some("max_output_tokens"));
+                return;
+            }
+        }
+
+        panic!("incomplete responses stream should yield a final response");
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/providers/deepseek.rs
+++ b/crates/rig-core/src/providers/deepseek.rs
@@ -18,7 +18,7 @@ use crate::client::{
     self, BearerAuth, Capabilities, Capable, DebugExt, ModelLister, Nothing, Provider,
     ProviderBuilder, ProviderClient,
 };
-use crate::completion::GetTokenUsage;
+use crate::completion::GetCompletionMetadata;
 use crate::http_client::{self, HttpClientExt};
 use crate::model::{Model, ModelList, ModelListingError};
 use crate::providers::openai;
@@ -245,7 +245,7 @@ pub struct Usage {
     pub prompt_tokens_details: Option<PromptTokensDetails>,
 }
 
-impl GetTokenUsage for Usage {
+impl GetCompletionMetadata for Usage {
     fn token_usage(&self) -> crate::completion::Usage {
         crate::completion::Usage {
             input_tokens: self.prompt_tokens as u64,
@@ -354,6 +354,9 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
         let choice = response.choices.first().ok_or_else(|| {
             CompletionError::ResponseError("Response contained no choices".to_owned())
         })?;
+        let terminal_metadata = openai::completion::terminal_metadata_from_finish_reason(Some(
+            choice.finish_reason.as_str(),
+        ));
         let content = match &choice.message {
             Message::Assistant {
                 content,
@@ -398,12 +401,12 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
         })?;
 
         let usage = response.usage.token_usage();
-
         Ok(completion::CompletionResponse {
             choice,
             usage,
             raw_response: response,
             message_id: None,
+            terminal_metadata,
         })
     }
 }

--- a/crates/rig-core/src/providers/gemini/completion.rs
+++ b/crates/rig-core/src/providers/gemini/completion.rs
@@ -37,7 +37,7 @@ use crate::providers::gemini::streaming::StreamingCompletionResponse;
 use crate::telemetry::{CompletionOperation, CompletionSpanBuilder, SpanCombinator};
 use crate::{
     OneOrMany,
-    completion::{self, CompletionError, CompletionRequest, GetTokenUsage},
+    completion::{self, CompletionError, CompletionRequest, GetCompletionMetadata},
 };
 use gemini_api_types::{
     Content, FinishReason, FunctionDeclaration, GenerateContentRequest, GenerateContentResponse,
@@ -406,6 +406,68 @@ pub(crate) fn function_call_finish_reason_error(
     }
 }
 
+pub(crate) fn terminal_metadata_from_finish_reason(
+    finish_reason: Option<&FinishReason>,
+) -> Option<completion::CompletionTerminalMetadata> {
+    let finish_reason = finish_reason?;
+    let (reason, raw_reason) = match finish_reason {
+        FinishReason::Stop => (completion::CompletionFinishReason::Stop, "STOP"),
+        FinishReason::MaxTokens => (completion::CompletionFinishReason::Length, "MAX_TOKENS"),
+        FinishReason::Safety => (completion::CompletionFinishReason::ContentFilter, "SAFETY"),
+        FinishReason::Recitation => (
+            completion::CompletionFinishReason::ContentFilter,
+            "RECITATION",
+        ),
+        FinishReason::Language => (
+            completion::CompletionFinishReason::ContentFilter,
+            "LANGUAGE",
+        ),
+        FinishReason::Blocklist => (
+            completion::CompletionFinishReason::ContentFilter,
+            "BLOCKLIST",
+        ),
+        FinishReason::ProhibitedContent => (
+            completion::CompletionFinishReason::ContentFilter,
+            "PROHIBITED_CONTENT",
+        ),
+        FinishReason::Spii => (completion::CompletionFinishReason::ContentFilter, "SPII"),
+        FinishReason::FinishReasonUnspecified => (
+            completion::CompletionFinishReason::Unknown,
+            "FINISH_REASON_UNSPECIFIED",
+        ),
+        FinishReason::Other => (completion::CompletionFinishReason::Unknown, "OTHER"),
+        FinishReason::MalformedFunctionCall => (
+            completion::CompletionFinishReason::Unknown,
+            "MALFORMED_FUNCTION_CALL",
+        ),
+        FinishReason::UnexpectedToolCall => (
+            completion::CompletionFinishReason::Unknown,
+            "UNEXPECTED_TOOL_CALL",
+        ),
+        FinishReason::MissingThoughtSignature => (
+            completion::CompletionFinishReason::Unknown,
+            "MISSING_THOUGHT_SIGNATURE",
+        ),
+        FinishReason::TooManyToolCalls => (
+            completion::CompletionFinishReason::Unknown,
+            "TOO_MANY_TOOL_CALLS",
+        ),
+        FinishReason::MalformedResponse => (
+            completion::CompletionFinishReason::Unknown,
+            "MALFORMED_RESPONSE",
+        ),
+        FinishReason::Unknown(raw_reason) => {
+            return Some(
+                completion::CompletionTerminalMetadata::new(
+                    completion::CompletionFinishReason::Unknown,
+                )
+                .with_raw_reason(raw_reason),
+            );
+        }
+    };
+    Some(completion::CompletionTerminalMetadata::new(reason).with_raw_reason(raw_reason))
+}
+
 impl TryFrom<GenerateContentResponse> for completion::CompletionResponse<GenerateContentResponse> {
     type Error = CompletionError;
 
@@ -420,6 +482,8 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse<Generat
         {
             return Err(err);
         }
+        let terminal_metadata =
+            terminal_metadata_from_finish_reason(candidate.finish_reason.as_ref());
 
         let content = candidate
             .content
@@ -513,7 +577,7 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse<Generat
         let usage = response
             .usage_metadata
             .as_ref()
-            .map(GetTokenUsage::token_usage)
+            .map(GetCompletionMetadata::token_usage)
             .unwrap_or_default();
 
         Ok(completion::CompletionResponse {
@@ -521,6 +585,7 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse<Generat
             usage,
             raw_response: response,
             message_id: None,
+            terminal_metadata,
         })
     }
 }
@@ -535,7 +600,7 @@ pub mod gemini_api_types {
     use serde::{Deserialize, Serialize};
     use serde_json::{Value, json};
 
-    use crate::completion::GetTokenUsage;
+    use crate::completion::GetCompletionMetadata;
     use crate::message::{DocumentSourceKind, ImageMediaType, MessageError, MimeType};
     use crate::{
         completion::CompletionError,
@@ -1424,7 +1489,7 @@ pub mod gemini_api_types {
         }
     }
 
-    impl GetTokenUsage for UsageMetadata {
+    impl GetCompletionMetadata for UsageMetadata {
         fn token_usage(&self) -> crate::completion::Usage {
             let mut usage = crate::completion::Usage::new();
 
@@ -1466,8 +1531,7 @@ pub mod gemini_api_types {
         ProhibitedContent,
     }
 
-    #[derive(Clone, Debug, Deserialize, Serialize)]
-    #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+    #[derive(Clone, Debug)]
     pub enum FinishReason {
         /// Default value. This value is unused.
         FinishReasonUnspecified,
@@ -1499,6 +1563,66 @@ pub mod gemini_api_types {
         TooManyToolCalls,
         /// The provider could not parse the generated response into a valid protocol shape.
         MalformedResponse,
+        /// A provider value introduced after this Rig version.
+        Unknown(String),
+    }
+
+    impl FinishReason {
+        fn as_raw_reason(&self) -> &str {
+            match self {
+                Self::FinishReasonUnspecified => "FINISH_REASON_UNSPECIFIED",
+                Self::Stop => "STOP",
+                Self::MaxTokens => "MAX_TOKENS",
+                Self::Safety => "SAFETY",
+                Self::Recitation => "RECITATION",
+                Self::Language => "LANGUAGE",
+                Self::Other => "OTHER",
+                Self::Blocklist => "BLOCKLIST",
+                Self::ProhibitedContent => "PROHIBITED_CONTENT",
+                Self::Spii => "SPII",
+                Self::MalformedFunctionCall => "MALFORMED_FUNCTION_CALL",
+                Self::UnexpectedToolCall => "UNEXPECTED_TOOL_CALL",
+                Self::MissingThoughtSignature => "MISSING_THOUGHT_SIGNATURE",
+                Self::TooManyToolCalls => "TOO_MANY_TOOL_CALLS",
+                Self::MalformedResponse => "MALFORMED_RESPONSE",
+                Self::Unknown(reason) => reason,
+            }
+        }
+    }
+
+    impl Serialize for FinishReason {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            serializer.serialize_str(self.as_raw_reason())
+        }
+    }
+
+    impl<'de> Deserialize<'de> for FinishReason {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            Ok(match String::deserialize(deserializer)?.as_str() {
+                "FINISH_REASON_UNSPECIFIED" => Self::FinishReasonUnspecified,
+                "STOP" => Self::Stop,
+                "MAX_TOKENS" => Self::MaxTokens,
+                "SAFETY" => Self::Safety,
+                "RECITATION" => Self::Recitation,
+                "LANGUAGE" => Self::Language,
+                "OTHER" => Self::Other,
+                "BLOCKLIST" => Self::Blocklist,
+                "PROHIBITED_CONTENT" => Self::ProhibitedContent,
+                "SPII" => Self::Spii,
+                "MALFORMED_FUNCTION_CALL" => Self::MalformedFunctionCall,
+                "UNEXPECTED_TOOL_CALL" => Self::UnexpectedToolCall,
+                "MISSING_THOUGHT_SIGNATURE" => Self::MissingThoughtSignature,
+                "TOO_MANY_TOOL_CALLS" => Self::TooManyToolCalls,
+                "MALFORMED_RESPONSE" => Self::MalformedResponse,
+                reason => Self::Unknown(reason.to_owned()),
+            })
+        }
     }
 
     #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2204,6 +2328,47 @@ mod tests {
 
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn finish_reason_normalization_preserves_gemini_reason() {
+        use crate::completion::CompletionFinishReason;
+
+        for (raw, expected, expected_raw) in [
+            (FinishReason::Stop, CompletionFinishReason::Stop, "STOP"),
+            (
+                FinishReason::MaxTokens,
+                CompletionFinishReason::Length,
+                "MAX_TOKENS",
+            ),
+            (
+                FinishReason::Safety,
+                CompletionFinishReason::ContentFilter,
+                "SAFETY",
+            ),
+            (
+                FinishReason::Other,
+                CompletionFinishReason::Unknown,
+                "OTHER",
+            ),
+        ] {
+            let metadata = terminal_metadata_from_finish_reason(Some(&raw))
+                .expect("supplied reason should produce metadata");
+            assert_eq!(metadata.reason(), expected);
+            assert_eq!(metadata.raw_reason(), Some(expected_raw));
+        }
+        assert_eq!(terminal_metadata_from_finish_reason(None), None);
+
+        let raw: FinishReason = serde_json::from_str(r#""FUTURE_REASON""#)
+            .expect("unknown provider reasons should deserialize");
+        let metadata = terminal_metadata_from_finish_reason(Some(&raw))
+            .expect("an unknown supplied reason should produce metadata");
+        assert_eq!(metadata.reason(), CompletionFinishReason::Unknown);
+        assert_eq!(metadata.raw_reason(), Some("FUTURE_REASON"));
+        assert_eq!(
+            serde_json::to_string(&raw).expect("unknown reason should serialize"),
+            r#""FUTURE_REASON""#
+        );
+    }
 
     #[test]
     fn test_usage_metadata_deserializes_without_total_token_count() {

--- a/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/mod.rs
@@ -4,7 +4,7 @@
 use base64::{Engine, prelude::BASE64_STANDARD};
 
 use crate::OneOrMany;
-use crate::completion::{self, CompletionError, CompletionRequest, GetTokenUsage};
+use crate::completion::{self, CompletionError, CompletionRequest, GetCompletionMetadata};
 use crate::http_client::HttpClientExt;
 use crate::message::{self, MimeType, Reasoning};
 use crate::telemetry::{CompletionOperation, CompletionSpanBuilder, SpanCombinator};
@@ -503,6 +503,7 @@ impl TryFrom<Interaction> for completion::CompletionResponse<Interaction> {
             usage,
             raw_response: response,
             message_id: None,
+            terminal_metadata: None,
         })
     }
 }
@@ -632,7 +633,7 @@ fn split_data_uri(
 /// Raw request/response types and convenience helpers for the Gemini Interactions API.
 pub mod interactions_api_types {
     use super::split_data_uri;
-    use crate::completion::{CompletionError, GetTokenUsage, Usage};
+    use crate::completion::{CompletionError, GetCompletionMetadata, Usage};
     use crate::message::{self, MimeType};
     use crate::telemetry::ProviderResponseExt;
     use base64::{Engine, prelude::BASE64_STANDARD};
@@ -740,7 +741,7 @@ pub mod interactions_api_types {
         pub input: Option<InteractionInput>,
     }
 
-    impl GetTokenUsage for Interaction {
+    impl GetCompletionMetadata for Interaction {
         fn token_usage(&self) -> Usage {
             self.usage
                 .as_ref()
@@ -1292,7 +1293,7 @@ pub mod interactions_api_types {
         pub total_tokens: Option<u64>,
     }
 
-    impl GetTokenUsage for InteractionUsage {
+    impl GetCompletionMetadata for InteractionUsage {
         fn token_usage(&self) -> Usage {
             let mut usage = Usage::new();
             usage.input_tokens = self.total_input_tokens.unwrap_or_default();

--- a/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/interactions_api/streaming.rs
@@ -12,7 +12,7 @@ use super::interactions_api_types::{
     InteractionSseEvent, InteractionUsage, Step, TextDelta, ThoughtSummaryContent,
     ThoughtSummaryDelta,
 };
-use crate::completion::{CompletionError, CompletionRequest, GetTokenUsage};
+use crate::completion::{CompletionError, CompletionRequest, GetCompletionMetadata};
 use crate::http_client::HttpClientExt;
 use crate::http_client::Request;
 use crate::http_client::sse::{Event, GenericEventSource};
@@ -40,7 +40,7 @@ pub type InteractionEventStream =
 pub type InteractionEventStream =
     Pin<Box<dyn Stream<Item = Result<InteractionSseEvent, CompletionError>>>>;
 
-impl GetTokenUsage for StreamingCompletionResponse {
+impl GetCompletionMetadata for StreamingCompletionResponse {
     fn token_usage(&self) -> crate::completion::Usage {
         self.usage
             .as_ref()

--- a/crates/rig-core/src/providers/gemini/streaming.rs
+++ b/crates/rig-core/src/providers/gemini/streaming.rs
@@ -12,7 +12,7 @@ use super::completion::{
     streaming_endpoint,
 };
 use crate::completion::message::ReasoningContent;
-use crate::completion::{CompletionError, CompletionRequest, GetTokenUsage};
+use crate::completion::{CompletionError, CompletionRequest, GetCompletionMetadata};
 use crate::http_client::HttpClientExt;
 use crate::http_client::sse::{Event, GenericEventSource};
 use crate::streaming;
@@ -45,7 +45,7 @@ pub struct PartialUsage {
     pub traffic_type: Option<TrafficType>,
 }
 
-impl GetTokenUsage for PartialUsage {
+impl GetCompletionMetadata for PartialUsage {
     fn token_usage(&self) -> crate::completion::Usage {
         let mut usage = crate::completion::Usage::new();
 
@@ -82,9 +82,13 @@ pub struct StreamingCompletionResponse {
     pub model_version: Option<String>,
 }
 
-impl GetTokenUsage for StreamingCompletionResponse {
+impl GetCompletionMetadata for StreamingCompletionResponse {
     fn token_usage(&self) -> crate::completion::Usage {
         self.usage_metadata.token_usage()
+    }
+
+    fn terminal_metadata(&self) -> Option<crate::completion::CompletionTerminalMetadata> {
+        super::completion::terminal_metadata_from_finish_reason(self.finish_reason.as_ref())
     }
 }
 
@@ -434,7 +438,7 @@ mod tests {
         let usage = response
             .usage_metadata
             .as_ref()
-            .map(GetTokenUsage::token_usage)
+            .map(GetCompletionMetadata::token_usage)
             .unwrap();
         assert_eq!(usage.input_tokens, 10);
         assert_eq!(usage.output_tokens, 5);

--- a/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
+++ b/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
@@ -13,7 +13,7 @@ use futures::StreamExt;
 use http::Request;
 use tracing_futures::Instrument;
 
-use crate::completion::{CompletionError, GetTokenUsage};
+use crate::completion::{CompletionError, CompletionTerminalMetadata, GetCompletionMetadata};
 use crate::http_client::HttpClientExt;
 use crate::http_client::sse::{Event, GenericEventSource};
 use crate::json_utils;
@@ -83,6 +83,7 @@ impl CompatibleToolCallChunk {
 #[derive(Debug, Clone)]
 pub(crate) struct CompatibleChoice<D> {
     pub(crate) finish_reason: CompatibleFinishReason,
+    pub(crate) terminal_metadata: Option<CompletionTerminalMetadata>,
     pub(crate) text: Option<String>,
     pub(crate) reasoning: Option<String>,
     pub(crate) tool_calls: Vec<CompatibleToolCallChunk>,
@@ -92,6 +93,7 @@ pub(crate) struct CompatibleChoice<D> {
 #[derive(Debug, Clone)]
 pub(crate) struct CompatibleChoiceData<T, D> {
     pub(crate) finish_reason: CompatibleFinishReason,
+    pub(crate) terminal_metadata: Option<CompletionTerminalMetadata>,
     pub(crate) text: Option<String>,
     pub(crate) reasoning: Option<String>,
     pub(crate) tool_calls: Vec<T>,
@@ -116,6 +118,7 @@ where
     fn from(value: CompatibleChoiceData<T, D>) -> Self {
         Self {
             finish_reason: value.finish_reason,
+            terminal_metadata: value.terminal_metadata,
             text: value.text,
             reasoning: value.reasoning,
             tool_calls: value.tool_calls.into_iter().map(Into::into).collect(),
@@ -156,13 +159,17 @@ where
 }
 
 pub(crate) trait CompatibleStreamProfile: WasmCompatSend {
-    type Usage: Clone + Default + GetTokenUsage + WasmCompatSend + 'static;
+    type Usage: Clone + Default + GetCompletionMetadata + WasmCompatSend + 'static;
     type Detail: WasmCompatSend + 'static;
-    type FinalResponse: Clone + Unpin + GetTokenUsage + WasmCompatSend + 'static;
+    type FinalResponse: Clone + Unpin + GetCompletionMetadata + WasmCompatSend + 'static;
 
     fn normalize_chunk(&self, data: &str) -> NormalizedCompatibleChunk<Self::Usage, Self::Detail>;
 
-    fn build_final_response(&self, usage: Self::Usage) -> Self::FinalResponse;
+    fn build_final_response(
+        &self,
+        usage: Self::Usage,
+        terminal_metadata: Option<CompletionTerminalMetadata>,
+    ) -> Self::FinalResponse;
 
     fn uses_distinct_tool_call_eviction(&self) -> bool {
         false
@@ -231,6 +238,7 @@ where
     let stream = stream! {
         let mut tool_calls: HashMap<usize, RawStreamingToolCall> = HashMap::new();
         let mut final_usage = None;
+        let mut terminal_metadata = None;
         let mut terminated_with_error = false;
 
         while let Some(event_result) = event_source.next().await {
@@ -273,6 +281,10 @@ where
                     let Some(choice) = chunk.choice else {
                         continue;
                     };
+
+                    if choice.terminal_metadata.is_some() {
+                        terminal_metadata = choice.terminal_metadata.clone();
+                    }
 
                     for incoming in choice.tool_calls {
                         if let Some(existing) = tool_calls.get(&incoming.index)
@@ -387,7 +399,7 @@ where
         let final_usage = final_usage.unwrap_or_default();
         record_usage(&span, &final_usage);
         yield Ok(RawStreamingChoice::FinalResponse(
-            profile.build_final_response(final_usage),
+            profile.build_final_response(final_usage, terminal_metadata),
         ));
     }
     .instrument(instrument_span);
@@ -399,7 +411,7 @@ where
 
 fn record_usage<T>(span: &tracing::Span, usage: &T)
 where
-    T: GetTokenUsage,
+    T: GetCompletionMetadata,
 {
     if span.is_disabled() {
         return;
@@ -576,7 +588,7 @@ fn take_finalized_tool_calls(
 
 #[cfg(test)]
 pub(crate) mod test_support {
-    use crate::completion::GetTokenUsage;
+    use crate::completion::GetCompletionMetadata;
     use crate::streaming::{self, StreamedAssistantContent};
     use bytes::Bytes;
     use futures::StreamExt;
@@ -613,7 +625,7 @@ pub(crate) mod test_support {
         expected_name: &str,
         expect_final_response: bool,
     ) where
-        R: Clone + Unpin + GetTokenUsage,
+        R: Clone + Unpin + GetCompletionMetadata,
     {
         let mut saw_final = false;
         let mut collected_tool_calls = Vec::new();

--- a/crates/rig-core/src/providers/mira.rs
+++ b/crates/rig-core/src/providers/mira.rs
@@ -313,7 +313,7 @@ impl crate::telemetry::ProviderResponseExt for CompletionResponse {
     }
 }
 
-impl crate::completion::GetTokenUsage for Usage {
+impl crate::completion::GetCompletionMetadata for Usage {
     fn token_usage(&self) -> crate::completion::Usage {
         let mut usage = crate::completion::Usage::new();
         usage.input_tokens = self.prompt_tokens as u64;
@@ -327,7 +327,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
     type Error = CompletionError;
 
     fn try_from(response: CompletionResponse) -> Result<Self, Self::Error> {
-        let (content, usage) = match &response {
+        let (content, usage, terminal_metadata) = match &response {
             CompletionResponse::Structured { choices, usage, .. } => {
                 let choice = choices.first().ok_or_else(|| {
                     CompletionError::ResponseError("Response contained no choices".to_owned())
@@ -390,11 +390,18 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                     }
                 };
 
-                (content, usage)
+                (
+                    content,
+                    usage,
+                    crate::providers::openai::completion::terminal_metadata_from_finish_reason(
+                        choice.finish_reason.as_deref(),
+                    ),
+                )
             }
             CompletionResponse::Simple(text) => (
                 vec![completion::AssistantContent::text(text)],
                 completion::Usage::new(),
+                None,
             ),
         };
 
@@ -409,6 +416,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             usage,
             raw_response: response,
             message_id: None,
+            terminal_metadata,
         })
     }
 }

--- a/crates/rig-core/src/providers/mistral/completion.rs
+++ b/crates/rig-core/src/providers/mistral/completion.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Deserializer, Serialize};
 
 use super::client::{MistralExt, Usage};
-use crate::completion::GetTokenUsage;
+use crate::completion::GetCompletionMetadata;
 use crate::providers::openai;
 use crate::{
     OneOrMany,
@@ -175,7 +175,7 @@ impl crate::telemetry::ProviderResponseExt for CompletionResponse {
     }
 }
 
-impl GetTokenUsage for Usage {
+impl GetCompletionMetadata for Usage {
     fn token_usage(&self) -> crate::completion::Usage {
         let mut usage = crate::completion::Usage::new();
         usage.input_tokens = self.prompt_tokens as u64;
@@ -186,11 +186,11 @@ impl GetTokenUsage for Usage {
     }
 }
 
-impl GetTokenUsage for CompletionResponse {
+impl GetCompletionMetadata for CompletionResponse {
     fn token_usage(&self) -> crate::completion::Usage {
         self.usage
             .as_ref()
-            .map(GetTokenUsage::token_usage)
+            .map(GetCompletionMetadata::token_usage)
             .unwrap_or_default()
     }
 }
@@ -202,6 +202,9 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
         let choice = response.choices.first().ok_or_else(|| {
             CompletionError::ResponseError("Response contained no choices".to_owned())
         })?;
+        let terminal_metadata = openai::completion::terminal_metadata_from_finish_reason(Some(
+            choice.finish_reason.as_str(),
+        ));
         let content = match &choice.message {
             Message::Assistant {
                 content,
@@ -254,12 +257,12 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             .unwrap_or_default();
 
         let message_id = response.id.clone();
-
         Ok(completion::CompletionResponse {
             choice,
             usage,
             raw_response: response,
             message_id: Some(message_id),
+            terminal_metadata,
         })
     }
 }

--- a/crates/rig-core/src/providers/ollama.rs
+++ b/crates/rig-core/src/providers/ollama.rs
@@ -41,7 +41,7 @@ use crate::client::{
     self, ApiKey, Capabilities, Capable, DebugExt, ModelLister, Nothing, Provider, ProviderBuilder,
     ProviderClient,
 };
-use crate::completion::{GetTokenUsage, Usage};
+use crate::completion::{GetCompletionMetadata, Usage};
 use crate::http_client::{self, HttpClientExt};
 use crate::message::DocumentSourceKind;
 use crate::model::{Model, ModelList, ModelListingError};
@@ -323,6 +323,7 @@ pub struct CompletionResponse {
 impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionResponse> {
     type Error = CompletionError;
     fn try_from(resp: CompletionResponse) -> Result<Self, Self::Error> {
+        let terminal_metadata = terminal_metadata_from_done_reason(resp.done_reason.as_deref());
         match resp.message {
             // Process only if an assistant message is present.
             Message::Assistant {
@@ -403,6 +404,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                     },
                     raw_response,
                     message_id: None,
+                    terminal_metadata,
                 })
             }
             _ => Err(CompletionError::ResponseError(
@@ -410,6 +412,18 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             )),
         }
     }
+}
+
+fn terminal_metadata_from_done_reason(
+    raw_reason: Option<&str>,
+) -> Option<completion::CompletionTerminalMetadata> {
+    let raw_reason = raw_reason?;
+    let reason = match raw_reason {
+        "stop" => completion::CompletionFinishReason::Stop,
+        "length" => completion::CompletionFinishReason::Length,
+        _ => completion::CompletionFinishReason::Unknown,
+    };
+    Some(completion::CompletionTerminalMetadata::new(reason).with_raw_reason(raw_reason))
 }
 
 /// Older reasoning models served by Ollama sometimes returned their reasoning
@@ -604,7 +618,7 @@ pub struct StreamingCompletionResponse {
     pub eval_duration: Option<u64>,
 }
 
-impl GetTokenUsage for StreamingCompletionResponse {
+impl GetCompletionMetadata for StreamingCompletionResponse {
     fn token_usage(&self) -> crate::completion::Usage {
         let mut usage = crate::completion::Usage::new();
         let input_tokens = self.prompt_eval_count.unwrap_or_default();
@@ -614,6 +628,10 @@ impl GetTokenUsage for StreamingCompletionResponse {
         usage.total_tokens = input_tokens + output_tokens;
 
         usage
+    }
+
+    fn terminal_metadata(&self) -> Option<completion::CompletionTerminalMetadata> {
+        terminal_metadata_from_done_reason(self.done_reason.as_deref())
     }
 }
 
@@ -1305,6 +1323,23 @@ pub struct ImageUrl {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn done_reason_normalization_preserves_unknown_and_missing_values() {
+        use crate::completion::CompletionFinishReason;
+
+        for (raw, expected) in [
+            ("stop", CompletionFinishReason::Stop),
+            ("length", CompletionFinishReason::Length),
+            ("load", CompletionFinishReason::Unknown),
+        ] {
+            let metadata = terminal_metadata_from_done_reason(Some(raw))
+                .expect("supplied reason should produce metadata");
+            assert_eq!(metadata.reason(), expected);
+            assert_eq!(metadata.raw_reason(), Some(raw));
+        }
+        assert_eq!(terminal_metadata_from_done_reason(None), None);
+    }
 
     #[test]
     fn splits_legacy_reasoning_with_or_without_opening_marker() {

--- a/crates/rig-core/src/providers/openai/completion/mod.rs
+++ b/crates/rig-core/src/providers/openai/completion/mod.rs
@@ -4,7 +4,7 @@
 
 use super::{client::ApiResponse, streaming::StreamingCompletionResponse};
 use crate::completion::{
-    CompletionError, CompletionRequest as CoreCompletionRequest, GetTokenUsage,
+    CompletionError, CompletionRequest as CoreCompletionRequest, GetCompletionMetadata,
 };
 use crate::http_client::{self, HttpClientExt};
 use crate::message::{AudioMediaType, DocumentSourceKind, ImageDetail, MimeType};
@@ -1145,6 +1145,8 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
         let choice = response.choices.first().ok_or_else(|| {
             CompletionError::ResponseError("Response contained no choices".to_owned())
         })?;
+        let terminal_metadata =
+            terminal_metadata_from_finish_reason(Some(choice.finish_reason.as_str()));
 
         let content = match &choice.message {
             Message::Assistant {
@@ -1203,16 +1205,34 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
         let usage = response
             .usage
             .as_ref()
-            .map(GetTokenUsage::token_usage)
+            .map(GetCompletionMetadata::token_usage)
             .unwrap_or_default();
-
         Ok(completion::CompletionResponse {
             choice,
             usage,
             raw_response: response,
             message_id: None,
+            terminal_metadata,
         })
     }
+}
+
+/// Normalize an OpenAI Chat Completions-compatible finish reason.
+///
+/// This helper is shared by blocking and streaming adapters, including the
+/// provider implementations that use the common compatible transport.
+pub(crate) fn terminal_metadata_from_finish_reason(
+    raw_reason: Option<&str>,
+) -> Option<completion::CompletionTerminalMetadata> {
+    let raw_reason = raw_reason?;
+    let reason = match raw_reason {
+        "stop" => completion::CompletionFinishReason::Stop,
+        "length" => completion::CompletionFinishReason::Length,
+        "tool_calls" | "function_call" => completion::CompletionFinishReason::ToolCalls,
+        "content_filter" => completion::CompletionFinishReason::ContentFilter,
+        _ => completion::CompletionFinishReason::Unknown,
+    };
+    Some(completion::CompletionTerminalMetadata::new(reason).with_raw_reason(raw_reason))
 }
 
 impl ProviderResponseExt for CompletionResponse {
@@ -1358,7 +1378,7 @@ impl fmt::Display for Usage {
     }
 }
 
-impl GetTokenUsage for Usage {
+impl GetCompletionMetadata for Usage {
     fn token_usage(&self) -> crate::completion::Usage {
         let mut usage = crate::providers::internal::completion_usage(
             self.prompt_tokens as u64,
@@ -1437,7 +1457,7 @@ pub trait OpenAICompatibleProvider: crate::client::Provider {
     /// fallbacks, DeepSeek's cache hit/miss counters) substitute their own.
     type StreamingUsage: Clone
         + Default
-        + GetTokenUsage
+        + GetCompletionMetadata
         + Serialize
         + serde::de::DeserializeOwned
         + Unpin
@@ -1448,7 +1468,7 @@ pub trait OpenAICompatibleProvider: crate::client::Provider {
     /// The chat-completions payload this provider returns.
     type Response: serde::de::DeserializeOwned
         + Serialize
-        + crate::telemetry::ProviderResponseExt<Usage: GetTokenUsage>
+        + crate::telemetry::ProviderResponseExt<Usage: GetCompletionMetadata>
         + TryInto<completion::CompletionResponse<Self::Response>, Error = CompletionError>
         + WasmCompatSend
         + WasmCompatSync;
@@ -2054,6 +2074,26 @@ mod tests {
     use crate::telemetry::ProviderResponseExt;
     use crate::test_utils::MockCompletionModel;
     use std::collections::HashMap;
+
+    #[test]
+    fn finish_reason_normalization_preserves_known_unknown_and_missing_values() {
+        use crate::completion::CompletionFinishReason;
+
+        for (raw, expected) in [
+            ("stop", CompletionFinishReason::Stop),
+            ("length", CompletionFinishReason::Length),
+            ("tool_calls", CompletionFinishReason::ToolCalls),
+            ("function_call", CompletionFinishReason::ToolCalls),
+            ("content_filter", CompletionFinishReason::ContentFilter),
+            ("future_reason", CompletionFinishReason::Unknown),
+        ] {
+            let metadata = terminal_metadata_from_finish_reason(Some(raw))
+                .expect("supplied reason should produce metadata");
+            assert_eq!(metadata.reason(), expected);
+            assert_eq!(metadata.raw_reason(), Some(raw));
+        }
+        assert_eq!(terminal_metadata_from_finish_reason(None), None);
+    }
 
     fn test_document(id: &str, text: &str) -> crate::completion::Document {
         crate::completion::Document {

--- a/crates/rig-core/src/providers/openai/completion/streaming.rs
+++ b/crates/rig-core/src/providers/openai/completion/streaming.rs
@@ -4,7 +4,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tracing::{Level, enabled};
 
-use crate::completion::{CompletionError, CompletionRequest, GetTokenUsage};
+use crate::completion::{
+    CompletionError, CompletionRequest, CompletionTerminalMetadata, GetCompletionMetadata,
+};
 use crate::http_client::HttpClientExt;
 use crate::json_utils::{self, merge};
 use crate::providers::internal::openai_chat_completions_compatible::{
@@ -118,14 +120,21 @@ struct StreamingCompletionChunk<U = Usage> {
 #[derive(Clone, Serialize, Deserialize)]
 pub struct StreamingCompletionResponse<U = Usage> {
     pub usage: U,
+    /// Canonical terminal metadata captured from the final choice chunk.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal_metadata: Option<CompletionTerminalMetadata>,
 }
 
-impl<U> GetTokenUsage for StreamingCompletionResponse<U>
+impl<U> GetCompletionMetadata for StreamingCompletionResponse<U>
 where
-    U: GetTokenUsage,
+    U: GetCompletionMetadata,
 {
     fn token_usage(&self) -> crate::completion::Usage {
         self.usage.token_usage()
+    }
+
+    fn terminal_metadata(&self) -> Option<CompletionTerminalMetadata> {
+        self.terminal_metadata.clone()
     }
 }
 
@@ -244,7 +253,7 @@ where
     Ext: OpenAICompatibleProvider + Clone + crate::wasm_compat::WasmCompatSend,
     U: Clone
         + Default
-        + GetTokenUsage
+        + GetCompletionMetadata
         + serde::de::DeserializeOwned
         + crate::wasm_compat::WasmCompatSend
         + Unpin
@@ -282,6 +291,16 @@ where
                         }
                         _ => CompatibleFinishReason::Other,
                     },
+                    terminal_metadata: choice.finish_reason.as_ref().and_then(|reason| {
+                        let raw_reason = match reason {
+                            FinishReason::ToolCalls => "tool_calls",
+                            FinishReason::Stop => "stop",
+                            FinishReason::ContentFilter => "content_filter",
+                            FinishReason::Length => "length",
+                            FinishReason::Other(reason) => reason.as_str(),
+                        };
+                        super::terminal_metadata_from_finish_reason(Some(raw_reason))
+                    }),
                     text: choice.delta.content.clone(),
                     reasoning: choice
                         .delta
@@ -297,8 +316,15 @@ where
         ))
     }
 
-    fn build_final_response(&self, usage: Self::Usage) -> Self::FinalResponse {
-        StreamingCompletionResponse { usage }
+    fn build_final_response(
+        &self,
+        usage: Self::Usage,
+        terminal_metadata: Option<CompletionTerminalMetadata>,
+    ) -> Self::FinalResponse {
+        StreamingCompletionResponse {
+            usage,
+            terminal_metadata,
+        }
     }
 
     fn decorate_tool_call(
@@ -716,7 +742,7 @@ mod tests {
             80
         );
 
-        // Verify core Usage also has cached_input_tokens via GetTokenUsage
+        // Verify core Usage also has cached_input_tokens via GetCompletionMetadata
         let core_usage = res.token_usage();
         assert_eq!(core_usage.cached_input_tokens, 80);
         assert_eq!(core_usage.input_tokens, 100);

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -15,7 +15,7 @@
 //! ```
 use super::InputAudio;
 use super::responses_api::streaming::StreamingCompletionResponse;
-use crate::completion::{CompletionError, GetTokenUsage};
+use crate::completion::{CompletionError, GetCompletionMetadata};
 use crate::http_client;
 use crate::http_client::HttpClientExt;
 use crate::json_utils;
@@ -958,7 +958,7 @@ impl ResponsesUsage {
     }
 }
 
-impl GetTokenUsage for ResponsesUsage {
+impl GetCompletionMetadata for ResponsesUsage {
     fn token_usage(&self) -> crate::completion::Usage {
         crate::completion::Usage {
             input_tokens: self.input_tokens,
@@ -2305,6 +2305,16 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
     type Error = CompletionError;
 
     fn try_from(response: CompletionResponse) -> Result<Self, Self::Error> {
+        if matches!(
+            response.status,
+            ResponseStatus::Failed | ResponseStatus::Cancelled
+        ) {
+            let body = serde_json::to_string(&response).unwrap_or_else(|_| {
+                format!("OpenAI response ended with status {:?}", response.status)
+            });
+            return Err(crate::provider_response::completion_error_from_body(body));
+        }
+        let terminal_metadata = terminal_metadata_from_response(&response);
         // Extract the msg_ ID from the first Output::Message item
         let message_id = response.output.iter().find_map(|item| match item {
             Output::Message(msg) => Some(msg.id.clone()),
@@ -2344,7 +2354,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
         let usage = response
             .usage
             .as_ref()
-            .map(GetTokenUsage::token_usage)
+            .map(GetCompletionMetadata::token_usage)
             .unwrap_or_default();
 
         Ok(completion::CompletionResponse {
@@ -2352,8 +2362,35 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             usage,
             raw_response: response,
             message_id,
+            terminal_metadata,
         })
     }
+}
+
+pub(crate) fn terminal_metadata_from_response(
+    response: &CompletionResponse,
+) -> Option<completion::CompletionTerminalMetadata> {
+    let (reason, raw_reason) = match response.status {
+        ResponseStatus::Completed => (completion::CompletionFinishReason::Stop, "completed"),
+        ResponseStatus::Incomplete => {
+            let raw_reason = response.incomplete_details.as_ref()?.reason.as_str();
+            return Some(terminal_metadata_from_incomplete_reason(raw_reason));
+        }
+        ResponseStatus::Failed | ResponseStatus::Cancelled => return None,
+        ResponseStatus::InProgress | ResponseStatus::Queued => return None,
+    };
+    Some(completion::CompletionTerminalMetadata::new(reason).with_raw_reason(raw_reason))
+}
+
+pub(crate) fn terminal_metadata_from_incomplete_reason(
+    raw_reason: &str,
+) -> completion::CompletionTerminalMetadata {
+    let reason = match raw_reason {
+        "max_output_tokens" => completion::CompletionFinishReason::Length,
+        "content_filter" => completion::CompletionFinishReason::ContentFilter,
+        _ => completion::CompletionFinishReason::Unknown,
+    };
+    completion::CompletionTerminalMetadata::new(reason).with_raw_reason(raw_reason)
 }
 
 /// An OpenAI Responses API message.
@@ -2778,6 +2815,45 @@ mod tests {
                 "required": ["location"]
             }),
         }
+    }
+
+    #[test]
+    fn incomplete_response_exposes_length_metadata_without_losing_raw_response() {
+        let response: CompletionResponse = serde_json::from_value(json!({
+            "id": "resp_incomplete",
+            "object": "response",
+            "created_at": 0,
+            "status": "incomplete",
+            "incomplete_details": { "reason": "max_output_tokens" },
+            "model": "gpt-test",
+            "output": [{
+                "type": "message",
+                "id": "msg_incomplete",
+                "status": "incomplete",
+                "role": "assistant",
+                "content": [{
+                    "type": "output_text",
+                    "annotations": [],
+                    "text": "partial"
+                }]
+            }],
+            "tools": []
+        }))
+        .expect("incomplete response should deserialize");
+
+        let converted: completion::CompletionResponse<CompletionResponse> = response
+            .try_into()
+            .expect("an output-limited response remains a successful completion");
+        let metadata = converted
+            .terminal_metadata
+            .as_ref()
+            .expect("incomplete reason should be normalized");
+        assert_eq!(
+            metadata.reason(),
+            completion::CompletionFinishReason::Length
+        );
+        assert_eq!(metadata.raw_reason(), Some("max_output_tokens"));
+        assert_eq!(converted.raw_response.status, ResponseStatus::Incomplete);
     }
 
     fn rig_tool_result(content: message::ToolResultContent) -> message::Message {

--- a/crates/rig-core/src/providers/openai/responses_api/streaming.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/streaming.rs
@@ -1,6 +1,6 @@
 //! The streaming module for the OpenAI Responses API.
 //! Please see the `openai_streaming` or `openai_streaming_with_tools` example for more practical usage.
-use crate::completion::{self, CompletionError, GetTokenUsage};
+use crate::completion::{self, CompletionError, CompletionTerminalMetadata, GetCompletionMetadata};
 use crate::http_client::HttpClientExt;
 use crate::http_client::sse::{Event, GenericEventSource};
 use crate::message::ReasoningContent;
@@ -45,6 +45,9 @@ pub struct StreamingCompletionResponse {
     /// The effective reasoning context from the terminal response event.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning_context: Option<String>,
+    /// Canonical terminal metadata from the terminal response event.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal_metadata: Option<CompletionTerminalMetadata>,
 }
 
 pub(crate) fn reasoning_choices_from_done_item(
@@ -81,9 +84,13 @@ pub(crate) fn reasoning_choices_from_done_item(
     choices
 }
 
-impl GetTokenUsage for StreamingCompletionResponse {
+impl GetCompletionMetadata for StreamingCompletionResponse {
     fn token_usage(&self) -> crate::completion::Usage {
         self.usage.token_usage()
+    }
+
+    fn terminal_metadata(&self) -> Option<CompletionTerminalMetadata> {
+        self.terminal_metadata.clone()
     }
 }
 
@@ -175,11 +182,12 @@ pub(crate) fn parse_sse_completion_body(
             if let StreamingCompletionChunk::Response(chunk) = chunk {
                 let ResponseChunk { kind, response, .. } = *chunk;
                 match kind {
-                    ResponseChunkKind::ResponseCompleted => {
+                    ResponseChunkKind::ResponseCompleted
+                    | ResponseChunkKind::ResponseIncomplete => {
                         completed = Some(response);
                         break;
                     }
-                    ResponseChunkKind::ResponseFailed | ResponseChunkKind::ResponseIncomplete => {
+                    ResponseChunkKind::ResponseFailed => {
                         return Err(crate::provider_response::completion_error_from_body(data));
                     }
                     _ => {}
@@ -194,13 +202,13 @@ pub(crate) fn parse_sse_completion_body(
         };
 
         match value.get("type").and_then(serde_json::Value::as_str) {
-            Some("response.completed") => {
+            Some("response.completed") | Some("response.incomplete") => {
                 if let Some(response) = value.get("response") {
                     completed = Some(serde_json::from_value(response.clone())?);
                     break;
                 }
             }
-            Some("response.failed") | Some("response.incomplete") => {
+            Some("response.failed") => {
                 return Err(crate::provider_response::completion_error_from_body(data));
             }
             Some("error") => {
@@ -212,7 +220,7 @@ pub(crate) fn parse_sse_completion_body(
 
     completed.ok_or_else(|| {
         CompletionError::ProviderError(format!(
-            "{provider_name} stream did not yield response.completed"
+            "{provider_name} stream did not yield a terminal response"
         ))
     })
 }
@@ -221,6 +229,7 @@ struct RawChoiceAccumulator {
     final_usage: ResponsesUsage,
     reasoning_metadata: Option<serde_json::Map<String, serde_json::Value>>,
     reasoning_context: Option<String>,
+    terminal_metadata: Option<CompletionTerminalMetadata>,
     tool_calls: Vec<StreamingRawChoice>,
     tool_call_internal_ids: std::collections::HashMap<String, String>,
 }
@@ -231,6 +240,7 @@ impl RawChoiceAccumulator {
             final_usage: initial_usage,
             reasoning_metadata: None,
             reasoning_context: None,
+            terminal_metadata: None,
             tool_calls: Vec::new(),
             tool_call_internal_ids: std::collections::HashMap::new(),
         }
@@ -317,7 +327,8 @@ impl RawChoiceAccumulator {
         raw_event_data: &str,
     ) -> Result<(), CompletionError> {
         match kind {
-            ResponseChunkKind::ResponseCompleted => {
+            ResponseChunkKind::ResponseCompleted | ResponseChunkKind::ResponseIncomplete => {
+                self.terminal_metadata = super::terminal_metadata_from_response(&response);
                 if let Some(usage) = response.usage {
                     self.final_usage = usage;
                 }
@@ -329,7 +340,7 @@ impl RawChoiceAccumulator {
                 }
                 Ok(())
             }
-            ResponseChunkKind::ResponseFailed | ResponseChunkKind::ResponseIncomplete => Err(
+            ResponseChunkKind::ResponseFailed => Err(
                 crate::provider_response::completion_error_from_body(raw_event_data),
             ),
             _ => Ok(()),
@@ -396,6 +407,7 @@ impl RawChoiceAccumulator {
                 usage: self.final_usage,
                 reasoning_metadata: self.reasoning_metadata,
                 reasoning_context: self.reasoning_context,
+                terminal_metadata: self.terminal_metadata,
             },
         ));
         choices
@@ -565,7 +577,7 @@ pub(crate) async fn completion_response_from_sse_body(
         usage: stream
             .response
             .as_ref()
-            .map(GetTokenUsage::token_usage)
+            .map(GetCompletionMetadata::token_usage)
             .unwrap_or_else(|| usage_from_raw_response(&raw_response)),
         message_id: stream
             .message_id
@@ -573,6 +585,7 @@ pub(crate) async fn completion_response_from_sse_body(
             .or_else(|| message_id_from_response(&raw_response)),
         choice: stream.choice,
         raw_response,
+        terminal_metadata: stream.response.terminal_metadata(),
     })
 }
 
@@ -596,7 +609,7 @@ fn usage_from_raw_response(response: &CompletionResponse) -> completion::Usage {
     response
         .usage
         .as_ref()
-        .map(GetTokenUsage::token_usage)
+        .map(GetCompletionMetadata::token_usage)
         .unwrap_or_default()
 }
 
@@ -1330,7 +1343,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn response_incomplete_chunk_uses_incomplete_details_reason() {
+    async fn response_incomplete_chunk_exposes_length_terminal_metadata() {
         let mut response = sample_response(ResponseStatus::Incomplete);
         response.incomplete_details = Some(IncompleteDetailsReason {
             reason: "max_output_tokens".to_string(),
@@ -1342,16 +1355,16 @@ mod tests {
             "response": response,
         });
 
-        let err = first_error_from_event(event).await;
+        let response = final_response_from_event(event).await;
+        let metadata = response
+            .terminal_metadata
+            .expect("incomplete response should retain terminal metadata");
 
-        assert!(matches!(
-            err,
-            crate::completion::CompletionError::ProviderResponse(_)
-        ));
-        assert_eq!(err.provider_response_status(), None);
-        assert!(err.provider_response_body().is_some_and(|body| {
-            body.contains("response.incomplete") && body.contains("max_output_tokens")
-        }));
+        assert_eq!(
+            metadata.reason(),
+            crate::completion::CompletionFinishReason::Length
+        );
+        assert_eq!(metadata.raw_reason(), Some("max_output_tokens"));
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/providers/openai/responses_api/websocket.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/websocket.rs
@@ -622,7 +622,7 @@ fn terminal_response_result(
     response: CompletionResponse,
 ) -> Result<CompletionResponse, CompletionError> {
     match response.status {
-        ResponseStatus::Completed => Ok(response),
+        ResponseStatus::Completed | ResponseStatus::Incomplete => Ok(response),
         // Deliberate two-tier behaviour: when the provider supplies its own error
         // object we preserve the full failed-response envelope through
         // `from_provider_body` (status: None, no HTTP status on the websocket
@@ -641,16 +641,6 @@ fn terminal_response_result(
                 "failed response",
             ))),
         },
-        ResponseStatus::Incomplete => {
-            let reason = response
-                .incomplete_details
-                .as_ref()
-                .map(|details| details.reason.as_str())
-                .unwrap_or("unknown reason");
-            Err(CompletionError::ProviderError(format!(
-                "OpenAI websocket response was incomplete: {reason}"
-            )))
-        }
         other => Err(CompletionError::ProviderError(format!(
             "OpenAI websocket response ended in state {other:?}"
         ))),
@@ -833,7 +823,8 @@ mod tests {
     use crate::client::CompletionClient;
     use crate::completion::CompletionModel;
     use crate::providers::openai::responses_api::{
-        CompletionResponse, ResponseError, ResponseObject, ResponseStatus, ResponsesUsage,
+        CompletionResponse, IncompleteDetailsReason, ResponseError, ResponseObject, ResponseStatus,
+        ResponsesUsage,
     };
     use futures::{SinkExt, StreamExt};
     use serde_json::json;
@@ -1035,10 +1026,18 @@ mod tests {
     }
 
     #[test]
-    fn terminal_response_requires_completed_status() {
+    fn terminal_response_accepts_completed_and_incomplete_statuses() {
         let completed = terminal_response_result(sample_response(ResponseStatus::Completed))
             .expect("completed response should succeed");
         assert_eq!(completed.id, "resp_123");
+
+        let mut incomplete = sample_response(ResponseStatus::Incomplete);
+        incomplete.incomplete_details = Some(IncompleteDetailsReason {
+            reason: "max_output_tokens".to_string(),
+        });
+        let incomplete = terminal_response_result(incomplete)
+            .expect("incomplete response contains a successful partial completion");
+        assert_eq!(incomplete.status, ResponseStatus::Incomplete);
 
         let failed = terminal_response_result(sample_response(ResponseStatus::Failed))
             .expect_err("failed response should error");

--- a/crates/rig-core/src/providers/openrouter/client.rs
+++ b/crates/rig-core/src/providers/openrouter/client.rs
@@ -3,7 +3,7 @@ use crate::{
         self, BearerAuth, Capabilities, Capable, DebugExt, Nothing, Provider, ProviderBuilder,
         ProviderClient,
     },
-    completion::GetTokenUsage,
+    completion::GetCompletionMetadata,
     http_client,
 };
 use http::HeaderValue;
@@ -120,7 +120,7 @@ impl std::fmt::Display for Usage {
     }
 }
 
-impl GetTokenUsage for Usage {
+impl GetCompletionMetadata for Usage {
     fn token_usage(&self) -> crate::completion::Usage {
         let (cached_input, cache_creation) = self
             .prompt_tokens_details

--- a/crates/rig-core/src/providers/openrouter/completion.rs
+++ b/crates/rig-core/src/providers/openrouter/completion.rs
@@ -582,6 +582,9 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
         let choice = response.choices.first().ok_or_else(|| {
             CompletionError::ResponseError("Response contained no choices".to_owned())
         })?;
+        let terminal_metadata = openai::completion::terminal_metadata_from_finish_reason(
+            choice.finish_reason.as_deref(),
+        );
 
         let content = match &choice.message {
             Message::Assistant {
@@ -727,12 +730,12 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
                 }
             })
             .unwrap_or_default();
-
         Ok(completion::CompletionResponse {
             choice,
             usage,
             raw_response: response,
             message_id: None,
+            terminal_metadata,
         })
     }
 }

--- a/crates/rig-core/src/providers/xai/completion.rs
+++ b/crates/rig-core/src/providers/xai/completion.rs
@@ -11,11 +11,14 @@ use tracing::{Instrument, Level, enabled};
 use super::api::{ApiResponse, Message, ToolDefinition};
 use super::client::Client;
 use crate::OneOrMany;
-use crate::completion::{self, CompletionError, CompletionRequest, GetTokenUsage};
+use crate::completion::{self, CompletionError, CompletionRequest, GetCompletionMetadata};
 use crate::http_client::HttpClientExt;
 use crate::providers::openai::responses_api::ToolChoice;
 use crate::providers::openai::responses_api::streaming::StreamingCompletionResponse;
-use crate::providers::openai::responses_api::{Output, ResponsesUsage};
+use crate::providers::openai::responses_api::{
+    IncompleteDetailsReason, Output, ResponseError, ResponsesUsage,
+    terminal_metadata_from_incomplete_reason,
+};
 use crate::streaming::StreamingCompletionResponse as BaseStreamingCompletionResponse;
 
 /// xAI completion models as of 2025-06-04
@@ -128,6 +131,10 @@ pub struct CompletionResponse {
     pub object: String,
     #[serde(default)]
     pub status: Option<String>,
+    #[serde(default)]
+    pub incomplete_details: Option<IncompleteDetailsReason>,
+    #[serde(default)]
+    pub error: Option<ResponseError>,
     pub usage: Option<ResponsesUsage>,
 }
 
@@ -135,6 +142,16 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
     type Error = CompletionError;
 
     fn try_from(response: CompletionResponse) -> Result<Self, Self::Error> {
+        if matches!(response.status.as_deref(), Some("failed" | "cancelled")) {
+            return Err(match serde_json::to_string(&response) {
+                Ok(body) => CompletionError::from_provider_body(body),
+                Err(error) => CompletionError::ProviderError(format!(
+                    "xAI response ended with status {}; failed to preserve response: {error}",
+                    response.status.as_deref().unwrap_or_default()
+                )),
+            });
+        }
+        let terminal_metadata = terminal_metadata_from_response(&response);
         let content: Vec<completion::AssistantContent> = response
             .output
             .iter()
@@ -149,7 +166,7 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
         let usage = response
             .usage
             .as_ref()
-            .map(GetTokenUsage::token_usage)
+            .map(GetCompletionMetadata::token_usage)
             .unwrap_or_default();
         let message_id = response.output.iter().find_map(|item| match item {
             Output::Message(message) => Some(message.id.clone()),
@@ -161,8 +178,28 @@ impl TryFrom<CompletionResponse> for completion::CompletionResponse<CompletionRe
             usage,
             raw_response: response,
             message_id,
+            terminal_metadata,
         })
     }
+}
+
+fn terminal_metadata_from_response(
+    response: &CompletionResponse,
+) -> Option<completion::CompletionTerminalMetadata> {
+    let raw_status = response.status.as_deref()?;
+    let reason = match raw_status {
+        "completed" => completion::CompletionFinishReason::Stop,
+        "incomplete" => {
+            return response
+                .incomplete_details
+                .as_ref()
+                .map(|details| terminal_metadata_from_incomplete_reason(&details.reason));
+        }
+        "failed" | "cancelled" => return None,
+        "in_progress" | "queued" => return None,
+        _ => completion::CompletionFinishReason::Unknown,
+    };
+    Some(completion::CompletionTerminalMetadata::new(reason).with_raw_reason(raw_status))
 }
 
 // ================================================================
@@ -276,12 +313,112 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::XAICompletionRequest;
+    use super::{
+        CompletionResponse as XAICompletionResponse, XAICompletionRequest,
+        terminal_metadata_from_response,
+    };
     use crate::OneOrMany;
     use crate::completion::request::Document;
     use crate::completion::{CompletionRequest, CompletionRequestBuilder, Message, ToolDefinition};
     use crate::message::ToolChoice;
     use crate::test_utils::MockCompletionModel;
+
+    #[test]
+    fn response_status_normalization_preserves_raw_status() {
+        use crate::completion::CompletionFinishReason;
+
+        let response: XAICompletionResponse = serde_json::from_value(serde_json::json!({
+            "id": "status-test",
+            "model": "grok-test",
+            "output": [],
+            "status": "completed",
+            "usage": null
+        }))
+        .expect("status fixture should deserialize");
+        let completed = terminal_metadata_from_response(&response)
+            .expect("completed status should be terminal");
+        assert_eq!(completed.reason(), CompletionFinishReason::Stop);
+        assert_eq!(completed.raw_reason(), Some("completed"));
+
+        let mut response = response;
+        response.status = Some("future_status".to_string());
+        let unknown = terminal_metadata_from_response(&response)
+            .expect("unknown terminal status should be preserved");
+        assert_eq!(unknown.reason(), CompletionFinishReason::Unknown);
+        assert_eq!(unknown.raw_reason(), Some("future_status"));
+
+        response.status = Some("in_progress".to_string());
+        assert_eq!(terminal_metadata_from_response(&response), None);
+        response.status = None;
+        assert_eq!(terminal_metadata_from_response(&response), None);
+    }
+
+    #[test]
+    fn incomplete_response_uses_provider_reason_for_terminal_metadata() {
+        use crate::completion::CompletionFinishReason;
+
+        for (raw_reason, expected) in [
+            ("max_output_tokens", CompletionFinishReason::Length),
+            ("content_filter", CompletionFinishReason::ContentFilter),
+            ("future_limit", CompletionFinishReason::Unknown),
+        ] {
+            let raw: XAICompletionResponse = serde_json::from_value(serde_json::json!({
+                "id": "resp_incomplete",
+                "model": "grok-test",
+                "status": "incomplete",
+                "incomplete_details": { "reason": raw_reason },
+                "output": [{
+                    "type": "message",
+                    "id": "msg_incomplete",
+                    "role": "assistant",
+                    "status": "incomplete",
+                    "content": [{
+                        "type": "output_text",
+                        "text": "partial",
+                        "annotations": []
+                    }]
+                }],
+                "usage": null
+            }))
+            .expect("incomplete response should deserialize");
+
+            let converted = crate::completion::CompletionResponse::try_from(raw)
+                .expect("partial completion should remain successful");
+            let metadata = converted
+                .terminal_metadata
+                .expect("incomplete reason should be normalized");
+            assert_eq!(metadata.reason(), expected);
+            assert_eq!(metadata.raw_reason(), Some(raw_reason));
+        }
+    }
+
+    #[test]
+    fn failed_response_preserves_provider_envelope() {
+        let response: XAICompletionResponse = serde_json::from_value(serde_json::json!({
+            "id": "xai-error",
+            "model": "grok-test",
+            "output": [],
+            "status": "failed",
+            "error": {
+                "code": "server_error",
+                "message": "xAI generation failed"
+            },
+            "usage": null
+        }))
+        .expect("failed response should deserialize");
+
+        let error = crate::completion::CompletionResponse::try_from(response)
+            .expect_err("failed status must remain a provider error");
+        assert_eq!(error.provider_response_status(), None);
+        let preserved = error
+            .provider_response_json()
+            .expect("preserved response should be JSON")
+            .expect("provider response should be present");
+        assert_eq!(preserved["status"], "failed");
+        assert_eq!(preserved["id"], "xai-error");
+        assert_eq!(preserved["error"]["code"], "server_error");
+        assert_eq!(preserved["error"]["message"], "xAI generation failed");
+    }
 
     #[test]
     fn xai_request_includes_normalized_documents() {

--- a/crates/rig-core/src/streaming.rs
+++ b/crates/rig-core/src/streaming.rs
@@ -10,7 +10,8 @@
 use crate::OneOrMany;
 use crate::agent::prompt_request::streaming::StreamingPromptRequest;
 use crate::completion::{
-    CompletionError, CompletionModel, CompletionResponse, GetTokenUsage, Message, Usage,
+    CompletionError, CompletionModel, CompletionResponse, CompletionTerminalMetadata,
+    GetCompletionMetadata, Message, Usage,
 };
 use crate::message::{
     AssistantContent, Reasoning, ReasoningContent, Text, ToolCall, ToolFunction, ToolResult,
@@ -239,7 +240,7 @@ pub type StreamingResult<R> =
 /// `inner` stream.
 pub struct StreamingCompletionResponse<R>
 where
-    R: Clone + Unpin + GetTokenUsage,
+    R: Clone + Unpin + GetCompletionMetadata,
 {
     pub(crate) inner: Abortable<StreamingResult<R>>,
     pub(crate) abort_handle: AbortHandle,
@@ -260,7 +261,7 @@ where
 
 impl<R> StreamingCompletionResponse<R>
 where
-    R: Clone + Unpin + GetTokenUsage,
+    R: Clone + Unpin + GetCompletionMetadata,
 {
     /// Wrap a provider stream and initialize aggregation state.
     pub fn stream(inner: StreamingResult<R>) -> StreamingCompletionResponse<R> {
@@ -314,6 +315,14 @@ where
     /// usage metrics.
     pub fn usage(&self) -> Usage {
         self.response.token_usage()
+    }
+
+    /// Canonical provider terminal metadata for this response.
+    ///
+    /// This remains `None` until a final response carrying a terminal reason is
+    /// received, and stays `None` when the provider supplied no reason.
+    pub fn terminal_metadata(&self) -> Option<CompletionTerminalMetadata> {
+        self.response.terminal_metadata()
     }
 
     fn append_text_chunk(&mut self, text: &str) {
@@ -412,15 +421,16 @@ fn merge_text_additional_params(existing: &mut serde_json::Value, incoming: serd
 
 impl<R> From<StreamingCompletionResponse<R>> for CompletionResponse<Option<R>>
 where
-    R: Clone + Unpin + GetTokenUsage,
+    R: Clone + Unpin + GetCompletionMetadata,
 {
     fn from(value: StreamingCompletionResponse<R>) -> CompletionResponse<Option<R>> {
         CompletionResponse {
             choice: value.choice,
-            // Derive usage from the final response. `Option<R>: GetTokenUsage`
+            // Derive usage from the final response. `Option<R>: GetCompletionMetadata`
             // yields the provider's usage when present and the zero sentinel
             // (`Usage::new`) when the stream produced no final response.
             usage: value.response.token_usage(),
+            terminal_metadata: value.response.terminal_metadata(),
             raw_response: value.response,
             message_id: value.message_id,
         }
@@ -429,7 +439,7 @@ where
 
 impl<R> Stream for StreamingCompletionResponse<R>
 where
-    R: Clone + Unpin + GetTokenUsage,
+    R: Clone + Unpin + GetCompletionMetadata,
 {
     type Item = Result<StreamedAssistantContent<R>, CompletionError>;
 
@@ -566,7 +576,7 @@ pub trait StreamingPrompt<M, R>
 where
     M: CompletionModel + 'static,
     <M as CompletionModel>::StreamingResponse: WasmCompatSend,
-    R: Clone + Unpin + GetTokenUsage,
+    R: Clone + Unpin + GetCompletionMetadata,
 {
     /// Stream a simple prompt to the model.
     ///
@@ -587,7 +597,7 @@ pub trait StreamingChat<M, R>: WasmCompatSend + WasmCompatSync
 where
     M: CompletionModel + 'static,
     <M as CompletionModel>::StreamingResponse: WasmCompatSend,
-    R: Clone + Unpin + GetTokenUsage,
+    R: Clone + Unpin + GetCompletionMetadata,
 {
     /// Stream a chat with history to the model.
     ///
@@ -770,7 +780,17 @@ mod tests {
 
     #[tokio::test]
     async fn into_completion_response_derives_usage_from_final_response() {
-        let mut stream = create_mock_stream();
+        let metadata =
+            CompletionTerminalMetadata::new(crate::completion::CompletionFinishReason::Length)
+                .with_raw_reason("length");
+        let stream_metadata = metadata.clone();
+        let raw_stream = stream! {
+            yield Ok(RawStreamingChoice::Message("response".to_string()));
+            yield Ok(RawStreamingChoice::FinalResponse(
+                MockResponse::with_total_tokens(15).with_terminal_metadata(stream_metadata)
+            ));
+        };
+        let mut stream = StreamingCompletionResponse::stream(to_stream_result(raw_stream));
 
         // Drain the stream so the final response (and its usage) is captured.
         while stream.next().await.is_some() {}
@@ -781,6 +801,7 @@ mod tests {
         // ...and the From conversion carries it instead of a zero sentinel.
         let response: CompletionResponse<Option<MockResponse>> = stream.into();
         assert_eq!(response.usage.total_tokens, 15);
+        assert_eq!(response.terminal_metadata, Some(metadata));
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/telemetry/mod.rs
+++ b/crates/rig-core/src/telemetry/mod.rs
@@ -4,7 +4,7 @@
 //! and more.
 
 use crate::OneOrMany;
-use crate::completion::{AssistantContent, GetTokenUsage, Message};
+use crate::completion::{AssistantContent, GetCompletionMetadata, Message};
 use crate::message::{
     DocumentSourceKind, Image, MimeType, Reasoning, ReasoningContent, ToolResult,
     ToolResultContent, UserContent,
@@ -452,7 +452,7 @@ pub trait SpanCombinator {
     /// Record Rig-normalized token usage fields on the span.
     fn record_token_usage<U>(&self, usage: &U)
     where
-        U: GetTokenUsage;
+        U: GetCompletionMetadata;
 
     /// Record provider response metadata such as response ID and model name.
     fn record_response_metadata<R>(&self, response: &R)
@@ -463,7 +463,7 @@ pub trait SpanCombinator {
 impl SpanCombinator for tracing::Span {
     fn record_token_usage<U>(&self, usage: &U)
     where
-        U: GetTokenUsage,
+        U: GetCompletionMetadata,
     {
         if self.is_disabled() {
             return;
@@ -512,7 +512,7 @@ impl SpanCombinator for tracing::Span {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::completion::{AssistantContent, GetTokenUsage, Message, Usage};
+    use crate::completion::{AssistantContent, GetCompletionMetadata, Message, Usage};
     use serde_json::json;
     use std::sync::{Arc, Mutex};
     use tracing::field::{Field, Visit};
@@ -523,7 +523,7 @@ mod tests {
     #[derive(Clone)]
     struct TestUsage(Usage);
 
-    impl GetTokenUsage for TestUsage {
+    impl GetCompletionMetadata for TestUsage {
         fn token_usage(&self) -> Usage {
             self.0
         }

--- a/crates/rig-core/src/test_utils/completion.rs
+++ b/crates/rig-core/src/test_utils/completion.rs
@@ -9,7 +9,7 @@ use crate::{
     OneOrMany,
     completion::{
         AssistantContent, CompletionError, CompletionModel, CompletionRequest, CompletionResponse,
-        Usage,
+        CompletionTerminalMetadata, Usage,
     },
     message::{ToolCall, ToolFunction},
     streaming::{StreamingCompletionResponse, StreamingResult},
@@ -56,6 +56,7 @@ struct MockTurnResponse {
     choice: OneOrMany<AssistantContent>,
     usage: Usage,
     message_id: Option<String>,
+    terminal_metadata: Option<CompletionTerminalMetadata>,
 }
 
 impl MockTurn {
@@ -97,6 +98,7 @@ impl MockTurn {
                 choice: OneOrMany::one(content),
                 usage: Usage::new(),
                 message_id: None,
+                terminal_metadata: None,
             }),
         }
     }
@@ -110,6 +112,7 @@ impl MockTurn {
                 choice: OneOrMany::many(content)?,
                 usage: Usage::new(),
                 message_id: None,
+                terminal_metadata: None,
             }),
         })
     }
@@ -144,13 +147,27 @@ impl MockTurn {
         self
     }
 
+    /// Set canonical terminal metadata for this turn.
+    pub fn with_terminal_metadata(mut self, metadata: CompletionTerminalMetadata) -> Self {
+        if let Ok(response) = &mut self.response {
+            response.terminal_metadata = Some(metadata);
+        }
+        self
+    }
+
     fn into_completion_response(self) -> Result<CompletionResponse<MockResponse>, CompletionError> {
         let response = self.response.map_err(MockError::into_completion_error)?;
         Ok(CompletionResponse {
             choice: response.choice,
             usage: response.usage,
-            raw_response: MockResponse::with_usage(response.usage),
+            raw_response: response.terminal_metadata.clone().map_or_else(
+                || MockResponse::with_usage(response.usage),
+                |metadata| {
+                    MockResponse::with_usage(response.usage).with_terminal_metadata(metadata)
+                },
+            ),
             message_id: response.message_id,
+            terminal_metadata: response.terminal_metadata,
         })
     }
 }
@@ -304,7 +321,7 @@ impl CompletionModel for MockCompletionModel {
 mod tests {
     use super::*;
     use crate::{
-        completion::GetTokenUsage,
+        completion::GetCompletionMetadata,
         message::Message,
         streaming::{StreamedAssistantContent, ToolCallDeltaContent},
     };

--- a/crates/rig-core/src/test_utils/internal_streaming_profiles.rs
+++ b/crates/rig-core/src/test_utils/internal_streaming_profiles.rs
@@ -1,7 +1,7 @@
 //! Crate-internal streaming profile helpers for compatible provider tests.
 
 use crate::{
-    completion::CompletionError,
+    completion::{CompletionError, CompletionTerminalMetadata},
     providers::internal::openai_chat_completions_compatible::{
         CompatibleChoice, CompatibleChunk, CompatibleFinishReason, CompatibleStreamProfile,
         CompatibleToolCallChunk,
@@ -25,6 +25,7 @@ fn tool_call_choice(
 ) -> CompatibleChoice<()> {
     CompatibleChoice {
         finish_reason,
+        terminal_metadata: None,
         text: None,
         reasoning: None,
         tool_calls,
@@ -71,7 +72,11 @@ impl CompatibleStreamProfile for ErrorAfterPendingToolCallProfile {
         }
     }
 
-    fn build_final_response(&self, _usage: Self::Usage) -> Self::FinalResponse {
+    fn build_final_response(
+        &self,
+        _usage: Self::Usage,
+        _terminal_metadata: Option<CompletionTerminalMetadata>,
+    ) -> Self::FinalResponse {
         MockResponse::new()
     }
 }
@@ -134,7 +139,11 @@ impl CompatibleStreamProfile for DistinctToolCallEvictionProfile {
         Ok(choice.map(test_chunk))
     }
 
-    fn build_final_response(&self, _usage: Self::Usage) -> Self::FinalResponse {
+    fn build_final_response(
+        &self,
+        _usage: Self::Usage,
+        _terminal_metadata: Option<CompletionTerminalMetadata>,
+    ) -> Self::FinalResponse {
         MockResponse::new()
     }
 
@@ -176,7 +185,11 @@ impl CompatibleStreamProfile for FinishReasonCleanupProfile {
         Ok(choice.map(test_chunk))
     }
 
-    fn build_final_response(&self, _usage: Self::Usage) -> Self::FinalResponse {
+    fn build_final_response(
+        &self,
+        _usage: Self::Usage,
+        _terminal_metadata: Option<CompletionTerminalMetadata>,
+    ) -> Self::FinalResponse {
         MockResponse::new()
     }
 }

--- a/crates/rig-core/src/test_utils/model_conformance.rs
+++ b/crates/rig-core/src/test_utils/model_conformance.rs
@@ -19,10 +19,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     agent::{
-        AgentBuilder, AgentHook, CompletionCallAction, CompletionCallEvent,
-        CompletionResponseEvent, HookContext, InvalidToolCallAction, MultiTurnStreamItem,
-        NoToolConfig, ObservationAction, OutputMode, RequestPatch, StreamingError,
-        ToolCall as ToolCallEvent, ToolCallAction, ToolResultAction, ToolResultEvent,
+        AgentBuilder, AgentHook, CompletionCallAction, CompletionCallEvent, HookContext,
+        InvalidToolCallAction, ModelTurnPrepared, MultiTurnStreamItem, NoToolConfig,
+        ObservationAction, OutputMode, RequestPatch, StreamingError, ToolCall as ToolCallEvent,
+        ToolCallAction, ToolResultAction, ToolResultEvent,
         run::{AgentRun, AgentRunStep, ModelTurn, ModelTurnOutcome},
     },
     completion::{
@@ -1256,7 +1256,9 @@ where
                 streamed_text.push_str(&text.text);
             }
             crate::streaming::StreamedAssistantContent::Final(response) => {
-                streamed_usage = Some(crate::completion::GetTokenUsage::token_usage(&response));
+                streamed_usage = Some(crate::completion::GetCompletionMetadata::token_usage(
+                    &response,
+                ));
             }
             crate::streaming::StreamedAssistantContent::ToolCall { .. }
             | crate::streaming::StreamedAssistantContent::ToolCallDelta { .. }
@@ -1394,10 +1396,10 @@ where
     struct CaptureTurn(Arc<Mutex<Option<ModelTurn>>>);
 
     impl AgentHook for CaptureTurn {
-        async fn on_completion_response(
+        async fn on_model_turn_prepared(
             &self,
             _ctx: &HookContext,
-            event: CompletionResponseEvent<'_>,
+            event: ModelTurnPrepared<'_>,
         ) -> ObservationAction {
             *lock_recover(&self.0) = Some(ModelTurn::new(
                 event.message_id.map(str::to_owned),

--- a/crates/rig-core/src/test_utils/streaming.rs
+++ b/crates/rig-core/src/test_utils/streaming.rs
@@ -1,7 +1,7 @@
 //! Streaming helpers for [`MockCompletionModel`](super::MockCompletionModel).
 
 use crate::{
-    completion::{CompletionError, GetTokenUsage, Usage},
+    completion::{CompletionError, CompletionTerminalMetadata, GetCompletionMetadata, Usage},
     message::ReasoningContent,
     streaming::{RawStreamingChoice, RawStreamingToolCall, ToolCallDeltaContent},
 };
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct MockResponse {
     usage: Usage,
+    terminal_metadata: Option<CompletionTerminalMetadata>,
 }
 
 impl MockResponse {
@@ -19,12 +20,16 @@ impl MockResponse {
     pub fn new() -> Self {
         Self {
             usage: Usage::new(),
+            terminal_metadata: None,
         }
     }
 
     /// Create a mock raw response carrying token usage.
     pub fn with_usage(usage: Usage) -> Self {
-        Self { usage }
+        Self {
+            usage,
+            terminal_metadata: None,
+        }
     }
 
     /// Create a mock raw response whose usage has only `total_tokens` set.
@@ -33,11 +38,21 @@ impl MockResponse {
         usage.total_tokens = total_tokens;
         Self::with_usage(usage)
     }
+
+    /// Attach canonical terminal metadata to this mock raw response.
+    pub fn with_terminal_metadata(mut self, metadata: CompletionTerminalMetadata) -> Self {
+        self.terminal_metadata = Some(metadata);
+        self
+    }
 }
 
-impl GetTokenUsage for MockResponse {
+impl GetCompletionMetadata for MockResponse {
     fn token_usage(&self) -> Usage {
         self.usage
+    }
+
+    fn terminal_metadata(&self) -> Option<CompletionTerminalMetadata> {
+        self.terminal_metadata.clone()
     }
 }
 
@@ -191,6 +206,14 @@ impl MockStreamEvent {
     /// Create a final response event with usage.
     pub fn final_response(usage: Usage) -> Self {
         Self::FinalResponse(MockResponse::with_usage(usage))
+    }
+
+    /// Create a final response event with usage and terminal metadata.
+    pub fn final_response_with_metadata(
+        usage: Usage,
+        metadata: CompletionTerminalMetadata,
+    ) -> Self {
+        Self::FinalResponse(MockResponse::with_usage(usage).with_terminal_metadata(metadata))
     }
 
     /// Create a final response event with default zero usage.

--- a/crates/rig-gemini-grpc/src/completion.rs
+++ b/crates/rig-gemini-grpc/src/completion.rs
@@ -400,6 +400,10 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse<Generat
             CompletionError::ResponseError("No response candidates in response".into())
         })?;
 
+        if let Some(error) = crate::gemini_protocol_finish_reason_error(&response) {
+            return Err(error);
+        }
+
         let content_ref = candidate.content.as_ref().ok_or_else(|| {
             CompletionError::ResponseError(format!(
                 "Gemini candidate missing content (finish_reason={})",
@@ -494,12 +498,14 @@ impl TryFrom<GenerateContentResponse> for completion::CompletionResponse<Generat
                 reasoning_tokens: 0,
             })
             .unwrap_or_default();
+        let terminal_metadata = crate::gemini_terminal_metadata(candidate.finish_reason);
 
         Ok(completion::CompletionResponse {
             choice,
             usage,
             raw_response: response,
             message_id: None,
+            terminal_metadata,
         })
     }
 }

--- a/crates/rig-gemini-grpc/src/lib.rs
+++ b/crates/rig-gemini-grpc/src/lib.rs
@@ -36,8 +36,8 @@ pub use proto::{
     GenerateContentResponse, Part, generative_service_client::GenerativeServiceClient,
 };
 
-// Implement GetTokenUsage for proto::GenerateContentResponse to support streaming
-impl rig_core::completion::GetTokenUsage for proto::GenerateContentResponse {
+// Implement GetCompletionMetadata for proto::GenerateContentResponse to support streaming
+impl rig_core::completion::GetCompletionMetadata for proto::GenerateContentResponse {
     fn token_usage(&self) -> rig_core::completion::Usage {
         self.usage_metadata
             .as_ref()
@@ -51,5 +51,146 @@ impl rig_core::completion::GetTokenUsage for proto::GenerateContentResponse {
                 reasoning_tokens: 0,
             })
             .unwrap_or_default()
+    }
+
+    fn terminal_metadata(&self) -> Option<rig_core::completion::CompletionTerminalMetadata> {
+        let reason = self.candidates.first()?.finish_reason;
+        gemini_terminal_metadata(reason)
+    }
+}
+
+fn gemini_terminal_metadata(
+    reason: i32,
+) -> Option<rig_core::completion::CompletionTerminalMetadata> {
+    use rig_core::completion::{CompletionFinishReason, CompletionTerminalMetadata};
+
+    if reason == proto::candidate::FinishReason::Unspecified as i32 {
+        return None;
+    }
+    let Ok(reason) = proto::candidate::FinishReason::try_from(reason) else {
+        return Some(
+            CompletionTerminalMetadata::new(CompletionFinishReason::Unknown)
+                .with_raw_reason(reason.to_string()),
+        );
+    };
+    let canonical = match reason {
+        proto::candidate::FinishReason::Stop => CompletionFinishReason::Stop,
+        proto::candidate::FinishReason::MaxTokens => CompletionFinishReason::Length,
+        proto::candidate::FinishReason::Safety
+        | proto::candidate::FinishReason::Recitation
+        | proto::candidate::FinishReason::Language
+        | proto::candidate::FinishReason::Blocklist
+        | proto::candidate::FinishReason::ProhibitedContent
+        | proto::candidate::FinishReason::Spii
+        | proto::candidate::FinishReason::ImageSafety
+        | proto::candidate::FinishReason::ImageProhibitedContent
+        | proto::candidate::FinishReason::ImageRecitation => CompletionFinishReason::ContentFilter,
+        _ => CompletionFinishReason::Unknown,
+    };
+    Some(CompletionTerminalMetadata::new(canonical).with_raw_reason(reason.as_str_name()))
+}
+
+fn gemini_protocol_finish_reason_error(
+    response: &proto::GenerateContentResponse,
+) -> Option<rig_core::completion::CompletionError> {
+    use proto::candidate::FinishReason;
+
+    let candidate = response.candidates.first()?;
+    let reason = FinishReason::try_from(candidate.finish_reason).ok()?;
+    if !matches!(
+        reason,
+        FinishReason::MalformedFunctionCall
+            | FinishReason::UnexpectedToolCall
+            | FinishReason::TooManyToolCalls
+    ) {
+        return None;
+    }
+
+    Some(match serde_json::to_string(response) {
+        Ok(body) => rig_core::completion::CompletionError::from_provider_body(body),
+        Err(error) => rig_core::completion::CompletionError::ProviderError(format!(
+            "Gemini gRPC stopped with {}: {}; failed to preserve response: {error}",
+            reason.as_str_name(),
+            candidate.finish_message.as_deref().unwrap_or("no details")
+        )),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rig_core::completion::CompletionFinishReason;
+
+    #[test]
+    fn grpc_finish_reason_normalization_preserves_proto_name() {
+        for (reason, expected) in [
+            (
+                proto::candidate::FinishReason::Stop,
+                CompletionFinishReason::Stop,
+            ),
+            (
+                proto::candidate::FinishReason::MaxTokens,
+                CompletionFinishReason::Length,
+            ),
+            (
+                proto::candidate::FinishReason::Safety,
+                CompletionFinishReason::ContentFilter,
+            ),
+            (
+                proto::candidate::FinishReason::Other,
+                CompletionFinishReason::Unknown,
+            ),
+        ] {
+            let metadata = gemini_terminal_metadata(reason as i32)
+                .expect("terminal proto reason should produce metadata");
+            assert_eq!(metadata.reason(), expected);
+            assert_eq!(metadata.raw_reason(), Some(reason.as_str_name()));
+        }
+        assert_eq!(
+            gemini_terminal_metadata(proto::candidate::FinishReason::Unspecified as i32),
+            None
+        );
+        let unknown = gemini_terminal_metadata(999)
+            .expect("an unknown nonzero proto value should produce metadata");
+        assert_eq!(unknown.reason(), CompletionFinishReason::Unknown);
+        assert_eq!(unknown.raw_reason(), Some("999"));
+    }
+
+    #[test]
+    fn grpc_protocol_finish_reasons_remain_provider_errors() {
+        for reason in [
+            proto::candidate::FinishReason::MalformedFunctionCall,
+            proto::candidate::FinishReason::UnexpectedToolCall,
+            proto::candidate::FinishReason::TooManyToolCalls,
+        ] {
+            let response = proto::GenerateContentResponse {
+                candidates: vec![proto::Candidate {
+                    finish_reason: reason as i32,
+                    finish_message: Some("invalid tool protocol".to_string()),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            };
+            let error = gemini_protocol_finish_reason_error(&response)
+                .expect("protocol finish reason should remain an error");
+            let body = error
+                .provider_response_json()
+                .expect("provider response should be JSON")
+                .expect("provider response should be preserved");
+            assert_eq!(body["candidates"][0]["finish_reason"], reason as i32);
+            assert_eq!(
+                body["candidates"][0]["finish_message"],
+                "invalid tool protocol"
+            );
+        }
+
+        let response = proto::GenerateContentResponse {
+            candidates: vec![proto::Candidate {
+                finish_reason: proto::candidate::FinishReason::Stop as i32,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        assert!(gemini_protocol_finish_reason_error(&response).is_none());
     }
 }

--- a/crates/rig-gemini-grpc/src/streaming.rs
+++ b/crates/rig-gemini-grpc/src/streaming.rs
@@ -40,6 +40,10 @@ pub(crate) async fn stream(
         while let Some(item) = response_stream.next().await {
             match item {
                 Ok(resp) => {
+                    if let Some(error) = super::gemini_protocol_finish_reason_error(&resp) {
+                        yield Err(error);
+                        return;
+                    }
                     let mut is_final = false;
 
                     if let Some(candidate) = resp.candidates.first() {

--- a/crates/rig-vertexai/src/completion.rs
+++ b/crates/rig-vertexai/src/completion.rs
@@ -6,7 +6,7 @@ use crate::types::{
 };
 use rig_core::completion::{
     CompletionError, CompletionModel as CompletionModelTrait, CompletionRequest,
-    CompletionResponse, GetTokenUsage,
+    CompletionResponse, CompletionTerminalMetadata, GetCompletionMetadata,
 };
 use rig_core::streaming::StreamingCompletionResponse;
 use serde::{Deserialize, Serialize};
@@ -37,9 +37,35 @@ pub struct CompletionModel {
 #[derive(Clone, Serialize, Deserialize)]
 pub struct PlaceholderStreamingResponse;
 
-impl GetTokenUsage for PlaceholderStreamingResponse {
+impl GetCompletionMetadata for PlaceholderStreamingResponse {
     fn token_usage(&self) -> rig_core::completion::Usage {
         rig_core::completion::Usage::new()
+    }
+}
+
+impl GetCompletionMetadata for VertexGenerateContentOutput {
+    fn token_usage(&self) -> rig_core::completion::Usage {
+        self.0
+            .usage_metadata
+            .as_ref()
+            .map(|usage| rig_core::completion::Usage {
+                input_tokens: usage.prompt_token_count as u64,
+                output_tokens: usage.candidates_token_count as u64,
+                total_tokens: usage.total_token_count as u64,
+                cached_input_tokens: 0,
+                cache_creation_input_tokens: 0,
+                tool_use_prompt_tokens: 0,
+                reasoning_tokens: 0,
+            })
+            .unwrap_or_default()
+    }
+
+    fn terminal_metadata(&self) -> Option<CompletionTerminalMetadata> {
+        self.0.candidates.first().and_then(|candidate| {
+            crate::types::completion_response::terminal_metadata_from_finish_reason(
+                &candidate.finish_reason,
+            )
+        })
     }
 }
 

--- a/crates/rig-vertexai/src/types/completion_response.rs
+++ b/crates/rig-vertexai/src/types/completion_response.rs
@@ -2,7 +2,9 @@ use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use google_cloud_aiplatform_v1 as vertexai;
 use rig_core::OneOrMany;
-use rig_core::completion::{CompletionError, CompletionResponse, Usage};
+use rig_core::completion::{
+    CompletionError, CompletionFinishReason, CompletionResponse, CompletionTerminalMetadata, Usage,
+};
 use rig_core::message::{
     AssistantContent, ImageDetail, ImageMediaType, MediaType, MimeType, Reasoning, Text, ToolCall,
     ToolFunction,
@@ -21,6 +23,19 @@ impl TryFrom<VertexGenerateContentOutput> for CompletionResponse<VertexGenerateC
         let candidate = response.candidates.first().ok_or_else(|| {
             CompletionError::ProviderError("No candidates in response".to_string())
         })?;
+
+        if matches!(
+            candidate.finish_reason,
+            vertexai::model::candidate::FinishReason::MalformedFunctionCall
+        ) {
+            return Err(match serde_json::to_string(&value) {
+                Ok(body) => CompletionError::from_provider_body(body),
+                Err(error) => CompletionError::ProviderError(format!(
+                    "Vertex stopped with MALFORMED_FUNCTION_CALL: {}; failed to preserve response: {error}",
+                    candidate.finish_message.as_deref().unwrap_or("no details")
+                )),
+            });
+        }
 
         let content = candidate
             .content
@@ -136,14 +151,47 @@ impl TryFrom<VertexGenerateContentOutput> for CompletionResponse<VertexGenerateC
                 reasoning_tokens: 0,
             })
             .unwrap_or_default();
+        let terminal_metadata = terminal_metadata_from_finish_reason(&candidate.finish_reason);
 
         Ok(CompletionResponse {
             choice,
             usage,
             raw_response: value,
             message_id: None,
+            terminal_metadata,
         })
     }
+}
+
+pub(crate) fn terminal_metadata_from_finish_reason(
+    reason: &vertexai::model::candidate::FinishReason,
+) -> Option<CompletionTerminalMetadata> {
+    use vertexai::model::candidate::FinishReason;
+
+    if matches!(reason, FinishReason::Unspecified) {
+        return None;
+    }
+
+    let canonical = match reason {
+        FinishReason::Stop => CompletionFinishReason::Stop,
+        FinishReason::MaxTokens => CompletionFinishReason::Length,
+        FinishReason::Safety
+        | FinishReason::Recitation
+        | FinishReason::Blocklist
+        | FinishReason::ProhibitedContent
+        | FinishReason::Spii
+        | FinishReason::ModelArmor => CompletionFinishReason::ContentFilter,
+        _ => CompletionFinishReason::Unknown,
+    };
+    let raw_reason = reason
+        .name()
+        .map(str::to_owned)
+        .or_else(|| reason.value().map(|value| value.to_string()));
+
+    Some(
+        CompletionTerminalMetadata::new(canonical)
+            .with_raw_reason(raw_reason.unwrap_or_else(|| reason.to_string())),
+    )
 }
 
 #[cfg(test)]
@@ -293,6 +341,11 @@ mod tests {
                 "Hello, world!".to_string()
             )))
         );
+        let metadata = response
+            .terminal_metadata
+            .expect("Vertex finish reason should be normalized");
+        assert_eq!(metadata.reason(), CompletionFinishReason::Stop);
+        assert_eq!(metadata.raw_reason(), Some("STOP"));
     }
 
     #[test]
@@ -316,6 +369,31 @@ mod tests {
             }
             _ => panic!("Expected ToolCall"),
         }
+    }
+
+    #[test]
+    fn malformed_function_call_remains_a_provider_error() {
+        let content = vertexai::model::Content::new()
+            .set_role("model")
+            .set_parts([vertexai::model::Part::new().set_text("not a valid tool call")]);
+        let candidate = vertexai::model::Candidate::new()
+            .set_content(content)
+            .set_finish_reason(vertexai::model::candidate::FinishReason::MalformedFunctionCall)
+            .set_finish_message("invalid function arguments");
+        let response = VertexGenerateContentOutput(
+            vertexai::model::GenerateContentResponse::new().set_candidates([candidate]),
+        );
+
+        let error = match CompletionResponse::try_from(response) {
+            Ok(_) => panic!("malformed function calls must not become successful turns"),
+            Err(error) => error,
+        };
+        assert_eq!(error.provider_response_status(), None);
+        let body = error
+            .provider_response_body()
+            .expect("provider response should be preserved");
+        assert!(body.contains("finishReason"));
+        assert!(body.contains("invalid function arguments"));
     }
 
     #[test]

--- a/examples/gemini_stream_kill_token_count/src/main.rs
+++ b/examples/gemini_stream_kill_token_count/src/main.rs
@@ -50,7 +50,7 @@ use std::time::Duration;
 
 use futures::{Stream, StreamExt};
 use rig::client::{CompletionClient, ProviderClient};
-use rig::completion::{CompletionError, CompletionModel, GetTokenUsage, Usage};
+use rig::completion::{CompletionError, CompletionModel, GetCompletionMetadata, Usage};
 use rig::providers::gemini;
 use rig::providers::gemini::completion::gemini_api_types::{
     AdditionalParameters, GenerationConfig, ThinkingConfig,
@@ -83,7 +83,7 @@ enum Disruption {
 /// disruption shape against a genuine Gemini stream's partial output.
 struct Disrupt<R>
 where
-    R: Clone + Unpin + GetTokenUsage,
+    R: Clone + Unpin + GetCompletionMetadata,
 {
     inner: StreamingCompletionResponse<R>,
     mode: Disruption,
@@ -94,7 +94,7 @@ where
 
 impl<R> Disrupt<R>
 where
-    R: Clone + Unpin + GetTokenUsage,
+    R: Clone + Unpin + GetCompletionMetadata,
 {
     fn new(inner: StreamingCompletionResponse<R>, mode: Disruption, after_chars: usize) -> Self {
         // For `None`, make the trigger unreachable so it never fires.
@@ -114,7 +114,7 @@ where
 
 impl<R> Stream for Disrupt<R>
 where
-    R: Clone + Unpin + GetTokenUsage,
+    R: Clone + Unpin + GetCompletionMetadata,
 {
     type Item = Result<StreamedAssistantContent<R>, CompletionError>;
 
@@ -201,7 +201,7 @@ async fn drain_with_accounting<S, R>(
 ) -> anyhow::Result<Report>
 where
     S: Stream<Item = Result<StreamedAssistantContent<R>, CompletionError>> + Unpin,
-    R: Clone + Unpin + GetTokenUsage,
+    R: Clone + Unpin + GetCompletionMetadata,
 {
     let mut output = String::new();
     let mut authoritative: Option<Usage> = None;

--- a/examples/openai_streaming_per_call_usage/src/main.rs
+++ b/examples/openai_streaming_per_call_usage/src/main.rs
@@ -163,7 +163,7 @@ async fn main() -> Result<()> {
     println!("\n\nfinal response: {}", response.output());
     print_usage("aggregate agent usage", response.usage());
 
-    if let Some(final_completion_call) = response.completion_calls().last().copied() {
+    if let Some(final_completion_call) = response.completion_calls().last() {
         let usage = final_completion_call.usage;
         if usage.has_values() {
             print_usage("final completion call usage", usage);

--- a/examples/request_hook/src/main.rs
+++ b/examples/request_hook/src/main.rs
@@ -22,7 +22,7 @@
 
 use anyhow::Result;
 use rig::agent::{
-    AgentHook, CompletionCallAction, CompletionCallEvent, CompletionResponseEvent, HookContext,
+    AgentHook, CompletionCallAction, CompletionCallEvent, HookContext, ModelTurnPrepared,
     ObservationAction, RequestPatch,
 };
 use rig::client::{CompletionClient, ProviderClient};
@@ -64,10 +64,10 @@ impl AgentHook for LoggingHook {
         CompletionCallAction::continue_run()
     }
 
-    async fn on_completion_response(
+    async fn on_model_turn_prepared(
         &self,
         ctx: &HookContext,
-        event: CompletionResponseEvent<'_>,
+        event: ModelTurnPrepared<'_>,
     ) -> ObservationAction {
         println!(
             "[run {}] received response (usage: {:?}, message_id: {:?}): {:?}",

--- a/tests/common/support.rs
+++ b/tests/common/support.rs
@@ -4,7 +4,7 @@
 use futures::StreamExt;
 use rig::{
     agent::{MultiTurnStreamItem, StreamingError, StreamingResult},
-    completion::{AssistantContent, GetTokenUsage, ToolDefinition},
+    completion::{AssistantContent, GetCompletionMetadata, ToolDefinition},
     embeddings::Embedding,
     streaming::{StreamedAssistantContent, StreamedUserContent, StreamingCompletionResponse},
     tool::Tool,
@@ -412,7 +412,7 @@ pub(crate) async fn assert_stream_contains_zero_arg_tool_call_named<R>(
     expected_name: &str,
     expect_final_response: bool,
 ) where
-    R: Clone + Unpin + GetTokenUsage,
+    R: Clone + Unpin + GetCompletionMetadata,
 {
     let mut saw_final = false;
     let mut saw_matching_tool_call = false;
@@ -559,7 +559,7 @@ pub(crate) async fn collect_raw_stream_observation<R>(
     mut stream: StreamingCompletionResponse<R>,
 ) -> RawStreamObservation
 where
-    R: Clone + Unpin + GetTokenUsage,
+    R: Clone + Unpin + GetCompletionMetadata,
 {
     let mut observation = RawStreamObservation::new();
 

--- a/tests/providers/anthropic/cassette/prompt_caching.rs
+++ b/tests/providers/anthropic/cassette/prompt_caching.rs
@@ -3,8 +3,8 @@
 use futures::StreamExt;
 use rig::client::CompletionClient;
 use rig::completion::{
-    AssistantContent, CompletionModel, CompletionResponse as RigCompletionResponse, GetTokenUsage,
-    ToolDefinition, Usage,
+    AssistantContent, CompletionModel, CompletionResponse as RigCompletionResponse,
+    GetCompletionMetadata, ToolDefinition, Usage,
 };
 use rig::message::ToolChoice;
 use rig::providers::anthropic;

--- a/tests/providers/chatgpt/request_hook.rs
+++ b/tests/providers/chatgpt/request_hook.rs
@@ -5,8 +5,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use rig::agent::{
-    AgentHook, CompletionCallAction, CompletionCallEvent, CompletionResponseEvent,
-    ObservationAction,
+    AgentHook, CompletionCallAction, CompletionCallEvent, ModelTurnPrepared, ObservationAction,
 };
 use rig::client::CompletionClient;
 use rig::completion::{Message, Prompt};
@@ -51,10 +50,10 @@ impl AgentHook for SessionIdHook<'_> {
         }
     }
 
-    async fn on_completion_response(
+    async fn on_model_turn_prepared(
         &self,
         _ctx: &rig::agent::HookContext,
-        event: CompletionResponseEvent<'_>,
+        event: ModelTurnPrepared<'_>,
     ) -> ObservationAction {
         self.response_calls.fetch_add(1, Ordering::SeqCst);
         match self.seen_response.lock() {
@@ -62,7 +61,7 @@ impl AgentHook for SessionIdHook<'_> {
                 *seen_response = Some(format!("{:?}", event.content));
                 ObservationAction::continue_run()
             }
-            Err(_) => ObservationAction::stop("response hook state unavailable"),
+            Err(_) => ObservationAction::stop("prepared-turn hook state unavailable"),
         }
     }
 }
@@ -97,7 +96,7 @@ async fn request_hook_records_prompt_and_response() -> Result<()> {
     let seen_response = hook
         .seen_response
         .lock()
-        .map_err(|_| anyhow!("response hook state unavailable"))?
+        .map_err(|_| anyhow!("prepared-turn hook state unavailable"))?
         .clone();
 
     anyhow::ensure!(

--- a/tests/providers/copilot/request_hook.rs
+++ b/tests/providers/copilot/request_hook.rs
@@ -5,8 +5,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use rig::agent::{
-    AgentHook, CompletionCallAction, CompletionCallEvent, CompletionResponseEvent,
-    ObservationAction,
+    AgentHook, CompletionCallAction, CompletionCallEvent, ModelTurnPrepared, ObservationAction,
 };
 use rig::client::CompletionClient;
 use rig::completion::{Message, Prompt};
@@ -51,10 +50,10 @@ impl AgentHook for SessionIdHook<'_> {
         }
     }
 
-    async fn on_completion_response(
+    async fn on_model_turn_prepared(
         &self,
         _ctx: &rig::agent::HookContext,
-        event: CompletionResponseEvent<'_>,
+        event: ModelTurnPrepared<'_>,
     ) -> ObservationAction {
         self.response_calls.fetch_add(1, Ordering::SeqCst);
         match self.seen_response.lock() {
@@ -62,7 +61,7 @@ impl AgentHook for SessionIdHook<'_> {
                 *seen_response = Some(format!("{:?}", event.content));
                 ObservationAction::continue_run()
             }
-            Err(_) => ObservationAction::stop("response hook state unavailable"),
+            Err(_) => ObservationAction::stop("prepared-turn hook state unavailable"),
         }
     }
 }
@@ -99,7 +98,7 @@ async fn request_hook_records_prompt_and_response() -> Result<()> {
             let seen_response = hook
                 .seen_response
                 .lock()
-                .map_err(|_| anyhow!("response hook state unavailable"))?
+                .map_err(|_| anyhow!("prepared-turn hook state unavailable"))?
                 .clone();
 
             anyhow::ensure!(

--- a/tests/providers/deepseek/request_hook.rs
+++ b/tests/providers/deepseek/request_hook.rs
@@ -5,8 +5,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use rig::agent::{
-    AgentHook, CompletionCallAction, CompletionCallEvent, CompletionResponseEvent,
-    ObservationAction,
+    AgentHook, CompletionCallAction, CompletionCallEvent, ModelTurnPrepared, ObservationAction,
 };
 use rig::client::CompletionClient;
 use rig::completion::{Message, Prompt};
@@ -52,10 +51,10 @@ impl AgentHook for SessionIdHook<'_> {
         }
     }
 
-    async fn on_completion_response(
+    async fn on_model_turn_prepared(
         &self,
         _ctx: &rig::agent::HookContext,
-        event: CompletionResponseEvent<'_>,
+        event: ModelTurnPrepared<'_>,
     ) -> ObservationAction {
         self.response_calls.fetch_add(1, Ordering::SeqCst);
         match self.seen_response.lock() {
@@ -63,7 +62,7 @@ impl AgentHook for SessionIdHook<'_> {
                 *seen_response = Some(format!("{:?}", event.content));
                 ObservationAction::continue_run()
             }
-            Err(_) => ObservationAction::stop("response hook state unavailable"),
+            Err(_) => ObservationAction::stop("prepared-turn hook state unavailable"),
         }
     }
 }
@@ -95,7 +94,7 @@ async fn request_hook_records_prompt_and_response() -> Result<()> {
             );
             anyhow::ensure!(
                 hook.response_calls.load(Ordering::SeqCst) == 1,
-                "expected one response hook call"
+                "expected one prepared-turn hook call"
             );
 
             let seen_prompt = hook
@@ -106,7 +105,7 @@ async fn request_hook_records_prompt_and_response() -> Result<()> {
             let seen_response = hook
                 .seen_response
                 .lock()
-                .map_err(|_| anyhow!("response hook state unavailable"))?
+                .map_err(|_| anyhow!("prepared-turn hook state unavailable"))?
                 .clone();
 
             anyhow::ensure!(

--- a/tests/providers/doubleword/cassette/request_hook.rs
+++ b/tests/providers/doubleword/cassette/request_hook.rs
@@ -4,8 +4,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use rig::agent::{
-    AgentHook, CompletionCallAction, CompletionCallEvent, CompletionResponseEvent,
-    ObservationAction,
+    AgentHook, CompletionCallAction, CompletionCallEvent, ModelTurnPrepared, ObservationAction,
 };
 use rig::client::CompletionClient;
 use rig::completion::{Message, Prompt};
@@ -43,10 +42,10 @@ impl AgentHook for ObservingHook {
         CompletionCallAction::continue_run()
     }
 
-    async fn on_completion_response(
+    async fn on_model_turn_prepared(
         &self,
         _ctx: &rig::agent::HookContext,
-        _event: CompletionResponseEvent<'_>,
+        _event: ModelTurnPrepared<'_>,
     ) -> ObservationAction {
         self.response_calls.fetch_add(1, Ordering::SeqCst);
         ObservationAction::continue_run()

--- a/tests/providers/gemini/cassette/agent_run_recovery.rs
+++ b/tests/providers/gemini/cassette/agent_run_recovery.rs
@@ -130,15 +130,15 @@ async fn repair_renames_tool_call_and_executes_it() {
                             assert!(repaired_calls < 6, "repair loop did not converge");
                         }
                         let ModelTurnOutcome::Continue {
-                            response_hook_suppressed,
+                            prepared_hook_suppressed,
                         } = outcome
                         else {
                             panic!("repaired turns continue: {outcome:?}");
                         };
                         assert_eq!(
-                            response_hook_suppressed,
+                            prepared_hook_suppressed,
                             repaired_calls > repaired_before,
-                            "exactly the recovered turns suppress the response hook"
+                            "exactly the recovered turns suppress the prepared-turn hook"
                         );
                     }
                     AgentRunStep::CallTools { calls } => {

--- a/tests/providers/gemini/cassette/agent_run_resume.rs
+++ b/tests/providers/gemini/cassette/agent_run_resume.rs
@@ -178,10 +178,10 @@ async fn resume_while_invalid_tool_call_awaits_resolution() {
                 matches!(
                     outcome,
                     ModelTurnOutcome::Continue {
-                        response_hook_suppressed: true
+                        prepared_hook_suppressed: true
                     }
                 ),
-                "recovered turns suppress the response hook"
+                "recovered turns suppress the prepared-turn hook"
             );
 
             // The skipped call comes back preresolved; the driver must not

--- a/tests/providers/gemini/cassette/agent_run_stepping.rs
+++ b/tests/providers/gemini/cassette/agent_run_stepping.rs
@@ -53,10 +53,10 @@ async fn hand_driven_single_turn_completes() {
                             matches!(
                                 outcome,
                                 ModelTurnOutcome::Continue {
-                                    response_hook_suppressed: false
+                                    prepared_hook_suppressed: false
                                 }
                             ),
-                            "unrecovered turns must not suppress the response hook"
+                            "unrecovered turns must not suppress the prepared-turn hook"
                         );
                     }
                     AgentRunStep::CallTools { calls } => {

--- a/tests/providers/gemini/cassette/agent_run_streamed.rs
+++ b/tests/providers/gemini/cassette/agent_run_streamed.rs
@@ -15,7 +15,7 @@ use rig::agent::{
     ToolCall as ToolCallEvent, ToolCallAction,
 };
 use rig::client::CompletionClient;
-use rig::completion::{GetTokenUsage, PromptError, Usage};
+use rig::completion::{GetCompletionMetadata, PromptError, Usage};
 use rig::message::{Message, ToolChoice, ToolResult};
 use rig::providers::gemini;
 use rig::streaming::{StreamedAssistantContent, StreamingPrompt};
@@ -79,7 +79,7 @@ async fn run_streamed_turn(
                 StreamedTurnEvent::EmitToolCallDelta { .. } => {}
                 StreamedTurnEvent::Completed { usage, .. } => {
                     if !recorded {
-                        run.record_streamed_completion_call(usage)
+                        run.record_streamed_completion_call(usage, None)
                             .expect("completion call should record while the turn is pending");
                         recorded = true;
                     }
@@ -107,7 +107,7 @@ async fn run_streamed_turn(
                                 } => {
                                     let drained_usage = drain_stream_usage(&mut stream).await;
                                     if !recorded {
-                                        run.record_streamed_completion_call(drained_usage).expect(
+                                        run.record_streamed_completion_call(drained_usage, None).expect(
                                             "abandoned turns may still record their completion call",
                                         );
                                     }
@@ -128,7 +128,7 @@ async fn run_streamed_turn(
         "the provider stream should end consistently"
     );
     if !recorded {
-        run.record_streamed_completion_call(Usage::new())
+        run.record_streamed_completion_call(Usage::new(), None)
             .expect("turns without provider usage still record a completion call");
     }
     let streamed_turn = assembler.finish(stream.message_id.clone(), &stream.choice);
@@ -138,7 +138,7 @@ async fn run_streamed_turn(
 
 async fn drain_stream_usage<R>(stream: &mut rig::streaming::StreamingCompletionResponse<R>) -> Usage
 where
-    R: Clone + Unpin + GetTokenUsage,
+    R: Clone + Unpin + GetCompletionMetadata,
 {
     while let Some(item) = stream.next().await {
         if let Ok(StreamedAssistantContent::Final(final_response)) = item {
@@ -157,7 +157,7 @@ async fn streamed_hand_driven_multi_turn_run_completes() {
             // record against.
             let mut fresh = AgentRun::new("unused");
             assert!(
-                fresh.record_streamed_completion_call(Usage::new()).is_err(),
+                fresh.record_streamed_completion_call(Usage::new(), None).is_err(),
                 "a phantom completion call must be rejected on a fresh run"
             );
 

--- a/tests/providers/gemini/cassette/hook_stress.rs
+++ b/tests/providers/gemini/cassette/hook_stress.rs
@@ -24,8 +24,8 @@ use std::sync::Mutex;
 
 use futures::StreamExt;
 use rig::agent::{
-    AgentHook, CompletionCallAction, CompletionCallEvent, CompletionResponseEvent, HookContext,
-    ModelTurnFinished, MultiTurnStreamItem, ObservationAction, RequestPatch, StreamingError,
+    AgentHook, CompletionCallAction, CompletionCallEvent, HookContext, ModelTurnPrepared,
+    MultiTurnStreamItem, ObservationAction, RequestPatch, StreamingError,
     ToolCall as ToolCallEvent, ToolCallAction, ToolResultAction, ToolResultEvent,
 };
 use rig::client::CompletionClient;
@@ -121,20 +121,12 @@ impl AgentHook for LifecycleRecorder {
         self.record(ctx, "CompletionCall");
         CompletionCallAction::continue_run()
     }
-    async fn on_completion_response(
+    async fn on_model_turn_prepared(
         &self,
         ctx: &HookContext,
-        _event: CompletionResponseEvent<'_>,
+        _event: ModelTurnPrepared<'_>,
     ) -> ObservationAction {
-        self.record(ctx, "CompletionResponse");
-        ObservationAction::continue_run()
-    }
-    async fn on_model_turn_finished(
-        &self,
-        ctx: &HookContext,
-        _event: ModelTurnFinished<'_>,
-    ) -> ObservationAction {
-        self.record(ctx, "ModelTurnFinished");
+        self.record(ctx, "ModelTurnPrepared");
         ObservationAction::continue_run()
     }
     async fn on_tool_call(&self, ctx: &HookContext, _event: ToolCallEvent<'_>) -> ToolCallAction {
@@ -153,7 +145,7 @@ impl AgentHook for LifecycleRecorder {
     }
 }
 
-/// Registered *after* [`LifecycleRecorder`]: on each `ModelTurnFinished` it reads
+/// Registered *after* [`LifecycleRecorder`]: on each `ModelTurnPrepared` it reads
 /// the shared `Scratchpad` tally the recorder wrote and appends it to an external
 /// log — proving the two hooks share run-scoped state that accumulates across
 /// turns.
@@ -169,10 +161,10 @@ impl ScratchpadReader {
 }
 
 impl AgentHook for ScratchpadReader {
-    async fn on_model_turn_finished(
+    async fn on_model_turn_prepared(
         &self,
         ctx: &HookContext,
-        _event: ModelTurnFinished<'_>,
+        _event: ModelTurnPrepared<'_>,
     ) -> ObservationAction {
         let tally = ctx
             .scratchpad()
@@ -345,7 +337,7 @@ async fn lifecycle_and_scratchpad_thread_across_multi_turn_blocking() {
             let tallies = reader_probe.tallies();
             assert!(
                 !tallies.is_empty(),
-                "ModelTurnFinished should fire, so the reader should see tallies"
+                "ModelTurnPrepared should fire, so the reader should see tallies"
             );
             assert!(
                 tallies.windows(2).all(|w| w[0] <= w[1]),
@@ -610,8 +602,8 @@ async fn streaming_lifecycle_ordering_and_context_streaming_flag() {
             );
             assert_eq!(recorder_probe.agent_name().as_deref(), Some("stress-agent"));
             assert!(
-                recorder_probe.count("ModelTurnFinished") >= 2,
-                "ModelTurnFinished must fire per accepted turn on the streaming surface"
+                recorder_probe.count("ModelTurnPrepared") >= 2,
+                "ModelTurnPrepared must fire per accepted turn on the streaming surface"
             );
             assert!(
                 add_calls.count() >= 1 && subtract_calls.count() >= 1,

--- a/tests/providers/gemini/cassette/hook_stress_context.rs
+++ b/tests/providers/gemini/cassette/hook_stress_context.rs
@@ -141,7 +141,7 @@ async fn scratchpad_tally_grows_across_turns_and_is_read_by_second_hook_blocking
                 )
                 .max_turns(6)
                 // Writer (tap) bumps the scratchpad tally on each ToolCall; the
-                // reader (a *different* hook) reads it on each ModelTurnFinished.
+                // reader (a *different* hook) reads it on each ModelTurnPrepared.
                 .add_hook(tap)
                 .add_hook(reader)
                 .await
@@ -152,7 +152,7 @@ async fn scratchpad_tally_grows_across_turns_and_is_read_by_second_hook_blocking
             let tallies = reader_probe.tallies();
             assert!(
                 tallies.len() >= 2,
-                "a multi-turn run should fire ModelTurnFinished at least twice, saw {tallies:?}"
+                "a multi-turn run should fire ModelTurnPrepared at least twice, saw {tallies:?}"
             );
             assert!(
                 tallies.windows(2).all(|w| w[0] <= w[1]),
@@ -264,7 +264,7 @@ async fn two_observe_only_hooks_both_observe_the_run_blocking() {
                 "CompletionCall",
                 "ToolCall",
                 "ToolResult",
-                "ModelTurnFinished",
+                "ModelTurnPrepared",
             ] {
                 assert_eq!(
                     first_probe.count(tag),

--- a/tests/providers/gemini/cassette/hook_stress_streaming.rs
+++ b/tests/providers/gemini/cassette/hook_stress_streaming.rs
@@ -1,5 +1,5 @@
 //! Hook-system stress suite: streaming lifecycle and blocking-vs-streaming
-//! parity — `TextDelta` / `StreamResponseFinish` / `ModelTurnFinished` on the
+//! parity — `TextDelta` / `ModelTurnPrepared` on the
 //! streaming surface, `ToolResultAction::Rewrite` redaction reaching the `FinalResponse`,
 //! `active_tools` narrowing and `Skip` on the streaming driver, and the same
 //! workflow producing the same answer on both surfaces. Recorded against real
@@ -21,7 +21,7 @@ use crate::support::{
 };
 
 #[tokio::test]
-async fn streaming_text_only_emits_text_deltas_and_stream_finish() {
+async fn streaming_text_only_emits_text_deltas_and_prepared_turn() {
     let tap = EventTap::default();
     let probe = tap.clone();
 
@@ -52,12 +52,8 @@ async fn streaming_text_only_emits_text_deltas_and_stream_finish() {
                 "a streamed text turn must emit TextDelta events"
             );
             assert!(
-                probe.count("StreamResponseFinish") >= 1,
-                "a streamed text turn must emit StreamResponseFinish"
-            );
-            assert!(
-                probe.count("ModelTurnFinished") >= 1,
-                "ModelTurnFinished must fire on the streaming surface"
+                probe.count("ModelTurnPrepared") >= 1,
+                "a streamed text turn must emit ModelTurnPrepared"
             );
         },
     )
@@ -65,7 +61,7 @@ async fn streaming_text_only_emits_text_deltas_and_stream_finish() {
 }
 
 #[tokio::test]
-async fn streaming_tool_turns_fire_model_turn_finished() {
+async fn streaming_tool_turns_fire_model_turn_prepared() {
     let add = CountingAdd::default();
     let subtract = CountingSubtract::default();
     let tap = EventTap::default();
@@ -103,8 +99,8 @@ async fn streaming_tool_turns_fire_model_turn_finished() {
                 "the streamed run should call tools"
             );
             assert!(
-                probe.count("ModelTurnFinished") >= 2,
-                "ModelTurnFinished must fire once per accepted turn on the streaming surface, \
+                probe.count("ModelTurnPrepared") >= 2,
+                "ModelTurnPrepared must fire once per accepted turn on the streaming surface, \
                  including tool turns"
             );
         },

--- a/tests/providers/gemini/cassette/interactions_api.rs
+++ b/tests/providers/gemini/cassette/interactions_api.rs
@@ -3,7 +3,7 @@
 use futures::StreamExt;
 use rig::OneOrMany;
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, GetTokenUsage};
+use rig::completion::{CompletionModel, GetCompletionMetadata};
 use rig::message::{
     AssistantContent, Message, ToolCall, ToolChoice, ToolResultContent, UserContent,
 };

--- a/tests/providers/gemini/cassette/streaming.rs
+++ b/tests/providers/gemini/cassette/streaming.rs
@@ -2,7 +2,7 @@
 
 use futures::StreamExt;
 use rig::client::CompletionClient;
-use rig::completion::{CompletionModel, GetTokenUsage};
+use rig::completion::{CompletionModel, GetCompletionMetadata};
 use rig::providers::gemini;
 use rig::providers::gemini::completion::gemini_api_types::{
     AdditionalParameters, FinishReason, GenerationConfig, ThinkingConfig, ThinkingLevel,

--- a/tests/providers/gemini/hook_stress_support.rs
+++ b/tests/providers/gemini/hook_stress_support.rs
@@ -13,10 +13,9 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, Mutex};
 
 use rig::agent::{
-    AgentHook, CompletionCallAction, CompletionCallEvent, CompletionResponseEvent, HookContext,
-    InvalidToolCallAction, ModelTurnFinished, ObservationAction, RequestPatch,
-    StreamResponseFinish, TextDelta, ToolCall as ToolCallEvent, ToolCallAction, ToolCallDelta,
-    ToolResultAction, ToolResultEvent,
+    AgentHook, CompletionCallAction, CompletionCallEvent, HookContext, InvalidToolCallAction,
+    ModelTurnPrepared, ObservationAction, RequestPatch, TextDelta, ToolCall as ToolCallEvent,
+    ToolCallAction, ToolCallDelta, ToolResultAction, ToolResultEvent,
 };
 use rig::completion::Document;
 use rig::tool::Tool;
@@ -199,20 +198,12 @@ impl AgentHook for EventTap {
         self.record(ctx, "CompletionCall");
         CompletionCallAction::continue_run()
     }
-    async fn on_completion_response(
+    async fn on_model_turn_prepared(
         &self,
         ctx: &HookContext,
-        _event: CompletionResponseEvent<'_>,
+        _event: ModelTurnPrepared<'_>,
     ) -> ObservationAction {
-        self.record(ctx, "CompletionResponse");
-        ObservationAction::continue_run()
-    }
-    async fn on_model_turn_finished(
-        &self,
-        ctx: &HookContext,
-        _event: ModelTurnFinished<'_>,
-    ) -> ObservationAction {
-        self.record(ctx, "ModelTurnFinished");
+        self.record(ctx, "ModelTurnPrepared");
         ObservationAction::continue_run()
     }
     async fn on_invalid_tool_call(
@@ -257,18 +248,10 @@ impl AgentHook for EventTap {
         self.record(ctx, "ToolCallDelta");
         ObservationAction::continue_run()
     }
-    async fn on_stream_response_finish(
-        &self,
-        ctx: &HookContext,
-        _event: StreamResponseFinish<'_>,
-    ) -> ObservationAction {
-        self.record(ctx, "StreamResponseFinish");
-        ObservationAction::continue_run()
-    }
 }
 
 /// Registered *after* an [`EventTap`]: reads the shared `Scratchpad` tally on each
-/// `ModelTurnFinished` and appends it — proving cross-hook, cross-turn shared
+/// `ModelTurnPrepared` and appends it — proving cross-hook, cross-turn shared
 /// state.
 #[derive(Clone, Default)]
 pub(crate) struct ScratchpadReader {
@@ -282,10 +265,10 @@ impl ScratchpadReader {
 }
 
 impl AgentHook for ScratchpadReader {
-    async fn on_model_turn_finished(
+    async fn on_model_turn_prepared(
         &self,
         ctx: &HookContext,
-        _event: ModelTurnFinished<'_>,
+        _event: ModelTurnPrepared<'_>,
     ) -> ObservationAction {
         let tally = ctx
             .scratchpad()

--- a/tests/providers/groq/agent_tool_sessions.rs
+++ b/tests/providers/groq/agent_tool_sessions.rs
@@ -11,7 +11,7 @@ use anyhow::Result;
 use futures::StreamExt;
 use rig::OneOrMany;
 use rig::client::CompletionClient;
-use rig::completion::{Chat, CompletionModel, GetTokenUsage, Message};
+use rig::completion::{Chat, CompletionModel, GetCompletionMetadata, Message};
 use rig::message::{AssistantContent, ToolChoice};
 use rig::providers::openai;
 use rig::streaming::{StreamedAssistantContent, StreamingChat, StreamingPrompt};

--- a/tests/providers/groq/request_hook.rs
+++ b/tests/providers/groq/request_hook.rs
@@ -5,8 +5,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use rig::agent::{
-    AgentHook, CompletionCallAction, CompletionCallEvent, CompletionResponseEvent,
-    ObservationAction,
+    AgentHook, CompletionCallAction, CompletionCallEvent, ModelTurnPrepared, ObservationAction,
 };
 use rig::client::{CompletionClient, ProviderClient};
 use rig::completion::{Message, Prompt};
@@ -53,10 +52,10 @@ impl AgentHook for SessionIdHook<'_> {
         }
     }
 
-    async fn on_completion_response(
+    async fn on_model_turn_prepared(
         &self,
         _ctx: &rig::agent::HookContext,
-        event: CompletionResponseEvent<'_>,
+        event: ModelTurnPrepared<'_>,
     ) -> ObservationAction {
         self.response_calls.fetch_add(1, Ordering::SeqCst);
         match self.seen_response.lock() {
@@ -64,7 +63,7 @@ impl AgentHook for SessionIdHook<'_> {
                 *seen_response = Some(format!("{:?}", event.content));
                 ObservationAction::continue_run()
             }
-            Err(_) => ObservationAction::stop("response hook state unavailable"),
+            Err(_) => ObservationAction::stop("prepared-turn hook state unavailable"),
         }
     }
 }
@@ -100,7 +99,7 @@ async fn request_hook_records_prompt_and_response() -> Result<()> {
     let seen_response = hook
         .seen_response
         .lock()
-        .map_err(|_| anyhow!("response hook state unavailable"))?
+        .map_err(|_| anyhow!("prepared-turn hook state unavailable"))?
         .clone();
 
     anyhow::ensure!(

--- a/tests/providers/llamacpp/request_hook.rs
+++ b/tests/providers/llamacpp/request_hook.rs
@@ -5,8 +5,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use rig::agent::{
-    AgentHook, CompletionCallAction, CompletionCallEvent, CompletionResponseEvent,
-    ObservationAction,
+    AgentHook, CompletionCallAction, CompletionCallEvent, ModelTurnPrepared, ObservationAction,
 };
 use rig::client::CompletionClient;
 use rig::completion::{Message, Prompt};
@@ -52,10 +51,10 @@ impl AgentHook for SessionIdHook<'_> {
         }
     }
 
-    async fn on_completion_response(
+    async fn on_model_turn_prepared(
         &self,
         _ctx: &rig::agent::HookContext,
-        event: CompletionResponseEvent<'_>,
+        event: ModelTurnPrepared<'_>,
     ) -> ObservationAction {
         self.response_calls.fetch_add(1, Ordering::SeqCst);
         match self.seen_response.lock() {
@@ -63,7 +62,7 @@ impl AgentHook for SessionIdHook<'_> {
                 *seen_response = Some(format!("{:?}", event.content));
                 ObservationAction::continue_run()
             }
-            Err(_) => ObservationAction::stop("response hook state unavailable"),
+            Err(_) => ObservationAction::stop("prepared-turn hook state unavailable"),
         }
     }
 }
@@ -98,7 +97,7 @@ async fn request_hook_records_prompt_and_response() -> Result<()> {
     let seen_response = hook
         .seen_response
         .lock()
-        .map_err(|_| anyhow!("response hook state unavailable"))?
+        .map_err(|_| anyhow!("prepared-turn hook state unavailable"))?
         .clone();
 
     anyhow::ensure!(

--- a/tests/providers/llamacpp/typed_prompt_tools.rs
+++ b/tests/providers/llamacpp/typed_prompt_tools.rs
@@ -7,9 +7,8 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rig::agent::{
-    AgentHook, CompletionCallAction, CompletionCallEvent, CompletionResponseEvent,
-    ObservationAction, ToolCall as ToolCallEvent, ToolCallAction, ToolResultAction,
-    ToolResultEvent,
+    AgentHook, CompletionCallAction, CompletionCallEvent, ModelTurnPrepared, ObservationAction,
+    ToolCall as ToolCallEvent, ToolCallAction, ToolResultAction, ToolResultEvent,
 };
 use rig::client::CompletionClient;
 use rig::completion::TypedPrompt;
@@ -72,10 +71,10 @@ impl AgentHook for StepLogger {
         CompletionCallAction::continue_run()
     }
 
-    async fn on_completion_response(
+    async fn on_model_turn_prepared(
         &self,
         _ctx: &rig::agent::HookContext,
-        event: CompletionResponseEvent<'_>,
+        event: ModelTurnPrepared<'_>,
     ) -> ObservationAction {
         let call_no = self.current_completion_call();
         println!("\n=== completion response #{call_no}: normalized choice ===");

--- a/tests/providers/llamafile/request_hook.rs
+++ b/tests/providers/llamafile/request_hook.rs
@@ -5,8 +5,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use rig::agent::{
-    AgentHook, CompletionCallAction, CompletionCallEvent, CompletionResponseEvent,
-    ObservationAction,
+    AgentHook, CompletionCallAction, CompletionCallEvent, ModelTurnPrepared, ObservationAction,
 };
 use rig::client::CompletionClient;
 use rig::completion::{Message, Prompt};
@@ -52,10 +51,10 @@ impl AgentHook for SessionIdHook<'_> {
         }
     }
 
-    async fn on_completion_response(
+    async fn on_model_turn_prepared(
         &self,
         _ctx: &rig::agent::HookContext,
-        event: CompletionResponseEvent<'_>,
+        event: ModelTurnPrepared<'_>,
     ) -> ObservationAction {
         self.response_calls.fetch_add(1, Ordering::SeqCst);
         match self.seen_response.lock() {
@@ -63,7 +62,7 @@ impl AgentHook for SessionIdHook<'_> {
                 *seen_response = Some(format!("{:?}", event.content));
                 ObservationAction::continue_run()
             }
-            Err(_) => ObservationAction::stop("response hook state unavailable"),
+            Err(_) => ObservationAction::stop("prepared-turn hook state unavailable"),
         }
     }
 }
@@ -102,7 +101,7 @@ async fn request_hook_records_prompt_and_response() -> Result<()> {
     let seen_response = hook
         .seen_response
         .lock()
-        .map_err(|_| anyhow!("response hook state unavailable"))?
+        .map_err(|_| anyhow!("prepared-turn hook state unavailable"))?
         .clone();
 
     anyhow::ensure!(

--- a/tests/providers/mistral/request_hook.rs
+++ b/tests/providers/mistral/request_hook.rs
@@ -5,8 +5,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use rig::agent::{
-    AgentHook, CompletionCallAction, CompletionCallEvent, CompletionResponseEvent,
-    ObservationAction,
+    AgentHook, CompletionCallAction, CompletionCallEvent, ModelTurnPrepared, ObservationAction,
 };
 use rig::client::{CompletionClient, ProviderClient};
 use rig::completion::{Message, Prompt};
@@ -53,10 +52,10 @@ impl AgentHook for SessionIdHook<'_> {
         }
     }
 
-    async fn on_completion_response(
+    async fn on_model_turn_prepared(
         &self,
         _ctx: &rig::agent::HookContext,
-        event: CompletionResponseEvent<'_>,
+        event: ModelTurnPrepared<'_>,
     ) -> ObservationAction {
         self.response_calls.fetch_add(1, Ordering::SeqCst);
         match self.seen_response.lock() {
@@ -64,7 +63,7 @@ impl AgentHook for SessionIdHook<'_> {
                 *seen_response = Some(format!("{:?}", event.content));
                 ObservationAction::continue_run()
             }
-            Err(_) => ObservationAction::stop("response hook state unavailable"),
+            Err(_) => ObservationAction::stop("prepared-turn hook state unavailable"),
         }
     }
 }
@@ -100,7 +99,7 @@ async fn request_hook_records_prompt_and_response() -> Result<()> {
     let seen_response = hook
         .seen_response
         .lock()
-        .map_err(|_| anyhow!("response hook state unavailable"))?
+        .map_err(|_| anyhow!("prepared-turn hook state unavailable"))?
         .clone();
 
     anyhow::ensure!(

--- a/tests/providers/openai/cassette/request_hook.rs
+++ b/tests/providers/openai/cassette/request_hook.rs
@@ -5,8 +5,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use rig::agent::{
-    AgentHook, CompletionCallAction, CompletionCallEvent, CompletionResponseEvent,
-    ObservationAction,
+    AgentHook, CompletionCallAction, CompletionCallEvent, ModelTurnPrepared, ObservationAction,
 };
 use rig::client::CompletionClient;
 use rig::completion::{Message, Prompt};
@@ -52,10 +51,10 @@ impl AgentHook for SessionIdHook<'_> {
         }
     }
 
-    async fn on_completion_response(
+    async fn on_model_turn_prepared(
         &self,
         _ctx: &rig::agent::HookContext,
-        event: CompletionResponseEvent<'_>,
+        event: ModelTurnPrepared<'_>,
     ) -> ObservationAction {
         self.response_calls.fetch_add(1, Ordering::SeqCst);
         match self.seen_response.lock() {
@@ -63,7 +62,7 @@ impl AgentHook for SessionIdHook<'_> {
                 *seen_response = Some(format!("{:?}", event.content));
                 ObservationAction::continue_run()
             }
-            Err(_) => ObservationAction::stop("response hook state unavailable"),
+            Err(_) => ObservationAction::stop("prepared-turn hook state unavailable"),
         }
     }
 }
@@ -100,7 +99,7 @@ async fn request_hook_records_prompt_and_response() -> Result<()> {
             let seen_response = hook
                 .seen_response
                 .lock()
-                .map_err(|_| anyhow!("response hook state unavailable"))?
+                .map_err(|_| anyhow!("prepared-turn hook state unavailable"))?
                 .clone();
 
             anyhow::ensure!(

--- a/tests/providers/openrouter/cassette/request_hook.rs
+++ b/tests/providers/openrouter/cassette/request_hook.rs
@@ -5,8 +5,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use rig::agent::{
-    AgentHook, CompletionCallAction, CompletionCallEvent, CompletionResponseEvent,
-    ObservationAction,
+    AgentHook, CompletionCallAction, CompletionCallEvent, ModelTurnPrepared, ObservationAction,
 };
 use rig::client::CompletionClient;
 use rig::completion::{Message, Prompt};
@@ -52,10 +51,10 @@ impl AgentHook for SessionIdHook<'_> {
         }
     }
 
-    async fn on_completion_response(
+    async fn on_model_turn_prepared(
         &self,
         _ctx: &rig::agent::HookContext,
-        event: CompletionResponseEvent<'_>,
+        event: ModelTurnPrepared<'_>,
     ) -> ObservationAction {
         self.response_calls.fetch_add(1, Ordering::SeqCst);
         match self.seen_response.lock() {
@@ -63,7 +62,7 @@ impl AgentHook for SessionIdHook<'_> {
                 *seen_response = Some(format!("{:?}", event.content));
                 ObservationAction::continue_run()
             }
-            Err(_) => ObservationAction::stop("response hook state unavailable"),
+            Err(_) => ObservationAction::stop("prepared-turn hook state unavailable"),
         }
     }
 }
@@ -100,7 +99,7 @@ async fn request_hook_records_prompt_and_response() -> Result<()> {
             let seen_response = hook
                 .seen_response
                 .lock()
-                .map_err(|_| anyhow!("response hook state unavailable"))?
+                .map_err(|_| anyhow!("prepared-turn hook state unavailable"))?
                 .clone();
 
             anyhow::ensure!(

--- a/tests/providers/xai/request_hook.rs
+++ b/tests/providers/xai/request_hook.rs
@@ -5,8 +5,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use rig::agent::{
-    AgentHook, CompletionCallAction, CompletionCallEvent, CompletionResponseEvent,
-    ObservationAction,
+    AgentHook, CompletionCallAction, CompletionCallEvent, ModelTurnPrepared, ObservationAction,
 };
 use rig::client::CompletionClient;
 use rig::completion::{Message, Prompt};
@@ -52,10 +51,10 @@ impl AgentHook for SessionIdHook<'_> {
         }
     }
 
-    async fn on_completion_response(
+    async fn on_model_turn_prepared(
         &self,
         _ctx: &rig::agent::HookContext,
-        event: CompletionResponseEvent<'_>,
+        event: ModelTurnPrepared<'_>,
     ) -> ObservationAction {
         self.response_calls.fetch_add(1, Ordering::SeqCst);
         match self.seen_response.lock() {
@@ -63,7 +62,7 @@ impl AgentHook for SessionIdHook<'_> {
                 *seen_response = Some(format!("{:?}", event.content));
                 ObservationAction::continue_run()
             }
-            Err(_) => ObservationAction::stop("response hook state unavailable"),
+            Err(_) => ObservationAction::stop("prepared-turn hook state unavailable"),
         }
     }
 }
@@ -100,7 +99,7 @@ async fn request_hook_records_prompt_and_response() -> Result<()> {
             let seen_response = hook
                 .seen_response
                 .lock()
-                .map_err(|_| anyhow!("response hook state unavailable"))?
+                .map_err(|_| anyhow!("prepared-turn hook state unavailable"))?
                 .clone();
 
             anyhow::ensure!(


### PR DESCRIPTION
## Summary

- add provider-independent `CompletionFinishReason` and `CompletionTerminalMetadata` to completion responses
- replace the response-specific managed hooks with one `ModelTurnPrepared` lifecycle event shared by blocking and streaming runs
- normalize terminal metadata across native and OpenAI-compatible providers while preserving provider-specific raw reasons
- propagate usage, message IDs, and finish reasons through direct responses, collected streams, completion calls, recovery, and model turns
- update examples, changelogs, provider tests, and lifecycle regression coverage

## Why

Managed agent runs previously exposed provider-specific response payloads through several lifecycle callbacks, making portable hooks difficult and leaving terminal conditions inconsistent between blocking and streaming APIs. This introduces one canonical prepared-turn boundary and one portable terminal metadata model.

## Impact

Hooks can now observe or stop an accepted model turn through the same API across providers and execution modes. Direct completion APIs continue to expose their typed raw provider response while also returning canonical terminal metadata.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check --workspace --all-targets --all-features`
- `cargo test`
- `cargo test -p rig-core --lib`
- `cargo test -p rig-core --doc`
- `cargo test -p rig-bedrock --lib`
- `cargo test -p rig-gemini-grpc --lib`
- `cargo test -p rig-vertexai --lib`
- targeted OpenAI, Anthropic, and Gemini cassette suites
- `cargo check -p rig-core --features wasm --target wasm32-unknown-unknown`
- `cargo doc --workspace --no-deps`

An independent full-diff review was completed after implementation; all confirmed findings were addressed and the final pass found no remaining P0/P1 issues.