### PR TITLE
Add response retry actions to agent hooks

### DIFF
--- a/crates/rig-core/src/agent/builder.rs
+++ b/crates/rig-core/src/agent/builder.rs
@@ -276,8 +276,8 @@ where
     /// stack; hooks run for every prompt request (unless more are added per
     /// request) in registration order. How their results compose is
     /// event-dependent: `CompletionCall` request patches accumulate and merge,
-    /// `ToolCall`/`ToolResult` rewrites chain, and only observe-only/recovery
-    /// events use first-non-`Continue`-wins. See the
+    /// `ToolCall`/`ToolResult` rewrites chain, and model-turn Retry/Stop actions
+    /// short-circuit later hooks. See the
     /// [`hook`](crate::agent::hook) module docs.
     pub fn add_hook<H>(mut self, hook: H) -> Self
     where

--- a/crates/rig-core/src/agent/hook.rs
+++ b/crates/rig-core/src/agent/hook.rs
@@ -12,8 +12,8 @@
 //! [`RequestPatch`] values accumulate and merge; tool-call argument rewrites and
 //! tool-result presentation rewrites chain into later hooks. Nested stacks obey
 //! the same rules as flat stacks, including preserving an argument rewrite when
-//! an inner stack later skips or stops. Every stop action short-circuits the
-//! remaining hooks for that event.
+//! an inner stack later skips or stops. [`ModelTurnAction::Retry`] and every stop
+//! action short-circuit the remaining hooks for that event.
 //!
 //! Register observe-only hooks before steering hooks when every observation is
 //! required: a steering stop intentionally prevents later observers from
@@ -26,29 +26,85 @@
 //! Blocking and streaming agents share the same request, tool-call, and
 //! tool-result resolution path. Streaming adds delta-specific observations, but
 //! shared lifecycle actions have identical semantics on both surfaces.
+//! Completed-response validation belongs in
+//! [`AgentHook::on_model_turn_finished`]. A retry consumes another call from the
+//! run's existing `max_turns` budget; hook-specific limits and counters belong in
+//! the run-scoped [`Scratchpad`]. [`RetryRequest::Repeat`] discards the rejected
+//! assistant turn and repeats the preceding request, while
+//! [`RetryRequest::Feedback`] records that assistant turn and adds corrective
+//! user feedback. Tool-bearing turns cannot be retried through this event; use
+//! tool-call hooks instead.
 //!
-//! # Example
+//! Streaming deltas are provisional until `on_model_turn_finished` accepts the
+//! turn. When it requests a retry, the stream emits
+//! [`MultiTurnStreamItem::ModelTurnRetried`](crate::agent::MultiTurnStreamItem::ModelTurnRetried)
+//! so consumers can discard or visually reset the rejected turn's provisional
+//! output.
+//!
+//! # Bounded response validation
+//!
+//! Retry limits belong to the hook rather than the agent. This example stores a
+//! per-hook-instance counter in the run-scoped scratchpad and stops explicitly
+//! when its limit is exhausted:
 //!
 //! ```
-//! use rig_core::agent::{
-//!     AgentHook, CompletionResponseEvent, HookContext, ObservationAction,
+//! use std::{collections::HashMap, sync::atomic::{AtomicUsize, Ordering}};
+//! use rig_core::{
+//!     agent::{
+//!         AgentHook, HookContext, ModelTurnAction, ModelTurnFinished, RetryRequest,
+//!     },
+//!     message::AssistantContent,
 //! };
 //!
-//! struct ResponseLogger;
+//! static NEXT_VALIDATOR_ID: AtomicUsize = AtomicUsize::new(1);
 //!
-//! impl AgentHook for ResponseLogger {
-//!     async fn on_completion_response(
-//!         &self,
-//!         _ctx: &HookContext,
-//!         event: CompletionResponseEvent<'_>,
-//!     ) -> ObservationAction {
-//!         println!(
-//!             "message {:?}: {:?} ({:?})",
-//!             event.message_id, event.content, event.usage
-//!         );
-//!         ObservationAction::continue_run()
+//! #[derive(Clone, Default)]
+//! struct ValidatorState {
+//!     attempts_by_instance: HashMap<usize, usize>,
+//! }
+//!
+//! struct ResponseValidator {
+//!     id: usize,
+//!     max_retries: usize,
+//! }
+//!
+//! impl ResponseValidator {
+//!     fn new(max_retries: usize) -> Self {
+//!         Self {
+//!             id: NEXT_VALIDATOR_ID.fetch_add(1, Ordering::Relaxed),
+//!             max_retries,
+//!         }
 //!     }
 //! }
+//!
+//! impl AgentHook for ResponseValidator {
+//!     async fn on_model_turn_finished(
+//!         &self,
+//!         ctx: &HookContext,
+//!         event: ModelTurnFinished<'_>,
+//!     ) -> ModelTurnAction {
+//!         let accepted = event.content.iter().any(|item| {
+//!             matches!(item, AssistantContent::Text(text) if text.text.contains("approved"))
+//!         });
+//!         if accepted {
+//!             return ModelTurnAction::continue_run();
+//!         }
+//!
+//!         let attempts = ctx.scratchpad().update::<ValidatorState, _>(|state| {
+//!             let attempts = state.attempts_by_instance.entry(self.id).or_default();
+//!             *attempts += 1;
+//!             *attempts
+//!         });
+//!         if attempts <= self.max_retries {
+//!             ModelTurnAction::retry(RetryRequest::feedback(
+//!                 "Return an approved response.",
+//!             ))
+//!         } else {
+//!             ModelTurnAction::stop("response validation retry limit exhausted")
+//!         }
+//!     }
+//! }
+//! # let _ = ResponseValidator::new(2);
 //! ```
 
 use std::collections::HashMap;
@@ -769,6 +825,59 @@ impl InvalidToolCallAction {
     }
 }
 
+/// How an accepted, tool-free model turn should be retried.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RetryRequest {
+    /// Discard the rejected assistant response and repeat the same request with
+    /// the same preceding history.
+    Repeat,
+    /// Record the rejected assistant response, append this corrective user
+    /// feedback, and make another model call.
+    Feedback(String),
+}
+
+impl RetryRequest {
+    /// Creates a retry that repeats the original request without retaining the
+    /// rejected assistant response in conversation history.
+    pub fn repeat() -> Self {
+        Self::Repeat
+    }
+
+    /// Creates a retry that retains the rejected response and appends corrective
+    /// user feedback.
+    pub fn feedback(feedback: impl Into<String>) -> Self {
+        Self::Feedback(feedback.into())
+    }
+}
+
+/// Action for the canonical completed-model-turn hook.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ModelTurnAction {
+    /// Accept the model turn and continue the run.
+    Continue,
+    /// Reject the model turn and request another model call.
+    Retry(RetryRequest),
+    /// Stop the run with a reason.
+    Stop(String),
+}
+
+impl ModelTurnAction {
+    /// Creates an action that accepts the model turn.
+    pub fn continue_run() -> Self {
+        Self::Continue
+    }
+
+    /// Creates an action that rejects the model turn and retries it.
+    pub fn retry(request: RetryRequest) -> Self {
+        Self::Retry(request)
+    }
+
+    /// Creates an action that stops the run with the supplied reason.
+    pub fn stop(reason: impl Into<String>) -> Self {
+        Self::Stop(reason.into())
+    }
+}
+
 /// Action for observe-only lifecycle events.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ObservationAction {
@@ -815,15 +924,19 @@ pub trait AgentHook: WasmCompatSend + WasmCompatSync {
         async { ObservationAction::Continue }
     }
 
-    /// Observes the content and usage produced at the end of a model turn.
+    /// Observes and may reject the canonical content produced by an accepted
+    /// model turn, before tool execution or successful finalization.
     ///
-    /// The default action continues the run.
+    /// [`ModelTurnAction::Retry`] is supported only for turns without tool
+    /// calls. Each retry consumes another call from the run's existing total
+    /// model-call budget. Hook-specific retry limits should be kept in the
+    /// run-scoped [`Scratchpad`]. The default action accepts the turn.
     fn on_model_turn_finished(
         &self,
         _ctx: &HookContext,
         _event: ModelTurnFinished<'_>,
-    ) -> impl Future<Output = ObservationAction> + WasmCompatSend {
-        async { ObservationAction::Continue }
+    ) -> impl Future<Output = ModelTurnAction> + WasmCompatSend {
+        async { ModelTurnAction::Continue }
     }
 
     /// Resolves a model-emitted tool call that cannot be dispatched as written.
@@ -928,7 +1041,7 @@ trait DynAgentHook: WasmCompatSend + WasmCompatSync {
         &'a self,
         ctx: &'a HookContext,
         event: ModelTurnFinished<'a>,
-    ) -> WasmBoxedFuture<'a, ObservationAction>;
+    ) -> WasmBoxedFuture<'a, ModelTurnAction>;
     fn invalid_tool_call<'a>(
         &'a self,
         ctx: &'a HookContext,
@@ -984,7 +1097,7 @@ where
         &'a self,
         ctx: &'a HookContext,
         event: ModelTurnFinished<'a>,
-    ) -> WasmBoxedFuture<'a, ObservationAction> {
+    ) -> WasmBoxedFuture<'a, ModelTurnAction> {
         Box::pin(self.on_model_turn_finished(ctx, event))
     }
     fn invalid_tool_call<'a>(
@@ -1167,14 +1280,14 @@ impl AgentHook for HookStack {
         &self,
         ctx: &HookContext,
         event: ModelTurnFinished<'_>,
-    ) -> ObservationAction {
+    ) -> ModelTurnAction {
         for hook in &self.hooks {
             let action = hook.model_turn_finished(ctx, event).await;
-            if !matches!(action, ObservationAction::Continue) {
+            if !matches!(action, ModelTurnAction::Continue) {
                 return action;
             }
         }
-        ObservationAction::Continue
+        ModelTurnAction::Continue
     }
     async fn on_invalid_tool_call(
         &self,
@@ -1296,6 +1409,111 @@ mod tests {
                 ..
             })
         ));
+    }
+
+    #[derive(Clone)]
+    struct ModelTurnRecorder {
+        label: usize,
+        log: Arc<std::sync::Mutex<Vec<usize>>>,
+        action: ModelTurnAction,
+    }
+
+    impl AgentHook for ModelTurnRecorder {
+        async fn on_model_turn_finished(
+            &self,
+            _ctx: &HookContext,
+            _event: ModelTurnFinished<'_>,
+        ) -> ModelTurnAction {
+            self.log.lock().unwrap().push(self.label);
+            self.action.clone()
+        }
+    }
+
+    fn model_turn_event(content: &OneOrMany<AssistantContent>) -> ModelTurnFinished<'_> {
+        ModelTurnFinished {
+            turn: 1,
+            content,
+            usage: Usage::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn model_turn_continue_visits_every_hook_in_order() {
+        let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut stack = HookStack::with(ModelTurnRecorder {
+            label: 1,
+            log: log.clone(),
+            action: ModelTurnAction::Continue,
+        });
+        stack.push(ModelTurnRecorder {
+            label: 2,
+            log: log.clone(),
+            action: ModelTurnAction::Continue,
+        });
+        let content = OneOrMany::one(AssistantContent::text("answer"));
+
+        assert_eq!(
+            stack
+                .on_model_turn_finished(&HookContext::new(false, None), model_turn_event(&content),)
+                .await,
+            ModelTurnAction::Continue
+        );
+        assert_eq!(*log.lock().unwrap(), vec![1, 2]);
+    }
+
+    #[tokio::test]
+    async fn model_turn_retry_and_stop_short_circuit_nested_stacks() {
+        let content = OneOrMany::one(AssistantContent::text("answer"));
+
+        let retry_log = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut inner = HookStack::with(ModelTurnRecorder {
+            label: 1,
+            log: retry_log.clone(),
+            action: ModelTurnAction::Continue,
+        });
+        inner.push(ModelTurnRecorder {
+            label: 2,
+            log: retry_log.clone(),
+            action: ModelTurnAction::retry(RetryRequest::repeat()),
+        });
+        inner.push(ModelTurnRecorder {
+            label: 3,
+            log: retry_log.clone(),
+            action: ModelTurnAction::Continue,
+        });
+        let mut outer = HookStack::with(inner);
+        outer.push(ModelTurnRecorder {
+            label: 4,
+            log: retry_log.clone(),
+            action: ModelTurnAction::Continue,
+        });
+
+        assert_eq!(
+            outer
+                .on_model_turn_finished(&HookContext::new(false, None), model_turn_event(&content),)
+                .await,
+            ModelTurnAction::retry(RetryRequest::repeat())
+        );
+        assert_eq!(*retry_log.lock().unwrap(), vec![1, 2]);
+
+        let stop_log = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut stopped = HookStack::with(ModelTurnRecorder {
+            label: 1,
+            log: stop_log.clone(),
+            action: ModelTurnAction::stop("stop"),
+        });
+        stopped.push(ModelTurnRecorder {
+            label: 2,
+            log: stop_log.clone(),
+            action: ModelTurnAction::Continue,
+        });
+        assert_eq!(
+            stopped
+                .on_model_turn_finished(&HookContext::new(false, None), model_turn_event(&content),)
+                .await,
+            ModelTurnAction::stop("stop")
+        );
+        assert_eq!(*stop_log.lock().unwrap(), vec![1]);
     }
 
     #[derive(Clone)]
@@ -2136,11 +2354,13 @@ mod migrated_tests {
         fn call(_: ToolCallAction) {}
         fn result(_: ToolResultAction) {}
         fn invalid(_: InvalidToolCallAction) {}
+        fn model_turn(_: ModelTurnAction) {}
         fn observation(_: ObservationAction) {}
         completion(CompletionCallAction::continue_run());
         call(ToolCallAction::run());
         result(ToolResultAction::keep());
         invalid(InvalidToolCallAction::fail());
+        model_turn(ModelTurnAction::retry(RetryRequest::repeat()));
         observation(ObservationAction::continue_run());
         let calls = AtomicUsize::new(0);
         calls.fetch_add(1, Ordering::Relaxed);

--- a/crates/rig-core/src/agent/mod.rs
+++ b/crates/rig-core/src/agent/mod.rs
@@ -163,9 +163,10 @@ pub use completion::Agent;
 pub use hook::CompletionCall as CompletionCallEvent;
 pub use hook::{
     AgentHook, CompletionCallAction, CompletionResponse as CompletionResponseEvent, HookContext,
-    HookStack, InvalidToolCallAction, InvalidToolCallContext, ModelTurnFinished, ObservationAction,
-    RequestPatch, RunId, Scratchpad, StepEventKind, StreamResponseFinish, TextDelta, ToolCall,
-    ToolCallAction, ToolCallDelta, ToolResultAction, ToolResultEvent,
+    HookStack, InvalidToolCallAction, InvalidToolCallContext, ModelTurnAction, ModelTurnFinished,
+    ObservationAction, RequestPatch, RetryRequest, RunId, Scratchpad, StepEventKind,
+    StreamResponseFinish, TextDelta, ToolCall, ToolCallAction, ToolCallDelta, ToolResultAction,
+    ToolResultEvent,
 };
 pub use prompt_request::streaming::{
     MultiTurnStreamItem, StreamingError, StreamingPromptRequest, StreamingResult, stream_to_stdout,

--- a/crates/rig-core/src/agent/prompt_request/mod.rs
+++ b/crates/rig-core/src/agent/prompt_request/mod.rs
@@ -258,8 +258,8 @@ where
     /// Append a hook for this request (on top of any the agent already carries).
     /// Hooks run in registration order; how their results compose is
     /// event-dependent (`CompletionCall` request patches accumulate and merge,
-    /// `ToolCall`/`ToolResult` rewrites chain, and only observe-only/recovery
-    /// events use first-non-`Continue`-wins). See the
+    /// `ToolCall`/`ToolResult` rewrites chain, and model-turn Retry/Stop actions
+    /// short-circuit later hooks). See the
     /// [`hook`](crate::agent::hook) module docs.
     pub fn add_hook<H>(mut self, hook: H) -> Self
     where

--- a/crates/rig-core/src/agent/prompt_request/streaming.rs
+++ b/crates/rig-core/src/agent/prompt_request/streaming.rs
@@ -11,9 +11,9 @@ use crate::{
         streamed::{StreamedResolution, StreamedTurnAssembler, StreamedTurnEvent},
     },
     agent::runner::{
-        AgentRunner, CompletionCallOutcome, ToolExecution, acquire_agent_span, append_run_messages,
-        build_chat_span, new_execute_tool_span, observe_action, resolve_completion_call,
-        run_single_tool,
+        AgentRunner, CompletionCallOutcome, ModelTurnDecision, ToolExecution, acquire_agent_span,
+        append_run_messages, build_chat_span, new_execute_tool_span, observe_action,
+        resolve_completion_call, resolve_model_turn, run_single_tool,
     },
     completion::GetTokenUsage,
     message::{AssistantContent, UserContent},
@@ -106,6 +106,18 @@ pub enum MultiTurnStreamItem<R> {
     /// }
     /// ```
     CompletionCall(CompletionCall),
+    /// The completed model turn was rejected by
+    /// [`AgentHook::on_model_turn_finished`] and another model call will be
+    /// attempted.
+    ///
+    /// Text and reasoning deltas for that turn may already have been emitted.
+    /// Consumers should discard or visually reset provisional output associated
+    /// with `turn`. The rejected turn's provider-final item and agent-level final
+    /// response are not emitted.
+    ModelTurnRetried {
+        /// One-based model-call index of the rejected turn.
+        turn: usize,
+    },
     /// The final result from the stream: the unified [`PromptResponse`] shared
     /// with the blocking surface.
     FinalResponse(PromptResponse),
@@ -326,8 +338,8 @@ where
     /// Append a hook to this request's hook stack (on top of any the agent
     /// already carries). Hooks run in registration order; how their results
     /// compose is event-dependent (`CompletionCall` request patches accumulate
-    /// and merge, `ToolCall`/`ToolResult` rewrites chain, and only
-    /// observe-only/recovery events use first-non-`Continue`-wins). See the
+    /// and merge, `ToolCall`/`ToolResult` rewrites chain, and model-turn
+    /// Retry/Stop actions short-circuit later hooks). See the
     /// [`hook`](crate::agent::hook) module docs.
     pub fn add_hook<H>(mut self, hook: H) -> Self
     where
@@ -1322,9 +1334,6 @@ where
                 yield Err(StreamingError::Prompt(Box::new(run.cancel_error(reason))));
                 return;
             }
-            if let Some(item) = pending_final {
-                yield Ok(MultiTurnStreamItem::stream_item(item));
-            }
             self.last_message_id = streamed_turn.message_id.clone();
             // The canonical (committed) assistant content: `finish` normalizes
             // reasoning/text/tool ordering, so this can differ from the raw
@@ -1337,6 +1346,43 @@ where
                 yield Err(Box::new(err).into());
                 return;
             }
+
+            // Normalized per-turn event, fired once the turn is committed on the
+            // streaming surface — including tool-only / reasoning-only turns that
+            // fire no `StreamResponseFinish`. Suppressed for recovered turns,
+            // mirroring the blocking surface's `Continue` arm.
+            let decision = if turn_recovered {
+                ModelTurnDecision::Accept
+            } else {
+                resolve_model_turn(
+                    &runner.hooks,
+                    hook_ctx,
+                    ModelTurnFinished {
+                        turn: hook_ctx.turn(),
+                        content: &canonical_choice,
+                        usage: last_usage,
+                    },
+                )
+                .await
+            };
+            match decision {
+                ModelTurnDecision::Accept => {}
+                ModelTurnDecision::Retry(request) => {
+                    if let Err(err) = run.retry_model_turn(request) {
+                        yield Err(Box::new(err).into());
+                        return;
+                    }
+                    yield Ok(MultiTurnStreamItem::ModelTurnRetried {
+                        turn: hook_ctx.turn(),
+                    });
+                    return;
+                }
+                ModelTurnDecision::Terminate(reason) => {
+                    yield Err(StreamingError::Prompt(Box::new(run.cancel_error(reason))));
+                    return;
+                }
+            }
+
             // Only accepted, canonical output belongs in content telemetry.
             // Keep caller-owned spans untouched, matching the blocking source.
             if self.created_agent_span && self.record_telemetry_content {
@@ -1350,28 +1396,8 @@ where
                 &canonical_choice,
                 runner.record_telemetry_content,
             );
-
-            // Normalized per-turn event, fired once the turn is committed on the
-            // streaming surface — including tool-only / reasoning-only turns that
-            // fire no `StreamResponseFinish`. Suppressed for recovered turns,
-            // mirroring the blocking surface's `Continue` arm.
-            if !turn_recovered
-                && let Some(reason) = observe_action(
-                    runner
-                        .hooks
-                        .on_model_turn_finished(
-                            hook_ctx,
-                            ModelTurnFinished {
-                                turn: hook_ctx.turn(),
-                                content: &canonical_choice,
-                                usage: last_usage,
-                            },
-                        )
-                        .await,
-                )
-            {
-                yield Err(StreamingError::Prompt(Box::new(run.cancel_error(reason))));
-                return;
+            if let Some(item) = pending_final {
+                yield Ok(MultiTurnStreamItem::stream_item(item));
             }
 
             self.last_final_choice = final_turn_content;

--- a/crates/rig-core/src/agent/run/mod.rs
+++ b/crates/rig-core/src/agent/run/mod.rs
@@ -71,7 +71,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     OneOrMany,
-    agent::hook::{InvalidToolCallAction, InvalidToolCallContext},
+    agent::hook::{InvalidToolCallAction, InvalidToolCallContext, RetryRequest},
     agent::prompt_request::{
         CompletionCall, PromptResponse, TOOL_NOT_EXECUTED_DUE_TO_INVALID_PEER,
         assistant_text_from_choice, build_full_history, build_history_for_request,
@@ -490,6 +490,60 @@ impl AgentRun {
         };
 
         OneOrMany::from_iter_optional(turn.items.clone())
+    }
+
+    /// Reject the accepted model turn and return the run to request preparation.
+    ///
+    /// This transition is valid only after a model turn has been accepted and
+    /// before [`Self::next_step`] advances it into tool execution or successful
+    /// finalization. It never changes usage, completion-call records, or the
+    /// current model-call count, so the next [`Self::next_step`] enforces the
+    /// existing total `max_turns` budget.
+    ///
+    /// [`RetryRequest::Repeat`] discards the rejected assistant response and
+    /// repeats the same prompt with the same preceding history.
+    /// [`RetryRequest::Feedback`] retains the rejected assistant response and
+    /// appends a user feedback message as the next prompt.
+    ///
+    /// Tool-bearing turns are rejected with [`PromptError::PromptCancelled`]
+    /// because ordinary feedback cannot safely follow unanswered tool calls.
+    /// Handle those turns through tool-call hooks instead.
+    pub fn retry_model_turn(&mut self, request: RetryRequest) -> Result<(), PromptError> {
+        let turn = match std::mem::replace(&mut self.state, RunState::Failed) {
+            RunState::AwaitingAdvance(turn) => turn,
+            other => {
+                self.state = other;
+                return Err(self.protocol_violation(
+                    "retry_model_turn called without an accepted model turn awaiting advancement",
+                ));
+            }
+        };
+
+        if turn.has_tool_calls {
+            return Err(PromptError::prompt_cancelled(
+                self.full_history(),
+                "response retry is not supported for tool-bearing model turns; handle tool calls through tool-call hooks",
+            ));
+        }
+
+        match request {
+            RetryRequest::Repeat => {}
+            RetryRequest::Feedback(feedback) => {
+                let Some(content) = OneOrMany::from_iter_optional(turn.items) else {
+                    return Err(self.protocol_violation(
+                        "retry_model_turn found an accepted turn without assistant content",
+                    ));
+                };
+                self.new_messages.push(Message::Assistant {
+                    id: turn.message_id,
+                    content,
+                });
+                self.new_messages.push(Message::user(feedback));
+            }
+        }
+
+        self.state = RunState::PreparingRequest;
+        Ok(())
     }
 
     /// The full conversation: input history followed by [`Self::messages`].
@@ -1577,6 +1631,130 @@ mod tests {
                 .len(),
             2
         );
+    }
+
+    #[test]
+    fn repeat_retry_reissues_same_prompt_without_rejected_response_in_history() {
+        let mut run = AgentRun::new("question").max_turns(2);
+        let (first_prompt, first_history, first_turn) = expect_call_model(&mut run);
+        assert_eq!(first_turn, 1);
+
+        expect_continue(
+            run.model_response(text_turn("rejected").with_usage_for_test(usage(3, 2)))
+                .expect("first model response"),
+        );
+        run.retry_model_turn(RetryRequest::Repeat)
+            .expect("repeat retry should be accepted");
+
+        let (second_prompt, second_history, second_turn) = expect_call_model(&mut run);
+        assert_eq!(second_turn, 2);
+        assert_eq!(second_prompt, first_prompt);
+        assert_eq!(second_history, first_history);
+        assert_eq!(run.messages(), &[Message::user("question")]);
+        assert_eq!(run.usage(), usage(3, 2));
+        assert_eq!(run.completion_calls().len(), 1);
+
+        expect_continue(
+            run.model_response(text_turn("accepted").with_usage_for_test(usage(4, 1)))
+                .expect("second model response"),
+        );
+        let response = expect_done(&mut run);
+        assert_eq!(response.output, "accepted");
+        assert_eq!(response.usage, usage(7, 3));
+        assert_eq!(response.completion_calls.len(), 2);
+        assert_eq!(
+            response.messages,
+            Some(vec![
+                Message::user("question"),
+                Message::assistant("accepted")
+            ])
+        );
+    }
+
+    #[test]
+    fn feedback_retry_records_rejected_response_and_corrective_user_message() {
+        let mut run = AgentRun::new("question").max_turns(2);
+        expect_call_model(&mut run);
+        expect_continue(
+            run.model_response(text_turn("rejected").with_usage_for_test(usage(2, 1)))
+                .expect("first model response"),
+        );
+        run.retry_model_turn(RetryRequest::Feedback("be precise".into()))
+            .expect("feedback retry should be accepted");
+
+        let (prompt, history, turn) = expect_call_model(&mut run);
+        assert_eq!(turn, 2);
+        assert_eq!(prompt, Message::user("be precise"));
+        assert_eq!(
+            history,
+            vec![Message::user("question"), Message::assistant("rejected")]
+        );
+
+        expect_continue(
+            run.model_response(text_turn("accepted").with_usage_for_test(usage(3, 2)))
+                .expect("second model response"),
+        );
+        let response = expect_done(&mut run);
+        assert_eq!(response.output, "accepted");
+        assert_eq!(response.usage, usage(5, 3));
+        assert_eq!(response.completion_calls.len(), 2);
+        assert_eq!(
+            response.messages,
+            Some(vec![
+                Message::user("question"),
+                Message::assistant("rejected"),
+                Message::user("be precise"),
+                Message::assistant("accepted"),
+            ])
+        );
+    }
+
+    #[test]
+    fn response_retry_consumes_existing_total_model_call_budget() {
+        let mut run = AgentRun::new("question").max_turns(1);
+        expect_call_model(&mut run);
+        expect_continue(
+            run.model_response(text_turn("rejected").with_usage_for_test(usage(2, 1)))
+                .expect("model response"),
+        );
+        run.retry_model_turn(RetryRequest::Repeat)
+            .expect("retry transition should succeed before budget check");
+
+        let error = run
+            .next_step()
+            .expect_err("retry should exhaust the one-call budget");
+        assert!(matches!(
+            error,
+            PromptError::MaxTurnsError { max_turns: 1, .. }
+        ));
+        assert_eq!(run.turn(), 1);
+        assert_eq!(run.usage(), usage(2, 1));
+        assert_eq!(run.completion_calls().len(), 1);
+    }
+
+    #[test]
+    fn response_retry_rejects_tool_bearing_turn_without_advancing_to_tools() {
+        let mut run = AgentRun::new("use a tool").max_turns(2);
+        expect_call_model(&mut run);
+        expect_continue(
+            run.model_response(tool_call_turn("call_1", "add"))
+                .expect("tool turn should be accepted"),
+        );
+
+        let error = run
+            .retry_model_turn(RetryRequest::Feedback("do not use tools".into()))
+            .expect_err("tool-bearing response retry must fail closed");
+        assert!(matches!(
+            error,
+            PromptError::PromptCancelled { reason, chat_history }
+                if reason.contains("tool-bearing model turns")
+                    && chat_history == vec![Message::user("use a tool")]
+        ));
+        let error = run
+            .next_step()
+            .expect_err("failed retry must not execute rejected tools");
+        assert!(matches!(error, PromptError::PromptCancelled { .. }));
+        assert_eq!(run.messages(), &[Message::user("use a tool")]);
     }
 
     #[test]

--- a/crates/rig-core/src/agent/runner.rs
+++ b/crates/rig-core/src/agent/runner.rs
@@ -38,8 +38,8 @@ use super::{
     hook::{
         AgentHook, CompletionCall, CompletionCallAction,
         CompletionResponse as CompletionResponseEvent, HookContext, HookStack,
-        InvalidToolCallAction, ModelTurnFinished, ObservationAction, RequestPatch,
-        ToolCall as ToolCallEvent, ToolCallAction, ToolResultAction, ToolResultEvent,
+        InvalidToolCallAction, ModelTurnAction, ModelTurnFinished, ObservationAction, RequestPatch,
+        RetryRequest, ToolCall as ToolCallEvent, ToolCallAction, ToolResultAction, ToolResultEvent,
     },
     prompt_request::{
         PromptResponse,
@@ -116,6 +116,27 @@ pub(crate) fn observe_action(action: ObservationAction) -> Option<String> {
     match action {
         ObservationAction::Continue => None,
         ObservationAction::Stop(reason) => Some(reason),
+    }
+}
+
+/// Medium-neutral decision produced by the canonical completed-turn hook.
+pub(crate) enum ModelTurnDecision {
+    Accept,
+    Retry(RetryRequest),
+    Terminate(String),
+}
+
+/// Resolve the canonical completed-turn hook identically for blocking and
+/// streaming model calls.
+pub(crate) async fn resolve_model_turn(
+    hooks: &HookStack,
+    ctx: &HookContext,
+    event: ModelTurnFinished<'_>,
+) -> ModelTurnDecision {
+    match hooks.on_model_turn_finished(ctx, event).await {
+        ModelTurnAction::Continue => ModelTurnDecision::Accept,
+        ModelTurnAction::Retry(request) => ModelTurnDecision::Retry(request),
+        ModelTurnAction::Stop(reason) => ModelTurnDecision::Terminate(reason),
     }
 }
 
@@ -247,8 +268,8 @@ where
     /// Append a hook to the stack (on top of any the agent already carries).
     /// Hooks run in registration order; how their results compose is
     /// event-dependent (`CompletionCall` request patches accumulate and merge,
-    /// `ToolCall`/`ToolResult` rewrites chain, and only observe-only/recovery
-    /// events use their event-specific stop action). See the
+    /// `ToolCall`/`ToolResult` rewrites chain, and model-turn Retry/Stop actions
+    /// short-circuit later hooks). See the
     /// [`hook`](crate::agent::hook) module docs.
     pub fn add_hook<H>(mut self, hook: H) -> Self
     where
@@ -952,17 +973,11 @@ where
                     ModelTurnOutcome::Continue {
                         response_hook_suppressed,
                     } => {
-                        if runner.record_telemetry_content
-                            && let Some(choice) = run.accepted_turn_choice()
-                        {
-                            crate::telemetry::record_model_output(&chat_span, &choice, true);
-                        }
-
                         if !response_hook_suppressed {
-                            // The response-finish event fires first, then the
-                            // normalized per-turn event. Both carry canonical
-                            // Rig data, are observe-only, and are suppressed for
-                            // recovered turns.
+                            // The observe-only response event fires first, then
+                            // the normalized per-turn steering event. Both carry
+                            // canonical Rig data and are suppressed for recovered
+                            // turns.
                             if let Some(reason) = observe_action(
                                 runner
                                     .hooks
@@ -980,22 +995,37 @@ where
                                 yield Err(StreamingError::Prompt(Box::new(run.cancel_error(reason))));
                                 return;
                             }
-                            if let Some(reason) = observe_action(
-                                runner
-                                    .hooks
-                                    .on_model_turn_finished(
-                                        hook_ctx,
-                                        ModelTurnFinished {
-                                            turn: hook_ctx.turn(),
-                                            content: &resp.choice,
-                                            usage: resp.usage,
-                                        },
-                                    )
-                                    .await,
-                            ) {
-                                yield Err(StreamingError::Prompt(Box::new(run.cancel_error(reason))));
-                                return;
+                            match resolve_model_turn(
+                                &runner.hooks,
+                                hook_ctx,
+                                ModelTurnFinished {
+                                    turn: hook_ctx.turn(),
+                                    content: &resp.choice,
+                                    usage: resp.usage,
+                                },
+                            )
+                            .await
+                            {
+                                ModelTurnDecision::Accept => {}
+                                ModelTurnDecision::Retry(request) => {
+                                    if let Err(err) = run.retry_model_turn(request) {
+                                        yield Err(Box::new(err).into());
+                                    }
+                                    return;
+                                }
+                                ModelTurnDecision::Terminate(reason) => {
+                                    yield Err(StreamingError::Prompt(Box::new(run.cancel_error(reason))));
+                                    return;
+                                }
                             }
+                        }
+                        // Record only turns accepted by the canonical steering
+                        // hook, matching the streaming surface and avoiding
+                        // telemetry leakage from validator-rejected content.
+                        if runner.record_telemetry_content
+                            && let Some(choice) = run.accepted_turn_choice()
+                        {
+                            crate::telemetry::record_model_output(&chat_span, &choice, true);
                         }
                         break;
                     }
@@ -1574,19 +1604,20 @@ mod tests {
 mod migrated_tests {
     use crate::agent::{
         CompletionCallAction, CompletionCallEvent, InvalidToolCallAction, InvalidToolCallContext,
-        ModelTurnFinished, ObservationAction, StreamResponseFinish, TextDelta, ToolCall,
-        ToolCallAction, ToolCallDelta, ToolResultAction, ToolResultEvent,
+        ModelTurnAction, ModelTurnFinished, ObservationAction, RetryRequest, StreamResponseFinish,
+        TextDelta, ToolCall, ToolCallAction, ToolCallDelta, ToolResultAction, ToolResultEvent,
     };
 
+    use std::collections::HashMap;
     use std::sync::{
         Arc, Mutex,
-        atomic::{AtomicBool, AtomicU32, Ordering::SeqCst},
+        atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering::SeqCst},
     };
 
     use futures::StreamExt;
     use serde::Deserialize;
     use serde_json::json;
-    use tokio::sync::Notify;
+    use tokio::sync::{Barrier, Notify};
 
     use crate::OneOrMany;
     use crate::agent::AgentBuilder;
@@ -1687,9 +1718,9 @@ mod migrated_tests {
             &self,
             _: &HookContext,
             _: ModelTurnFinished<'_>,
-        ) -> ObservationAction {
+        ) -> ModelTurnAction {
             self.record(StepEventKind::ModelTurnFinished);
-            ObservationAction::continue_run()
+            ModelTurnAction::continue_run()
         }
         async fn on_invalid_tool_call(
             &self,
@@ -1791,12 +1822,12 @@ mod migrated_tests {
             &self,
             _ctx: &HookContext,
             event: ModelTurnFinished<'_>,
-        ) -> ObservationAction {
+        ) -> ModelTurnAction {
             self.committed
                 .lock()
                 .expect("committed snapshots")
                 .push(event.content.clone());
-            ObservationAction::continue_run()
+            ModelTurnAction::continue_run()
         }
     }
 
@@ -1841,9 +1872,9 @@ mod migrated_tests {
             &self,
             _ctx: &HookContext,
             _event: ModelTurnFinished<'_>,
-        ) -> ObservationAction {
+        ) -> ModelTurnAction {
             self.model_turns.fetch_add(1, SeqCst);
-            ObservationAction::continue_run()
+            ModelTurnAction::continue_run()
         }
     }
 
@@ -1929,6 +1960,414 @@ mod migrated_tests {
         assert_eq!(streaming[0].message_id.as_deref(), Some("msg-canonical"));
     }
 
+    static NEXT_RESPONSE_VALIDATOR_ID: AtomicUsize = AtomicUsize::new(1);
+
+    #[derive(Clone, Default)]
+    struct ResponseValidatorState {
+        attempts_by_hook: HashMap<usize, usize>,
+    }
+
+    /// Bounded response policy whose exhausted-limit behavior is to accept the
+    /// latest response. The per-instance map key prevents same-type hooks from
+    /// sharing counters inside one run; Scratchpad keeps the whole map run-local.
+    #[derive(Clone)]
+    struct ResponseValidator {
+        id: usize,
+        rejected_text: &'static str,
+        max_retries: usize,
+        retry_request: RetryRequest,
+        barrier: Option<Arc<Barrier>>,
+        observed: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl ResponseValidator {
+        fn new(rejected_text: &'static str, max_retries: usize) -> Self {
+            Self {
+                id: NEXT_RESPONSE_VALIDATOR_ID.fetch_add(1, SeqCst),
+                rejected_text,
+                max_retries,
+                retry_request: RetryRequest::feedback("return an acceptable response"),
+                barrier: None,
+                observed: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        fn repeating(rejected_text: &'static str, max_retries: usize) -> Self {
+            Self {
+                retry_request: RetryRequest::repeat(),
+                ..Self::new(rejected_text, max_retries)
+            }
+        }
+
+        fn with_barrier(mut self, barrier: Arc<Barrier>) -> Self {
+            self.barrier = Some(barrier);
+            self
+        }
+
+        fn observed(&self) -> Vec<String> {
+            self.observed
+                .lock()
+                .expect("validator observations")
+                .clone()
+        }
+    }
+
+    impl AgentHook for ResponseValidator {
+        async fn on_model_turn_finished(
+            &self,
+            ctx: &HookContext,
+            event: ModelTurnFinished<'_>,
+        ) -> ModelTurnAction {
+            let text = crate::agent::prompt_request::assistant_text_from_choice(event.content);
+            self.observed
+                .lock()
+                .expect("validator observations")
+                .push(text.clone());
+            if text != self.rejected_text {
+                return ModelTurnAction::Continue;
+            }
+
+            let attempts = ctx
+                .scratchpad()
+                .update::<ResponseValidatorState, _>(|state| {
+                    let attempts = state.attempts_by_hook.entry(self.id).or_default();
+                    *attempts += 1;
+                    *attempts
+                });
+            if attempts == 1
+                && let Some(barrier) = &self.barrier
+            {
+                barrier.wait().await;
+            }
+
+            if attempts <= self.max_retries {
+                ModelTurnAction::retry(self.retry_request.clone())
+            } else {
+                ModelTurnAction::Continue
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn blocking_repeat_reissues_the_identical_request_history() {
+        let model =
+            MockCompletionModel::from_turns([MockTurn::text("bad"), MockTurn::text("accepted")]);
+        let response = AgentBuilder::new(model.clone())
+            .add_hook(ResponseValidator::repeating("bad", 1))
+            .build()
+            .runner("question")
+            .max_turns(2)
+            .run()
+            .await
+            .expect("blocking repeat retry");
+
+        let requests = model.requests();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].chat_history, requests[1].chat_history);
+        assert_eq!(response.output, "accepted");
+        assert_eq!(
+            response.messages,
+            Some(vec![
+                Message::user("question"),
+                Message::assistant("accepted"),
+            ])
+        );
+        assert_eq!(response.completion_calls.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn retry_scratchpad_state_is_isolated_between_runs() {
+        let model = MockCompletionModel::from_turns([
+            MockTurn::text("bad"),
+            MockTurn::text("good one"),
+            MockTurn::text("bad"),
+            MockTurn::text("good two"),
+        ]);
+        let validator = ResponseValidator::new("bad", 1);
+        let agent = AgentBuilder::new(model.clone()).add_hook(validator).build();
+
+        let first = agent
+            .runner("first")
+            .max_turns(2)
+            .run()
+            .await
+            .expect("first run");
+        let second = agent
+            .runner("second")
+            .max_turns(2)
+            .run()
+            .await
+            .expect("second run");
+
+        assert_eq!(first.output, "good one");
+        assert_eq!(second.output, "good two");
+        assert_eq!(model.request_count(), 4);
+    }
+
+    #[tokio::test]
+    async fn concurrent_runs_do_not_share_retry_counters() {
+        let model = MockCompletionModel::from_turns([
+            MockTurn::text("bad"),
+            MockTurn::text("bad"),
+            MockTurn::text("good one"),
+            MockTurn::text("good two"),
+        ]);
+        let validator = ResponseValidator::new("bad", 1).with_barrier(Arc::new(Barrier::new(2)));
+        let agent = AgentBuilder::new(model.clone()).add_hook(validator).build();
+
+        let (first, second) = tokio::join!(
+            agent.runner("first").max_turns(2).run(),
+            agent.runner("second").max_turns(2).run(),
+        );
+        let first = first.expect("first concurrent run");
+        let second = second.expect("second concurrent run");
+
+        assert!(first.output.starts_with("good"));
+        assert!(second.output.starts_with("good"));
+        assert_ne!(first.output, second.output);
+        assert_eq!(model.request_count(), 4);
+    }
+
+    #[tokio::test]
+    async fn multiple_same_type_retry_hooks_use_independent_scratchpad_keys() {
+        let model = MockCompletionModel::from_turns([
+            MockTurn::text("bad-a"),
+            MockTurn::text("bad-b"),
+            MockTurn::text("good"),
+        ]);
+        let agent = AgentBuilder::new(model.clone())
+            .add_hook(ResponseValidator::new("bad-a", 1))
+            .add_hook(ResponseValidator::new("bad-b", 1))
+            .build();
+
+        let response = agent
+            .runner("validate")
+            .max_turns(3)
+            .run()
+            .await
+            .expect("run with two validators");
+
+        assert_eq!(response.output, "good");
+        assert_eq!(model.request_count(), 3);
+    }
+
+    #[tokio::test]
+    async fn blocking_and_streaming_feedback_retry_have_matching_results_and_accounting() {
+        let first_usage = Usage {
+            input_tokens: 2,
+            output_tokens: 1,
+            total_tokens: 3,
+            ..Usage::new()
+        };
+        let second_usage = Usage {
+            input_tokens: 4,
+            output_tokens: 2,
+            total_tokens: 6,
+            ..Usage::new()
+        };
+        let blocking_model = MockCompletionModel::from_turns([
+            MockTurn::text("bad").with_usage(first_usage),
+            MockTurn::text("accepted").with_usage(second_usage),
+        ]);
+        let blocking_validator = ResponseValidator::new("bad", 1);
+        let blocking = AgentBuilder::new(blocking_model.clone())
+            .add_hook(blocking_validator.clone())
+            .build()
+            .runner("question")
+            .max_turns(2)
+            .run()
+            .await
+            .expect("blocking retry");
+
+        let streaming_model = MockCompletionModel::from_stream_turns([
+            [
+                MockStreamEvent::text("bad"),
+                MockStreamEvent::final_response(first_usage),
+            ],
+            [
+                MockStreamEvent::text("accepted"),
+                MockStreamEvent::final_response(second_usage),
+            ],
+        ]);
+        let streaming_validator = ResponseValidator::new("bad", 1);
+        let mut stream = AgentBuilder::new(streaming_model.clone())
+            .add_hook(streaming_validator.clone())
+            .build()
+            .runner("question")
+            .max_turns(2)
+            .stream()
+            .await;
+        let mut retry_turns = Vec::new();
+        let mut provider_finals = 0;
+        let mut streamed_calls = Vec::new();
+        let mut streaming = None;
+        while let Some(item) = stream.next().await {
+            match item.expect("stream item") {
+                MultiTurnStreamItem::ModelTurnRetried { turn } => retry_turns.push(turn),
+                MultiTurnStreamItem::CompletionCall(call) => streamed_calls.push(call),
+                MultiTurnStreamItem::StreamAssistantItem(StreamedAssistantContent::Final(_)) => {
+                    provider_finals += 1;
+                }
+                MultiTurnStreamItem::FinalResponse(response) => streaming = Some(response),
+                _ => {}
+            }
+        }
+        let streaming = streaming.expect("stream final response");
+
+        assert_eq!(retry_turns, vec![1]);
+        assert_eq!(
+            provider_finals, 1,
+            "the rejected provider final is suppressed"
+        );
+        assert_eq!(blocking.output, "accepted");
+        assert_eq!(streaming.output, blocking.output);
+        assert_eq!(streaming.usage, blocking.usage);
+        assert_eq!(streaming.messages, blocking.messages);
+        assert_eq!(streaming.completion_calls, blocking.completion_calls);
+        assert_eq!(streamed_calls, streaming.completion_calls);
+        assert_eq!(blocking_validator.observed(), vec!["bad", "accepted"]);
+        assert_eq!(streaming_validator.observed(), vec!["bad", "accepted"]);
+        assert_eq!(blocking_model.request_count(), 2);
+        assert_eq!(streaming_model.request_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn streaming_retry_then_max_turn_exhaustion_terminates_cleanly() {
+        let usage = canonical_usage();
+        let model = MockCompletionModel::from_stream_turns([[
+            MockStreamEvent::text("bad"),
+            MockStreamEvent::final_response(usage),
+        ]]);
+        let mut stream = AgentBuilder::new(model)
+            .add_hook(ResponseValidator::new("bad", 1))
+            .build()
+            .runner("question")
+            .max_turns(1)
+            .stream()
+            .await;
+        let mut saw_call = false;
+        let mut saw_retry = false;
+        let mut saw_final = false;
+        let mut error = None;
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(MultiTurnStreamItem::CompletionCall(call)) => {
+                    saw_call = true;
+                    assert_eq!(call.usage, usage);
+                }
+                Ok(MultiTurnStreamItem::ModelTurnRetried { turn: 1 }) => saw_retry = true,
+                Ok(MultiTurnStreamItem::FinalResponse(_)) => saw_final = true,
+                Ok(_) => {}
+                Err(err) => error = Some(err),
+            }
+        }
+
+        assert!(saw_call);
+        assert!(saw_retry);
+        assert!(!saw_final);
+        assert!(matches!(
+            error,
+            Some(StreamingError::Prompt(error))
+                if matches!(error.as_ref(), PromptError::MaxTurnsError { max_turns: 1, .. })
+        ));
+    }
+
+    #[derive(Clone)]
+    struct CountingRetryTool(Arc<AtomicUsize>);
+
+    impl Tool for CountingRetryTool {
+        const NAME: &'static str = "counting_retry_tool";
+        type Error = MockToolError;
+        type Args = serde_json::Value;
+        type Output = String;
+
+        fn description(&self) -> String {
+            "Counts executions".to_string()
+        }
+
+        fn parameters(&self) -> serde_json::Value {
+            json!({"type": "object", "properties": {}})
+        }
+
+        async fn call(
+            &self,
+            _context: &mut ToolContext,
+            _args: Self::Args,
+        ) -> Result<Self::Output, Self::Error> {
+            self.0.fetch_add(1, SeqCst);
+            Ok("ran".to_string())
+        }
+    }
+
+    #[tokio::test]
+    async fn retrying_tool_bearing_response_fails_before_tool_execution() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let result = AgentBuilder::new(MockCompletionModel::from_turns([MockTurn::tool_call(
+            "tc1",
+            CountingRetryTool::NAME,
+            json!({}),
+        )]))
+        .tool(CountingRetryTool(calls.clone()))
+        .add_hook(ResponseValidator::new("", 1))
+        .build()
+        .runner("use the tool")
+        .max_turns(2)
+        .run()
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(PromptError::PromptCancelled { reason, chat_history })
+                if reason.contains("tool-bearing model turns")
+                    && chat_history == vec![Message::user("use the tool")]
+        ));
+        assert_eq!(calls.load(SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn streaming_tool_bearing_retry_suppresses_finals_and_never_executes_tool() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let model = MockCompletionModel::from_stream_turns([[
+            MockStreamEvent::tool_call("tc1", CountingRetryTool::NAME, json!({})),
+            MockStreamEvent::final_response_with_total_tokens(1),
+        ]]);
+        let mut stream = AgentBuilder::new(model)
+            .tool(CountingRetryTool(calls.clone()))
+            .add_hook(ResponseValidator::new("", 1))
+            .build()
+            .runner("use the tool")
+            .max_turns(2)
+            .stream()
+            .await;
+        let mut saw_provider_final = false;
+        let mut saw_run_final = false;
+        let mut error = None;
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(MultiTurnStreamItem::StreamAssistantItem(StreamedAssistantContent::Final(
+                    _,
+                ))) => saw_provider_final = true,
+                Ok(MultiTurnStreamItem::FinalResponse(_)) => saw_run_final = true,
+                Ok(_) => {}
+                Err(err) => error = Some(err),
+            }
+        }
+
+        assert!(!saw_provider_final, "the rejected provider final is hidden");
+        assert!(!saw_run_final, "a rejected tool turn cannot finish the run");
+        assert!(matches!(
+            error,
+            Some(StreamingError::Prompt(error))
+                if matches!(
+                    error.as_ref(),
+                    PromptError::PromptCancelled { reason, chat_history }
+                        if reason.contains("tool-bearing model turns")
+                            && chat_history == &[Message::user("use the tool")]
+                )
+        ));
+        assert_eq!(calls.load(SeqCst), 0);
+    }
+
     #[tokio::test]
     async fn streaming_response_finish_without_provider_message_id_reports_none() {
         let hook = FinishLifecycleHook::default();
@@ -1951,7 +2390,7 @@ mod migrated_tests {
     }
 
     #[tokio::test]
-    async fn streaming_response_finish_runs_before_buffered_final_is_exposed() {
+    async fn streaming_response_finish_and_model_turn_run_before_buffered_final_is_exposed() {
         let hook = FinishLifecycleHook::default();
         let mut stream = AgentBuilder::new(MockCompletionModel::from_stream_turns([[
             MockStreamEvent::text("canonical response"),
@@ -1975,8 +2414,8 @@ mod migrated_tests {
                 assert_eq!(snapshots[0].message_id.as_deref(), Some("msg-after-final"));
                 assert_eq!(
                     hook.model_turns.load(SeqCst),
-                    0,
-                    "the turn must remain uncommitted while the final item is yielded"
+                    1,
+                    "the canonical turn hook must accept the turn before final exposure"
                 );
             }
         }
@@ -3195,6 +3634,7 @@ mod migrated_tests {
         use std::collections::{HashMap, HashSet};
         use std::sync::{Arc, Mutex};
 
+        use futures::StreamExt;
         use tracing::Instrument;
         use tracing::field::{Field, Visit};
         use tracing::span::{Attributes, Record};
@@ -3204,8 +3644,10 @@ mod migrated_tests {
 
         use crate::agent::{AgentBuilder, HookContext, ToolResultAction, ToolResultEvent};
         use crate::completion::Usage;
-        use crate::test_utils::{MockAddTool, MockCompletionModel, MockTurn};
+        use crate::test_utils::{MockAddTool, MockCompletionModel, MockStreamEvent, MockTurn};
         use crate::tool::{ToolContext, ToolExecutionError};
+
+        use super::ResponseValidator;
 
         #[derive(Clone)]
         struct CapturedSpan {
@@ -3335,6 +3777,98 @@ mod migrated_tests {
                 .tool(MockAddTool)
                 .build();
             let _ = agent.runner("add 2 and 3").max_turns(3).run().await;
+        }
+
+        async fn run_blocking_retry_with_content_telemetry() {
+            AgentBuilder::new(MockCompletionModel::from_turns([
+                MockTurn::text("rejected"),
+                MockTurn::text("accepted"),
+            ]))
+            .record_content_telemetry(true)
+            .add_hook(ResponseValidator::new("rejected", 1))
+            .build()
+            .runner("question")
+            .max_turns(2)
+            .run()
+            .await
+            .expect("blocking retry should succeed");
+        }
+
+        async fn run_streaming_retry_with_content_telemetry() {
+            let mut stream = AgentBuilder::new(MockCompletionModel::from_stream_turns([
+                [
+                    MockStreamEvent::text("rejected"),
+                    MockStreamEvent::final_response_with_total_tokens(1),
+                ],
+                [
+                    MockStreamEvent::text("accepted"),
+                    MockStreamEvent::final_response_with_total_tokens(1),
+                ],
+            ]))
+            .record_content_telemetry(true)
+            .add_hook(ResponseValidator::new("rejected", 1))
+            .build()
+            .runner("question")
+            .max_turns(2)
+            .stream()
+            .await;
+            while let Some(item) = stream.next().await {
+                item.expect("streaming retry item");
+            }
+        }
+
+        #[tokio::test]
+        async fn rejected_turn_content_is_not_recorded_on_either_surface() {
+            let _isolation = crate::test_utils::scoped_tracing_subscriber_guard().await;
+            let captured = Captured::default();
+            let subscriber = Registry::default().with(CaptureLayer {
+                captured: captured.clone(),
+            });
+            let _default = tracing::subscriber::set_default(subscriber);
+
+            // Register both transport callsites with this subscriber before
+            // inspecting field recordings.
+            run_blocking_retry_with_content_telemetry().await;
+            run_streaming_retry_with_content_telemetry().await;
+            tracing::callsite::rebuild_interest_cache();
+            captured.clear();
+
+            run_blocking_retry_with_content_telemetry().await;
+            let blocking = captured.snapshot();
+            let blocking_chats = blocking
+                .iter()
+                .filter(|span| span.name == "chat")
+                .collect::<Vec<_>>();
+            assert_eq!(blocking_chats.len(), 2);
+            assert!(
+                !blocking_chats[0]
+                    .field_names
+                    .contains("gen_ai.output.messages")
+            );
+            assert!(
+                blocking_chats[1]
+                    .field_names
+                    .contains("gen_ai.output.messages")
+            );
+
+            captured.clear();
+            run_streaming_retry_with_content_telemetry().await;
+            let streaming = captured.snapshot();
+            let streaming_chats = streaming
+                .iter()
+                .filter(|span| span.name == "chat_streaming")
+                .collect::<Vec<_>>();
+            assert_eq!(streaming_chats.len(), 2);
+            assert!(
+                !streaming_chats[0]
+                    .field_names
+                    .contains("gen_ai.output.messages")
+            );
+            assert!(
+                streaming_chats[1]
+                    .field_names
+                    .contains("gen_ai.output.messages")
+            );
         }
 
         #[tokio::test]
@@ -7389,7 +7923,7 @@ mod migrated_tests {
             &self,
             _ctx: &HookContext,
             event: ModelTurnFinished<'_>,
-        ) -> ObservationAction {
+        ) -> ModelTurnAction {
             if let ModelTurnFinished { turn, content, .. } = event
                 && turn == 1
             {
@@ -7404,7 +7938,7 @@ mod migrated_tests {
                     .collect();
                 *self.kinds.lock().expect("kinds") = Some(kinds);
             }
-            ObservationAction::continue_run()
+            ModelTurnAction::continue_run()
         }
     }
 
@@ -7628,12 +8162,12 @@ mod migrated_tests {
             &self,
             ctx: &HookContext,
             _event: ModelTurnFinished<'_>,
-        ) -> ObservationAction {
+        ) -> ModelTurnAction {
             if ctx.turn() == 1 {
                 self.handle.add_tool(FinalResultTool).await;
             }
 
-            ObservationAction::continue_run()
+            ModelTurnAction::continue_run()
         }
 
         async fn on_completion_call(
@@ -8053,7 +8587,7 @@ mod migrated_tests {
             &self,
             _ctx: &HookContext,
             event: ModelTurnFinished<'_>,
-        ) -> ObservationAction {
+        ) -> ModelTurnAction {
             if let ModelTurnFinished { content, .. } = event
                 && content.iter().any(|c| {
                     matches!(c, AssistantContent::ToolCall(tc) if tc.function.name == "final_result")
@@ -8061,7 +8595,7 @@ mod migrated_tests {
             {
                 *self.saw_output_tool_call.lock().expect("lock") = true;
             }
-            ObservationAction::continue_run()
+            ModelTurnAction::continue_run()
         }
     }
 

--- a/crates/rig-core/src/extractor.rs
+++ b/crates/rig-core/src/extractor.rs
@@ -346,7 +346,8 @@ mod tests {
 
     use super::*;
     use crate::agent::{
-        CompletionCallAction, CompletionResponseEvent, HookContext, ObservationAction, RequestPatch,
+        CompletionCallAction, CompletionResponseEvent, HookContext, ModelTurnAction,
+        ObservationAction, RequestPatch,
     };
     use crate::message::{AssistantContent, ToolCall, ToolFunction};
     use crate::test_utils::{MockCompletionModel, MockTurn};
@@ -412,9 +413,9 @@ mod tests {
             &self,
             _ctx: &HookContext,
             _event: crate::agent::ModelTurnFinished<'_>,
-        ) -> ObservationAction {
+        ) -> ModelTurnAction {
             self.model_turns.fetch_add(1, Ordering::SeqCst);
-            ObservationAction::Continue
+            ModelTurnAction::Continue
         }
 
         async fn on_invalid_tool_call(
@@ -509,13 +510,13 @@ mod tests {
             &self,
             _ctx: &HookContext,
             _event: crate::agent::ModelTurnFinished<'_>,
-        ) -> ObservationAction {
+        ) -> ModelTurnAction {
             if matches!(self.phase, StopFirstBilledResponseAt::ModelTurnFinished)
                 && self.calls.fetch_add(1, Ordering::SeqCst) == 0
             {
-                ObservationAction::stop("stop first billed model turn")
+                ModelTurnAction::stop("stop first billed model turn")
             } else {
-                ObservationAction::continue_run()
+                ModelTurnAction::continue_run()
             }
         }
     }

--- a/crates/rig-core/src/test_utils/model_conformance.rs
+++ b/crates/rig-core/src/test_utils/model_conformance.rs
@@ -1828,6 +1828,7 @@ where
                 final_response = Some(response);
             }
             MultiTurnStreamItem::StreamAssistantItem(_)
+            | MultiTurnStreamItem::ModelTurnRetried { .. }
             | MultiTurnStreamItem::ToolExecutionCommitted { .. } => {}
         }
     }

--- a/tests/providers/gemini/cassette/hook_stress.rs
+++ b/tests/providers/gemini/cassette/hook_stress.rs
@@ -25,8 +25,8 @@ use std::sync::Mutex;
 use futures::StreamExt;
 use rig::agent::{
     AgentHook, CompletionCallAction, CompletionCallEvent, CompletionResponseEvent, HookContext,
-    ModelTurnFinished, MultiTurnStreamItem, ObservationAction, RequestPatch, StreamingError,
-    ToolCall as ToolCallEvent, ToolCallAction, ToolResultAction, ToolResultEvent,
+    ModelTurnAction, ModelTurnFinished, MultiTurnStreamItem, ObservationAction, RequestPatch,
+    StreamingError, ToolCall as ToolCallEvent, ToolCallAction, ToolResultAction, ToolResultEvent,
 };
 use rig::client::CompletionClient;
 use rig::completion::{Document, Prompt};
@@ -133,9 +133,9 @@ impl AgentHook for LifecycleRecorder {
         &self,
         ctx: &HookContext,
         _event: ModelTurnFinished<'_>,
-    ) -> ObservationAction {
+    ) -> ModelTurnAction {
         self.record(ctx, "ModelTurnFinished");
-        ObservationAction::continue_run()
+        ModelTurnAction::continue_run()
     }
     async fn on_tool_call(&self, ctx: &HookContext, _event: ToolCallEvent<'_>) -> ToolCallAction {
         self.record(ctx, "ToolCall");
@@ -173,14 +173,14 @@ impl AgentHook for ScratchpadReader {
         &self,
         ctx: &HookContext,
         _event: ModelTurnFinished<'_>,
-    ) -> ObservationAction {
+    ) -> ModelTurnAction {
         let tally = ctx
             .scratchpad()
             .get::<ToolCallTally>()
             .map(|t| t.0)
             .unwrap_or(0);
         self.tallies.lock().expect("tallies").push(tally);
-        ObservationAction::continue_run()
+        ModelTurnAction::continue_run()
     }
 }
 

--- a/tests/providers/gemini/hook_stress_support.rs
+++ b/tests/providers/gemini/hook_stress_support.rs
@@ -14,7 +14,7 @@ use std::sync::{Arc, Mutex};
 
 use rig::agent::{
     AgentHook, CompletionCallAction, CompletionCallEvent, CompletionResponseEvent, HookContext,
-    InvalidToolCallAction, ModelTurnFinished, ObservationAction, RequestPatch,
+    InvalidToolCallAction, ModelTurnAction, ModelTurnFinished, ObservationAction, RequestPatch,
     StreamResponseFinish, TextDelta, ToolCall as ToolCallEvent, ToolCallAction, ToolCallDelta,
     ToolResultAction, ToolResultEvent,
 };
@@ -211,9 +211,9 @@ impl AgentHook for EventTap {
         &self,
         ctx: &HookContext,
         _event: ModelTurnFinished<'_>,
-    ) -> ObservationAction {
+    ) -> ModelTurnAction {
         self.record(ctx, "ModelTurnFinished");
-        ObservationAction::continue_run()
+        ModelTurnAction::continue_run()
     }
     async fn on_invalid_tool_call(
         &self,
@@ -286,14 +286,14 @@ impl AgentHook for ScratchpadReader {
         &self,
         ctx: &HookContext,
         _event: ModelTurnFinished<'_>,
-    ) -> ObservationAction {
+    ) -> ModelTurnAction {
         let tally = ctx
             .scratchpad()
             .get::<ToolCallTally>()
             .map(|t| t.0)
             .unwrap_or(0);
         self.tallies.lock().expect("tallies").push(tally);
-        ObservationAction::continue_run()
+        ModelTurnAction::continue_run()
     }
 }
 


### PR DESCRIPTION
## Summary

- Add event-specific `ModelTurnAction` and `RetryRequest` hook controls for accepting, retrying, or stopping completed model turns.
- Add a stateless `AgentRun::retry_model_turn` transition with repeat and feedback retries governed by the existing `max_turns` budget.
- Keep blocking and streaming behavior aligned, including `ModelTurnRetried` events and fail-closed handling for tool-bearing rejected turns.
- Add regression coverage for retry composition, lifecycle ordering, telemetry, streaming final suppression, turn budgets, and tool safety.

## Motivation

Agent hooks could observe or stop a completed model turn, but could not reject a response and request another model call. Validators and policy hooks therefore had no transport-independent way to ask the model to repeat the turn or retry with corrective feedback.

## Behavior

- `RetryRequest::Repeat` retries the same turn without adding feedback.
- `RetryRequest::Feedback(String)` appends corrective context for the next model call.
- Retry decisions do not add persistent builder state; bounded policies can use the run-scoped `Scratchpad`.
- Tool-bearing turns are rejected fail-closed: tools from a rejected turn are never executed.
- Rejected provider finals are not exposed as accepted stream or run finals, while completion records and usage accounting remain available.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo test`
- `cargo test -p rig-core --all-features` — 1,448 passed, 8 ignored; doctests 107 passed, 18 ignored
- `cargo test -p rig-core --all-features retry -- --nocapture` — 27 passed
- `cargo check -p rig-core --target wasm32-unknown-unknown --features wasm`
- `cargo doc --workspace --no-deps` — passed with two pre-existing rustdoc warnings

An independent full-diff review found one telemetry-ordering issue and one streaming coverage gap. Both were fixed, affected checks were rerun, and the final review found no remaining actionable issues.