### PR TITLE
feat(agent): add response retry hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "agent_with_retry_hook"
+version = "0.40.0"
+dependencies = [
+ "anyhow",
+ "rig",
+ "tokio",
+]
+
+[[package]]
 name = "agent_with_tools"
 version = "0.40.0"
 dependencies = [

--- a/crates/rig-core/src/agent/builder.rs
+++ b/crates/rig-core/src/agent/builder.rs
@@ -276,8 +276,8 @@ where
     /// stack; hooks run for every prompt request (unless more are added per
     /// request) in registration order. How their results compose is
     /// event-dependent: `CompletionCall` request patches accumulate and merge,
-    /// `ToolCall`/`ToolResult` rewrites chain, and only observe-only/recovery
-    /// events use first-non-`Continue`-wins. See the
+    /// `ToolCall`/`ToolResult` rewrites chain, while model-turn steering and
+    /// observe-only/recovery events use first-non-`Continue`-wins. See the
     /// [`hook`](crate::agent::hook) module docs.
     pub fn add_hook<H>(mut self, hook: H) -> Self
     where

--- a/crates/rig-core/src/agent/hook.rs
+++ b/crates/rig-core/src/agent/hook.rs
@@ -56,10 +56,11 @@
 //!
 //! # Retrying a completed model turn
 //!
-//! A hook can reject a tool-free turn and either repeat the same request or
-//! preserve the rejected response and append corrective feedback. Retries use
-//! the run's existing total model-call budget. A narrower policy limit belongs
-//! to the hook and can be stored in the run-scoped [`Scratchpad`]:
+//! A hook can reject a tool-free turn and either reuse the same prompt and
+//! preceding history with fresh request preparation, or preserve the rejected
+//! response and append corrective feedback. Retries use the run's existing
+//! total model-call budget. A narrower policy limit belongs to the hook and can
+//! be stored in the run-scoped [`Scratchpad`]:
 //!
 //! ```
 //! use std::{collections::HashMap, sync::atomic::{AtomicUsize, Ordering}};
@@ -424,7 +425,11 @@ pub struct ModelTurnFinished<'a> {
 /// How an accepted, tool-free model turn should be retried.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RetryRequest {
-    /// Discard the rejected response and issue the same request again.
+    /// Discard the rejected response and reuse the same prompt and preceding
+    /// history with fresh request preparation.
+    ///
+    /// Completion-call hooks, retrieval, and dynamic tool resolution run again,
+    /// so the resulting provider request may differ from the rejected attempt.
     Repeat,
     /// Preserve the rejected assistant response and append corrective feedback.
     Feedback(String),
@@ -453,7 +458,8 @@ impl ModelTurnAction {
         Self::Continue
     }
 
-    /// Discards the response and repeats the same request.
+    /// Discards the response and reuses the same prompt and preceding history
+    /// with fresh request preparation.
     pub fn repeat() -> Self {
         Self::Retry(RetryRequest::Repeat)
     }

--- a/crates/rig-core/src/agent/hook.rs
+++ b/crates/rig-core/src/agent/hook.rs
@@ -2250,11 +2250,15 @@ mod migrated_tests {
     #[test]
     fn action_types_are_event_specific() {
         fn completion(_: CompletionCallAction) {}
+        fn model_turn(_: ModelTurnAction) {}
+        fn retry_request(_: RetryRequest) {}
         fn call(_: ToolCallAction) {}
         fn result(_: ToolResultAction) {}
         fn invalid(_: InvalidToolCallAction) {}
         fn observation(_: ObservationAction) {}
         completion(CompletionCallAction::continue_run());
+        model_turn(ModelTurnAction::retry_with_feedback("try again"));
+        retry_request(RetryRequest::Repeat);
         call(ToolCallAction::run());
         result(ToolResultAction::keep());
         invalid(InvalidToolCallAction::fail());

--- a/crates/rig-core/src/agent/hook.rs
+++ b/crates/rig-core/src/agent/hook.rs
@@ -10,10 +10,10 @@
 //!
 //! Hooks run in registration order through [`HookStack`]. Completion-call
 //! [`RequestPatch`] values accumulate and merge; tool-call argument rewrites and
-//! tool-result presentation rewrites chain into later hooks. Nested stacks obey
-//! the same rules as flat stacks, including preserving an argument rewrite when
-//! an inner stack later skips or stops. Every stop action short-circuits the
-//! remaining hooks for that event.
+//! tool-result presentation rewrites chain into later hooks. A
+//! [`ModelTurnAction::Retry`] or stop action short-circuits the remaining hooks
+//! for that event. Nested stacks obey the same rules as flat stacks, including
+//! preserving an argument rewrite when an inner stack later skips or stops.
 //!
 //! Register observe-only hooks before steering hooks when every observation is
 //! required: a steering stop intentionally prevents later observers from
@@ -23,9 +23,12 @@
 //! remain unchanged for policy decisions and execution-outcome metadata. A
 //! tool-result stop omits result content from telemetry.
 //!
-//! Blocking and streaming agents share the same request, tool-call, and
-//! tool-result resolution path. Streaming adds delta-specific observations, but
-//! shared lifecycle actions have identical semantics on both surfaces.
+//! Blocking and streaming agents share model-turn, request, tool-call, and
+//! tool-result resolution. Streaming adds delta-specific observations, but
+//! shared lifecycle actions have identical semantics on both surfaces. Streamed
+//! deltas are provisional until the model turn is accepted; a retry is surfaced
+//! as [`MultiTurnStreamItem::ModelTurnRetried`](crate::agent::MultiTurnStreamItem::ModelTurnRetried)
+//! so consumers can discard the rejected turn's deltas.
 //!
 //! # Example
 //!
@@ -49,6 +52,67 @@
 //!         ObservationAction::continue_run()
 //!     }
 //! }
+//! ```
+//!
+//! # Retrying a completed model turn
+//!
+//! A hook can reject a tool-free turn and either repeat the same request or
+//! preserve the rejected response and append corrective feedback. Retries use
+//! the run's existing total model-call budget. A narrower policy limit belongs
+//! to the hook and can be stored in the run-scoped [`Scratchpad`]:
+//!
+//! ```
+//! use std::{collections::HashMap, sync::atomic::{AtomicUsize, Ordering}};
+//! use rig_core::{
+//!     agent::{AgentHook, HookContext, ModelTurnAction, ModelTurnFinished},
+//!     message::AssistantContent,
+//! };
+//!
+//! static NEXT_HOOK_ID: AtomicUsize = AtomicUsize::new(1);
+//!
+//! #[derive(Clone, Default)]
+//! struct RetryCounts(HashMap<usize, usize>);
+//!
+//! struct RetryOnMarker {
+//!     id: usize,
+//!     max_retries: usize,
+//! }
+//!
+//! impl RetryOnMarker {
+//!     fn new(max_retries: usize) -> Self {
+//!         Self {
+//!             id: NEXT_HOOK_ID.fetch_add(1, Ordering::Relaxed),
+//!             max_retries,
+//!         }
+//!     }
+//! }
+//!
+//! impl AgentHook for RetryOnMarker {
+//!     async fn on_model_turn_finished(
+//!         &self,
+//!         ctx: &HookContext,
+//!         event: ModelTurnFinished<'_>,
+//!     ) -> ModelTurnAction {
+//!         let rejected = event.content.iter().any(|content| {
+//!             matches!(content, AssistantContent::Text(text) if text.text.contains("RETRY"))
+//!         });
+//!         if !rejected {
+//!             return ModelTurnAction::continue_run();
+//!         }
+//!
+//!         let attempt = ctx.scratchpad().update::<RetryCounts, _>(|counts| {
+//!             let attempt = counts.0.entry(self.id).or_default();
+//!             *attempt += 1;
+//!             *attempt
+//!         });
+//!         if attempt <= self.max_retries {
+//!             ModelTurnAction::retry_with_feedback("Return a complete answer.")
+//!         } else {
+//!             ModelTurnAction::stop("response retry limit exceeded")
+//!         }
+//!     }
+//! }
+//! # let _hook = RetryOnMarker::new(2);
 //! ```
 
 use std::collections::HashMap;
@@ -343,14 +407,66 @@ pub struct CompletionResponse<'a> {
 }
 
 /// Medium-neutral accepted model-turn event.
+///
+/// The turn is canonicalized and parked in the run state, but has not yet been
+/// advanced into tool execution or finalization. A hook may therefore reject a
+/// tool-free turn with [`ModelTurnAction::Retry`].
 #[derive(Clone, Copy)]
 pub struct ModelTurnFinished<'a> {
     /// One-based model-call index.
     pub turn: usize,
-    /// Canonical committed assistant content.
+    /// Canonical assistant content parked for hook acceptance.
     pub content: &'a OneOrMany<AssistantContent>,
     /// Usage reported for the turn.
     pub usage: Usage,
+}
+
+/// How an accepted, tool-free model turn should be retried.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RetryRequest {
+    /// Discard the rejected response and issue the same request again.
+    Repeat,
+    /// Preserve the rejected assistant response and append corrective feedback.
+    Feedback(String),
+}
+
+/// Action for the medium-neutral [`ModelTurnFinished`] event.
+///
+/// Every retry consumes the run's existing total model-call budget. Rig does
+/// not impose a separate response-retry limit; hooks that need one should keep
+/// run-scoped state in [`HookContext::scratchpad`]. Retrying a turn containing
+/// tool calls is rejected so provider-visible history never contains unanswered
+/// calls. Use tool-call hooks to steer those turns instead.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ModelTurnAction {
+    /// Accept the turn and continue the run.
+    Continue,
+    /// Reject the turn and request another model call.
+    Retry(RetryRequest),
+    /// Stop the run with a reason.
+    Stop(String),
+}
+
+impl ModelTurnAction {
+    /// Accepts the completed model turn.
+    pub fn continue_run() -> Self {
+        Self::Continue
+    }
+
+    /// Discards the response and repeats the same request.
+    pub fn repeat() -> Self {
+        Self::Retry(RetryRequest::Repeat)
+    }
+
+    /// Preserves the response, appends corrective feedback, and retries.
+    pub fn retry_with_feedback(feedback: impl Into<String>) -> Self {
+        Self::Retry(RetryRequest::Feedback(feedback.into()))
+    }
+
+    /// Stops the run with the supplied reason.
+    pub fn stop(reason: impl Into<String>) -> Self {
+        Self::Stop(reason.into())
+    }
 }
 
 /// Pre-execution tool event.
@@ -815,15 +931,16 @@ pub trait AgentHook: WasmCompatSend + WasmCompatSync {
         async { ObservationAction::Continue }
     }
 
-    /// Observes the content and usage produced at the end of a model turn.
+    /// Observes or rejects the content produced at the end of a model turn.
     ///
-    /// The default action continues the run.
+    /// A retry is valid only for a tool-free turn and consumes the existing
+    /// total model-call budget. The default action accepts the turn.
     fn on_model_turn_finished(
         &self,
         _ctx: &HookContext,
         _event: ModelTurnFinished<'_>,
-    ) -> impl Future<Output = ObservationAction> + WasmCompatSend {
-        async { ObservationAction::Continue }
+    ) -> impl Future<Output = ModelTurnAction> + WasmCompatSend {
+        async { ModelTurnAction::Continue }
     }
 
     /// Resolves a model-emitted tool call that cannot be dispatched as written.
@@ -928,7 +1045,7 @@ trait DynAgentHook: WasmCompatSend + WasmCompatSync {
         &'a self,
         ctx: &'a HookContext,
         event: ModelTurnFinished<'a>,
-    ) -> WasmBoxedFuture<'a, ObservationAction>;
+    ) -> WasmBoxedFuture<'a, ModelTurnAction>;
     fn invalid_tool_call<'a>(
         &'a self,
         ctx: &'a HookContext,
@@ -984,7 +1101,7 @@ where
         &'a self,
         ctx: &'a HookContext,
         event: ModelTurnFinished<'a>,
-    ) -> WasmBoxedFuture<'a, ObservationAction> {
+    ) -> WasmBoxedFuture<'a, ModelTurnAction> {
         Box::pin(self.on_model_turn_finished(ctx, event))
     }
     fn invalid_tool_call<'a>(
@@ -1167,14 +1284,14 @@ impl AgentHook for HookStack {
         &self,
         ctx: &HookContext,
         event: ModelTurnFinished<'_>,
-    ) -> ObservationAction {
+    ) -> ModelTurnAction {
         for hook in &self.hooks {
             let action = hook.model_turn_finished(ctx, event).await;
-            if !matches!(action, ObservationAction::Continue) {
+            if !matches!(action, ModelTurnAction::Continue) {
                 return action;
             }
         }
-        ObservationAction::Continue
+        ModelTurnAction::Continue
     }
     async fn on_invalid_tool_call(
         &self,

--- a/crates/rig-core/src/agent/mod.rs
+++ b/crates/rig-core/src/agent/mod.rs
@@ -163,9 +163,10 @@ pub use completion::Agent;
 pub use hook::CompletionCall as CompletionCallEvent;
 pub use hook::{
     AgentHook, CompletionCallAction, CompletionResponse as CompletionResponseEvent, HookContext,
-    HookStack, InvalidToolCallAction, InvalidToolCallContext, ModelTurnFinished, ObservationAction,
-    RequestPatch, RunId, Scratchpad, StepEventKind, StreamResponseFinish, TextDelta, ToolCall,
-    ToolCallAction, ToolCallDelta, ToolResultAction, ToolResultEvent,
+    HookStack, InvalidToolCallAction, InvalidToolCallContext, ModelTurnAction, ModelTurnFinished,
+    ObservationAction, RequestPatch, RetryRequest, RunId, Scratchpad, StepEventKind,
+    StreamResponseFinish, TextDelta, ToolCall, ToolCallAction, ToolCallDelta, ToolResultAction,
+    ToolResultEvent,
 };
 pub use prompt_request::streaming::{
     MultiTurnStreamItem, StreamingError, StreamingPromptRequest, StreamingResult, stream_to_stdout,

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -258,8 +258,8 @@ where
     /// Append a hook for this request (on top of any the agent already carries).
     /// Hooks run in registration order; how their results compose is
     /// event-dependent (`CompletionCall` request patches accumulate and merge,
-    /// `ToolCall`/`ToolResult` rewrites chain, and only observe-only/recovery
-    /// events use first-non-`Continue`-wins). See the
+    /// `ToolCall`/`ToolResult` rewrites chain, while model-turn steering and
+    /// observe-only/recovery events use first-non-`Continue`-wins). See the
     /// [`hook`](crate::agent::hook) module docs.
     pub fn add_hook<H>(mut self, hook: H) -> Self
     where

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -11,9 +11,9 @@ use crate::{
         streamed::{StreamedResolution, StreamedTurnAssembler, StreamedTurnEvent},
     },
     agent::runner::{
-        AgentRunner, CompletionCallOutcome, ToolExecution, acquire_agent_span, append_run_messages,
-        build_chat_span, new_execute_tool_span, observe_action, resolve_completion_call,
-        run_single_tool,
+        AgentRunner, CompletionCallOutcome, ModelTurnDecision, ToolExecution, acquire_agent_span,
+        append_run_messages, build_chat_span, new_execute_tool_span, observe_action,
+        resolve_completion_call, resolve_model_turn_action, run_single_tool,
     },
     completion::GetTokenUsage,
     message::{AssistantContent, UserContent},
@@ -106,6 +106,16 @@ pub enum MultiTurnStreamItem<R> {
     /// }
     /// ```
     CompletionCall(CompletionCall),
+    /// The completed model turn was rejected by a hook for retry.
+    ///
+    /// Text and reasoning deltas emitted for this turn were provisional. A
+    /// consumer should discard or visually reset output associated with `turn`.
+    /// A subsequent attempt is made only if the run's total model-call budget
+    /// permits it.
+    ModelTurnRetried {
+        /// One-based model-call index of the rejected turn.
+        turn: usize,
+    },
     /// The final result from the stream: the unified [`PromptResponse`] shared
     /// with the blocking surface.
     FinalResponse(PromptResponse),
@@ -326,8 +336,8 @@ where
     /// Append a hook to this request's hook stack (on top of any the agent
     /// already carries). Hooks run in registration order; how their results
     /// compose is event-dependent (`CompletionCall` request patches accumulate
-    /// and merge, `ToolCall`/`ToolResult` rewrites chain, and only
-    /// observe-only/recovery events use first-non-`Continue`-wins). See the
+    /// and merge, `ToolCall`/`ToolResult` rewrites chain, while model-turn
+    /// steering and observe-only/recovery events use first-non-`Continue`-wins). See the
     /// [`hook`](crate::agent::hook) module docs.
     pub fn add_hook<H>(mut self, hook: H) -> Self
     where
@@ -1322,11 +1332,8 @@ where
                 yield Err(StreamingError::Prompt(Box::new(run.cancel_error(reason))));
                 return;
             }
-            if let Some(item) = pending_final {
-                yield Ok(MultiTurnStreamItem::stream_item(item));
-            }
             self.last_message_id = streamed_turn.message_id.clone();
-            // The canonical (committed) assistant content: `finish` normalizes
+            // The canonical assistant content: `finish` normalizes
             // reasoning/text/tool ordering, so this can differ from the raw
             // `stream.choice` aggregate. `ModelTurnFinished` — the normalized
             // per-turn event — carries this, matching what is recorded into run
@@ -1337,7 +1344,62 @@ where
                 yield Err(Box::new(err).into());
                 return;
             }
-            // Only accepted, canonical output belongs in content telemetry.
+            // Normalized per-turn event, fired once the turn is parked for
+            // acceptance on the streaming surface — including tool-only /
+            // reasoning-only turns that fire no `StreamResponseFinish`.
+            // Suppressed for recovered turns, mirroring the blocking surface's
+            // `Continue` arm.
+            if !turn_recovered {
+                let action = runner
+                    .hooks
+                    .on_model_turn_finished(
+                        hook_ctx,
+                        ModelTurnFinished {
+                            turn: hook_ctx.turn(),
+                            content: &canonical_choice,
+                            usage: last_usage,
+                        },
+                    )
+                    .await;
+                match resolve_model_turn_action(run, action) {
+                    Ok(ModelTurnDecision::Advance) => {}
+                    Ok(ModelTurnDecision::Retried) => {
+                        yield Ok(MultiTurnStreamItem::ModelTurnRetried {
+                            turn: hook_ctx.turn(),
+                        });
+                        return;
+                    }
+                    Ok(ModelTurnDecision::Terminate(reason)) => {
+                        // Before model-turn steering was added, Stop observed
+                        // this already completed provider turn: its buffered
+                        // final and content telemetry were visible before the
+                        // cancellation. Preserve that behavior while Retry
+                        // alone suppresses the provisional final.
+                        if self.created_agent_span && self.record_telemetry_content {
+                            agent_span.record(
+                                "gen_ai.completion",
+                                assistant_text_from_choice(&canonical_choice),
+                            );
+                        }
+                        crate::telemetry::record_model_output(
+                            &chat_span,
+                            &canonical_choice,
+                            runner.record_telemetry_content,
+                        );
+                        if let Some(item) = pending_final.take() {
+                            yield Ok(MultiTurnStreamItem::stream_item(item));
+                        }
+                        yield Err(StreamingError::Prompt(Box::new(run.cancel_error(reason))));
+                        return;
+                    }
+                    Err(err) => {
+                        yield Err(StreamingError::Prompt(Box::new(err)));
+                        return;
+                    }
+                }
+            }
+
+            // Only hook-accepted canonical output belongs in content telemetry.
             // Keep caller-owned spans untouched, matching the blocking source.
             if self.created_agent_span && self.record_telemetry_content {
                 agent_span.record(
@@ -1351,29 +1413,9 @@ where
                 runner.record_telemetry_content,
             );
 
-            // Normalized per-turn event, fired once the turn is committed on the
-            // streaming surface — including tool-only / reasoning-only turns that
-            // fire no `StreamResponseFinish`. Suppressed for recovered turns,
-            // mirroring the blocking surface's `Continue` arm.
-            if !turn_recovered
-                && let Some(reason) = observe_action(
-                    runner
-                        .hooks
-                        .on_model_turn_finished(
-                            hook_ctx,
-                            ModelTurnFinished {
-                                turn: hook_ctx.turn(),
-                                content: &canonical_choice,
-                                usage: last_usage,
-                            },
-                        )
-                        .await,
-                )
-            {
-                yield Err(StreamingError::Prompt(Box::new(run.cancel_error(reason))));
-                return;
+            if let Some(item) = pending_final {
+                yield Ok(MultiTurnStreamItem::stream_item(item));
             }
-
             self.last_final_choice = final_turn_content;
         })
     }
@@ -1536,10 +1578,11 @@ where
 
 /// Helper function to stream assistant-visible completion output to stdout.
 ///
-/// This helper prints streamed assistant text and reasoning only. Streaming
-/// metadata events, such as `MultiTurnStreamItem::CompletionCall`, are not
-/// printed; metadata is returned on the [`PromptResponse`] via accessors such as
-/// [`PromptResponse::completion_calls`].
+/// This helper prints streamed assistant text and reasoning. Streaming metadata
+/// events, such as `MultiTurnStreamItem::CompletionCall`, are not printed;
+/// metadata is returned on the [`PromptResponse`] via accessors such as
+/// [`PromptResponse::completion_calls`]. A model-turn retry prints a visible
+/// boundary because text already written to stdout cannot be retracted.
 pub async fn stream_to_stdout<R>(
     stream: &mut StreamingResult<R>,
 ) -> Result<PromptResponse, std::io::Error> {
@@ -1562,6 +1605,10 @@ pub async fn stream_to_stdout<R>(
             }
             Ok(MultiTurnStreamItem::FinalResponse(res)) => {
                 final_res = res;
+            }
+            Ok(MultiTurnStreamItem::ModelTurnRetried { turn }) => {
+                print!("\n[model turn {turn} rejected; retry requested]\nResponse: ");
+                std::io::Write::flush(&mut std::io::stdout())?;
             }
             Err(err) => {
                 eprintln!("Error: {err}");

--- a/crates/rig-core/src/agent/run/mod.rs
+++ b/crates/rig-core/src/agent/run/mod.rs
@@ -496,9 +496,10 @@ impl AgentRun {
     ///
     /// [`RetryRequest::Repeat`] discards the rejected assistant response and
     /// repeats the same prompt. [`RetryRequest::Feedback`] records the rejected
-    /// response followed by corrective user feedback. Both modes preserve
-    /// completion-call and usage accounting, and the next call consumes the
-    /// existing total model-call budget.
+    /// response followed by corrective user feedback. Canonical empty assistant
+    /// turns are omitted from history, matching normal turn advancement. Both
+    /// modes preserve completion-call and usage accounting, and the next call
+    /// consumes the existing total model-call budget.
     ///
     /// Tool-bearing turns cannot be retried through this operation because
     /// preserving them without matching tool results would create invalid
@@ -530,10 +531,12 @@ impl AgentRun {
                         "model-turn retry lost the rejected assistant content",
                     ));
                 };
-                self.new_messages.push(Message::Assistant {
-                    id: turn.message_id,
-                    content,
-                });
+                if !is_empty_assistant_turn(&content) {
+                    self.new_messages.push(Message::Assistant {
+                        id: turn.message_id,
+                        content,
+                    });
+                }
                 self.new_messages.push(Message::user(feedback));
             }
         }

--- a/crates/rig-core/src/agent/run/mod.rs
+++ b/crates/rig-core/src/agent/run/mod.rs
@@ -515,16 +515,9 @@ impl AgentRun {
         };
 
         if turn.has_tool_calls {
-            let mut history = self.full_history();
-            if let Some(content) = OneOrMany::from_iter_optional(turn.items.clone()) {
-                history.push(Message::Assistant {
-                    id: turn.message_id.clone(),
-                    content,
-                });
-            }
             return Err(PromptError::prompt_cancelled(
-                history,
-                "model-turn retry does not support tool-bearing turns; use tool-call hooks instead",
+                self.full_history(),
+                "model-turn retry does not support tool-bearing model turns; use tool-call hooks instead",
             ));
         }
 
@@ -1726,8 +1719,16 @@ mod tests {
             .retry_model_turn(RetryRequest::Feedback("do not call tools".to_string()))
             .expect_err("tool-bearing retries must fail closed");
 
-        assert!(matches!(err, PromptError::PromptCancelled { .. }));
-        assert!(err.to_string().contains("tool-bearing turns"));
+        let PromptError::PromptCancelled {
+            chat_history,
+            reason,
+        } = err
+        else {
+            panic!("tool-bearing retry should return PromptCancelled");
+        };
+        assert!(reason.contains("tool-bearing model turns"));
+        assert!(reason.contains("tool-call hooks"));
+        assert_eq!(chat_history, vec![Message::user("add things")]);
         assert!(run.next_step().is_err(), "failed run cannot execute tools");
     }
 

--- a/crates/rig-core/src/agent/run/mod.rs
+++ b/crates/rig-core/src/agent/run/mod.rs
@@ -71,7 +71,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     OneOrMany,
-    agent::hook::{InvalidToolCallAction, InvalidToolCallContext},
+    agent::hook::{InvalidToolCallAction, InvalidToolCallContext, RetryRequest},
     agent::prompt_request::{
         CompletionCall, PromptResponse, TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER,
         assistant_text_from_choice, build_full_history, build_history_for_request,
@@ -490,6 +490,63 @@ impl AgentRun {
         };
 
         OneOrMany::from_iter_optional(turn.items.clone())
+    }
+
+    /// Reject the accepted, tool-free model turn and prepare another model call.
+    ///
+    /// [`RetryRequest::Repeat`] discards the rejected assistant response and
+    /// repeats the same prompt. [`RetryRequest::Feedback`] records the rejected
+    /// response followed by corrective user feedback. Both modes preserve
+    /// completion-call and usage accounting, and the next call consumes the
+    /// existing total model-call budget.
+    ///
+    /// Tool-bearing turns cannot be retried through this operation because
+    /// preserving them without matching tool results would create invalid
+    /// provider-visible history. Use tool-call hooks to steer those turns.
+    pub fn retry_model_turn(&mut self, request: RetryRequest) -> Result<(), PromptError> {
+        let turn = match std::mem::replace(&mut self.state, RunState::Failed) {
+            RunState::AwaitingAdvance(turn) => turn,
+            other => {
+                self.state = other;
+                return Err(self.protocol_violation(
+                    "retry_model_turn called without an accepted turn awaiting advancement",
+                ));
+            }
+        };
+
+        if turn.has_tool_calls {
+            let mut history = self.full_history();
+            if let Some(content) = OneOrMany::from_iter_optional(turn.items.clone()) {
+                history.push(Message::Assistant {
+                    id: turn.message_id.clone(),
+                    content,
+                });
+            }
+            return Err(PromptError::prompt_cancelled(
+                history,
+                "model-turn retry does not support tool-bearing turns; use tool-call hooks instead",
+            ));
+        }
+
+        match request {
+            RetryRequest::Repeat => {}
+            RetryRequest::Feedback(feedback) => {
+                let Some(content) = OneOrMany::from_iter_optional(turn.items) else {
+                    return Err(PromptError::prompt_cancelled(
+                        self.full_history(),
+                        "model-turn retry lost the rejected assistant content",
+                    ));
+                };
+                self.new_messages.push(Message::Assistant {
+                    id: turn.message_id,
+                    content,
+                });
+                self.new_messages.push(Message::user(feedback));
+            }
+        }
+
+        self.state = RunState::PreparingRequest;
+        Ok(())
     }
 
     /// The full conversation: input history followed by [`Self::messages`].
@@ -1577,6 +1634,101 @@ mod tests {
                 .len(),
             2
         );
+    }
+
+    #[test]
+    fn repeated_model_turn_reuses_prompt_without_recording_rejected_response() {
+        let first_usage = usage(10, 3);
+        let second_usage = usage(7, 2);
+        let mut run = AgentRun::new("question").max_turns(2);
+
+        let (first_prompt, first_history, first_turn) = expect_call_model(&mut run);
+        assert_eq!(first_prompt, Message::user("question"));
+        assert!(first_history.is_empty());
+        assert_eq!(first_turn, 1);
+        expect_continue(
+            run.model_response(text_turn("rejected").with_usage_for_test(first_usage))
+                .expect("first response"),
+        );
+
+        run.retry_model_turn(RetryRequest::Repeat)
+            .expect("repeat should be accepted");
+        let (second_prompt, second_history, second_turn) = expect_call_model(&mut run);
+        assert_eq!(second_prompt, Message::user("question"));
+        assert!(second_history.is_empty());
+        assert_eq!(second_turn, 2);
+        assert_eq!(run.messages(), &[Message::user("question")]);
+
+        expect_continue(
+            run.model_response(text_turn("accepted").with_usage_for_test(second_usage))
+                .expect("second response"),
+        );
+        let response = expect_done(&mut run);
+        assert_eq!(response.output, "accepted");
+        assert_eq!(response.usage, first_usage + second_usage);
+        assert_eq!(response.completion_calls.len(), 2);
+        let messages = response.messages.expect("response history");
+        assert_eq!(messages.len(), 2);
+        assert!(!format!("{messages:?}").contains("rejected"));
+    }
+
+    #[test]
+    fn feedback_retry_records_rejected_response_and_corrective_prompt() {
+        let mut run = AgentRun::new("question").max_turns(2);
+
+        expect_call_model(&mut run);
+        expect_continue(
+            run.model_response(text_turn("rejected"))
+                .expect("first response"),
+        );
+        run.retry_model_turn(RetryRequest::Feedback("try another approach".to_string()))
+            .expect("feedback retry should be accepted");
+
+        let (prompt, history, turn) = expect_call_model(&mut run);
+        assert_eq!(prompt, Message::user("try another approach"));
+        assert_eq!(turn, 2);
+        assert_eq!(
+            history,
+            vec![Message::user("question"), Message::assistant("rejected")]
+        );
+    }
+
+    #[test]
+    fn repeated_model_turn_consumes_existing_max_turns_budget() {
+        let mut run = AgentRun::new("question");
+
+        expect_call_model(&mut run);
+        expect_continue(
+            run.model_response(text_turn("rejected"))
+                .expect("first response"),
+        );
+        run.retry_model_turn(RetryRequest::Repeat)
+            .expect("state transition itself should succeed");
+
+        let err = run.next_step().expect_err("second call must exceed budget");
+        assert!(matches!(
+            err,
+            PromptError::MaxTurnsError { max_turns: 1, .. }
+        ));
+        assert_eq!(run.completion_calls().len(), 1);
+    }
+
+    #[test]
+    fn model_turn_retry_rejects_tool_calls_without_advancing_to_execution() {
+        let mut run = AgentRun::new("add things").max_turns(2);
+
+        expect_call_model(&mut run);
+        expect_continue(
+            run.model_response(tool_call_turn("call_1", "add"))
+                .expect("tool response"),
+        );
+        let err = run
+            .retry_model_turn(RetryRequest::Feedback("do not call tools".to_string()))
+            .expect_err("tool-bearing retries must fail closed");
+
+        assert!(matches!(err, PromptError::PromptCancelled { .. }));
+        assert!(err.to_string().contains("tool-bearing turns"));
+        assert!(run.next_step().is_err(), "failed run cannot execute tools");
     }
 
     #[test]

--- a/crates/rig-core/src/agent/run/mod.rs
+++ b/crates/rig-core/src/agent/run/mod.rs
@@ -495,11 +495,12 @@ impl AgentRun {
     /// Reject the accepted, tool-free model turn and prepare another model call.
     ///
     /// [`RetryRequest::Repeat`] discards the rejected assistant response and
-    /// repeats the same prompt. [`RetryRequest::Feedback`] records the rejected
-    /// response followed by corrective user feedback. Canonical empty assistant
-    /// turns are omitted from history, matching normal turn advancement. Both
-    /// modes preserve completion-call and usage accounting, and the next call
-    /// consumes the existing total model-call budget.
+    /// reuses the same prompt and preceding history with fresh request
+    /// preparation. [`RetryRequest::Feedback`] records the rejected response
+    /// followed by corrective user feedback. Canonical empty assistant turns
+    /// are omitted from history, matching normal turn advancement. Both modes
+    /// preserve completion-call and usage accounting, and the next call consumes
+    /// the existing total model-call budget.
     ///
     /// Tool-bearing turns cannot be retried through this operation because
     /// preserving them without matching tool results would create invalid

--- a/crates/rig-core/src/agent/runner.rs
+++ b/crates/rig-core/src/agent/runner.rs
@@ -9094,6 +9094,52 @@ mod migrated_tests {
     }
 
     #[tokio::test]
+    async fn blocking_empty_feedback_retry_omits_empty_assistant_history() {
+        let first_usage = retry_usage(5, 1);
+        let second_usage = retry_usage(7, 2);
+        let model = MockCompletionModel::from_turns([
+            MockTurn::text("").with_usage(first_usage),
+            MockTurn::text("accepted").with_usage(second_usage),
+        ]);
+        let response = AgentBuilder::new(model.clone())
+            .add_hook(BoundedResponseRetry::new(
+                "",
+                1,
+                TestRetryMode::Feedback("provide an answer"),
+            ))
+            .build()
+            .runner("question")
+            .max_turns(2)
+            .run()
+            .await
+            .expect("feedback retry should recover from an empty turn");
+
+        assert_eq!(response.output, "accepted");
+        assert_eq!(response.usage, first_usage + second_usage);
+        assert_eq!(response.completion_calls.len(), 2);
+        assert_eq!(
+            response.messages.expect("response messages"),
+            vec![
+                Message::user("question"),
+                Message::user("provide an answer"),
+                Message::assistant("accepted"),
+            ]
+        );
+        assert_eq!(
+            model.requests()[1]
+                .chat_history
+                .iter()
+                .cloned()
+                .collect::<Vec<_>>(),
+            vec![
+                Message::user("question"),
+                Message::user("provide an answer"),
+            ],
+            "the retry request must not contain an empty assistant message"
+        );
+    }
+
+    #[tokio::test]
     async fn streaming_model_turn_retry_marks_rollback_and_matches_blocking_accounting() {
         let first_usage = retry_usage(10, 3);
         let second_usage = retry_usage(7, 2);
@@ -9210,6 +9256,77 @@ mod migrated_tests {
         assert_eq!(
             serde_json::to_value(streaming.messages).expect("streaming history"),
             serde_json::to_value(blocking.messages).expect("blocking history")
+        );
+    }
+
+    #[tokio::test]
+    async fn streaming_empty_feedback_retry_omits_empty_assistant_history() {
+        let first_usage = retry_usage(5, 1);
+        let second_usage = retry_usage(7, 2);
+        let model = MockCompletionModel::from_stream_turns([
+            [
+                MockStreamEvent::text(""),
+                MockStreamEvent::final_response(first_usage),
+            ],
+            [
+                MockStreamEvent::text("accepted"),
+                MockStreamEvent::final_response(second_usage),
+            ],
+        ]);
+        let mut stream = AgentBuilder::new(model.clone())
+            .add_hook(BoundedResponseRetry::new(
+                "",
+                1,
+                TestRetryMode::Feedback("provide an answer"),
+            ))
+            .build()
+            .runner("question")
+            .max_turns(2)
+            .stream()
+            .await;
+
+        let mut retries = Vec::new();
+        let mut provider_finals = 0;
+        let mut completion_calls = 0;
+        let mut final_response = None;
+        while let Some(item) = stream.next().await {
+            match item.expect("stream item") {
+                MultiTurnStreamItem::ModelTurnRetried { turn } => retries.push(turn),
+                MultiTurnStreamItem::CompletionCall(_) => completion_calls += 1,
+                MultiTurnStreamItem::StreamAssistantItem(StreamedAssistantContent::Final(_)) => {
+                    provider_finals += 1;
+                }
+                MultiTurnStreamItem::FinalResponse(response) => final_response = Some(response),
+                _ => {}
+            }
+        }
+
+        assert_eq!(retries, vec![1]);
+        assert_eq!(provider_finals, 1, "the rejected final is suppressed");
+        assert_eq!(completion_calls, 2);
+        let response = final_response.expect("run final response");
+        assert_eq!(response.output, "accepted");
+        assert_eq!(response.usage, first_usage + second_usage);
+        assert_eq!(response.completion_calls.len(), 2);
+        assert_eq!(
+            response.messages.expect("response messages"),
+            vec![
+                Message::user("question"),
+                Message::user("provide an answer"),
+                Message::assistant("accepted"),
+            ]
+        );
+        assert_eq!(
+            model.requests()[1]
+                .chat_history
+                .iter()
+                .cloned()
+                .collect::<Vec<_>>(),
+            vec![
+                Message::user("question"),
+                Message::user("provide an answer"),
+            ],
+            "the retry request must not contain an empty assistant message"
         );
     }
 

--- a/crates/rig-core/src/agent/runner.rs
+++ b/crates/rig-core/src/agent/runner.rs
@@ -38,7 +38,7 @@ use super::{
     hook::{
         AgentHook, CompletionCall, CompletionCallAction,
         CompletionResponse as CompletionResponseEvent, HookContext, HookStack,
-        InvalidToolCallAction, ModelTurnFinished, ObservationAction, RequestPatch,
+        InvalidToolCallAction, ModelTurnAction, ModelTurnFinished, ObservationAction, RequestPatch,
         ToolCall as ToolCallEvent, ToolCallAction, ToolResultAction, ToolResultEvent,
     },
     prompt_request::{
@@ -116,6 +116,34 @@ pub(crate) fn observe_action(action: ObservationAction) -> Option<String> {
     match action {
         ObservationAction::Continue => None,
         ObservationAction::Stop(reason) => Some(reason),
+    }
+}
+
+/// Resolved outcome of the shared, medium-neutral model-turn hook.
+pub(crate) enum ModelTurnDecision {
+    /// Accept the turn and advance normally.
+    Advance,
+    /// The turn was rejected and the run is ready to issue another model call.
+    Retried,
+    /// Stop the run with the supplied reason.
+    Terminate(String),
+}
+
+/// Apply a model-turn hook action to the sans-IO run.
+///
+/// Both blocking and streaming sources use this resolver so retry history,
+/// tool-turn rejection, and state transitions cannot diverge by medium.
+pub(crate) fn resolve_model_turn_action(
+    run: &mut AgentRun,
+    action: ModelTurnAction,
+) -> Result<ModelTurnDecision, PromptError> {
+    match action {
+        ModelTurnAction::Continue => Ok(ModelTurnDecision::Advance),
+        ModelTurnAction::Retry(request) => {
+            run.retry_model_turn(request)?;
+            Ok(ModelTurnDecision::Retried)
+        }
+        ModelTurnAction::Stop(reason) => Ok(ModelTurnDecision::Terminate(reason)),
     }
 }
 
@@ -247,8 +275,8 @@ where
     /// Append a hook to the stack (on top of any the agent already carries).
     /// Hooks run in registration order; how their results compose is
     /// event-dependent (`CompletionCall` request patches accumulate and merge,
-    /// `ToolCall`/`ToolResult` rewrites chain, and only observe-only/recovery
-    /// events use their event-specific stop action). See the
+    /// `ToolCall`/`ToolResult` rewrites chain, while model-turn steering and
+    /// observe-only/recovery events use their event-specific terminal action). See the
     /// [`hook`](crate::agent::hook) module docs.
     pub fn add_hook<H>(mut self, hook: H) -> Self
     where
@@ -952,17 +980,11 @@ where
                     ModelTurnOutcome::Continue {
                         response_hook_suppressed,
                     } => {
-                        if runner.record_telemetry_content
-                            && let Some(choice) = run.accepted_turn_choice()
-                        {
-                            crate::telemetry::record_model_output(&chat_span, &choice, true);
-                        }
-
                         if !response_hook_suppressed {
                             // The response-finish event fires first, then the
-                            // normalized per-turn event. Both carry canonical
-                            // Rig data, are observe-only, and are suppressed for
-                            // recovered turns.
+                            // normalized per-turn event. The first observes;
+                            // the second can accept, retry, or stop the canonical
+                            // turn. Both are suppressed for recovered turns.
                             if let Some(reason) = observe_action(
                                 runner
                                     .hooks
@@ -977,25 +999,54 @@ where
                                     )
                                     .await,
                             ) {
+                                if runner.record_telemetry_content
+                                    && let Some(choice) = run.accepted_turn_choice()
+                                {
+                                    crate::telemetry::record_model_output(
+                                        &chat_span, &choice, true,
+                                    );
+                                }
                                 yield Err(StreamingError::Prompt(Box::new(run.cancel_error(reason))));
                                 return;
                             }
-                            if let Some(reason) = observe_action(
-                                runner
-                                    .hooks
-                                    .on_model_turn_finished(
-                                        hook_ctx,
-                                        ModelTurnFinished {
-                                            turn: hook_ctx.turn(),
-                                            content: &resp.choice,
-                                            usage: resp.usage,
-                                        },
-                                    )
-                                    .await,
-                            ) {
-                                yield Err(StreamingError::Prompt(Box::new(run.cancel_error(reason))));
-                                return;
+                            let action = runner
+                                .hooks
+                                .on_model_turn_finished(
+                                    hook_ctx,
+                                    ModelTurnFinished {
+                                        turn: hook_ctx.turn(),
+                                        content: &resp.choice,
+                                        usage: resp.usage,
+                                    },
+                                )
+                                .await;
+                            match resolve_model_turn_action(run, action) {
+                                Ok(ModelTurnDecision::Advance) => {}
+                                Ok(ModelTurnDecision::Retried) => break,
+                                Ok(ModelTurnDecision::Terminate(reason)) => {
+                                    if runner.record_telemetry_content
+                                        && let Some(choice) = run.accepted_turn_choice()
+                                    {
+                                        crate::telemetry::record_model_output(
+                                            &chat_span, &choice, true,
+                                        );
+                                    }
+                                    yield Err(StreamingError::Prompt(Box::new(
+                                        run.cancel_error(reason),
+                                    )));
+                                    return;
+                                }
+                                Err(err) => {
+                                    yield Err(StreamingError::Prompt(Box::new(err)));
+                                    return;
+                                }
                             }
+                        }
+
+                        if runner.record_telemetry_content
+                            && let Some(choice) = run.accepted_turn_choice()
+                        {
+                            crate::telemetry::record_model_output(&chat_span, &choice, true);
                         }
                         break;
                     }
@@ -1572,21 +1623,24 @@ mod tests {
 #[cfg(test)]
 #[allow(irrefutable_let_patterns, unreachable_patterns)]
 mod migrated_tests {
+    use std::collections::HashMap;
+
     use crate::agent::{
-        CompletionCallAction, CompletionCallEvent, InvalidToolCallAction, InvalidToolCallContext,
-        ModelTurnFinished, ObservationAction, StreamResponseFinish, TextDelta, ToolCall,
-        ToolCallAction, ToolCallDelta, ToolResultAction, ToolResultEvent,
+        CompletionCallAction, CompletionCallEvent, HookStack, InvalidToolCallAction,
+        InvalidToolCallContext, ModelTurnAction, ModelTurnFinished, ObservationAction,
+        StreamResponseFinish, TextDelta, ToolCall, ToolCallAction, ToolCallDelta, ToolResultAction,
+        ToolResultEvent,
     };
 
     use std::sync::{
         Arc, Mutex,
-        atomic::{AtomicBool, AtomicU32, Ordering::SeqCst},
+        atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering::SeqCst},
     };
 
     use futures::StreamExt;
     use serde::Deserialize;
     use serde_json::json;
-    use tokio::sync::Notify;
+    use tokio::sync::{Barrier, Notify};
 
     use crate::OneOrMany;
     use crate::agent::AgentBuilder;
@@ -1687,9 +1741,9 @@ mod migrated_tests {
             &self,
             _: &HookContext,
             _: ModelTurnFinished<'_>,
-        ) -> ObservationAction {
+        ) -> ModelTurnAction {
             self.record(StepEventKind::ModelTurnFinished);
-            ObservationAction::continue_run()
+            ModelTurnAction::continue_run()
         }
         async fn on_invalid_tool_call(
             &self,
@@ -1791,12 +1845,12 @@ mod migrated_tests {
             &self,
             _ctx: &HookContext,
             event: ModelTurnFinished<'_>,
-        ) -> ObservationAction {
+        ) -> ModelTurnAction {
             self.committed
                 .lock()
                 .expect("committed snapshots")
                 .push(event.content.clone());
-            ObservationAction::continue_run()
+            ModelTurnAction::continue_run()
         }
     }
 
@@ -1841,9 +1895,9 @@ mod migrated_tests {
             &self,
             _ctx: &HookContext,
             _event: ModelTurnFinished<'_>,
-        ) -> ObservationAction {
+        ) -> ModelTurnAction {
             self.model_turns.fetch_add(1, SeqCst);
-            ObservationAction::continue_run()
+            ModelTurnAction::continue_run()
         }
     }
 
@@ -1975,8 +2029,8 @@ mod migrated_tests {
                 assert_eq!(snapshots[0].message_id.as_deref(), Some("msg-after-final"));
                 assert_eq!(
                     hook.model_turns.load(SeqCst),
-                    0,
-                    "the turn must remain uncommitted while the final item is yielded"
+                    1,
+                    "the canonical turn hook must accept the turn before final exposure"
                 );
             }
         }
@@ -2028,6 +2082,61 @@ mod migrated_tests {
                     error.as_ref(),
                     PromptError::PromptCancelled { chat_history, reason }
                         if chat_history == &[prompt] && reason == "stop at stream EOF"
+                )
+        ));
+    }
+
+    struct StopCompletedModelTurn;
+
+    impl AgentHook for StopCompletedModelTurn {
+        async fn on_model_turn_finished(
+            &self,
+            _ctx: &HookContext,
+            _event: ModelTurnFinished<'_>,
+        ) -> ModelTurnAction {
+            ModelTurnAction::stop("stop completed model turn")
+        }
+    }
+
+    #[tokio::test]
+    async fn streaming_model_turn_stop_preserves_completed_provider_final() {
+        let prompt = Message::user("canonical prompt");
+        let mut stream = AgentBuilder::new(MockCompletionModel::from_stream_turns([[
+            MockStreamEvent::text("canonical response"),
+            MockStreamEvent::final_response(canonical_usage()),
+        ]]))
+        .add_hook(StopCompletedModelTurn)
+        .build()
+        .runner(prompt.clone())
+        .stream()
+        .await;
+
+        let mut provider_finals = 0;
+        let mut saw_retry = false;
+        let mut saw_run_final = false;
+        let mut error = None;
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(MultiTurnStreamItem::StreamAssistantItem(StreamedAssistantContent::Final(
+                    _,
+                ))) => provider_finals += 1,
+                Ok(MultiTurnStreamItem::ModelTurnRetried { .. }) => saw_retry = true,
+                Ok(MultiTurnStreamItem::FinalResponse(_)) => saw_run_final = true,
+                Ok(_) => {}
+                Err(err) => error = Some(err),
+            }
+        }
+
+        assert_eq!(provider_finals, 1);
+        assert!(!saw_retry);
+        assert!(!saw_run_final);
+        assert!(matches!(
+            error,
+            Some(StreamingError::Prompt(error))
+                if matches!(
+                    error.as_ref(),
+                    PromptError::PromptCancelled { reason, .. }
+                        if reason == "stop completed model turn"
                 )
         ));
     }
@@ -7389,7 +7498,7 @@ mod migrated_tests {
             &self,
             _ctx: &HookContext,
             event: ModelTurnFinished<'_>,
-        ) -> ObservationAction {
+        ) -> ModelTurnAction {
             if let ModelTurnFinished { turn, content, .. } = event
                 && turn == 1
             {
@@ -7404,7 +7513,7 @@ mod migrated_tests {
                     .collect();
                 *self.kinds.lock().expect("kinds") = Some(kinds);
             }
-            ObservationAction::continue_run()
+            ModelTurnAction::continue_run()
         }
     }
 
@@ -7628,12 +7737,12 @@ mod migrated_tests {
             &self,
             ctx: &HookContext,
             _event: ModelTurnFinished<'_>,
-        ) -> ObservationAction {
+        ) -> ModelTurnAction {
             if ctx.turn() == 1 {
                 self.handle.add_tool(FinalResultTool).await;
             }
 
-            ObservationAction::continue_run()
+            ModelTurnAction::continue_run()
         }
 
         async fn on_completion_call(
@@ -8053,7 +8162,7 @@ mod migrated_tests {
             &self,
             _ctx: &HookContext,
             event: ModelTurnFinished<'_>,
-        ) -> ObservationAction {
+        ) -> ModelTurnAction {
             if let ModelTurnFinished { content, .. } = event
                 && content.iter().any(|c| {
                     matches!(c, AssistantContent::ToolCall(tc) if tc.function.name == "final_result")
@@ -8061,7 +8170,7 @@ mod migrated_tests {
             {
                 *self.saw_output_tool_call.lock().expect("lock") = true;
             }
-            ObservationAction::continue_run()
+            ModelTurnAction::continue_run()
         }
     }
 
@@ -8538,5 +8647,696 @@ mod migrated_tests {
             tool_result_text_in_history(&messages, "denied by policy: `subtract` not allowed"),
             "the policy denial reason must reach the model as the subtract tool result"
         );
+    }
+
+    static NEXT_RESPONSE_RETRY_HOOK_ID: AtomicU64 = AtomicU64::new(1);
+
+    #[derive(Clone, Default)]
+    struct ResponseRetryAttempts(HashMap<u64, usize>);
+
+    #[derive(Clone)]
+    enum TestRetryMode {
+        Repeat,
+        Feedback(&'static str),
+    }
+
+    /// A policy-owned retry budget. The framework only enforces `max_turns`;
+    /// this hook stores its narrower limit in the run-scoped scratchpad.
+    #[derive(Clone)]
+    struct BoundedResponseRetry {
+        id: u64,
+        rejected_text: &'static str,
+        max_retries: usize,
+        mode: TestRetryMode,
+    }
+
+    impl BoundedResponseRetry {
+        fn new(rejected_text: &'static str, max_retries: usize, mode: TestRetryMode) -> Self {
+            Self {
+                id: NEXT_RESPONSE_RETRY_HOOK_ID.fetch_add(1, SeqCst),
+                rejected_text,
+                max_retries,
+                mode,
+            }
+        }
+    }
+
+    impl AgentHook for BoundedResponseRetry {
+        async fn on_model_turn_finished(
+            &self,
+            ctx: &HookContext,
+            event: ModelTurnFinished<'_>,
+        ) -> ModelTurnAction {
+            let rejected = event.content.iter().any(
+                |content| matches!(content, AssistantContent::Text(text) if text.text == self.rejected_text),
+            );
+            if !rejected {
+                return ModelTurnAction::continue_run();
+            }
+
+            let attempt = ctx
+                .scratchpad()
+                .update::<ResponseRetryAttempts, _>(|attempts| {
+                    let attempt = attempts.0.entry(self.id).or_default();
+                    *attempt += 1;
+                    *attempt
+                });
+            if attempt > self.max_retries {
+                return ModelTurnAction::stop(format!(
+                    "response retry limit ({}) exceeded",
+                    self.max_retries
+                ));
+            }
+
+            match self.mode {
+                TestRetryMode::Repeat => ModelTurnAction::repeat(),
+                TestRetryMode::Feedback(feedback) => ModelTurnAction::retry_with_feedback(feedback),
+            }
+        }
+    }
+
+    fn retry_usage(input_tokens: u64, output_tokens: u64) -> Usage {
+        Usage {
+            input_tokens,
+            output_tokens,
+            total_tokens: input_tokens + output_tokens,
+            ..Usage::new()
+        }
+    }
+
+    #[tokio::test]
+    async fn blocking_model_turn_repeat_preserves_accounting_and_reuses_request() {
+        let first_usage = retry_usage(10, 3);
+        let second_usage = retry_usage(7, 2);
+        let model = MockCompletionModel::from_turns([
+            MockTurn::text("rejected").with_usage(first_usage),
+            MockTurn::text("accepted").with_usage(second_usage),
+        ]);
+        let response = AgentBuilder::new(model.clone())
+            .add_hook(BoundedResponseRetry::new(
+                "rejected",
+                1,
+                TestRetryMode::Repeat,
+            ))
+            .build()
+            .runner("question")
+            .max_turns(2)
+            .run()
+            .await
+            .expect("repeat should recover");
+
+        assert_eq!(response.output, "accepted");
+        assert_eq!(response.usage, first_usage + second_usage);
+        assert_eq!(response.completion_calls.len(), 2);
+        let messages = response.messages.expect("response messages");
+        assert_eq!(
+            messages,
+            vec![Message::user("question"), Message::assistant("accepted")]
+        );
+
+        let requests = model.requests();
+        assert_eq!(requests.len(), 2);
+        let first = requests[0].chat_history.iter().cloned().collect::<Vec<_>>();
+        let second = requests[1].chat_history.iter().cloned().collect::<Vec<_>>();
+        assert_eq!(first, vec![Message::user("question")]);
+        assert_eq!(second, first, "Repeat must resend the same request");
+    }
+
+    #[tokio::test]
+    async fn blocking_model_turn_feedback_preserves_rejected_response() {
+        let model = MockCompletionModel::from_turns([
+            MockTurn::text("rejected"),
+            MockTurn::text("accepted"),
+        ]);
+        let response = AgentBuilder::new(model.clone())
+            .add_hook(BoundedResponseRetry::new(
+                "rejected",
+                1,
+                TestRetryMode::Feedback("try another approach"),
+            ))
+            .build()
+            .runner("question")
+            .max_turns(2)
+            .run()
+            .await
+            .expect("feedback retry should recover");
+
+        assert_eq!(response.output, "accepted");
+        assert_eq!(
+            response.messages.expect("response messages"),
+            vec![
+                Message::user("question"),
+                Message::assistant("rejected"),
+                Message::user("try another approach"),
+                Message::assistant("accepted"),
+            ]
+        );
+        let second_request = &model.requests()[1];
+        assert_eq!(
+            second_request
+                .chat_history
+                .iter()
+                .cloned()
+                .collect::<Vec<_>>(),
+            vec![
+                Message::user("question"),
+                Message::assistant("rejected"),
+                Message::user("try another approach"),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn streaming_model_turn_retry_marks_rollback_and_matches_blocking_accounting() {
+        let first_usage = retry_usage(10, 3);
+        let second_usage = retry_usage(7, 2);
+        let model = MockCompletionModel::from_stream_turns([
+            [
+                MockStreamEvent::text("rejected"),
+                MockStreamEvent::final_response(first_usage),
+            ],
+            [
+                MockStreamEvent::text("accepted"),
+                MockStreamEvent::final_response(second_usage),
+            ],
+        ]);
+        let mut stream = AgentBuilder::new(model.clone())
+            .add_hook(BoundedResponseRetry::new(
+                "rejected",
+                1,
+                TestRetryMode::Repeat,
+            ))
+            .build()
+            .runner("question")
+            .max_turns(2)
+            .stream()
+            .await;
+
+        let mut retries = Vec::new();
+        let mut provider_finals = 0;
+        let mut completion_calls = 0;
+        let mut final_response = None;
+        while let Some(item) = stream.next().await {
+            match item.expect("stream item") {
+                MultiTurnStreamItem::ModelTurnRetried { turn } => retries.push(turn),
+                MultiTurnStreamItem::CompletionCall(_) => completion_calls += 1,
+                MultiTurnStreamItem::StreamAssistantItem(StreamedAssistantContent::Final(_)) => {
+                    provider_finals += 1
+                }
+                MultiTurnStreamItem::FinalResponse(response) => final_response = Some(response),
+                _ => {}
+            }
+        }
+
+        assert_eq!(retries, vec![1]);
+        assert_eq!(
+            provider_finals, 1,
+            "the rejected provider final is suppressed"
+        );
+        assert_eq!(completion_calls, 2);
+        let response = final_response.expect("run final response");
+        assert_eq!(response.output, "accepted");
+        assert_eq!(response.usage, first_usage + second_usage);
+        assert_eq!(response.completion_calls.len(), 2);
+        assert_eq!(
+            response.messages.expect("response messages"),
+            vec![Message::user("question"), Message::assistant("accepted")]
+        );
+        assert_eq!(model.requests().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn streaming_feedback_retry_matches_blocking_history_and_usage() {
+        let first_usage = retry_usage(5, 2);
+        let second_usage = retry_usage(8, 4);
+        let blocking = AgentBuilder::new(MockCompletionModel::from_turns([
+            MockTurn::text("rejected").with_usage(first_usage),
+            MockTurn::text("accepted").with_usage(second_usage),
+        ]))
+        .add_hook(BoundedResponseRetry::new(
+            "rejected",
+            1,
+            TestRetryMode::Feedback("correct the answer"),
+        ))
+        .build()
+        .runner("question")
+        .max_turns(2)
+        .run()
+        .await
+        .expect("blocking feedback retry");
+
+        let mut stream = AgentBuilder::new(MockCompletionModel::from_stream_turns([
+            [
+                MockStreamEvent::text("rejected"),
+                MockStreamEvent::final_response(first_usage),
+            ],
+            [
+                MockStreamEvent::text("accepted"),
+                MockStreamEvent::final_response(second_usage),
+            ],
+        ]))
+        .add_hook(BoundedResponseRetry::new(
+            "rejected",
+            1,
+            TestRetryMode::Feedback("correct the answer"),
+        ))
+        .build()
+        .runner("question")
+        .max_turns(2)
+        .stream()
+        .await;
+        let mut saw_retry = false;
+        let mut streaming = None;
+        while let Some(item) = stream.next().await {
+            match item.expect("stream item") {
+                MultiTurnStreamItem::ModelTurnRetried { turn: 1 } => saw_retry = true,
+                MultiTurnStreamItem::FinalResponse(response) => streaming = Some(response),
+                _ => {}
+            }
+        }
+
+        let streaming = streaming.expect("streaming final response");
+        assert!(saw_retry);
+        assert_eq!(streaming.output, blocking.output);
+        assert_eq!(streaming.usage, blocking.usage);
+        assert_eq!(streaming.completion_calls, blocking.completion_calls);
+        assert_eq!(
+            serde_json::to_value(streaming.messages).expect("streaming history"),
+            serde_json::to_value(blocking.messages).expect("blocking history")
+        );
+    }
+
+    #[tokio::test]
+    async fn response_retry_preserves_model_turn_hook_order_across_surfaces() {
+        let blocking_events = RecordingHook::default();
+        AgentBuilder::new(MockCompletionModel::from_turns([
+            MockTurn::text("rejected"),
+            MockTurn::text("accepted"),
+        ]))
+        .add_hook(blocking_events.clone())
+        .add_hook(BoundedResponseRetry::new(
+            "rejected",
+            1,
+            TestRetryMode::Repeat,
+        ))
+        .build()
+        .runner("question")
+        .max_turns(2)
+        .run()
+        .await
+        .expect("blocking retry");
+
+        let streaming_events = RecordingHook::default();
+        let mut stream = AgentBuilder::new(MockCompletionModel::from_stream_turns([
+            [
+                MockStreamEvent::text("rejected"),
+                MockStreamEvent::final_response_with_default_usage(),
+            ],
+            [
+                MockStreamEvent::text("accepted"),
+                MockStreamEvent::final_response_with_default_usage(),
+            ],
+        ]))
+        .add_hook(streaming_events.clone())
+        .add_hook(BoundedResponseRetry::new(
+            "rejected",
+            1,
+            TestRetryMode::Repeat,
+        ))
+        .build()
+        .runner("question")
+        .max_turns(2)
+        .stream()
+        .await;
+        while let Some(item) = stream.next().await {
+            item.expect("streaming retry item");
+        }
+
+        let shared_order = |events: &RecordingHook| {
+            events
+                .events
+                .lock()
+                .expect("events")
+                .iter()
+                .copied()
+                .filter(|event| {
+                    matches!(
+                        event,
+                        StepEventKind::CompletionCall | StepEventKind::ModelTurnFinished
+                    )
+                })
+                .collect::<Vec<_>>()
+        };
+        let expected = vec![
+            StepEventKind::CompletionCall,
+            StepEventKind::ModelTurnFinished,
+            StepEventKind::CompletionCall,
+            StepEventKind::ModelTurnFinished,
+        ];
+        assert_eq!(shared_order(&blocking_events), expected);
+        assert_eq!(shared_order(&streaming_events), expected);
+
+        let blocking_order = blocking_events.events.lock().expect("events").clone();
+        assert_eq!(
+            blocking_order,
+            vec![
+                StepEventKind::CompletionCall,
+                StepEventKind::CompletionResponse,
+                StepEventKind::ModelTurnFinished,
+                StepEventKind::CompletionCall,
+                StepEventKind::CompletionResponse,
+                StepEventKind::ModelTurnFinished,
+            ]
+        );
+        let streaming_order = streaming_events.events.lock().expect("events").clone();
+        assert_eq!(
+            streaming_order,
+            vec![
+                StepEventKind::CompletionCall,
+                StepEventKind::TextDelta,
+                StepEventKind::StreamResponseFinish,
+                StepEventKind::ModelTurnFinished,
+                StepEventKind::CompletionCall,
+                StepEventKind::TextDelta,
+                StepEventKind::StreamResponseFinish,
+                StepEventKind::ModelTurnFinished,
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn streaming_model_turn_retry_respects_max_turns() {
+        let model = MockCompletionModel::from_stream_turns([[
+            MockStreamEvent::text("rejected"),
+            MockStreamEvent::final_response_with_default_usage(),
+        ]]);
+        let mut stream = AgentBuilder::new(model)
+            .add_hook(BoundedResponseRetry::new(
+                "rejected",
+                1,
+                TestRetryMode::Repeat,
+            ))
+            .build()
+            .runner("question")
+            .max_turns(1)
+            .stream()
+            .await;
+
+        let mut saw_rollback = false;
+        let mut error = None;
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(MultiTurnStreamItem::ModelTurnRetried { turn: 1 }) => saw_rollback = true,
+                Ok(_) => {}
+                Err(err) => error = Some(err),
+            }
+        }
+        assert!(saw_rollback);
+        assert!(matches!(
+            error,
+            Some(StreamingError::Prompt(error))
+                if matches!(error.as_ref(), PromptError::MaxTurnsError { max_turns: 1, .. })
+        ));
+    }
+
+    struct AlwaysRepeatModelTurn;
+
+    impl AgentHook for AlwaysRepeatModelTurn {
+        async fn on_model_turn_finished(
+            &self,
+            _ctx: &HookContext,
+            _event: ModelTurnFinished<'_>,
+        ) -> ModelTurnAction {
+            ModelTurnAction::repeat()
+        }
+    }
+
+    #[tokio::test]
+    async fn model_turn_retry_rejects_tool_turn_before_tool_hooks_or_execution() {
+        let recorder = RecordingHook::default();
+        let err = AgentBuilder::new(MockCompletionModel::from_turns([MockTurn::tool_call(
+            "tc1",
+            "add",
+            json!({"x": 1, "y": 2}),
+        )]))
+        .tool(MockAddTool)
+        .add_hook(recorder.clone())
+        .add_hook(AlwaysRepeatModelTurn)
+        .build()
+        .runner("add")
+        .max_turns(2)
+        .run()
+        .await
+        .expect_err("tool-bearing retry must fail closed");
+
+        assert!(matches!(err, PromptError::PromptCancelled { .. }));
+        assert!(err.to_string().contains("tool-bearing turns"));
+        assert_eq!(recorder.count(StepEventKind::ToolCall), 0);
+        assert_eq!(recorder.count(StepEventKind::ToolResult), 0);
+    }
+
+    #[tokio::test]
+    async fn streaming_model_turn_retry_rejects_tool_turn_without_committed_execution() {
+        let recorder = RecordingHook::default();
+        let mut stream = AgentBuilder::new(MockCompletionModel::from_stream_turns([[
+            MockStreamEvent::tool_call_name_delta("tc1", "ic1", "add"),
+            MockStreamEvent::tool_call_arguments_delta("tc1", "ic1", r#"{"x":1,"y":2}"#),
+            MockStreamEvent::tool_call("tc1", "add", json!({"x": 1, "y": 2})),
+            MockStreamEvent::final_response_with_default_usage(),
+        ]]))
+        .tool(MockAddTool)
+        .add_hook(recorder.clone())
+        .add_hook(AlwaysRepeatModelTurn)
+        .build()
+        .runner("add")
+        .max_turns(2)
+        .stream()
+        .await;
+
+        let mut execution_commits = 0;
+        let mut tool_results = 0;
+        let mut error = None;
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(MultiTurnStreamItem::ToolExecutionCommitted { .. }) => execution_commits += 1,
+                Ok(MultiTurnStreamItem::StreamUserItem(StreamedUserContent::ToolResult {
+                    ..
+                })) => tool_results += 1,
+                Ok(_) => {}
+                Err(err) => error = Some(err),
+            }
+        }
+
+        assert!(matches!(
+            error,
+            Some(StreamingError::Prompt(error))
+                if matches!(error.as_ref(), PromptError::PromptCancelled { .. })
+                    && error.to_string().contains("tool-bearing turns")
+        ));
+        assert_eq!(execution_commits, 0);
+        assert_eq!(tool_results, 0);
+        assert_eq!(recorder.count(StepEventKind::ToolCall), 0);
+        assert_eq!(recorder.count(StepEventKind::ToolResult), 0);
+    }
+
+    #[derive(Clone)]
+    struct BarrierResponseRetry {
+        inner: BoundedResponseRetry,
+        barrier: Arc<Barrier>,
+    }
+
+    impl AgentHook for BarrierResponseRetry {
+        async fn on_model_turn_finished(
+            &self,
+            ctx: &HookContext,
+            event: ModelTurnFinished<'_>,
+        ) -> ModelTurnAction {
+            let rejected = event.content.iter().any(
+                |content| matches!(content, AssistantContent::Text(text) if text.text == "rejected"),
+            );
+            if rejected {
+                self.barrier.wait().await;
+            }
+            self.inner.on_model_turn_finished(ctx, event).await
+        }
+    }
+
+    #[tokio::test]
+    async fn concurrent_runs_of_same_agent_have_independent_retry_budgets() {
+        let hook = BarrierResponseRetry {
+            inner: BoundedResponseRetry::new("rejected", 1, TestRetryMode::Repeat),
+            barrier: Arc::new(Barrier::new(2)),
+        };
+        let agent = AgentBuilder::new(MockCompletionModel::from_turns([
+            MockTurn::text("rejected"),
+            MockTurn::text("rejected"),
+            MockTurn::text("accepted one"),
+            MockTurn::text("accepted two"),
+        ]))
+        .add_hook(hook)
+        .build();
+
+        let first = agent.runner("first").max_turns(2).run();
+        let second = agent.runner("second").max_turns(2).run();
+        let (first, second) = tokio::join!(first, second);
+        let first = first.expect("first run");
+        let second = second.expect("second run");
+
+        let outputs = std::collections::HashSet::from([first.output, second.output]);
+        assert_eq!(
+            outputs,
+            std::collections::HashSet::from([
+                "accepted one".to_string(),
+                "accepted two".to_string(),
+            ])
+        );
+        assert_eq!(first.completion_calls.len(), 2);
+        assert_eq!(second.completion_calls.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn retry_scratchpad_state_is_isolated_by_run_and_hook_instance() {
+        let shared_hook = BoundedResponseRetry::new("rejected", 1, TestRetryMode::Repeat);
+        let first_ctx = HookContext::new(false, None);
+        let second_ctx = HookContext::new(false, None);
+        let content = OneOrMany::one(AssistantContent::text("rejected"));
+        let first_event = ModelTurnFinished {
+            turn: 1,
+            content: &content,
+            usage: Usage::new(),
+        };
+        let second_event = first_event;
+
+        let (first, second) = tokio::join!(
+            shared_hook.on_model_turn_finished(&first_ctx, first_event),
+            shared_hook.on_model_turn_finished(&second_ctx, second_event),
+        );
+        assert!(matches!(first, ModelTurnAction::Retry(_)));
+        assert!(matches!(second, ModelTurnAction::Retry(_)));
+        assert!(matches!(
+            shared_hook
+                .on_model_turn_finished(&first_ctx, first_event)
+                .await,
+            ModelTurnAction::Stop(_)
+        ));
+
+        let same_run_ctx = HookContext::new(false, None);
+        let first_hook = BoundedResponseRetry::new("first", 1, TestRetryMode::Repeat);
+        let second_hook = BoundedResponseRetry::new("second", 1, TestRetryMode::Repeat);
+        let first_content = OneOrMany::one(AssistantContent::text("first"));
+        let second_content = OneOrMany::one(AssistantContent::text("second"));
+        let first_action = first_hook
+            .on_model_turn_finished(
+                &same_run_ctx,
+                ModelTurnFinished {
+                    turn: 1,
+                    content: &first_content,
+                    usage: Usage::new(),
+                },
+            )
+            .await;
+        let second_action = second_hook
+            .on_model_turn_finished(
+                &same_run_ctx,
+                ModelTurnFinished {
+                    turn: 2,
+                    content: &second_content,
+                    usage: Usage::new(),
+                },
+            )
+            .await;
+        assert!(matches!(first_action, ModelTurnAction::Retry(_)));
+        assert!(matches!(second_action, ModelTurnAction::Retry(_)));
+    }
+
+    #[derive(Clone)]
+    struct FixedModelTurnAction {
+        action: ModelTurnAction,
+        calls: Arc<AtomicU32>,
+    }
+
+    impl AgentHook for FixedModelTurnAction {
+        async fn on_model_turn_finished(
+            &self,
+            _ctx: &HookContext,
+            _event: ModelTurnFinished<'_>,
+        ) -> ModelTurnAction {
+            self.calls.fetch_add(1, SeqCst);
+            self.action.clone()
+        }
+    }
+
+    #[tokio::test]
+    async fn model_turn_action_short_circuits_flat_and_nested_hook_stacks() {
+        let content = OneOrMany::one(AssistantContent::text("response"));
+        let event = ModelTurnFinished {
+            turn: 1,
+            content: &content,
+            usage: Usage::new(),
+        };
+        let ctx = HookContext::new(false, None);
+
+        let first_calls = Arc::new(AtomicU32::new(0));
+        let retry_calls = Arc::new(AtomicU32::new(0));
+        let skipped_calls = Arc::new(AtomicU32::new(0));
+        let mut flat = HookStack::new();
+        flat.push(FixedModelTurnAction {
+            action: ModelTurnAction::Continue,
+            calls: first_calls.clone(),
+        });
+        flat.push(FixedModelTurnAction {
+            action: ModelTurnAction::repeat(),
+            calls: retry_calls.clone(),
+        });
+        flat.push(FixedModelTurnAction {
+            action: ModelTurnAction::stop("unreachable"),
+            calls: skipped_calls.clone(),
+        });
+        assert!(matches!(
+            flat.on_model_turn_finished(&ctx, event).await,
+            ModelTurnAction::Retry(_)
+        ));
+        assert_eq!(first_calls.load(SeqCst), 1);
+        assert_eq!(retry_calls.load(SeqCst), 1);
+        assert_eq!(skipped_calls.load(SeqCst), 0);
+
+        let nested_retry_calls = Arc::new(AtomicU32::new(0));
+        let outer_skipped_calls = Arc::new(AtomicU32::new(0));
+        let mut nested = HookStack::new();
+        nested.push(FixedModelTurnAction {
+            action: ModelTurnAction::retry_with_feedback("fix it"),
+            calls: nested_retry_calls.clone(),
+        });
+        let mut outer = HookStack::new();
+        outer.push(nested);
+        outer.push(FixedModelTurnAction {
+            action: ModelTurnAction::Continue,
+            calls: outer_skipped_calls.clone(),
+        });
+        assert!(matches!(
+            outer.on_model_turn_finished(&ctx, event).await,
+            ModelTurnAction::Retry(crate::agent::RetryRequest::Feedback(feedback))
+                if feedback == "fix it"
+        ));
+        assert_eq!(nested_retry_calls.load(SeqCst), 1);
+        assert_eq!(outer_skipped_calls.load(SeqCst), 0);
+
+        let stop_calls = Arc::new(AtomicU32::new(0));
+        let after_stop_calls = Arc::new(AtomicU32::new(0));
+        let mut stopping = HookStack::new();
+        stopping.push(FixedModelTurnAction {
+            action: ModelTurnAction::stop("stop now"),
+            calls: stop_calls.clone(),
+        });
+        stopping.push(FixedModelTurnAction {
+            action: ModelTurnAction::Continue,
+            calls: after_stop_calls.clone(),
+        });
+        assert!(matches!(
+            stopping.on_model_turn_finished(&ctx, event).await,
+            ModelTurnAction::Stop(reason) if reason == "stop now"
+        ));
+        assert_eq!(stop_calls.load(SeqCst), 1);
+        assert_eq!(after_stop_calls.load(SeqCst), 0);
     }
 }

--- a/crates/rig-core/src/agent/runner.rs
+++ b/crates/rig-core/src/agent/runner.rs
@@ -3304,6 +3304,7 @@ mod migrated_tests {
         use std::collections::{HashMap, HashSet};
         use std::sync::{Arc, Mutex};
 
+        use futures::StreamExt;
         use tracing::Instrument;
         use tracing::field::{Field, Visit};
         use tracing::span::{Attributes, Record};
@@ -3311,10 +3312,15 @@ mod migrated_tests {
         use tracing_subscriber::layer::{Context, SubscriberExt};
         use tracing_subscriber::{Layer, Registry, registry::LookupSpan};
 
-        use crate::agent::{AgentBuilder, HookContext, ToolResultAction, ToolResultEvent};
-        use crate::completion::Usage;
-        use crate::test_utils::{MockAddTool, MockCompletionModel, MockTurn};
+        use crate::agent::{
+            AgentBuilder, HookContext, MultiTurnStreamItem, ToolResultAction, ToolResultEvent,
+        };
+        use crate::completion::{PromptError, Usage};
+        use crate::streaming::StreamedAssistantContent;
+        use crate::test_utils::{MockAddTool, MockCompletionModel, MockStreamEvent, MockTurn};
         use crate::tool::{ToolContext, ToolExecutionError};
+
+        use super::{BoundedResponseRetry, StopCompletedModelTurn, TestRetryMode};
 
         #[derive(Clone)]
         struct CapturedSpan {
@@ -3322,6 +3328,7 @@ mod migrated_tests {
             name: String,
             field_names: HashSet<String>,
             u64_fields: HashMap<String, u64>,
+            string_fields: HashMap<String, Vec<String>>,
         }
 
         #[derive(Clone, Default)]
@@ -3338,16 +3345,26 @@ mod migrated_tests {
                     name: name.to_string(),
                     field_names: HashSet::new(),
                     u64_fields: HashMap::new(),
+                    string_fields: HashMap::new(),
                 });
             }
 
-            fn record(&self, id: &Id, names: HashSet<String>, u64s: HashMap<String, u64>) {
+            fn record(
+                &self,
+                id: &Id,
+                names: HashSet<String>,
+                u64s: HashMap<String, u64>,
+                strings: HashMap<String, String>,
+            ) {
                 let id = id.into_u64();
                 if let Ok(mut spans) = self.spans.lock()
                     && let Some(span) = spans.iter_mut().find(|s| s.id == id)
                 {
                     span.field_names.extend(names);
                     span.u64_fields.extend(u64s);
+                    for (name, value) in strings {
+                        span.string_fields.entry(name).or_default().push(value);
+                    }
                 }
             }
 
@@ -3387,7 +3404,8 @@ mod migrated_tests {
             fn on_record(&self, span: &Id, values: &Record<'_>, _ctx: Context<'_, S>) {
                 let mut visitor = FieldVisitor::default();
                 values.record(&mut visitor);
-                self.captured.record(span, visitor.names, visitor.u64s);
+                self.captured
+                    .record(span, visitor.names, visitor.u64s, visitor.strings);
             }
 
             fn on_follows_from(&self, span: &Id, follows: &Id, _ctx: Context<'_, S>) {
@@ -3399,6 +3417,7 @@ mod migrated_tests {
         struct FieldVisitor {
             names: HashSet<String>,
             u64s: HashMap<String, u64>,
+            strings: HashMap<String, String>,
         }
 
         impl Visit for FieldVisitor {
@@ -3407,12 +3426,16 @@ mod migrated_tests {
                 self.u64s.insert(field.name().to_string(), value);
             }
 
-            fn record_str(&mut self, field: &Field, _value: &str) {
+            fn record_str(&mut self, field: &Field, value: &str) {
                 self.names.insert(field.name().to_string());
+                self.strings
+                    .insert(field.name().to_string(), value.to_string());
             }
 
-            fn record_debug(&mut self, field: &Field, _value: &dyn std::fmt::Debug) {
+            fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
                 self.names.insert(field.name().to_string());
+                self.strings
+                    .insert(field.name().to_string(), format!("{value:?}"));
             }
         }
 
@@ -3444,6 +3467,270 @@ mod migrated_tests {
                 .tool(MockAddTool)
                 .build();
             let _ = agent.runner("add 2 and 3").max_turns(3).run().await;
+        }
+
+        async fn run_blocking_response_retry_with_content_telemetry() {
+            AgentBuilder::new(MockCompletionModel::from_turns([
+                MockTurn::text("rejected"),
+                MockTurn::text("accepted"),
+            ]))
+            .record_content_telemetry(true)
+            .add_hook(BoundedResponseRetry::new(
+                "rejected",
+                1,
+                TestRetryMode::Repeat,
+            ))
+            .build()
+            .runner("question")
+            .max_turns(2)
+            .run()
+            .await
+            .expect("blocking retry should succeed");
+        }
+
+        async fn run_streaming_response_retry_with_content_telemetry() {
+            let mut stream = AgentBuilder::new(MockCompletionModel::from_stream_turns([
+                [
+                    MockStreamEvent::text("rejected"),
+                    MockStreamEvent::final_response_with_default_usage(),
+                ],
+                [
+                    MockStreamEvent::text("accepted"),
+                    MockStreamEvent::final_response_with_default_usage(),
+                ],
+            ]))
+            .record_content_telemetry(true)
+            .add_hook(BoundedResponseRetry::new(
+                "rejected",
+                1,
+                TestRetryMode::Repeat,
+            ))
+            .build()
+            .runner("question")
+            .max_turns(2)
+            .stream()
+            .await;
+
+            let mut saw_final = false;
+            while let Some(item) = stream.next().await {
+                if let MultiTurnStreamItem::FinalResponse(response) =
+                    item.expect("streaming retry item")
+                {
+                    saw_final = true;
+                    assert_eq!(response.output, "accepted");
+                }
+            }
+            assert!(saw_final, "streaming retry should produce a final response");
+        }
+
+        async fn run_blocking_model_turn_stop_with_content_telemetry() {
+            let error = AgentBuilder::new(MockCompletionModel::from_turns([MockTurn::text(
+                "stopped blocking response",
+            )]))
+            .record_content_telemetry(true)
+            .add_hook(StopCompletedModelTurn)
+            .build()
+            .runner("question")
+            .run()
+            .await
+            .expect_err("blocking model-turn stop should cancel the run");
+
+            assert!(matches!(
+                error,
+                PromptError::PromptCancelled { reason, .. }
+                    if reason == "stop completed model turn"
+            ));
+        }
+
+        async fn run_streaming_model_turn_stop_with_content_telemetry() {
+            let mut stream = AgentBuilder::new(MockCompletionModel::from_stream_turns([[
+                MockStreamEvent::text("stopped streaming response"),
+                MockStreamEvent::final_response_with_default_usage(),
+            ]]))
+            .record_content_telemetry(true)
+            .add_hook(StopCompletedModelTurn)
+            .build()
+            .runner("question")
+            .stream()
+            .await;
+
+            let mut provider_finals = 0;
+            let mut agent_finals = 0;
+            let mut retries = 0;
+            let mut errors = 0;
+            while let Some(item) = stream.next().await {
+                match item {
+                    Ok(MultiTurnStreamItem::StreamAssistantItem(
+                        StreamedAssistantContent::Final(_),
+                    )) => provider_finals += 1,
+                    Ok(MultiTurnStreamItem::FinalResponse(_)) => agent_finals += 1,
+                    Ok(MultiTurnStreamItem::ModelTurnRetried { .. }) => retries += 1,
+                    Ok(_) => {}
+                    Err(error) => {
+                        errors += 1;
+                        assert!(matches!(
+                            error,
+                            super::StreamingError::Prompt(error)
+                                if matches!(
+                                    error.as_ref(),
+                                    PromptError::PromptCancelled { reason, .. }
+                                        if reason == "stop completed model turn"
+                                )
+                        ));
+                    }
+                }
+            }
+
+            assert_eq!(provider_finals, 1);
+            assert_eq!(agent_finals, 0);
+            assert_eq!(retries, 0);
+            assert_eq!(errors, 1);
+        }
+
+        #[tokio::test]
+        async fn response_retry_records_only_accepted_content_on_both_surfaces() {
+            let _isolation = crate::test_utils::scoped_tracing_subscriber_guard().await;
+            let captured = Captured::default();
+            let subscriber = Registry::default().with(CaptureLayer {
+                captured: captured.clone(),
+            });
+            let _default = tracing::subscriber::set_default(subscriber);
+
+            // Register both transport callsites under this subscriber before
+            // inspecting field recordings.
+            run_blocking_response_retry_with_content_telemetry().await;
+            run_streaming_response_retry_with_content_telemetry().await;
+            tracing::callsite::rebuild_interest_cache();
+            captured.clear();
+
+            run_blocking_response_retry_with_content_telemetry().await;
+            let blocking = captured.snapshot();
+            let blocking_chats = blocking
+                .iter()
+                .filter(|span| span.name == "chat")
+                .collect::<Vec<_>>();
+            assert_eq!(blocking_chats.len(), 2);
+            assert!(
+                !blocking_chats[0]
+                    .field_names
+                    .contains("gen_ai.output.messages"),
+                "rejected blocking content must not be recorded as model output"
+            );
+            assert!(
+                blocking_chats[1]
+                    .field_names
+                    .contains("gen_ai.output.messages"),
+                "accepted blocking content must be recorded as model output"
+            );
+            let blocking_output = blocking_chats[1]
+                .string_fields
+                .get("gen_ai.output.messages")
+                .expect("accepted blocking output value");
+            assert!(
+                blocking_output
+                    .iter()
+                    .any(|value| value.contains("accepted"))
+            );
+            assert!(
+                blocking_output
+                    .iter()
+                    .all(|value| !value.contains("rejected"))
+            );
+            let blocking_completion = blocking
+                .iter()
+                .find(|span| span.name == "invoke_agent")
+                .and_then(|span| span.string_fields.get("gen_ai.completion"))
+                .expect("accepted blocking run-level completion");
+            assert_eq!(blocking_completion, &["accepted"]);
+
+            captured.clear();
+            run_streaming_response_retry_with_content_telemetry().await;
+            let streaming = captured.snapshot();
+            let streaming_chats = streaming
+                .iter()
+                .filter(|span| span.name == "chat_streaming")
+                .collect::<Vec<_>>();
+            assert_eq!(streaming_chats.len(), 2);
+            assert!(
+                !streaming_chats[0]
+                    .field_names
+                    .contains("gen_ai.output.messages"),
+                "rejected streaming content must not be recorded as model output"
+            );
+            assert!(
+                streaming_chats[1]
+                    .field_names
+                    .contains("gen_ai.output.messages"),
+                "accepted streaming content must be recorded as model output"
+            );
+            let streaming_output = streaming_chats[1]
+                .string_fields
+                .get("gen_ai.output.messages")
+                .expect("accepted streaming output value");
+            assert!(
+                streaming_output
+                    .iter()
+                    .any(|value| value.contains("accepted"))
+            );
+            assert!(
+                streaming_output
+                    .iter()
+                    .all(|value| !value.contains("rejected"))
+            );
+            let streaming_completion = streaming
+                .iter()
+                .find(|span| span.name == "invoke_agent")
+                .and_then(|span| span.string_fields.get("gen_ai.completion"))
+                .expect("accepted streaming run-level completion");
+            assert_eq!(streaming_completion, &["accepted"]);
+        }
+
+        #[tokio::test]
+        async fn model_turn_stop_preserves_completed_content_telemetry_on_both_surfaces() {
+            let _isolation = crate::test_utils::scoped_tracing_subscriber_guard().await;
+            let captured = Captured::default();
+            let subscriber = Registry::default().with(CaptureLayer {
+                captured: captured.clone(),
+            });
+            let _default = tracing::subscriber::set_default(subscriber);
+
+            run_blocking_model_turn_stop_with_content_telemetry().await;
+            run_streaming_model_turn_stop_with_content_telemetry().await;
+            tracing::callsite::rebuild_interest_cache();
+            captured.clear();
+
+            run_blocking_model_turn_stop_with_content_telemetry().await;
+            let blocking = captured.snapshot();
+            let blocking_output = blocking
+                .iter()
+                .find(|span| span.name == "chat")
+                .and_then(|span| span.string_fields.get("gen_ai.output.messages"))
+                .expect("stopped blocking turn should retain output telemetry");
+            assert!(
+                blocking_output
+                    .iter()
+                    .any(|value| value.contains("stopped blocking response"))
+            );
+
+            captured.clear();
+            run_streaming_model_turn_stop_with_content_telemetry().await;
+            let streaming = captured.snapshot();
+            let streaming_output = streaming
+                .iter()
+                .find(|span| span.name == "chat_streaming")
+                .and_then(|span| span.string_fields.get("gen_ai.output.messages"))
+                .expect("stopped streaming turn should retain output telemetry");
+            assert!(
+                streaming_output
+                    .iter()
+                    .any(|value| value.contains("stopped streaming response"))
+            );
+            let streaming_completion = streaming
+                .iter()
+                .find(|span| span.name == "invoke_agent")
+                .and_then(|span| span.string_fields.get("gen_ai.completion"))
+                .expect("stopped streaming turn should retain run-level completion telemetry");
+            assert_eq!(streaming_completion, &["stopped streaming response"]);
         }
 
         #[tokio::test]
@@ -9074,12 +9361,15 @@ mod migrated_tests {
     #[tokio::test]
     async fn model_turn_retry_rejects_tool_turn_before_tool_hooks_or_execution() {
         let recorder = RecordingHook::default();
+        let executions = Arc::new(AtomicU32::new(0));
         let err = AgentBuilder::new(MockCompletionModel::from_turns([MockTurn::tool_call(
             "tc1",
             "add",
             json!({"x": 1, "y": 2}),
         )]))
-        .tool(MockAddTool)
+        .tool(CountingAddTool {
+            calls: executions.clone(),
+        })
         .add_hook(recorder.clone())
         .add_hook(AlwaysRepeatModelTurn)
         .build()
@@ -9089,22 +9379,34 @@ mod migrated_tests {
         .await
         .expect_err("tool-bearing retry must fail closed");
 
-        assert!(matches!(err, PromptError::PromptCancelled { .. }));
-        assert!(err.to_string().contains("tool-bearing turns"));
+        let PromptError::PromptCancelled {
+            chat_history,
+            reason,
+        } = err
+        else {
+            panic!("tool-bearing retry should return PromptCancelled");
+        };
+        assert!(reason.contains("tool-bearing model turns"));
+        assert!(reason.contains("tool-call hooks"));
+        assert_eq!(chat_history, vec![Message::user("add")]);
         assert_eq!(recorder.count(StepEventKind::ToolCall), 0);
         assert_eq!(recorder.count(StepEventKind::ToolResult), 0);
+        assert_eq!(executions.load(SeqCst), 0);
     }
 
     #[tokio::test]
     async fn streaming_model_turn_retry_rejects_tool_turn_without_committed_execution() {
         let recorder = RecordingHook::default();
+        let executions = Arc::new(AtomicU32::new(0));
         let mut stream = AgentBuilder::new(MockCompletionModel::from_stream_turns([[
             MockStreamEvent::tool_call_name_delta("tc1", "ic1", "add"),
             MockStreamEvent::tool_call_arguments_delta("tc1", "ic1", r#"{"x":1,"y":2}"#),
             MockStreamEvent::tool_call("tc1", "add", json!({"x": 1, "y": 2})),
             MockStreamEvent::final_response_with_default_usage(),
         ]]))
-        .tool(MockAddTool)
+        .tool(CountingAddTool {
+            calls: executions.clone(),
+        })
         .add_hook(recorder.clone())
         .add_hook(AlwaysRepeatModelTurn)
         .build()
@@ -9115,6 +9417,9 @@ mod migrated_tests {
 
         let mut execution_commits = 0;
         let mut tool_results = 0;
+        let mut provider_finals = 0;
+        let mut agent_finals = 0;
+        let mut retry_markers = 0;
         let mut error = None;
         while let Some(item) = stream.next().await {
             match item {
@@ -9122,21 +9427,37 @@ mod migrated_tests {
                 Ok(MultiTurnStreamItem::StreamUserItem(StreamedUserContent::ToolResult {
                     ..
                 })) => tool_results += 1,
+                Ok(MultiTurnStreamItem::StreamAssistantItem(StreamedAssistantContent::Final(
+                    _,
+                ))) => provider_finals += 1,
+                Ok(MultiTurnStreamItem::FinalResponse(_)) => agent_finals += 1,
+                Ok(MultiTurnStreamItem::ModelTurnRetried { .. }) => retry_markers += 1,
                 Ok(_) => {}
                 Err(err) => error = Some(err),
             }
         }
 
-        assert!(matches!(
-            error,
-            Some(StreamingError::Prompt(error))
-                if matches!(error.as_ref(), PromptError::PromptCancelled { .. })
-                    && error.to_string().contains("tool-bearing turns")
-        ));
+        let Some(StreamingError::Prompt(error)) = error else {
+            panic!("tool-bearing streaming retry should return PromptCancelled");
+        };
+        let PromptError::PromptCancelled {
+            chat_history,
+            reason,
+        } = error.as_ref()
+        else {
+            panic!("tool-bearing streaming retry should return PromptCancelled");
+        };
+        assert!(reason.contains("tool-bearing model turns"));
+        assert!(reason.contains("tool-call hooks"));
+        assert_eq!(chat_history, &[Message::user("add")]);
         assert_eq!(execution_commits, 0);
         assert_eq!(tool_results, 0);
+        assert_eq!(provider_finals, 0);
+        assert_eq!(agent_finals, 0);
+        assert_eq!(retry_markers, 0);
         assert_eq!(recorder.count(StepEventKind::ToolCall), 0);
         assert_eq!(recorder.count(StepEventKind::ToolResult), 0);
+        assert_eq!(executions.load(SeqCst), 0);
     }
 
     #[derive(Clone)]

--- a/crates/rig-core/src/agent/runner.rs
+++ b/crates/rig-core/src/agent/runner.rs
@@ -8957,6 +8957,32 @@ mod migrated_tests {
         mode: TestRetryMode,
     }
 
+    #[derive(Clone, Default)]
+    struct StatefulCompletionPatch {
+        calls: Arc<AtomicU32>,
+    }
+
+    impl StatefulCompletionPatch {
+        fn calls(&self) -> u32 {
+            self.calls.load(SeqCst)
+        }
+    }
+
+    impl AgentHook for StatefulCompletionPatch {
+        async fn on_completion_call(
+            &self,
+            _ctx: &HookContext,
+            _event: crate::agent::CompletionCallEvent<'_>,
+        ) -> CompletionCallAction {
+            let call = self.calls.fetch_add(1, SeqCst);
+            CompletionCallAction::patch(RequestPatch::new().temperature(if call == 0 {
+                0.1
+            } else {
+                0.9
+            }))
+        }
+    }
+
     impl BoundedResponseRetry {
         fn new(rejected_text: &'static str, max_retries: usize, mode: TestRetryMode) -> Self {
             Self {
@@ -9012,14 +9038,16 @@ mod migrated_tests {
     }
 
     #[tokio::test]
-    async fn blocking_model_turn_repeat_preserves_accounting_and_reuses_request() {
+    async fn blocking_model_turn_repeat_preserves_prompt_history_with_fresh_preparation() {
         let first_usage = retry_usage(10, 3);
         let second_usage = retry_usage(7, 2);
+        let completion_patch = StatefulCompletionPatch::default();
         let model = MockCompletionModel::from_turns([
             MockTurn::text("rejected").with_usage(first_usage),
             MockTurn::text("accepted").with_usage(second_usage),
         ]);
         let response = AgentBuilder::new(model.clone())
+            .add_hook(completion_patch.clone())
             .add_hook(BoundedResponseRetry::new(
                 "rejected",
                 1,
@@ -9046,7 +9074,13 @@ mod migrated_tests {
         let first = requests[0].chat_history.iter().cloned().collect::<Vec<_>>();
         let second = requests[1].chat_history.iter().cloned().collect::<Vec<_>>();
         assert_eq!(first, vec![Message::user("question")]);
-        assert_eq!(second, first, "Repeat must resend the same request");
+        assert_eq!(
+            second, first,
+            "Repeat must preserve the prompt and preceding history"
+        );
+        assert_eq!(requests[0].temperature, Some(0.1));
+        assert_eq!(requests[1].temperature, Some(0.9));
+        assert_eq!(completion_patch.calls(), 2);
     }
 
     #[tokio::test]

--- a/crates/rig-core/src/extractor.rs
+++ b/crates/rig-core/src/extractor.rs
@@ -346,7 +346,8 @@ mod tests {
 
     use super::*;
     use crate::agent::{
-        CompletionCallAction, CompletionResponseEvent, HookContext, ObservationAction, RequestPatch,
+        CompletionCallAction, CompletionResponseEvent, HookContext, ModelTurnAction,
+        ObservationAction, RequestPatch,
     };
     use crate::message::{AssistantContent, ToolCall, ToolFunction};
     use crate::test_utils::{MockCompletionModel, MockTurn};
@@ -412,9 +413,9 @@ mod tests {
             &self,
             _ctx: &HookContext,
             _event: crate::agent::ModelTurnFinished<'_>,
-        ) -> ObservationAction {
+        ) -> ModelTurnAction {
             self.model_turns.fetch_add(1, Ordering::SeqCst);
-            ObservationAction::Continue
+            ModelTurnAction::Continue
         }
 
         async fn on_invalid_tool_call(
@@ -509,13 +510,13 @@ mod tests {
             &self,
             _ctx: &HookContext,
             _event: crate::agent::ModelTurnFinished<'_>,
-        ) -> ObservationAction {
+        ) -> ModelTurnAction {
             if matches!(self.phase, StopFirstBilledResponseAt::ModelTurnFinished)
                 && self.calls.fetch_add(1, Ordering::SeqCst) == 0
             {
-                ObservationAction::stop("stop first billed model turn")
+                ModelTurnAction::stop("stop first billed model turn")
             } else {
-                ObservationAction::continue_run()
+                ModelTurnAction::continue_run()
             }
         }
     }

--- a/crates/rig-core/src/test_utils/model_conformance.rs
+++ b/crates/rig-core/src/test_utils/model_conformance.rs
@@ -1828,7 +1828,8 @@ where
                 final_response = Some(response);
             }
             MultiTurnStreamItem::StreamAssistantItem(_)
-            | MultiTurnStreamItem::ToolExecutionCommitted { .. } => {}
+            | MultiTurnStreamItem::ToolExecutionCommitted { .. }
+            | MultiTurnStreamItem::ModelTurnRetried { .. } => {}
         }
     }
     let result = final_response.ok_or_else(|| {

--- a/examples/agent_with_retry_hook/Cargo.toml
+++ b/examples/agent_with_retry_hook/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "agent_with_retry_hook"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+rig.workspace = true
+anyhow = { workspace = true }
+tokio = { workspace = true, features = ["full"] }

--- a/examples/agent_with_retry_hook/src/main.rs
+++ b/examples/agent_with_retry_hook/src/main.rs
@@ -6,8 +6,9 @@
 //!
 //! [`RetryMode::Feedback`] preserves the rejected assistant response and adds a
 //! corrective user message. [`RetryMode::Repeat`] discards the response and
-//! repeats the same request. Tool-bearing turns must instead be handled by
-//! tool-call hooks.
+//! reuses the same prompt and preceding history with fresh request preparation.
+//! Completion-call hooks, retrieval, and dynamic tool resolution therefore run
+//! again. Tool-bearing turns must instead be handled by tool-call hooks.
 //!
 //! Requires `OPENAI_API_KEY`. Run with:
 //! `cargo run -p agent_with_retry_hook`.
@@ -121,9 +122,10 @@ async fn main() -> Result<()> {
     println!("Final response: {}", response.output);
     println!("Model calls: {}", response.completion_calls.len());
 
-    // Repeat is a distinct policy: it discards the rejected response and sends
-    // the same request again. It is configured here but not run because this
-    // deterministic protocol deliberately returns the same marker each time.
+    // Repeat is a distinct policy: it discards the rejected response and reuses
+    // the prompt and preceding history, while freshly preparing the next
+    // request. It is configured here but not run because this deterministic
+    // protocol deliberately returns the same marker each time.
     let _repeat_agent = client
         .agent(openai::GPT_4O_MINI)
         .default_max_turns(2)

--- a/examples/agent_with_retry_hook/src/main.rs
+++ b/examples/agent_with_retry_hook/src/main.rs
@@ -1,0 +1,134 @@
+//! Retries a completed, tool-free model turn from an [`AgentHook`].
+//!
+//! `RetryOnMarker` owns its policy limit in the run-scoped [`HookContext`]
+//! scratchpad. Rig does not add a separate retry counter to the agent: every
+//! retry consumes the request's existing `max_turns` model-call budget.
+//!
+//! [`RetryMode::Feedback`] preserves the rejected assistant response and adds a
+//! corrective user message. [`RetryMode::Repeat`] discards the response and
+//! repeats the same request. Tool-bearing turns must instead be handled by
+//! tool-call hooks.
+//!
+//! Requires `OPENAI_API_KEY`. Run with:
+//! `cargo run -p agent_with_retry_hook`.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use anyhow::Result;
+use rig::agent::{AgentHook, HookContext, ModelTurnAction, ModelTurnFinished};
+use rig::client::{CompletionClient, ProviderClient};
+use rig::message::AssistantContent;
+use rig::providers::openai;
+
+static NEXT_RETRY_HOOK_ID: AtomicUsize = AtomicUsize::new(1);
+
+#[derive(Clone, Default)]
+struct RetryAttempts(HashMap<usize, usize>);
+
+#[derive(Clone, Copy)]
+enum RetryMode {
+    Repeat,
+    Feedback(&'static str),
+}
+
+struct RetryOnMarker {
+    id: usize,
+    marker: &'static str,
+    max_retries: usize,
+    mode: RetryMode,
+}
+
+impl RetryOnMarker {
+    fn with_feedback(marker: &'static str, max_retries: usize, feedback: &'static str) -> Self {
+        Self {
+            id: NEXT_RETRY_HOOK_ID.fetch_add(1, Ordering::Relaxed),
+            marker,
+            max_retries,
+            mode: RetryMode::Feedback(feedback),
+        }
+    }
+
+    fn repeat(marker: &'static str, max_retries: usize) -> Self {
+        Self {
+            id: NEXT_RETRY_HOOK_ID.fetch_add(1, Ordering::Relaxed),
+            marker,
+            max_retries,
+            mode: RetryMode::Repeat,
+        }
+    }
+}
+
+impl AgentHook for RetryOnMarker {
+    async fn on_model_turn_finished(
+        &self,
+        ctx: &HookContext,
+        event: ModelTurnFinished<'_>,
+    ) -> ModelTurnAction {
+        let should_retry = event.content.iter().any(|content| {
+            matches!(content, AssistantContent::Text(text) if text.text.contains(self.marker))
+        });
+        if !should_retry {
+            return ModelTurnAction::continue_run();
+        }
+
+        let attempt = ctx.scratchpad().update(|attempts: &mut RetryAttempts| {
+            let attempt = attempts.0.entry(self.id).or_default();
+            *attempt += 1;
+            *attempt
+        });
+        if attempt > self.max_retries {
+            return ModelTurnAction::stop(format!(
+                "response retry limit ({}) exceeded",
+                self.max_retries
+            ));
+        }
+
+        println!(
+            "[turn {}] rejected response; retry {attempt}/{}",
+            event.turn, self.max_retries
+        );
+        match self.mode {
+            RetryMode::Repeat => ModelTurnAction::repeat(),
+            RetryMode::Feedback(feedback) => ModelTurnAction::retry_with_feedback(feedback),
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let client = openai::Client::from_env()?;
+    let agent = client
+        .agent(openai::GPT_4O_MINI)
+        .preamble(
+            "Follow this protocol exactly. For the initial request, reply exactly \
+             `RETRY: incomplete draft`. If the latest user message asks you to \
+             replace the rejected response, reply exactly `ACCEPTED`.",
+        )
+        .build();
+
+    let response = agent
+        .runner("Begin the retry-hook demonstration.")
+        .max_turns(2)
+        .add_hook(RetryOnMarker::with_feedback(
+            "RETRY:",
+            1,
+            "Replace the rejected response. Reply exactly `ACCEPTED`.",
+        ))
+        .run()
+        .await?;
+
+    println!("Final response: {}", response.output);
+    println!("Model calls: {}", response.completion_calls.len());
+
+    // Repeat is a distinct policy: it discards the rejected response and sends
+    // the same request again. It is configured here but not run because this
+    // deterministic protocol deliberately returns the same marker each time.
+    let _repeat_agent = client
+        .agent(openai::GPT_4O_MINI)
+        .default_max_turns(2)
+        .add_hook(RetryOnMarker::repeat("RETRY:", 1))
+        .build();
+
+    Ok(())
+}

--- a/tests/cassettes/openai/response_retry/rejected_response_is_retried_with_feedback.yaml
+++ b/tests/cassettes/openai/response_retry/rejected_response_is_retried_with_feedback.yaml
@@ -1,0 +1,33 @@
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"input":[{"content":[{"text":"Begin the retry-hook demonstration.","type":"input_text"}],"role":"user","type":"message"}],"instructions":"Follow this protocol exactly. For the initial request, reply exactly `RETRY: incomplete draft`. If the latest user message asks you to replace the rejected response, reply exactly `ACCEPTED`.","model":"gpt-4o-mini","temperature":0.0}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"background":false,"billing":{"payer":"developer"},"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_1","incomplete_details":null,"instructions":"Follow this protocol exactly. For the initial request, reply exactly `RETRY: incomplete draft`. If the latest user message asks you to replace the rejected response, reply exactly `ACCEPTED`.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-4o-mini-2024-07-18","moderation":null,"object":"response","output":[{"content":[{"annotations":[],"logprobs":[],"text":"RETRY: incomplete draft","type":"output_text"}],"id":"msg_REDACTED_1","role":"assistant","status":"completed","type":"message"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","status":"completed","store":true,"temperature":0.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":56,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":6,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":62},"user":null}'
+---
+when:
+  path: /v1/responses
+  method: POST
+  query_param: []
+  header:
+  - name: accept
+    value: '*/*'
+  - name: content-type
+    value: application/json
+  body: '{"input":[{"content":[{"text":"Begin the retry-hook demonstration.","type":"input_text"}],"role":"user","type":"message"},{"content":[{"text":"RETRY: incomplete draft","type":"output_text"}],"id":"msg_REDACTED_1","role":"assistant","status":"completed","type":"message"},{"content":[{"text":"Replace the rejected response. Reply exactly `ACCEPTED`.","type":"input_text"}],"role":"user","type":"message"}],"instructions":"Follow this protocol exactly. For the initial request, reply exactly `RETRY: incomplete draft`. If the latest user message asks you to replace the rejected response, reply exactly `ACCEPTED`.","model":"gpt-4o-mini","temperature":0.0}'
+then:
+  status: 200
+  header:
+  - name: content-type
+    value: application/json
+  body: '{"background":false,"billing":{"payer":"developer"},"completed_at":0,"created_at":0,"error":null,"frequency_penalty":0.0,"id":"resp_REDACTED_2","incomplete_details":null,"instructions":"Follow this protocol exactly. For the initial request, reply exactly `RETRY: incomplete draft`. If the latest user message asks you to replace the rejected response, reply exactly `ACCEPTED`.","max_output_tokens":null,"max_tool_calls":null,"metadata":{},"model":"gpt-4o-mini-2024-07-18","moderation":null,"object":"response","output":[{"content":[{"annotations":[],"logprobs":[],"text":"ACCEPTED","type":"output_text"}],"id":"msg_REDACTED_2","role":"assistant","status":"completed","type":"message"}],"parallel_tool_calls":true,"presence_penalty":0.0,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":"in_memory","reasoning":{"context":null,"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","status":"completed","store":true,"temperature":0.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tool_usage":{"image_gen":{"input_tokens":0,"input_tokens_details":{"image_tokens":0,"text_tokens":0},"output_tokens":0,"output_tokens_details":{"image_tokens":0,"text_tokens":0},"total_tokens":0},"web_search":{"num_requests":0}},"tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":81,"input_tokens_details":{"cache_write_tokens":0,"cached_tokens":0},"output_tokens":4,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":85},"user":null}'

--- a/tests/providers/gemini/cassette/hook_stress.rs
+++ b/tests/providers/gemini/cassette/hook_stress.rs
@@ -25,8 +25,8 @@ use std::sync::Mutex;
 use futures::StreamExt;
 use rig::agent::{
     AgentHook, CompletionCallAction, CompletionCallEvent, CompletionResponseEvent, HookContext,
-    ModelTurnFinished, MultiTurnStreamItem, ObservationAction, RequestPatch, StreamingError,
-    ToolCall as ToolCallEvent, ToolCallAction, ToolResultAction, ToolResultEvent,
+    ModelTurnAction, ModelTurnFinished, MultiTurnStreamItem, ObservationAction, RequestPatch,
+    StreamingError, ToolCall as ToolCallEvent, ToolCallAction, ToolResultAction, ToolResultEvent,
 };
 use rig::client::CompletionClient;
 use rig::completion::{Document, Prompt};
@@ -133,9 +133,9 @@ impl AgentHook for LifecycleRecorder {
         &self,
         ctx: &HookContext,
         _event: ModelTurnFinished<'_>,
-    ) -> ObservationAction {
+    ) -> ModelTurnAction {
         self.record(ctx, "ModelTurnFinished");
-        ObservationAction::continue_run()
+        ModelTurnAction::continue_run()
     }
     async fn on_tool_call(&self, ctx: &HookContext, _event: ToolCallEvent<'_>) -> ToolCallAction {
         self.record(ctx, "ToolCall");
@@ -173,14 +173,14 @@ impl AgentHook for ScratchpadReader {
         &self,
         ctx: &HookContext,
         _event: ModelTurnFinished<'_>,
-    ) -> ObservationAction {
+    ) -> ModelTurnAction {
         let tally = ctx
             .scratchpad()
             .get::<ToolCallTally>()
             .map(|t| t.0)
             .unwrap_or(0);
         self.tallies.lock().expect("tallies").push(tally);
-        ObservationAction::continue_run()
+        ModelTurnAction::continue_run()
     }
 }
 

--- a/tests/providers/gemini/hook_stress_support.rs
+++ b/tests/providers/gemini/hook_stress_support.rs
@@ -14,7 +14,7 @@ use std::sync::{Arc, Mutex};
 
 use rig::agent::{
     AgentHook, CompletionCallAction, CompletionCallEvent, CompletionResponseEvent, HookContext,
-    InvalidToolCallAction, ModelTurnFinished, ObservationAction, RequestPatch,
+    InvalidToolCallAction, ModelTurnAction, ModelTurnFinished, ObservationAction, RequestPatch,
     StreamResponseFinish, TextDelta, ToolCall as ToolCallEvent, ToolCallAction, ToolCallDelta,
     ToolResultAction, ToolResultEvent,
 };
@@ -211,9 +211,9 @@ impl AgentHook for EventTap {
         &self,
         ctx: &HookContext,
         _event: ModelTurnFinished<'_>,
-    ) -> ObservationAction {
+    ) -> ModelTurnAction {
         self.record(ctx, "ModelTurnFinished");
-        ObservationAction::continue_run()
+        ModelTurnAction::continue_run()
     }
     async fn on_invalid_tool_call(
         &self,
@@ -286,14 +286,14 @@ impl AgentHook for ScratchpadReader {
         &self,
         ctx: &HookContext,
         _event: ModelTurnFinished<'_>,
-    ) -> ObservationAction {
+    ) -> ModelTurnAction {
         let tally = ctx
             .scratchpad()
             .get::<ToolCallTally>()
             .map(|t| t.0)
             .unwrap_or(0);
         self.tallies.lock().expect("tallies").push(tally);
-        ObservationAction::continue_run()
+        ModelTurnAction::continue_run()
     }
 }
 

--- a/tests/providers/openai/cassette/response_retry.rs
+++ b/tests/providers/openai/cassette/response_retry.rs
@@ -1,0 +1,111 @@
+//! OpenAI-backed regression coverage for retrying a completed model turn.
+
+use rig::agent::{AgentHook, HookContext, ModelTurnAction, ModelTurnFinished};
+use rig::client::CompletionClient;
+use rig::completion::Message;
+use rig::message::{AssistantContent, UserContent};
+use rig::providers::openai;
+
+use super::super::support::with_openai_cassette;
+
+#[derive(Clone, Default)]
+struct RetryAttempts(usize);
+
+struct RetryOnceOnMarker;
+
+impl AgentHook for RetryOnceOnMarker {
+    async fn on_model_turn_finished(
+        &self,
+        ctx: &HookContext,
+        event: ModelTurnFinished<'_>,
+    ) -> ModelTurnAction {
+        let rejected = event.content.iter().any(|content| {
+            matches!(content, AssistantContent::Text(text) if text.text.contains("RETRY:"))
+        });
+        if !rejected {
+            return ModelTurnAction::continue_run();
+        }
+
+        let attempt = ctx.scratchpad().update(|attempts: &mut RetryAttempts| {
+            attempts.0 += 1;
+            attempts.0
+        });
+        if attempt == 1 {
+            ModelTurnAction::retry_with_feedback(
+                "Replace the rejected response. Reply exactly `ACCEPTED`.",
+            )
+        } else {
+            ModelTurnAction::stop("response retry limit exceeded")
+        }
+    }
+}
+
+#[tokio::test]
+async fn rejected_response_is_retried_with_feedback() {
+    with_openai_cassette(
+        "response_retry/rejected_response_is_retried_with_feedback",
+        |client| async move {
+            let response = client
+                .agent(openai::GPT_4O_MINI)
+                .preamble(
+                    "Follow this protocol exactly. For the initial request, reply exactly \
+                 `RETRY: incomplete draft`. If the latest user message asks you to \
+                 replace the rejected response, reply exactly `ACCEPTED`.",
+                )
+                .temperature(0.0)
+                .build()
+                .runner("Begin the retry-hook demonstration.")
+                .max_turns(2)
+                .add_hook(RetryOnceOnMarker)
+                .run()
+                .await
+                .expect("the feedback retry should recover");
+
+            assert_eq!(response.output.trim(), "ACCEPTED");
+            assert_eq!(response.completion_calls.len(), 2);
+            assert!(response.usage.input_tokens > 0);
+            assert!(response.usage.output_tokens > 0);
+            let transcript = response
+                .messages
+                .expect("response history")
+                .into_iter()
+                .map(|message| match message {
+                    Message::System { content } => ("system", content),
+                    Message::User { content } => (
+                        "user",
+                        content
+                            .iter()
+                            .filter_map(|content| match content {
+                                UserContent::Text(text) => Some(text.text.as_str()),
+                                _ => None,
+                            })
+                            .collect::<String>(),
+                    ),
+                    Message::Assistant { content, .. } => (
+                        "assistant",
+                        content
+                            .iter()
+                            .filter_map(|content| match content {
+                                AssistantContent::Text(text) => Some(text.text.as_str()),
+                                _ => None,
+                            })
+                            .collect::<String>(),
+                    ),
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(
+                transcript,
+                vec![
+                    ("user", "Begin the retry-hook demonstration.".to_string()),
+                    ("assistant", "RETRY: incomplete draft".to_string()),
+                    (
+                        "user",
+                        "Replace the rejected response. Reply exactly `ACCEPTED`.".to_string(),
+                    ),
+                    ("assistant", "ACCEPTED".to_string()),
+                ]
+            );
+        },
+    )
+    .await;
+}

--- a/tests/providers/openai/mod.rs
+++ b/tests/providers/openai/mod.rs
@@ -15,6 +15,7 @@ mod cassette {
     mod reasoning_roundtrip;
     mod reasoning_tool_roundtrip;
     mod request_hook;
+    mod response_retry;
     mod response_schema;
     mod responses_behaviors;
     mod responses_input_item;


### PR DESCRIPTION
## Description

Add a typed response-retry action to the canonical `on_model_turn_finished` hook without adding retry configuration or counters to agent builders, agents, runners, or run state.

The new `ModelTurnAction` lets hooks accept, retry, or stop a completed model turn. Retry requests explicitly distinguish between:

- `Repeat`, which discards the rejected assistant response and reuses the same prompt and preceding history with fresh request preparation. Completion-call hooks, retrieval, and dynamic tool resolution run again, so the resulting provider request may differ from the rejected attempt.
- `Feedback`, which preserves a non-empty rejected assistant response and appends corrective user feedback before the next model call. Canonical empty assistant turns are omitted from history.

Both modes retain usage and completion-call accounting and consume the existing `max_turns` model-call budget. Policy-specific limits remain hook-owned and can use the run-scoped `Scratchpad`; the public documentation and runnable `agent_with_retry_hook` example demonstrate a bounded, instance-isolated policy.

Blocking and streaming execution share the same action resolver and stateless `AgentRun` transition. Streaming retries suppress the rejected provider final and emit `ModelTurnRetried` so consumers can reset provisional deltas. Tool-bearing response retries fail before tool execution to avoid constructing provider-visible history with unanswered calls.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [x] Documentation update

`AgentHook::on_model_turn_finished` now returns `ModelTurnAction` instead of `ObservationAction`.

## Testing

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test`
- [x] `cargo doc --workspace --no-deps`
- [x] Recorded and replayed the OpenAI response-retry cassette
- [x] OpenAI cassette registration and secret-safety checks

Regression coverage includes blocking and streaming Repeat/Feedback behavior, fresh request preparation on Repeat, canonical empty-turn history handling, total-budget exhaustion, usage and completion-call accounting, hook ordering and nested stacks, run/concurrency isolation, streaming rollback signaling, fail-safe tool-bearing retries, and a live-recorded OpenAI feedback-retry history.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove the feature works
- [x] New and existing unit tests pass locally with my changes

## Notes

Response retries intentionally do not support turns containing tool calls. Those turns must be steered with tool-call hooks so Rig never persists unanswered tool calls as ordinary conversation history.
