### PR TITLE
feat: add the experimental native ECS runtime (rig-ecs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - *(aws)* Stop enabling the AWS SDK's legacy Rustls connector in the Bedrock and S3 Vectors integrations, removing vulnerable `rustls-webpki` 0.101 from their active dependency graphs while retaining the modern default HTTPS client.
 
+### Added
+
+- *(ecs)* Experimental, native-only ECS-based agent runtime in the new
+  `rig-ecs` crate, built on the third-party `bevy_ecs` engine. Opt in with the
+  `ecs` feature and use it through `rig::ecs` (and `rig::ecs::prelude`); the
+  classic runtime remains the default. The ECS world is authoritative for agent
+  topology and run progression, with provider/tool/memory work modeled as owned
+  effects re-entering through validated ingress. Construction uses
+  `EcsClientExt::ecs_agent`, distinct from the classic
+  `CompletionClient::agent`, so both runtimes can be imported together without
+  method collisions.
+
 ### Changed
 
 - *(core, agent)* [**breaking**] Split the monolithic core into a portable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,6 +745,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_type_match"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f548ad2c4031f2902e3edc1f29c29e835829437de49562d8eb5dc5584d3a1043"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "astral-tokio-tar"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,6 +851,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -882,6 +902,9 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "autocfg"
@@ -1470,6 +1493,152 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_ecs"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9cf7a3ee41342dd7b5a5d82e200d0e8efb933169247fce853b4ad633d51e87d"
+dependencies = [
+ "arrayvec",
+ "bevy_ecs_macros",
+ "bevy_platform",
+ "bevy_ptr",
+ "bevy_reflect",
+ "bevy_tasks",
+ "bevy_utils",
+ "bitflags 2.11.1",
+ "bumpalo",
+ "concurrent-queue",
+ "derive_more",
+ "fixedbitset",
+ "indexmap 2.14.0",
+ "log",
+ "nonmax",
+ "serde",
+ "slotmap",
+ "smallvec",
+ "thiserror 2.0.18",
+ "variadics_please",
+]
+
+[[package]]
+name = "bevy_ecs_macros"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "908baf585e2ea16bd53ef0da57b69580478af0059d2dbdb4369991ac9794b618"
+dependencies = [
+ "bevy_macro_utils",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "bevy_macro_utils"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b147843b81a7ec548876ff97fa7bfdc646ef2567cb465566259237b39664438"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "toml_edit 0.23.10+spec-1.0.0",
+]
+
+[[package]]
+name = "bevy_platform"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec6b36504169b644acd26a5469fd8d371aa6f1d73ee5c01b1b1181ae1cefbf9b"
+dependencies = [
+ "critical-section",
+ "foldhash 0.2.0",
+ "futures-channel",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+ "spin 0.10.1",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "bevy_ptr"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7a9329e8dc4e01ced480eeec4902e6d7cb56e56ec37f6fbc4323e5c937290a7"
+
+[[package]]
+name = "bevy_reflect"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1dfeb67a9fe4f59003a84f5f99ba6302141c70e926601cbc6abfd4a1eea9ca9"
+dependencies = [
+ "assert_type_match",
+ "bevy_platform",
+ "bevy_ptr",
+ "bevy_reflect_derive",
+ "bevy_utils",
+ "derive_more",
+ "disqualified",
+ "downcast-rs",
+ "erased-serde",
+ "foldhash 0.2.0",
+ "glam",
+ "indexmap 2.14.0",
+ "serde",
+ "smallvec",
+ "smol_str",
+ "thiserror 2.0.18",
+ "uuid",
+ "variadics_please",
+ "wgpu-types",
+]
+
+[[package]]
+name = "bevy_reflect_derive"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "475f68c93e9cd5f17e9167635c8533a4f388f12d38245a202359e4c2721d87ba"
+dependencies = [
+ "bevy_macro_utils",
+ "indexmap 2.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "uuid",
+]
+
+[[package]]
+name = "bevy_tasks"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384eb04d80aa38664d69988fd30cbbe03e937ecb65c66aa6abe60ce0bca826aa"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "atomic-waker",
+ "bevy_platform",
+ "crossbeam-queue",
+ "derive_more",
+ "futures-lite",
+ "heapless 0.9.3",
+ "pin-project",
+]
+
+[[package]]
+name = "bevy_utils"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2111910cd7a4b1e6ce07eaaeb6f68a2c0ea0ca609ed0d0d506e3eb161101435b"
+dependencies = [
+ "bevy_platform",
+ "disqualified",
+ "thread_local",
+]
+
+[[package]]
 name = "bigdecimal"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1707,6 +1876,12 @@ dependencies = [
  "serde_repr",
  "time",
 ]
+
+[[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "borsh"
@@ -2279,6 +2454,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+ "portable-atomic",
 ]
 
 [[package]]
@@ -3592,6 +3768,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "disqualified"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9c272297e804878a2a4b707cfcfc6d2328b5bb936944613b4fdf2b9269afdfd"
+
+[[package]]
 name = "dmp"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3617,6 +3799,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "downcast-rs"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 
 [[package]]
 name = "dtoa"
@@ -3695,6 +3883,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecs_agent"
+version = "0.40.0"
+dependencies = [
+ "anyhow",
+ "rig",
+ "tokio",
+]
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3746,6 +3943,15 @@ dependencies = [
  "sec1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3837,6 +4043,17 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -4131,6 +4348,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "flume"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4138,7 +4366,7 @@ checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -4193,6 +4421,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -4294,6 +4532,16 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -4703,6 +4951,15 @@ checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
 dependencies = [
  "color_quant",
  "weezl",
+]
+
+[[package]]
+name = "glam"
+version = "0.30.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -5155,7 +5412,7 @@ dependencies = [
  "atomic-polyfill",
  "hash32 0.2.1",
  "rustc_version",
- "spin",
+ "spin 0.9.8",
  "stable_deref_trait",
 ]
 
@@ -5166,6 +5423,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
  "hash32 0.3.1",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
+dependencies = [
+ "hash32 0.3.1",
+ "portable-atomic",
  "stable_deref_trait",
 ]
 
@@ -6130,6 +6398,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.46.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a699d3e77675e6aa4bfffe3b907c8b5f7ed3241f9965bffb25475ad4b08d05"
+dependencies = [
+ "ahash 0.8.12",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex 0.18.0",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "jsonschema-regex",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema-regex"
+version = "0.46.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbd1086b01b9349fd4ef9a07433965af64c8ce8159abe633a189e4ff817bd13"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6738,7 +7042,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -7238,6 +7542,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7659,6 +7969,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonmax"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+
+[[package]]
 name = "noop_proc_macro"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7721,6 +8037,12 @@ dependencies = [
  "smallvec",
  "zeroize",
 ]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
 
 [[package]]
 name = "num-complex"
@@ -8676,7 +8998,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -9498,6 +9820,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.46.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fbf332a2f81899f6836f22c03da73dae8a664c32e3016b84692c23cddadc95d"
+dependencies = [
+ "ahash 0.8.12",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9808,6 +10147,7 @@ dependencies = [
  "rig-candle",
  "rig-core",
  "rig-derive",
+ "rig-ecs",
  "rig-fastembed",
  "rig-gemini-grpc",
  "rig-helixdb",
@@ -9984,6 +10324,27 @@ dependencies = [
  "tokio",
  "tracing-subscriber",
  "trybuild",
+]
+
+[[package]]
+name = "rig-ecs"
+version = "0.40.0"
+dependencies = [
+ "anyhow",
+ "bevy_ecs",
+ "futures",
+ "http 1.4.2",
+ "jsonschema",
+ "rig-core",
+ "rig-runtime-conformance",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -11445,6 +11806,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11458,6 +11828,15 @@ name = "smawk"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
+name = "smol_str"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "snafu"
@@ -11557,6 +11936,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spin"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -12776,10 +13164,19 @@ dependencies = [
  "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.2",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -12793,14 +13190,26 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.23.10+spec-1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap 2.14.0",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -12809,7 +13218,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -13245,6 +13654,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typemap_rev"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13313,6 +13728,12 @@ name = "unicode-blocks"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b12e05d9e06373163a9bb6bb8c263c261b396643a99445fe6b9811fd376581b"
+
+[[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
 
 [[package]]
 name = "unicode-ident"
@@ -13501,6 +13922,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "uwl"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13522,6 +13953,17 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "variadics_please"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b6d82be61465f97d42bd1d15bf20f3b0a3a0905018f38f9d6f6962055b0b5c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "vart"
@@ -13820,6 +14262,21 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "wgpu-types"
+version = "27.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afdcf84c395990db737f2dd91628706cb31e86d72e53482320d368e52b5da5eb"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytemuck",
+ "js-sys",
+ "log",
+ "serde",
+ "thiserror 2.0.18",
+ "web-sys",
+]
 
 [[package]]
 name = "whoami"
@@ -14174,6 +14631,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ edition = "2024"
 # `rig.workspace = true` (add per-example features at the use site).
 rig = { path = ".", version = "0.40.0" }
 rig-agent = { path = "crates/rig-agent", version = "0.40.0" }
+rig-ecs = { path = "crates/rig-ecs", version = "0.40.0" }
 rig-core = { path = "crates/rig-core", version = "0.40.0" }
 anyhow = "1.0.102"
 arrow-array = "58"
@@ -69,6 +70,7 @@ aws-smithy-runtime-api = "1.11.3"
 aws-smithy-types = "1.3.2"
 base64 = "0.22.1"
 bytes = "1.10.1"
+bevy_ecs = { version = "0.18.1", default-features = false }
 candle-core = "0.11.0"
 candle-nn = "0.11.0"
 candle-transformers = "0.11.0"
@@ -122,6 +124,7 @@ url = "2.5"
 rusqlite = "0.32"
 scylla = "1.2.0"
 schemars = "1.0.4"
+jsonschema = { version = "0.46.5", default-features = false }
 serde = "1.0.219"
 serde_yaml = "0.9.34"
 serde_json = "1.0.150"
@@ -168,6 +171,7 @@ workspace = true
 [dependencies]
 rig-core = { path = "crates/rig-core", version = "0.40.0", default-features = false }
 rig-agent = { path = "crates/rig-agent", version = "0.40.0", optional = true, default-features = false }
+rig-ecs = { path = "crates/rig-ecs", version = "0.40.0", optional = true, default-features = false }
 rig-bedrock = { path = "crates/rig-bedrock", version = "0.40.0", optional = true, default-features = false }
 rig-candle = { path = "crates/rig-candle", version = "0.40.0", optional = true, default-features = false }
 rig-fastembed = { path = "crates/rig-fastembed", version = "0.40.0", optional = true, default-features = false }
@@ -262,6 +266,7 @@ url = { workspace = true }
 [features]
 default = ["rig-core/default", "agent", "derive", "rustls"]
 agent = ["dep:rig-agent"]
+ecs = ["dep:rig-ecs"]
 test-utils = ["rig-core/test-utils", "rig-agent?/test-utils"]
 # Internal: opt in to the slow nested-`cargo check` facade build tests
 # (`tests/tool_facade_features.rs`). Not in `default`; `--all-features` (CI's

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -12,6 +12,9 @@ facade:
 - **`rig`** — the facade you depend on. It re-exports both at their familiar
   `rig::…` paths.
 
+A new experimental **`rig-ecs`** runtime is also available (opt-in via the `ecs`
+feature); it does not affect existing code.
+
 ## If you depend on the `rig` facade (most users)
 
 **Almost nothing changes.** These all keep working:

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ More information about this crate can be found in the [official](https://rig.rs/
 
 ## Features
 - Agentic workflows that can handle multi-turn streaming and prompting
-- A classic agent runtime enabled by default
+- A classic runtime enabled by default and an experimental, opt-in native ECS runtime
 - Full [GenAI Semantic Convention](https://opentelemetry.io/docs/specs/semconv/gen-ai/) compatibility
 - 20+ model providers, all under one singular unified interface
 - 10+ vector store integrations, all under one singular unified interface
@@ -81,9 +81,18 @@ Rig separates portable provider/backend contracts from agent orchestration:
 - `rig-agent` contains the classic builder, prompt/streaming traits, typed hooks,
   contextual tools, extraction, and the serializable `AgentRun` state machine. It
   remains enabled by default.
+- `rig-ecs` contains the experimental native-only ECS runtime. Enable the root
+  `ecs` feature and use `rig::ecs`; it is intentionally absent from the default
+  prelude.
 
-The root `rig` facade re-exports both at their familiar paths, so most code
-depends only on `rig`.
+```toml
+[dependencies]
+rig = { version = "0.40", features = ["ecs"] }
+```
+
+Classic construction uses `CompletionClient::agent`; ECS construction uses the
+distinct `EcsClientExt::ecs_agent`, so importing both runtime extensions is
+unambiguous. See the [`ecs_agent` example](examples/ecs_agent/src/main.rs).
 
 ## Who is using Rig?
 Below is a non-exhaustive list of companies and people who are using Rig:

--- a/crates/rig-agent/README.md
+++ b/crates/rig-agent/README.md
@@ -6,7 +6,7 @@ tools, extraction, and runtime integrations.
 
 Most applications should use the root `rig` facade, where this runtime remains
 enabled by default. Low-level provider and backend contracts live in
-`rig-core`.
+`rig-core`; the experimental ECS-native sibling runtime lives in `rig-ecs`.
 
 Direct users import construction and prompting explicitly:
 

--- a/crates/rig-ecs/Cargo.toml
+++ b/crates/rig-ecs/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "rig-ecs"
+version.workspace = true
+edition.workspace = true
+# Pinned above the rest of the workspace: the `bevy_ecs` engine requires a newer
+# MSRV than the portable crates. This crate is experimental and opt-in.
+rust-version = "1.89"
+license = "MIT"
+readme = "README.md"
+description = "Experimental native Bevy ECS runtime for Rig"
+repository = "https://github.com/0xPlaygrounds/rig"
+
+[lints]
+workspace = true
+
+[dependencies]
+bevy_ecs = { workspace = true, default-features = false, features = ["std"] }
+futures = { workspace = true }
+http = { workspace = true }
+jsonschema = { workspace = true }
+rig-core = { path = "../rig-core", version = "0.40.0", default-features = false }
+schemars = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
+tracing = { workspace = true }
+uuid = { workspace = true, features = ["serde", "v4"] }
+
+[dev-dependencies]
+anyhow = { workspace = true }
+rig-core = { path = "../rig-core", version = "0.40.0", default-features = false, features = ["test-utils"] }
+rig-runtime-conformance = { path = "../rig-runtime-conformance" }

--- a/crates/rig-ecs/README.md
+++ b/crates/rig-ecs/README.md
@@ -1,0 +1,59 @@
+# rig-ecs
+
+`rig-ecs` is Rig's experimental, native-only Bevy ECS agent runtime. It uses
+the portable model, message, memory, and tool contracts from `rig-core`, while
+keeping topology, policy, progression, effects, cancellation, and persistence
+inside an authoritative ECS world.
+
+The classic `rig-agent` runtime remains Rig's default. Select this crate
+directly or enable the root `rig` crate's `ecs` feature and import
+`rig::ecs::prelude::*`.
+
+This runtime does not wrap `rig-agent`, `AgentRun`, or hooks. Async providers,
+tools, vector-store retrieval adapters, and memories receive owned requests and
+return through bounded, correlated ingress. `install_vector_store` records a
+distinct store capability while executing the portable vector-index tool
+contract through the same immutable grant and effect path. Snapshots contain
+stable domain records only and require tenant-owned bindings with explicit,
+caller-defined implementation/configuration identities before resumable state
+can be persisted or rebound.
+
+Conversation memories must return canonical histories from `load`: every
+assistant tool call paired with its results in the next message (which may
+also carry ordinary user content), no consecutive assistant messages, and no
+orphaned tool results. Truncating or summarizing memories must therefore cut
+on turn boundaries. A non-canonical loaded history fails the run immediately
+(code `memory_history`) before any model call.
+
+Run lifecycles, model/tool/memory effects, canonical tool commits, and rejected
+ingress emit content-redacted `tracing` spans and events. Model effects use the
+core-owned completion-parent marker so provider GenAI metadata enriches one
+span instead of creating a duplicate model span.
+
+WebAssembly is intentionally unsupported by this experimental crate. That
+native target policy does not change `rig-core` or `rig-agent` WASM support.
+
+```rust,ignore
+use rig_ecs::{EcsClientExt, LocalRuntime};
+use rig_core::{client::ProviderClient, providers::openai};
+
+let client = openai::Client::from_env()?;
+let definition = client
+    .ecs_agent(openai::GPT_5_2)
+    .preamble("Answer concisely.")
+    .build();
+let mut runtime = LocalRuntime::new()?;
+let agent = runtime.spawn_agent(definition)?;
+let result = runtime.run(agent, "Why use an ECS runtime?").await?;
+```
+
+`LocalRuntime` exposes concrete provider finals through typed local blocking
+and live streaming APIs when the provider supplies one; `start_streaming`
+yields provisional events before that optional typed final and reports subscriber
+lag or a concrete-type mismatch explicitly.
+`HostedRuntime` deliberately exposes only a redacted, non-persisted diagnostic
+envelope. Protected snapshots require a caller-supplied authenticated
+`SnapshotProtector`. The default snapshot policy is metadata-only; canonical
+run content requires explicit `SnapshotContentPolicy::CanonicalRunState`
+selection. Restore rejects duplicate, missing, identity-mismatched, or
+cross-tenant topology before reconstructing ECS entities.

--- a/crates/rig-ecs/src/components.rs
+++ b/crates/rig-ecs/src/components.rs
@@ -1,0 +1,686 @@
+//! Authoritative ECS topology and run-state components.
+
+use std::{
+    collections::{BTreeMap, BTreeSet, VecDeque},
+    fmt,
+    sync::Arc,
+};
+
+use bevy_ecs::prelude::{Component, Entity, Resource};
+use rig_core::{
+    completion::{AssistantContent, Message, ToolDefinition, Usage},
+    message::ToolCall,
+    tool::ToolOutput,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::effects::EffectIntent;
+use crate::{
+    AgentId, AgentSpec, CapabilityId, EffectHeader, EffectRejection, Generation, GrantId, MemoryId,
+    ModelId, OperationId, RunId, RuntimeId, StreamingMode, TenantId,
+};
+
+/// Agent specification entity stored in the authoritative world.
+#[derive(Clone, Component, Debug)]
+pub struct AgentNode {
+    /// Stable agent identity.
+    pub id: AgentId,
+    /// Immutable construction policy.
+    pub spec: AgentSpec,
+    /// Provider capability fact used by `OutputMode::Auto` policy.
+    pub composes_native_output_with_tools: bool,
+}
+
+/// Executable capability category.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum CapabilityKind {
+    /// Context-free portable tool.
+    Tool,
+    /// Portable store or vector retrieval adapter.
+    Store,
+}
+
+/// Versioned executable capability entity.
+#[derive(Clone, Component, Deserialize, Serialize)]
+pub struct CapabilityNode {
+    /// Stable version identity.
+    pub id: CapabilityId,
+    /// Owning tenant.
+    pub tenant_id: TenantId,
+    /// Capability category.
+    pub kind: CapabilityKind,
+    /// Provider-facing definition when this is a tool.
+    pub definition: Option<ToolDefinition>,
+    /// Monotonic revision stored in immutable turn snapshots.
+    pub revision: u64,
+    /// Retired versions remain available to already-dispatched snapshots only.
+    pub retired: bool,
+}
+
+impl fmt::Debug for CapabilityNode {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CapabilityNode")
+            .field("id", &self.id)
+            .field("tenant_id", &"<redacted>")
+            .field("kind", &self.kind)
+            .field("definition_configured", &self.definition.is_some())
+            .field("revision", &self.revision)
+            .field("retired", &self.retired)
+            .finish()
+    }
+}
+
+/// Explicit authorization relationship between an agent and a capability version.
+#[derive(Clone, Component, Deserialize, Serialize)]
+pub struct GrantNode {
+    /// Stable grant identity.
+    pub id: GrantId,
+    /// Authorized agent.
+    pub agent_id: AgentId,
+    /// Exact capability version.
+    pub capability_id: CapabilityId,
+    /// Tenant security boundary shared by both endpoints.
+    pub tenant_id: TenantId,
+    /// Revoked grants cannot enter new turn snapshots.
+    pub revoked: bool,
+}
+
+impl fmt::Debug for GrantNode {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("GrantNode")
+            .field("id", &self.id)
+            .field("agent_id", &self.agent_id)
+            .field("capability_id", &self.capability_id)
+            .field("tenant_id", &"<redacted>")
+            .field("revoked", &self.revoked)
+            .finish()
+    }
+}
+
+/// Current lifecycle phase for one run.
+#[derive(Clone, Copy, Component, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum RunPhase {
+    /// Waiting to dispatch or receive memory history.
+    LoadingMemory,
+    /// Ready to construct an owned model request.
+    ReadyModel,
+    /// Waiting for a model effect.
+    WaitingModel,
+    /// A model outcome is waiting for policy interpretation.
+    EvaluatingModel,
+    /// Waiting for one deterministic tool batch.
+    WaitingTools,
+    /// Waiting to append newly committed messages to memory.
+    AppendingMemory,
+    /// Terminal and observable until explicit retention cleanup.
+    Terminal,
+}
+
+/// Stable run topology and progression component.
+#[derive(Clone, Component)]
+pub struct RunNode {
+    /// Stable run identity.
+    pub id: RunId,
+    /// Owning agent.
+    pub agent_id: AgentId,
+    /// Selected model implementation.
+    pub model_id: ModelId,
+    /// Owning tenant.
+    pub tenant_id: TenantId,
+    /// Current generation.
+    pub generation: Generation,
+    /// Current lifecycle phase.
+    pub phase: RunPhase,
+    /// Model execution surface.
+    pub streaming: StreamingMode,
+    /// Runtime tick at creation.
+    pub created_tick: u64,
+}
+
+impl fmt::Debug for RunNode {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RunNode")
+            .field("id", &self.id)
+            .field("agent_id", &self.agent_id)
+            .field("model_id", &self.model_id)
+            .field("tenant_id", &"<redacted>")
+            .field("generation", &self.generation)
+            .field("phase", &self.phase)
+            .field("streaming", &self.streaming)
+            .field("created_tick", &self.created_tick)
+            .finish()
+    }
+}
+
+/// Canonical committed transcript; provisional and rejected content never enters it.
+#[derive(Clone, Component, Default, Deserialize, Serialize)]
+pub struct CanonicalTranscript {
+    /// Ordered canonical messages.
+    pub messages: Vec<Message>,
+    /// First message belonging to this run rather than loaded memory.
+    pub new_messages_start: usize,
+}
+
+impl fmt::Debug for CanonicalTranscript {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CanonicalTranscript")
+            .field("message_count", &self.messages.len())
+            .field("new_messages_start", &self.new_messages_start)
+            .finish()
+    }
+}
+
+/// One billed completed model operation.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ModelCallRecord {
+    /// Stable operation identity.
+    pub operation_id: OperationId,
+    /// Usage reported for this operation.
+    pub usage: Usage,
+    /// Whether policy accepted the response into canonical state.
+    pub accepted: bool,
+}
+
+/// Run-level usage and model-operation accounting.
+#[derive(Clone, Component, Debug, Default, Deserialize, Serialize)]
+pub struct RunAccounting {
+    /// Number of model operations dispatched, including retries and continuations.
+    pub model_calls_dispatched: usize,
+    /// Aggregated usage for completed billed operations.
+    pub usage: Usage,
+    /// Exactly one record per accepted completion ingress.
+    pub model_calls: Vec<ModelCallRecord>,
+    /// Number of invalid effect messages rejected without mutation.
+    pub rejected_effects: usize,
+}
+
+/// Stable terminal outcome category.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
+pub enum TerminalReason {
+    /// Canonical assistant response completed successfully.
+    Completed,
+    /// Explicit cancellation won terminal arbitration.
+    Cancelled,
+    /// ECS policy stopped the run.
+    Stopped,
+    /// Total model-call budget was exhausted.
+    ModelCallBudgetExhausted,
+    /// Provider, tool, memory, validation, or schedule failure.
+    Failed {
+        /// Stable failure category safe for snapshots and redacted diagnostics.
+        code: String,
+    },
+}
+
+/// Terminal state remains separate from observation and cleanup.
+#[derive(Clone, Component, Debug, Deserialize, Serialize)]
+pub struct TerminalState {
+    /// Terminal outcome.
+    pub reason: TerminalReason,
+    /// Tick at which terminal arbitration completed.
+    pub terminal_tick: u64,
+}
+
+/// Non-persisted operator diagnostic for a failed terminal run.
+#[derive(Component, Debug)]
+pub(crate) struct TerminalDiagnostic {
+    pub(crate) message: String,
+}
+
+/// Non-persisted typed cause retained for local error inspection.
+#[derive(Clone, Component)]
+pub(crate) enum TerminalCause {
+    Model(Arc<crate::ModelEffectError>),
+    Memory(Arc<crate::MemoryEffectError>),
+}
+
+/// Observation marker required before retention cleanup may remove a run.
+#[derive(Clone, Component, Debug, Deserialize, Serialize)]
+pub struct TerminalObservation {
+    /// Tick at which a handle observed the terminal result.
+    pub observed_tick: u64,
+}
+
+/// Explicit cancellation request processed before ingress and dispatch.
+#[derive(Clone, Copy, Component, Debug)]
+pub(crate) struct CancellationRequest;
+
+/// Exact capability authorization advertised to one model turn.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct AdvertisedCapability {
+    /// Exact capability version.
+    pub capability_id: CapabilityId,
+    /// Exact active grant.
+    pub grant_id: GrantId,
+    /// Capability revision.
+    pub revision: u64,
+    /// Provider-facing tool definition.
+    pub definition: ToolDefinition,
+}
+
+/// Immutable tool and grant snapshot for the currently active model turn.
+#[derive(Clone, Component, Debug, Default, Deserialize, Serialize)]
+pub(crate) struct TurnCapabilitySnapshot {
+    pub(crate) entries: Vec<AdvertisedCapability>,
+    pub(crate) output_tool_name: Option<String>,
+}
+
+/// Active operation validation state.
+#[derive(Clone, Debug)]
+pub(crate) struct ActiveOperation {
+    pub(crate) header: EffectHeader,
+    pub(crate) kind: ActiveOperationKind,
+    pub(crate) expected_tool_call_id: Option<String>,
+    pub(crate) expected_tool_order: Option<usize>,
+    pub(crate) completed: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ActiveOperationKind {
+    Model,
+    Tool,
+    MemoryLoad,
+    MemoryAppend,
+}
+
+/// All operations that may still produce ingress for a run.
+#[derive(Component, Debug, Default)]
+pub(crate) struct ActiveOperations(pub(crate) BTreeMap<OperationId, ActiveOperation>);
+
+/// Next provisional stream sequence expected for each active model operation.
+#[derive(Component, Debug, Default)]
+pub(crate) struct AcceptedDeltas(pub(crate) BTreeMap<OperationId, u64>);
+
+/// One accepted model effect awaiting policy interpretation.
+#[derive(Component)]
+pub(crate) struct PendingModelOutcome {
+    pub(crate) operation_id: OperationId,
+    pub(crate) choice: Vec<AssistantContent>,
+    pub(crate) message_id: Option<String>,
+}
+
+impl fmt::Debug for PendingModelOutcome {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PendingModelOutcome")
+            .field("operation_id", &self.operation_id)
+            .field("choice_count", &self.choice.len())
+            .field("message_id_configured", &self.message_id.is_some())
+            .finish()
+    }
+}
+
+/// One tool invocation in a deterministic batch.
+pub(crate) struct PlannedToolCall {
+    pub(crate) call: ToolCall,
+    pub(crate) capability_id: CapabilityId,
+    pub(crate) grant_id: GrantId,
+    pub(crate) revision: u64,
+    pub(crate) order: usize,
+    pub(crate) operation_id: Option<OperationId>,
+    pub(crate) result: Option<ToolOutput>,
+    pub(crate) suppressed: bool,
+}
+
+impl fmt::Debug for PlannedToolCall {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PlannedToolCall")
+            .field("tool_name", &self.call.function.name)
+            .field("capability_id", &self.capability_id)
+            .field("grant_id", &self.grant_id)
+            .field("revision", &self.revision)
+            .field("order", &self.order)
+            .field("operation_id", &self.operation_id)
+            .field("result_configured", &self.result.is_some())
+            .field("suppressed", &self.suppressed)
+            .field("arguments", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Tool batch committed only after every non-suppressed sibling completes.
+#[derive(Component)]
+pub(crate) struct PendingToolBatch {
+    pub(crate) assistant_content: Vec<AssistantContent>,
+    pub(crate) message_id: Option<String>,
+    pub(crate) calls: Vec<PlannedToolCall>,
+}
+
+impl fmt::Debug for PendingToolBatch {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PendingToolBatch")
+            .field("assistant_content_count", &self.assistant_content.len())
+            .field("message_id_configured", &self.message_id.is_some())
+            .field("call_count", &self.calls.len())
+            .finish()
+    }
+}
+
+/// Non-persisted local provider final for the latest accepted model operation.
+#[derive(Component, Debug)]
+pub(crate) struct RawFinalRecord {
+    pub(crate) operation_id: OperationId,
+    pub(crate) raw: crate::effects::ErasedRawFinal,
+}
+
+/// Memory lifecycle and committed-only append bookkeeping.
+#[derive(Component)]
+pub(crate) struct MemoryProgress {
+    pub(crate) memory_id: MemoryId,
+    pub(crate) conversation_id: String,
+    pub(crate) loaded: bool,
+    pub(crate) appended: bool,
+}
+
+impl fmt::Debug for MemoryProgress {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("MemoryProgress")
+            .field("memory_id", &self.memory_id)
+            .field("conversation_id", &"<redacted>")
+            .field("loaded", &self.loaded)
+            .field("appended", &self.appended)
+            .finish()
+    }
+}
+
+/// Structured output recovery state held as ECS data.
+#[derive(Component)]
+pub(crate) struct StructuredOutputState {
+    pub(crate) schema: schemars::Schema,
+    pub(crate) policy: crate::StructuredOutputPolicy,
+    pub(crate) resolved_mode: crate::OutputMode,
+    pub(crate) output_tool_name: Option<String>,
+    pub(crate) retries: usize,
+    pub(crate) value: Option<serde_json::Value>,
+}
+
+impl fmt::Debug for StructuredOutputState {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StructuredOutputState")
+            .field("policy", &self.policy)
+            .field("resolved_mode", &self.resolved_mode)
+            .field("output_tool_configured", &self.output_tool_name.is_some())
+            .field("retries", &self.retries)
+            .field("value_configured", &self.value.is_some())
+            .field("schema", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Per-run request-only corrective feedback excluded from committed history.
+#[derive(Component, Default)]
+pub(crate) struct RecoveryFeedback(pub(crate) Vec<String>);
+
+impl fmt::Debug for RecoveryFeedback {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RecoveryFeedback")
+            .field("message_count", &self.0.len())
+            .finish()
+    }
+}
+
+/// Number of response retry decisions already taken.
+#[derive(Component, Debug, Default)]
+pub(crate) struct ResponseRetryState(pub(crate) usize);
+
+/// Number of invalid-call retry decisions already taken.
+#[derive(Component, Debug, Default)]
+pub(crate) struct InvalidToolRetryState(pub(crate) usize);
+
+/// Public lifecycle events emitted from authoritative ECS transitions.
+#[derive(Clone, PartialEq)]
+#[non_exhaustive]
+pub enum RunEvent {
+    /// An owned model operation was dispatched.
+    ModelDispatched(OperationId),
+    /// Provider streaming content is provisional and not canonical history.
+    Provisional {
+        /// Model operation that emitted the delta.
+        operation_id: OperationId,
+        /// Provider-normalized delta.
+        delta: Box<crate::ProvisionalDelta>,
+    },
+    /// A complete provider final became available after stream success.
+    ProviderFinal {
+        /// Model operation that produced the final.
+        operation_id: OperationId,
+        /// Concrete local type name without response content.
+        provider_type: &'static str,
+    },
+    /// A portable tool operation was dispatched.
+    ToolDispatched {
+        /// Tool operation identity.
+        operation_id: OperationId,
+        /// Model tool-call identity.
+        tool_call_id: String,
+    },
+    /// A tool result committed in stable model-call order.
+    ToolCommitted {
+        /// Tool operation identity.
+        operation_id: OperationId,
+        /// Model tool-call identity.
+        tool_call_id: String,
+    },
+    /// A response was rejected and rolled back before a fresh model request.
+    ResponseRetried,
+    /// An invalid tool call was suppressed without execution.
+    ToolSuppressed {
+        /// Model tool-call identity.
+        tool_call_id: String,
+    },
+    /// The run reached an externally observable terminal state.
+    Terminal(TerminalReason),
+    /// Invalid ingress was rejected without mutating authoritative state.
+    EffectRejected(crate::EffectRejectionReason),
+}
+
+impl fmt::Debug for RunEvent {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ModelDispatched(operation_id) => formatter
+                .debug_tuple("ModelDispatched")
+                .field(operation_id)
+                .finish(),
+            Self::Provisional {
+                operation_id,
+                delta,
+            } => formatter
+                .debug_struct("Provisional")
+                .field("operation_id", operation_id)
+                .field("delta_kind", &delta.kind())
+                .finish(),
+            Self::ProviderFinal {
+                operation_id,
+                provider_type,
+            } => formatter
+                .debug_struct("ProviderFinal")
+                .field("operation_id", operation_id)
+                .field("provider_type", provider_type)
+                .finish(),
+            Self::ToolDispatched {
+                operation_id,
+                tool_call_id,
+            } => formatter
+                .debug_struct("ToolDispatched")
+                .field("operation_id", operation_id)
+                .field("tool_call_id", tool_call_id)
+                .finish(),
+            Self::ToolCommitted {
+                operation_id,
+                tool_call_id,
+            } => formatter
+                .debug_struct("ToolCommitted")
+                .field("operation_id", operation_id)
+                .field("tool_call_id", tool_call_id)
+                .finish(),
+            Self::ResponseRetried => formatter.write_str("ResponseRetried"),
+            Self::ToolSuppressed { tool_call_id } => formatter
+                .debug_struct("ToolSuppressed")
+                .field("tool_call_id", tool_call_id)
+                .finish(),
+            Self::Terminal(reason) => formatter.debug_tuple("Terminal").field(reason).finish(),
+            Self::EffectRejected(reason) => formatter
+                .debug_tuple("EffectRejected")
+                .field(reason)
+                .finish(),
+        }
+    }
+}
+
+/// Bounded event log and lag-aware broadcast channel for one run.
+#[derive(Component, Debug)]
+pub(crate) struct RunEvents {
+    pub(crate) events: VecDeque<RunEvent>,
+    capacity: usize,
+    sender: tokio::sync::broadcast::Sender<RunEvent>,
+}
+
+impl RunEvents {
+    pub(crate) fn new(capacity: usize) -> Self {
+        let (sender, _) = tokio::sync::broadcast::channel(capacity);
+        Self {
+            events: VecDeque::with_capacity(capacity),
+            capacity,
+            sender,
+        }
+    }
+
+    pub(crate) fn subscribe(&self) -> tokio::sync::broadcast::Receiver<RunEvent> {
+        self.sender.subscribe()
+    }
+
+    pub(crate) fn publish(&mut self, event: RunEvent) {
+        if self.events.len() == self.capacity {
+            self.events.pop_front();
+        }
+        self.events.push_back(event.clone());
+        let _ = self.sender.send(event);
+    }
+}
+
+/// Resource populated by the driver before each schedule pass.
+#[derive(Resource, Default)]
+pub(crate) struct PendingIngress(pub(crate) Vec<crate::EffectIngress>);
+
+/// Owned effects emitted by dispatch systems and drained by the driver.
+#[derive(Resource, Default)]
+pub(crate) struct PendingEffects(pub(crate) Vec<EffectIntent>);
+
+/// Rejected ingress audit records.
+#[derive(Resource, Default)]
+pub(crate) struct RejectionLog(pub(crate) Vec<EffectRejection>);
+
+/// Monotonic schedule tick.
+#[derive(Resource, Default)]
+pub(crate) struct RuntimeTick(pub(crate) u64);
+
+/// Monotonic count bumped by authoritative mutations to one run.
+#[derive(Component, Debug, Default)]
+pub(crate) struct RunProgress(pub(crate) u64);
+
+/// Marker for a dispatchable run waiting for room in the bounded effect queue.
+///
+/// This is authoritative waiting state rather than synthetic progress: drivers
+/// can await global effect-capacity changes without treating another run's load
+/// as quiescence or consuming the livelock-pass budget.
+#[derive(Component, Debug, Default)]
+pub(crate) struct EffectQueueWait;
+
+/// Non-persisted parent span for one runtime-owned run lifecycle.
+#[derive(Component)]
+pub(crate) struct RunTelemetrySpan(pub(crate) tracing::Span);
+
+/// Retired, unreferenced capability implementations ready for registry cleanup.
+#[derive(Resource, Default)]
+pub(crate) struct CapabilitiesToDrop(pub(crate) Vec<CapabilityId>);
+
+/// Runtime identity resource used by ingress validation.
+#[derive(Resource)]
+pub(crate) struct RuntimeIdentity(pub(crate) RuntimeId);
+
+/// Stable lookup from domain IDs to Bevy entities.
+#[derive(Resource, Default)]
+pub(crate) struct TopologyIndex {
+    pub(crate) agents: BTreeMap<AgentId, Entity>,
+    pub(crate) runs: BTreeMap<RunId, Entity>,
+    pub(crate) capabilities: BTreeMap<CapabilityId, Entity>,
+    pub(crate) grants: BTreeMap<GrantId, Entity>,
+}
+
+/// Capability versions referenced by active turn snapshots.
+#[derive(Resource, Default)]
+pub(crate) struct CapabilityReferences(pub(crate) BTreeMap<CapabilityId, BTreeSet<RunId>>);
+
+#[cfg(test)]
+mod debug_tests {
+    use rig_core::message::ToolFunction;
+
+    use super::*;
+
+    #[test]
+    fn private_ecs_state_debug_is_content_redacted() {
+        let secret = "secret-ecs-content-734563";
+        let call = ToolCall::new(
+            "call".to_string(),
+            ToolFunction::new(
+                "safe_tool".to_string(),
+                serde_json::json!({"token": secret}),
+            ),
+        );
+        let pending_model = PendingModelOutcome {
+            operation_id: OperationId::new(),
+            choice: vec![AssistantContent::text(secret)],
+            message_id: Some(secret.to_string()),
+        };
+        let planned = PlannedToolCall {
+            call,
+            capability_id: CapabilityId::new(),
+            grant_id: GrantId::new(),
+            revision: 1,
+            order: 0,
+            operation_id: None,
+            result: Some(ToolOutput::text(secret)),
+            suppressed: false,
+        };
+        let pending_batch = PendingToolBatch {
+            assistant_content: vec![AssistantContent::text(secret)],
+            message_id: Some(secret.to_string()),
+            calls: vec![planned],
+        };
+        let memory = MemoryProgress {
+            memory_id: MemoryId::new(),
+            conversation_id: secret.to_string(),
+            loaded: false,
+            appended: false,
+        };
+        let structured = StructuredOutputState {
+            schema: schemars::schema_for!(String),
+            policy: crate::StructuredOutputPolicy::default(),
+            resolved_mode: crate::OutputMode::Native,
+            output_tool_name: Some(secret.to_string()),
+            retries: 0,
+            value: Some(serde_json::json!({"secret": secret})),
+        };
+        let recovery = RecoveryFeedback(vec![secret.to_string()]);
+
+        for debug in [
+            format!("{pending_model:?}"),
+            format!("{pending_batch:?}"),
+            format!("{memory:?}"),
+            format!("{structured:?}"),
+            format!("{recovery:?}"),
+        ] {
+            assert!(!debug.contains(secret));
+        }
+    }
+}

--- a/crates/rig-ecs/src/config.rs
+++ b/crates/rig-ecs/src/config.rs
@@ -1,0 +1,318 @@
+//! Runtime and agent construction data.
+
+use std::{fmt, time::Duration};
+
+use rig_core::message::ToolChoice;
+use schemars::{JsonSchema, Schema};
+use serde::{Deserialize, Serialize};
+
+use crate::{InvalidToolPolicy, MemoryId, ModelId, StructuredOutputPolicy, TenantId};
+
+/// Whether model effects use blocking or provider-streaming completion.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub enum StreamingMode {
+    /// Use `CompletionModel::completion`.
+    #[default]
+    Blocking,
+    /// Use `CompletionModel::stream` and expose provisional events.
+    Streaming,
+}
+
+/// ECS-native response acceptance and retry policy.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
+pub enum ResponseRetryPolicy {
+    /// Accept every tool-free model response.
+    #[default]
+    Accept,
+    /// Reject an empty tool-free text response and retry with feedback.
+    RejectEmpty {
+        /// Maximum response-retry attempts.
+        max_retries: usize,
+    },
+}
+
+/// Bounded operational configuration for one runtime world.
+#[derive(Clone, Debug)]
+pub struct RuntimeConfig {
+    /// Capacity of the owned effect ingress queue.
+    pub ingress_capacity: usize,
+    /// Maximum owned effects queued before execution permits are available.
+    pub effect_queue_capacity: usize,
+    /// Maximum lifecycle events retained and broadcast per run.
+    pub event_capacity: usize,
+    /// Maximum rejected ingress audit records retained by the runtime.
+    pub rejection_capacity: usize,
+    /// Maximum effects executing at once.
+    pub max_effects: usize,
+    /// Maximum model calls executing at once.
+    pub max_model_calls: usize,
+    /// Maximum tool calls executing at once.
+    pub max_tool_calls: usize,
+    /// Maximum schedule passes without quiescence.
+    pub max_schedule_passes: usize,
+    /// Timeout applied independently to each effect.
+    pub effect_timeout: Duration,
+    /// Number of schedule ticks to retain an observed terminal run.
+    ///
+    /// Ticks advance once per schedule pass, so aging is schedule-load
+    /// relative: a busy runtime burns retention windows faster than an idle
+    /// one. Every `step` that returns `Terminal` to the run's handle counts
+    /// as an observation and renews this lease, so the window ages from the
+    /// last observation; restore renews the lease of unobserved terminal
+    /// runs.
+    pub terminal_retention_ticks: u64,
+    /// Number of schedule ticks to retain a terminal run that was never observed.
+    ///
+    /// This bounds state held for genuinely abandoned handles — runs whose
+    /// terminal state no caller ever saw via `step`, `finish_run`, or a
+    /// driver. The same schedule-load-relative tick caveat applies.
+    pub unobserved_terminal_retention_ticks: u64,
+}
+
+impl Default for RuntimeConfig {
+    fn default() -> Self {
+        Self {
+            ingress_capacity: 256,
+            effect_queue_capacity: 256,
+            event_capacity: 512,
+            rejection_capacity: 512,
+            max_effects: 32,
+            max_model_calls: 8,
+            max_tool_calls: 16,
+            max_schedule_passes: 1_024,
+            effect_timeout: Duration::from_secs(120),
+            terminal_retention_ticks: 16,
+            unobserved_terminal_retention_ticks: 1_024,
+        }
+    }
+}
+
+impl RuntimeConfig {
+    pub(crate) fn validate(&self) -> Result<(), crate::RuntimeError> {
+        let bounds = [
+            ("ingress_capacity", self.ingress_capacity),
+            ("effect_queue_capacity", self.effect_queue_capacity),
+            ("event_capacity", self.event_capacity),
+            ("rejection_capacity", self.rejection_capacity),
+            ("max_effects", self.max_effects),
+            ("max_model_calls", self.max_model_calls),
+            ("max_tool_calls", self.max_tool_calls),
+            ("max_schedule_passes", self.max_schedule_passes),
+        ];
+        if let Some((field, _)) = bounds.into_iter().find(|(_, value)| *value == 0) {
+            return Err(crate::RuntimeError::InvalidConfiguration { field });
+        }
+        if self.unobserved_terminal_retention_ticks == 0 {
+            return Err(crate::RuntimeError::InvalidConfiguration {
+                field: "unobserved_terminal_retention_ticks",
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Immutable agent configuration stored in ECS topology.
+#[derive(Clone, Deserialize, Serialize)]
+pub struct AgentSpec {
+    /// Stable model binding selected for the agent.
+    pub model_id: ModelId,
+    /// Tenant that owns the agent and every run it spawns.
+    pub tenant_id: TenantId,
+    /// Optional observability name, recorded only when telemetry content is explicitly enabled.
+    pub name: Option<String>,
+    /// Optional system preamble.
+    pub preamble: Option<String>,
+    /// Total model-call budget including initial calls, retries, and continuations.
+    pub max_model_calls: usize,
+    /// Invalid-tool policy.
+    pub invalid_tool_policy: InvalidToolPolicy,
+    /// Tool-free response retry policy.
+    pub response_retry_policy: ResponseRetryPolicy,
+    /// Optional structured output schema and recovery policy.
+    pub structured_output: Option<(Schema, StructuredOutputPolicy)>,
+    /// Optional conversation memory binding.
+    pub memory_id: Option<MemoryId>,
+    /// Optional conversation identifier used by memory effects.
+    pub conversation_id: Option<String>,
+    /// Provider tool-choice request policy.
+    pub tool_choice: Option<ToolChoice>,
+    /// Sampling temperature forwarded to every model request.
+    pub temperature: Option<f64>,
+    /// Maximum generated tokens forwarded to every model request.
+    pub max_tokens: Option<u64>,
+    /// Provider-specific request parameters.
+    pub additional_params: Option<serde_json::Value>,
+    /// Whether sensitive provider telemetry content may be recorded.
+    pub record_telemetry_content: bool,
+    /// Default model execution surface for new runs.
+    pub streaming: StreamingMode,
+}
+
+impl fmt::Debug for AgentSpec {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AgentSpec")
+            .field("model_id", &self.model_id)
+            .field("tenant_id", &"<redacted>")
+            .field("name_configured", &self.name.is_some())
+            .field("preamble_configured", &self.preamble.is_some())
+            .field("max_model_calls", &self.max_model_calls)
+            .field("invalid_tool_policy", &self.invalid_tool_policy)
+            .field("response_retry_policy", &self.response_retry_policy)
+            .field(
+                "structured_output_configured",
+                &self.structured_output.is_some(),
+            )
+            .field("memory_id", &self.memory_id)
+            .field(
+                "conversation_id_configured",
+                &self.conversation_id.is_some(),
+            )
+            .field("tool_choice", &self.tool_choice)
+            .field("temperature_configured", &self.temperature.is_some())
+            .field("max_tokens_configured", &self.max_tokens.is_some())
+            .field(
+                "additional_params_configured",
+                &self.additional_params.is_some(),
+            )
+            .field("record_telemetry_content", &self.record_telemetry_content)
+            .field("streaming", &self.streaming)
+            .finish()
+    }
+}
+
+impl AgentSpec {
+    /// Construct an agent specification for one rebound model and tenant.
+    #[must_use]
+    pub fn new(model_id: ModelId, tenant_id: TenantId) -> Self {
+        Self {
+            model_id,
+            tenant_id,
+            name: None,
+            preamble: None,
+            max_model_calls: 8,
+            invalid_tool_policy: InvalidToolPolicy::Fail,
+            response_retry_policy: ResponseRetryPolicy::Accept,
+            structured_output: None,
+            memory_id: None,
+            conversation_id: None,
+            tool_choice: None,
+            temperature: None,
+            max_tokens: None,
+            additional_params: None,
+            record_telemetry_content: false,
+            streaming: StreamingMode::Blocking,
+        }
+    }
+
+    /// Set an optional diagnostic name.
+    #[must_use]
+    pub fn name(mut self, value: impl Into<String>) -> Self {
+        self.name = Some(value.into());
+        self
+    }
+
+    /// Set the system preamble.
+    #[must_use]
+    pub fn preamble(mut self, value: impl Into<String>) -> Self {
+        self.preamble = Some(value.into());
+        self
+    }
+
+    /// Set the total model-call budget. Zero prevents the initial call.
+    #[must_use]
+    pub fn max_model_calls(mut self, value: usize) -> Self {
+        self.max_model_calls = value;
+        self
+    }
+
+    /// Select the invalid-tool policy.
+    #[must_use]
+    pub fn invalid_tool_policy(mut self, value: InvalidToolPolicy) -> Self {
+        self.invalid_tool_policy = value;
+        self
+    }
+
+    /// Select the response retry policy.
+    #[must_use]
+    pub fn response_retry_policy(mut self, value: ResponseRetryPolicy) -> Self {
+        self.response_retry_policy = value;
+        self
+    }
+
+    /// Configure typed structured output.
+    #[must_use]
+    pub fn structured_output<T>(mut self, policy: StructuredOutputPolicy) -> Self
+    where
+        T: JsonSchema,
+    {
+        self.structured_output = Some((schemars::schema_for!(T), policy));
+        self
+    }
+
+    /// Configure a raw structured-output schema.
+    #[must_use]
+    pub fn structured_output_raw(mut self, schema: Schema, policy: StructuredOutputPolicy) -> Self {
+        self.structured_output = Some((schema, policy));
+        self
+    }
+
+    /// Configure conversation memory.
+    ///
+    /// The bound memory's `load` must return a canonical history: tool calls
+    /// paired with their results in the immediately following message (which
+    /// may also carry ordinary user content), no consecutive assistant
+    /// messages, and no orphaned tool results.
+    /// Truncating or summarizing memories must cut on turn boundaries. A
+    /// non-canonical loaded history fails the run with code `memory_history`
+    /// before any model call is made.
+    #[must_use]
+    pub fn memory(mut self, memory_id: MemoryId, conversation_id: impl Into<String>) -> Self {
+        self.memory_id = Some(memory_id);
+        self.conversation_id = Some(conversation_id.into());
+        self
+    }
+
+    /// Select provider tool choice.
+    #[must_use]
+    pub fn tool_choice(mut self, value: ToolChoice) -> Self {
+        self.tool_choice = Some(value);
+        self
+    }
+
+    /// Set the sampling temperature used for model requests.
+    #[must_use]
+    pub fn temperature(mut self, value: f64) -> Self {
+        self.temperature = Some(value);
+        self
+    }
+
+    /// Set the maximum generated-token count used for model requests.
+    #[must_use]
+    pub fn max_tokens(mut self, value: u64) -> Self {
+        self.max_tokens = Some(value);
+        self
+    }
+
+    /// Set provider-specific parameters.
+    #[must_use]
+    pub fn additional_params(mut self, value: serde_json::Value) -> Self {
+        self.additional_params = Some(value);
+        self
+    }
+
+    /// Opt in to sensitive telemetry content for this agent.
+    #[must_use]
+    pub fn record_telemetry_content(mut self, value: bool) -> Self {
+        self.record_telemetry_content = value;
+        self
+    }
+
+    /// Select the default blocking or streaming model surface.
+    #[must_use]
+    pub fn streaming(mut self, value: StreamingMode) -> Self {
+        self.streaming = value;
+        self
+    }
+}

--- a/crates/rig-ecs/src/debug.rs
+++ b/crates/rig-ecs/src/debug.rs
@@ -1,0 +1,100 @@
+//! Redacted ECS explanations derived from authoritative facts.
+
+use crate::{
+    AgentId, CanonicalTranscript, RunAccounting, RunEvent, RunHandle, RunId, RunPhase,
+    RuntimeError, TerminalReason,
+    components::{RunEvents, RunNode, TerminalState},
+    runtime::LocalRuntime,
+};
+
+/// Content policy for an explicit run explanation request.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum ContentVisibility {
+    /// Redact prompts, model output, tool arguments/results, and memory content.
+    #[default]
+    Redacted,
+    /// Include the canonical committed transcript only.
+    Canonical,
+}
+
+/// Stable explanation derived from ECS facts without provider finals or implementation handles.
+#[derive(Clone, Debug)]
+pub struct RunExplanation {
+    /// Stable run identity.
+    pub run_id: RunId,
+    /// Owning agent identity.
+    pub agent_id: AgentId,
+    /// Current lifecycle phase.
+    pub phase: RunPhase,
+    /// Terminal reason when present.
+    pub terminal_reason: Option<TerminalReason>,
+    /// Number of model calls dispatched.
+    pub model_calls_dispatched: usize,
+    /// Number of completed model-call records.
+    pub model_calls_completed: usize,
+    /// Number of rejected effect messages.
+    pub rejected_effects: usize,
+    /// Event category names with content removed.
+    pub event_kinds: Vec<&'static str>,
+    /// Canonical transcript included only after explicit opt-in.
+    pub canonical_transcript: Option<Vec<rig_core::completion::Message>>,
+}
+
+impl LocalRuntime {
+    /// Explain one retained run, redacting content unless explicitly requested.
+    pub fn explain(
+        &self,
+        handle: RunHandle,
+        visibility: ContentVisibility,
+    ) -> Result<RunExplanation, RuntimeError> {
+        let entity = self.validate_handle(handle)?;
+        let run = self
+            .world
+            .get::<RunNode>(entity)
+            .ok_or(RuntimeError::UnknownRun(handle.run_id))?;
+        let accounting = self
+            .world
+            .get::<RunAccounting>(entity)
+            .ok_or(RuntimeError::UnknownRun(handle.run_id))?;
+        let terminal_reason = self
+            .world
+            .get::<TerminalState>(entity)
+            .map(|terminal| terminal.reason.clone());
+        let event_kinds = self
+            .world
+            .get::<RunEvents>(entity)
+            .map(|events| events.events.iter().map(event_kind).collect())
+            .unwrap_or_default();
+        let canonical_transcript = matches!(visibility, ContentVisibility::Canonical).then(|| {
+            self.world
+                .get::<CanonicalTranscript>(entity)
+                .map(|transcript| transcript.messages.clone())
+                .unwrap_or_default()
+        });
+        Ok(RunExplanation {
+            run_id: run.id,
+            agent_id: run.agent_id,
+            phase: run.phase,
+            terminal_reason,
+            model_calls_dispatched: accounting.model_calls_dispatched,
+            model_calls_completed: accounting.model_calls.len(),
+            rejected_effects: accounting.rejected_effects,
+            event_kinds,
+            canonical_transcript,
+        })
+    }
+}
+
+fn event_kind(event: &RunEvent) -> &'static str {
+    match event {
+        RunEvent::ModelDispatched(_) => "model_dispatched",
+        RunEvent::Provisional { .. } => "provisional",
+        RunEvent::ProviderFinal { .. } => "provider_final",
+        RunEvent::ToolDispatched { .. } => "tool_dispatched",
+        RunEvent::ToolCommitted { .. } => "tool_committed",
+        RunEvent::ResponseRetried => "response_retried",
+        RunEvent::ToolSuppressed { .. } => "tool_suppressed",
+        RunEvent::Terminal(_) => "terminal",
+        RunEvent::EffectRejected(_) => "effect_rejected",
+    }
+}

--- a/crates/rig-ecs/src/effects.rs
+++ b/crates/rig-ecs/src/effects.rs
@@ -1,0 +1,564 @@
+//! Owned asynchronous effect requests and validated completion ingress.
+
+use std::{any::Any, fmt, sync::Arc};
+
+use rig_core::{
+    completion::{AssistantContent, CompletionRequest, Usage},
+    streaming::ToolCallDeltaContent,
+    tool::{ToolExecutionError, ToolOutput},
+};
+
+use crate::{
+    CapabilityId, CorrelationId, Generation, GrantId, MemoryId, ModelId, OperationId, RunId,
+    RuntimeId, TenantId,
+};
+
+/// Complete identity and authorization context carried by every effect message.
+#[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct EffectHeader {
+    /// Runtime world that issued the operation.
+    pub runtime_id: RuntimeId,
+    /// Run that owns the operation.
+    pub run_id: RunId,
+    /// Stable operation identity.
+    pub operation_id: OperationId,
+    /// Run generation at dispatch time.
+    pub generation: Generation,
+    /// Per-attempt correlation identity.
+    pub correlation_id: CorrelationId,
+    /// Tenant security boundary.
+    pub tenant_id: TenantId,
+    /// Capability used by a tool effect.
+    pub capability_id: Option<CapabilityId>,
+    /// Grant authorizing a tool effect.
+    pub grant_id: Option<GrantId>,
+    /// Exact advertised capability revision.
+    pub capability_revision: Option<u64>,
+}
+
+impl fmt::Debug for EffectHeader {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("EffectHeader")
+            .field("runtime_id", &self.runtime_id)
+            .field("run_id", &self.run_id)
+            .field("operation_id", &self.operation_id)
+            .field("generation", &self.generation)
+            .field("correlation_id", &"<redacted>")
+            .field("tenant_id", &"<redacted>")
+            .field("capability_id", &self.capability_id)
+            .field("grant_id", &self.grant_id)
+            .field("capability_revision", &self.capability_revision)
+            .finish()
+    }
+}
+
+/// Owned model request dispatched outside the ECS world.
+#[derive(Clone)]
+pub struct ModelEffectIntent {
+    /// Correlation and ownership header.
+    pub header: EffectHeader,
+    /// Rebound model implementation identity.
+    pub model_id: ModelId,
+    /// Fully owned provider-neutral completion request.
+    pub request: CompletionRequest,
+    /// Whether to consume the provider streaming surface.
+    pub streaming: bool,
+}
+
+impl fmt::Debug for ModelEffectIntent {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ModelEffectIntent")
+            .field("header", &self.header)
+            .field("model_id", &self.model_id)
+            .field("streaming", &self.streaming)
+            .field("request", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Owned portable tool request dispatched outside the ECS world.
+#[derive(Clone)]
+pub struct ToolEffectIntent {
+    /// Correlation, authorization, and ownership header.
+    pub header: EffectHeader,
+    /// Model tool-call identity used for transcript pairing.
+    pub tool_call_id: String,
+    /// Provider-specific call identity.
+    pub provider_call_id: Option<String>,
+    /// Exact provider-facing tool name advertised for the turn.
+    pub name: String,
+    /// Fully owned JSON arguments.
+    pub arguments: serde_json::Value,
+    /// Stable model-call order used for deterministic commit.
+    pub order: usize,
+}
+
+impl fmt::Debug for ToolEffectIntent {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ToolEffectIntent")
+            .field("header", &self.header)
+            .field("tool_call_id", &self.tool_call_id)
+            .field(
+                "provider_call_id_configured",
+                &self.provider_call_id.is_some(),
+            )
+            .field("name", &self.name)
+            .field("arguments", &"<redacted>")
+            .field("order", &self.order)
+            .finish()
+    }
+}
+
+/// Owned memory request dispatched outside the ECS world.
+#[derive(Clone)]
+pub enum MemoryEffectIntent {
+    /// Load history before the first model call.
+    Load {
+        /// Correlation and ownership header.
+        header: EffectHeader,
+        /// Rebound memory implementation identity.
+        memory_id: MemoryId,
+        /// Conversation key.
+        conversation_id: String,
+    },
+    /// Append only newly committed canonical messages.
+    Append {
+        /// Correlation and ownership header.
+        header: EffectHeader,
+        /// Rebound memory implementation identity.
+        memory_id: MemoryId,
+        /// Conversation key.
+        conversation_id: String,
+        /// Canonical messages committed by this successful run.
+        messages: Vec<rig_core::completion::Message>,
+    },
+}
+
+impl fmt::Debug for MemoryEffectIntent {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Load {
+                header, memory_id, ..
+            } => formatter
+                .debug_struct("MemoryEffectIntent::Load")
+                .field("header", header)
+                .field("memory_id", memory_id)
+                .field("conversation_id", &"<redacted>")
+                .finish(),
+            Self::Append {
+                header,
+                memory_id,
+                messages,
+                ..
+            } => formatter
+                .debug_struct("MemoryEffectIntent::Append")
+                .field("header", header)
+                .field("memory_id", memory_id)
+                .field("conversation_id", &"<redacted>")
+                .field("message_count", &messages.len())
+                .finish(),
+        }
+    }
+}
+
+impl MemoryEffectIntent {
+    /// Borrow the shared effect header.
+    #[must_use]
+    pub const fn header(&self) -> &EffectHeader {
+        match self {
+            Self::Load { header, .. } | Self::Append { header, .. } => header,
+        }
+    }
+}
+
+/// One owned effect waiting for bounded execution.
+#[derive(Clone, Debug)]
+pub enum EffectIntent {
+    /// Provider model operation.
+    Model(Box<ModelEffectIntent>),
+    /// Portable tool operation.
+    Tool(ToolEffectIntent),
+    /// Conversation-memory operation.
+    Memory(MemoryEffectIntent),
+}
+
+impl EffectIntent {
+    /// Borrow the identity header for scheduling and cancellation.
+    #[must_use]
+    pub const fn header(&self) -> &EffectHeader {
+        match self {
+            Self::Model(intent) => &intent.header,
+            Self::Tool(intent) => &intent.header,
+            Self::Memory(intent) => intent.header(),
+        }
+    }
+}
+
+/// Provider-stream item observable before the containing model turn commits.
+#[derive(Clone, serde::Deserialize, PartialEq, serde::Serialize)]
+#[non_exhaustive]
+pub enum ProvisionalDelta {
+    /// Text delta.
+    Text(String),
+    /// Complete tool call normalized by the provider stream.
+    ToolCall(rig_core::message::ToolCall),
+    /// Partial tool-call data.
+    ToolCallDelta {
+        /// Provider tool-call identity.
+        id: String,
+        /// Rig-internal stream correlation identity.
+        internal_call_id: String,
+        /// Name or argument delta.
+        content: ToolCallDeltaContent,
+    },
+    /// Complete reasoning block.
+    Reasoning(rig_core::message::Reasoning),
+    /// Partial reasoning text.
+    ReasoningDelta {
+        /// Provider reasoning identity.
+        id: Option<String>,
+        /// Partial text.
+        reasoning: String,
+    },
+    /// Provider-native item that is not part of canonical transcript state.
+    Unknown(serde_json::Value),
+}
+
+impl ProvisionalDelta {
+    pub(crate) const fn kind(&self) -> &'static str {
+        match self {
+            Self::Text(_) => "text",
+            Self::ToolCall(_) => "tool_call",
+            Self::ToolCallDelta { .. } => "tool_call_delta",
+            Self::Reasoning(_) => "reasoning",
+            Self::ReasoningDelta { .. } => "reasoning_delta",
+            Self::Unknown(_) => "unknown",
+        }
+    }
+}
+
+impl fmt::Debug for ProvisionalDelta {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProvisionalDelta")
+            .field("kind", &self.kind())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Non-persisted type-erased provider final retained only on local surfaces.
+#[derive(Clone)]
+pub struct ErasedRawFinal {
+    value: Arc<dyn Any + Send + Sync>,
+    type_name: &'static str,
+}
+
+impl ErasedRawFinal {
+    pub(crate) fn new<T>(value: T) -> Self
+    where
+        T: Any + Send + Sync,
+    {
+        Self {
+            value: Arc::new(value),
+            type_name: std::any::type_name::<T>(),
+        }
+    }
+
+    /// Concrete Rust type name for diagnostics without exposing content.
+    #[must_use]
+    pub const fn type_name(&self) -> &'static str {
+        self.type_name
+    }
+
+    /// Downcast the local side channel to the concrete provider response.
+    #[must_use]
+    pub fn downcast<T>(&self) -> Option<Arc<T>>
+    where
+        T: Any + Send + Sync,
+    {
+        Arc::downcast::<T>(Arc::clone(&self.value)).ok()
+    }
+}
+
+impl fmt::Debug for ErasedRawFinal {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ErasedRawFinal")
+            .field("type_name", &self.type_name)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Canonical result of one completed model effect.
+pub struct ModelEffectOutput {
+    /// Aggregated assistant choice after a complete blocking response or stream.
+    pub choice: Vec<AssistantContent>,
+    /// Provider-reported usage for this billed operation.
+    pub usage: Usage,
+    /// Provider-assigned assistant message identity.
+    pub message_id: Option<String>,
+    /// Concrete non-persisted provider final when the surface produced one.
+    pub raw_final: Option<ErasedRawFinal>,
+}
+
+impl fmt::Debug for ModelEffectOutput {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ModelEffectOutput")
+            .field("choice_items", &self.choice.len())
+            .field("usage", &self.usage)
+            .field("message_id_configured", &self.message_id.is_some())
+            .field(
+                "raw_final_type",
+                &self.raw_final.as_ref().map(ErasedRawFinal::type_name),
+            )
+            .finish()
+    }
+}
+
+/// Canonical result of one portable tool effect.
+pub enum ToolEffectOutput {
+    /// Successful canonical tool output.
+    Success(ToolOutput),
+    /// Normalized tool failure with safe model-visible output.
+    Failure(ToolExecutionError),
+}
+
+impl fmt::Debug for ToolEffectOutput {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Success(_) => "ToolEffectOutput::Success(<redacted>)",
+            Self::Failure(_) => "ToolEffectOutput::Failure(<redacted>)",
+        })
+    }
+}
+
+/// Canonical result of one memory effect.
+pub enum MemoryEffectOutput {
+    /// Loaded conversation history.
+    Loaded(Vec<rig_core::completion::Message>),
+    /// Append completed successfully.
+    Appended,
+}
+
+impl fmt::Debug for MemoryEffectOutput {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Loaded(messages) => formatter
+                .debug_tuple("MemoryEffectOutput::Loaded")
+                .field(&format_args!("{} messages", messages.len()))
+                .finish(),
+            Self::Appended => formatter.write_str("MemoryEffectOutput::Appended"),
+        }
+    }
+}
+
+/// Typed failures produced while executing an owned model effect.
+#[derive(thiserror::Error)]
+#[non_exhaustive]
+pub enum ModelEffectError {
+    /// The provider rejected or failed the completion operation.
+    #[error("provider completion failed")]
+    Provider(#[source] rig_core::completion::CompletionError),
+    /// A provisional stream item could not cross the bounded ingress channel.
+    #[error("runtime effect ingress closed before model streaming completed")]
+    IngressClosed,
+    /// The configured effect deadline elapsed.
+    #[error("model effect timed out")]
+    TimedOut,
+    /// Restoration or retirement left the stable model identity unbound.
+    #[error("model binding `{model_id}` is unavailable")]
+    MissingBinding {
+        /// Stable model identity that could not be resolved.
+        model_id: ModelId,
+    },
+}
+
+impl ModelEffectError {
+    /// Inspect a preserved provider response body without exposing it in diagnostics.
+    #[must_use]
+    pub fn provider_response_body(&self) -> Option<&str> {
+        match self {
+            Self::Provider(error) => error.provider_response_body(),
+            _ => None,
+        }
+    }
+
+    /// Inspect a preserved provider response HTTP status.
+    #[must_use]
+    pub fn provider_response_status(&self) -> Option<http::StatusCode> {
+        match self {
+            Self::Provider(error) => error.provider_response_status(),
+            _ => None,
+        }
+    }
+
+    /// Parse a preserved provider response body as JSON.
+    pub fn provider_response_json(&self) -> Result<Option<serde_json::Value>, serde_json::Error> {
+        match self {
+            Self::Provider(error) => error.provider_response_json(),
+            _ => Ok(None),
+        }
+    }
+}
+
+impl fmt::Debug for ModelEffectError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_tuple(match self {
+                Self::Provider(_) => "Provider",
+                Self::IngressClosed => "IngressClosed",
+                Self::TimedOut => "TimedOut",
+                Self::MissingBinding { .. } => "MissingBinding",
+            })
+            .field(&self.to_string())
+            .finish()
+    }
+}
+
+/// Typed failures produced while executing an owned conversation-memory effect.
+#[derive(thiserror::Error)]
+#[non_exhaustive]
+pub enum MemoryEffectError {
+    /// The portable memory backend failed.
+    #[error("conversation memory backend failed")]
+    Backend(#[source] rig_core::memory::MemoryError),
+    /// The configured effect deadline elapsed.
+    #[error("conversation memory effect timed out")]
+    TimedOut,
+    /// Restoration or retirement left the stable memory identity unbound.
+    #[error("memory binding `{memory_id}` is unavailable")]
+    MissingBinding {
+        /// Stable memory identity that could not be resolved.
+        memory_id: MemoryId,
+    },
+}
+
+impl fmt::Debug for MemoryEffectError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_tuple(match self {
+                Self::Backend(_) => "Backend",
+                Self::TimedOut => "TimedOut",
+                Self::MissingBinding { .. } => "MissingBinding",
+            })
+            .field(&self.to_string())
+            .finish()
+    }
+}
+
+/// Terminal payload returned by one completed effect future.
+#[derive(Debug)]
+pub enum EffectCompletion {
+    /// Model operation result.
+    Model {
+        /// Fully correlated effect header.
+        header: EffectHeader,
+        /// Success or normalized provider failure.
+        result: Result<ModelEffectOutput, ModelEffectError>,
+    },
+    /// Tool operation result.
+    Tool {
+        /// Fully correlated effect header.
+        header: EffectHeader,
+        /// Model tool-call identity.
+        tool_call_id: String,
+        /// Stable model-call order.
+        order: usize,
+        /// Success or normalized tool failure.
+        result: ToolEffectOutput,
+    },
+    /// Memory operation result.
+    Memory {
+        /// Fully correlated effect header.
+        header: EffectHeader,
+        /// Success or normalized backend failure.
+        result: Result<MemoryEffectOutput, MemoryEffectError>,
+    },
+}
+
+impl EffectCompletion {
+    /// Borrow the shared correlation header.
+    #[must_use]
+    pub const fn header(&self) -> &EffectHeader {
+        match self {
+            Self::Model { header, .. }
+            | Self::Tool { header, .. }
+            | Self::Memory { header, .. } => header,
+        }
+    }
+}
+
+/// One message crossing the bounded effect ingress boundary.
+#[derive(Debug)]
+pub enum EffectIngress {
+    /// Provisional streaming content that cannot mutate canonical history.
+    Delta {
+        /// Fully correlated model effect header.
+        header: EffectHeader,
+        /// Monotonic provider-stream item sequence within this operation.
+        sequence: u64,
+        /// Provisional provider-normalized content.
+        delta: ProvisionalDelta,
+    },
+    /// Final completion of an effect.
+    Completion(EffectCompletion),
+}
+
+impl EffectIngress {
+    pub(crate) fn run_id(&self) -> RunId {
+        match self {
+            Self::Delta { header, .. } => header.run_id,
+            Self::Completion(completion) => completion.header().run_id,
+        }
+    }
+}
+
+/// Stable reason an ingress message was rejected without mutating state.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[non_exhaustive]
+pub enum EffectRejectionReason {
+    /// Header names another runtime world.
+    ForeignRuntime,
+    /// Run is missing, cleaned, or foreign.
+    UnknownRun,
+    /// Header tenant differs from the authoritative run tenant.
+    WrongTenant,
+    /// Header generation is stale or superseded.
+    WrongGeneration,
+    /// Operation is no longer active.
+    UnknownOperation,
+    /// Correlation identity differs from the active attempt.
+    WrongCorrelation,
+    /// Capability, grant, or revision differs from the immutable turn snapshot.
+    WrongAuthorization,
+    /// Completion was already accepted.
+    Duplicate,
+    /// A provisional stream sequence skipped ahead of the next expected item.
+    OutOfOrder,
+    /// Completion payload does not match the dispatched operation identity.
+    WrongPayload,
+    /// Run is terminal or canceled.
+    Late,
+}
+
+/// Auditable record of rejected effect ingress.
+#[derive(Clone, Debug)]
+pub struct EffectRejection {
+    /// Rejected header.
+    pub header: EffectHeader,
+    /// Validation rule that rejected it.
+    pub reason: EffectRejectionReason,
+}
+
+/// Redacted hosted/erased provider-final envelope.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HostedProviderDiagnostic {
+    /// Operation that produced the final.
+    pub operation_id: OperationId,
+    /// Concrete type name, never serialized provider content.
+    pub provider_type: &'static str,
+}

--- a/crates/rig-ecs/src/error.rs
+++ b/crates/rig-ecs/src/error.rs
@@ -1,0 +1,312 @@
+//! Typed construction, runtime, and snapshot failures.
+
+use std::{fmt, sync::Arc};
+
+use crate::{
+    AgentId, CapabilityId, CapabilityKind, GrantId, MemoryEffectError, MemoryId, ModelEffectError,
+    ModelId, RunId, RuntimeId, TenantId,
+};
+
+/// Failures returned by ECS runtime operations.
+#[derive(thiserror::Error)]
+#[non_exhaustive]
+pub enum RuntimeError {
+    /// A bounded runtime setting was zero or otherwise invalid.
+    #[error("runtime configuration field `{field}` must be non-zero")]
+    InvalidConfiguration {
+        /// Invalid configuration field.
+        field: &'static str,
+    },
+    /// An agent specification contains an inconsistent capability relationship.
+    #[error("invalid agent specification: {reason}")]
+    InvalidAgentSpec {
+        /// Stable diagnostic that contains no user data.
+        reason: &'static str,
+    },
+    /// A run prompt would make the canonical transcript invalid at insertion.
+    #[error("invalid run prompt: {reason}")]
+    InvalidPrompt {
+        /// Stable diagnostic that contains no user data.
+        reason: &'static str,
+    },
+    /// A model binding was not registered.
+    #[error("model binding `{0}` is not registered")]
+    UnknownModel(ModelId),
+    /// A memory binding was not registered.
+    #[error("memory binding `{0}` is not registered")]
+    UnknownMemory(MemoryId),
+    /// An agent identity was not present in the world.
+    #[error("agent `{0}` is not present in this runtime")]
+    UnknownAgent(AgentId),
+    /// A run identity was not present in the world.
+    #[error("run `{0}` is not present in this runtime")]
+    UnknownRun(RunId),
+    /// Hosted runs have one schedule driver to preserve ordered ownership.
+    #[error("run `{0}` already has an active hosted driver")]
+    RunAlreadyDriven(RunId),
+    /// A capability identity was not present in the world or registry.
+    #[error("capability `{0}` is not present in this runtime")]
+    UnknownCapability(CapabilityId),
+    /// Replacing a persistable capability requires the replacement's stable identity.
+    #[error("replacement for persistable capability `{0}` requires a binding identity")]
+    PersistenceIdentityRequired(CapabilityId),
+    /// A grant identity was not present in the world.
+    #[error("grant `{0}` is not present in this runtime")]
+    UnknownGrant(GrantId),
+    /// A revoked grant cannot authorize another capability version.
+    #[error("grant `{0}` is revoked and cannot authorize replacement")]
+    RevokedGrant(GrantId),
+    /// A retired capability cannot be used as a replacement predecessor.
+    #[error("capability `{0}` is retired and cannot be replaced")]
+    RetiredCapability(CapabilityId),
+    /// The immutable capability revision chain exhausted its integer domain.
+    #[error("capability `{0}` cannot advance beyond its current revision")]
+    CapabilityRevisionOverflow(CapabilityId),
+    /// One agent cannot advertise two active grants under the same provider name.
+    #[error("agent `{agent_id}` already has an active capability named `{name}`")]
+    DuplicateToolName {
+        /// Agent whose active capability namespace would become ambiguous.
+        agent_id: AgentId,
+        /// Colliding provider-facing name.
+        name: String,
+    },
+    /// A replacement implementation must preserve the capability category.
+    #[error(
+        "capability `{capability_id}` has kind {actual:?}; this replacement requires {expected:?}"
+    )]
+    CapabilityKindMismatch {
+        /// Existing immutable capability identity.
+        capability_id: CapabilityId,
+        /// Kind required by the replacement API.
+        expected: CapabilityKind,
+        /// Kind recorded on the predecessor capability.
+        actual: CapabilityKind,
+    },
+    /// A handle belongs to a different runtime world.
+    #[error("handle belongs to runtime `{actual}`, not `{expected}")]
+    ForeignRuntime {
+        /// Runtime expected by the receiver.
+        expected: RuntimeId,
+        /// Runtime carried by the handle.
+        actual: RuntimeId,
+    },
+    /// A handle generation is no longer authoritative.
+    #[error("run `{run_id}` generation is stale")]
+    StaleHandle {
+        /// Stale run identity.
+        run_id: RunId,
+    },
+    /// A tenant attempted to cross an ownership boundary.
+    #[error("tenant ownership boundary mismatch")]
+    TenantMismatch {
+        /// Tenant that owns the target state.
+        expected: TenantId,
+        /// Tenant presented by the operation.
+        actual: TenantId,
+    },
+    /// The run exhausted its total model-call budget.
+    #[error("run exhausted its total model-call budget")]
+    ModelCallBudgetExhausted,
+    /// A provider model effect failed.
+    #[error("model effect failed")]
+    ModelEffect(#[source] Arc<ModelEffectError>),
+    /// A conversation-memory effect failed.
+    #[error("memory effect failed")]
+    MemoryEffect(#[source] Arc<MemoryEffectError>),
+    /// A structured output could not be recovered within policy bounds.
+    #[error("structured output validation failed: {0}")]
+    StructuredOutput(String),
+    /// A run failed under a typed ECS policy or topology invariant.
+    #[error("run failed with code `{code}`: {diagnostic}")]
+    RunFailed {
+        /// Stable machine-readable terminal code.
+        code: String,
+        /// Redacted operator-facing diagnostic.
+        diagnostic: String,
+    },
+    /// The bounded ingress channel was closed unexpectedly.
+    #[error("the runtime effect ingress channel closed")]
+    IngressClosed,
+    /// The bounded ingress queue rejected externally injected work.
+    #[error("the runtime effect ingress queue is full")]
+    IngressFull,
+    /// A requested typed provider final did not match the concrete response.
+    #[error("provider final type mismatch: expected `{expected}`, received `{actual}`")]
+    RawFinalTypeMismatch {
+        /// Concrete type requested by the caller.
+        expected: &'static str,
+        /// Concrete type produced by the provider binding.
+        actual: &'static str,
+    },
+    /// A bounded lifecycle subscriber did not keep up with the producer.
+    #[error("runtime event subscriber lagged by {skipped} events")]
+    EventStreamLagged {
+        /// Number of events evicted before the subscriber observed them.
+        skipped: u64,
+    },
+    /// The convenience streaming collector reached its configured event bound.
+    #[error("streaming event collection reached configured capacity {capacity}")]
+    EventCollectionLimit {
+        /// Maximum events collected by the convenience surface.
+        capacity: usize,
+    },
+    /// Schedule progression exceeded the configured pass bound.
+    #[error("the ECS schedule did not reach quiescence within the configured pass bound")]
+    Livelock,
+    /// No owned effect produced ingress within the configured effect timeout.
+    #[error("owned effect produced no ingress before its configured timeout")]
+    EffectWaitTimedOut,
+    /// The run was explicitly cancelled.
+    #[error("run was cancelled")]
+    Cancelled,
+    /// The run stopped under policy without producing a completion.
+    #[error("run stopped under policy")]
+    Stopped,
+    /// The run completed without canonical assistant text.
+    #[error("run completed without canonical assistant text")]
+    MissingFinalText,
+    /// A protected snapshot operation failed.
+    #[error(transparent)]
+    Snapshot(#[from] SnapshotError),
+}
+
+impl fmt::Debug for RuntimeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self {
+            Self::InvalidConfiguration { .. } => "InvalidConfiguration",
+            Self::InvalidAgentSpec { .. } => "InvalidAgentSpec",
+            Self::InvalidPrompt { .. } => "InvalidPrompt",
+            Self::UnknownModel(_) => "UnknownModel",
+            Self::UnknownMemory(_) => "UnknownMemory",
+            Self::UnknownAgent(_) => "UnknownAgent",
+            Self::UnknownRun(_) => "UnknownRun",
+            Self::RunAlreadyDriven(_) => "RunAlreadyDriven",
+            Self::UnknownCapability(_) => "UnknownCapability",
+            Self::PersistenceIdentityRequired(_) => "PersistenceIdentityRequired",
+            Self::UnknownGrant(_) => "UnknownGrant",
+            Self::RevokedGrant(_) => "RevokedGrant",
+            Self::RetiredCapability(_) => "RetiredCapability",
+            Self::CapabilityRevisionOverflow(_) => "CapabilityRevisionOverflow",
+            Self::DuplicateToolName { .. } => "DuplicateToolName",
+            Self::CapabilityKindMismatch { .. } => "CapabilityKindMismatch",
+            Self::ForeignRuntime { .. } => "ForeignRuntime",
+            Self::StaleHandle { .. } => "StaleHandle",
+            Self::TenantMismatch { .. } => "TenantMismatch",
+            Self::ModelCallBudgetExhausted => "ModelCallBudgetExhausted",
+            Self::ModelEffect(_) => "ModelEffect",
+            Self::MemoryEffect(_) => "MemoryEffect",
+            Self::StructuredOutput(_) => "StructuredOutput",
+            Self::RunFailed { .. } => "RunFailed",
+            Self::IngressClosed => "IngressClosed",
+            Self::IngressFull => "IngressFull",
+            Self::RawFinalTypeMismatch { .. } => "RawFinalTypeMismatch",
+            Self::EventStreamLagged { .. } => "EventStreamLagged",
+            Self::EventCollectionLimit { .. } => "EventCollectionLimit",
+            Self::Livelock => "Livelock",
+            Self::EffectWaitTimedOut => "EffectWaitTimedOut",
+            Self::Cancelled => "Cancelled",
+            Self::Stopped => "Stopped",
+            Self::MissingFinalText => "MissingFinalText",
+            Self::Snapshot(_) => "Snapshot",
+        };
+        formatter
+            .debug_struct("RuntimeError")
+            .field("kind", &kind)
+            .finish()
+    }
+}
+
+impl RuntimeError {
+    /// Inspect a provider response body preserved by a typed model failure.
+    #[must_use]
+    pub fn provider_response_body(&self) -> Option<&str> {
+        match self {
+            Self::ModelEffect(error) => error.provider_response_body(),
+            _ => None,
+        }
+    }
+
+    /// Inspect a provider response status preserved by a typed model failure.
+    #[must_use]
+    pub fn provider_response_status(&self) -> Option<http::StatusCode> {
+        match self {
+            Self::ModelEffect(error) => error.provider_response_status(),
+            _ => None,
+        }
+    }
+
+    /// Parse a preserved provider response body as JSON.
+    pub fn provider_response_json(&self) -> Result<Option<serde_json::Value>, serde_json::Error> {
+        match self {
+            Self::ModelEffect(error) => error.provider_response_json(),
+            _ => Ok(None),
+        }
+    }
+}
+
+/// Failures while protecting, validating, restoring, or rebinding a snapshot.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum SnapshotError {
+    /// Snapshot protection failed.
+    #[error("snapshot protection failed: {0}")]
+    Protect(String),
+    /// Snapshot unprotection failed.
+    #[error("snapshot unprotection failed: {0}")]
+    Unprotect(String),
+    /// The protected payload digest did not match.
+    #[error("snapshot integrity validation failed")]
+    Integrity,
+    /// The schema version is unsupported.
+    #[error("unsupported snapshot schema version {0}")]
+    UnsupportedVersion(u32),
+    /// Stable records violate an ownership or relationship invariant.
+    #[error("snapshot relationship validation failed: {0}")]
+    InvalidRelationship(String),
+    /// A required exact model implementation was not rebound.
+    #[error("snapshot requires missing model binding `{0}`")]
+    MissingModel(ModelId),
+    /// A required exact capability implementation was not rebound.
+    #[error("snapshot requires missing capability binding `{0}`")]
+    MissingCapability(CapabilityId),
+    /// A required exact memory implementation was not rebound.
+    #[error("snapshot requires missing memory binding `{0}`")]
+    MissingMemory(MemoryId),
+    /// A live implementation was not assigned a stable persistence identity.
+    #[error("snapshot requires an explicit persistence identity for {kind} binding `{id}`")]
+    MissingBindingIdentity {
+        /// Stable binding identifier.
+        id: String,
+        /// Binding category.
+        kind: &'static str,
+    },
+    /// Metadata-only persistence cannot safely retain a memory conversation key.
+    #[error(
+        "metadata-only snapshot cannot represent memory-enabled agent `{0}`; use canonical run state or remove conversation memory"
+    )]
+    MetadataOnlyMemory(AgentId),
+    /// Metadata-only persistence would remove a behavior-bearing system preamble.
+    #[error(
+        "metadata-only snapshot cannot represent preamble-bearing agent `{0}`; use canonical run state or remove the preamble"
+    )]
+    MetadataOnlyPreamble(AgentId),
+    /// Arbitrary provider parameters are intentionally never persisted.
+    #[error(
+        "snapshot cannot represent agent `{0}` with provider additional parameters; remove or re-register that configuration before snapshotting"
+    )]
+    NonPersistableProviderParameters(AgentId),
+    /// A rebound implementation has the right stable ID but the wrong concrete type.
+    #[error("snapshot binding `{id}` has a mismatched {kind} implementation")]
+    BindingMismatch {
+        /// Stable binding identity.
+        id: String,
+        /// Binding category.
+        kind: &'static str,
+    },
+    /// Snapshot serialization failed.
+    #[error("snapshot serialization failed: {0}")]
+    Serialization(#[from] serde_json::Error),
+    /// The world is not at a safe persistence point.
+    #[error("snapshot requires quiescent runs with no active effects")]
+    NotQuiescent,
+}

--- a/crates/rig-ecs/src/identity.rs
+++ b/crates/rig-ecs/src/identity.rs
@@ -1,0 +1,170 @@
+//! Stable domain identity used across ECS entities, effects, and snapshots.
+
+use std::fmt;
+
+use bevy_ecs::prelude::Component;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+macro_rules! stable_id {
+    ($name:ident, $description:literal, $redacted_debug:literal) => {
+        #[doc = $description]
+        #[derive(Clone, Copy, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+        #[serde(transparent)]
+        pub struct $name(Uuid);
+
+        impl $name {
+            #[doc = concat!("Generate a new ", stringify!($name), ".")]
+            #[must_use]
+            pub fn new() -> Self {
+                Self(Uuid::new_v4())
+            }
+
+            #[doc = concat!("Construct a ", stringify!($name), " from a stable UUID.")]
+            #[must_use]
+            pub const fn from_uuid(value: Uuid) -> Self {
+                Self(value)
+            }
+
+            #[doc = concat!("Borrow the UUID backing this ", stringify!($name), ".")]
+            #[must_use]
+            pub const fn as_uuid(self) -> Uuid {
+                self.0
+            }
+        }
+
+        impl Default for $name {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                self.0.fmt(formatter)
+            }
+        }
+
+        impl fmt::Debug for $name {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                if $redacted_debug {
+                    formatter.write_str(concat!(stringify!($name), "(<redacted>)"))
+                } else {
+                    self.0.fmt(formatter)
+                }
+            }
+        }
+    };
+}
+
+stable_id!(
+    RuntimeId,
+    "Stable identity of one local or hosted ECS world.",
+    false
+);
+stable_id!(
+    AgentId,
+    "Stable identity of an agent specification entity.",
+    false
+);
+stable_id!(RunId, "Stable identity of one agent run.", false);
+stable_id!(
+    OperationId,
+    "Stable identity of one asynchronous effect operation.",
+    false
+);
+stable_id!(
+    ModelId,
+    "Stable identity of a rebound model implementation.",
+    false
+);
+stable_id!(
+    CapabilityId,
+    "Stable identity of one versioned executable capability.",
+    false
+);
+stable_id!(
+    GrantId,
+    "Stable identity of an agent-to-capability authorization grant.",
+    false
+);
+stable_id!(
+    MemoryId,
+    "Stable identity of a rebound conversation-memory implementation.",
+    false
+);
+stable_id!(
+    CorrelationId,
+    "Unforgeable correlation identity for one effect attempt.",
+    false
+);
+stable_id!(TenantId, "Stable tenant security boundary.", true);
+
+/// Caller-defined stable implementation and configuration revision identity.
+///
+/// Snapshot rebinding compares this value instead of Rust type names, so two
+/// instances of the same type with incompatible endpoints, credentials, model
+/// settings, or behavior revisions cannot be confused accidentally.
+#[derive(Clone, Copy, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
+pub struct BindingIdentity([u8; 32]);
+
+impl BindingIdentity {
+    /// Derive a stable identity from an implementation name and configuration revision.
+    #[must_use]
+    pub fn new(implementation: &str, revision: &str) -> Self {
+        let mut hasher = Sha256::new();
+        hasher.update(implementation.as_bytes());
+        hasher.update([0]);
+        hasher.update(revision.as_bytes());
+        Self(hasher.finalize().into())
+    }
+
+    /// Borrow the digest backing this identity.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl fmt::Debug for BindingIdentity {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("BindingIdentity(<redacted>)")
+    }
+}
+
+impl fmt::Display for BindingIdentity {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in self.0.iter().take(6) {
+            write!(formatter, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Monotonic run generation used to reject superseded async results.
+#[derive(
+    Clone,
+    Copy,
+    Component,
+    Debug,
+    Default,
+    Deserialize,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    Serialize,
+)]
+#[serde(transparent)]
+pub struct Generation(pub u64);
+
+impl Generation {
+    /// Return the next generation, saturating at the integer limit.
+    #[must_use]
+    pub const fn next(self) -> Self {
+        Self(self.0.saturating_add(1))
+    }
+}

--- a/crates/rig-ecs/src/lib.rs
+++ b/crates/rig-ecs/src/lib.rs
@@ -1,0 +1,54 @@
+//! Experimental native-only Bevy ECS runtime for Rig.
+//!
+//! The ECS world is authoritative for agent topology and run progression.
+//! Provider, tool, and memory futures receive owned effect values and return
+//! through validated ingress carrying runtime, run, operation, generation,
+//! tenant, capability, grant, revision, and correlation identity.
+//!
+//! The classic runtime remains the supported default. This crate is opt-in,
+//! native-only, and intentionally does not depend on `rig-agent`.
+
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+#[cfg(target_family = "wasm")]
+compile_error!("rig-ecs is an experimental native-only runtime; use rig-agent on WebAssembly");
+
+mod components;
+mod config;
+mod debug;
+mod effects;
+mod error;
+mod identity;
+mod persistence;
+mod policy;
+mod runtime;
+mod schedule;
+
+/// Common imports for constructing and operating the ECS runtime.
+pub mod prelude;
+
+pub use components::{
+    AgentNode, CanonicalTranscript, CapabilityKind, CapabilityNode, GrantNode, ModelCallRecord,
+    RunAccounting, RunEvent, RunPhase, TerminalObservation, TerminalReason, TerminalState,
+};
+pub use config::{AgentSpec, ResponseRetryPolicy, RuntimeConfig, StreamingMode};
+pub use debug::{ContentVisibility, RunExplanation};
+pub use effects::{
+    EffectCompletion, EffectHeader, EffectIngress, EffectRejection, EffectRejectionReason,
+    HostedProviderDiagnostic, MemoryEffectError, MemoryEffectOutput, ModelEffectError,
+    ModelEffectOutput, ProvisionalDelta, ToolEffectOutput,
+};
+pub use error::{RuntimeError, SnapshotError};
+pub use identity::{
+    AgentId, BindingIdentity, CapabilityId, CorrelationId, Generation, GrantId, MemoryId, ModelId,
+    OperationId, RunId, RuntimeId, TenantId,
+};
+pub use persistence::{
+    ProtectedSnapshot, RebindRegistry, SnapshotContentPolicy, SnapshotProtector,
+};
+pub use policy::{InvalidToolPolicy, OutputMode, StructuredOutputPolicy};
+pub use runtime::{
+    EcsAgentBuilder, EcsAgentDefinition, EcsClientExt, EcsModelExt, HostedRuntime, LocalRunResult,
+    LocalRuntime, LocalStreamingRun, RunHandle, RunStepStatus, StreamingRunEvent,
+    StreamingRunResult, ToolGrant,
+};

--- a/crates/rig-ecs/src/persistence.rs
+++ b/crates/rig-ecs/src/persistence.rs
@@ -1,0 +1,1330 @@
+//! Protected, versioned stable-domain snapshots with exact implementation rebinding.
+
+use std::{
+    any::Any,
+    collections::{BTreeMap, BTreeSet, HashMap},
+    sync::Arc,
+};
+
+use bevy_ecs::prelude::*;
+use rig_core::{
+    completion::{AssistantContent, CompletionModel, Message},
+    memory::ConversationMemory,
+    message::UserContent,
+    tool::{PortableDynamicTool, PortableTool},
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::{
+    AgentId, AgentNode, AgentSpec, BindingIdentity, CapabilityId, CapabilityNode, Generation,
+    GrantNode, MemoryId, ModelId, RunAccounting, RunId, RunPhase, RuntimeConfig, RuntimeError,
+    SnapshotError, TenantId,
+    components::{
+        AcceptedDeltas, ActiveOperations, AdvertisedCapability, CanonicalTranscript,
+        CapabilityReferences, EffectQueueWait, InvalidToolRetryState, MemoryProgress,
+        RecoveryFeedback, ResponseRetryState, RunEvents, RunNode, RunProgress, RunTelemetrySpan,
+        RuntimeTick, StructuredOutputState, TerminalObservation, TerminalState, TopologyIndex,
+        TurnCapabilitySnapshot,
+    },
+    runtime::{
+        DynamicToolBinding, LocalRuntime, MemoryBinding, ModelBinding, ToolBinding,
+        TypedMemoryBinding, TypedModelBinding, TypedToolBinding,
+    },
+    schedule::checked_usage_sum,
+};
+
+const SNAPSHOT_VERSION: u32 = 2;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum CanonicalTranscriptError {
+    #[error("consecutive assistant messages are not canonical")]
+    ConsecutiveAssistant,
+    #[error("assistant tool-call identities must be unique within a turn")]
+    DuplicateToolCall,
+    #[error("tool results must immediately and exactly answer the preceding assistant calls")]
+    InvalidToolPairing,
+    #[error("tool results cannot appear without a preceding assistant tool call")]
+    OrphanToolResult,
+    #[error("assistant tool calls cannot remain unanswered")]
+    OrphanToolCall,
+}
+
+/// Resumable canonical-transcript checker.
+///
+/// One validator observes a message stream incrementally; the run's live state
+/// is kept in [`TranscriptValidation`] so commits validate only the appended
+/// tail while restore, snapshot, and memory-load acceptance scan whole slices.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct TranscriptValidator {
+    previous_assistant: bool,
+    pending_tool_calls: Option<BTreeSet<String>>,
+}
+
+impl TranscriptValidator {
+    pub(crate) fn observe(&mut self, message: &Message) -> Result<(), CanonicalTranscriptError> {
+        if let Some(expected) = self.pending_tool_calls.take() {
+            let Message::User { content } = message else {
+                return Err(CanonicalTranscriptError::InvalidToolPairing);
+            };
+            let results = content
+                .iter()
+                .filter_map(|item| match item {
+                    UserContent::ToolResult(result) => Some(result.id.clone()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+            let unique_results = results.iter().cloned().collect::<BTreeSet<_>>();
+            // Pairing is keyed strictly on identities — each expected id
+            // exactly once, nothing unexpected — but the pairing message may
+            // also carry ordinary user content: rig's message model allows
+            // mixed content and classic-runtime histories rely on it.
+            if results.len() != unique_results.len() || unique_results != expected {
+                return Err(CanonicalTranscriptError::InvalidToolPairing);
+            }
+            self.previous_assistant = false;
+            return Ok(());
+        }
+        match message {
+            Message::Assistant { content, .. } => {
+                if self.previous_assistant {
+                    return Err(CanonicalTranscriptError::ConsecutiveAssistant);
+                }
+                self.previous_assistant = true;
+                let calls = content
+                    .iter()
+                    .filter_map(|item| match item {
+                        AssistantContent::ToolCall(call) => Some(call.id.clone()),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>();
+                let unique_calls = calls.iter().cloned().collect::<BTreeSet<_>>();
+                if calls.len() != unique_calls.len() {
+                    return Err(CanonicalTranscriptError::DuplicateToolCall);
+                }
+                if !unique_calls.is_empty() {
+                    self.pending_tool_calls = Some(unique_calls);
+                }
+            }
+            Message::User { content } => {
+                self.previous_assistant = false;
+                if content
+                    .iter()
+                    .any(|item| matches!(item, UserContent::ToolResult(_)))
+                {
+                    return Err(CanonicalTranscriptError::OrphanToolResult);
+                }
+            }
+            Message::System { .. } => self.previous_assistant = false,
+        }
+        Ok(())
+    }
+
+    /// Check the pairing-completeness required at every rest point (each
+    /// committed turn, snapshot, and restore).
+    pub(crate) fn finish(&self) -> Result<(), CanonicalTranscriptError> {
+        if self.pending_tool_calls.is_some() {
+            return Err(CanonicalTranscriptError::OrphanToolCall);
+        }
+        Ok(())
+    }
+
+    /// Validate a whole slice and return the resulting resumable state.
+    pub(crate) fn over(
+        messages: &[Message],
+    ) -> Result<TranscriptValidator, CanonicalTranscriptError> {
+        let mut validator = TranscriptValidator::default();
+        for message in messages {
+            validator.observe(message)?;
+        }
+        Ok(validator)
+    }
+}
+
+/// Live transcript-validator state for one run; never serialized — restore
+/// reseeds it by scanning the restored transcript.
+#[derive(Component, Clone, Debug, Default)]
+pub(crate) struct TranscriptValidation(pub(crate) TranscriptValidator);
+
+pub(crate) fn validate_canonical_transcript(
+    messages: &[Message],
+) -> Result<(), CanonicalTranscriptError> {
+    TranscriptValidator::over(messages)?.finish()
+}
+
+/// Content retained in a protected snapshot.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub enum SnapshotContentPolicy {
+    /// Persist topology and binding metadata only; omit prompts, transcripts,
+    /// memory keys, recovery feedback, structured values, and provider params.
+    #[default]
+    MetadataOnly,
+    /// Explicitly persist canonical run and agent configuration content.
+    CanonicalRunState,
+}
+
+/// Caller-supplied authenticated protection for a serialized stable snapshot payload.
+pub trait SnapshotProtector: Send + Sync {
+    /// Stable algorithm/key identifier recorded outside the protected payload.
+    fn protector_id(&self) -> &str;
+
+    /// Encrypt and authenticate plaintext snapshot bytes.
+    fn protect(&self, plaintext: &[u8]) -> Result<Vec<u8>, SnapshotError>;
+
+    /// Authenticate and decrypt protected snapshot bytes.
+    fn unprotect(&self, protected: &[u8]) -> Result<Vec<u8>, SnapshotError>;
+}
+
+/// Opaque protected snapshot envelope; its payload is never interpreted without a protector.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ProtectedSnapshot {
+    /// Stable schema version used for early compatibility checks.
+    pub version: u32,
+    /// Protection implementation/key identifier.
+    pub protector_id: String,
+    /// Protected serialized stable-domain payload.
+    pub payload: Vec<u8>,
+    /// SHA-256 digest of the protected bytes for corruption detection before unprotection.
+    pub protected_digest: [u8; 32],
+}
+
+/// Exact implementation bindings required to restore stable domain records.
+#[derive(Default)]
+pub struct RebindRegistry {
+    pub(crate) models: HashMap<ModelId, Arc<dyn ModelBinding>>,
+    pub(crate) tools: HashMap<CapabilityId, Arc<dyn ToolBinding>>,
+    pub(crate) memories: HashMap<MemoryId, Arc<dyn MemoryBinding>>,
+    pub(crate) model_tenants: HashMap<ModelId, TenantId>,
+    pub(crate) memory_tenants: HashMap<MemoryId, TenantId>,
+    pub(crate) model_binding_identities: HashMap<ModelId, BindingIdentity>,
+    pub(crate) tool_binding_identities: HashMap<CapabilityId, BindingIdentity>,
+    pub(crate) tool_kinds: HashMap<CapabilityId, crate::CapabilityKind>,
+    pub(crate) memory_binding_identities: HashMap<MemoryId, BindingIdentity>,
+}
+
+impl RebindRegistry {
+    /// Construct an empty exact-rebinding registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Bind one exact stable model identity to a concrete implementation.
+    pub fn bind_model<M>(
+        &mut self,
+        id: ModelId,
+        tenant_id: TenantId,
+        identity: BindingIdentity,
+        model: M,
+    ) -> &mut Self
+    where
+        M: CompletionModel + Send + Sync + 'static,
+        M::Response: Any + Send + Sync,
+        M::StreamingResponse: Any + Send + Sync,
+    {
+        self.models.insert(id, Arc::new(TypedModelBinding(model)));
+        self.model_tenants.insert(id, tenant_id);
+        self.model_binding_identities.insert(id, identity);
+        self
+    }
+
+    /// Bind one exact capability version to a concrete portable tool.
+    pub fn bind_tool<T>(
+        &mut self,
+        id: CapabilityId,
+        identity: BindingIdentity,
+        tool: T,
+    ) -> &mut Self
+    where
+        T: PortableTool + Send + Sync + 'static,
+        T::Args: Send + Sync + 'static,
+        T::Output: Send + 'static,
+    {
+        self.tools
+            .insert(id, Arc::new(TypedToolBinding(Arc::new(tool))));
+        self.tool_binding_identities.insert(id, identity);
+        self.tool_kinds.insert(id, crate::CapabilityKind::Tool);
+        self
+    }
+
+    /// Bind one exact vector-store capability to a concrete portable index.
+    pub fn bind_vector_store<I>(
+        &mut self,
+        id: CapabilityId,
+        identity: BindingIdentity,
+        index: I,
+    ) -> &mut Self
+    where
+        I: rig_core::vector_store::VectorStoreIndex + PortableTool + Send + Sync + 'static,
+        I::Args: Send + Sync + 'static,
+        I::Output: Send + 'static,
+    {
+        self.tools
+            .insert(id, Arc::new(TypedToolBinding(Arc::new(index))));
+        self.tool_binding_identities.insert(id, identity);
+        self.tool_kinds.insert(id, crate::CapabilityKind::Store);
+        self
+    }
+
+    /// Bind one exact capability version to a context-free dynamic tool.
+    pub fn bind_dynamic_tool(
+        &mut self,
+        id: CapabilityId,
+        identity: BindingIdentity,
+        tool: PortableDynamicTool,
+    ) -> &mut Self {
+        self.tools.insert(id, Arc::new(DynamicToolBinding(tool)));
+        self.tool_binding_identities.insert(id, identity);
+        self.tool_kinds.insert(id, crate::CapabilityKind::Tool);
+        self
+    }
+
+    /// Bind one exact memory identity to a concrete backend.
+    pub fn bind_memory<M>(
+        &mut self,
+        id: MemoryId,
+        tenant_id: TenantId,
+        identity: BindingIdentity,
+        memory: M,
+    ) -> &mut Self
+    where
+        M: ConversationMemory + Send + Sync + 'static,
+    {
+        self.memories
+            .insert(id, Arc::new(TypedMemoryBinding(Arc::new(memory))));
+        self.memory_tenants.insert(id, tenant_id);
+        self.memory_binding_identities.insert(id, identity);
+        self
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+struct DomainSnapshot {
+    version: u32,
+    content_policy: SnapshotContentPolicy,
+    runtime_tick: u64,
+    agents: Vec<AgentRecord>,
+    capabilities: Vec<CapabilityRecord>,
+    grants: Vec<GrantNode>,
+    runs: Vec<RunRecord>,
+    model_bindings: Vec<BindingRecord<ModelId>>,
+    memory_bindings: Vec<BindingRecord<MemoryId>>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct BindingRecord<I> {
+    id: I,
+    tenant_id: TenantId,
+    binding_identity: BindingIdentity,
+}
+
+#[derive(Deserialize, Serialize)]
+struct AgentRecord {
+    id: AgentId,
+    spec: AgentSpec,
+    composes_native_output_with_tools: bool,
+}
+
+#[derive(Deserialize, Serialize)]
+struct CapabilityRecord {
+    node: CapabilityNode,
+    binding_identity: Option<BindingIdentity>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct RunRecord {
+    id: RunId,
+    agent_id: AgentId,
+    model_id: ModelId,
+    tenant_id: TenantId,
+    generation: Generation,
+    phase: RunPhase,
+    streaming: crate::StreamingMode,
+    created_tick: u64,
+    transcript: CanonicalTranscript,
+    accounting: RunAccounting,
+    terminal: Option<TerminalState>,
+    observation: Option<TerminalObservation>,
+    memory: Option<MemoryRecord>,
+    structured: Option<StructuredRecord>,
+    feedback: Vec<String>,
+    response_retries: usize,
+    invalid_tool_retries: usize,
+    turn_snapshot: Option<TurnSnapshotRecord>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct MemoryRecord {
+    memory_id: MemoryId,
+    conversation_id: String,
+    loaded: bool,
+    appended: bool,
+}
+
+#[derive(Deserialize, Serialize)]
+struct StructuredRecord {
+    schema: schemars::Schema,
+    policy: crate::StructuredOutputPolicy,
+    resolved_mode: crate::OutputMode,
+    output_tool_name: Option<String>,
+    retries: usize,
+    value: Option<serde_json::Value>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct TurnSnapshotRecord {
+    entries: Vec<AdvertisedCapability>,
+    output_tool_name: Option<String>,
+}
+
+impl LocalRuntime {
+    /// Serialize metadata-only stable domain records with caller-supplied protection.
+    pub fn protected_snapshot(
+        &self,
+        protector: &dyn SnapshotProtector,
+    ) -> Result<ProtectedSnapshot, SnapshotError> {
+        self.protected_snapshot_with_policy(protector, SnapshotContentPolicy::MetadataOnly)
+    }
+
+    /// Serialize stable domain records under an explicit content-retention policy.
+    pub fn protected_snapshot_with_policy(
+        &self,
+        protector: &dyn SnapshotProtector,
+        content_policy: SnapshotContentPolicy,
+    ) -> Result<ProtectedSnapshot, SnapshotError> {
+        let mut runs = Vec::new();
+        let run_entities = if matches!(content_policy, SnapshotContentPolicy::CanonicalRunState) {
+            self.world
+                .resource::<TopologyIndex>()
+                .runs
+                .values()
+                .copied()
+                .collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        };
+        for entity in run_entities {
+            let run = self.world.get::<RunNode>(entity).ok_or_else(|| {
+                SnapshotError::InvalidRelationship("missing run node".to_string())
+            })?;
+            if !matches!(run.phase, RunPhase::ReadyModel | RunPhase::Terminal)
+                || self
+                    .world
+                    .get::<ActiveOperations>(entity)
+                    .is_some_and(|operations| operations.0.values().any(|op| !op.completed))
+                || self.world.entity(entity).contains::<EffectQueueWait>()
+            {
+                return Err(SnapshotError::NotQuiescent);
+            }
+            let transcript = self
+                .world
+                .get::<CanonicalTranscript>(entity)
+                .cloned()
+                .ok_or_else(|| {
+                    SnapshotError::InvalidRelationship("missing transcript".to_string())
+                })?;
+            // Persist-side twin of the restore-side check: a snapshot that
+            // restore would refuse must fail here, at save time.
+            if let Err(error) = validate_canonical_transcript(&transcript.messages) {
+                return Err(SnapshotError::InvalidRelationship(format!(
+                    "run `{}` has a non-canonical transcript: {error}",
+                    run.id
+                )));
+            }
+            let accounting = self
+                .world
+                .get::<RunAccounting>(entity)
+                .cloned()
+                .ok_or_else(|| {
+                    SnapshotError::InvalidRelationship("missing accounting".to_string())
+                })?;
+            let memory = self
+                .world
+                .get::<MemoryProgress>(entity)
+                .map(|memory| MemoryRecord {
+                    memory_id: memory.memory_id,
+                    conversation_id: memory.conversation_id.clone(),
+                    loaded: memory.loaded,
+                    appended: memory.appended,
+                });
+            let structured = self
+                .world
+                .get::<StructuredOutputState>(entity)
+                .map(|state| StructuredRecord {
+                    schema: state.schema.clone(),
+                    policy: state.policy.clone(),
+                    resolved_mode: state.resolved_mode,
+                    output_tool_name: state.output_tool_name.clone(),
+                    retries: state.retries,
+                    value: state.value.clone(),
+                });
+            runs.push(RunRecord {
+                id: run.id,
+                agent_id: run.agent_id,
+                model_id: run.model_id,
+                tenant_id: run.tenant_id,
+                generation: run.generation,
+                phase: run.phase,
+                streaming: run.streaming,
+                created_tick: run.created_tick,
+                transcript,
+                accounting,
+                terminal: self.world.get::<TerminalState>(entity).cloned(),
+                observation: self.world.get::<TerminalObservation>(entity).cloned(),
+                memory,
+                structured,
+                feedback: self
+                    .world
+                    .get::<RecoveryFeedback>(entity)
+                    .map(|feedback| feedback.0.clone())
+                    .unwrap_or_default(),
+                response_retries: self
+                    .world
+                    .get::<ResponseRetryState>(entity)
+                    .map_or(0, |state| state.0),
+                invalid_tool_retries: self
+                    .world
+                    .get::<InvalidToolRetryState>(entity)
+                    .map_or(0, |state| state.0),
+                turn_snapshot: self
+                    .world
+                    .get::<TurnCapabilitySnapshot>(entity)
+                    .map(|snapshot| TurnSnapshotRecord {
+                        entries: snapshot.entries.clone(),
+                        output_tool_name: snapshot.output_tool_name.clone(),
+                    }),
+            });
+        }
+        runs.sort_by_key(|run| run.id);
+
+        let mut agents = self
+            .world
+            .resource::<TopologyIndex>()
+            .agents
+            .values()
+            .filter_map(|entity| self.world.get::<AgentNode>(*entity))
+            .map(|agent| {
+                if agent.spec.additional_params.is_some() {
+                    return Err(SnapshotError::NonPersistableProviderParameters(agent.id));
+                }
+                let mut spec = agent.spec.clone();
+                spec.additional_params = None;
+                if matches!(content_policy, SnapshotContentPolicy::MetadataOnly) {
+                    if spec.memory_id.is_some() {
+                        return Err(SnapshotError::MetadataOnlyMemory(agent.id));
+                    }
+                    if spec.preamble.is_some() {
+                        return Err(SnapshotError::MetadataOnlyPreamble(agent.id));
+                    }
+                    spec.name = None;
+                    spec.preamble = None;
+                    spec.memory_id = None;
+                    spec.conversation_id = None;
+                    spec.record_telemetry_content = false;
+                }
+                Ok(AgentRecord {
+                    id: agent.id,
+                    spec,
+                    composes_native_output_with_tools: agent.composes_native_output_with_tools,
+                })
+            })
+            .collect::<Result<Vec<_>, SnapshotError>>()?;
+        agents.sort_by_key(|agent| agent.id);
+
+        let mut capabilities = self
+            .world
+            .resource::<TopologyIndex>()
+            .capabilities
+            .values()
+            .filter_map(|entity| self.world.get::<CapabilityNode>(*entity))
+            .map(|node| {
+                let binding_identity = if self.tools.contains_key(&node.id) {
+                    Some(*self.tool_binding_identities.get(&node.id).ok_or_else(|| {
+                        SnapshotError::MissingBindingIdentity {
+                            id: node.id.to_string(),
+                            kind: "capability",
+                        }
+                    })?)
+                } else {
+                    None
+                };
+                Ok(CapabilityRecord {
+                    node: node.clone(),
+                    binding_identity,
+                })
+            })
+            .collect::<Result<Vec<_>, SnapshotError>>()?;
+        capabilities.sort_by_key(|record| record.node.id);
+
+        let mut grants = self
+            .world
+            .resource::<TopologyIndex>()
+            .grants
+            .values()
+            .filter_map(|entity| self.world.get::<GrantNode>(*entity).cloned())
+            .collect::<Vec<_>>();
+        grants.sort_by_key(|grant| grant.id);
+
+        let referenced_models = agents
+            .iter()
+            .map(|agent| agent.spec.model_id)
+            .chain(runs.iter().map(|run| run.model_id))
+            .collect::<BTreeSet<_>>();
+        let referenced_memories = agents
+            .iter()
+            .filter_map(|agent| agent.spec.memory_id)
+            .chain(
+                runs.iter()
+                    .filter_map(|run| run.memory.as_ref().map(|memory| memory.memory_id)),
+            )
+            .collect::<BTreeSet<_>>();
+        let mut model_bindings = referenced_models
+            .iter()
+            .map(|id| {
+                if !self.models.contains_key(id) {
+                    return Err(SnapshotError::MissingModel(*id));
+                }
+                Ok(BindingRecord {
+                    id: *id,
+                    tenant_id: *self.model_tenants.get(id).ok_or_else(|| {
+                        SnapshotError::InvalidRelationship(format!(
+                            "model binding `{id}` has no tenant owner"
+                        ))
+                    })?,
+                    binding_identity: *self.model_binding_identities.get(id).ok_or_else(|| {
+                        SnapshotError::MissingBindingIdentity {
+                            id: id.to_string(),
+                            kind: "model",
+                        }
+                    })?,
+                })
+            })
+            .collect::<Result<Vec<_>, SnapshotError>>()?;
+        model_bindings.sort_by_key(|binding| binding.id);
+        let mut memory_bindings = referenced_memories
+            .iter()
+            .map(|id| {
+                if !self.memories.contains_key(id) {
+                    return Err(SnapshotError::MissingMemory(*id));
+                }
+                Ok(BindingRecord {
+                    id: *id,
+                    tenant_id: *self.memory_tenants.get(id).ok_or_else(|| {
+                        SnapshotError::InvalidRelationship(format!(
+                            "memory binding `{id}` has no tenant owner"
+                        ))
+                    })?,
+                    binding_identity: *self.memory_binding_identities.get(id).ok_or_else(|| {
+                        SnapshotError::MissingBindingIdentity {
+                            id: id.to_string(),
+                            kind: "memory",
+                        }
+                    })?,
+                })
+            })
+            .collect::<Result<Vec<_>, SnapshotError>>()?;
+        memory_bindings.sort_by_key(|binding| binding.id);
+
+        let plaintext = serde_json::to_vec(&DomainSnapshot {
+            version: SNAPSHOT_VERSION,
+            content_policy,
+            runtime_tick: self.world.resource::<RuntimeTick>().0,
+            agents,
+            capabilities,
+            grants,
+            runs,
+            model_bindings,
+            memory_bindings,
+        })?;
+        let payload = protector.protect(&plaintext)?;
+        let protected_digest = Sha256::digest(&payload).into();
+        Ok(ProtectedSnapshot {
+            version: SNAPSHOT_VERSION,
+            protector_id: protector.protector_id().to_string(),
+            payload,
+            protected_digest,
+        })
+    }
+
+    /// Restore stable ECS domain state into a new runtime identity after exact rebinding.
+    pub fn restore(
+        config: RuntimeConfig,
+        protected: &ProtectedSnapshot,
+        protector: &dyn SnapshotProtector,
+        mut bindings: RebindRegistry,
+    ) -> Result<Self, RuntimeError> {
+        if protected.version != SNAPSHOT_VERSION {
+            return Err(SnapshotError::UnsupportedVersion(protected.version).into());
+        }
+        if protected.protector_id != protector.protector_id() {
+            return Err(SnapshotError::Unprotect(
+                "snapshot protector identifier does not match".to_string(),
+            )
+            .into());
+        }
+        let digest: [u8; 32] = Sha256::digest(&protected.payload).into();
+        if digest != protected.protected_digest {
+            return Err(SnapshotError::Integrity.into());
+        }
+        let plaintext = protector.unprotect(&protected.payload)?;
+        let snapshot: DomainSnapshot =
+            serde_json::from_slice(&plaintext).map_err(SnapshotError::Serialization)?;
+        if snapshot.version != SNAPSHOT_VERSION {
+            return Err(SnapshotError::UnsupportedVersion(snapshot.version).into());
+        }
+        validate_snapshot(&snapshot, &bindings)?;
+        let mut runtime = Self::with_config(config)?;
+        runtime.world.resource_mut::<RuntimeTick>().0 = snapshot.runtime_tick;
+        runtime.models = std::mem::take(&mut bindings.models);
+        runtime.tools = std::mem::take(&mut bindings.tools);
+        runtime.memories = std::mem::take(&mut bindings.memories);
+        runtime.model_tenants = std::mem::take(&mut bindings.model_tenants);
+        runtime.memory_tenants = std::mem::take(&mut bindings.memory_tenants);
+        runtime.model_binding_identities = std::mem::take(&mut bindings.model_binding_identities);
+        runtime.tool_binding_identities = std::mem::take(&mut bindings.tool_binding_identities);
+        runtime.memory_binding_identities = std::mem::take(&mut bindings.memory_binding_identities);
+
+        for agent in snapshot.agents {
+            let entity = runtime
+                .world
+                .spawn(AgentNode {
+                    id: agent.id,
+                    spec: agent.spec,
+                    composes_native_output_with_tools: agent.composes_native_output_with_tools,
+                })
+                .id();
+            runtime
+                .world
+                .resource_mut::<TopologyIndex>()
+                .agents
+                .insert(agent.id, entity);
+        }
+        for capability in snapshot.capabilities {
+            let id = capability.node.id;
+            let entity = runtime.world.spawn(capability.node).id();
+            runtime
+                .world
+                .resource_mut::<TopologyIndex>()
+                .capabilities
+                .insert(id, entity);
+        }
+        for grant in snapshot.grants {
+            let id = grant.id;
+            let entity = runtime.world.spawn(grant).id();
+            runtime
+                .world
+                .resource_mut::<TopologyIndex>()
+                .grants
+                .insert(id, entity);
+        }
+        for run in snapshot.runs {
+            let run_id = run.id;
+            if !runtime
+                .world
+                .resource::<TopologyIndex>()
+                .agents
+                .contains_key(&run.agent_id)
+            {
+                return Err(SnapshotError::InvalidRelationship(format!(
+                    "run `{}` references missing agent `{}`",
+                    run.id, run.agent_id
+                ))
+                .into());
+            }
+            let generation = run.generation.next();
+            let run_span = tracing::info_span!(
+                target: "rig::ecs",
+                "rig.ecs.run",
+                run.id = %run.id,
+                run.generation = generation.0,
+                run.streaming = ?run.streaming,
+                run.tenant = "<redacted>",
+                restored = true,
+            );
+            let validation = TranscriptValidator::over(&run.transcript.messages)
+                .map(TranscriptValidation)
+                .map_err(|error| {
+                    SnapshotError::InvalidRelationship(format!(
+                        "run `{}` has a non-canonical transcript: {error}",
+                        run.id
+                    ))
+                })?;
+            let mut entity = runtime.world.spawn((
+                RunNode {
+                    id: run.id,
+                    agent_id: run.agent_id,
+                    model_id: run.model_id,
+                    tenant_id: run.tenant_id,
+                    generation,
+                    phase: run.phase,
+                    streaming: run.streaming,
+                    created_tick: run.created_tick,
+                },
+                run.transcript,
+                validation,
+                run.accounting,
+                ActiveOperations::default(),
+                AcceptedDeltas::default(),
+                RecoveryFeedback(run.feedback),
+                ResponseRetryState(run.response_retries),
+                InvalidToolRetryState(run.invalid_tool_retries),
+                RunEvents::new(runtime.config.event_capacity),
+                RunProgress::default(),
+                RunTelemetrySpan(run_span),
+            ));
+            if let Some(mut terminal) = run.terminal {
+                if run.observation.is_none() {
+                    // Restoring renews the retention lease for runs nobody has
+                    // observed yet — the snapshot was taken to preserve them.
+                    terminal.terminal_tick = snapshot.runtime_tick;
+                }
+                entity.insert(terminal);
+            }
+            if let Some(observation) = run.observation {
+                entity.insert(observation);
+            }
+            if let Some(memory) = run.memory {
+                entity.insert(MemoryProgress {
+                    memory_id: memory.memory_id,
+                    conversation_id: memory.conversation_id,
+                    loaded: memory.loaded,
+                    appended: memory.appended,
+                });
+            }
+            if let Some(structured) = run.structured {
+                entity.insert(StructuredOutputState {
+                    schema: structured.schema,
+                    policy: structured.policy,
+                    resolved_mode: structured.resolved_mode,
+                    output_tool_name: structured.output_tool_name,
+                    retries: structured.retries,
+                    value: structured.value,
+                });
+            }
+            let referenced_capabilities = run
+                .turn_snapshot
+                .as_ref()
+                .map(|snapshot| {
+                    snapshot
+                        .entries
+                        .iter()
+                        .map(|entry| entry.capability_id)
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            if let Some(snapshot) = run.turn_snapshot {
+                entity.insert(TurnCapabilitySnapshot {
+                    entries: snapshot.entries,
+                    output_tool_name: snapshot.output_tool_name,
+                });
+            }
+            let run_entity = entity.id();
+            for capability_id in referenced_capabilities {
+                runtime
+                    .world
+                    .resource_mut::<CapabilityReferences>()
+                    .0
+                    .entry(capability_id)
+                    .or_default()
+                    .insert(run_id);
+            }
+            runtime
+                .world
+                .resource_mut::<TopologyIndex>()
+                .runs
+                .insert(run_id, run_entity);
+        }
+        Ok(runtime)
+    }
+}
+
+fn validate_snapshot(
+    snapshot: &DomainSnapshot,
+    bindings: &RebindRegistry,
+) -> Result<(), SnapshotError> {
+    if snapshot
+        .agents
+        .iter()
+        .any(|agent| agent.spec.additional_params.is_some())
+    {
+        return Err(SnapshotError::InvalidRelationship(
+            "snapshot contains prohibited provider parameters".to_string(),
+        ));
+    }
+    if matches!(snapshot.content_policy, SnapshotContentPolicy::MetadataOnly)
+        && (!snapshot.runs.is_empty()
+            || snapshot.agents.iter().any(|agent| {
+                agent.spec.name.is_some()
+                    || agent.spec.preamble.is_some()
+                    || agent.spec.memory_id.is_some()
+                    || agent.spec.conversation_id.is_some()
+                    || agent.spec.additional_params.is_some()
+                    || agent.spec.record_telemetry_content
+            }))
+    {
+        return Err(SnapshotError::InvalidRelationship(
+            "metadata-only snapshot contains prohibited run or agent content".to_string(),
+        ));
+    }
+    let mut model_records = BTreeMap::new();
+    for expected in &snapshot.model_bindings {
+        if model_records.insert(expected.id, expected).is_some() {
+            return Err(SnapshotError::InvalidRelationship(format!(
+                "duplicate model binding record `{}`",
+                expected.id
+            )));
+        }
+        if !bindings.models.contains_key(&expected.id) {
+            return Err(SnapshotError::MissingModel(expected.id));
+        }
+        if bindings.model_tenants.get(&expected.id) != Some(&expected.tenant_id)
+            || bindings.model_binding_identities.get(&expected.id)
+                != Some(&expected.binding_identity)
+        {
+            return Err(SnapshotError::BindingMismatch {
+                id: expected.id.to_string(),
+                kind: "model",
+            });
+        }
+    }
+
+    let mut memory_records = BTreeMap::new();
+    for expected in &snapshot.memory_bindings {
+        if memory_records.insert(expected.id, expected).is_some() {
+            return Err(SnapshotError::InvalidRelationship(format!(
+                "duplicate memory binding record `{}`",
+                expected.id
+            )));
+        }
+        if !bindings.memories.contains_key(&expected.id) {
+            return Err(SnapshotError::MissingMemory(expected.id));
+        }
+        if bindings.memory_tenants.get(&expected.id) != Some(&expected.tenant_id)
+            || bindings.memory_binding_identities.get(&expected.id)
+                != Some(&expected.binding_identity)
+        {
+            return Err(SnapshotError::BindingMismatch {
+                id: expected.id.to_string(),
+                kind: "memory",
+            });
+        }
+    }
+
+    let mut agents = BTreeMap::new();
+    for agent in &snapshot.agents {
+        if agents.insert(agent.id, agent).is_some() {
+            return Err(SnapshotError::InvalidRelationship(format!(
+                "duplicate agent `{}`",
+                agent.id
+            )));
+        }
+        if !model_records.contains_key(&agent.spec.model_id) {
+            return Err(SnapshotError::MissingModel(agent.spec.model_id));
+        }
+        if model_records
+            .get(&agent.spec.model_id)
+            .is_none_or(|record| record.tenant_id != agent.spec.tenant_id)
+        {
+            return Err(SnapshotError::InvalidRelationship(format!(
+                "agent `{}` crosses its model binding tenant boundary",
+                agent.id
+            )));
+        }
+        let model = bindings
+            .models
+            .get(&agent.spec.model_id)
+            .ok_or(SnapshotError::MissingModel(agent.spec.model_id))?;
+        if model.composes_native_output_with_tools() != agent.composes_native_output_with_tools {
+            return Err(SnapshotError::BindingMismatch {
+                id: agent.spec.model_id.to_string(),
+                kind: "model capability",
+            });
+        }
+        if let Some(memory_id) = agent.spec.memory_id {
+            if !memory_records.contains_key(&memory_id) {
+                return Err(SnapshotError::MissingMemory(memory_id));
+            }
+            if memory_records
+                .get(&memory_id)
+                .is_none_or(|record| record.tenant_id != agent.spec.tenant_id)
+            {
+                return Err(SnapshotError::InvalidRelationship(format!(
+                    "agent `{}` crosses its memory binding tenant boundary",
+                    agent.id
+                )));
+            }
+            if agent.spec.conversation_id.is_none() {
+                return Err(SnapshotError::InvalidRelationship(format!(
+                    "agent `{}` configures memory without a conversation identifier",
+                    agent.id
+                )));
+            }
+        } else if agent.spec.conversation_id.is_some() {
+            return Err(SnapshotError::InvalidRelationship(format!(
+                "agent `{}` configures a conversation identifier without memory",
+                agent.id
+            )));
+        }
+    }
+
+    let mut capabilities = BTreeMap::new();
+    for capability in &snapshot.capabilities {
+        if capabilities
+            .insert(capability.node.id, capability)
+            .is_some()
+        {
+            return Err(SnapshotError::InvalidRelationship(format!(
+                "duplicate capability `{}`",
+                capability.node.id
+            )));
+        }
+        if let Some(expected) = capability.binding_identity {
+            let actual = bindings
+                .tools
+                .get(&capability.node.id)
+                .ok_or(SnapshotError::MissingCapability(capability.node.id))?;
+            if bindings.tool_binding_identities.get(&capability.node.id) != Some(&expected)
+                || bindings.tool_kinds.get(&capability.node.id) != Some(&capability.node.kind)
+                || capability.node.definition.as_ref() != Some(&actual.definition())
+            {
+                return Err(SnapshotError::BindingMismatch {
+                    id: capability.node.id.to_string(),
+                    kind: "capability",
+                });
+            }
+        } else if matches!(
+            capability.node.kind,
+            crate::CapabilityKind::Tool | crate::CapabilityKind::Store
+        ) {
+            return Err(SnapshotError::MissingCapability(capability.node.id));
+        }
+    }
+
+    let mut grants = BTreeMap::new();
+    for grant in &snapshot.grants {
+        if grants.insert(grant.id, grant).is_some() {
+            return Err(SnapshotError::InvalidRelationship(format!(
+                "duplicate grant `{}`",
+                grant.id
+            )));
+        }
+        let agent = agents.get(&grant.agent_id).ok_or_else(|| {
+            SnapshotError::InvalidRelationship(format!(
+                "grant `{}` references missing agent `{}`",
+                grant.id, grant.agent_id
+            ))
+        })?;
+        let capability = capabilities.get(&grant.capability_id).ok_or_else(|| {
+            SnapshotError::InvalidRelationship(format!(
+                "grant `{}` references missing capability `{}`",
+                grant.id, grant.capability_id
+            ))
+        })?;
+        if grant.tenant_id != agent.spec.tenant_id || grant.tenant_id != capability.node.tenant_id {
+            return Err(SnapshotError::InvalidRelationship(format!(
+                "grant `{}` crosses a tenant ownership boundary",
+                grant.id
+            )));
+        }
+    }
+
+    let mut active_tool_names = BTreeSet::new();
+    for grant in grants.values().copied().filter(|grant| !grant.revoked) {
+        let Some(capability) = capabilities.get(&grant.capability_id) else {
+            continue;
+        };
+        if capability.node.retired {
+            continue;
+        }
+        let Some(definition) = capability.node.definition.as_ref() else {
+            continue;
+        };
+        if !active_tool_names.insert((grant.agent_id, definition.name.clone())) {
+            return Err(SnapshotError::InvalidRelationship(format!(
+                "agent `{}` has duplicate active capability name `{}`",
+                grant.agent_id, definition.name
+            )));
+        }
+    }
+
+    let mut runs = BTreeSet::new();
+    for run in &snapshot.runs {
+        if !runs.insert(run.id) {
+            return Err(SnapshotError::InvalidRelationship(format!(
+                "duplicate run `{}`",
+                run.id
+            )));
+        }
+        if !matches!(run.phase, RunPhase::ReadyModel | RunPhase::Terminal) {
+            return Err(SnapshotError::InvalidRelationship(format!(
+                "run `{}` is not at a quiescent persistence phase",
+                run.id
+            )));
+        }
+        if run.transcript.new_messages_start > run.transcript.messages.len() {
+            return Err(SnapshotError::InvalidRelationship(format!(
+                "run `{}` has an out-of-range new-message boundary",
+                run.id
+            )));
+        }
+        if let Err(error) = validate_canonical_transcript(&run.transcript.messages) {
+            return Err(SnapshotError::InvalidRelationship(format!(
+                "run `{}` has a non-canonical transcript: {error}",
+                run.id
+            )));
+        }
+        if run.accounting.model_calls_dispatched < run.accounting.model_calls.len() {
+            return Err(SnapshotError::InvalidRelationship(format!(
+                "run `{}` records more completed model calls than dispatches",
+                run.id
+            )));
+        }
+        let mut operation_ids = BTreeSet::new();
+        let mut recorded_usage = rig_core::completion::Usage::new();
+        for call in &run.accounting.model_calls {
+            if !operation_ids.insert(call.operation_id) {
+                return Err(SnapshotError::InvalidRelationship(format!(
+                    "run `{}` has duplicate model-call operation identities",
+                    run.id
+                )));
+            }
+            recorded_usage = checked_usage_sum(recorded_usage, call.usage).ok_or_else(|| {
+                SnapshotError::InvalidRelationship(format!(
+                    "run `{}` has overflowing model-call usage",
+                    run.id
+                ))
+            })?;
+        }
+        if recorded_usage != run.accounting.usage {
+            return Err(SnapshotError::InvalidRelationship(format!(
+                "run `{}` aggregate usage does not match its model-call records",
+                run.id
+            )));
+        }
+        let agent = agents.get(&run.agent_id).ok_or_else(|| {
+            SnapshotError::InvalidRelationship(format!(
+                "run `{}` references missing agent `{}`",
+                run.id, run.agent_id
+            ))
+        })?;
+        if run.model_id != agent.spec.model_id || !model_records.contains_key(&run.model_id) {
+            return Err(SnapshotError::InvalidRelationship(format!(
+                "run `{}` does not use its agent's rebound model",
+                run.id
+            )));
+        }
+        if run.tenant_id != agent.spec.tenant_id {
+            return Err(SnapshotError::InvalidRelationship(format!(
+                "run `{}` crosses its agent's tenant boundary",
+                run.id
+            )));
+        }
+        if run.accounting.model_calls_dispatched > agent.spec.max_model_calls {
+            return Err(SnapshotError::InvalidRelationship(format!(
+                "run `{}` exceeds its agent's model-call budget",
+                run.id
+            )));
+        }
+        match (&run.structured, &agent.spec.structured_output) {
+            (Some(structured), Some((schema, policy)))
+                if structured.schema == *schema && structured.policy == *policy =>
+            {
+                if structured.retries > policy.max_retries {
+                    return Err(SnapshotError::InvalidRelationship(format!(
+                        "run `{}` exceeds its structured-output retry policy",
+                        run.id
+                    )));
+                }
+                let output_tool_consistent =
+                    matches!(structured.resolved_mode, crate::OutputMode::Tool)
+                        == structured.output_tool_name.is_some();
+                let resolution_consistent = match policy.mode {
+                    crate::OutputMode::Auto => matches!(
+                        structured.resolved_mode,
+                        crate::OutputMode::Auto
+                            | crate::OutputMode::Native
+                            | crate::OutputMode::Tool
+                    ),
+                    crate::OutputMode::Native => matches!(
+                        structured.resolved_mode,
+                        crate::OutputMode::Auto | crate::OutputMode::Native
+                    ),
+                    crate::OutputMode::Prompted => matches!(
+                        structured.resolved_mode,
+                        crate::OutputMode::Auto | crate::OutputMode::Prompted
+                    ),
+                    crate::OutputMode::Tool => matches!(
+                        structured.resolved_mode,
+                        crate::OutputMode::Auto
+                            | crate::OutputMode::Native
+                            | crate::OutputMode::Tool
+                    ),
+                };
+                if !output_tool_consistent || !resolution_consistent {
+                    return Err(SnapshotError::InvalidRelationship(format!(
+                        "run `{}` has inconsistent structured-output resolution state",
+                        run.id
+                    )));
+                }
+                if let Some(value) = &structured.value {
+                    let schema_valid = jsonschema::validator_for(structured.schema.as_value())
+                        .is_ok_and(|validator| validator.is_valid(value));
+                    let completed = run.terminal.as_ref().is_some_and(|terminal| {
+                        matches!(terminal.reason, crate::TerminalReason::Completed)
+                    });
+                    if !matches!(run.phase, RunPhase::Terminal) || !completed || !schema_valid {
+                        return Err(SnapshotError::InvalidRelationship(format!(
+                            "run `{}` has an invalid structured-output value",
+                            run.id
+                        )));
+                    }
+                }
+            }
+            (None, None) => {}
+            _ => {
+                return Err(SnapshotError::InvalidRelationship(format!(
+                    "run `{}` does not preserve its agent's structured-output policy",
+                    run.id
+                )));
+            }
+        }
+        let response_retry_limit = match agent.spec.response_retry_policy {
+            crate::ResponseRetryPolicy::Accept => 0,
+            crate::ResponseRetryPolicy::RejectEmpty { max_retries } => max_retries,
+        };
+        if run.response_retries > response_retry_limit {
+            return Err(SnapshotError::InvalidRelationship(format!(
+                "run `{}` exceeds its response retry policy",
+                run.id
+            )));
+        }
+        let invalid_tool_retry_limit = match agent.spec.invalid_tool_policy {
+            crate::InvalidToolPolicy::Retry { max_retries } => max_retries,
+            crate::InvalidToolPolicy::Fail
+            | crate::InvalidToolPolicy::Repair
+            | crate::InvalidToolPolicy::Skip
+            | crate::InvalidToolPolicy::Stop => 0,
+        };
+        if run.invalid_tool_retries > invalid_tool_retry_limit {
+            return Err(SnapshotError::InvalidRelationship(format!(
+                "run `{}` exceeds its invalid-tool retry policy",
+                run.id
+            )));
+        }
+        if matches!(run.phase, RunPhase::Terminal) != run.terminal.is_some() {
+            return Err(SnapshotError::InvalidRelationship(format!(
+                "run `{}` has inconsistent terminal state",
+                run.id
+            )));
+        }
+        if run.observation.is_some() && run.terminal.is_none() {
+            return Err(SnapshotError::InvalidRelationship(format!(
+                "run `{}` was observed before becoming terminal",
+                run.id
+            )));
+        }
+        if run
+            .terminal
+            .as_ref()
+            .is_some_and(|terminal| terminal.terminal_tick < run.created_tick)
+            || run.observation.as_ref().is_some_and(|observation| {
+                run.terminal
+                    .as_ref()
+                    .is_some_and(|terminal| observation.observed_tick < terminal.terminal_tick)
+            })
+        {
+            return Err(SnapshotError::InvalidRelationship(format!(
+                "run `{}` has out-of-order lifecycle ticks",
+                run.id
+            )));
+        }
+        if run.created_tick > snapshot.runtime_tick
+            || run
+                .terminal
+                .as_ref()
+                .is_some_and(|terminal| terminal.terminal_tick > snapshot.runtime_tick)
+            || run
+                .observation
+                .as_ref()
+                .is_some_and(|observation| observation.observed_tick > snapshot.runtime_tick)
+        {
+            return Err(SnapshotError::InvalidRelationship(format!(
+                "run `{}` has lifecycle ticks ahead of the snapshot runtime tick",
+                run.id
+            )));
+        }
+        match (
+            &run.memory,
+            agent.spec.memory_id,
+            &agent.spec.conversation_id,
+        ) {
+            (Some(memory), Some(memory_id), Some(conversation_id))
+                if memory.memory_id == memory_id
+                    && memory.conversation_id == *conversation_id
+                    && memory_records.contains_key(&memory.memory_id) =>
+            {
+                // A run may legitimately fail or be cancelled before its
+                // memory load succeeds; only those terminals may be unloaded.
+                let must_have_loaded = memory.appended
+                    || run.terminal.as_ref().is_none_or(|terminal| {
+                        matches!(terminal.reason, crate::TerminalReason::Completed)
+                    });
+                if (!memory.loaded && must_have_loaded)
+                    || (!matches!(run.phase, RunPhase::Terminal) && memory.appended)
+                    || (memory.appended
+                        && run.terminal.as_ref().is_none_or(|terminal| {
+                            !matches!(terminal.reason, crate::TerminalReason::Completed)
+                        }))
+                {
+                    return Err(SnapshotError::InvalidRelationship(format!(
+                        "run `{}` has inconsistent conversation memory lifecycle flags",
+                        run.id
+                    )));
+                }
+            }
+            (None, None, None) => {}
+            _ => {
+                return Err(SnapshotError::InvalidRelationship(format!(
+                    "run `{}` has inconsistent conversation memory topology",
+                    run.id
+                )));
+            }
+        }
+        if let Some(turn) = &run.turn_snapshot {
+            let mut entries = BTreeSet::new();
+            for entry in &turn.entries {
+                if !entries.insert((entry.capability_id, entry.grant_id, entry.revision)) {
+                    return Err(SnapshotError::InvalidRelationship(format!(
+                        "run `{}` has a duplicate advertised capability",
+                        run.id
+                    )));
+                }
+                let capability = capabilities.get(&entry.capability_id).ok_or_else(|| {
+                    SnapshotError::InvalidRelationship(format!(
+                        "run `{}` snapshots missing capability `{}`",
+                        run.id, entry.capability_id
+                    ))
+                })?;
+                let grant = grants.get(&entry.grant_id).ok_or_else(|| {
+                    SnapshotError::InvalidRelationship(format!(
+                        "run `{}` snapshots missing grant `{}`",
+                        run.id, entry.grant_id
+                    ))
+                })?;
+                if capability.node.tenant_id != run.tenant_id
+                    || capability.node.revision != entry.revision
+                    || capability.node.definition.as_ref() != Some(&entry.definition)
+                    || grant.agent_id != run.agent_id
+                    || grant.capability_id != entry.capability_id
+                    || grant.tenant_id != run.tenant_id
+                {
+                    return Err(SnapshotError::InvalidRelationship(format!(
+                        "run `{}` has a mismatched advertised capability snapshot",
+                        run.id
+                    )));
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/rig-ecs/src/policy.rs
+++ b/crates/rig-ecs/src/policy.rs
@@ -1,0 +1,69 @@
+//! ECS-native policy values interpreted by ordered runtime systems.
+
+use serde::{Deserialize, Serialize};
+
+/// Policy applied when a model requests a tool outside its immutable turn
+/// snapshot, or emits duplicate tool-call identities within one turn.
+///
+/// Duplicate identities are handled here because they can never commit to the
+/// canonical transcript; under [`InvalidToolPolicy::Skip`] each repeat is
+/// dropped and only the first occurrence executes. This deliberately diverges
+/// from the classic runtime, which executes duplicate-identity calls as-is.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
+pub enum InvalidToolPolicy {
+    /// Fail the run immediately.
+    #[default]
+    Fail,
+    /// Re-prompt the model with corrective feedback up to the configured bound.
+    ///
+    /// Unadvertised-tool and duplicate-identity recoveries share one retry
+    /// budget per run: a turn recovered for either defect kind consumes an
+    /// attempt from the same counter.
+    Retry {
+        /// Maximum invalid-call recovery attempts.
+        max_retries: usize,
+    },
+    /// Repair a case-insensitive, unambiguous tool-name mismatch.
+    Repair,
+    /// Commit a paired error result without executing the suppressed call.
+    Skip,
+    /// Stop the run without executing or committing the invalid call.
+    Stop,
+}
+
+/// How structured output is requested from the provider.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[non_exhaustive]
+pub enum OutputMode {
+    /// Select native output when it composes with tools, otherwise use a synthetic tool.
+    #[default]
+    Auto,
+    /// Apply the provider-native output schema.
+    Native,
+    /// Advertise a collision-safe synthetic terminal output tool.
+    Tool,
+    /// Add a schema instruction to the request without a provider constraint.
+    Prompted,
+}
+
+/// Bounded validation and recovery policy for structured output.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct StructuredOutputPolicy {
+    /// Selected output enforcement mode.
+    pub mode: OutputMode,
+    /// Maximum corrective model calls after invalid structured output.
+    pub max_retries: usize,
+    /// Commit the last canonical assistant response when recovery is exhausted.
+    pub best_effort: bool,
+}
+
+impl Default for StructuredOutputPolicy {
+    fn default() -> Self {
+        Self {
+            mode: OutputMode::Auto,
+            max_retries: 2,
+            best_effort: false,
+        }
+    }
+}

--- a/crates/rig-ecs/src/prelude.rs
+++ b/crates/rig-ecs/src/prelude.rs
@@ -1,0 +1,9 @@
+//! Convenient imports for the experimental ECS runtime.
+
+pub use crate::{
+    AgentSpec, BindingIdentity, ContentVisibility, EcsAgentBuilder, EcsClientExt, EcsModelExt,
+    HostedRuntime, InvalidToolPolicy, LocalRuntime, OutputMode, RebindRegistry,
+    ResponseRetryPolicy, RunHandle, RuntimeConfig, SnapshotContentPolicy, SnapshotProtector,
+    StreamingMode, StructuredOutputPolicy, ToolGrant,
+};
+pub use rig_core::{completion::CompletionModel, tool::PortableTool};

--- a/crates/rig-ecs/src/runtime.rs
+++ b/crates/rig-ecs/src/runtime.rs
@@ -1,0 +1,2873 @@
+//! Local and hosted drivers over the same authoritative ECS schedule.
+
+use std::{
+    any::Any,
+    collections::{BTreeMap, BTreeSet, HashMap},
+    fmt,
+    future::Future,
+    marker::PhantomData,
+    pin::Pin,
+    sync::{Arc, Mutex, MutexGuard},
+};
+
+use bevy_ecs::{prelude::*, schedule::Schedule};
+use futures::StreamExt;
+use rig_core::{
+    client::CompletionClient,
+    completion::{CompletionModel, CompletionRequest, Message},
+    memory::ConversationMemory,
+    message::ToolChoice,
+    streaming::StreamedAssistantContent,
+    tool::{
+        IntoToolOutput, PortableDynamicTool, PortableTool, ToolExecutionError, ToolOutput,
+        portable_tool_definition,
+    },
+};
+use tokio::{
+    sync::{Notify, OwnedSemaphorePermit, Semaphore, broadcast, mpsc, watch},
+    task::{AbortHandle, JoinSet},
+};
+use tracing::Instrument;
+
+use crate::effects::{
+    EffectCompletion, EffectIntent, ErasedRawFinal, MemoryEffectError, ModelEffectError,
+};
+use crate::{
+    AgentId, AgentNode, AgentSpec, BindingIdentity, CapabilityId, CapabilityKind, CapabilityNode,
+    EffectHeader, EffectIngress, Generation, GrantId, GrantNode, HostedProviderDiagnostic,
+    InvalidToolPolicy, MemoryId, ModelId, OperationId, ProvisionalDelta, ResponseRetryPolicy,
+    RunAccounting, RunEvent, RunId, RuntimeConfig, RuntimeError, RuntimeId, StreamingMode,
+    StructuredOutputPolicy, TenantId,
+    components::{
+        AcceptedDeltas, ActiveOperations, CancellationRequest, CanonicalTranscript,
+        CapabilitiesToDrop, CapabilityReferences, EffectQueueWait, InvalidToolRetryState,
+        MemoryProgress, PendingEffects, PendingIngress, RawFinalRecord, RecoveryFeedback,
+        RejectionLog, ResponseRetryState, RunEvents, RunNode, RunPhase, RunProgress,
+        RunTelemetrySpan, RuntimeIdentity, RuntimeTick, StructuredOutputState, TerminalCause,
+        TerminalDiagnostic, TerminalObservation, TerminalReason, TerminalState, TopologyIndex,
+    },
+};
+
+type NativeFuture<T> = Pin<Box<dyn Future<Output = T> + Send + 'static>>;
+
+struct EffectCapacityGuard(watch::Sender<u64>);
+
+impl Drop for EffectCapacityGuard {
+    fn drop(&mut self) {
+        self.0.send_modify(|epoch| *epoch = epoch.saturating_add(1));
+    }
+}
+
+fn try_acquire_permits(
+    global: &Arc<Semaphore>,
+    secondary: Option<&Arc<Semaphore>>,
+) -> Option<(OwnedSemaphorePermit, Option<OwnedSemaphorePermit>)> {
+    let global_permit = Arc::clone(global).try_acquire_owned().ok()?;
+    match secondary {
+        None => Some((global_permit, None)),
+        // The global permit drops here when the kind-specific limit is
+        // exhausted, preserving acquire-global-then-kind ordering.
+        Some(limit) => match Arc::clone(limit).try_acquire_owned() {
+            Ok(permit) => Some((global_permit, Some(permit))),
+            Err(_) => None,
+        },
+    }
+}
+
+fn lock_unpoisoned<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    match mutex.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct IngressSender {
+    sender: mpsc::Sender<EffectIngress>,
+    run_notifies: Arc<Mutex<HashMap<RunId, Arc<Notify>>>>,
+    ingress_progress_tx: watch::Sender<u64>,
+}
+
+impl IngressSender {
+    fn run_notifies(&self) -> MutexGuard<'_, HashMap<RunId, Arc<Notify>>> {
+        lock_unpoisoned(&self.run_notifies)
+    }
+
+    async fn send(
+        &self,
+        ingress: EffectIngress,
+    ) -> Result<(), mpsc::error::SendError<EffectIngress>> {
+        let run_id = ingress.run_id();
+        self.sender.send(ingress).await?;
+        self.ingress_progress_tx
+            .send_modify(|epoch| *epoch = epoch.saturating_add(1));
+        if let Some(notify) = self.run_notifies().get(&run_id) {
+            notify.notify_one();
+        }
+        Ok(())
+    }
+
+    fn try_send(&self, ingress: EffectIngress) -> Result<(), RuntimeError> {
+        let run_id = ingress.run_id();
+        self.sender.try_send(ingress).map_err(|error| match error {
+            mpsc::error::TrySendError::Full(_) => RuntimeError::IngressFull,
+            mpsc::error::TrySendError::Closed(_) => RuntimeError::IngressClosed,
+        })?;
+        self.ingress_progress_tx
+            .send_modify(|epoch| *epoch = epoch.saturating_add(1));
+        if let Some(notify) = self.run_notifies().get(&run_id) {
+            notify.notify_one();
+        }
+        Ok(())
+    }
+}
+
+pub(crate) trait ModelBinding: Send + Sync {
+    fn complete(
+        &self,
+        request: CompletionRequest,
+    ) -> NativeFuture<Result<crate::effects::ModelEffectOutput, ModelEffectError>>;
+
+    fn stream(
+        &self,
+        request: CompletionRequest,
+        header: EffectHeader,
+        ingress: IngressSender,
+    ) -> NativeFuture<Result<crate::effects::ModelEffectOutput, ModelEffectError>>;
+
+    fn composes_native_output_with_tools(&self) -> bool;
+}
+
+pub(crate) struct TypedModelBinding<M>(pub(crate) M);
+
+impl<M> ModelBinding for TypedModelBinding<M>
+where
+    M: CompletionModel + Send + Sync + 'static,
+    M::Response: Any + Send + Sync,
+    M::StreamingResponse: Any + Send + Sync,
+{
+    fn complete(
+        &self,
+        request: CompletionRequest,
+    ) -> NativeFuture<Result<crate::effects::ModelEffectOutput, ModelEffectError>> {
+        let model = self.0.clone();
+        Box::pin(async move {
+            let response = model
+                .completion(request)
+                .await
+                .map_err(ModelEffectError::Provider)?;
+            Ok(crate::effects::ModelEffectOutput {
+                choice: response.choice.into_iter().collect(),
+                usage: response.usage,
+                message_id: response.message_id,
+                raw_final: Some(ErasedRawFinal::new(response.raw_response)),
+            })
+        })
+    }
+
+    fn stream(
+        &self,
+        request: CompletionRequest,
+        header: EffectHeader,
+        ingress: IngressSender,
+    ) -> NativeFuture<Result<crate::effects::ModelEffectOutput, ModelEffectError>> {
+        let model = self.0.clone();
+        Box::pin(async move {
+            let mut response = model
+                .stream(request)
+                .await
+                .map_err(ModelEffectError::Provider)?;
+            let mut raw_final = None;
+            let mut sequence = 0_u64;
+            while let Some(item) = response.next().await {
+                let item = item.map_err(ModelEffectError::Provider)?;
+                let delta = match item {
+                    StreamedAssistantContent::Text(text) => Some(ProvisionalDelta::Text(text.text)),
+                    StreamedAssistantContent::ToolCall { tool_call, .. } => {
+                        Some(ProvisionalDelta::ToolCall(tool_call))
+                    }
+                    StreamedAssistantContent::ToolCallDelta {
+                        id,
+                        internal_call_id,
+                        content,
+                    } => Some(ProvisionalDelta::ToolCallDelta {
+                        id,
+                        internal_call_id,
+                        content,
+                    }),
+                    StreamedAssistantContent::Reasoning(reasoning) => {
+                        Some(ProvisionalDelta::Reasoning(reasoning))
+                    }
+                    StreamedAssistantContent::ReasoningDelta { id, reasoning } => {
+                        Some(ProvisionalDelta::ReasoningDelta { id, reasoning })
+                    }
+                    StreamedAssistantContent::Unknown(value) => {
+                        Some(ProvisionalDelta::Unknown(value))
+                    }
+                    StreamedAssistantContent::Final(final_response) => {
+                        raw_final = Some(ErasedRawFinal::new(final_response));
+                        None
+                    }
+                };
+                if let Some(delta) = delta {
+                    ingress
+                        .send(EffectIngress::Delta {
+                            header,
+                            sequence,
+                            delta,
+                        })
+                        .await
+                        .map_err(|_| ModelEffectError::IngressClosed)?;
+                    sequence = sequence.saturating_add(1);
+                }
+            }
+            let usage = response.usage();
+            Ok(crate::effects::ModelEffectOutput {
+                choice: response.choice.into_iter().collect(),
+                usage,
+                message_id: response.message_id,
+                raw_final,
+            })
+        })
+    }
+
+    fn composes_native_output_with_tools(&self) -> bool {
+        self.0.composes_native_output_with_tools()
+    }
+}
+
+pub(crate) trait ToolBinding: Send + Sync {
+    fn definition(&self) -> rig_core::completion::ToolDefinition;
+
+    fn execute(
+        &self,
+        arguments: serde_json::Value,
+    ) -> NativeFuture<Result<ToolOutput, ToolExecutionError>>;
+}
+
+pub(crate) struct TypedToolBinding<T>(pub(crate) Arc<T>);
+
+impl<T> ToolBinding for TypedToolBinding<T>
+where
+    T: PortableTool + Send + Sync + 'static,
+    T::Args: Send + Sync + 'static,
+    T::Output: Send + 'static,
+{
+    fn definition(&self) -> rig_core::completion::ToolDefinition {
+        portable_tool_definition(self.0.as_ref())
+    }
+
+    fn execute(
+        &self,
+        arguments: serde_json::Value,
+    ) -> NativeFuture<Result<ToolOutput, ToolExecutionError>> {
+        let tool = Arc::clone(&self.0);
+        Box::pin(async move {
+            let arguments = serde_json::from_value(arguments).map_err(|error| {
+                ToolExecutionError::invalid_args(error.to_string()).with_source(error)
+            })?;
+            let output = tool
+                .call(arguments)
+                .await
+                .map_err(|error| tool.map_error(error))?;
+            output.into_tool_output()
+        })
+    }
+}
+
+pub(crate) struct DynamicToolBinding(pub(crate) PortableDynamicTool);
+
+impl ToolBinding for DynamicToolBinding {
+    fn definition(&self) -> rig_core::completion::ToolDefinition {
+        self.0.definition()
+    }
+
+    fn execute(
+        &self,
+        arguments: serde_json::Value,
+    ) -> NativeFuture<Result<ToolOutput, ToolExecutionError>> {
+        let tool = self.0.clone();
+        Box::pin(async move { tool.execute(arguments).await })
+    }
+}
+
+pub(crate) trait MemoryBinding: Send + Sync {
+    fn load(
+        &self,
+        conversation_id: String,
+    ) -> NativeFuture<Result<Vec<Message>, MemoryEffectError>>;
+
+    fn append(
+        &self,
+        conversation_id: String,
+        messages: Vec<Message>,
+    ) -> NativeFuture<Result<(), MemoryEffectError>>;
+}
+
+pub(crate) struct TypedMemoryBinding<M>(pub(crate) Arc<M>);
+
+impl<M> MemoryBinding for TypedMemoryBinding<M>
+where
+    M: ConversationMemory + Send + Sync + 'static,
+{
+    fn load(
+        &self,
+        conversation_id: String,
+    ) -> NativeFuture<Result<Vec<Message>, MemoryEffectError>> {
+        let memory = Arc::clone(&self.0);
+        Box::pin(async move {
+            memory
+                .load(&conversation_id)
+                .await
+                .map_err(MemoryEffectError::Backend)
+        })
+    }
+
+    fn append(
+        &self,
+        conversation_id: String,
+        messages: Vec<Message>,
+    ) -> NativeFuture<Result<(), MemoryEffectError>> {
+        let memory = Arc::clone(&self.0);
+        Box::pin(async move {
+            memory
+                .append(&conversation_id, messages)
+                .await
+                .map_err(MemoryEffectError::Backend)
+        })
+    }
+}
+
+/// Built agent definition that keeps the concrete model until runtime registration.
+pub struct EcsAgentDefinition<M> {
+    pub(crate) model: M,
+    pub(crate) spec: AgentSpec,
+    pub(crate) binding_identity: Option<BindingIdentity>,
+}
+
+impl<M> EcsAgentDefinition<M> {
+    /// Stable model identity that will be registered with this definition.
+    #[must_use]
+    pub const fn model_id(&self) -> ModelId {
+        self.spec.model_id
+    }
+}
+
+/// Builder for an ECS-native agent specification.
+pub struct EcsAgentBuilder<M> {
+    model: M,
+    spec: AgentSpec,
+    binding_identity: Option<BindingIdentity>,
+}
+
+impl<M> EcsAgentBuilder<M>
+where
+    M: CompletionModel,
+{
+    /// Construct a builder around one concrete completion model.
+    #[must_use]
+    pub fn new(model: M) -> Self {
+        Self {
+            model,
+            spec: AgentSpec::new(ModelId::new(), TenantId::new()),
+            binding_identity: None,
+        }
+    }
+
+    /// Set the tenant security boundary.
+    #[must_use]
+    pub fn tenant(mut self, tenant_id: TenantId) -> Self {
+        self.spec.tenant_id = tenant_id;
+        self
+    }
+
+    /// Set an optional diagnostic agent name.
+    #[must_use]
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.spec = self.spec.name(name);
+        self
+    }
+
+    /// Set a system preamble.
+    #[must_use]
+    pub fn preamble(mut self, preamble: impl Into<String>) -> Self {
+        self.spec = self.spec.preamble(preamble);
+        self
+    }
+
+    /// Set the total model-call budget.
+    #[must_use]
+    pub fn max_model_calls(mut self, value: usize) -> Self {
+        self.spec = self.spec.max_model_calls(value);
+        self
+    }
+
+    /// Set invalid-tool recovery policy.
+    #[must_use]
+    pub fn invalid_tool_policy(mut self, value: InvalidToolPolicy) -> Self {
+        self.spec = self.spec.invalid_tool_policy(value);
+        self
+    }
+
+    /// Set tool-free response retry policy.
+    #[must_use]
+    pub fn response_retry_policy(mut self, value: ResponseRetryPolicy) -> Self {
+        self.spec = self.spec.response_retry_policy(value);
+        self
+    }
+
+    /// Configure typed structured output.
+    #[must_use]
+    pub fn structured_output<T>(mut self, policy: StructuredOutputPolicy) -> Self
+    where
+        T: schemars::JsonSchema,
+    {
+        self.spec = self.spec.structured_output::<T>(policy);
+        self
+    }
+
+    /// Configure a raw structured-output schema.
+    #[must_use]
+    pub fn structured_output_raw(
+        mut self,
+        schema: schemars::Schema,
+        policy: StructuredOutputPolicy,
+    ) -> Self {
+        self.spec = self.spec.structured_output_raw(schema, policy);
+        self
+    }
+
+    /// Configure conversation memory.
+    #[must_use]
+    pub fn memory(mut self, memory_id: MemoryId, conversation_id: impl Into<String>) -> Self {
+        self.spec = self.spec.memory(memory_id, conversation_id);
+        self
+    }
+
+    /// Select provider tool-choice policy.
+    #[must_use]
+    pub fn tool_choice(mut self, value: ToolChoice) -> Self {
+        self.spec = self.spec.tool_choice(value);
+        self
+    }
+
+    /// Set the sampling temperature used for model requests.
+    #[must_use]
+    pub fn temperature(mut self, value: f64) -> Self {
+        self.spec = self.spec.temperature(value);
+        self
+    }
+
+    /// Set the maximum generated-token count used for model requests.
+    #[must_use]
+    pub fn max_tokens(mut self, value: u64) -> Self {
+        self.spec = self.spec.max_tokens(value);
+        self
+    }
+
+    /// Set provider-specific request parameters.
+    #[must_use]
+    pub fn additional_params(mut self, value: serde_json::Value) -> Self {
+        self.spec = self.spec.additional_params(value);
+        self
+    }
+
+    /// Opt in to sensitive provider telemetry content.
+    #[must_use]
+    pub fn record_telemetry_content(mut self, value: bool) -> Self {
+        self.spec = self.spec.record_telemetry_content(value);
+        self
+    }
+
+    /// Select provider streaming for new runs.
+    #[must_use]
+    pub fn streaming(mut self, value: StreamingMode) -> Self {
+        self.spec = self.spec.streaming(value);
+        self
+    }
+
+    /// Assign the stable implementation/configuration identity required by snapshots.
+    #[must_use]
+    pub fn binding_identity(mut self, identity: BindingIdentity) -> Self {
+        self.binding_identity = Some(identity);
+        self
+    }
+
+    /// Finish the immutable agent definition.
+    #[must_use]
+    pub fn build(self) -> EcsAgentDefinition<M> {
+        EcsAgentDefinition {
+            model: self.model,
+            spec: self.spec,
+            binding_identity: self.binding_identity,
+        }
+    }
+}
+
+/// Distinct construction extension for completion provider clients.
+pub trait EcsClientExt: CompletionClient {
+    /// Construct an ECS agent builder without colliding with classic `.agent()`.
+    fn ecs_agent(&self, model: impl Into<String>) -> EcsAgentBuilder<Self::CompletionModel> {
+        EcsAgentBuilder::new(self.completion_model(model))
+    }
+}
+
+impl<C> EcsClientExt for C where C: CompletionClient {}
+
+/// Distinct construction extension for concrete completion models.
+pub trait EcsModelExt: CompletionModel + Sized {
+    /// Convert this model into an ECS agent builder.
+    fn into_ecs_agent_builder(self) -> EcsAgentBuilder<Self> {
+        EcsAgentBuilder::new(self)
+    }
+}
+
+impl<M> EcsModelExt for M where M: CompletionModel {}
+
+/// Stable handle to one run in one runtime generation.
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub struct RunHandle {
+    /// Runtime world identity.
+    pub runtime_id: RuntimeId,
+    /// Stable run identity.
+    pub run_id: RunId,
+    /// Generation captured when the handle was created.
+    pub generation: Generation,
+    /// Tenant that owns the run.
+    pub tenant_id: TenantId,
+}
+
+impl fmt::Debug for RunHandle {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RunHandle")
+            .field("runtime_id", &self.runtime_id)
+            .field("run_id", &self.run_id)
+            .field("generation", &self.generation)
+            .field("tenant_id", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Exact capability version and grant returned during portable-tool installation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ToolGrant {
+    /// Installed capability version.
+    pub capability_id: CapabilityId,
+    /// Grant authorizing one agent to advertise it.
+    pub grant_id: GrantId,
+    /// Capability revision captured by new turns.
+    pub revision: u64,
+}
+
+/// Whether a single bounded schedule pass is quiescent, progressing, or terminal.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RunStepStatus {
+    /// No effect or policy transition is currently ready.
+    Quiescent,
+    /// At least one transition or dispatch occurred.
+    Progressed,
+    /// An owned effect delivered external ingress for the target run.
+    ///
+    /// Drivers reset their consecutive schedule-pass bound at this boundary;
+    /// a valid long stream is not a scheduler livelock.
+    EffectProgressed,
+    /// The run reached terminal state.
+    Terminal,
+}
+
+/// Canonical local terminal result with a typed raw-final side-channel accessor.
+#[derive(Clone)]
+pub struct LocalRunResult {
+    /// Stable run identity.
+    pub run_id: RunId,
+    /// Final canonical assistant text, if present.
+    pub text: Option<String>,
+    /// Full canonical transcript including loaded history.
+    pub transcript: Vec<Message>,
+    /// Aggregated provider usage.
+    pub usage: rig_core::completion::Usage,
+    /// Exactly-once model call records.
+    pub model_calls: Vec<crate::ModelCallRecord>,
+    /// Observable terminal reason.
+    pub terminal_reason: TerminalReason,
+    /// Validated structured value when configured and produced.
+    pub structured_output: Option<serde_json::Value>,
+    /// Bounded retained tail of runtime events available before cleanup.
+    pub events: Vec<RunEvent>,
+    /// Operation that owns the retained provider final.
+    pub raw_final_operation: Option<OperationId>,
+    /// Operator-facing non-persisted diagnostic for a failed terminal run.
+    pub failure_diagnostic: Option<String>,
+    raw_final: Option<ErasedRawFinal>,
+    failure_cause: Option<TerminalCause>,
+}
+
+impl fmt::Debug for LocalRunResult {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("LocalRunResult")
+            .field("run_id", &self.run_id)
+            .field("text_available", &self.text.is_some())
+            .field("transcript_messages", &self.transcript.len())
+            .field("usage", &self.usage)
+            .field("model_calls", &self.model_calls)
+            .field("terminal_reason", &self.terminal_reason)
+            .field(
+                "structured_output_available",
+                &self.structured_output.is_some(),
+            )
+            .field("event_count", &self.events.len())
+            .field("raw_final_operation", &self.raw_final_operation)
+            .field("raw_final_type", &self.raw_final_type())
+            .field(
+                "failure_diagnostic_available",
+                &self.failure_diagnostic.is_some(),
+            )
+            .finish()
+    }
+}
+
+impl LocalRunResult {
+    /// Downcast the non-persisted local provider final to its concrete type.
+    #[must_use]
+    pub fn raw_final<T>(&self) -> Option<Arc<T>>
+    where
+        T: Any + Send + Sync,
+    {
+        self.raw_final.as_ref()?.downcast::<T>()
+    }
+
+    /// Return the concrete raw-final type name without exposing its content.
+    #[must_use]
+    pub fn raw_final_type(&self) -> Option<&'static str> {
+        self.raw_final.as_ref().map(ErasedRawFinal::type_name)
+    }
+
+    /// Return the non-persisted typed model failure, when one caused termination.
+    #[must_use]
+    pub fn model_error(&self) -> Option<&ModelEffectError> {
+        match self.failure_cause.as_ref()? {
+            TerminalCause::Model(error) => Some(error),
+            TerminalCause::Memory(_) => None,
+        }
+    }
+
+    /// Return the non-persisted typed memory failure, when one occurred.
+    #[must_use]
+    pub fn memory_error(&self) -> Option<&MemoryEffectError> {
+        match self.failure_cause.as_ref()? {
+            TerminalCause::Memory(error) => Some(error),
+            TerminalCause::Model(_) => None,
+        }
+    }
+}
+
+/// One streaming lifecycle event with a concrete typed provider-final variant.
+#[derive(Clone)]
+#[non_exhaustive]
+pub enum StreamingRunEvent<R> {
+    /// Runtime event other than the matching provider final.
+    Runtime(Box<RunEvent>),
+    /// Concrete provider final emitted only after the entire stream succeeded.
+    ProviderFinal {
+        /// Model operation that produced the final.
+        operation_id: OperationId,
+        /// Concrete provider response.
+        response: Arc<R>,
+    },
+}
+
+impl<R> fmt::Debug for StreamingRunEvent<R> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Runtime(event) => formatter.debug_tuple("Runtime").field(event).finish(),
+            Self::ProviderFinal { operation_id, .. } => formatter
+                .debug_struct("ProviderFinal")
+                .field("operation_id", operation_id)
+                .field("response_type", &std::any::type_name::<R>())
+                .field("response", &"<redacted>")
+                .finish(),
+        }
+    }
+}
+
+/// Collected streaming run outcome and typed event sequence.
+#[derive(Clone)]
+pub struct StreamingRunResult<R> {
+    /// Canonical terminal result.
+    pub result: LocalRunResult,
+    /// Provisional deltas and, when supplied by the provider, its accepted concrete final.
+    pub events: Vec<StreamingRunEvent<R>>,
+}
+
+impl<R> fmt::Debug for StreamingRunResult<R> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StreamingRunResult")
+            .field("result", &self.result)
+            .field("event_count", &self.events.len())
+            .finish()
+    }
+}
+
+/// Live typed streaming run over the same authoritative local schedule.
+pub struct LocalStreamingRun<'runtime, R> {
+    runtime: &'runtime mut LocalRuntime,
+    handle: RunHandle,
+    receiver: broadcast::Receiver<RunEvent>,
+    terminal_seen: bool,
+    closed: bool,
+    response: PhantomData<fn() -> R>,
+}
+
+impl<R> LocalStreamingRun<'_, R>
+where
+    R: Any + Send + Sync + 'static,
+{
+    /// Stable handle for cancellation, diagnostics, or hosted coordination.
+    #[must_use]
+    pub const fn handle(&self) -> RunHandle {
+        self.handle
+    }
+
+    /// Cancel an active stream, abort its owned effect, and observe its retained result.
+    ///
+    /// If the run already reached terminal state, this only observes and returns that
+    /// terminal result. Dropping the stream without calling `finish` or `cancel` performs
+    /// the same cancellation/observation cleanup but discards the result.
+    pub fn cancel(mut self) -> Result<LocalRunResult, RuntimeError> {
+        self.runtime.abandon_stream(self.handle)?;
+        let result = self.runtime.finish_run(self.handle)?;
+        self.closed = true;
+        Ok(result)
+    }
+
+    /// Yield the next live event, preserving provisional-before-final ordering.
+    pub async fn next_event(&mut self) -> Result<Option<StreamingRunEvent<R>>, RuntimeError> {
+        let mut remaining_passes = self.runtime.config.max_schedule_passes;
+        let mut target_effect_deadline = None;
+        loop {
+            match self.receiver.try_recv() {
+                Ok(event) => {
+                    if matches!(event, RunEvent::Terminal(_)) {
+                        self.terminal_seen = true;
+                    }
+                    if let RunEvent::ProviderFinal { operation_id, .. } = event {
+                        let entity = self.runtime.validate_handle(self.handle)?;
+                        let raw = self
+                            .runtime
+                            .world
+                            .get::<RawFinalRecord>(entity)
+                            .filter(|raw| raw.operation_id == operation_id)
+                            .ok_or(RuntimeError::RunFailed {
+                                code: "missing_provider_final".to_string(),
+                                diagnostic: "accepted provider final side channel is unavailable"
+                                    .to_string(),
+                            })?;
+                        let actual = raw.raw.type_name();
+                        let response =
+                            raw.raw
+                                .downcast::<R>()
+                                .ok_or(RuntimeError::RawFinalTypeMismatch {
+                                    expected: std::any::type_name::<R>(),
+                                    actual,
+                                })?;
+                        return Ok(Some(StreamingRunEvent::ProviderFinal {
+                            operation_id,
+                            response,
+                        }));
+                    }
+                    return Ok(Some(StreamingRunEvent::Runtime(Box::new(event))));
+                }
+                Err(broadcast::error::TryRecvError::Lagged(skipped)) => {
+                    return Err(RuntimeError::EventStreamLagged { skipped });
+                }
+                Err(broadcast::error::TryRecvError::Closed) => {
+                    return Err(RuntimeError::IngressClosed);
+                }
+                Err(broadcast::error::TryRecvError::Empty) if self.terminal_seen => {
+                    return Ok(None);
+                }
+                Err(broadcast::error::TryRecvError::Empty) => {}
+            }
+
+            let mut capacity_rx = self.runtime.effect_capacity_tx.subscribe();
+            match self.runtime.step_with_ingress_limit(self.handle, 1).await? {
+                RunStepStatus::Terminal => {}
+                RunStepStatus::Progressed => {
+                    if remaining_passes == 0 {
+                        crate::schedule::fail_effect_wait(
+                            &mut self.runtime.world,
+                            self.handle.run_id,
+                            RuntimeError::Livelock.to_string(),
+                        );
+                        return Err(RuntimeError::Livelock);
+                    }
+                    remaining_passes -= 1;
+                }
+                RunStepStatus::EffectProgressed => {
+                    remaining_passes = self.runtime.config.max_schedule_passes;
+                    target_effect_deadline = None;
+                }
+                RunStepStatus::Quiescent => {
+                    if self
+                        .runtime
+                        .wait_quiescent(self.handle, &mut capacity_rx, &mut target_effect_deadline)
+                        .await?
+                    {
+                        remaining_passes = self.runtime.config.max_schedule_passes;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Materialize the canonical result after the terminal event was observed.
+    pub fn finish(mut self) -> Result<LocalRunResult, RuntimeError> {
+        if !self.terminal_seen {
+            return Err(RuntimeError::Livelock);
+        }
+        let result = self.runtime.finish_run(self.handle)?;
+        self.closed = true;
+        LocalRuntime::ensure_completed(result)
+    }
+}
+
+impl<R> Drop for LocalStreamingRun<'_, R> {
+    fn drop(&mut self) {
+        if !self.closed {
+            let _ = self.runtime.abandon_stream(self.handle);
+        }
+    }
+}
+
+struct LocalRunGuard<'runtime> {
+    runtime: &'runtime mut LocalRuntime,
+    handle: RunHandle,
+    closed: bool,
+}
+
+impl Drop for LocalRunGuard<'_> {
+    fn drop(&mut self) {
+        if !self.closed {
+            let _ = self.runtime.abandon_stream(self.handle);
+        }
+    }
+}
+
+/// Authoritative native ECS runtime.
+pub struct LocalRuntime {
+    pub(crate) world: World,
+    pub(crate) schedule: Schedule,
+    pub(crate) config: RuntimeConfig,
+    pub(crate) models: HashMap<ModelId, Arc<dyn ModelBinding>>,
+    pub(crate) tools: HashMap<CapabilityId, Arc<dyn ToolBinding>>,
+    pub(crate) memories: HashMap<MemoryId, Arc<dyn MemoryBinding>>,
+    pub(crate) model_tenants: HashMap<ModelId, TenantId>,
+    pub(crate) memory_tenants: HashMap<MemoryId, TenantId>,
+    pub(crate) model_binding_identities: HashMap<ModelId, BindingIdentity>,
+    pub(crate) tool_binding_identities: HashMap<CapabilityId, BindingIdentity>,
+    pub(crate) memory_binding_identities: HashMap<MemoryId, BindingIdentity>,
+    ingress_tx: IngressSender,
+    ingress_rx: mpsc::Receiver<EffectIngress>,
+    effects: JoinSet<()>,
+    aborts: BTreeMap<OperationId, (RunId, AbortHandle)>,
+    global_limit: Arc<Semaphore>,
+    model_limit: Arc<Semaphore>,
+    tool_limit: Arc<Semaphore>,
+    effect_capacity_tx: watch::Sender<u64>,
+}
+
+impl LocalRuntime {
+    /// Construct a native ECS runtime with bounded defaults.
+    pub fn new() -> Result<Self, RuntimeError> {
+        Self::with_config(RuntimeConfig::default())
+    }
+
+    /// Construct a runtime with explicit bounds and retention policy.
+    pub fn with_config(config: RuntimeConfig) -> Result<Self, RuntimeError> {
+        config.validate()?;
+        let runtime_id = RuntimeId::new();
+        let (sender, ingress_rx) = mpsc::channel(config.ingress_capacity);
+        let (effect_capacity_tx, _) = watch::channel(0);
+        let (ingress_progress_tx, _) = watch::channel(0);
+        let ingress_tx = IngressSender {
+            sender,
+            run_notifies: Arc::new(Mutex::new(HashMap::new())),
+            ingress_progress_tx,
+        };
+        let mut world = World::new();
+        world.insert_resource(RuntimeIdentity(runtime_id));
+        world.insert_resource(RuntimeTick::default());
+        world.insert_resource(TopologyIndex::default());
+        world.insert_resource(PendingIngress::default());
+        world.insert_resource(PendingEffects::default());
+        world.insert_resource(RejectionLog::default());
+        world.insert_resource(CapabilityReferences::default());
+        world.insert_resource(CapabilitiesToDrop::default());
+        world.insert_resource(crate::schedule::RuntimeConfigResource(config.clone()));
+        let schedule = crate::schedule::build_schedule();
+        Ok(Self {
+            world,
+            schedule,
+            models: HashMap::new(),
+            tools: HashMap::new(),
+            memories: HashMap::new(),
+            model_tenants: HashMap::new(),
+            memory_tenants: HashMap::new(),
+            model_binding_identities: HashMap::new(),
+            tool_binding_identities: HashMap::new(),
+            memory_binding_identities: HashMap::new(),
+            ingress_tx,
+            ingress_rx,
+            effects: JoinSet::new(),
+            aborts: BTreeMap::new(),
+            global_limit: Arc::new(Semaphore::new(config.max_effects)),
+            model_limit: Arc::new(Semaphore::new(config.max_model_calls)),
+            tool_limit: Arc::new(Semaphore::new(config.max_tool_calls)),
+            effect_capacity_tx,
+            config,
+        })
+    }
+
+    /// Return this world's stable runtime identity.
+    #[must_use]
+    pub fn id(&self) -> RuntimeId {
+        self.world.resource::<RuntimeIdentity>().0
+    }
+
+    /// Borrow the authoritative ECS world for read-only inspection.
+    #[must_use]
+    pub const fn world(&self) -> &World {
+        &self.world
+    }
+
+    /// Register a concrete model under a generated stable binding identity.
+    pub fn register_model<M>(&mut self, tenant_id: TenantId, model: M) -> ModelId
+    where
+        M: CompletionModel + Send + Sync + 'static,
+        M::Response: Any + Send + Sync,
+        M::StreamingResponse: Any + Send + Sync,
+    {
+        let id = ModelId::new();
+        self.bind_model(id, tenant_id, None, model);
+        id
+    }
+
+    /// Register a tenant-owned model with a stable snapshot rebinding identity.
+    pub fn register_persistable_model<M>(
+        &mut self,
+        tenant_id: TenantId,
+        identity: BindingIdentity,
+        model: M,
+    ) -> ModelId
+    where
+        M: CompletionModel + Send + Sync + 'static,
+        M::Response: Any + Send + Sync,
+        M::StreamingResponse: Any + Send + Sync,
+    {
+        let id = ModelId::new();
+        self.bind_model(id, tenant_id, Some(identity), model);
+        id
+    }
+
+    pub(crate) fn bind_model<M>(
+        &mut self,
+        id: ModelId,
+        tenant_id: TenantId,
+        identity: Option<BindingIdentity>,
+        model: M,
+    ) where
+        M: CompletionModel + Send + Sync + 'static,
+        M::Response: Any + Send + Sync,
+        M::StreamingResponse: Any + Send + Sync,
+    {
+        self.models.insert(id, Arc::new(TypedModelBinding(model)));
+        self.model_tenants.insert(id, tenant_id);
+        if let Some(identity) = identity {
+            self.model_binding_identities.insert(id, identity);
+        }
+    }
+
+    /// Register a concrete conversation memory under a generated stable identity.
+    pub fn register_memory<M>(&mut self, tenant_id: TenantId, memory: M) -> MemoryId
+    where
+        M: ConversationMemory + Send + Sync + 'static,
+    {
+        let id = MemoryId::new();
+        self.bind_memory(id, tenant_id, None, memory);
+        id
+    }
+
+    /// Register tenant-owned memory with a stable snapshot rebinding identity.
+    pub fn register_persistable_memory<M>(
+        &mut self,
+        tenant_id: TenantId,
+        identity: BindingIdentity,
+        memory: M,
+    ) -> MemoryId
+    where
+        M: ConversationMemory + Send + Sync + 'static,
+    {
+        let id = MemoryId::new();
+        self.bind_memory(id, tenant_id, Some(identity), memory);
+        id
+    }
+
+    pub(crate) fn bind_memory<M>(
+        &mut self,
+        id: MemoryId,
+        tenant_id: TenantId,
+        identity: Option<BindingIdentity>,
+        memory: M,
+    ) where
+        M: ConversationMemory + Send + Sync + 'static,
+    {
+        self.memories
+            .insert(id, Arc::new(TypedMemoryBinding(Arc::new(memory))));
+        self.memory_tenants.insert(id, tenant_id);
+        if let Some(identity) = identity {
+            self.memory_binding_identities.insert(id, identity);
+        }
+    }
+
+    /// Spawn a built ECS agent and register its concrete model implementation.
+    pub fn spawn_agent<M>(
+        &mut self,
+        definition: EcsAgentDefinition<M>,
+    ) -> Result<AgentId, RuntimeError>
+    where
+        M: CompletionModel + Send + Sync + 'static,
+        M::Response: Any + Send + Sync,
+        M::StreamingResponse: Any + Send + Sync,
+    {
+        self.validate_agent_memory(&definition.spec)?;
+        self.bind_model(
+            definition.spec.model_id,
+            definition.spec.tenant_id,
+            definition.binding_identity,
+            definition.model,
+        );
+        self.spawn_agent_spec(definition.spec)
+    }
+
+    fn validate_agent_memory(&self, spec: &AgentSpec) -> Result<(), RuntimeError> {
+        match (spec.memory_id, spec.conversation_id.is_some()) {
+            (Some(_), false) => {
+                return Err(RuntimeError::InvalidAgentSpec {
+                    reason: "memory requires a conversation identifier",
+                });
+            }
+            (None, true) => {
+                return Err(RuntimeError::InvalidAgentSpec {
+                    reason: "a conversation identifier requires memory",
+                });
+            }
+            (Some(_), true) | (None, false) => {}
+        }
+        if let Some(memory_id) = spec.memory_id
+            && !self.memories.contains_key(&memory_id)
+        {
+            return Err(RuntimeError::UnknownMemory(memory_id));
+        }
+        if let Some(memory_id) = spec.memory_id
+            && let Some(owner) = self.memory_tenants.get(&memory_id)
+            && *owner != spec.tenant_id
+        {
+            return Err(RuntimeError::TenantMismatch {
+                expected: *owner,
+                actual: spec.tenant_id,
+            });
+        }
+        Ok(())
+    }
+
+    /// Spawn an agent from an already rebound model identity.
+    pub fn spawn_agent_spec(&mut self, spec: AgentSpec) -> Result<AgentId, RuntimeError> {
+        self.validate_agent_memory(&spec)?;
+        if !self.models.contains_key(&spec.model_id) {
+            return Err(RuntimeError::UnknownModel(spec.model_id));
+        }
+        if let Some(owner) = self.model_tenants.get(&spec.model_id)
+            && *owner != spec.tenant_id
+        {
+            return Err(RuntimeError::TenantMismatch {
+                expected: *owner,
+                actual: spec.tenant_id,
+            });
+        }
+        let id = AgentId::new();
+        let composes_native_output_with_tools = self
+            .models
+            .get(&spec.model_id)
+            .is_some_and(|model| model.composes_native_output_with_tools());
+        let entity = self
+            .world
+            .spawn(AgentNode {
+                id,
+                spec,
+                composes_native_output_with_tools,
+            })
+            .id();
+        self.world
+            .resource_mut::<TopologyIndex>()
+            .agents
+            .insert(id, entity);
+        Ok(id)
+    }
+
+    /// Install and grant one portable tool to an agent.
+    pub fn install_tool<T>(&mut self, agent_id: AgentId, tool: T) -> Result<ToolGrant, RuntimeError>
+    where
+        T: PortableTool + Send + Sync + 'static,
+        T::Args: Send + Sync + 'static,
+        T::Output: Send + 'static,
+    {
+        let binding: Arc<dyn ToolBinding> = Arc::new(TypedToolBinding(Arc::new(tool)));
+        self.install_tool_binding(agent_id, 1, CapabilityKind::Tool, None, binding)
+    }
+
+    /// Install a portable tool with a stable implementation/configuration identity.
+    pub fn install_persistable_tool<T>(
+        &mut self,
+        agent_id: AgentId,
+        identity: BindingIdentity,
+        tool: T,
+    ) -> Result<ToolGrant, RuntimeError>
+    where
+        T: PortableTool + Send + Sync + 'static,
+        T::Args: Send + Sync + 'static,
+        T::Output: Send + 'static,
+    {
+        let binding: Arc<dyn ToolBinding> = Arc::new(TypedToolBinding(Arc::new(tool)));
+        self.install_tool_binding(agent_id, 1, CapabilityKind::Tool, Some(identity), binding)
+    }
+
+    /// Install and grant a portable vector index as an executable retrieval capability.
+    ///
+    /// Vector indexes use `rig-core`'s portable tool implementation, while the
+    /// ECS topology records their distinct store capability kind. Retrieval
+    /// calls therefore use the same immutable grant snapshot, owned effect,
+    /// correlation validation, and deterministic commit path as other tools.
+    pub fn install_vector_store<I>(
+        &mut self,
+        agent_id: AgentId,
+        index: I,
+    ) -> Result<ToolGrant, RuntimeError>
+    where
+        I: rig_core::vector_store::VectorStoreIndex + PortableTool + Send + Sync + 'static,
+        I::Args: Send + Sync + 'static,
+        I::Output: Send + 'static,
+    {
+        let binding: Arc<dyn ToolBinding> = Arc::new(TypedToolBinding(Arc::new(index)));
+        self.install_tool_binding(agent_id, 1, CapabilityKind::Store, None, binding)
+    }
+
+    /// Install a portable vector index with a stable snapshot rebinding identity.
+    pub fn install_persistable_vector_store<I>(
+        &mut self,
+        agent_id: AgentId,
+        identity: BindingIdentity,
+        index: I,
+    ) -> Result<ToolGrant, RuntimeError>
+    where
+        I: rig_core::vector_store::VectorStoreIndex + PortableTool + Send + Sync + 'static,
+        I::Args: Send + Sync + 'static,
+        I::Output: Send + 'static,
+    {
+        let binding: Arc<dyn ToolBinding> = Arc::new(TypedToolBinding(Arc::new(index)));
+        self.install_tool_binding(agent_id, 1, CapabilityKind::Store, Some(identity), binding)
+    }
+
+    /// Install a runtime-authored context-free dynamic tool.
+    pub fn install_dynamic_tool(
+        &mut self,
+        agent_id: AgentId,
+        tool: PortableDynamicTool,
+    ) -> Result<ToolGrant, RuntimeError> {
+        let binding: Arc<dyn ToolBinding> = Arc::new(DynamicToolBinding(tool));
+        self.install_tool_binding(agent_id, 1, CapabilityKind::Tool, None, binding)
+    }
+
+    /// Install a dynamic tool with a stable snapshot rebinding identity.
+    pub fn install_persistable_dynamic_tool(
+        &mut self,
+        agent_id: AgentId,
+        identity: BindingIdentity,
+        tool: PortableDynamicTool,
+    ) -> Result<ToolGrant, RuntimeError> {
+        let binding: Arc<dyn ToolBinding> = Arc::new(DynamicToolBinding(tool));
+        self.install_tool_binding(agent_id, 1, CapabilityKind::Tool, Some(identity), binding)
+    }
+
+    fn install_tool_binding(
+        &mut self,
+        agent_id: AgentId,
+        revision: u64,
+        kind: CapabilityKind,
+        binding_identity: Option<BindingIdentity>,
+        binding: Arc<dyn ToolBinding>,
+    ) -> Result<ToolGrant, RuntimeError> {
+        let agent_entity = self
+            .world
+            .resource::<TopologyIndex>()
+            .agents
+            .get(&agent_id)
+            .copied()
+            .ok_or(RuntimeError::UnknownAgent(agent_id))?;
+        let tenant_id = self
+            .world
+            .get::<AgentNode>(agent_entity)
+            .ok_or(RuntimeError::UnknownAgent(agent_id))?
+            .spec
+            .tenant_id;
+        let definition = binding.definition();
+        self.ensure_unique_active_tool_name(agent_id, &definition.name, None)?;
+        let capability_id = CapabilityId::new();
+        let grant_id = GrantId::new();
+        let capability_entity = self
+            .world
+            .spawn(CapabilityNode {
+                id: capability_id,
+                tenant_id,
+                kind,
+                definition: Some(definition),
+                revision,
+                retired: false,
+            })
+            .id();
+        let grant_entity = self
+            .world
+            .spawn(GrantNode {
+                id: grant_id,
+                agent_id,
+                capability_id,
+                tenant_id,
+                revoked: false,
+            })
+            .id();
+        let mut index = self.world.resource_mut::<TopologyIndex>();
+        index.capabilities.insert(capability_id, capability_entity);
+        index.grants.insert(grant_id, grant_entity);
+        self.tools.insert(capability_id, binding);
+        if let Some(identity) = binding_identity {
+            self.tool_binding_identities.insert(capability_id, identity);
+        }
+        Ok(ToolGrant {
+            capability_id,
+            grant_id,
+            revision,
+        })
+    }
+
+    fn ensure_unique_active_tool_name(
+        &self,
+        agent_id: AgentId,
+        name: &str,
+        excluded_grant: Option<GrantId>,
+    ) -> Result<(), RuntimeError> {
+        let index = self.world.resource::<TopologyIndex>();
+        let collision = index.grants.values().any(|grant_entity| {
+            let Some(grant) = self.world.get::<GrantNode>(*grant_entity) else {
+                return false;
+            };
+            if grant.revoked || grant.agent_id != agent_id || Some(grant.id) == excluded_grant {
+                return false;
+            }
+            index
+                .capabilities
+                .get(&grant.capability_id)
+                .and_then(|entity| self.world.get::<CapabilityNode>(*entity))
+                .is_some_and(|capability| {
+                    !capability.retired
+                        && capability
+                            .definition
+                            .as_ref()
+                            .is_some_and(|definition| definition.name == name)
+                })
+        });
+        if collision {
+            return Err(RuntimeError::DuplicateToolName {
+                agent_id,
+                name: name.to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Replace a tool with a new immutable capability version and grant.
+    pub fn replace_tool<T>(&mut self, grant_id: GrantId, tool: T) -> Result<ToolGrant, RuntimeError>
+    where
+        T: PortableTool + Send + Sync + 'static,
+        T::Args: Send + Sync + 'static,
+        T::Output: Send + 'static,
+    {
+        self.replace_tool_with_identity(grant_id, CapabilityKind::Tool, None, tool)
+    }
+
+    /// Replace a persistable tool or store capability with a new exact binding identity.
+    pub fn replace_persistable_tool<T>(
+        &mut self,
+        grant_id: GrantId,
+        identity: BindingIdentity,
+        tool: T,
+    ) -> Result<ToolGrant, RuntimeError>
+    where
+        T: PortableTool + Send + Sync + 'static,
+        T::Args: Send + Sync + 'static,
+        T::Output: Send + 'static,
+    {
+        self.replace_tool_with_identity(grant_id, CapabilityKind::Tool, Some(identity), tool)
+    }
+
+    /// Replace a vector-store capability with a new immutable store version.
+    pub fn replace_vector_store<I>(
+        &mut self,
+        grant_id: GrantId,
+        index: I,
+    ) -> Result<ToolGrant, RuntimeError>
+    where
+        I: rig_core::vector_store::VectorStoreIndex + PortableTool + Send + Sync + 'static,
+        I::Args: Send + Sync + 'static,
+        I::Output: Send + 'static,
+    {
+        self.replace_tool_with_identity(grant_id, CapabilityKind::Store, None, index)
+    }
+
+    /// Replace a persistable vector store with a new exact binding identity.
+    pub fn replace_persistable_vector_store<I>(
+        &mut self,
+        grant_id: GrantId,
+        identity: BindingIdentity,
+        index: I,
+    ) -> Result<ToolGrant, RuntimeError>
+    where
+        I: rig_core::vector_store::VectorStoreIndex + PortableTool + Send + Sync + 'static,
+        I::Args: Send + Sync + 'static,
+        I::Output: Send + 'static,
+    {
+        self.replace_tool_with_identity(grant_id, CapabilityKind::Store, Some(identity), index)
+    }
+
+    fn replace_tool_with_identity<T>(
+        &mut self,
+        grant_id: GrantId,
+        expected_kind: CapabilityKind,
+        binding_identity: Option<BindingIdentity>,
+        tool: T,
+    ) -> Result<ToolGrant, RuntimeError>
+    where
+        T: PortableTool + Send + Sync + 'static,
+        T::Args: Send + Sync + 'static,
+        T::Output: Send + 'static,
+    {
+        let grant_entity = self
+            .world
+            .resource::<TopologyIndex>()
+            .grants
+            .get(&grant_id)
+            .copied()
+            .ok_or(RuntimeError::UnknownGrant(grant_id))?;
+        let old_grant = self
+            .world
+            .get::<GrantNode>(grant_entity)
+            .cloned()
+            .ok_or(RuntimeError::UnknownGrant(grant_id))?;
+        if old_grant.revoked {
+            return Err(RuntimeError::RevokedGrant(grant_id));
+        }
+        let capability_entity = self
+            .world
+            .resource::<TopologyIndex>()
+            .capabilities
+            .get(&old_grant.capability_id)
+            .copied()
+            .ok_or(RuntimeError::UnknownCapability(old_grant.capability_id))?;
+        let (old_revision, old_kind, old_retired) = self
+            .world
+            .get::<CapabilityNode>(capability_entity)
+            .map(|capability| (capability.revision, capability.kind, capability.retired))
+            .ok_or(RuntimeError::UnknownCapability(old_grant.capability_id))?;
+        if old_retired {
+            return Err(RuntimeError::RetiredCapability(old_grant.capability_id));
+        }
+        if old_kind != expected_kind {
+            return Err(RuntimeError::CapabilityKindMismatch {
+                capability_id: old_grant.capability_id,
+                expected: expected_kind,
+                actual: old_kind,
+            });
+        }
+        if binding_identity.is_none()
+            && self
+                .tool_binding_identities
+                .contains_key(&old_grant.capability_id)
+        {
+            return Err(RuntimeError::PersistenceIdentityRequired(
+                old_grant.capability_id,
+            ));
+        }
+        let new_revision =
+            old_revision
+                .checked_add(1)
+                .ok_or(RuntimeError::CapabilityRevisionOverflow(
+                    old_grant.capability_id,
+                ))?;
+        let binding: Arc<dyn ToolBinding> = Arc::new(TypedToolBinding(Arc::new(tool)));
+        let replacement_name = binding.definition().name;
+        self.ensure_unique_active_tool_name(old_grant.agent_id, &replacement_name, Some(grant_id))?;
+        if let Some(mut capability) = self.world.get_mut::<CapabilityNode>(capability_entity) {
+            capability.retired = true;
+        }
+        if let Some(mut grant) = self.world.get_mut::<GrantNode>(grant_entity) {
+            grant.revoked = true;
+        }
+        self.install_tool_binding(
+            old_grant.agent_id,
+            new_revision,
+            old_kind,
+            binding_identity,
+            binding,
+        )
+    }
+
+    /// Retire the capability version behind a grant and revoke it for new turns.
+    pub fn retire_tool(&mut self, grant_id: GrantId) -> Result<(), RuntimeError> {
+        let grant_entity = self
+            .world
+            .resource::<TopologyIndex>()
+            .grants
+            .get(&grant_id)
+            .copied()
+            .ok_or(RuntimeError::UnknownGrant(grant_id))?;
+        let capability_id = self
+            .world
+            .get::<GrantNode>(grant_entity)
+            .ok_or(RuntimeError::UnknownGrant(grant_id))?
+            .capability_id;
+        if let Some(mut grant) = self.world.get_mut::<GrantNode>(grant_entity) {
+            grant.revoked = true;
+        }
+        let capability_entity = self
+            .world
+            .resource::<TopologyIndex>()
+            .capabilities
+            .get(&capability_id)
+            .copied()
+            .ok_or(RuntimeError::UnknownCapability(capability_id))?;
+        if let Some(mut capability) = self.world.get_mut::<CapabilityNode>(capability_entity) {
+            capability.retired = true;
+        }
+        Ok(())
+    }
+
+    /// Revoke one grant without retiring its capability implementation.
+    pub fn revoke_grant(&mut self, grant_id: GrantId) -> Result<(), RuntimeError> {
+        let entity = self
+            .world
+            .resource::<TopologyIndex>()
+            .grants
+            .get(&grant_id)
+            .copied()
+            .ok_or(RuntimeError::UnknownGrant(grant_id))?;
+        let mut grant = self
+            .world
+            .get_mut::<GrantNode>(entity)
+            .ok_or(RuntimeError::UnknownGrant(grant_id))?;
+        grant.revoked = true;
+        Ok(())
+    }
+
+    /// Return the exact capability and grant represented by a stable grant ID.
+    pub fn tool_grant(&self, grant_id: GrantId) -> Result<ToolGrant, RuntimeError> {
+        let index = self.world.resource::<TopologyIndex>();
+        let grant_entity = index
+            .grants
+            .get(&grant_id)
+            .copied()
+            .ok_or(RuntimeError::UnknownGrant(grant_id))?;
+        let grant = self
+            .world
+            .get::<GrantNode>(grant_entity)
+            .ok_or(RuntimeError::UnknownGrant(grant_id))?;
+        let capability_entity = index
+            .capabilities
+            .get(&grant.capability_id)
+            .copied()
+            .ok_or(RuntimeError::UnknownCapability(grant.capability_id))?;
+        let capability = self
+            .world
+            .get::<CapabilityNode>(capability_entity)
+            .ok_or(RuntimeError::UnknownCapability(grant.capability_id))?;
+        Ok(ToolGrant {
+            capability_id: capability.id,
+            grant_id,
+            revision: capability.revision,
+        })
+    }
+
+    /// Return the executable category recorded for a stable capability identity.
+    pub fn capability_kind(
+        &self,
+        capability_id: CapabilityId,
+    ) -> Result<CapabilityKind, RuntimeError> {
+        let entity = self
+            .world
+            .resource::<TopologyIndex>()
+            .capabilities
+            .get(&capability_id)
+            .copied()
+            .ok_or(RuntimeError::UnknownCapability(capability_id))?;
+        self.world
+            .get::<CapabilityNode>(entity)
+            .map(|capability| capability.kind)
+            .ok_or(RuntimeError::UnknownCapability(capability_id))
+    }
+
+    /// Begin one run without waiting for provider or tool I/O.
+    pub fn start_run(
+        &mut self,
+        agent_id: AgentId,
+        prompt: impl Into<Message>,
+    ) -> Result<RunHandle, RuntimeError> {
+        let agent_entity = self
+            .world
+            .resource::<TopologyIndex>()
+            .agents
+            .get(&agent_id)
+            .copied()
+            .ok_or(RuntimeError::UnknownAgent(agent_id))?;
+        let agent = self
+            .world
+            .get::<AgentNode>(agent_entity)
+            .cloned()
+            .ok_or(RuntimeError::UnknownAgent(agent_id))?;
+        let prompt = prompt.into();
+        if matches!(prompt, Message::Assistant { .. }) {
+            return Err(RuntimeError::InvalidPrompt {
+                reason: "an assistant-role prompt cannot precede a model reply canonically",
+            });
+        }
+        let validation = crate::persistence::TranscriptValidator::over(std::slice::from_ref(
+            &prompt,
+        ))
+        .map_err(|_| RuntimeError::InvalidPrompt {
+            reason: "prompt content violates canonical transcript invariants",
+        })?;
+        let run_id = RunId::new();
+        let generation = Generation::default();
+        let tick = self.world.resource::<RuntimeTick>().0;
+        let telemetry_agent_name = match (
+            agent.spec.record_telemetry_content,
+            agent.spec.name.as_deref(),
+        ) {
+            (true, Some(name)) => name,
+            (false, Some(_)) => "<redacted>",
+            (_, None) => "",
+        };
+        let run_span = tracing::info_span!(
+            target: "rig::ecs",
+            "rig.ecs.run",
+            run.id = %run_id,
+            run.generation = generation.0,
+            run.streaming = ?agent.spec.streaming,
+            run.tenant = "<redacted>",
+            rig.agent.name = %telemetry_agent_name,
+        );
+        let mut entity = self.world.spawn((
+            RunNode {
+                id: run_id,
+                agent_id,
+                model_id: agent.spec.model_id,
+                tenant_id: agent.spec.tenant_id,
+                generation,
+                phase: if agent.spec.memory_id.is_some() {
+                    RunPhase::LoadingMemory
+                } else {
+                    RunPhase::ReadyModel
+                },
+                streaming: agent.spec.streaming,
+                created_tick: tick,
+            },
+            CanonicalTranscript {
+                messages: vec![prompt],
+                new_messages_start: 0,
+            },
+            crate::persistence::TranscriptValidation(validation),
+            RunAccounting::default(),
+            ActiveOperations::default(),
+            AcceptedDeltas::default(),
+            RecoveryFeedback::default(),
+            ResponseRetryState::default(),
+            InvalidToolRetryState::default(),
+            RunEvents::new(self.config.event_capacity),
+            RunProgress::default(),
+            RunTelemetrySpan(run_span),
+        ));
+        if let (Some(memory_id), Some(conversation_id)) =
+            (agent.spec.memory_id, agent.spec.conversation_id.clone())
+        {
+            entity.insert(MemoryProgress {
+                memory_id,
+                conversation_id,
+                loaded: false,
+                appended: false,
+            });
+        }
+        if let Some((schema, policy)) = agent.spec.structured_output.clone() {
+            entity.insert(StructuredOutputState {
+                schema,
+                policy,
+                resolved_mode: crate::OutputMode::Auto,
+                output_tool_name: None,
+                retries: 0,
+                value: None,
+            });
+        }
+        let run_entity = entity.id();
+        self.world
+            .resource_mut::<TopologyIndex>()
+            .runs
+            .insert(run_id, run_entity);
+        Ok(RunHandle {
+            runtime_id: self.id(),
+            run_id,
+            generation,
+            tenant_id: agent.spec.tenant_id,
+        })
+    }
+
+    pub(crate) fn validate_handle(&self, handle: RunHandle) -> Result<Entity, RuntimeError> {
+        if handle.runtime_id != self.id() {
+            return Err(RuntimeError::ForeignRuntime {
+                expected: self.id(),
+                actual: handle.runtime_id,
+            });
+        }
+        let entity = self
+            .world
+            .resource::<TopologyIndex>()
+            .runs
+            .get(&handle.run_id)
+            .copied()
+            .ok_or(RuntimeError::UnknownRun(handle.run_id))?;
+        let run = self
+            .world
+            .get::<RunNode>(entity)
+            .ok_or(RuntimeError::UnknownRun(handle.run_id))?;
+        if run.tenant_id != handle.tenant_id {
+            return Err(RuntimeError::TenantMismatch {
+                expected: run.tenant_id,
+                actual: handle.tenant_id,
+            });
+        }
+        if run.generation != handle.generation {
+            return Err(RuntimeError::StaleHandle {
+                run_id: handle.run_id,
+            });
+        }
+        Ok(entity)
+    }
+
+    /// Reacquire the valid handle for a retained run owned by `tenant_id`.
+    ///
+    /// This is the supported way to address a run after [`LocalRuntime::restore`],
+    /// which advances every restored run's generation and thereby staleness-rejects
+    /// handles minted by the snapshotted runtime.
+    ///
+    /// Note that a [`RunHandle`] is therefore not an unforgeable capability:
+    /// any code that learns `(run_id, tenant_id)` — run identities appear in
+    /// events and telemetry — can mint a live handle and, for example, cancel
+    /// the run. Isolation between untrusting callers inside one tenant must be
+    /// enforced by the embedder, not by handle possession.
+    pub fn run_handle(
+        &self,
+        run_id: RunId,
+        tenant_id: TenantId,
+    ) -> Result<RunHandle, RuntimeError> {
+        let entity = self
+            .world
+            .resource::<TopologyIndex>()
+            .runs
+            .get(&run_id)
+            .copied()
+            .ok_or(RuntimeError::UnknownRun(run_id))?;
+        let run = self
+            .world
+            .get::<RunNode>(entity)
+            .ok_or(RuntimeError::UnknownRun(run_id))?;
+        if run.tenant_id != tenant_id {
+            return Err(RuntimeError::TenantMismatch {
+                expected: run.tenant_id,
+                actual: tenant_id,
+            });
+        }
+        Ok(RunHandle {
+            runtime_id: self.id(),
+            run_id,
+            generation: run.generation,
+            tenant_id,
+        })
+    }
+
+    /// Request cancellation. The cancellation system wins before pending ingress.
+    pub fn cancel(&mut self, handle: RunHandle) -> Result<(), RuntimeError> {
+        let entity = self.validate_handle(handle)?;
+        if !self.world.entity(entity).contains::<TerminalState>() {
+            self.world.entity_mut(entity).insert(CancellationRequest);
+        }
+        Ok(())
+    }
+
+    fn abandon_stream(&mut self, handle: RunHandle) -> Result<(), RuntimeError> {
+        let entity = self.validate_handle(handle)?;
+        if !self.world.entity(entity).contains::<TerminalState>() {
+            self.world.entity_mut(entity).insert(CancellationRequest);
+            self.stage_available_ingress(None, self.config.ingress_capacity);
+            self.schedule.run(&mut self.world);
+            self.spawn_pending_effects();
+            self.prune_effect_tasks();
+        }
+        let entity = self.validate_handle(handle)?;
+        if !self.world.entity(entity).contains::<TerminalState>() {
+            return Err(RuntimeError::Livelock);
+        }
+        let tick = self.world.resource::<RuntimeTick>().0;
+        self.world.entity_mut(entity).insert(TerminalObservation {
+            observed_tick: tick,
+        });
+        Ok(())
+    }
+
+    /// Subscribe to bounded lifecycle events for an active or retained run.
+    pub fn subscribe(
+        &mut self,
+        handle: RunHandle,
+    ) -> Result<broadcast::Receiver<RunEvent>, RuntimeError> {
+        let entity = self.validate_handle(handle)?;
+        let events = self
+            .world
+            .get::<RunEvents>(entity)
+            .ok_or(RuntimeError::UnknownRun(handle.run_id))?;
+        Ok(events.subscribe())
+    }
+
+    /// Return all rejected effect records retained by the runtime.
+    #[must_use]
+    pub fn effect_rejections(&self) -> &[crate::EffectRejection] {
+        &self.world.resource::<RejectionLog>().0
+    }
+
+    /// Inject ingress for testing or an externally hosted executor.
+    pub fn ingest(&mut self, ingress: EffectIngress) -> Result<(), RuntimeError> {
+        self.ingress_tx.try_send(ingress)
+    }
+
+    /// Return active effect headers for diagnostics and hosted execution.
+    pub fn active_effect_headers(
+        &self,
+        handle: RunHandle,
+    ) -> Result<Vec<EffectHeader>, RuntimeError> {
+        let entity = self.validate_handle(handle)?;
+        let operations = self
+            .world
+            .get::<ActiveOperations>(entity)
+            .ok_or(RuntimeError::UnknownRun(handle.run_id))?;
+        Ok(operations
+            .0
+            .values()
+            .filter(|operation| !operation.completed)
+            .map(|operation| operation.header)
+            .collect())
+    }
+
+    fn spawn_pending_effects(&mut self) {
+        let intents = std::mem::take(&mut self.world.resource_mut::<PendingEffects>().0);
+        let mut deferred = Vec::new();
+        for intent in intents {
+            let operation_id = intent.header().operation_id;
+            let run_id = intent.header().run_id;
+            let run_is_active = self
+                .world
+                .resource::<TopologyIndex>()
+                .runs
+                .get(&run_id)
+                .copied()
+                .is_some_and(|entity| !self.world.entity(entity).contains::<TerminalState>());
+            if !run_is_active {
+                continue;
+            }
+            let parent = self
+                .world
+                .resource::<TopologyIndex>()
+                .runs
+                .get(&run_id)
+                .and_then(|entity| self.world.get::<RunTelemetrySpan>(*entity))
+                .map(|telemetry| telemetry.0.clone())
+                .unwrap_or_else(tracing::Span::none);
+            let effect_span = match &intent {
+                EffectIntent::Model(_) => tracing::info_span!(
+                    target: "rig::completion_parent",
+                    parent: &parent,
+                    "chat",
+                    rig.completion_parent = true,
+                    gen_ai.operation.name = tracing::field::Empty,
+                    gen_ai.provider.name = tracing::field::Empty,
+                    gen_ai.request.model = tracing::field::Empty,
+                    gen_ai.system_instructions = tracing::field::Empty,
+                    gen_ai.response.id = tracing::field::Empty,
+                    gen_ai.response.model = tracing::field::Empty,
+                    gen_ai.usage.input_tokens = tracing::field::Empty,
+                    gen_ai.usage.output_tokens = tracing::field::Empty,
+                    gen_ai.usage.cache_read.input_tokens = tracing::field::Empty,
+                    gen_ai.usage.cache_creation.input_tokens = tracing::field::Empty,
+                    gen_ai.usage.tool_use_prompt_tokens = tracing::field::Empty,
+                    gen_ai.usage.reasoning_tokens = tracing::field::Empty,
+                    gen_ai.input.messages = tracing::field::Empty,
+                    gen_ai.output.messages = tracing::field::Empty,
+                    rig.run.id = %run_id,
+                    rig.operation.id = %operation_id,
+                ),
+                EffectIntent::Tool(intent) => tracing::info_span!(
+                    target: "rig::ecs",
+                    parent: &parent,
+                    "rig.ecs.tool_effect",
+                    rig.run.id = %run_id,
+                    rig.operation.id = %operation_id,
+                    tool.name = %intent.name,
+                ),
+                EffectIntent::Memory(intent) => {
+                    let kind = match intent {
+                        crate::effects::MemoryEffectIntent::Load { .. } => "load",
+                        crate::effects::MemoryEffectIntent::Append { .. } => "append",
+                    };
+                    tracing::info_span!(
+                        target: "rig::ecs",
+                        parent: &parent,
+                        "rig.ecs.memory_effect",
+                        rig.run.id = %run_id,
+                        rig.operation.id = %operation_id,
+                        memory.operation = kind,
+                    )
+                }
+            };
+            let ingress = self.ingress_tx.clone();
+            let timeout = self.config.effect_timeout;
+            let kind_limit = match &intent {
+                EffectIntent::Model(_) => Some(&self.model_limit),
+                EffectIntent::Tool(_) => Some(&self.tool_limit),
+                EffectIntent::Memory(_) => None,
+            };
+            let Some(permits) = try_acquire_permits(&self.global_limit, kind_limit) else {
+                deferred.push(intent);
+                continue;
+            };
+            let task: NativeFuture<()> = match intent {
+                EffectIntent::Model(intent) => {
+                    let binding = self
+                        .model_tenants
+                        .get(&intent.model_id)
+                        .filter(|owner| **owner == intent.header.tenant_id)
+                        .and_then(|_| self.models.get(&intent.model_id))
+                        .cloned();
+                    Box::pin(async move {
+                        let _permits = permits;
+                        let result = match binding {
+                            Some(binding) => {
+                                let future = if intent.streaming {
+                                    binding.stream(intent.request, intent.header, ingress.clone())
+                                } else {
+                                    binding.complete(intent.request)
+                                };
+                                match tokio::time::timeout(timeout, future).await {
+                                    Ok(result) => result,
+                                    Err(_) => Err(ModelEffectError::TimedOut),
+                                }
+                            }
+                            None => Err(ModelEffectError::MissingBinding {
+                                model_id: intent.model_id,
+                            }),
+                        };
+                        let _ = ingress
+                            .send(EffectIngress::Completion(EffectCompletion::Model {
+                                header: intent.header,
+                                result,
+                            }))
+                            .await;
+                    })
+                }
+                EffectIntent::Tool(intent) => {
+                    let binding = intent
+                        .header
+                        .capability_id
+                        .and_then(|id| self.tools.get(&id).cloned());
+                    Box::pin(async move {
+                        let _permits = permits;
+                        let result = match binding {
+                            Some(binding) if binding.definition().name == intent.name => {
+                                match tokio::time::timeout(
+                                    timeout,
+                                    binding.execute(intent.arguments),
+                                )
+                                .await
+                                {
+                                    Ok(Ok(output)) => {
+                                        crate::effects::ToolEffectOutput::Success(output)
+                                    }
+                                    Ok(Err(error)) => {
+                                        crate::effects::ToolEffectOutput::Failure(error)
+                                    }
+                                    Err(_) => crate::effects::ToolEffectOutput::Failure(
+                                        ToolExecutionError::timeout("tool effect timed out"),
+                                    ),
+                                }
+                            }
+                            Some(_) => crate::effects::ToolEffectOutput::Failure(
+                                ToolExecutionError::permission_denied(
+                                    "advertised tool identity did not match its exact capability binding",
+                                ),
+                            ),
+                            None => crate::effects::ToolEffectOutput::Failure(
+                                ToolExecutionError::not_found(
+                                    "exact tool capability implementation is unavailable",
+                                ),
+                            ),
+                        };
+                        let _ = ingress
+                            .send(EffectIngress::Completion(EffectCompletion::Tool {
+                                header: intent.header,
+                                tool_call_id: intent.tool_call_id,
+                                order: intent.order,
+                                result,
+                            }))
+                            .await;
+                    })
+                }
+                EffectIntent::Memory(intent) => {
+                    let (header, memory_id) = match &intent {
+                        crate::effects::MemoryEffectIntent::Load {
+                            header, memory_id, ..
+                        }
+                        | crate::effects::MemoryEffectIntent::Append {
+                            header, memory_id, ..
+                        } => (*header, *memory_id),
+                    };
+                    let binding = self
+                        .memory_tenants
+                        .get(&memory_id)
+                        .filter(|owner| **owner == header.tenant_id)
+                        .and_then(|_| self.memories.get(&memory_id))
+                        .cloned();
+                    Box::pin(async move {
+                        let _permits = permits;
+                        let result = match (binding, intent) {
+                            (
+                                Some(binding),
+                                crate::effects::MemoryEffectIntent::Load {
+                                    conversation_id, ..
+                                },
+                            ) => match tokio::time::timeout(timeout, binding.load(conversation_id))
+                                .await
+                            {
+                                Ok(result) => {
+                                    result.map(crate::effects::MemoryEffectOutput::Loaded)
+                                }
+                                Err(_) => Err(MemoryEffectError::TimedOut),
+                            },
+                            (
+                                Some(binding),
+                                crate::effects::MemoryEffectIntent::Append {
+                                    conversation_id,
+                                    messages,
+                                    ..
+                                },
+                            ) => match tokio::time::timeout(
+                                timeout,
+                                binding.append(conversation_id, messages),
+                            )
+                            .await
+                            {
+                                Ok(result) => {
+                                    result.map(|()| crate::effects::MemoryEffectOutput::Appended)
+                                }
+                                Err(_) => Err(MemoryEffectError::TimedOut),
+                            },
+                            (None, _) => Err(MemoryEffectError::MissingBinding { memory_id }),
+                        };
+                        let _ = ingress
+                            .send(EffectIngress::Completion(EffectCompletion::Memory {
+                                header,
+                                result,
+                            }))
+                            .await;
+                    })
+                }
+            };
+            let capacity_guard = EffectCapacityGuard(self.effect_capacity_tx.clone());
+            let task = async move {
+                let _capacity_guard = capacity_guard;
+                task.await;
+            };
+            let abort = self.effects.spawn(task.instrument(effect_span));
+            self.aborts.insert(operation_id, (run_id, abort));
+        }
+        self.world.resource_mut::<PendingEffects>().0 = deferred;
+    }
+
+    fn prune_effect_tasks(&mut self) {
+        while self.effects.try_join_next().is_some() {}
+        let terminal_runs = self
+            .world
+            .query::<(&RunNode, Option<&TerminalState>)>()
+            .iter(&self.world)
+            .filter_map(|(run, terminal)| terminal.map(|_| run.id))
+            .collect::<Vec<_>>();
+        for (run_id, abort) in self.aborts.values() {
+            if terminal_runs.contains(run_id) {
+                abort.abort();
+            }
+        }
+        self.aborts.retain(|operation_id, (run_id, _)| {
+            if terminal_runs.contains(run_id) {
+                return false;
+            }
+            self.world
+                .resource::<TopologyIndex>()
+                .runs
+                .get(run_id)
+                .and_then(|entity| self.world.get::<ActiveOperations>(*entity))
+                .and_then(|operations| operations.0.get(operation_id))
+                .is_some_and(|operation| !operation.completed)
+        });
+        for capability_id in std::mem::take(&mut self.world.resource_mut::<CapabilitiesToDrop>().0)
+        {
+            self.tools.remove(&capability_id);
+            self.tool_binding_identities.remove(&capability_id);
+        }
+    }
+
+    fn stage_available_ingress(&mut self, target_run: Option<RunId>, limit: usize) -> bool {
+        let (already_staged, mut target_progress) = {
+            let pending = self.world.resource::<PendingIngress>();
+            (
+                pending.0.len(),
+                pending
+                    .0
+                    .iter()
+                    .any(|ingress| target_run.is_some_and(|target| target == ingress.run_id())),
+            )
+        };
+        for _ in 0..limit.saturating_sub(already_staged) {
+            let Ok(ingress) = self.ingress_rx.try_recv() else {
+                break;
+            };
+            let run_id = ingress.run_id();
+            target_progress |= target_run.is_some_and(|target| run_id == target);
+            self.world.resource_mut::<PendingIngress>().0.push(ingress);
+        }
+        target_progress
+    }
+
+    /// Run one bounded deterministic schedule pass and dispatch newly owned effects.
+    pub async fn step(&mut self, handle: RunHandle) -> Result<RunStepStatus, RuntimeError> {
+        self.step_with_ingress_limit(handle, self.config.ingress_capacity)
+            .await
+    }
+
+    async fn step_with_ingress_limit(
+        &mut self,
+        handle: RunHandle,
+        ingress_limit: usize,
+    ) -> Result<RunStepStatus, RuntimeError> {
+        let entity = self.validate_handle(handle)?;
+        let target_ingress_staged =
+            self.stage_available_ingress(Some(handle.run_id), ingress_limit);
+        let before = self
+            .world
+            .get::<RunProgress>(entity)
+            .map_or(0, |progress| progress.0);
+        self.schedule.run(&mut self.world);
+        self.spawn_pending_effects();
+        self.prune_effect_tasks();
+        if self
+            .world
+            .get_entity(entity)
+            .is_ok_and(|entity_ref| entity_ref.contains::<TerminalState>())
+        {
+            // Returning `Terminal` to the handle holder is an observation, and
+            // each one renews the retention lease: a caller actively polling a
+            // terminal run never loses its result, while a handle that stops
+            // being stepped ages out from its last observation.
+            let tick = self.world.resource::<RuntimeTick>().0;
+            self.world.entity_mut(entity).insert(TerminalObservation {
+                observed_tick: tick,
+            });
+            return Ok(RunStepStatus::Terminal);
+        }
+        if !self
+            .world
+            .resource::<TopologyIndex>()
+            .runs
+            .contains_key(&handle.run_id)
+        {
+            return Err(RuntimeError::UnknownRun(handle.run_id));
+        }
+        let after = self
+            .world
+            .get::<RunProgress>(entity)
+            .map_or(before, |progress| progress.0);
+        if after == before {
+            Ok(RunStepStatus::Quiescent)
+        } else if target_ingress_staged {
+            Ok(RunStepStatus::EffectProgressed)
+        } else {
+            Ok(RunStepStatus::Progressed)
+        }
+    }
+
+    /// Wait for one bounded effect message and stage it for the next schedule pass.
+    pub async fn wait_for_effect(&mut self) -> Result<(), RuntimeError> {
+        let deadline = tokio::time::Instant::now() + self.config.effect_timeout;
+        self.wait_for_effect_for(None, deadline).await.map(|_| ())
+    }
+
+    async fn wait_for_effect_for(
+        &mut self,
+        target_run: Option<RunId>,
+        deadline: tokio::time::Instant,
+    ) -> Result<bool, RuntimeError> {
+        let ingress = tokio::time::timeout_at(deadline, self.ingress_rx.recv())
+            .await
+            .map_err(|_| RuntimeError::EffectWaitTimedOut)?
+            .ok_or(RuntimeError::IngressClosed)?;
+        let run_id = ingress.run_id();
+        self.world.resource_mut::<PendingIngress>().0.push(ingress);
+        Ok(target_run.is_none_or(|target| target == run_id))
+    }
+
+    fn waits_for_effect_capacity(&self, handle: RunHandle) -> Result<bool, RuntimeError> {
+        let entity = self.validate_handle(handle)?;
+        Ok(self.world.entity(entity).contains::<EffectQueueWait>())
+    }
+
+    async fn wait_for_effect_capacity(
+        &self,
+        receiver: &mut watch::Receiver<u64>,
+    ) -> Result<(), RuntimeError> {
+        tokio::time::timeout(self.config.effect_timeout, receiver.changed())
+            .await
+            .map_err(|_| RuntimeError::EffectWaitTimedOut)?
+            .map_err(|_| RuntimeError::IngressClosed)
+    }
+
+    // The one quiescent-wait contract shared by the blocking and streaming
+    // local drivers. Only real progress (`EffectProgressed`, observed by the
+    // caller) clears the effect deadline: staged-but-rejected ingress cannot
+    // extend an effect wait. Capacity release also wakes the pass so a
+    // semaphore-deferred intent spawns even when its owner was aborted without
+    // ingress. Returns whether the caller should reset its pass budget. The
+    // hosted driver intentionally has its own wait (short world locks, notify
+    // plus two watch channels, timeout-to-finish) and must not be folded in.
+    async fn wait_quiescent(
+        &mut self,
+        handle: RunHandle,
+        capacity_rx: &mut watch::Receiver<u64>,
+        target_effect_deadline: &mut Option<tokio::time::Instant>,
+    ) -> Result<bool, RuntimeError> {
+        let has_active = !self.active_effect_headers(handle)?.is_empty();
+        if has_active {
+            let deadline = *target_effect_deadline
+                .get_or_insert_with(|| tokio::time::Instant::now() + self.config.effect_timeout);
+            tokio::select! {
+                result = self.wait_for_effect_for(Some(handle.run_id), deadline) => match result {
+                    Err(error) => {
+                        crate::schedule::fail_effect_wait(
+                            &mut self.world,
+                            handle.run_id,
+                            error.to_string(),
+                        );
+                        Ok(false)
+                    }
+                    Ok(target_staged) => Ok(target_staged),
+                },
+                changed = capacity_rx.changed() => match changed {
+                    Ok(()) => Ok(true),
+                    Err(_) => {
+                        crate::schedule::fail_effect_wait(
+                            &mut self.world,
+                            handle.run_id,
+                            RuntimeError::IngressClosed.to_string(),
+                        );
+                        Ok(false)
+                    }
+                },
+            }
+        } else if self.waits_for_effect_capacity(handle)? {
+            *target_effect_deadline = None;
+            if let Err(error) = self.wait_for_effect_capacity(capacity_rx).await {
+                crate::schedule::fail_effect_wait(
+                    &mut self.world,
+                    handle.run_id,
+                    error.to_string(),
+                );
+                Ok(false)
+            } else {
+                Ok(true)
+            }
+        } else {
+            crate::schedule::fail_effect_wait(
+                &mut self.world,
+                handle.run_id,
+                "run became quiescent before reaching terminal state".to_string(),
+            );
+            Ok(false)
+        }
+    }
+
+    /// Drive one run to terminal state without collapsing its terminal reason into an error.
+    pub async fn drive_to_terminal(
+        &mut self,
+        handle: RunHandle,
+    ) -> Result<LocalRunResult, RuntimeError> {
+        let mut remaining_passes = self.config.max_schedule_passes;
+        let mut target_effect_deadline = None;
+        loop {
+            let mut capacity_rx = self.effect_capacity_tx.subscribe();
+            match self.step(handle).await? {
+                RunStepStatus::Terminal => return self.finish_run(handle),
+                RunStepStatus::Progressed => {
+                    if remaining_passes == 0 {
+                        break;
+                    }
+                    remaining_passes -= 1;
+                }
+                RunStepStatus::EffectProgressed => {
+                    remaining_passes = self.config.max_schedule_passes;
+                    target_effect_deadline = None;
+                }
+                RunStepStatus::Quiescent => {
+                    if self
+                        .wait_quiescent(handle, &mut capacity_rx, &mut target_effect_deadline)
+                        .await?
+                    {
+                        remaining_passes = self.config.max_schedule_passes;
+                    }
+                }
+            }
+        }
+        crate::schedule::fail_effect_wait(
+            &mut self.world,
+            handle.run_id,
+            RuntimeError::Livelock.to_string(),
+        );
+        self.finish_run(handle)
+    }
+
+    /// Start and drive a run using the agent's configured model surface.
+    pub async fn run(
+        &mut self,
+        agent_id: AgentId,
+        prompt: impl Into<Message>,
+    ) -> Result<LocalRunResult, RuntimeError> {
+        self.run_with_mode(agent_id, prompt, None).await
+    }
+
+    /// Start and drive a run through the provider blocking surface.
+    pub async fn run_blocking(
+        &mut self,
+        agent_id: AgentId,
+        prompt: impl Into<Message>,
+    ) -> Result<LocalRunResult, RuntimeError> {
+        self.run_with_mode(agent_id, prompt, Some(StreamingMode::Blocking))
+            .await
+    }
+
+    async fn run_with_mode(
+        &mut self,
+        agent_id: AgentId,
+        prompt: impl Into<Message>,
+        mode: Option<StreamingMode>,
+    ) -> Result<LocalRunResult, RuntimeError> {
+        let handle = self.start_run(agent_id, prompt)?;
+        if let Some(mode) = mode {
+            let entity = self.validate_handle(handle)?;
+            if let Some(mut run) = self.world.get_mut::<RunNode>(entity) {
+                run.streaming = mode;
+            }
+        }
+        let mut guard = LocalRunGuard {
+            runtime: self,
+            handle,
+            closed: false,
+        };
+        let result = guard.runtime.drive_to_terminal(handle).await?;
+        guard.closed = true;
+        Self::ensure_completed(result)
+    }
+
+    /// Start and drive a provider-streaming run with concrete typed final events.
+    pub async fn run_streaming<R>(
+        &mut self,
+        agent_id: AgentId,
+        prompt: impl Into<Message>,
+    ) -> Result<StreamingRunResult<R>, RuntimeError>
+    where
+        R: Any + Send + Sync + 'static,
+    {
+        let mut stream = self.start_streaming::<R>(agent_id, prompt)?;
+        let mut events = Vec::new();
+        while let Some(event) = stream.next_event().await? {
+            if events.len() == stream.runtime.config.event_capacity {
+                return Err(RuntimeError::EventCollectionLimit {
+                    capacity: stream.runtime.config.event_capacity,
+                });
+            }
+            events.push(event);
+        }
+        let result = stream.finish()?;
+        Ok(StreamingRunResult { result, events })
+    }
+
+    /// Start a live provider-streaming run with a concrete provider-final type.
+    pub fn start_streaming<R>(
+        &mut self,
+        agent_id: AgentId,
+        prompt: impl Into<Message>,
+    ) -> Result<LocalStreamingRun<'_, R>, RuntimeError>
+    where
+        R: Any + Send + Sync + 'static,
+    {
+        let handle = self.start_run(agent_id, prompt)?;
+        let entity = self.validate_handle(handle)?;
+        if let Some(mut run) = self.world.get_mut::<RunNode>(entity) {
+            run.streaming = StreamingMode::Streaming;
+        }
+        let receiver = self.subscribe(handle)?;
+        Ok(LocalStreamingRun {
+            runtime: self,
+            handle,
+            receiver,
+            terminal_seen: false,
+            closed: false,
+            response: PhantomData,
+        })
+    }
+
+    fn ensure_completed(result: LocalRunResult) -> Result<LocalRunResult, RuntimeError> {
+        match &result.terminal_reason {
+            TerminalReason::Completed => Ok(result),
+            TerminalReason::Cancelled => Err(RuntimeError::Cancelled),
+            TerminalReason::Stopped => Err(RuntimeError::Stopped),
+            TerminalReason::ModelCallBudgetExhausted => Err(RuntimeError::ModelCallBudgetExhausted),
+            TerminalReason::Failed { code } => {
+                let diagnostic = result
+                    .failure_diagnostic
+                    .clone()
+                    .unwrap_or_else(|| code.clone());
+                match code.as_str() {
+                    "model_effect" => match result.failure_cause {
+                        Some(TerminalCause::Model(error)) => Err(RuntimeError::ModelEffect(error)),
+                        _ => Err(RuntimeError::RunFailed {
+                            code: code.clone(),
+                            diagnostic,
+                        }),
+                    },
+                    "memory_effect" => match result.failure_cause {
+                        Some(TerminalCause::Memory(error)) => {
+                            Err(RuntimeError::MemoryEffect(error))
+                        }
+                        _ => Err(RuntimeError::RunFailed {
+                            code: code.clone(),
+                            diagnostic,
+                        }),
+                    },
+                    "structured_output" => Err(RuntimeError::StructuredOutput(diagnostic)),
+                    _ => Err(RuntimeError::RunFailed {
+                        code: code.clone(),
+                        diagnostic,
+                    }),
+                }
+            }
+        }
+    }
+
+    /// Materialize and observe a retained terminal run without triggering cleanup.
+    pub fn finish_run(&mut self, handle: RunHandle) -> Result<LocalRunResult, RuntimeError> {
+        let entity = self.validate_handle(handle)?;
+        let terminal = self
+            .world
+            .get::<TerminalState>(entity)
+            .cloned()
+            .ok_or(RuntimeError::Livelock)?;
+        let tick = self.world.resource::<RuntimeTick>().0;
+        self.world.entity_mut(entity).insert(TerminalObservation {
+            observed_tick: tick,
+        });
+        let transcript = self
+            .world
+            .get::<CanonicalTranscript>(entity)
+            .cloned()
+            .ok_or(RuntimeError::UnknownRun(handle.run_id))?;
+        let accounting = self
+            .world
+            .get::<RunAccounting>(entity)
+            .cloned()
+            .ok_or(RuntimeError::UnknownRun(handle.run_id))?;
+        let events = self
+            .world
+            .get::<RunEvents>(entity)
+            .map(|events| events.events.iter().cloned().collect())
+            .unwrap_or_default();
+        let raw = self.world.get::<RawFinalRecord>(entity);
+        let raw_final_operation = raw.map(|raw| raw.operation_id);
+        let raw_final = raw.map(|raw| raw.raw.clone());
+        let structured_output = self
+            .world
+            .get::<StructuredOutputState>(entity)
+            .and_then(|state| state.value.clone());
+        let failure_diagnostic = self
+            .world
+            .get::<TerminalDiagnostic>(entity)
+            .map(|diagnostic| diagnostic.message.clone());
+        let failure_cause = self.world.get::<TerminalCause>(entity).cloned();
+        let text = transcript.messages.iter().rev().find_map(|message| {
+            let Message::Assistant { content, .. } = message else {
+                return None;
+            };
+            let text = content
+                .iter()
+                .filter_map(|item| match item {
+                    rig_core::completion::AssistantContent::Text(text) => Some(text.text.as_str()),
+                    _ => None,
+                })
+                .collect::<String>();
+            (!text.is_empty()).then_some(text)
+        });
+        Ok(LocalRunResult {
+            run_id: handle.run_id,
+            text,
+            transcript: transcript.messages,
+            usage: accounting.usage,
+            model_calls: accounting.model_calls,
+            terminal_reason: terminal.reason,
+            structured_output,
+            events,
+            raw_final_operation,
+            failure_diagnostic,
+            raw_final,
+            failure_cause,
+        })
+    }
+}
+
+impl Drop for LocalRuntime {
+    fn drop(&mut self) {
+        self.effects.abort_all();
+    }
+}
+
+/// Serialized hosted driver that invokes the same schedule and effect adapters.
+#[derive(Clone)]
+pub struct HostedRuntime {
+    inner: Arc<tokio::sync::Mutex<LocalRuntime>>,
+    run_notifies: Arc<Mutex<HashMap<RunId, Arc<Notify>>>>,
+    effect_capacity_tx: watch::Sender<u64>,
+    ingress_progress_tx: watch::Sender<u64>,
+    driving_runs: Arc<Mutex<BTreeSet<RunId>>>,
+}
+
+struct HostedDriveGuard {
+    driving_runs: Arc<Mutex<BTreeSet<RunId>>>,
+    run_id: RunId,
+}
+
+impl Drop for HostedDriveGuard {
+    fn drop(&mut self) {
+        lock_unpoisoned(&self.driving_runs).remove(&self.run_id);
+    }
+}
+
+impl HostedRuntime {
+    /// Wrap a local runtime without changing schedule semantics.
+    #[must_use]
+    pub fn new(runtime: LocalRuntime) -> Self {
+        let run_notifies = Arc::clone(&runtime.ingress_tx.run_notifies);
+        let effect_capacity_tx = runtime.effect_capacity_tx.clone();
+        let ingress_progress_tx = runtime.ingress_tx.ingress_progress_tx.clone();
+        Self {
+            inner: Arc::new(tokio::sync::Mutex::new(runtime)),
+            run_notifies,
+            effect_capacity_tx,
+            ingress_progress_tx,
+            driving_runs: Arc::new(Mutex::new(BTreeSet::new())),
+        }
+    }
+
+    fn run_notifies(&self) -> MutexGuard<'_, HashMap<RunId, Arc<Notify>>> {
+        lock_unpoisoned(&self.run_notifies)
+    }
+
+    fn run_notify(&self, run_id: RunId) -> Arc<Notify> {
+        Arc::clone(
+            self.run_notifies()
+                .entry(run_id)
+                .or_insert_with(|| Arc::new(Notify::new())),
+        )
+    }
+
+    /// Start a run while holding the world lock only for the synchronous mutation.
+    pub async fn start_run(
+        &self,
+        agent_id: AgentId,
+        prompt: impl Into<Message>,
+    ) -> Result<RunHandle, RuntimeError> {
+        let handle = self.inner.lock().await.start_run(agent_id, prompt)?;
+        self.run_notify(handle.run_id);
+        Ok(handle)
+    }
+
+    /// Request cancellation without waiting for a convenience `run` lock.
+    pub async fn cancel(&self, handle: RunHandle) -> Result<(), RuntimeError> {
+        self.inner.lock().await.cancel(handle)?;
+        self.run_notify(handle.run_id).notify_one();
+        Ok(())
+    }
+
+    /// Reacquire the valid handle for a retained run owned by `tenant_id`.
+    pub async fn run_handle(
+        &self,
+        run_id: RunId,
+        tenant_id: TenantId,
+    ) -> Result<RunHandle, RuntimeError> {
+        self.inner.lock().await.run_handle(run_id, tenant_id)
+    }
+
+    /// Run one short schedule pass without holding the lock across effect I/O.
+    pub async fn step(&self, handle: RunHandle) -> Result<RunStepStatus, RuntimeError> {
+        let mut runtime = self.inner.lock().await;
+        let result = runtime.step(handle).await;
+        // Cleaned-up runs must release their notify entries, or abandoned hosted
+        // handles would grow this map without bound.
+        let retained_runs = &runtime.world.resource::<TopologyIndex>().runs;
+        self.run_notifies()
+            .retain(|run_id, _| retained_runs.contains_key(run_id));
+        result
+    }
+
+    /// Observe a retained terminal result.
+    pub async fn finish_run(&self, handle: RunHandle) -> Result<LocalRunResult, RuntimeError> {
+        let result = self.inner.lock().await.finish_run(handle);
+        if result.is_ok() {
+            self.run_notifies().remove(&handle.run_id);
+        }
+        result
+    }
+
+    /// Drive a hosted run while yielding between short world locks.
+    ///
+    /// Dropping this future releases its single-driver lease but intentionally leaves the run
+    /// and its owned effects active. A hosted caller may resume the same handle or cancel it
+    /// explicitly; dropping a driver is not an implicit cancellation boundary.
+    pub async fn drive_to_terminal(
+        &self,
+        handle: RunHandle,
+    ) -> Result<LocalRunResult, RuntimeError> {
+        {
+            let inserted = lock_unpoisoned(&self.driving_runs).insert(handle.run_id);
+            if !inserted {
+                return Err(RuntimeError::RunAlreadyDriven(handle.run_id));
+            }
+        }
+        let _drive_guard = HostedDriveGuard {
+            driving_runs: Arc::clone(&self.driving_runs),
+            run_id: handle.run_id,
+        };
+        let (max_schedule_passes, effect_timeout) = {
+            let runtime = self.inner.lock().await;
+            (
+                runtime.config.max_schedule_passes,
+                runtime.config.effect_timeout,
+            )
+        };
+        let run_notify = self.run_notify(handle.run_id);
+        let mut remaining_passes = max_schedule_passes;
+        let mut target_effect_deadline = None;
+        loop {
+            let mut capacity_rx = self.effect_capacity_tx.subscribe();
+            let mut ingress_progress_rx = self.ingress_progress_tx.subscribe();
+            match self.step(handle).await? {
+                RunStepStatus::Terminal => return self.finish_run(handle).await,
+                RunStepStatus::Progressed => {
+                    if remaining_passes == 0 {
+                        break;
+                    }
+                    remaining_passes -= 1;
+                    tokio::task::yield_now().await;
+                }
+                RunStepStatus::EffectProgressed => {
+                    remaining_passes = max_schedule_passes;
+                    target_effect_deadline = None;
+                    tokio::task::yield_now().await;
+                }
+                RunStepStatus::Quiescent => {
+                    let notified = run_notify.notified();
+                    let (has_active, waits_for_capacity) = {
+                        let runtime = self.inner.lock().await;
+                        (
+                            !runtime.active_effect_headers(handle)?.is_empty(),
+                            runtime.waits_for_effect_capacity(handle)?,
+                        )
+                    };
+                    if !has_active && !waits_for_capacity {
+                        let mut runtime = self.inner.lock().await;
+                        crate::schedule::fail_effect_wait(
+                            &mut runtime.world,
+                            handle.run_id,
+                            "run became quiescent before reaching terminal state".to_string(),
+                        );
+                        return runtime.finish_run(handle);
+                    }
+                    let wait = async {
+                        tokio::select! {
+                            () = notified => Ok(()),
+                            changed = ingress_progress_rx.changed() => changed,
+                            changed = capacity_rx.changed() => changed,
+                        }
+                    };
+                    let wait_result = if has_active {
+                        let deadline = *target_effect_deadline
+                            .get_or_insert_with(|| tokio::time::Instant::now() + effect_timeout);
+                        tokio::time::timeout_at(deadline, wait).await
+                    } else {
+                        target_effect_deadline = None;
+                        tokio::time::timeout(effect_timeout, wait).await
+                    };
+                    if !matches!(wait_result, Ok(Ok(()))) {
+                        let mut runtime = self.inner.lock().await;
+                        crate::schedule::fail_effect_wait(
+                            &mut runtime.world,
+                            handle.run_id,
+                            "hosted effect wait timed out".to_string(),
+                        );
+                        return runtime.finish_run(handle);
+                    }
+                    remaining_passes = max_schedule_passes;
+                }
+            }
+        }
+        let mut runtime = self.inner.lock().await;
+        crate::schedule::fail_effect_wait(
+            &mut runtime.world,
+            handle.run_id,
+            RuntimeError::Livelock.to_string(),
+        );
+        runtime.finish_run(handle)
+    }
+
+    /// Return a redacted provider-final diagnostic for hosted/erased consumers.
+    pub async fn provider_diagnostic(
+        &self,
+        handle: RunHandle,
+    ) -> Result<Option<HostedProviderDiagnostic>, RuntimeError> {
+        let runtime = self.inner.lock().await;
+        let entity = runtime.validate_handle(handle)?;
+        Ok(runtime
+            .world
+            .get::<crate::components::RawFinalRecord>(entity)
+            .map(|record| HostedProviderDiagnostic {
+                operation_id: record.operation_id,
+                provider_type: record.raw.type_name(),
+            }))
+    }
+}
+
+#[cfg(test)]
+mod portable_adapter_tests {
+    use rig_core::tool::{PortableTool, ToolErrorKind};
+    use rig_runtime_conformance::{
+        PortableEmbeddingFixture, portable_dynamic_fixture, portable_fixture_output,
+    };
+
+    use super::{DynamicToolBinding, ToolBinding, TypedToolBinding};
+
+    #[tokio::test]
+    async fn portable_embedding_binding_preserves_classification_and_rich_error() {
+        let binding =
+            TypedToolBinding(std::sync::Arc::new(PortableEmbeddingFixture::new("shared")));
+
+        assert_eq!(
+            binding.definition().name,
+            <PortableEmbeddingFixture as PortableTool>::NAME
+        );
+        let result = binding
+            .execute(serde_json::json!({"value": "ignored", "fail": true}))
+            .await;
+        assert!(result.is_err(), "portable fixture unexpectedly succeeded");
+        let Err(error) = result else {
+            return;
+        };
+        assert_eq!(error.kind(), ToolErrorKind::Provider);
+        assert_eq!(error.code(), Some("portable_fixture"));
+        assert_eq!(
+            error.model_output(),
+            &portable_fixture_output("portable failure")
+        );
+    }
+
+    #[tokio::test]
+    async fn portable_dynamic_binding_preserves_classification_and_rich_error() {
+        let binding = DynamicToolBinding(portable_dynamic_fixture());
+        let result = binding
+            .execute(serde_json::json!({"value": "ignored", "fail": true}))
+            .await;
+        assert!(result.is_err(), "portable fixture unexpectedly succeeded");
+        let Err(error) = result else {
+            return;
+        };
+        assert_eq!(error.kind(), ToolErrorKind::Provider);
+        assert_eq!(error.code(), Some("portable_dynamic_fixture"));
+        assert_eq!(
+            error.model_output(),
+            &portable_fixture_output("portable dynamic failure")
+        );
+    }
+}
+
+// This module panics inside a provider double to model an effect task that dies
+// without sending ingress; expectations are confined to test setup.
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod driver_wait_tests {
+    use std::time::Duration;
+
+    use rig_core::{
+        completion::{CompletionError, CompletionRequest, CompletionResponse},
+        streaming::StreamingCompletionResponse,
+        test_utils::{MockCompletionModel, MockResponse},
+    };
+
+    use super::{CompletionModel, HostedRuntime, LocalRuntime};
+    use crate::{
+        AgentSpec, CorrelationId, EffectCompletion, EffectHeader, EffectIngress, ModelEffectError,
+        OperationId, RuntimeConfig, TenantId, TerminalReason,
+    };
+
+    /// A model whose spawned effect task dies without ever sending ingress.
+    #[derive(Clone)]
+    struct SilentModel;
+
+    impl CompletionModel for SilentModel {
+        type Response = MockResponse;
+        type StreamingResponse = MockResponse;
+        type Client = ();
+
+        fn make(_: &Self::Client, _: impl Into<String>) -> Self {
+            Self
+        }
+
+        async fn completion(
+            &self,
+            _request: CompletionRequest,
+        ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+            panic!("silent model never completes")
+        }
+
+        async fn stream(
+            &self,
+            _request: CompletionRequest,
+        ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+            panic!("silent model never streams")
+        }
+    }
+
+    #[tokio::test]
+    async fn rejected_target_ingress_cannot_extend_the_effect_deadline() {
+        let mut runtime = LocalRuntime::with_config(RuntimeConfig {
+            effect_timeout: Duration::from_millis(200),
+            ..RuntimeConfig::default()
+        })
+        .expect("runtime");
+        let tenant_id = TenantId::new();
+        let model_id = runtime.register_model(tenant_id, SilentModel);
+        let agent = runtime
+            .spawn_agent_spec(AgentSpec::new(model_id, tenant_id))
+            .expect("agent");
+        let handle = runtime.start_run(agent, "hang").expect("run");
+        let ingress = runtime.ingress_tx.clone();
+        let runtime_id = runtime.id();
+        let flooder = tokio::spawn(async move {
+            loop {
+                let header = EffectHeader {
+                    runtime_id,
+                    run_id: handle.run_id,
+                    operation_id: OperationId::new(),
+                    generation: handle.generation,
+                    correlation_id: CorrelationId::new(),
+                    tenant_id: handle.tenant_id,
+                    capability_id: None,
+                    grant_id: None,
+                    capability_revision: None,
+                };
+                let garbage = EffectIngress::Completion(EffectCompletion::Model {
+                    header,
+                    result: Err(ModelEffectError::TimedOut),
+                });
+                if ingress.send(garbage).await.is_err() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        });
+
+        let result =
+            tokio::time::timeout(Duration::from_secs(5), runtime.drive_to_terminal(handle))
+                .await
+                .expect("rejected target ingress must not extend the effect deadline")
+                .expect("driver result");
+        flooder.abort();
+
+        assert!(matches!(
+            result.terminal_reason,
+            TerminalReason::Failed { ref code } if code == "effect_wait"
+        ));
+    }
+
+    #[tokio::test]
+    async fn hosted_notify_entries_are_pruned_with_cleaned_runs() {
+        let mut local = LocalRuntime::with_config(RuntimeConfig {
+            terminal_retention_ticks: 64,
+            unobserved_terminal_retention_ticks: 2,
+            ..RuntimeConfig::default()
+        })
+        .expect("runtime");
+        let tenant_id = TenantId::new();
+        let abandoned_model =
+            local.register_model(tenant_id, MockCompletionModel::text("abandoned"));
+        let keeper_model = local.register_model(tenant_id, MockCompletionModel::text("keeper"));
+        let abandoned_agent = local
+            .spawn_agent_spec(AgentSpec::new(abandoned_model, tenant_id))
+            .expect("agent");
+        let keeper_agent = local
+            .spawn_agent_spec(AgentSpec::new(keeper_model, tenant_id))
+            .expect("agent");
+        let hosted = HostedRuntime::new(local);
+        let abandoned = hosted
+            .start_run(abandoned_agent, "abandoned")
+            .await
+            .expect("run");
+        hosted.cancel(abandoned).await.expect("cancel");
+        assert!(hosted.run_notifies().contains_key(&abandoned.run_id));
+        let keeper = hosted.start_run(keeper_agent, "keeper").await.expect("run");
+
+        for _ in 0..64 {
+            if !hosted.run_notifies().contains_key(&abandoned.run_id) {
+                break;
+            }
+            let _ = hosted.step(keeper).await;
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
+
+        assert!(!hosted.run_notifies().contains_key(&abandoned.run_id));
+    }
+}

--- a/crates/rig-ecs/src/schedule.rs
+++ b/crates/rig-ecs/src/schedule.rs
@@ -1,0 +1,2119 @@
+//! Deterministic ordered ECS schedule and progression systems.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
+
+use bevy_ecs::{
+    prelude::*,
+    schedule::{IntoScheduleConfigs, ScheduleLabel, SystemSet},
+};
+use rig_core::{
+    OneOrMany,
+    completion::{AssistantContent, CompletionRequest, Message, ToolDefinition},
+    message::{ToolCall, ToolChoice, ToolResult, UserContent},
+    tool::ToolOutput,
+};
+use sha2::{Digest, Sha256};
+
+use crate::{
+    CapabilityId, CorrelationId, EffectHeader, EffectIngress, EffectRejection,
+    EffectRejectionReason, InvalidToolPolicy, OperationId, OutputMode, ResponseRetryPolicy,
+    RunEvent, RunId, RuntimeConfig, StreamingMode, TerminalReason,
+    components::{
+        AcceptedDeltas, ActiveOperation, ActiveOperationKind, ActiveOperations,
+        AdvertisedCapability, AgentNode, CancellationRequest, CanonicalTranscript,
+        CapabilitiesToDrop, CapabilityNode, CapabilityReferences, EffectQueueWait, GrantNode,
+        InvalidToolRetryState, MemoryProgress, ModelCallRecord, PendingEffects, PendingIngress,
+        PendingModelOutcome, PendingToolBatch, PlannedToolCall, RawFinalRecord, RecoveryFeedback,
+        RejectionLog, ResponseRetryState, RunAccounting, RunEvents, RunNode, RunPhase, RunProgress,
+        RuntimeIdentity, RuntimeTick, StructuredOutputState, TerminalCause, TerminalDiagnostic,
+        TerminalObservation, TerminalState, TopologyIndex, TurnCapabilitySnapshot,
+    },
+    effects::{
+        EffectCompletion, EffectIntent, MemoryEffectIntent, MemoryEffectOutput, ModelEffectIntent,
+        ToolEffectIntent,
+    },
+};
+
+/// Label for one complete Rig ECS progression pass.
+#[derive(Clone, Debug, Hash, Eq, PartialEq, ScheduleLabel)]
+pub struct RigSchedule;
+
+/// Explicitly ordered lifecycle stages.
+#[derive(Clone, Debug, Hash, Eq, PartialEq, SystemSet)]
+pub enum RigSystemSet {
+    /// Cancellation and terminal arbitration runs first.
+    Cancellation,
+    /// Correlated external messages enter authoritative state.
+    Ingress,
+    /// ECS policy interprets accepted outcomes.
+    Policy,
+    /// Owned effects leave the world.
+    Dispatch,
+    /// Completed batches and terminal outcomes become observable.
+    Observation,
+    /// Observed retained state and retired capabilities are safely removed.
+    Cleanup,
+}
+
+pub(crate) fn build_schedule() -> Schedule {
+    let mut schedule = Schedule::new(RigSchedule);
+    schedule.configure_sets(
+        (
+            RigSystemSet::Cancellation,
+            RigSystemSet::Ingress,
+            RigSystemSet::Policy,
+            RigSystemSet::Dispatch,
+            RigSystemSet::Observation,
+            RigSystemSet::Cleanup,
+        )
+            .chain(),
+    );
+    // Every system here is an exclusive `&mut World` system, so there are no
+    // deferred command queues to apply between stages; the chained tuple is
+    // the complete ordering story.
+    schedule.add_systems(
+        (
+            advance_tick.in_set(RigSystemSet::Cancellation),
+            process_cancellation.in_set(RigSystemSet::Cancellation),
+            process_ingress.in_set(RigSystemSet::Ingress),
+            evaluate_model_outcomes.in_set(RigSystemSet::Policy),
+            dispatch_memory_effects.in_set(RigSystemSet::Dispatch),
+            dispatch_model_effects.in_set(RigSystemSet::Dispatch),
+            dispatch_tool_effects.in_set(RigSystemSet::Dispatch),
+            commit_tool_batches.in_set(RigSystemSet::Observation),
+            cleanup_terminal_runs.in_set(RigSystemSet::Cleanup),
+            cleanup_retired_capabilities.in_set(RigSystemSet::Cleanup),
+        )
+            .chain(),
+    );
+    schedule
+}
+
+fn bump_progress(world: &mut World, entity: Entity) {
+    if let Some(mut progress) = world.get_mut::<RunProgress>(entity) {
+        progress.0 = progress.0.saturating_add(1);
+    }
+}
+
+fn advance_tick(world: &mut World) {
+    world.resource_mut::<RuntimeTick>().0 = world.resource::<RuntimeTick>().0.saturating_add(1);
+}
+
+fn publish(world: &mut World, entity: Entity, event: RunEvent) {
+    if let Some(mut events) = world.get_mut::<RunEvents>(entity) {
+        events.publish(event);
+    }
+}
+
+fn set_terminal(
+    world: &mut World,
+    entity: Entity,
+    reason: TerminalReason,
+    diagnostic: Option<String>,
+) {
+    if world.entity(entity).contains::<TerminalState>() {
+        return;
+    }
+    let tick = world.resource::<RuntimeTick>().0;
+    let run_id = world.get::<RunNode>(entity).map(|run| run.id);
+    if let Some(mut run) = world.get_mut::<RunNode>(entity) {
+        run.phase = RunPhase::Terminal;
+    }
+    if !matches!(reason, TerminalReason::Completed)
+        && let Some(mut operations) = world.get_mut::<ActiveOperations>(entity)
+    {
+        for operation in operations.0.values_mut() {
+            operation.completed = true;
+        }
+    }
+    let preserve_raw = matches!(reason, TerminalReason::Completed);
+    let mut entity_mut = world.entity_mut(entity);
+    entity_mut.insert(TerminalState {
+        reason: reason.clone(),
+        terminal_tick: tick,
+    });
+    entity_mut.remove::<PendingModelOutcome>();
+    entity_mut.remove::<PendingToolBatch>();
+    entity_mut.remove::<TurnCapabilitySnapshot>();
+    entity_mut.remove::<EffectQueueWait>();
+    if let Some(message) = diagnostic {
+        entity_mut.insert(TerminalDiagnostic { message });
+    }
+    if !preserve_raw {
+        entity_mut.remove::<RawFinalRecord>();
+    }
+    publish(world, entity, RunEvent::Terminal(reason));
+    tracing::info!(
+        target: "rig::ecs",
+        run_id = ?run_id,
+        terminal_reason = ?world.get::<TerminalState>(entity).map(|state| &state.reason),
+        "run reached terminal state"
+    );
+    bump_progress(world, entity);
+}
+
+fn fail_run(world: &mut World, entity: Entity, code: &str, diagnostic: impl Into<String>) {
+    set_terminal(
+        world,
+        entity,
+        TerminalReason::Failed {
+            code: code.to_string(),
+        },
+        Some(diagnostic.into()),
+    );
+}
+
+fn process_cancellation(world: &mut World) {
+    let entities = {
+        let mut query = world.query_filtered::<Entity, With<CancellationRequest>>();
+        query.iter(world).collect::<Vec<_>>()
+    };
+    for entity in entities {
+        world.entity_mut(entity).remove::<CancellationRequest>();
+        set_terminal(world, entity, TerminalReason::Cancelled, None);
+    }
+}
+
+fn reject_ingress(
+    world: &mut World,
+    entity: Option<Entity>,
+    header: EffectHeader,
+    reason: EffectRejectionReason,
+) {
+    tracing::warn!(
+        target: "rig::ecs",
+        run_id = %header.run_id,
+        operation_id = %header.operation_id,
+        rejection_reason = ?reason,
+        "effect ingress rejected"
+    );
+    let capacity = world
+        .resource::<RuntimeConfigResource>()
+        .0
+        .rejection_capacity;
+    let mut rejections = world.resource_mut::<RejectionLog>();
+    if rejections.0.len() == capacity {
+        rejections.0.remove(0);
+    }
+    rejections.0.push(EffectRejection { header, reason });
+    if let Some(entity) = entity {
+        if let Some(mut accounting) = world.get_mut::<RunAccounting>(entity) {
+            accounting.rejected_effects = accounting.rejected_effects.saturating_add(1);
+        }
+        publish(world, entity, RunEvent::EffectRejected(reason));
+    }
+}
+
+fn validate_ingress(
+    world: &World,
+    header: EffectHeader,
+) -> Result<(Entity, ActiveOperation), (Option<Entity>, EffectRejectionReason)> {
+    if header.runtime_id != world.resource::<RuntimeIdentity>().0 {
+        return Err((None, EffectRejectionReason::ForeignRuntime));
+    }
+    let Some(entity) = world
+        .resource::<TopologyIndex>()
+        .runs
+        .get(&header.run_id)
+        .copied()
+    else {
+        return Err((None, EffectRejectionReason::UnknownRun));
+    };
+    let Some(run) = world.get::<RunNode>(entity) else {
+        return Err((None, EffectRejectionReason::UnknownRun));
+    };
+    if run.tenant_id != header.tenant_id {
+        return Err((Some(entity), EffectRejectionReason::WrongTenant));
+    }
+    if world.entity(entity).contains::<TerminalState>() {
+        return Err((Some(entity), EffectRejectionReason::Late));
+    }
+    if run.generation != header.generation {
+        return Err((Some(entity), EffectRejectionReason::WrongGeneration));
+    }
+    let Some(operation) = world
+        .get::<ActiveOperations>(entity)
+        .and_then(|operations| operations.0.get(&header.operation_id))
+        .cloned()
+    else {
+        return Err((Some(entity), EffectRejectionReason::UnknownOperation));
+    };
+    if operation.completed {
+        return Err((Some(entity), EffectRejectionReason::Duplicate));
+    }
+    if operation.header.correlation_id != header.correlation_id {
+        return Err((Some(entity), EffectRejectionReason::WrongCorrelation));
+    }
+    if operation.header.capability_id != header.capability_id
+        || operation.header.grant_id != header.grant_id
+        || operation.header.capability_revision != header.capability_revision
+    {
+        return Err((Some(entity), EffectRejectionReason::WrongAuthorization));
+    }
+    Ok((entity, operation))
+}
+
+fn mark_operation_complete(world: &mut World, entity: Entity, operation_id: OperationId) {
+    if let Some(mut operations) = world.get_mut::<ActiveOperations>(entity)
+        && let Some(operation) = operations.0.get_mut(&operation_id)
+    {
+        operation.completed = true;
+    }
+    if let Some(mut accepted) = world.get_mut::<AcceptedDeltas>(entity) {
+        accepted.0.remove(&operation_id);
+    }
+}
+
+fn accept_delta_sequence(
+    accepted: &mut AcceptedDeltas,
+    operation_id: OperationId,
+    sequence: u64,
+) -> Result<(), EffectRejectionReason> {
+    let expected = accepted.0.entry(operation_id).or_insert(0);
+    if sequence < *expected {
+        return Err(EffectRejectionReason::Duplicate);
+    }
+    if sequence > *expected {
+        return Err(EffectRejectionReason::OutOfOrder);
+    }
+    *expected = expected.saturating_add(1);
+    Ok(())
+}
+
+fn process_ingress(world: &mut World) {
+    let ingress = std::mem::take(&mut world.resource_mut::<PendingIngress>().0);
+    for message in ingress {
+        let header = match &message {
+            EffectIngress::Delta { header, .. } => *header,
+            EffectIngress::Completion(completion) => *completion.header(),
+        };
+        let (entity, operation) = match validate_ingress(world, header) {
+            Ok(validated) => validated,
+            Err((entity, reason)) => {
+                reject_ingress(world, entity, header, reason);
+                continue;
+            }
+        };
+        match message {
+            EffectIngress::Delta {
+                sequence, delta, ..
+            } => {
+                if operation.kind != ActiveOperationKind::Model {
+                    reject_ingress(
+                        world,
+                        Some(entity),
+                        header,
+                        EffectRejectionReason::WrongAuthorization,
+                    );
+                    continue;
+                }
+                let sequence_result =
+                    world
+                        .get_mut::<AcceptedDeltas>(entity)
+                        .map_or(Ok(()), |mut accepted| {
+                            accept_delta_sequence(&mut accepted, header.operation_id, sequence)
+                        });
+                if let Err(reason) = sequence_result {
+                    reject_ingress(world, Some(entity), header, reason);
+                    continue;
+                }
+                publish(
+                    world,
+                    entity,
+                    RunEvent::Provisional {
+                        operation_id: header.operation_id,
+                        delta: Box::new(delta),
+                    },
+                );
+                bump_progress(world, entity);
+            }
+            EffectIngress::Completion(completion) => {
+                if let Some(reason) = completion_rejection(&completion, &operation) {
+                    reject_ingress(world, Some(entity), header, reason);
+                    continue;
+                }
+                mark_operation_complete(world, entity, header.operation_id);
+                accept_completion(world, entity, operation.kind, completion);
+            }
+        }
+    }
+}
+
+fn completion_rejection(
+    completion: &EffectCompletion,
+    operation: &ActiveOperation,
+) -> Option<EffectRejectionReason> {
+    match completion {
+        EffectCompletion::Model { .. } => (operation.kind != ActiveOperationKind::Model)
+            .then_some(EffectRejectionReason::WrongAuthorization),
+        EffectCompletion::Tool {
+            tool_call_id,
+            order,
+            ..
+        } => {
+            if operation.kind != ActiveOperationKind::Tool {
+                Some(EffectRejectionReason::WrongAuthorization)
+            } else if operation.expected_tool_call_id.as_deref() != Some(tool_call_id.as_str())
+                || operation.expected_tool_order != Some(*order)
+            {
+                Some(EffectRejectionReason::WrongPayload)
+            } else {
+                None
+            }
+        }
+        EffectCompletion::Memory { result, .. } => match result {
+            Ok(MemoryEffectOutput::Loaded(_)) => (operation.kind
+                != ActiveOperationKind::MemoryLoad)
+                .then_some(EffectRejectionReason::WrongPayload),
+            Ok(MemoryEffectOutput::Appended) => (operation.kind
+                != ActiveOperationKind::MemoryAppend)
+                .then_some(EffectRejectionReason::WrongPayload),
+            Err(_)
+                if matches!(
+                    operation.kind,
+                    ActiveOperationKind::MemoryLoad | ActiveOperationKind::MemoryAppend
+                ) =>
+            {
+                None
+            }
+            Err(_) => Some(EffectRejectionReason::WrongAuthorization),
+        },
+    }
+}
+
+fn accept_completion(
+    world: &mut World,
+    entity: Entity,
+    operation_kind: ActiveOperationKind,
+    completion: EffectCompletion,
+) {
+    match completion {
+        EffectCompletion::Model { header, result } => match result {
+            Ok(output) => {
+                let Some(aggregate_usage) = world
+                    .get::<RunAccounting>(entity)
+                    .and_then(|accounting| checked_usage_sum(accounting.usage, output.usage))
+                else {
+                    fail_run(
+                        world,
+                        entity,
+                        "usage_overflow",
+                        "provider usage exceeded the supported accounting range",
+                    );
+                    return;
+                };
+                if let Some(mut accounting) = world.get_mut::<RunAccounting>(entity) {
+                    accounting.usage = aggregate_usage;
+                    accounting.model_calls.push(ModelCallRecord {
+                        operation_id: header.operation_id,
+                        usage: output.usage,
+                        accepted: false,
+                    });
+                }
+                let mut entity_mut = world.entity_mut(entity);
+                if let Some(raw) = output.raw_final {
+                    entity_mut.insert(RawFinalRecord {
+                        operation_id: header.operation_id,
+                        raw,
+                    });
+                } else {
+                    entity_mut.remove::<RawFinalRecord>();
+                }
+                entity_mut.insert(PendingModelOutcome {
+                    operation_id: header.operation_id,
+                    choice: output.choice,
+                    message_id: output.message_id,
+                });
+                if let Some(mut run) = entity_mut.get_mut::<RunNode>() {
+                    run.phase = RunPhase::EvaluatingModel;
+                }
+                bump_progress(world, entity);
+            }
+            Err(error) => {
+                let diagnostic = error.to_string();
+                world
+                    .entity_mut(entity)
+                    .insert(TerminalCause::Model(Arc::new(error)));
+                fail_run(world, entity, "model_effect", diagnostic);
+            }
+        },
+        EffectCompletion::Tool {
+            header,
+            tool_call_id,
+            order,
+            result,
+        } => {
+            let output = match result {
+                crate::effects::ToolEffectOutput::Success(output) => output,
+                crate::effects::ToolEffectOutput::Failure(error) => error.model_output().clone(),
+            };
+            let mut matched = false;
+            if let Some(mut batch) = world.get_mut::<PendingToolBatch>(entity)
+                && let Some(call) = batch.calls.iter_mut().find(|call| {
+                    call.order == order
+                        && call.call.id == tool_call_id
+                        && call.operation_id == Some(header.operation_id)
+                })
+            {
+                call.result = Some(output);
+                matched = true;
+            }
+            if !matched {
+                reject_ingress(
+                    world,
+                    Some(entity),
+                    header,
+                    EffectRejectionReason::WrongCorrelation,
+                );
+            } else {
+                bump_progress(world, entity);
+            }
+        }
+        EffectCompletion::Memory { result, .. } => match result {
+            Ok(MemoryEffectOutput::Loaded(mut messages)) => {
+                // Loaded history is foreign content: validate it here, where
+                // failure is cheap and correctly attributed to the memory,
+                // before any model call sees it.
+                let candidate_state = {
+                    let existing = world
+                        .get::<CanonicalTranscript>(entity)
+                        .map(|transcript| transcript.messages.as_slice())
+                        .unwrap_or_default();
+                    crate::persistence::TranscriptValidator::over(&messages).and_then(
+                        |mut validator| {
+                            existing
+                                .iter()
+                                .try_for_each(|message| validator.observe(message))
+                                .map(|()| validator)
+                        },
+                    )
+                };
+                match candidate_state {
+                    Err(error) => {
+                        fail_run(
+                            world,
+                            entity,
+                            "memory_history",
+                            format!(
+                                "conversation memory returned a non-canonical history: {error}"
+                            ),
+                        );
+                    }
+                    Ok(validator) => {
+                        // Transcript and validator must move together; a
+                        // missing transcript fails terminally rather than
+                        // silently desyncing the pair.
+                        if let Some(mut transcript) = world.get_mut::<CanonicalTranscript>(entity) {
+                            let prompt = std::mem::take(&mut transcript.messages);
+                            transcript.new_messages_start = messages.len();
+                            messages.extend(prompt);
+                            transcript.messages = messages;
+                            if let Some(mut validation) =
+                                world.get_mut::<crate::persistence::TranscriptValidation>(entity)
+                            {
+                                validation.0 = validator;
+                            }
+                            if let Some(mut memory) = world.get_mut::<MemoryProgress>(entity) {
+                                memory.loaded = true;
+                            }
+                            if let Some(mut run) = world.get_mut::<RunNode>(entity) {
+                                run.phase = RunPhase::ReadyModel;
+                            }
+                            bump_progress(world, entity);
+                        } else {
+                            fail_run(
+                                world,
+                                entity,
+                                "canonical_transcript",
+                                "run has no canonical transcript to accept loaded history into",
+                            );
+                        }
+                    }
+                }
+            }
+            Ok(MemoryEffectOutput::Appended) => {
+                if let Some(mut memory) = world.get_mut::<MemoryProgress>(entity) {
+                    memory.appended = true;
+                }
+                set_terminal(world, entity, TerminalReason::Completed, None);
+            }
+            Err(error) if operation_kind == ActiveOperationKind::MemoryAppend => {
+                let diagnostic =
+                    format!("conversation memory append failed after canonical commit: {error}");
+                world
+                    .entity_mut(entity)
+                    .insert(TerminalCause::Memory(Arc::new(error)));
+                set_terminal(world, entity, TerminalReason::Completed, Some(diagnostic));
+            }
+            Err(error) => {
+                let diagnostic = error.to_string();
+                world
+                    .entity_mut(entity)
+                    .insert(TerminalCause::Memory(Arc::new(error)));
+                fail_run(world, entity, "memory_effect", diagnostic);
+            }
+        },
+    }
+}
+
+pub(crate) fn checked_usage_sum(
+    left: rig_core::completion::Usage,
+    right: rig_core::completion::Usage,
+) -> Option<rig_core::completion::Usage> {
+    Some(rig_core::completion::Usage {
+        input_tokens: left.input_tokens.checked_add(right.input_tokens)?,
+        output_tokens: left.output_tokens.checked_add(right.output_tokens)?,
+        total_tokens: left.total_tokens.checked_add(right.total_tokens)?,
+        cached_input_tokens: left
+            .cached_input_tokens
+            .checked_add(right.cached_input_tokens)?,
+        cache_creation_input_tokens: left
+            .cache_creation_input_tokens
+            .checked_add(right.cache_creation_input_tokens)?,
+        tool_use_prompt_tokens: left
+            .tool_use_prompt_tokens
+            .checked_add(right.tool_use_prompt_tokens)?,
+        reasoning_tokens: left.reasoning_tokens.checked_add(right.reasoning_tokens)?,
+    })
+}
+
+fn agent_for_run(world: &World, run: &RunNode) -> Option<AgentNode> {
+    let entity = world
+        .resource::<TopologyIndex>()
+        .agents
+        .get(&run.agent_id)
+        .copied()?;
+    world.get::<AgentNode>(entity).cloned()
+}
+
+fn mark_call_accepted(world: &mut World, entity: Entity, operation_id: OperationId) {
+    if let Some(mut accounting) = world.get_mut::<RunAccounting>(entity)
+        && let Some(record) = accounting
+            .model_calls
+            .iter_mut()
+            .find(|record| record.operation_id == operation_id)
+    {
+        record.accepted = true;
+    }
+}
+
+fn clear_recovery_feedback(world: &mut World, entity: Entity) {
+    if let Some(mut feedback) = world.get_mut::<RecoveryFeedback>(entity) {
+        feedback.0.clear();
+    }
+}
+
+// The one rollback contract for every model-response retry: corrective
+// feedback in, provisional raw final out, run back to ReadyModel.
+fn reset_for_model_retry(world: &mut World, entity: Entity, feedback: String) {
+    if let Some(mut messages) = world.get_mut::<RecoveryFeedback>(entity) {
+        messages.0.push(feedback);
+    }
+    world.entity_mut(entity).remove::<RawFinalRecord>();
+    if let Some(mut run) = world.get_mut::<RunNode>(entity) {
+        run.phase = RunPhase::ReadyModel;
+    }
+    publish(world, entity, RunEvent::ResponseRetried);
+    bump_progress(world, entity);
+}
+
+trait RetryCounter: Component<Mutability = bevy_ecs::component::Mutable> {
+    fn count(&self) -> usize;
+    fn bump(&mut self);
+}
+
+impl RetryCounter for ResponseRetryState {
+    fn count(&self) -> usize {
+        self.0
+    }
+    fn bump(&mut self) {
+        self.0 = self.0.saturating_add(1);
+    }
+}
+
+impl RetryCounter for InvalidToolRetryState {
+    fn count(&self) -> usize {
+        self.0
+    }
+    fn bump(&mut self) {
+        self.0 = self.0.saturating_add(1);
+    }
+}
+
+// The one retry ladder: consume budget and re-ask the model, or fail the run.
+fn bump_retry_or_fail<C: RetryCounter>(
+    world: &mut World,
+    entity: Entity,
+    max_retries: usize,
+    feedback: &str,
+    code: &str,
+    exhausted: String,
+) {
+    let retries = world.get::<C>(entity).map_or(0, RetryCounter::count);
+    if retries < max_retries {
+        if let Some(mut state) = world.get_mut::<C>(entity) {
+            state.bump();
+        }
+        reset_for_model_retry(world, entity, feedback.to_string());
+    } else {
+        fail_run(world, entity, code, exhausted);
+    }
+}
+
+// Duplicate identities can never commit canonically (the same validation
+// restore enforces), so every model turn — structured-output turns included —
+// passes through this ladder before any handler runs. Returns whether the
+// outcome was consumed; `Skip` falls through and the handlers drop repeats.
+fn apply_duplicate_identity_policy(
+    world: &mut World,
+    entity: Entity,
+    agent: &AgentNode,
+    duplicate_id: &str,
+) -> bool {
+    match agent.spec.invalid_tool_policy {
+        InvalidToolPolicy::Skip => false,
+        InvalidToolPolicy::Fail | InvalidToolPolicy::Repair => {
+            fail_run(
+                world,
+                entity,
+                "duplicate_tool_call",
+                format!("model emitted duplicate tool call identity `{duplicate_id}`"),
+            );
+            true
+        }
+        InvalidToolPolicy::Retry { max_retries } => {
+            bump_retry_or_fail::<InvalidToolRetryState>(
+                world,
+                entity,
+                max_retries,
+                "Tool call identities must be unique. Re-issue each tool call with a distinct id.",
+                "duplicate_tool_call",
+                format!("duplicate tool call retry exhausted for `{duplicate_id}`"),
+            );
+            true
+        }
+        InvalidToolPolicy::Stop => {
+            set_terminal(world, entity, TerminalReason::Stopped, None);
+            true
+        }
+    }
+}
+
+fn finalize_accepted_turn(world: &mut World, entity: Entity, operation_id: OperationId) {
+    mark_call_accepted(world, entity, operation_id);
+    clear_recovery_feedback(world, entity);
+    publish_provider_final(world, entity, operation_id);
+    complete_success(world, entity);
+}
+
+fn find_output_call(choice: &[AssistantContent], output_name: &str) -> Option<ToolCall> {
+    choice.iter().find_map(|content| match content {
+        AssistantContent::ToolCall(call) if call.function.name == output_name => Some(call.clone()),
+        _ => None,
+    })
+}
+
+// Structured finals never carry tool calls; the output call survives as text.
+fn structured_final_content(
+    choice: Vec<AssistantContent>,
+    output_call: Option<&ToolCall>,
+) -> Vec<AssistantContent> {
+    let mut content = choice
+        .into_iter()
+        .filter(|content| !matches!(content, AssistantContent::ToolCall(_)))
+        .collect::<Vec<_>>();
+    if let Some(call) = output_call {
+        content.push(AssistantContent::text(call.function.arguments.to_string()));
+    }
+    content
+}
+
+// Commit-time gate: the transcript must satisfy the same canonical invariants
+// `restore` enforces, so the runtime can never persist state it refuses to load.
+fn commit_assistant_turn(
+    world: &mut World,
+    entity: Entity,
+    message_id: Option<String>,
+    content: OneOrMany<AssistantContent>,
+    results: Option<OneOrMany<UserContent>>,
+) -> bool {
+    let mut staged = vec![Message::Assistant {
+        id: message_id,
+        content,
+    }];
+    if let Some(content) = results {
+        staged.push(Message::User { content });
+    }
+    // Tail-only validation: loaded history and prior turns were validated at
+    // their own boundaries, so only the appended turn is checked here, against
+    // the run's live resumable validator state.
+    let mut validator = world
+        .get::<crate::persistence::TranscriptValidation>(entity)
+        .map(|validation| validation.0.clone());
+    let outcome = validator.as_mut().map_or(
+        Err("run has no transcript validation state".to_string()),
+        |validator| {
+            staged
+                .iter()
+                .try_for_each(|message| validator.observe(message))
+                .and_then(|()| validator.finish())
+                .map_err(|error| format!("refusing to commit a non-canonical model turn: {error}"))
+        },
+    );
+    if let Err(diagnostic) = outcome {
+        fail_run(world, entity, "canonical_transcript", diagnostic);
+        return false;
+    }
+    let Some(mut transcript) = world.get_mut::<CanonicalTranscript>(entity) else {
+        fail_run(
+            world,
+            entity,
+            "canonical_transcript",
+            "run has no canonical transcript to commit into",
+        );
+        return false;
+    };
+    transcript.messages.extend(staged);
+    if let (Some(mut validation), Some(validator)) = (
+        world.get_mut::<crate::persistence::TranscriptValidation>(entity),
+        validator,
+    ) {
+        validation.0 = validator;
+    }
+    true
+}
+
+fn publish_provider_final(world: &mut World, entity: Entity, operation_id: OperationId) {
+    let provider_type = world
+        .get::<RawFinalRecord>(entity)
+        .filter(|record| record.operation_id == operation_id)
+        .map(|record| record.raw.type_name());
+    if let Some(provider_type) = provider_type {
+        publish(
+            world,
+            entity,
+            RunEvent::ProviderFinal {
+                operation_id,
+                provider_type,
+            },
+        );
+    }
+}
+
+fn assistant_text(choice: &[AssistantContent]) -> String {
+    choice
+        .iter()
+        .filter_map(|content| match content {
+            AssistantContent::Text(text) => Some(text.text.as_str()),
+            _ => None,
+        })
+        .collect::<String>()
+}
+
+fn complete_success(world: &mut World, entity: Entity) {
+    let pending_append = world
+        .get::<MemoryProgress>(entity)
+        .is_some_and(|memory| !memory.appended);
+    if pending_append {
+        if let Some(mut run) = world.get_mut::<RunNode>(entity) {
+            run.phase = RunPhase::AppendingMemory;
+        }
+        bump_progress(world, entity);
+    } else {
+        set_terminal(world, entity, TerminalReason::Completed, None);
+    }
+}
+
+fn validate_schema(value: &serde_json::Value, schema: &serde_json::Value) -> bool {
+    jsonschema::validator_for(schema).is_ok_and(|validator| validator.is_valid(value))
+}
+
+fn retry_structured_output(
+    world: &mut World,
+    entity: Entity,
+    choice: Vec<AssistantContent>,
+    message_id: Option<String>,
+    operation_id: OperationId,
+) {
+    let Some(state) = world.get::<StructuredOutputState>(entity) else {
+        return;
+    };
+    let can_retry = state.retries < state.policy.max_retries;
+    let best_effort = state.policy.best_effort;
+    if can_retry {
+        if let Some(mut state) = world.get_mut::<StructuredOutputState>(entity) {
+            state.retries = state.retries.saturating_add(1);
+        }
+        reset_for_model_retry(
+            world,
+            entity,
+            "The previous response did not satisfy the required JSON schema. Return a valid structured response."
+                .to_string(),
+        );
+    } else if best_effort {
+        // A best-effort turn is final: tool calls can never be answered after it,
+        // so the schema-invalid output call is preserved as text, like the valid path.
+        let output_call = world
+            .get::<StructuredOutputState>(entity)
+            .and_then(|state| state.output_tool_name.clone())
+            .and_then(|name| find_output_call(&choice, &name));
+        let final_content = structured_final_content(choice, output_call.as_ref());
+        if let Some(content) = OneOrMany::from_iter_optional(final_content) {
+            if commit_assistant_turn(world, entity, message_id, content, None) {
+                finalize_accepted_turn(world, entity, operation_id);
+            }
+        } else {
+            fail_run(
+                world,
+                entity,
+                "structured_output",
+                "best-effort structured output was empty",
+            );
+        }
+    } else {
+        fail_run(
+            world,
+            entity,
+            "structured_output",
+            "structured output recovery was exhausted",
+        );
+    }
+}
+
+fn evaluate_model_outcomes(world: &mut World) {
+    let entities = {
+        let mut query = world.query_filtered::<Entity, With<PendingModelOutcome>>();
+        query.iter(world).collect::<Vec<_>>()
+    };
+    for entity in entities {
+        if world.entity(entity).contains::<TerminalState>() {
+            continue;
+        }
+        let Some(outcome) = world.entity_mut(entity).take::<PendingModelOutcome>() else {
+            continue;
+        };
+        let Some(run) = world.get::<RunNode>(entity).cloned() else {
+            continue;
+        };
+        let Some(agent) = agent_for_run(world, &run) else {
+            fail_run(
+                world,
+                entity,
+                "unknown_agent",
+                "run agent topology disappeared",
+            );
+            continue;
+        };
+
+        let duplicate_id = {
+            let mut seen = BTreeSet::new();
+            outcome.choice.iter().find_map(|content| match content {
+                AssistantContent::ToolCall(call) if !seen.insert(call.id.clone()) => {
+                    Some(call.id.clone())
+                }
+                _ => None,
+            })
+        };
+        if let Some(duplicate_id) = duplicate_id
+            && apply_duplicate_identity_policy(world, entity, &agent, &duplicate_id)
+        {
+            continue;
+        }
+
+        let output_call = world
+            .get::<StructuredOutputState>(entity)
+            .and_then(|state| state.output_tool_name.clone())
+            .and_then(|name| find_output_call(&outcome.choice, &name));
+        if let Some(output_call) = output_call {
+            handle_structured_output_call(world, entity, outcome, output_call);
+            continue;
+        }
+
+        let tool_calls = outcome
+            .choice
+            .iter()
+            .filter_map(|content| match content {
+                AssistantContent::ToolCall(call) => Some(call.clone()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        if !tool_calls.is_empty() {
+            evaluate_tool_calls(world, entity, &agent, outcome, tool_calls);
+            continue;
+        }
+
+        if let Some(resolved_mode) = world
+            .get::<StructuredOutputState>(entity)
+            .map(|state| state.resolved_mode)
+        {
+            if matches!(resolved_mode, OutputMode::Tool) {
+                retry_structured_output(
+                    world,
+                    entity,
+                    outcome.choice,
+                    outcome.message_id,
+                    outcome.operation_id,
+                );
+                continue;
+            }
+            let text = assistant_text(&outcome.choice);
+            let parsed = serde_json::from_str::<serde_json::Value>(text.trim()).ok();
+            let valid = parsed.as_ref().is_some_and(|value| {
+                world
+                    .get::<StructuredOutputState>(entity)
+                    .is_some_and(|state| validate_schema(value, state.schema.as_value()))
+            });
+            if valid {
+                if let Some(mut state) = world.get_mut::<StructuredOutputState>(entity) {
+                    state.value = parsed;
+                }
+            } else {
+                retry_structured_output(
+                    world,
+                    entity,
+                    outcome.choice,
+                    outcome.message_id,
+                    outcome.operation_id,
+                );
+                continue;
+            }
+        }
+
+        let text = assistant_text(&outcome.choice);
+        if text.trim().is_empty()
+            && let ResponseRetryPolicy::RejectEmpty { max_retries } =
+                agent.spec.response_retry_policy
+        {
+            handle_empty_response_retry(world, entity, max_retries);
+            continue;
+        }
+
+        let Some(content) = OneOrMany::from_iter_optional(outcome.choice) else {
+            fail_run(
+                world,
+                entity,
+                "empty_choice",
+                "provider returned an empty assistant choice",
+            );
+            continue;
+        };
+        if !commit_assistant_turn(world, entity, outcome.message_id, content, None) {
+            continue;
+        }
+        finalize_accepted_turn(world, entity, outcome.operation_id);
+    }
+}
+
+fn handle_structured_output_call(
+    world: &mut World,
+    entity: Entity,
+    outcome: PendingModelOutcome,
+    output_call: ToolCall,
+) {
+    // Every tool call other than the first occurrence of the output call is
+    // suppressed — including a same-id repeat surviving under `Skip`.
+    let mut saw_output_call = false;
+    for peer in outcome.choice.iter().filter_map(|content| match content {
+        AssistantContent::ToolCall(call) => Some(call),
+        _ => None,
+    }) {
+        if !saw_output_call && peer.id == output_call.id {
+            saw_output_call = true;
+            continue;
+        }
+        publish(
+            world,
+            entity,
+            RunEvent::ToolSuppressed {
+                tool_call_id: peer.id.clone(),
+            },
+        );
+    }
+    let valid = world
+        .get::<StructuredOutputState>(entity)
+        .is_some_and(|state| {
+            validate_schema(&output_call.function.arguments, state.schema.as_value())
+        });
+    if valid {
+        if let Some(mut state) = world.get_mut::<StructuredOutputState>(entity) {
+            state.value = Some(output_call.function.arguments.clone());
+        }
+        let final_content = structured_final_content(outcome.choice, Some(&output_call));
+        let Some(final_content) = OneOrMany::from_iter_optional(final_content) else {
+            fail_run(
+                world,
+                entity,
+                "empty_structured_final",
+                "structured finalization produced no canonical content",
+            );
+            return;
+        };
+        if commit_assistant_turn(world, entity, outcome.message_id, final_content, None) {
+            finalize_accepted_turn(world, entity, outcome.operation_id);
+        }
+    } else {
+        retry_structured_output(
+            world,
+            entity,
+            outcome.choice,
+            outcome.message_id,
+            outcome.operation_id,
+        );
+    }
+}
+
+fn handle_empty_response_retry(world: &mut World, entity: Entity, max_retries: usize) {
+    bump_retry_or_fail::<ResponseRetryState>(
+        world,
+        entity,
+        max_retries,
+        "The previous response was empty. Return a substantive answer.",
+        "response_retry_exhausted",
+        "empty response retry policy was exhausted".to_string(),
+    );
+}
+
+fn evaluate_tool_calls(
+    world: &mut World,
+    entity: Entity,
+    agent: &AgentNode,
+    outcome: PendingModelOutcome,
+    tool_calls: Vec<ToolCall>,
+) {
+    // Duplicate identities were already routed through the recovery ladder in
+    // `evaluate_model_outcomes`; reaching here under `Skip` means each repeat
+    // is dropped and only the first occurrence runs.
+    let snapshot = world
+        .get::<TurnCapabilitySnapshot>(entity)
+        .cloned()
+        .unwrap_or_default();
+    let mut definitions = BTreeMap::new();
+    for entry in snapshot.entries {
+        definitions.insert(entry.definition.name.clone(), entry);
+    }
+    let mut planned = Vec::new();
+    let mut invalid = None;
+    let mut planned_ids = BTreeSet::new();
+    for (order, mut call) in tool_calls.into_iter().enumerate() {
+        if !planned_ids.insert(call.id.clone()) {
+            // Only reachable under `Skip`: the repeat is dropped from the turn
+            // entirely so the committed pairing stays canonical.
+            publish(
+                world,
+                entity,
+                RunEvent::ToolSuppressed {
+                    tool_call_id: call.id,
+                },
+            );
+            continue;
+        }
+        let mut entry = definitions.get(&call.function.name).cloned();
+        if entry.is_none() && matches!(agent.spec.invalid_tool_policy, InvalidToolPolicy::Repair) {
+            let matches = definitions
+                .iter()
+                .filter(|(name, _)| name.eq_ignore_ascii_case(&call.function.name))
+                .map(|(_, entry)| entry.clone())
+                .collect::<Vec<_>>();
+            if let [repaired] = matches.as_slice() {
+                call.function.name.clone_from(&repaired.definition.name);
+                entry = Some(repaired.clone());
+            }
+        }
+        if let Some(entry) = entry {
+            planned.push(PlannedToolCall {
+                call,
+                capability_id: entry.capability_id,
+                grant_id: entry.grant_id,
+                revision: entry.revision,
+                order,
+                operation_id: None,
+                result: None,
+                suppressed: false,
+            });
+        } else if matches!(agent.spec.invalid_tool_policy, InvalidToolPolicy::Skip) {
+            let call_id = call.id.clone();
+            planned.push(PlannedToolCall {
+                call,
+                capability_id: CapabilityId::new(),
+                grant_id: crate::GrantId::new(),
+                revision: 0,
+                order,
+                operation_id: None,
+                result: Some(ToolOutput::text(
+                    "tool call skipped because it was not advertised",
+                )),
+                suppressed: true,
+            });
+            publish(
+                world,
+                entity,
+                RunEvent::ToolSuppressed {
+                    tool_call_id: call_id,
+                },
+            );
+        } else {
+            invalid = Some(call.function.name);
+            break;
+        }
+    }
+    if let Some(name) = invalid {
+        match agent.spec.invalid_tool_policy {
+            InvalidToolPolicy::Fail | InvalidToolPolicy::Repair => fail_run(
+                world,
+                entity,
+                "invalid_tool",
+                format!("model requested unadvertised tool `{name}`"),
+            ),
+            InvalidToolPolicy::Retry { max_retries } => {
+                bump_retry_or_fail::<InvalidToolRetryState>(
+                    world,
+                    entity,
+                    max_retries,
+                    &format!(
+                        "Tool `{name}` is unavailable. Use only an advertised tool or answer without it."
+                    ),
+                    "invalid_tool_retry_exhausted",
+                    format!("invalid tool retry exhausted for `{name}`"),
+                );
+            }
+            InvalidToolPolicy::Stop => set_terminal(world, entity, TerminalReason::Stopped, None),
+            InvalidToolPolicy::Skip => {}
+        }
+        return;
+    }
+
+    let mut content_ids = BTreeSet::new();
+    let repaired_content = outcome
+        .choice
+        .into_iter()
+        .filter_map(|content| match content {
+            AssistantContent::ToolCall(original) => {
+                if !content_ids.insert(original.id.clone()) {
+                    return None;
+                }
+                Some(
+                    planned
+                        .iter()
+                        .find(|planned| planned.call.id == original.id)
+                        .map_or(AssistantContent::ToolCall(original), |planned| {
+                            AssistantContent::ToolCall(planned.call.clone())
+                        }),
+                )
+            }
+            content => Some(content),
+        })
+        .collect::<Vec<_>>();
+    world.entity_mut(entity).insert(PendingToolBatch {
+        assistant_content: repaired_content,
+        message_id: outcome.message_id,
+        calls: planned,
+    });
+    if let Some(mut run) = world.get_mut::<RunNode>(entity) {
+        run.phase = RunPhase::WaitingTools;
+    }
+    mark_call_accepted(world, entity, outcome.operation_id);
+    clear_recovery_feedback(world, entity);
+    publish_provider_final(world, entity, outcome.operation_id);
+    bump_progress(world, entity);
+}
+
+fn new_header(world: &World, run: &RunNode) -> EffectHeader {
+    EffectHeader {
+        runtime_id: world.resource::<RuntimeIdentity>().0,
+        run_id: run.id,
+        operation_id: OperationId::new(),
+        generation: run.generation,
+        correlation_id: CorrelationId::new(),
+        tenant_id: run.tenant_id,
+        capability_id: None,
+        grant_id: None,
+        capability_revision: None,
+    }
+}
+
+fn has_active_kind(world: &World, entity: Entity, kind: ActiveOperationKind) -> bool {
+    world
+        .get::<ActiveOperations>(entity)
+        .is_some_and(|operations| {
+            operations
+                .0
+                .values()
+                .any(|operation| operation.kind == kind && !operation.completed)
+        })
+}
+
+fn register_operation(
+    world: &mut World,
+    entity: Entity,
+    header: EffectHeader,
+    kind: ActiveOperationKind,
+) {
+    if let Some(mut operations) = world.get_mut::<ActiveOperations>(entity) {
+        operations.0.insert(
+            header.operation_id,
+            ActiveOperation {
+                header,
+                kind,
+                expected_tool_call_id: None,
+                expected_tool_order: None,
+                completed: false,
+            },
+        );
+    }
+}
+
+fn register_tool_operation(
+    world: &mut World,
+    entity: Entity,
+    header: EffectHeader,
+    tool_call_id: String,
+    order: usize,
+) {
+    if let Some(mut operations) = world.get_mut::<ActiveOperations>(entity) {
+        operations.0.insert(
+            header.operation_id,
+            ActiveOperation {
+                header,
+                kind: ActiveOperationKind::Tool,
+                expected_tool_call_id: Some(tool_call_id),
+                expected_tool_order: Some(order),
+                completed: false,
+            },
+        );
+    }
+}
+
+fn enqueue_effect(world: &mut World, entity: Entity, intent: EffectIntent) -> bool {
+    let capacity = world
+        .resource::<RuntimeConfigResource>()
+        .0
+        .effect_queue_capacity;
+    if world.resource::<PendingEffects>().0.len() >= capacity {
+        // Record a real waiting transition once. Repeated full-queue passes do
+        // not manufacture progress and therefore cannot exhaust the target
+        // run's livelock budget while another run owns the bounded capacity.
+        if !world.entity(entity).contains::<EffectQueueWait>() {
+            world.entity_mut(entity).insert(EffectQueueWait);
+            bump_progress(world, entity);
+        }
+        false
+    } else {
+        world.entity_mut(entity).remove::<EffectQueueWait>();
+        world.resource_mut::<PendingEffects>().0.push(intent);
+        true
+    }
+}
+
+fn dispatch_memory_effects(world: &mut World) {
+    let mut entities = {
+        let mut query = world.query::<(Entity, &RunNode, &MemoryProgress)>();
+        query
+            .iter(world)
+            .filter_map(|(entity, run, memory)| {
+                let kind = match run.phase {
+                    RunPhase::LoadingMemory if !memory.loaded => {
+                        Some(ActiveOperationKind::MemoryLoad)
+                    }
+                    RunPhase::AppendingMemory if !memory.appended => {
+                        Some(ActiveOperationKind::MemoryAppend)
+                    }
+                    _ => None,
+                }?;
+                (!has_active_kind(world, entity, kind)).then_some((
+                    entity,
+                    run.clone(),
+                    memory.memory_id,
+                    memory.conversation_id.clone(),
+                    kind,
+                ))
+            })
+            .collect::<Vec<_>>()
+    };
+    entities.sort_by_key(|(_, run, ..)| run.id);
+    for (entity, run, memory_id, conversation_id, kind) in entities {
+        let header = new_header(world, &run);
+        let intent = if kind == ActiveOperationKind::MemoryLoad {
+            MemoryEffectIntent::Load {
+                header,
+                memory_id,
+                conversation_id,
+            }
+        } else {
+            let messages = world
+                .get::<CanonicalTranscript>(entity)
+                .and_then(|transcript| {
+                    transcript
+                        .messages
+                        .get(transcript.new_messages_start..)
+                        .map(<[_]>::to_vec)
+                })
+                .unwrap_or_default();
+            MemoryEffectIntent::Append {
+                header,
+                memory_id,
+                conversation_id,
+                messages,
+            }
+        };
+        if !enqueue_effect(world, entity, EffectIntent::Memory(intent)) {
+            continue;
+        }
+        register_operation(world, entity, header, kind);
+        bump_progress(world, entity);
+    }
+}
+
+fn collect_turn_capabilities(world: &World, run: &RunNode) -> Vec<AdvertisedCapability> {
+    let index = world.resource::<TopologyIndex>();
+    let mut entries = index
+        .grants
+        .values()
+        .filter_map(|entity| world.get::<GrantNode>(*entity))
+        .filter(|grant| {
+            !grant.revoked && grant.agent_id == run.agent_id && grant.tenant_id == run.tenant_id
+        })
+        .filter_map(|grant| {
+            let entity = index.capabilities.get(&grant.capability_id)?;
+            let capability = world.get::<CapabilityNode>(*entity)?;
+            (!capability.retired && capability.tenant_id == run.tenant_id)
+                .then_some((grant, capability))
+        })
+        .filter_map(|(grant, capability)| {
+            let definition = capability.definition.clone()?;
+            Some(AdvertisedCapability {
+                capability_id: capability.id,
+                grant_id: grant.id,
+                revision: capability.revision,
+                definition,
+            })
+        })
+        .collect::<Vec<_>>();
+    entries.sort_by(|left, right| {
+        left.definition
+            .name
+            .cmp(&right.definition.name)
+            .then(left.capability_id.cmp(&right.capability_id))
+            .then(left.grant_id.cmp(&right.grant_id))
+    });
+    entries
+}
+
+fn output_tool_callable(tool_choice: Option<&ToolChoice>, output_tool_name: &str) -> bool {
+    match tool_choice {
+        None | Some(ToolChoice::Auto | ToolChoice::Required) => true,
+        Some(ToolChoice::Specific { function_names }) => {
+            function_names.iter().any(|name| name == output_tool_name)
+        }
+        Some(ToolChoice::None) => false,
+    }
+}
+
+fn resolve_output_mode(
+    has_executable_tools: bool,
+    output_tool_callable: bool,
+    provider_composes_native: bool,
+    requested: OutputMode,
+) -> OutputMode {
+    match requested {
+        OutputMode::Native => OutputMode::Native,
+        OutputMode::Prompted => OutputMode::Prompted,
+        OutputMode::Tool if output_tool_callable => OutputMode::Tool,
+        OutputMode::Tool => OutputMode::Native,
+        OutputMode::Auto
+            if has_executable_tools && output_tool_callable && !provider_composes_native =>
+        {
+            OutputMode::Tool
+        }
+        OutputMode::Auto => OutputMode::Native,
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ToolChoicePolicyError {
+    #[error("ToolChoice::Required forces a tool call, but no tools are advertised")]
+    RequiredWithoutTools,
+    #[error("ToolChoice::Specific requires at least one function name")]
+    EmptySpecific,
+    #[error("ToolChoice::Specific requested tools not advertised this turn: {missing:?}")]
+    MissingSpecific { missing: Vec<String> },
+}
+
+fn allowed_executable_tool_names(
+    executable_tool_names: &BTreeSet<String>,
+    tool_choice: Option<&ToolChoice>,
+    output_tool_name: Option<&str>,
+) -> Result<BTreeSet<String>, ToolChoicePolicyError> {
+    match tool_choice {
+        None | Some(ToolChoice::Auto) => Ok(executable_tool_names.clone()),
+        Some(ToolChoice::None) => Ok(BTreeSet::new()),
+        Some(ToolChoice::Required) => {
+            if executable_tool_names.is_empty() && output_tool_name.is_none() {
+                Err(ToolChoicePolicyError::RequiredWithoutTools)
+            } else {
+                Ok(executable_tool_names.clone())
+            }
+        }
+        Some(ToolChoice::Specific { function_names }) => {
+            if function_names.is_empty() {
+                return Err(ToolChoicePolicyError::EmptySpecific);
+            }
+            let requested = function_names.iter().cloned().collect::<BTreeSet<_>>();
+            let missing = requested
+                .iter()
+                .filter(|name| {
+                    !executable_tool_names.contains(*name)
+                        && output_tool_name != Some(name.as_str())
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            if !missing.is_empty() {
+                return Err(ToolChoicePolicyError::MissingSpecific { missing });
+            }
+            Ok(requested
+                .intersection(executable_tool_names)
+                .cloned()
+                .collect())
+        }
+    }
+}
+
+fn output_tool_name(schema: &schemars::Schema, names: &BTreeSet<String>) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(schema.as_value().to_string().as_bytes());
+    let digest = hasher.finalize();
+    let prefix = digest
+        .iter()
+        .take(4)
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    let mut candidate = format!("__rig_output_{prefix}");
+    while names.contains(&candidate) {
+        candidate.push('_');
+    }
+    candidate
+}
+
+fn dispatch_model_effects(world: &mut World) {
+    let mut entities = {
+        let mut query = world.query::<(Entity, &RunNode)>();
+        query
+            .iter(world)
+            .filter(|(entity, run)| {
+                run.phase == RunPhase::ReadyModel
+                    && !has_active_kind(world, *entity, ActiveOperationKind::Model)
+                    && !world.entity(*entity).contains::<TerminalState>()
+            })
+            .map(|(entity, run)| (entity, run.clone()))
+            .collect::<Vec<_>>()
+    };
+    entities.sort_by_key(|(_, run)| run.id);
+    for (entity, run) in entities {
+        let Some(agent) = agent_for_run(world, &run) else {
+            fail_run(
+                world,
+                entity,
+                "unknown_agent",
+                "run agent topology disappeared",
+            );
+            continue;
+        };
+        let dispatched = world
+            .get::<RunAccounting>(entity)
+            .map_or(0, |accounting| accounting.model_calls_dispatched);
+        if dispatched >= agent.spec.max_model_calls {
+            set_terminal(
+                world,
+                entity,
+                TerminalReason::ModelCallBudgetExhausted,
+                None,
+            );
+            continue;
+        }
+
+        let mut entries = collect_turn_capabilities(world, &run);
+        let executable_tool_names = entries
+            .iter()
+            .map(|entry| entry.definition.name.clone())
+            .collect::<BTreeSet<_>>();
+        let mut preamble = agent.spec.preamble.clone();
+        let mut output_schema = None;
+        let mut selected_output_name = None;
+        let mut output_tool_schema = None;
+        if let Some(state) = world.get::<StructuredOutputState>(entity).map(|state| {
+            (
+                state.schema.clone(),
+                state.policy.clone(),
+                state.output_tool_name.clone(),
+            )
+        }) {
+            let candidate = state
+                .2
+                .clone()
+                .unwrap_or_else(|| output_tool_name(&state.0, &executable_tool_names));
+            let callable = output_tool_callable(agent.spec.tool_choice.as_ref(), &candidate);
+            let resolved = if state.2.is_some() {
+                OutputMode::Tool
+            } else {
+                resolve_output_mode(
+                    !entries.is_empty(),
+                    callable,
+                    agent.composes_native_output_with_tools,
+                    state.1.mode,
+                )
+            };
+            if matches!(resolved, OutputMode::Tool)
+                && (!callable || executable_tool_names.contains(&candidate))
+            {
+                fail_run(
+                    world,
+                    entity,
+                    "invalid_tool_choice",
+                    if !callable {
+                        format!(
+                            "the active tool choice cannot call structured-output tool `{candidate}`"
+                        )
+                    } else {
+                        format!(
+                            "real tool `{candidate}` conflicts with the structured-output tool reserved for this run"
+                        )
+                    },
+                );
+                continue;
+            }
+            match resolved {
+                OutputMode::Native => output_schema = Some(state.0.clone()),
+                OutputMode::Prompted => {
+                    let instruction = format!(
+                        "Respond with only JSON satisfying this schema: {}",
+                        state.0.as_value()
+                    );
+                    preamble = Some(match preamble {
+                        Some(base) => format!("{base}\n\n{instruction}"),
+                        None => instruction,
+                    });
+                }
+                OutputMode::Tool => {
+                    let instruction = format!(
+                        "When the answer is ready, call `{candidate}` exactly once with the structured final result."
+                    );
+                    preamble = Some(match preamble {
+                        Some(base) => format!("{base}\n\n{instruction}"),
+                        None => instruction,
+                    });
+                    selected_output_name = Some(candidate);
+                    output_tool_schema = Some(state.0.clone());
+                }
+                OutputMode::Auto => {}
+            }
+            if let Some(mut output) = world.get_mut::<StructuredOutputState>(entity) {
+                output.resolved_mode = resolved;
+                if selected_output_name.is_some() {
+                    output.output_tool_name.clone_from(&selected_output_name);
+                }
+            }
+        }
+        let allowed_tool_names = match allowed_executable_tool_names(
+            &executable_tool_names,
+            agent.spec.tool_choice.as_ref(),
+            selected_output_name.as_deref(),
+        ) {
+            Ok(allowed) => allowed,
+            Err(error) => {
+                fail_run(world, entity, "invalid_tool_choice", error.to_string());
+                continue;
+            }
+        };
+        entries.retain(|entry| allowed_tool_names.contains(&entry.definition.name));
+        let mut definitions = entries
+            .iter()
+            .map(|entry| entry.definition.clone())
+            .collect::<Vec<_>>();
+        if let (Some(name), Some(schema)) = (&selected_output_name, output_tool_schema) {
+            definitions.push(ToolDefinition {
+                name: name.clone(),
+                description: "Finalize the run with arguments satisfying the output schema."
+                    .to_string(),
+                parameters: schema.to_value(),
+            });
+        }
+
+        let Some(transcript) = world.get::<CanonicalTranscript>(entity) else {
+            continue;
+        };
+        let mut history = transcript.messages.clone();
+        if let Some(feedback) = world.get::<RecoveryFeedback>(entity) {
+            history.extend(feedback.0.iter().cloned().map(Message::user));
+        }
+        let Some(chat_history) = OneOrMany::from_iter_optional(history) else {
+            fail_run(
+                world,
+                entity,
+                "empty_history",
+                "model request had no canonical messages",
+            );
+            continue;
+        };
+        let request = CompletionRequest {
+            model: None,
+            preamble,
+            chat_history,
+            documents: Vec::new(),
+            tools: definitions,
+            temperature: agent.spec.temperature,
+            max_tokens: agent.spec.max_tokens,
+            tool_choice: agent.spec.tool_choice.clone(),
+            additional_params: agent.spec.additional_params.clone(),
+            output_schema,
+            record_telemetry_content: agent.spec.record_telemetry_content,
+        };
+        let header = new_header(world, &run);
+        if !enqueue_effect(
+            world,
+            entity,
+            EffectIntent::Model(Box::new(ModelEffectIntent {
+                header,
+                model_id: run.model_id,
+                request,
+                streaming: matches!(run.streaming, StreamingMode::Streaming),
+            })),
+        ) {
+            continue;
+        }
+        register_operation(world, entity, header, ActiveOperationKind::Model);
+        for entry in &entries {
+            world
+                .resource_mut::<CapabilityReferences>()
+                .0
+                .entry(entry.capability_id)
+                .or_default()
+                .insert(run.id);
+        }
+        world.entity_mut(entity).insert(TurnCapabilitySnapshot {
+            entries,
+            output_tool_name: selected_output_name,
+        });
+        if let Some(mut accounting) = world.get_mut::<RunAccounting>(entity) {
+            accounting.model_calls_dispatched = accounting.model_calls_dispatched.saturating_add(1);
+        }
+        if let Some(mut run) = world.get_mut::<RunNode>(entity) {
+            run.phase = RunPhase::WaitingModel;
+        }
+        publish(
+            world,
+            entity,
+            RunEvent::ModelDispatched(header.operation_id),
+        );
+        bump_progress(world, entity);
+    }
+}
+
+fn dispatch_tool_effects(world: &mut World) {
+    let mut entities = {
+        let mut query = world.query_filtered::<Entity, With<PendingToolBatch>>();
+        query.iter(world).collect::<Vec<_>>()
+    };
+    entities.sort_by_key(|entity| world.get::<RunNode>(*entity).map(|run| run.id));
+    for entity in entities {
+        if world.entity(entity).contains::<TerminalState>() {
+            continue;
+        }
+        let Some(run) = world.get::<RunNode>(entity).cloned() else {
+            continue;
+        };
+        let mut calls = world
+            .get::<PendingToolBatch>(entity)
+            .map(|batch| {
+                batch
+                    .calls
+                    .iter()
+                    .filter(|call| {
+                        !call.suppressed && call.operation_id.is_none() && call.result.is_none()
+                    })
+                    .map(|call| {
+                        (
+                            call.order,
+                            call.call.clone(),
+                            call.capability_id,
+                            call.grant_id,
+                            call.revision,
+                        )
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        calls.sort_by_key(|(order, ..)| *order);
+        for (order, call, capability_id, grant_id, revision) in calls {
+            let mut header = new_header(world, &run);
+            header.capability_id = Some(capability_id);
+            header.grant_id = Some(grant_id);
+            header.capability_revision = Some(revision);
+            let tool_call_id = call.id.clone();
+            let effect = EffectIntent::Tool(ToolEffectIntent {
+                header,
+                tool_call_id: tool_call_id.clone(),
+                provider_call_id: call.call_id.clone(),
+                name: call.function.name,
+                arguments: call.function.arguments,
+                order,
+            });
+            if !enqueue_effect(world, entity, effect) {
+                break;
+            }
+            register_tool_operation(world, entity, header, tool_call_id.clone(), order);
+            if let Some(mut batch) = world.get_mut::<PendingToolBatch>(entity)
+                && let Some(planned) = batch
+                    .calls
+                    .iter_mut()
+                    .find(|planned| planned.order == order)
+            {
+                planned.operation_id = Some(header.operation_id);
+            }
+            publish(
+                world,
+                entity,
+                RunEvent::ToolDispatched {
+                    operation_id: header.operation_id,
+                    tool_call_id,
+                },
+            );
+            bump_progress(world, entity);
+        }
+    }
+}
+
+fn commit_tool_batches(world: &mut World) {
+    let entities = {
+        let mut query = world.query_filtered::<Entity, With<PendingToolBatch>>();
+        query
+            .iter(world)
+            .filter(|entity| {
+                world
+                    .get::<PendingToolBatch>(*entity)
+                    .is_some_and(|batch| batch.calls.iter().all(|call| call.result.is_some()))
+            })
+            .collect::<Vec<_>>()
+    };
+    for entity in entities {
+        if world.entity(entity).contains::<TerminalState>() {
+            continue;
+        }
+        let Some(mut batch) = world.entity_mut(entity).take::<PendingToolBatch>() else {
+            continue;
+        };
+        let run_id = world.get::<RunNode>(entity).map(|run| run.id);
+        let tool_count = batch.calls.len();
+        batch.calls.sort_by_key(|call| call.order);
+        let Some(assistant_content) = OneOrMany::from_iter_optional(batch.assistant_content) else {
+            fail_run(
+                world,
+                entity,
+                "empty_tool_turn",
+                "tool batch had no assistant content",
+            );
+            continue;
+        };
+        let results = batch
+            .calls
+            .iter()
+            .filter_map(|call| {
+                let output = call.result.clone()?;
+                Some(UserContent::ToolResult(ToolResult {
+                    id: call.call.id.clone(),
+                    call_id: call.call.call_id.clone(),
+                    content: output.into_content(),
+                }))
+            })
+            .collect::<Vec<_>>();
+        let Some(results) = OneOrMany::from_iter_optional(results) else {
+            fail_run(
+                world,
+                entity,
+                "missing_tool_result",
+                "tool batch completed without paired results",
+            );
+            continue;
+        };
+        if !commit_assistant_turn(
+            world,
+            entity,
+            batch.message_id,
+            assistant_content,
+            Some(results),
+        ) {
+            continue;
+        }
+        for call in batch.calls {
+            if let Some(operation_id) = call.operation_id {
+                publish(
+                    world,
+                    entity,
+                    RunEvent::ToolCommitted {
+                        operation_id,
+                        tool_call_id: call.call.id,
+                    },
+                );
+            }
+        }
+        if let Some(mut run) = world.get_mut::<RunNode>(entity) {
+            run.phase = RunPhase::ReadyModel;
+        }
+        tracing::info!(
+            target: "rig::ecs",
+            run_id = ?run_id,
+            tool_count,
+            "tool batch committed to canonical transcript"
+        );
+        bump_progress(world, entity);
+    }
+}
+
+fn cleanup_terminal_runs(world: &mut World) {
+    let (observed_retention, unobserved_retention) = world
+        .get_resource::<RuntimeConfigResource>()
+        .map_or((16, 1_024), |config| {
+            (
+                config.0.terminal_retention_ticks,
+                config.0.unobserved_terminal_retention_ticks,
+            )
+        });
+    let tick = world.resource::<RuntimeTick>().0;
+    let entities = {
+        let mut query = world.query::<(
+            Entity,
+            &RunNode,
+            &TerminalState,
+            Option<&TerminalObservation>,
+        )>();
+        query
+            .iter(world)
+            .filter(|(entity, _, terminal, observation)| {
+                let (age_origin, retention) = match observation {
+                    Some(observation) => (
+                        observation.observed_tick.max(terminal.terminal_tick),
+                        observed_retention,
+                    ),
+                    None => (terminal.terminal_tick, unobserved_retention),
+                };
+                tick.saturating_sub(age_origin) >= retention
+                    && world
+                        .get::<ActiveOperations>(*entity)
+                        .is_none_or(|operations| operations.0.values().all(|op| op.completed))
+            })
+            .map(|(entity, run, _, _)| (entity, run.id))
+            .collect::<Vec<_>>()
+    };
+    for (entity, run_id) in entities {
+        world.resource_mut::<TopologyIndex>().runs.remove(&run_id);
+        let mut capability_references = world.resource_mut::<CapabilityReferences>();
+        for references in capability_references.0.values_mut() {
+            references.remove(&run_id);
+        }
+        capability_references
+            .0
+            .retain(|_, references| !references.is_empty());
+        let _ = world.despawn(entity);
+        bump_progress(world, entity);
+    }
+}
+
+fn cleanup_retired_capabilities(world: &mut World) {
+    let candidates = {
+        let mut query = world.query::<(Entity, &CapabilityNode)>();
+        query
+            .iter(world)
+            .filter(|(_, capability)| capability.retired)
+            .filter(|(_, capability)| {
+                world
+                    .resource::<CapabilityReferences>()
+                    .0
+                    .get(&capability.id)
+                    .is_none_or(BTreeSet::is_empty)
+            })
+            .filter(|(_, capability)| {
+                world
+                    .resource::<TopologyIndex>()
+                    .grants
+                    .values()
+                    .filter_map(|entity| world.get::<GrantNode>(*entity))
+                    .all(|grant| grant.capability_id != capability.id || grant.revoked)
+            })
+            .map(|(entity, capability)| (entity, capability.id))
+            .collect::<Vec<_>>()
+    };
+    for (entity, capability_id) in candidates {
+        let grant_entities = world
+            .resource::<TopologyIndex>()
+            .grants
+            .iter()
+            .filter_map(|(grant_id, grant_entity)| {
+                world
+                    .get::<GrantNode>(*grant_entity)
+                    .is_some_and(|grant| grant.capability_id == capability_id)
+                    .then_some((*grant_id, *grant_entity))
+            })
+            .collect::<Vec<_>>();
+        {
+            let mut index = world.resource_mut::<TopologyIndex>();
+            for (grant_id, _) in &grant_entities {
+                index.grants.remove(grant_id);
+            }
+            index.capabilities.remove(&capability_id);
+        }
+        world
+            .resource_mut::<CapabilityReferences>()
+            .0
+            .remove(&capability_id);
+        for (_, grant_entity) in grant_entities {
+            let _ = world.despawn(grant_entity);
+        }
+        world
+            .resource_mut::<CapabilitiesToDrop>()
+            .0
+            .push(capability_id);
+        let _ = world.despawn(entity);
+        bump_progress(world, entity);
+    }
+}
+
+/// Runtime config resource kept private so schedule cleanup uses the same bounds.
+#[derive(Resource, Clone)]
+pub(crate) struct RuntimeConfigResource(pub(crate) RuntimeConfig);
+
+/// Force a terminal failure when an external wait path cannot continue.
+pub(crate) fn fail_effect_wait(world: &mut World, run_id: RunId, error: String) {
+    let entity = world.resource::<TopologyIndex>().runs.get(&run_id).copied();
+    if let Some(entity) = entity {
+        fail_run(world, entity, "effect_wait", error);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{AgentId, Generation, GrantId, ModelId, TenantId};
+
+    #[test]
+    fn stream_sequence_tracking_is_constant_space_and_strictly_monotonic() {
+        let operation_id = OperationId::new();
+        let mut accepted = AcceptedDeltas::default();
+
+        for sequence in 0..100_000 {
+            assert_eq!(
+                accept_delta_sequence(&mut accepted, operation_id, sequence),
+                Ok(())
+            );
+        }
+
+        assert_eq!(accepted.0.len(), 1);
+        assert_eq!(accepted.0.get(&operation_id), Some(&100_000));
+        assert_eq!(
+            accept_delta_sequence(&mut accepted, operation_id, 99_999),
+            Err(EffectRejectionReason::Duplicate)
+        );
+        assert_eq!(
+            accept_delta_sequence(&mut accepted, operation_id, 100_001),
+            Err(EffectRejectionReason::OutOfOrder)
+        );
+        assert_eq!(accepted.0.len(), 1);
+    }
+
+    #[test]
+    fn repeated_retirement_and_observation_cleanup_releases_all_bookkeeping() {
+        let mut world = World::new();
+        world.insert_resource(TopologyIndex::default());
+        world.insert_resource(CapabilityReferences::default());
+        world.insert_resource(CapabilitiesToDrop::default());
+        world.insert_resource(RuntimeTick(100));
+        world.insert_resource(RuntimeConfigResource(RuntimeConfig {
+            terminal_retention_ticks: 0,
+            ..RuntimeConfig::default()
+        }));
+
+        for _ in 0..64 {
+            let tenant_id = TenantId::new();
+            let capability_id = CapabilityId::new();
+            let grant_id = GrantId::new();
+            let capability_entity = world
+                .spawn(CapabilityNode {
+                    id: capability_id,
+                    tenant_id,
+                    kind: crate::CapabilityKind::Tool,
+                    definition: None,
+                    revision: 1,
+                    retired: true,
+                })
+                .id();
+            let grant_entity = world
+                .spawn(GrantNode {
+                    id: grant_id,
+                    agent_id: AgentId::new(),
+                    capability_id,
+                    tenant_id,
+                    revoked: true,
+                })
+                .id();
+            {
+                let mut index = world.resource_mut::<TopologyIndex>();
+                index.capabilities.insert(capability_id, capability_entity);
+                index.grants.insert(grant_id, grant_entity);
+            }
+            world
+                .resource_mut::<CapabilityReferences>()
+                .0
+                .insert(capability_id, BTreeSet::new());
+
+            cleanup_retired_capabilities(&mut world);
+
+            assert!(world.get::<CapabilityNode>(capability_entity).is_none());
+            assert!(world.get::<GrantNode>(grant_entity).is_none());
+            assert!(world.resource::<TopologyIndex>().capabilities.is_empty());
+            assert!(world.resource::<TopologyIndex>().grants.is_empty());
+            assert!(world.resource::<CapabilityReferences>().0.is_empty());
+        }
+        let dropped = &world.resource::<CapabilitiesToDrop>().0;
+        assert_eq!(dropped.len(), 64);
+        assert_eq!(dropped.iter().copied().collect::<BTreeSet<_>>().len(), 64);
+
+        for _ in 0..64 {
+            let run_id = RunId::new();
+            let capability_id = CapabilityId::new();
+            let run_entity = world
+                .spawn((
+                    RunNode {
+                        id: run_id,
+                        agent_id: AgentId::new(),
+                        model_id: ModelId::new(),
+                        tenant_id: TenantId::new(),
+                        generation: Generation(0),
+                        phase: RunPhase::Terminal,
+                        streaming: StreamingMode::Blocking,
+                        created_tick: 0,
+                    },
+                    TerminalState {
+                        reason: TerminalReason::Completed,
+                        terminal_tick: 1,
+                    },
+                    TerminalObservation { observed_tick: 1 },
+                    ActiveOperations::default(),
+                ))
+                .id();
+            world
+                .resource_mut::<TopologyIndex>()
+                .runs
+                .insert(run_id, run_entity);
+            world
+                .resource_mut::<CapabilityReferences>()
+                .0
+                .insert(capability_id, BTreeSet::from([run_id]));
+
+            cleanup_terminal_runs(&mut world);
+
+            assert!(world.get::<RunNode>(run_entity).is_none());
+            assert!(world.resource::<TopologyIndex>().runs.is_empty());
+            assert!(world.resource::<CapabilityReferences>().0.is_empty());
+        }
+    }
+}

--- a/crates/rig-ecs/tests/conformance.rs
+++ b/crates/rig-ecs/tests/conformance.rs
@@ -1,0 +1,1474 @@
+#![allow(clippy::panic_in_result_fn)]
+
+use std::{
+    collections::BTreeSet,
+    convert::Infallible,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use anyhow::{Context, Result};
+use rig_core::{
+    completion::{
+        AssistantContent, CompletionError, CompletionModel, CompletionRequest, CompletionResponse,
+        Message, Usage,
+    },
+    memory::{ConversationMemory, MemoryError},
+    streaming::StreamingCompletionResponse,
+    test_utils::{
+        AppendFailingMemory, CountingMemory, MockCompletionModel, MockResponse, MockStreamEvent,
+        MockTurn,
+    },
+    tool::{PortableDynamicTool, PortableTool, ToolOutput},
+    wasm_compat::WasmBoxedFuture,
+};
+use rig_ecs::{
+    AgentSpec, EcsModelExt, EffectCompletion, EffectIngress, EffectRejectionReason,
+    InvalidToolPolicy, LocalRuntime, MemoryEffectOutput, ModelEffectOutput, OutputMode,
+    ProvisionalDelta, ResponseRetryPolicy, RunEvent, RuntimeConfig, RuntimeError, StreamingMode,
+    StructuredOutputPolicy, TenantId, TerminalReason,
+};
+use rig_runtime_conformance::{
+    ALL_SCENARIOS, CountingPortableTool, ScenarioId, ScenarioReport, scenario, verify_report,
+};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+#[derive(Clone)]
+struct DelayedModel {
+    inner: MockCompletionModel,
+    delay: Duration,
+}
+
+impl CompletionModel for DelayedModel {
+    type Response = MockResponse;
+    type StreamingResponse = MockResponse;
+    type Client = ();
+
+    fn make(_: &Self::Client, _: impl Into<String>) -> Self {
+        Self {
+            inner: MockCompletionModel::default(),
+            delay: Duration::ZERO,
+        }
+    }
+
+    async fn completion(
+        &self,
+        request: CompletionRequest,
+    ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+        tokio::time::sleep(self.delay).await;
+        self.inner.completion(request).await
+    }
+
+    async fn stream(
+        &self,
+        request: CompletionRequest,
+    ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+        tokio::time::sleep(self.delay).await;
+        self.inner.stream(request).await
+    }
+}
+
+fn test_runtime() -> Result<LocalRuntime> {
+    Ok(LocalRuntime::with_config(RuntimeConfig {
+        effect_timeout: Duration::from_secs(2),
+        max_schedule_passes: 2_048,
+        terminal_retention_ticks: 2,
+        ..RuntimeConfig::default()
+    })?)
+}
+
+fn report(id: ScenarioId) -> ScenarioReport {
+    ScenarioReport::new("rig-ecs", id)
+}
+
+fn evidence<T>(report: &mut ScenarioReport, index: usize, actual: T) -> Result<()>
+where
+    T: Serialize,
+{
+    let observation = scenario(report.scenario_id)
+        .and_then(|definition| definition.observations.get(index))
+        .map(|observation| observation.description)
+        .context("shared observation index must exist")?;
+    report.observe(observation, actual)?;
+    Ok(())
+}
+
+fn role_sequence_valid(messages: &[Message]) -> bool {
+    !messages.is_empty()
+        && messages
+            .windows(2)
+            .all(|pair| !matches!(pair, [Message::Assistant { .. }, Message::Assistant { .. }]))
+}
+
+#[derive(Clone, Default)]
+struct CountingLoadFailure(Arc<AtomicUsize>);
+
+impl CountingLoadFailure {
+    fn append_count(&self) -> usize {
+        self.0.load(Ordering::SeqCst)
+    }
+}
+
+impl ConversationMemory for CountingLoadFailure {
+    fn load<'a>(
+        &'a self,
+        _conversation_id: &'a str,
+    ) -> WasmBoxedFuture<'a, Result<Vec<Message>, MemoryError>> {
+        Box::pin(async {
+            Err(MemoryError::backend(std::io::Error::other(
+                "counted load failure",
+            )))
+        })
+    }
+
+    fn append<'a>(
+        &'a self,
+        _conversation_id: &'a str,
+        _messages: Vec<Message>,
+    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+        self.0.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async { Ok(()) })
+    }
+
+    fn clear<'a>(
+        &'a self,
+        _conversation_id: &'a str,
+    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+        Box::pin(async { Ok(()) })
+    }
+}
+
+async fn model_call_budgets() -> Result<ScenarioReport> {
+    let zero_model = MockCompletionModel::text("unused");
+    let mut zero_runtime = test_runtime()?;
+    let zero_agent = zero_runtime.spawn_agent(
+        zero_model
+            .clone()
+            .into_ecs_agent_builder()
+            .max_model_calls(0)
+            .build(),
+    )?;
+    let zero_error = zero_runtime
+        .run(zero_agent, "zero")
+        .await
+        .err()
+        .context("zero must reject before I/O")?;
+
+    let retry_model = MockCompletionModel::new([MockTurn::text(""), MockTurn::text("accepted")]);
+    let mut retry_runtime = test_runtime()?;
+    let retry_agent = retry_runtime.spawn_agent(
+        retry_model
+            .clone()
+            .into_ecs_agent_builder()
+            .max_model_calls(2)
+            .response_retry_policy(ResponseRetryPolicy::RejectEmpty { max_retries: 1 })
+            .build(),
+    )?;
+    let retry_result = retry_runtime.run(retry_agent, "retry").await?;
+
+    let mut report = report(ScenarioId::ModelCallBudgets);
+    evidence(
+        &mut report,
+        0,
+        matches!(zero_error, RuntimeError::ModelCallBudgetExhausted)
+            && zero_model.request_count() == 0,
+    )?;
+    evidence(
+        &mut report,
+        1,
+        (retry_model.request_count(), retry_result.model_calls.len()),
+    )?;
+    Ok(report)
+}
+
+async fn canonical_transcript() -> Result<ScenarioReport> {
+    let model = MockCompletionModel::new([MockTurn::text(""), MockTurn::text("kept")]);
+    let mut runtime = test_runtime()?;
+    let agent = runtime.spawn_agent(
+        model
+            .into_ecs_agent_builder()
+            .response_retry_policy(ResponseRetryPolicy::RejectEmpty { max_retries: 1 })
+            .build(),
+    )?;
+    let result = runtime.run(agent, "prompt").await?;
+
+    let rejected_absent = result
+        .transcript
+        .iter()
+        .all(|message| !matches!(message, Message::Assistant { content, .. } if content.iter().any(|item| matches!(item, AssistantContent::Text(text) if text.text.is_empty()))));
+    let mut report = report(ScenarioId::CanonicalTranscript);
+    evidence(&mut report, 0, role_sequence_valid(&result.transcript))?;
+    evidence(&mut report, 1, result.transcript.len())?;
+    evidence(&mut report, 2, rejected_absent)?;
+    Ok(report)
+}
+
+async fn tool_pairing() -> Result<ScenarioReport> {
+    let first = AssistantContent::tool_call(
+        "first",
+        "counting_portable_tool",
+        serde_json::json!({"value":"first"}),
+    );
+    let second = AssistantContent::tool_call(
+        "second",
+        "counting_portable_tool",
+        serde_json::json!({"value":"second"}),
+    );
+    let model = MockCompletionModel::new([
+        MockTurn::from_contents([first, second])?,
+        MockTurn::text("done"),
+    ]);
+    let tool = CountingPortableTool::default();
+    let mut runtime = test_runtime()?;
+    let agent = runtime.spawn_agent(model.into_ecs_agent_builder().build())?;
+    runtime.install_tool(agent, tool)?;
+    let result = runtime.run(agent, "pair").await?;
+    let result_ids = match result.transcript.get(2) {
+        Some(Message::User { content }) => content
+            .iter()
+            .filter_map(|content| match content {
+                rig_core::message::UserContent::ToolResult(result) => Some(result.id.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>(),
+        _ => Vec::new(),
+    };
+    let mut report = report(ScenarioId::ToolCallResultPairing);
+    evidence(&mut report, 0, result_ids.len())?;
+    evidence(&mut report, 1, result_ids)?;
+    Ok(report)
+}
+
+async fn usage_accounting() -> Result<ScenarioReport> {
+    let usage = Usage {
+        total_tokens: 7,
+        ..Usage::new()
+    };
+    let model = DelayedModel {
+        inner: MockCompletionModel::new([MockTurn::text("unused")]),
+        delay: Duration::from_millis(50),
+    };
+    let mut runtime = test_runtime()?;
+    let agent = runtime.spawn_agent(model.into_ecs_agent_builder().build())?;
+    let handle = runtime.start_run(agent, "usage")?;
+    let _ = runtime.step(handle).await?;
+    let header = runtime
+        .active_effect_headers(handle)?
+        .first()
+        .copied()
+        .context("model operation must be active")?;
+    for _ in 0..2 {
+        runtime.ingest(EffectIngress::Completion(EffectCompletion::Model {
+            header,
+            result: Ok(ModelEffectOutput {
+                choice: vec![AssistantContent::text("done")],
+                usage,
+                message_id: Some("usage-message".to_string()),
+                raw_final: None,
+            }),
+        }))?;
+    }
+    let result = runtime.drive_to_terminal(handle).await?;
+    let billed_model = MockCompletionModel::new([
+        MockTurn::text("").with_usage(Usage {
+            total_tokens: 3,
+            ..Usage::new()
+        }),
+        MockTurn::text("accepted").with_usage(Usage {
+            total_tokens: 5,
+            ..Usage::new()
+        }),
+    ]);
+    let mut billed_runtime = test_runtime()?;
+    let billed_agent = billed_runtime.spawn_agent(
+        billed_model
+            .into_ecs_agent_builder()
+            .response_retry_policy(ResponseRetryPolicy::RejectEmpty { max_retries: 1 })
+            .max_model_calls(2)
+            .build(),
+    )?;
+    let billed = billed_runtime.run(billed_agent, "billed retry").await?;
+    let mut report = report(ScenarioId::UsageAccounting);
+    evidence(&mut report, 0, result.model_calls.len() == 1)?;
+    evidence(
+        &mut report,
+        1,
+        billed.model_calls.len() == 2
+            && billed
+                .model_calls
+                .iter()
+                .filter(|call| call.accepted)
+                .count()
+                == 1
+            && billed.usage.total_tokens == 8,
+    )?;
+    evidence(
+        &mut report,
+        2,
+        result
+            .events
+            .iter()
+            .filter(|event| {
+                matches!(
+                    event,
+                    RunEvent::EffectRejected(EffectRejectionReason::Duplicate)
+                )
+            })
+            .count()
+            == 1
+            && result.usage.total_tokens == 7,
+    )?;
+    Ok(report)
+}
+
+async fn run_invalid_policy(
+    policy: InvalidToolPolicy,
+    name: &str,
+    install: bool,
+) -> Result<(TerminalReason, usize, usize)> {
+    let model = MockCompletionModel::new([
+        MockTurn::tool_call("invalid", name, serde_json::json!({"value":"x"})),
+        MockTurn::text("recovered"),
+    ]);
+    let tool = CountingPortableTool::default();
+    let mut runtime = test_runtime()?;
+    let agent = runtime.spawn_agent(
+        model
+            .clone()
+            .into_ecs_agent_builder()
+            .invalid_tool_policy(policy)
+            .build(),
+    )?;
+    if install {
+        runtime.install_tool(agent, tool.clone())?;
+    }
+    let handle = runtime.start_run(agent, "invalid")?;
+    let result = runtime.drive_to_terminal(handle).await?;
+    Ok((
+        result.terminal_reason,
+        tool.calls().len(),
+        model.request_count(),
+    ))
+}
+
+async fn invalid_tool_recovery() -> Result<ScenarioReport> {
+    let fail = run_invalid_policy(InvalidToolPolicy::Fail, "missing", false).await?;
+    let retry = run_invalid_policy(
+        InvalidToolPolicy::Retry { max_retries: 1 },
+        "missing",
+        false,
+    )
+    .await?;
+    let repair =
+        run_invalid_policy(InvalidToolPolicy::Repair, "COUNTING_PORTABLE_TOOL", true).await?;
+    let skip = run_invalid_policy(InvalidToolPolicy::Skip, "missing", false).await?;
+    let stop = run_invalid_policy(InvalidToolPolicy::Stop, "missing", false).await?;
+    let distinguishable = matches!(fail.0, TerminalReason::Failed { .. })
+        && matches!(retry.0, TerminalReason::Completed)
+        && matches!(repair.0, TerminalReason::Completed)
+        && matches!(skip.0, TerminalReason::Completed)
+        && matches!(stop.0, TerminalReason::Stopped)
+        && retry.2 == 2
+        && repair.1 == 1;
+    let suppressed_never_executed = fail.1 == 0 && retry.1 == 0 && skip.1 == 0 && stop.1 == 0;
+    let mut report = report(ScenarioId::InvalidToolRecovery);
+    evidence(&mut report, 0, distinguishable)?;
+    evidence(&mut report, 1, suppressed_never_executed)?;
+    Ok(report)
+}
+
+async fn response_retry_rollback() -> Result<ScenarioReport> {
+    let model = MockCompletionModel::new([MockTurn::text(""), MockTurn::text("accepted")]);
+    let mut runtime = test_runtime()?;
+    let agent = runtime.spawn_agent(
+        model
+            .clone()
+            .into_ecs_agent_builder()
+            .response_retry_policy(ResponseRetryPolicy::RejectEmpty { max_retries: 1 })
+            .max_model_calls(2)
+            .build(),
+    )?;
+    let result = runtime.run(agent, "prompt").await?;
+
+    let requests = model.requests();
+    let corrective_feedback = requests
+        .get(1)
+        .is_some_and(|request| request.chat_history.len() > 1);
+
+    let tool_model = MockCompletionModel::new([
+        MockTurn::tool_call(
+            "real",
+            "counting_portable_tool",
+            serde_json::json!({"value":"executed"}),
+        ),
+        MockTurn::text("tool continuation"),
+    ]);
+    let tool = CountingPortableTool::default();
+    let mut tool_runtime = test_runtime()?;
+    let tool_agent = tool_runtime.spawn_agent(
+        tool_model
+            .clone()
+            .into_ecs_agent_builder()
+            .response_retry_policy(ResponseRetryPolicy::RejectEmpty { max_retries: 1 })
+            .max_model_calls(2)
+            .build(),
+    )?;
+    tool_runtime.install_tool(tool_agent, tool.clone())?;
+    let tool_result = tool_runtime.run(tool_agent, "tool-bearing").await?;
+
+    let repeated_model = MockCompletionModel::new([MockTurn::text(""), MockTurn::text("")]);
+    let mut repeated_runtime = test_runtime()?;
+    let repeated_agent = repeated_runtime.spawn_agent(
+        repeated_model
+            .clone()
+            .into_ecs_agent_builder()
+            .response_retry_policy(ResponseRetryPolicy::RejectEmpty { max_retries: 1 })
+            .max_model_calls(2)
+            .build(),
+    )?;
+    let repeated_handle = repeated_runtime.start_run(repeated_agent, "repeat policy")?;
+    let repeated = repeated_runtime.drive_to_terminal(repeated_handle).await?;
+    let rejected_absent = result.transcript.len() == 2
+        && result.text.as_deref() == Some("accepted")
+        && result
+            .model_calls
+            .iter()
+            .filter(|record| record.accepted)
+            .count()
+            == 1;
+    let mut report = report(ScenarioId::ResponseRetryRollback);
+    evidence(&mut report, 0, requests.len() == 2)?;
+    evidence(
+        &mut report,
+        1,
+        tool_result.text.as_deref() == Some("tool continuation")
+            && tool.calls().len() == 1
+            && tool_model.request_count() == 2,
+    )?;
+    evidence(
+        &mut report,
+        2,
+        corrective_feedback
+            && requests.get(1).is_some_and(|request| {
+                serde_json::to_string(&request.chat_history)
+                    .is_ok_and(|history| history.contains("previous response was empty"))
+            }),
+    )?;
+    evidence(
+        &mut report,
+        3,
+        matches!(repeated.terminal_reason, TerminalReason::Failed { .. })
+            && repeated_model.request_count() == 2,
+    )?;
+    evidence(
+        &mut report,
+        4,
+        requests.len() == 2 && result.model_calls.len() == 2,
+    )?;
+    evidence(&mut report, 5, rejected_absent)?;
+    Ok(report)
+}
+
+async fn stop_and_cancellation() -> Result<ScenarioReport> {
+    let stopped = run_invalid_policy(InvalidToolPolicy::Stop, "missing", false).await?;
+    let model = MockCompletionModel::text("late");
+    let mut runtime = test_runtime()?;
+    let agent = runtime.spawn_agent(model.into_ecs_agent_builder().build())?;
+    let handle = runtime.start_run(agent, "cancel")?;
+    let _ = runtime.step(handle).await?;
+    let header = runtime
+        .active_effect_headers(handle)?
+        .first()
+        .copied()
+        .context("active model header")?;
+    runtime.cancel(handle)?;
+    runtime.ingest(EffectIngress::Delta {
+        header,
+        sequence: 0,
+        delta: ProvisionalDelta::Text("too-late".to_string()),
+    })?;
+    let result = runtime.drive_to_terminal(handle).await?;
+    let terminal_blocks_commit = matches!(result.terminal_reason, TerminalReason::Cancelled)
+        && result.transcript == [Message::user("cancel")]
+        && result
+            .events
+            .iter()
+            .any(|event| matches!(event, RunEvent::EffectRejected(EffectRejectionReason::Late)));
+    let before_cleanup = runtime.finish_run(handle).is_ok();
+    // Stepping the run's own handle would renew its observation lease, so the
+    // retention window is aged through a second run's schedule passes.
+    let pump_agent = runtime.spawn_agent(
+        MockCompletionModel::text("pump")
+            .into_ecs_agent_builder()
+            .build(),
+    )?;
+    let pump = runtime.start_run(pump_agent, "pump")?;
+    let _ = runtime.drive_to_terminal(pump).await?;
+    let _ = runtime.step(pump).await;
+    let _ = runtime.step(pump).await;
+    let after_cleanup = matches!(runtime.finish_run(handle), Err(RuntimeError::UnknownRun(_)));
+    let mut report = report(ScenarioId::StopAndCancellation);
+    evidence(
+        &mut report,
+        0,
+        matches!(stopped.0, TerminalReason::Stopped) && stopped.1 == 0,
+    )?;
+    evidence(&mut report, 1, terminal_blocks_commit)?;
+    evidence(
+        &mut report,
+        2,
+        result
+            .events
+            .iter()
+            .any(|event| matches!(event, RunEvent::Terminal(_))),
+    )?;
+    evidence(&mut report, 3, before_cleanup && after_cleanup)?;
+    Ok(report)
+}
+
+#[derive(Debug, Deserialize, JsonSchema, Serialize)]
+struct Answer {
+    answer: String,
+}
+
+fn synthetic_name(schema: &schemars::Schema) -> String {
+    let digest = Sha256::digest(schema.as_value().to_string().as_bytes());
+    let prefix = digest
+        .iter()
+        .take(4)
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    format!("__rig_output_{prefix}")
+}
+
+async fn structured_output() -> Result<ScenarioReport> {
+    let schema = schemars::schema_for!(Answer);
+    let base_name = synthetic_name(&schema);
+    let collision_name = format!("{base_name}_");
+    let model = MockCompletionModel::new([MockTurn::tool_call(
+        "output",
+        &collision_name,
+        serde_json::json!({"answer":"ok"}),
+    )]);
+    let mut runtime = test_runtime()?;
+    let agent = runtime.spawn_agent(
+        model
+            .clone()
+            .into_ecs_agent_builder()
+            .structured_output::<Answer>(StructuredOutputPolicy {
+                mode: OutputMode::Tool,
+                max_retries: 1,
+                best_effort: false,
+            })
+            .build(),
+    )?;
+    runtime.install_dynamic_tool(
+        agent,
+        PortableDynamicTool::new(
+            base_name.clone(),
+            "collision",
+            serde_json::json!({"type":"object"}),
+            |_| Box::pin(async { Ok(ToolOutput::text("must not execute")) }),
+        ),
+    )?;
+    let result = runtime.run(agent, "structured").await?;
+    let request = model.requests().into_iter().next().context("request")?;
+
+    let prompted_model = MockCompletionModel::text(r#"{"answer":"prompted"}"#);
+    let mut prompted_runtime = test_runtime()?;
+    let prompted_agent = prompted_runtime.spawn_agent(
+        prompted_model
+            .clone()
+            .into_ecs_agent_builder()
+            .structured_output::<Answer>(StructuredOutputPolicy {
+                mode: OutputMode::Prompted,
+                max_retries: 0,
+                best_effort: false,
+            })
+            .build(),
+    )?;
+    let prompted = prompted_runtime.run(prompted_agent, "prompted").await?;
+    let prompted_request = prompted_model.requests();
+
+    let native_model = MockCompletionModel::text(r#"{"answer":"native"}"#);
+    let mut native_runtime = test_runtime()?;
+    let native_agent = native_runtime.spawn_agent(
+        native_model
+            .clone()
+            .into_ecs_agent_builder()
+            .structured_output::<Answer>(StructuredOutputPolicy {
+                mode: OutputMode::Native,
+                max_retries: 0,
+                best_effort: false,
+            })
+            .build(),
+    )?;
+    let native = native_runtime.run(native_agent, "native").await?;
+
+    let auto_native_model = MockCompletionModel::text(r#"{"answer":"auto-native"}"#);
+    let mut auto_native_runtime = test_runtime()?;
+    let auto_native_agent = auto_native_runtime.spawn_agent(
+        auto_native_model
+            .clone()
+            .into_ecs_agent_builder()
+            .structured_output::<Answer>(StructuredOutputPolicy::default())
+            .build(),
+    )?;
+    let auto_native = auto_native_runtime
+        .run(auto_native_agent, "auto native")
+        .await?;
+
+    let auto_tool_model = MockCompletionModel::new([MockTurn::tool_call(
+        "auto-output",
+        &base_name,
+        serde_json::json!({"answer":"auto-tool"}),
+    )]);
+    let mut auto_tool_runtime = test_runtime()?;
+    let auto_tool_agent = auto_tool_runtime.spawn_agent(
+        auto_tool_model
+            .clone()
+            .into_ecs_agent_builder()
+            .structured_output::<Answer>(StructuredOutputPolicy::default())
+            .build(),
+    )?;
+    auto_tool_runtime.install_tool(auto_tool_agent, CountingPortableTool::default())?;
+    let auto_tool = auto_tool_runtime.run(auto_tool_agent, "auto tool").await?;
+
+    let recovery_model =
+        MockCompletionModel::new([MockTurn::text("invalid-one"), MockTurn::text("invalid-two")]);
+    let mut recovery_runtime = test_runtime()?;
+    let recovery_agent = recovery_runtime.spawn_agent(
+        recovery_model
+            .clone()
+            .into_ecs_agent_builder()
+            .max_model_calls(2)
+            .structured_output::<Answer>(StructuredOutputPolicy {
+                mode: OutputMode::Native,
+                max_retries: 1,
+                best_effort: true,
+            })
+            .build(),
+    )?;
+    let recovery = recovery_runtime
+        .run(recovery_agent, "bounded recovery")
+        .await?;
+
+    let modes_work = result.structured_output == Some(serde_json::json!({"answer":"ok"}))
+        && prompted.structured_output == Some(serde_json::json!({"answer":"prompted"}))
+        && native.structured_output == Some(serde_json::json!({"answer":"native"}))
+        && auto_native.structured_output == Some(serde_json::json!({"answer":"auto-native"}))
+        && auto_tool.structured_output == Some(serde_json::json!({"answer":"auto-tool"}))
+        && prompted_request
+            .first()
+            .is_some_and(|request| request.output_schema.is_none())
+        && native_model
+            .requests()
+            .first()
+            .is_some_and(|request| request.output_schema.is_some())
+        && auto_native_model
+            .requests()
+            .first()
+            .is_some_and(|request| request.output_schema.is_some() && request.tools.is_empty())
+        && auto_tool_model.requests().first().is_some_and(|request| {
+            request.output_schema.is_none()
+                && request
+                    .tools
+                    .iter()
+                    .any(|tool| tool.name == "counting_portable_tool")
+                && request.tools.iter().any(|tool| tool.name == base_name)
+        });
+    let mut report = report(ScenarioId::StructuredOutput);
+    evidence(&mut report, 0, modes_work)?;
+    evidence(
+        &mut report,
+        1,
+        request.tools.iter().any(|tool| tool.name == collision_name)
+            && request.tools.iter().any(|tool| tool.name == base_name),
+    )?;
+    evidence(
+        &mut report,
+        2,
+        recovery.text.as_deref() == Some("invalid-two")
+            && recovery.structured_output.is_none()
+            && recovery_model.request_count() == 2,
+    )?;
+    Ok(report)
+}
+
+async fn memory() -> Result<ScenarioReport> {
+    let model = MockCompletionModel::text("done");
+    let memory = CountingMemory::default();
+    let mut runtime = test_runtime()?;
+    let tenant_id = TenantId::new();
+    let memory_id = runtime.register_memory(tenant_id, memory.clone());
+    let agent = runtime.spawn_agent(
+        model
+            .clone()
+            .into_ecs_agent_builder()
+            .tenant(tenant_id)
+            .memory(memory_id, "thread")
+            .build(),
+    )?;
+    let result = runtime.run(agent, "prompt").await?;
+
+    let multi_memory = CountingMemory::default();
+    let multi_model = MockCompletionModel::new([
+        MockTurn::tool_call(
+            "memory-tool",
+            "counting_portable_tool",
+            serde_json::json!({"value":"remembered"}),
+        ),
+        MockTurn::text("multi-step done"),
+    ]);
+    let mut multi_runtime = test_runtime()?;
+    let multi_tenant = TenantId::new();
+    let multi_memory_id = multi_runtime.register_memory(multi_tenant, multi_memory.clone());
+    let multi_agent = multi_runtime.spawn_agent(
+        multi_model
+            .into_ecs_agent_builder()
+            .tenant(multi_tenant)
+            .memory(multi_memory_id, "multi-step")
+            .max_model_calls(2)
+            .build(),
+    )?;
+    multi_runtime.install_tool(multi_agent, CountingPortableTool::default())?;
+    let multi_result = multi_runtime.run(multi_agent, "multi").await?;
+
+    let stopped_memory = CountingMemory::default();
+    let stopped_model =
+        MockCompletionModel::new([MockTurn::tool_call("bad", "missing", serde_json::json!({}))]);
+    let mut stopped_runtime = test_runtime()?;
+    let stopped_tenant_id = TenantId::new();
+    let stopped_memory_id =
+        stopped_runtime.register_memory(stopped_tenant_id, stopped_memory.clone());
+    let stopped_agent = stopped_runtime.spawn_agent(
+        stopped_model
+            .into_ecs_agent_builder()
+            .tenant(stopped_tenant_id)
+            .memory(stopped_memory_id, "thread")
+            .invalid_tool_policy(InvalidToolPolicy::Stop)
+            .build(),
+    )?;
+    let handle = stopped_runtime.start_run(stopped_agent, "stop")?;
+    let stopped = stopped_runtime.drive_to_terminal(handle).await?;
+
+    let mut failing_runtime = test_runtime()?;
+    let failing_tenant_id = TenantId::new();
+    let failing_memory = CountingLoadFailure::default();
+    let failing_memory_id =
+        failing_runtime.register_memory(failing_tenant_id, failing_memory.clone());
+    let failing_model = MockCompletionModel::text("unused");
+    let failing_agent = failing_runtime.spawn_agent(
+        failing_model
+            .clone()
+            .into_ecs_agent_builder()
+            .tenant(failing_tenant_id)
+            .memory(failing_memory_id, "thread")
+            .build(),
+    )?;
+    let load_failure = failing_runtime.run(failing_agent, "load").await;
+
+    let mut append_runtime = test_runtime()?;
+    let append_tenant_id = TenantId::new();
+    let append_memory = append_runtime.register_memory(
+        append_tenant_id,
+        AppendFailingMemory::new("ECS append failure"),
+    );
+    let append_agent = append_runtime.spawn_agent(
+        MockCompletionModel::text("append survives")
+            .into_ecs_agent_builder()
+            .tenant(append_tenant_id)
+            .memory(append_memory, "thread")
+            .build(),
+    )?;
+    let append_result = append_runtime.run(append_agent, "append").await?;
+    let mut report = report(ScenarioId::Memory);
+    evidence(
+        &mut report,
+        0,
+        memory.load_count() == 1
+            && model
+                .requests()
+                .first()
+                .is_some_and(|request| request.chat_history.len() == 1),
+    )?;
+    evidence(
+        &mut report,
+        1,
+        memory.append_count() == 1 && result.transcript.len() == 2,
+    )?;
+    evidence(
+        &mut report,
+        2,
+        multi_result.text.as_deref() == Some("multi-step done") && multi_memory.append_count() == 1,
+    )?;
+    evidence(
+        &mut report,
+        3,
+        matches!(load_failure, Err(RuntimeError::MemoryEffect(_)))
+            && failing_model.request_count() == 0,
+    )?;
+    evidence(
+        &mut report,
+        4,
+        append_result.text.as_deref() == Some("append survives")
+            && append_result
+                .failure_diagnostic
+                .as_deref()
+                .is_some_and(|message| message.contains("append failed")),
+    )?;
+    evidence(
+        &mut report,
+        5,
+        matches!(stopped.terminal_reason, TerminalReason::Stopped)
+            && stopped_memory.append_count() == 0
+            && failing_memory.append_count() == 0,
+    )?;
+    Ok(report)
+}
+
+async fn blocking_streaming_parity() -> Result<ScenarioReport> {
+    let blocking_model = MockCompletionModel::new([MockTurn::text("same").with_usage(Usage {
+        total_tokens: 4,
+        ..Usage::new()
+    })]);
+    let streaming_model = MockCompletionModel::from_stream_turns([[
+        MockStreamEvent::text("sa"),
+        MockStreamEvent::text("me"),
+        MockStreamEvent::final_response_with_total_tokens(4),
+    ]]);
+    let mut blocking_runtime = test_runtime()?;
+    let blocking_agent =
+        blocking_runtime.spawn_agent(blocking_model.into_ecs_agent_builder().build())?;
+    let blocking = blocking_runtime
+        .run_blocking(blocking_agent, "prompt")
+        .await?;
+    let mut streaming_runtime = test_runtime()?;
+    let streaming_agent =
+        streaming_runtime.spawn_agent(streaming_model.into_ecs_agent_builder().build())?;
+    let streaming = streaming_runtime
+        .run_streaming::<MockResponse>(streaming_agent, "prompt")
+        .await?
+        .result;
+    let parity = blocking.text == streaming.text
+        && blocking.transcript == streaming.transcript
+        && blocking.usage == streaming.usage
+        && blocking.terminal_reason == streaming.terminal_reason;
+    let mut blocking_error_runtime = test_runtime()?;
+    let blocking_error_agent = blocking_error_runtime.spawn_agent(
+        MockCompletionModel::new([MockTurn::error("parity failure")])
+            .into_ecs_agent_builder()
+            .build(),
+    )?;
+    let blocking_error = blocking_error_runtime
+        .run_blocking(blocking_error_agent, "error")
+        .await;
+    let mut streaming_error_runtime = test_runtime()?;
+    let streaming_error_agent = streaming_error_runtime.spawn_agent(
+        MockCompletionModel::from_stream_turns([[MockStreamEvent::error("parity failure")]])
+            .into_ecs_agent_builder()
+            .streaming(StreamingMode::Streaming)
+            .build(),
+    )?;
+    let streaming_error = streaming_error_runtime
+        .run_streaming::<MockResponse>(streaming_error_agent, "error")
+        .await;
+    let mut report = report(ScenarioId::BlockingStreamingParity);
+    evidence(&mut report, 0, parity)?;
+    evidence(
+        &mut report,
+        1,
+        matches!(blocking_error, Err(RuntimeError::ModelEffect(_)))
+            && matches!(streaming_error, Err(RuntimeError::ModelEffect(_))),
+    )?;
+    Ok(report)
+}
+
+async fn provider_final_exposure() -> Result<ScenarioReport> {
+    let model = MockCompletionModel::from_stream_turns([[
+        MockStreamEvent::text("ok"),
+        MockStreamEvent::final_response_with_total_tokens(1),
+    ]]);
+    let mut runtime = test_runtime()?;
+    let agent = runtime.spawn_agent(model.into_ecs_agent_builder().build())?;
+    let result = runtime
+        .run_streaming::<MockResponse>(agent, "stream")
+        .await?;
+    let typed = result
+        .events
+        .iter()
+        .any(|event| matches!(event, rig_ecs::StreamingRunEvent::ProviderFinal { .. }));
+
+    let failing = MockCompletionModel::from_stream_turns([[
+        MockStreamEvent::text("early"),
+        MockStreamEvent::final_response_with_total_tokens(1),
+        MockStreamEvent::error("late"),
+    ]]);
+    let mut failing_runtime = test_runtime()?;
+    let failing_agent = failing_runtime.spawn_agent(
+        failing
+            .into_ecs_agent_builder()
+            .streaming(StreamingMode::Streaming)
+            .build(),
+    )?;
+    let handle = failing_runtime.start_run(failing_agent, "stream")?;
+    let failure = failing_runtime.drive_to_terminal(handle).await?;
+    let mut report = report(ScenarioId::ProviderFinalExposure);
+    evidence(&mut report, 0, typed)?;
+    evidence(
+        &mut report,
+        1,
+        failure.raw_final::<MockResponse>().is_none()
+            && matches!(failure.terminal_reason, TerminalReason::Failed { .. }),
+    )?;
+    Ok(report)
+}
+
+async fn provisional_streaming() -> Result<ScenarioReport> {
+    let model = MockCompletionModel::from_stream_turns([[
+        MockStreamEvent::text("provisional"),
+        MockStreamEvent::error("reject"),
+    ]]);
+    let mut runtime = test_runtime()?;
+    let agent = runtime.spawn_agent(
+        model
+            .into_ecs_agent_builder()
+            .streaming(StreamingMode::Streaming)
+            .build(),
+    )?;
+    let handle = runtime.start_run(agent, "prompt")?;
+    let result = runtime.drive_to_terminal(handle).await?;
+    let observed = result.events.iter().any(|event| {
+        let RunEvent::Provisional { delta, .. } = event else {
+            return false;
+        };
+        matches!(delta.as_ref(), ProvisionalDelta::Text(text) if text == "provisional")
+    });
+
+    let retry_model = MockCompletionModel::from_stream_turns([
+        [
+            MockStreamEvent::text("not-json"),
+            MockStreamEvent::final_response_with_total_tokens(1),
+        ],
+        [
+            MockStreamEvent::text(r#"{"answer":"accepted"}"#),
+            MockStreamEvent::final_response_with_total_tokens(1),
+        ],
+    ]);
+    let mut retry_runtime = test_runtime()?;
+    let retry_agent = retry_runtime.spawn_agent(
+        retry_model
+            .into_ecs_agent_builder()
+            .streaming(StreamingMode::Streaming)
+            .max_model_calls(2)
+            .structured_output::<Answer>(StructuredOutputPolicy {
+                mode: OutputMode::Native,
+                max_retries: 1,
+                best_effort: false,
+            })
+            .build(),
+    )?;
+    let retried = retry_runtime
+        .run_streaming::<MockResponse>(retry_agent, "retry")
+        .await?
+        .result;
+    let retry_observed = retried.events.iter().any(|event| {
+        matches!(
+            event,
+            RunEvent::Provisional { delta, .. }
+                if matches!(delta.as_ref(), ProvisionalDelta::Text(text) if text == "not-json")
+        )
+    });
+
+    let stop_model = MockCompletionModel::from_stream_turns([[
+        MockStreamEvent::text("stop-provisional"),
+        MockStreamEvent::tool_call("invalid", "missing", serde_json::json!({})),
+        MockStreamEvent::final_response_with_total_tokens(1),
+    ]]);
+    let mut stop_runtime = test_runtime()?;
+    let stop_agent = stop_runtime.spawn_agent(
+        stop_model
+            .into_ecs_agent_builder()
+            .streaming(StreamingMode::Streaming)
+            .invalid_tool_policy(InvalidToolPolicy::Stop)
+            .build(),
+    )?;
+    let stop_handle = stop_runtime.start_run(stop_agent, "stop")?;
+    let stopped = stop_runtime.drive_to_terminal(stop_handle).await?;
+    let stop_observed = stopped.events.iter().any(|event| {
+        matches!(
+            event,
+            RunEvent::Provisional { delta, .. }
+                if matches!(delta.as_ref(), ProvisionalDelta::Text(text) if text == "stop-provisional")
+        )
+    });
+
+    let cancel_model = MockCompletionModel::from_stream_turns([[
+        MockStreamEvent::text("cancel-provisional"),
+        MockStreamEvent::final_response_with_total_tokens(1),
+    ]]);
+    let mut cancel_runtime = test_runtime()?;
+    let cancel_agent = cancel_runtime.spawn_agent(
+        cancel_model
+            .into_ecs_agent_builder()
+            .streaming(StreamingMode::Streaming)
+            .build(),
+    )?;
+    let mut cancel_stream =
+        cancel_runtime.start_streaming::<MockResponse>(cancel_agent, "cancel")?;
+    let mut cancel_observed = false;
+    while let Some(event) = cancel_stream.next_event().await? {
+        if matches!(
+            event,
+            rig_ecs::StreamingRunEvent::Runtime(event)
+                if matches!(*event, RunEvent::Provisional { .. })
+        ) {
+            cancel_observed = true;
+            break;
+        }
+    }
+    let cancelled = cancel_stream.cancel()?;
+    let mut report = report(ScenarioId::ProvisionalStreaming);
+    evidence(&mut report, 0, observed)?;
+    evidence(
+        &mut report,
+        1,
+        retry_observed
+            && !serde_json::to_string(&retried.transcript)?.contains("not-json")
+            && retried.text.as_deref() == Some(r#"{"answer":"accepted"}"#),
+    )?;
+    evidence(
+        &mut report,
+        2,
+        result.transcript == [Message::user("prompt")],
+    )?;
+    evidence(
+        &mut report,
+        3,
+        stop_observed
+            && matches!(stopped.terminal_reason, TerminalReason::Stopped)
+            && stopped.transcript == [Message::user("stop")],
+    )?;
+    evidence(
+        &mut report,
+        4,
+        cancel_observed
+            && matches!(cancelled.terminal_reason, TerminalReason::Cancelled)
+            && cancelled.transcript == [Message::user("cancel")],
+    )?;
+    Ok(report)
+}
+
+async fn tool_suppression() -> Result<ScenarioReport> {
+    let skipped = run_invalid_policy(InvalidToolPolicy::Skip, "missing", false).await?;
+    let invalid_peer_model = MockCompletionModel::new([
+        MockTurn::from_contents([
+            AssistantContent::tool_call("invalid-peer", "missing", serde_json::json!({})),
+            AssistantContent::tool_call(
+                "valid-peer",
+                "counting_portable_tool",
+                serde_json::json!({"value":"valid"}),
+            ),
+        ])?,
+        MockTurn::text("continued"),
+    ]);
+    let invalid_peer_tool = CountingPortableTool::default();
+    let mut invalid_peer_runtime = test_runtime()?;
+    let invalid_peer_agent = invalid_peer_runtime.spawn_agent(
+        invalid_peer_model
+            .into_ecs_agent_builder()
+            .invalid_tool_policy(InvalidToolPolicy::Skip)
+            .max_model_calls(2)
+            .build(),
+    )?;
+    invalid_peer_runtime.install_tool(invalid_peer_agent, invalid_peer_tool.clone())?;
+    let invalid_peer_result = invalid_peer_runtime
+        .run(invalid_peer_agent, "invalid peer")
+        .await?;
+
+    let schema = schemars::schema_for!(Answer);
+    let output_name = synthetic_name(&schema);
+    let model = MockCompletionModel::new([MockTurn::from_contents([
+        AssistantContent::tool_call(
+            "peer",
+            "counting_portable_tool",
+            serde_json::json!({"value":"must-not-run"}),
+        ),
+        AssistantContent::tool_call("output", output_name, serde_json::json!({"answer":"done"})),
+    ])?]);
+    let tool = CountingPortableTool::default();
+    let mut runtime = test_runtime()?;
+    let agent = runtime.spawn_agent(
+        model
+            .into_ecs_agent_builder()
+            .structured_output::<Answer>(StructuredOutputPolicy {
+                mode: OutputMode::Tool,
+                max_retries: 0,
+                best_effort: false,
+            })
+            .build(),
+    )?;
+    runtime.install_tool(agent, tool.clone())?;
+    let result = runtime.run(agent, "finalize").await?;
+
+    let stopped = run_invalid_policy(InvalidToolPolicy::Stop, "missing", false).await?;
+    let cancellation_tool = CountingPortableTool::default();
+    let cancellation_model = DelayedModel {
+        inner: MockCompletionModel::new([MockTurn::tool_call(
+            "cancelled",
+            "counting_portable_tool",
+            serde_json::json!({"value":"must-not-run"}),
+        )]),
+        delay: Duration::from_millis(100),
+    };
+    let mut cancellation_runtime = test_runtime()?;
+    let cancellation_agent =
+        cancellation_runtime.spawn_agent(cancellation_model.into_ecs_agent_builder().build())?;
+    cancellation_runtime.install_tool(cancellation_agent, cancellation_tool.clone())?;
+    let cancellation_handle = cancellation_runtime.start_run(cancellation_agent, "cancel tool")?;
+    let _ = cancellation_runtime.step(cancellation_handle).await?;
+    cancellation_runtime.cancel(cancellation_handle)?;
+    let cancelled = cancellation_runtime
+        .drive_to_terminal(cancellation_handle)
+        .await?;
+
+    let mut report = report(ScenarioId::ToolSuppression);
+    evidence(
+        &mut report,
+        0,
+        invalid_peer_tool.calls().len() == 1
+            && invalid_peer_result.text.as_deref() == Some("continued")
+            && invalid_peer_result.events.iter().any(|event| {
+                matches!(event, RunEvent::ToolSuppressed { tool_call_id } if tool_call_id == "invalid-peer")
+            }),
+    )?;
+    evidence(&mut report, 1, skipped.1 == 0)?;
+    evidence(
+        &mut report,
+        2,
+        tool.calls().is_empty()
+            && result
+                .events
+                .iter()
+                .any(|event| matches!(event, RunEvent::ToolSuppressed { tool_call_id } if tool_call_id == "peer")),
+    )?;
+    evidence(&mut report, 3, stopped.1 == 0)?;
+    evidence(
+        &mut report,
+        4,
+        matches!(cancelled.terminal_reason, TerminalReason::Cancelled)
+            && cancellation_tool.calls().is_empty(),
+    )?;
+    Ok(report)
+}
+
+#[derive(Clone)]
+struct ConcurrencyProbe {
+    active: Arc<AtomicUsize>,
+    max_active: Arc<AtomicUsize>,
+    completed: Arc<Mutex<Vec<String>>>,
+}
+
+#[derive(Deserialize)]
+struct ProbeArgs {
+    value: String,
+    delay_ms: u64,
+}
+
+impl PortableTool for ConcurrencyProbe {
+    const NAME: &'static str = "concurrency_probe";
+    type Args = ProbeArgs;
+    type Output = serde_json::Value;
+    type Error = Infallible;
+
+    fn description(&self) -> String {
+        "bounded concurrency probe".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({"type":"object"})
+    }
+
+    async fn call(&self, arguments: Self::Args) -> Result<Self::Output, Self::Error> {
+        let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
+        self.max_active.fetch_max(active, Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(arguments.delay_ms)).await;
+        self.active.fetch_sub(1, Ordering::SeqCst);
+        self.completed
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(arguments.value.clone());
+        Ok(serde_json::json!({"value": arguments.value}))
+    }
+}
+
+async fn concurrency() -> Result<ScenarioReport> {
+    let model = MockCompletionModel::new([
+        MockTurn::from_contents([
+            AssistantContent::tool_call(
+                "slow",
+                "concurrency_probe",
+                serde_json::json!({"value":"slow","delay_ms":20}),
+            ),
+            AssistantContent::tool_call(
+                "fast",
+                "concurrency_probe",
+                serde_json::json!({"value":"fast","delay_ms":1}),
+            ),
+        ])?,
+        MockTurn::text("done"),
+    ]);
+    let probe = ConcurrencyProbe {
+        active: Arc::new(AtomicUsize::new(0)),
+        max_active: Arc::new(AtomicUsize::new(0)),
+        completed: Arc::new(Mutex::new(Vec::new())),
+    };
+    let mut runtime = LocalRuntime::with_config(RuntimeConfig {
+        max_tool_calls: 2,
+        effect_timeout: Duration::from_secs(2),
+        ..RuntimeConfig::default()
+    })?;
+    let agent = runtime.spawn_agent(model.into_ecs_agent_builder().build())?;
+    runtime.install_tool(agent, probe.clone())?;
+    let result = runtime.run(agent, "parallel").await?;
+    let ids = match result.transcript.get(2) {
+        Some(Message::User { content }) => content
+            .iter()
+            .filter_map(|content| match content {
+                rig_core::message::UserContent::ToolResult(result) => Some(result.id.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>(),
+        _ => Vec::new(),
+    };
+    let completion_order = probe
+        .completed
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone();
+    let mut report = report(ScenarioId::Concurrency);
+    evidence(&mut report, 0, probe.max_active.load(Ordering::SeqCst) <= 2)?;
+    evidence(&mut report, 1, ids)?;
+    evidence(&mut report, 2, completion_order)?;
+    Ok(report)
+}
+
+async fn stale_result_handling() -> Result<ScenarioReport> {
+    let model = DelayedModel {
+        inner: MockCompletionModel::text("done"),
+        delay: Duration::from_millis(20),
+    };
+    let mut runtime = test_runtime()?;
+    let tenant_id = TenantId::new();
+    let model_id = runtime.register_model(tenant_id, model);
+    let agent = runtime.spawn_agent_spec(AgentSpec::new(model_id, tenant_id))?;
+    let handle = runtime.start_run(agent, "hostile")?;
+    let _ = runtime.step(handle).await?;
+    let header = runtime
+        .active_effect_headers(handle)?
+        .first()
+        .copied()
+        .context("active header")?;
+    let mut wrong_runtime = header;
+    wrong_runtime.runtime_id = rig_ecs::RuntimeId::new();
+    let mut wrong_tenant = header;
+    wrong_tenant.tenant_id = TenantId::new();
+    let mut wrong_generation = header;
+    wrong_generation.generation = header.generation.next();
+    let mut wrong_correlation = header;
+    wrong_correlation.correlation_id = rig_ecs::CorrelationId::new();
+    let mut wrong_authorization = header;
+    wrong_authorization.capability_id = Some(rig_ecs::CapabilityId::new());
+    for hostile in [
+        wrong_runtime,
+        wrong_tenant,
+        wrong_generation,
+        wrong_correlation,
+        wrong_authorization,
+    ] {
+        runtime.ingest(EffectIngress::Delta {
+            header: hostile,
+            sequence: 0,
+            delta: ProvisionalDelta::Text("hostile".to_string()),
+        })?;
+    }
+    runtime.ingest(EffectIngress::Delta {
+        header,
+        sequence: 0,
+        delta: ProvisionalDelta::Text("once".to_string()),
+    })?;
+    runtime.ingest(EffectIngress::Delta {
+        header,
+        sequence: 0,
+        delta: ProvisionalDelta::Text("once".to_string()),
+    })?;
+    runtime.ingest(EffectIngress::Completion(EffectCompletion::Memory {
+        header,
+        result: Ok(MemoryEffectOutput::Appended),
+    }))?;
+    let result = runtime.drive_to_terminal(handle).await?;
+    let reasons = runtime
+        .effect_rejections()
+        .iter()
+        .map(|rejection| rejection.reason)
+        .collect::<BTreeSet<_>>();
+    let wrong_payload_count = runtime
+        .effect_rejections()
+        .iter()
+        .filter(|rejection| {
+            matches!(
+                rejection.reason,
+                EffectRejectionReason::WrongAuthorization | EffectRejectionReason::WrongPayload
+            )
+        })
+        .count();
+
+    let cancel_model = MockCompletionModel::text("late");
+    let mut cancel_runtime = test_runtime()?;
+    let cancel_agent = cancel_runtime.spawn_agent(cancel_model.into_ecs_agent_builder().build())?;
+    let cancel_handle = cancel_runtime.start_run(cancel_agent, "cancel")?;
+    let _ = cancel_runtime.step(cancel_handle).await?;
+    let cancel_header = cancel_runtime
+        .active_effect_headers(cancel_handle)?
+        .first()
+        .copied()
+        .context("cancel header")?;
+    cancel_runtime.cancel(cancel_handle)?;
+    cancel_runtime.ingest(EffectIngress::Delta {
+        header: cancel_header,
+        sequence: 0,
+        delta: ProvisionalDelta::Text("late".to_string()),
+    })?;
+    let canceled = cancel_runtime.drive_to_terminal(cancel_handle).await?;
+
+    let superseded_model = DelayedModel {
+        inner: MockCompletionModel::new([MockTurn::text("provider-late")]),
+        delay: Duration::from_millis(200),
+    };
+    let mut superseded_runtime = test_runtime()?;
+    let superseded_agent = superseded_runtime.spawn_agent(
+        superseded_model
+            .into_ecs_agent_builder()
+            .response_retry_policy(ResponseRetryPolicy::RejectEmpty { max_retries: 1 })
+            .max_model_calls(2)
+            .build(),
+    )?;
+    let superseded_handle = superseded_runtime.start_run(superseded_agent, "superseded")?;
+    let _ = superseded_runtime.step(superseded_handle).await?;
+    let first_header = superseded_runtime
+        .active_effect_headers(superseded_handle)?
+        .first()
+        .copied()
+        .context("first retry operation")?;
+    superseded_runtime.ingest(EffectIngress::Completion(EffectCompletion::Model {
+        header: first_header,
+        result: Ok(ModelEffectOutput {
+            choice: vec![AssistantContent::text("")],
+            usage: Usage::new(),
+            message_id: None,
+            raw_final: None,
+        }),
+    }))?;
+    let _ = superseded_runtime.step(superseded_handle).await?;
+    let second_header = superseded_runtime
+        .active_effect_headers(superseded_handle)?
+        .into_iter()
+        .find(|header| header.operation_id != first_header.operation_id)
+        .context("retried model operation")?;
+    superseded_runtime.ingest(EffectIngress::Completion(EffectCompletion::Model {
+        header: first_header,
+        result: Ok(ModelEffectOutput {
+            choice: vec![AssistantContent::text("superseded content")],
+            usage: Usage::new(),
+            message_id: None,
+            raw_final: None,
+        }),
+    }))?;
+    superseded_runtime.ingest(EffectIngress::Completion(EffectCompletion::Model {
+        header: second_header,
+        result: Ok(ModelEffectOutput {
+            choice: vec![AssistantContent::text("accepted retry")],
+            usage: Usage::new(),
+            message_id: None,
+            raw_final: None,
+        }),
+    }))?;
+    let superseded = superseded_runtime
+        .drive_to_terminal(superseded_handle)
+        .await?;
+    let superseded_rejected = superseded_runtime
+        .effect_rejections()
+        .iter()
+        .any(|rejection| {
+            rejection.header.operation_id == first_header.operation_id
+                && rejection.reason == EffectRejectionReason::Duplicate
+        });
+    let all_boundaries_rejected = [
+        EffectRejectionReason::ForeignRuntime,
+        EffectRejectionReason::WrongTenant,
+        EffectRejectionReason::WrongGeneration,
+        EffectRejectionReason::WrongCorrelation,
+        EffectRejectionReason::WrongAuthorization,
+    ]
+    .iter()
+    .all(|reason| reasons.contains(reason));
+    let mut report = report(ScenarioId::StaleResultHandling);
+    evidence(
+        &mut report,
+        0,
+        reasons.contains(&EffectRejectionReason::Duplicate),
+    )?;
+    evidence(
+        &mut report,
+        1,
+        reasons.contains(&EffectRejectionReason::WrongCorrelation)
+            && wrong_payload_count >= 2
+            && result.text.as_deref() == Some("done"),
+    )?;
+    evidence(
+        &mut report,
+        2,
+        superseded_rejected
+            && superseded.text.as_deref() == Some("accepted retry")
+            && !serde_json::to_string(&superseded.transcript)?.contains("superseded content"),
+    )?;
+    evidence(
+        &mut report,
+        3,
+        matches!(canceled.terminal_reason, TerminalReason::Cancelled)
+            && canceled.transcript == [Message::user("cancel")],
+    )?;
+    evidence(&mut report, 4, all_boundaries_rejected)?;
+    Ok(report)
+}
+
+#[tokio::test]
+async fn every_shared_scenario_passes_the_ecs_runtime() -> Result<()> {
+    let reports = [
+        model_call_budgets().await?,
+        canonical_transcript().await?,
+        tool_pairing().await?,
+        usage_accounting().await?,
+        invalid_tool_recovery().await?,
+        response_retry_rollback().await?,
+        stop_and_cancellation().await?,
+        structured_output().await?,
+        memory().await?,
+        blocking_streaming_parity().await?,
+        provider_final_exposure().await?,
+        provisional_streaming().await?,
+        tool_suppression().await?,
+        concurrency().await?,
+        stale_result_handling().await?,
+    ];
+    assert_eq!(reports.len(), ALL_SCENARIOS.len());
+    for report in reports {
+        verify_report(&report)?;
+    }
+    Ok(())
+}

--- a/crates/rig-ecs/tests/runtime.rs
+++ b/crates/rig-ecs/tests/runtime.rs
@@ -1,0 +1,3949 @@
+// This integration harness deliberately panics inside a provider double to
+// verify task-failure containment and mutates JSON snapshots by stable keys to
+// exercise malformed persistence input. Those operations are confined to test
+// construction rather than production runtime paths.
+#![allow(clippy::indexing_slicing, clippy::panic, clippy::panic_in_result_fn)]
+
+use std::{
+    convert::Infallible,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use anyhow::{Context, Result};
+use rig_core::{
+    OneOrMany,
+    completion::{
+        AssistantContent, CompletionError, CompletionModel, CompletionRequest, CompletionResponse,
+        Message, Usage,
+    },
+    memory::{ConversationMemory, MemoryError},
+    message::{ToolCall, ToolChoice, ToolFunction, ToolResult, ToolResultContent, UserContent},
+    streaming::StreamingCompletionResponse,
+    test_utils::{CountingMemory, MockCompletionModel, MockResponse, MockStreamEvent, MockTurn},
+    tool::{PortableDynamicTool, PortableTool, ToolOutput},
+    vector_store::{VectorSearchRequest, VectorStoreError, VectorStoreIndex, request::Filter},
+    wasm_compat::{WasmBoxedFuture, WasmCompatSend},
+};
+use rig_ecs::{
+    AgentSpec, BindingIdentity, CapabilityKind, CapabilityNode, ContentVisibility, CorrelationId,
+    EcsModelExt, EffectCompletion, EffectHeader, EffectIngress, EffectRejectionReason, Generation,
+    GrantNode, HostedRuntime, InvalidToolPolicy, LocalRunResult, LocalRuntime, ModelEffectError,
+    OperationId, OutputMode, ProtectedSnapshot, ProvisionalDelta, RebindRegistry,
+    ResponseRetryPolicy, RunEvent, RunHandle, RunId, RunPhase, RunStepStatus, RuntimeConfig,
+    RuntimeError, SnapshotContentPolicy, SnapshotError, SnapshotProtector, StreamingMode,
+    StreamingRunEvent, StructuredOutputPolicy, TenantId, TerminalReason, ToolEffectOutput,
+};
+use rig_runtime_conformance::{
+    CountingPortableTool, PortableEmbeddingFixture, portable_dynamic_fixture,
+    portable_fixture_output,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tokio::sync::Semaphore;
+
+#[derive(Clone)]
+struct DifferentMock(MockCompletionModel);
+
+impl CompletionModel for DifferentMock {
+    type Response = MockResponse;
+    type StreamingResponse = MockResponse;
+    type Client = ();
+
+    fn make(_: &Self::Client, _: impl Into<String>) -> Self {
+        Self(MockCompletionModel::default())
+    }
+
+    async fn completion(
+        &self,
+        request: CompletionRequest,
+    ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+        self.0.completion(request).await
+    }
+
+    async fn stream(
+        &self,
+        request: CompletionRequest,
+    ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+        self.0.stream(request).await
+    }
+}
+
+#[derive(Clone)]
+struct SlowMock {
+    inner: MockCompletionModel,
+    delay: Duration,
+}
+
+#[derive(Clone)]
+struct PanicModel;
+
+impl CompletionModel for PanicModel {
+    type Response = MockResponse;
+    type StreamingResponse = MockResponse;
+    type Client = ();
+
+    fn make(_: &Self::Client, _: impl Into<String>) -> Self {
+        Self
+    }
+
+    async fn completion(
+        &self,
+        _request: CompletionRequest,
+    ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+        panic!("test model panic")
+    }
+
+    async fn stream(
+        &self,
+        _request: CompletionRequest,
+    ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+        panic!("test model panic")
+    }
+}
+
+impl CompletionModel for SlowMock {
+    type Response = MockResponse;
+    type StreamingResponse = MockResponse;
+    type Client = ();
+
+    fn make(_: &Self::Client, _: impl Into<String>) -> Self {
+        Self {
+            inner: MockCompletionModel::default(),
+            delay: Duration::ZERO,
+        }
+    }
+
+    async fn completion(
+        &self,
+        request: CompletionRequest,
+    ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+        tokio::time::sleep(self.delay).await;
+        self.inner.completion(request).await
+    }
+
+    async fn stream(
+        &self,
+        request: CompletionRequest,
+    ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+        tokio::time::sleep(self.delay).await;
+        self.inner.stream(request).await
+    }
+}
+
+#[derive(Clone)]
+struct GateTool {
+    permits: Arc<Semaphore>,
+    calls: Arc<AtomicUsize>,
+}
+
+#[derive(Deserialize)]
+struct GateArgs {
+    value: String,
+}
+
+impl PortableTool for GateTool {
+    const NAME: &'static str = "gate_tool";
+    type Args = GateArgs;
+    type Output = String;
+    type Error = Infallible;
+
+    fn description(&self) -> String {
+        "test-only gated portable tool".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "required": ["value"],
+            "properties": {"value": {"type": "string"}}
+        })
+    }
+
+    async fn call(&self, arguments: Self::Args) -> Result<Self::Output, Self::Error> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        if let Ok(permit) = Arc::clone(&self.permits).acquire_owned().await {
+            permit.forget();
+        }
+        Ok(arguments.value)
+    }
+}
+
+#[derive(Clone, Copy)]
+struct OrderedDelayTool;
+
+#[derive(Deserialize)]
+struct OrderedDelayArgs {
+    value: String,
+    delay_ms: u64,
+}
+
+impl PortableTool for OrderedDelayTool {
+    const NAME: &'static str = "ordered_delay_tool";
+    type Args = OrderedDelayArgs;
+    type Output = String;
+    type Error = Infallible;
+
+    fn description(&self) -> String {
+        "return a value after a test-controlled delay".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "required": ["value", "delay_ms"],
+            "properties": {
+                "value": {"type": "string"},
+                "delay_ms": {"type": "integer"}
+            }
+        })
+    }
+
+    async fn call(&self, arguments: Self::Args) -> Result<Self::Output, Self::Error> {
+        tokio::time::sleep(Duration::from_millis(arguments.delay_ms)).await;
+        Ok(arguments.value)
+    }
+}
+
+fn runtime() -> Result<LocalRuntime> {
+    Ok(LocalRuntime::with_config(RuntimeConfig {
+        effect_timeout: Duration::from_secs(2),
+        terminal_retention_ticks: 2,
+        ..RuntimeConfig::default()
+    })?)
+}
+
+#[derive(Clone, Default)]
+struct FixtureVectorStore {
+    calls: Arc<AtomicUsize>,
+}
+
+impl VectorStoreIndex for FixtureVectorStore {
+    type Filter = Filter<serde_json::Value>;
+
+    async fn top_n<T>(
+        &self,
+        _request: VectorSearchRequest<Self::Filter>,
+    ) -> Result<Vec<(f64, String, T)>, VectorStoreError>
+    where
+        T: for<'a> Deserialize<'a> + WasmCompatSend,
+    {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        let document = serde_json::from_value(serde_json::json!({
+            "body": "retrieved through a correlated store effect"
+        }))?;
+        Ok(vec![(0.99, "doc-1".to_string(), document)])
+    }
+
+    async fn top_n_ids(
+        &self,
+        _request: VectorSearchRequest<Self::Filter>,
+    ) -> Result<Vec<(f64, String)>, VectorStoreError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok(vec![(0.99, "doc-1".to_string())])
+    }
+}
+
+#[tokio::test]
+async fn local_blocking_returns_canonical_text_and_concrete_raw_final() -> Result<()> {
+    let model = MockCompletionModel::new([MockTurn::text("hello").with_usage(Usage {
+        total_tokens: 3,
+        ..Usage::new()
+    })]);
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(
+        model
+            .clone()
+            .into_ecs_agent_builder()
+            .tenant(TenantId::new())
+            .build(),
+    )?;
+
+    let result = runtime.run_blocking(agent, "hi").await?;
+
+    assert_eq!(result.text.as_deref(), Some("hello"));
+    assert_eq!(result.usage.total_tokens, 3);
+    assert!(result.raw_final::<MockResponse>().is_some());
+    assert_eq!(model.request_count(), 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn ecs_requests_preserve_effective_preamble_for_opt_in_telemetry() -> Result<()> {
+    for record_content in [false, true] {
+        let model = MockCompletionModel::text("done");
+        let mut runtime = runtime()?;
+        let agent = runtime.spawn_agent(
+            model
+                .clone()
+                .into_ecs_agent_builder()
+                .preamble("effective system policy")
+                .record_telemetry_content(record_content)
+                .build(),
+        )?;
+
+        let _ = runtime.run(agent, "prompt").await?;
+        let request = model.requests().pop().context("recorded model request")?;
+        assert_eq!(request.preamble.as_deref(), Some("effective system policy"));
+        assert_eq!(request.record_telemetry_content, record_content);
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn ecs_agent_request_controls_reach_the_provider_request() -> Result<()> {
+    let model = MockCompletionModel::text("done");
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(
+        model
+            .clone()
+            .into_ecs_agent_builder()
+            .temperature(0.35)
+            .max_tokens(321)
+            .build(),
+    )?;
+
+    let _ = runtime.run(agent, "request controls").await?;
+    let request = model.requests().pop().context("recorded model request")?;
+
+    assert_eq!(request.temperature, Some(0.35));
+    assert_eq!(request.max_tokens, Some(321));
+    Ok(())
+}
+
+#[tokio::test]
+async fn zero_model_budget_rejects_before_provider_dispatch() -> Result<()> {
+    let model = MockCompletionModel::text("must not run");
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(
+        model
+            .clone()
+            .into_ecs_agent_builder()
+            .max_model_calls(0)
+            .build(),
+    )?;
+
+    let error = runtime
+        .run(agent, "hi")
+        .await
+        .err()
+        .context("zero model-call budget must fail")?;
+
+    assert!(matches!(error, RuntimeError::ModelCallBudgetExhausted));
+    assert_eq!(model.request_count(), 0);
+    Ok(())
+}
+
+#[tokio::test]
+async fn portable_tool_effect_commits_call_and_result_before_continuation() -> Result<()> {
+    let model = MockCompletionModel::new([
+        MockTurn::tool_call(
+            "call-1",
+            "counting_portable_tool",
+            serde_json::json!({"value": "owned"}),
+        ),
+        MockTurn::text("done"),
+    ]);
+    let tool = CountingPortableTool::default();
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(model.into_ecs_agent_builder().build())?;
+    runtime.install_tool(agent, tool.clone())?;
+
+    let result = runtime.run(agent, "use tool").await?;
+
+    assert_eq!(tool.calls(), ["owned"]);
+    assert_eq!(result.text.as_deref(), Some("done"));
+    assert_eq!(result.model_calls.len(), 2);
+    assert!(matches!(
+        result.transcript.get(1),
+        Some(Message::Assistant { content, .. })
+            if matches!(content.first_ref(), AssistantContent::ToolCall(call) if call.id == "call-1")
+    ));
+    assert!(matches!(
+        result.transcript.get(2),
+        Some(Message::User { .. })
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn portable_embedding_and_dynamic_tools_preserve_rich_outputs_in_ecs() -> Result<()> {
+    let embedding_name = <PortableEmbeddingFixture as PortableTool>::NAME;
+    let embedding_model = MockCompletionModel::new([
+        MockTurn::tool_call(
+            "embedding-success",
+            embedding_name,
+            serde_json::json!({"value": "ok"}),
+        ),
+        MockTurn::tool_call(
+            "embedding-failure",
+            embedding_name,
+            serde_json::json!({"value": "ignored", "fail": true}),
+        ),
+        MockTurn::text("embedding done"),
+    ]);
+    let embedding_tool = PortableEmbeddingFixture::new("shared");
+    let portable_schema = rig_core::embeddings::ToolSchema::try_from(&embedding_tool)?;
+    let mut embedding_runtime = runtime()?;
+    let embedding_agent =
+        embedding_runtime.spawn_agent(embedding_model.clone().into_ecs_agent_builder().build())?;
+    embedding_runtime.install_tool(embedding_agent, embedding_tool)?;
+
+    let embedding_result = embedding_runtime
+        .run(embedding_agent, "use portable embedding tool twice")
+        .await?;
+    let first_request = embedding_model
+        .requests()
+        .into_iter()
+        .next()
+        .context("embedding model request")?;
+    let definition = first_request
+        .tools
+        .iter()
+        .find(|definition| definition.name == portable_schema.name)
+        .context("portable embedding definition")?;
+    assert_eq!(definition.description, "shared portable embedding fixture");
+    assert_eq!(
+        definition.parameters,
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "value": {"type": "string"},
+                "fail": {"type": "boolean"}
+            },
+            "required": ["value"]
+        })
+    );
+
+    let embedding_outputs = embedding_result
+        .transcript
+        .iter()
+        .filter_map(|message| match message {
+            Message::User { content } => content.iter().find_map(|content| match content {
+                UserContent::ToolResult(result) => {
+                    Some(ToolOutput::content(result.content.clone()))
+                }
+                _ => None,
+            }),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        embedding_outputs,
+        [
+            portable_fixture_output("shared:ok"),
+            portable_fixture_output("portable failure")
+        ]
+    );
+
+    let dynamic = portable_dynamic_fixture();
+    let dynamic_model = MockCompletionModel::new([
+        MockTurn::tool_call(
+            "dynamic-success",
+            "portable_runtime_name",
+            serde_json::json!({"value": "ok"}),
+        ),
+        MockTurn::tool_call(
+            "dynamic-failure",
+            "portable_runtime_name",
+            serde_json::json!({"value": "ignored", "fail": true}),
+        ),
+        MockTurn::text("dynamic done"),
+    ]);
+    let mut dynamic_runtime = runtime()?;
+    let dynamic_agent =
+        dynamic_runtime.spawn_agent(dynamic_model.into_ecs_agent_builder().build())?;
+    dynamic_runtime.install_dynamic_tool(dynamic_agent, dynamic)?;
+    let dynamic_result = dynamic_runtime
+        .run(dynamic_agent, "use dynamic tool")
+        .await?;
+    let dynamic_outputs = dynamic_result
+        .transcript
+        .iter()
+        .filter_map(|message| match message {
+            Message::User { content } => content.iter().find_map(|content| match content {
+                UserContent::ToolResult(result) => {
+                    Some(ToolOutput::content(result.content.clone()))
+                }
+                _ => None,
+            }),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        dynamic_outputs,
+        [
+            portable_fixture_output("dynamic:ok"),
+            portable_fixture_output("portable dynamic failure")
+        ]
+    );
+    Ok(())
+}
+
+#[derive(Debug, PartialEq)]
+struct NormalizedRun {
+    text: Option<String>,
+    transcript: serde_json::Value,
+    usage: Usage,
+    accepted_calls: Vec<bool>,
+    events: Vec<String>,
+}
+
+fn normalize_run(result: &LocalRunResult) -> Result<NormalizedRun> {
+    let events = result
+        .events
+        .iter()
+        .map(|event| match event {
+            RunEvent::ModelDispatched(_) => "model:dispatched".to_string(),
+            RunEvent::Provisional { delta, .. } => format!(
+                "model:delta:{}",
+                match delta.as_ref() {
+                    ProvisionalDelta::Text(_) => "text",
+                    ProvisionalDelta::ToolCall(_) => "tool-call",
+                    ProvisionalDelta::ToolCallDelta { .. } => "tool-call-delta",
+                    ProvisionalDelta::Reasoning(_) => "reasoning",
+                    ProvisionalDelta::ReasoningDelta { .. } => "reasoning-delta",
+                    ProvisionalDelta::Unknown(_) => "unknown",
+                    _ => "future-delta",
+                }
+            ),
+            RunEvent::ProviderFinal { .. } => "model:provider-final".to_string(),
+            RunEvent::ToolDispatched { tool_call_id, .. } => {
+                format!("tool:dispatched:{tool_call_id}")
+            }
+            RunEvent::ToolCommitted { tool_call_id, .. } => {
+                format!("tool:committed:{tool_call_id}")
+            }
+            RunEvent::ResponseRetried => "response:retried".to_string(),
+            RunEvent::ToolSuppressed { tool_call_id } => {
+                format!("tool:suppressed:{tool_call_id}")
+            }
+            RunEvent::Terminal(reason) => format!("terminal:{reason:?}"),
+            RunEvent::EffectRejected(reason) => format!("effect:rejected:{reason:?}"),
+            _ => "runtime:future-event".to_string(),
+        })
+        .collect();
+    Ok(NormalizedRun {
+        text: result.text.clone(),
+        transcript: serde_json::to_value(&result.transcript)?,
+        usage: result.usage,
+        accepted_calls: result
+            .model_calls
+            .iter()
+            .map(|call| call.accepted)
+            .collect(),
+        events,
+    })
+}
+
+async fn run_with_agent_and_run_insertion_order(
+    reverse: bool,
+) -> Result<(NormalizedRun, NormalizedRun)> {
+    let tool_turn = MockTurn::from_contents([
+        AssistantContent::tool_call(
+            "slow-call",
+            OrderedDelayTool::NAME,
+            serde_json::json!({"value": "slow", "delay_ms": 30}),
+        ),
+        AssistantContent::tool_call(
+            "fast-call",
+            OrderedDelayTool::NAME,
+            serde_json::json!({"value": "fast", "delay_ms": 1}),
+        ),
+    ])?;
+    let tool_model = MockCompletionModel::new([tool_turn, MockTurn::text("tool batch done")]);
+    let plain_model = MockCompletionModel::text("plain done");
+    let mut runtime = LocalRuntime::with_config(RuntimeConfig {
+        max_effects: 4,
+        max_model_calls: 2,
+        max_tool_calls: 2,
+        effect_timeout: Duration::from_secs(1),
+        ..RuntimeConfig::default()
+    })?;
+
+    let (tool_agent, plain_agent) = if reverse {
+        let plain = runtime.spawn_agent(plain_model.into_ecs_agent_builder().build())?;
+        let tool = runtime.spawn_agent(
+            tool_model
+                .into_ecs_agent_builder()
+                .max_model_calls(2)
+                .build(),
+        )?;
+        (tool, plain)
+    } else {
+        let tool = runtime.spawn_agent(
+            tool_model
+                .into_ecs_agent_builder()
+                .max_model_calls(2)
+                .build(),
+        )?;
+        let plain = runtime.spawn_agent(plain_model.into_ecs_agent_builder().build())?;
+        (tool, plain)
+    };
+    runtime.install_tool(tool_agent, OrderedDelayTool)?;
+
+    let (tool_handle, plain_handle) = if reverse {
+        let plain = runtime.start_run(plain_agent, "plain prompt")?;
+        let tool = runtime.start_run(tool_agent, "tool prompt")?;
+        (tool, plain)
+    } else {
+        let tool = runtime.start_run(tool_agent, "tool prompt")?;
+        let plain = runtime.start_run(plain_agent, "plain prompt")?;
+        (tool, plain)
+    };
+
+    let (tool_result, plain_result) = if reverse {
+        let plain = runtime.drive_to_terminal(plain_handle).await?;
+        let tool = runtime.drive_to_terminal(tool_handle).await?;
+        (tool, plain)
+    } else {
+        let tool = runtime.drive_to_terminal(tool_handle).await?;
+        let plain = runtime.drive_to_terminal(plain_handle).await?;
+        (tool, plain)
+    };
+    Ok((normalize_run(&tool_result)?, normalize_run(&plain_result)?))
+}
+
+#[tokio::test]
+async fn shuffled_entity_insertion_preserves_deterministic_run_results() -> Result<()> {
+    let forward = run_with_agent_and_run_insertion_order(false).await?;
+    let reversed = run_with_agent_and_run_insertion_order(true).await?;
+
+    assert_eq!(forward, reversed);
+    assert_eq!(forward.0.text.as_deref(), Some("tool batch done"));
+    let transcript = forward.0.transcript.to_string();
+    assert!(transcript.find("slow-call") < transcript.find("fast-call"));
+    assert!(transcript.find("slow") < transcript.find("fast"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn vector_store_adapter_uses_store_topology_and_correlated_effects() -> Result<()> {
+    let model = MockCompletionModel::new([
+        MockTurn::tool_call(
+            "store-call",
+            "search_vector_store",
+            serde_json::json!({"query": "runtime split", "samples": 1}),
+        ),
+        MockTurn::text("grounded answer"),
+    ]);
+    let store = FixtureVectorStore::default();
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(model.into_ecs_agent_builder().build())?;
+    let grant = runtime.install_vector_store(agent, store.clone())?;
+
+    let result = runtime.run(agent, "retrieve context").await?;
+
+    assert_eq!(store.calls.load(Ordering::SeqCst), 1);
+    assert_eq!(result.text.as_deref(), Some("grounded answer"));
+    assert_eq!(
+        runtime.capability_kind(grant.capability_id)?,
+        CapabilityKind::Store
+    );
+    assert!(matches!(
+        result.transcript.get(2),
+        Some(Message::User { .. })
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn memory_loads_before_model_and_appends_only_successful_commits() -> Result<()> {
+    let model = MockCompletionModel::text("remembered");
+    let memory = CountingMemory::default();
+    let mut runtime = runtime()?;
+    let tenant_id = TenantId::new();
+    let memory_id = runtime.register_memory(tenant_id, memory.clone());
+    let agent = runtime.spawn_agent(
+        model
+            .clone()
+            .into_ecs_agent_builder()
+            .tenant(tenant_id)
+            .memory(memory_id, "conversation")
+            .build(),
+    )?;
+
+    let result = runtime.run(agent, "hello").await?;
+
+    assert_eq!(memory.load_count(), 1);
+    assert_eq!(memory.append_count(), 1);
+    let first_request = model
+        .requests()
+        .into_iter()
+        .next()
+        .context("memory-backed model request")?;
+    assert_eq!(first_request.chat_history.len(), 1);
+    assert_eq!(result.transcript.len(), 2);
+    Ok(())
+}
+
+#[tokio::test]
+async fn later_stream_error_keeps_deltas_provisional_and_suppresses_raw_final() -> Result<()> {
+    let model = MockCompletionModel::from_stream_turns([[
+        MockStreamEvent::text("early"),
+        MockStreamEvent::final_response_with_total_tokens(2),
+        MockStreamEvent::error("late failure"),
+    ]]);
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(
+        model
+            .into_ecs_agent_builder()
+            .streaming(StreamingMode::Streaming)
+            .build(),
+    )?;
+    let handle = runtime.start_run(agent, "stream")?;
+    // The public stepping path preserves the failed terminal result for inspection.
+    let outcome = runtime.drive_to_terminal(handle).await?;
+
+    assert!(matches!(
+        outcome.terminal_reason,
+        TerminalReason::Failed { .. }
+    ));
+    assert!(outcome.raw_final::<MockResponse>().is_none());
+    assert!(
+        outcome
+            .events
+            .iter()
+            .any(|event| matches!(event, rig_ecs::RunEvent::Provisional { .. }))
+    );
+    assert_eq!(outcome.transcript, [Message::user("stream")]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn live_stream_preserves_identical_chunks_before_typed_final() -> Result<()> {
+    let model = MockCompletionModel::from_stream_turns([[
+        MockStreamEvent::text("same"),
+        MockStreamEvent::text("same"),
+        MockStreamEvent::final_response_with_total_tokens(2),
+    ]]);
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(model.into_ecs_agent_builder().build())?;
+    let mut stream = runtime.start_streaming::<MockResponse>(agent, "stream")?;
+    let mut sequence = Vec::new();
+
+    while let Some(event) = stream.next_event().await? {
+        match event {
+            StreamingRunEvent::Runtime(event) => match *event {
+                RunEvent::Provisional { delta, .. } => {
+                    if matches!(delta.as_ref(), ProvisionalDelta::Text(text) if text == "same") {
+                        sequence.push("delta");
+                    }
+                }
+                RunEvent::Terminal(_) => sequence.push("terminal"),
+                _ => {}
+            },
+            StreamingRunEvent::ProviderFinal { .. } => sequence.push("provider-final"),
+            _ => {}
+        }
+    }
+    let result = stream.finish()?;
+
+    assert_eq!(sequence, ["delta", "delta", "provider-final", "terminal"]);
+    assert_eq!(result.text.as_deref(), Some("samesame"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn legal_stream_without_provider_final_omits_typed_final_event() -> Result<()> {
+    let model = MockCompletionModel::from_stream_turns([[MockStreamEvent::text("text only")]]);
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(model.into_ecs_agent_builder().build())?;
+
+    let streamed = runtime
+        .run_streaming::<MockResponse>(agent, "no raw final")
+        .await?;
+
+    assert_eq!(streamed.result.text.as_deref(), Some("text only"));
+    assert!(streamed.result.raw_final::<MockResponse>().is_none());
+    assert!(
+        !streamed
+            .events
+            .iter()
+            .any(|event| matches!(event, StreamingRunEvent::ProviderFinal { .. }))
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn streaming_convenience_collector_enforces_event_capacity() -> Result<()> {
+    let model = MockCompletionModel::from_stream_turns([[
+        MockStreamEvent::text("one"),
+        MockStreamEvent::text("two"),
+        MockStreamEvent::text("three"),
+        MockStreamEvent::text("four"),
+        MockStreamEvent::final_response_with_total_tokens(4),
+    ]]);
+    let mut runtime = LocalRuntime::with_config(RuntimeConfig {
+        ingress_capacity: 1,
+        event_capacity: 3,
+        effect_timeout: Duration::from_secs(1),
+        ..RuntimeConfig::default()
+    })?;
+    let agent = runtime.spawn_agent(model.into_ecs_agent_builder().build())?;
+
+    let error = runtime
+        .run_streaming::<MockResponse>(agent, "bounded collection")
+        .await
+        .err()
+        .context("collector must reject unbounded accumulation")?;
+
+    assert!(matches!(
+        error,
+        RuntimeError::EventCollectionLimit { capacity: 3 }
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn long_stream_resets_consecutive_pass_bound_for_local_and_hosted_drivers() -> Result<()> {
+    fn stream_model() -> MockCompletionModel {
+        MockCompletionModel::from_stream_turns([[
+            MockStreamEvent::text("a"),
+            MockStreamEvent::text("b"),
+            MockStreamEvent::text("c"),
+            MockStreamEvent::text("d"),
+            MockStreamEvent::text("e"),
+            MockStreamEvent::text("f"),
+            MockStreamEvent::final_response_with_total_tokens(6),
+        ]])
+    }
+
+    let config = RuntimeConfig {
+        ingress_capacity: 1,
+        max_schedule_passes: 2,
+        effect_timeout: Duration::from_secs(1),
+        ..RuntimeConfig::default()
+    };
+    let mut local = LocalRuntime::with_config(config.clone())?;
+    let local_agent = local.spawn_agent(
+        stream_model()
+            .into_ecs_agent_builder()
+            .streaming(StreamingMode::Streaming)
+            .build(),
+    )?;
+    let local_result = local.run(local_agent, "local stream").await?;
+    assert_eq!(local_result.text.as_deref(), Some("abcdef"));
+
+    let mut hosted_local = LocalRuntime::with_config(config)?;
+    let hosted_agent = hosted_local.spawn_agent(
+        stream_model()
+            .into_ecs_agent_builder()
+            .streaming(StreamingMode::Streaming)
+            .build(),
+    )?;
+    let hosted = HostedRuntime::new(hosted_local);
+    let handle = hosted.start_run(hosted_agent, "hosted stream").await?;
+    let hosted_result = hosted.drive_to_terminal(handle).await?;
+    assert_eq!(hosted_result.text.as_deref(), Some("abcdef"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn dropping_live_stream_cancels_before_provider_dispatch() -> Result<()> {
+    let inner = MockCompletionModel::text("must not run");
+    let model = SlowMock {
+        inner: inner.clone(),
+        delay: Duration::from_secs(1),
+    };
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(model.into_ecs_agent_builder().build())?;
+    let stream = runtime.start_streaming::<MockResponse>(agent, "drop immediately")?;
+    let handle = stream.handle();
+
+    drop(stream);
+
+    let result = runtime.finish_run(handle)?;
+    assert!(matches!(result.terminal_reason, TerminalReason::Cancelled));
+    assert_eq!(result.transcript, [Message::user("drop immediately")]);
+    assert!(runtime.active_effect_headers(handle)?.is_empty());
+    assert_eq!(inner.request_count(), 0);
+    Ok(())
+}
+
+#[tokio::test]
+async fn dropping_live_stream_after_provisional_delta_prevents_commit() -> Result<()> {
+    let model = MockCompletionModel::from_stream_turns([[
+        MockStreamEvent::text("provisional"),
+        MockStreamEvent::final_response_with_total_tokens(1),
+    ]]);
+    let mut runtime = LocalRuntime::with_config(RuntimeConfig {
+        ingress_capacity: 1,
+        effect_timeout: Duration::from_secs(1),
+        ..RuntimeConfig::default()
+    })?;
+    let agent = runtime.spawn_agent(model.into_ecs_agent_builder().build())?;
+    let mut stream = runtime.start_streaming::<MockResponse>(agent, "drop after delta")?;
+    let handle = stream.handle();
+
+    loop {
+        let event = stream
+            .next_event()
+            .await?
+            .context("stream must publish a provisional delta")?;
+        if matches!(
+            event,
+            StreamingRunEvent::Runtime(event)
+                if matches!(*event, RunEvent::Provisional { .. })
+        ) {
+            break;
+        }
+    }
+    drop(stream);
+
+    let result = runtime.finish_run(handle)?;
+    assert!(matches!(result.terminal_reason, TerminalReason::Cancelled));
+    assert_eq!(result.transcript, [Message::user("drop after delta")]);
+    assert!(result.raw_final::<MockResponse>().is_none());
+    assert!(runtime.active_effect_headers(handle)?.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn typed_stream_reports_provider_final_type_mismatch() -> Result<()> {
+    let model = MockCompletionModel::from_stream_turns([[
+        MockStreamEvent::text("done"),
+        MockStreamEvent::final_response_with_total_tokens(1),
+    ]]);
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(model.into_ecs_agent_builder().build())?;
+
+    let error = runtime
+        .run_streaming::<String>(agent, "stream")
+        .await
+        .err()
+        .context("wrong provider-final type must be explicit")?;
+
+    assert!(matches!(error, RuntimeError::RawFinalTypeMismatch { .. }));
+    Ok(())
+}
+
+#[tokio::test]
+async fn provider_usage_overflow_fails_without_panicking_or_wrapping() -> Result<()> {
+    let model = MockCompletionModel::new([
+        MockTurn::text("").with_usage(Usage {
+            total_tokens: u64::MAX,
+            ..Usage::new()
+        }),
+        MockTurn::text("would overflow").with_usage(Usage {
+            total_tokens: 1,
+            ..Usage::new()
+        }),
+    ]);
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(
+        model
+            .into_ecs_agent_builder()
+            .response_retry_policy(ResponseRetryPolicy::RejectEmpty { max_retries: 1 })
+            .build(),
+    )?;
+    let handle = runtime.start_run(agent, "usage")?;
+
+    let result = runtime.drive_to_terminal(handle).await?;
+
+    assert!(matches!(
+        result.terminal_reason,
+        TerminalReason::Failed { ref code } if code == "usage_overflow"
+    ));
+    assert_eq!(result.usage.total_tokens, u64::MAX);
+    assert_eq!(result.model_calls.len(), 1);
+    Ok(())
+}
+
+#[tokio::test]
+async fn wrong_tool_payload_does_not_consume_the_legitimate_completion() -> Result<()> {
+    let model = MockCompletionModel::new([
+        MockTurn::tool_call(
+            "real-call",
+            "gate_tool",
+            serde_json::json!({"value":"real"}),
+        ),
+        MockTurn::text("done"),
+    ]);
+    let permits = Arc::new(Semaphore::new(0));
+    let calls = Arc::new(AtomicUsize::new(0));
+    let tool = GateTool {
+        permits: Arc::clone(&permits),
+        calls: Arc::clone(&calls),
+    };
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(model.into_ecs_agent_builder().build())?;
+    runtime.install_tool(agent, tool)?;
+    let handle = runtime.start_run(agent, "tool")?;
+
+    let _ = runtime.step(handle).await?;
+    runtime.wait_for_effect().await?;
+    let _ = runtime.step(handle).await?;
+    let header = runtime
+        .active_effect_headers(handle)?
+        .into_iter()
+        .next()
+        .context("tool operation must remain active")?;
+    runtime.ingest(EffectIngress::Completion(EffectCompletion::Tool {
+        header,
+        tool_call_id: "forged-call".to_string(),
+        order: 0,
+        result: ToolEffectOutput::Success(ToolOutput::text("forged")),
+    }))?;
+    let _ = runtime.step(handle).await?;
+
+    assert_eq!(runtime.active_effect_headers(handle)?, [header]);
+    assert!(runtime.effect_rejections().iter().any(|rejection| {
+        rejection.header.operation_id == header.operation_id
+            && rejection.reason == EffectRejectionReason::WrongPayload
+    }));
+
+    permits.add_permits(1);
+    let result = runtime.drive_to_terminal(handle).await?;
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    assert_eq!(result.text.as_deref(), Some("done"));
+    assert!(!serde_json::to_string(&result.transcript)?.contains("forged"));
+    Ok(())
+}
+
+#[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
+struct StructuredAnswer {
+    answer: String,
+}
+
+fn assert_no_orphan_tool_use(messages: &[Message]) {
+    let answered = messages
+        .iter()
+        .filter_map(|message| match message {
+            Message::User { content } => Some(content),
+            _ => None,
+        })
+        .flat_map(|content| content.iter())
+        .filter_map(|content| match content {
+            rig_core::message::UserContent::ToolResult(result) => Some(result.id.as_str()),
+            _ => None,
+        })
+        .collect::<std::collections::BTreeSet<_>>();
+    for content in messages.iter().filter_map(|message| match message {
+        Message::Assistant { content, .. } => Some(content),
+        _ => None,
+    }) {
+        for item in content.iter() {
+            if let AssistantContent::ToolCall(call) = item {
+                assert!(
+                    answered.contains(call.id.as_str()),
+                    "assistant tool call has no matching result"
+                );
+            }
+        }
+    }
+}
+
+fn synthetic_output_tool_name<T>(real_tool_names: &[&str]) -> String
+where
+    T: schemars::JsonSchema,
+{
+    let schema = schemars::schema_for!(T);
+    let mut hasher = Sha256::new();
+    hasher.update(schema.as_value().to_string().as_bytes());
+    let prefix = hasher
+        .finalize()
+        .iter()
+        .take(4)
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    let mut candidate = format!("__rig_output_{prefix}");
+    while real_tool_names.contains(&candidate.as_str()) {
+        candidate.push('_');
+    }
+    candidate
+}
+
+#[tokio::test]
+async fn tool_choice_none_degrades_tool_output_mode_to_native() -> Result<()> {
+    let model = MockCompletionModel::text(r#"{"answer":"native"}"#);
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(
+        model
+            .clone()
+            .into_ecs_agent_builder()
+            .tool_choice(ToolChoice::None)
+            .structured_output::<StructuredAnswer>(StructuredOutputPolicy {
+                mode: OutputMode::Tool,
+                max_retries: 0,
+                best_effort: false,
+            })
+            .build(),
+    )?;
+    runtime.install_tool(agent, CountingPortableTool::default())?;
+
+    let result = runtime.run(agent, "none").await?;
+    let request = model.requests().pop().context("model request")?;
+
+    assert!(request.output_schema.is_some());
+    assert!(request.tools.is_empty());
+    assert_eq!(
+        result.structured_output,
+        Some(serde_json::json!({"answer":"native"}))
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn specific_real_tool_degrades_tool_output_mode_to_native() -> Result<()> {
+    let model = MockCompletionModel::text(r#"{"answer":"native"}"#);
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(
+        model
+            .clone()
+            .into_ecs_agent_builder()
+            .tool_choice(ToolChoice::Specific {
+                function_names: vec!["counting_portable_tool".to_string()],
+            })
+            .structured_output::<StructuredAnswer>(StructuredOutputPolicy {
+                mode: OutputMode::Tool,
+                max_retries: 0,
+                best_effort: false,
+            })
+            .build(),
+    )?;
+    runtime.install_tool(agent, CountingPortableTool::default())?;
+
+    let _ = runtime.run(agent, "specific real").await?;
+    let request = model.requests().pop().context("model request")?;
+
+    assert!(request.output_schema.is_some());
+    assert_eq!(request.tools.len(), 1);
+    assert_eq!(request.tools[0].name, "counting_portable_tool");
+    Ok(())
+}
+
+#[tokio::test]
+async fn invalid_specific_and_unsatisfied_required_choices_fail_before_io() -> Result<()> {
+    for choice in [
+        ToolChoice::Specific {
+            function_names: Vec::new(),
+        },
+        ToolChoice::Specific {
+            function_names: vec!["unknown".to_string()],
+        },
+        ToolChoice::Required,
+    ] {
+        let model = MockCompletionModel::text("must not run");
+        let mut runtime = runtime()?;
+        let agent = runtime.spawn_agent(
+            model
+                .clone()
+                .into_ecs_agent_builder()
+                .tool_choice(choice)
+                .build(),
+        )?;
+        let error = runtime
+            .run(agent, "invalid choice")
+            .await
+            .err()
+            .context("invalid choice must fail")?;
+        assert!(matches!(
+            error,
+            RuntimeError::RunFailed { ref code, .. } if code == "invalid_tool_choice"
+        ));
+        assert_eq!(model.request_count(), 0);
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn specific_synthetic_output_tool_stays_pinned_across_retry() -> Result<()> {
+    let output_name = synthetic_output_tool_name::<StructuredAnswer>(&[]);
+    let model = MockCompletionModel::new([
+        MockTurn::tool_call("invalid", output_name.clone(), serde_json::json!({})),
+        MockTurn::tool_call(
+            "valid",
+            output_name.clone(),
+            serde_json::json!({"answer":"tool"}),
+        ),
+    ]);
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(
+        model
+            .clone()
+            .into_ecs_agent_builder()
+            .tool_choice(ToolChoice::Specific {
+                function_names: vec![output_name.clone()],
+            })
+            .structured_output::<StructuredAnswer>(StructuredOutputPolicy {
+                mode: OutputMode::Tool,
+                max_retries: 1,
+                best_effort: false,
+            })
+            .build(),
+    )?;
+
+    let result = runtime.run(agent, "specific output").await?;
+
+    assert_eq!(
+        result.structured_output,
+        Some(serde_json::json!({"answer":"tool"}))
+    );
+    assert_eq!(model.request_count(), 2);
+    assert_eq!(result.text.as_deref(), Some(r#"{"answer":"tool"}"#));
+    assert_no_orphan_tool_use(&result.transcript);
+    assert!(
+        model
+            .requests()
+            .iter()
+            .all(|request| { request.tools.len() == 1 && request.tools[0].name == output_name })
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn required_choice_is_satisfied_by_the_synthetic_output_tool() -> Result<()> {
+    let output_name = synthetic_output_tool_name::<StructuredAnswer>(&[]);
+    let model = MockCompletionModel::new([MockTurn::tool_call(
+        "required",
+        output_name.clone(),
+        serde_json::json!({"answer":"required"}),
+    )]);
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(
+        model
+            .clone()
+            .into_ecs_agent_builder()
+            .tool_choice(ToolChoice::Required)
+            .structured_output::<StructuredAnswer>(StructuredOutputPolicy {
+                mode: OutputMode::Tool,
+                max_retries: 0,
+                best_effort: false,
+            })
+            .build(),
+    )?;
+
+    let result = runtime.run(agent, "required output").await?;
+
+    assert_eq!(
+        result.structured_output,
+        Some(serde_json::json!({"answer":"required"}))
+    );
+    assert_eq!(result.text.as_deref(), Some(r#"{"answer":"required"}"#));
+    assert_no_orphan_tool_use(&result.transcript);
+    let request = model.requests().pop().context("model request")?;
+    assert_eq!(request.tools.len(), 1);
+    assert_eq!(request.tools[0].name, output_name);
+    Ok(())
+}
+
+#[tokio::test]
+async fn structured_output_validates_and_best_effort_commits_last_response() -> Result<()> {
+    let policy = StructuredOutputPolicy {
+        mode: OutputMode::Native,
+        max_retries: 0,
+        best_effort: true,
+    };
+    let model = MockCompletionModel::text("not-json");
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(
+        model
+            .into_ecs_agent_builder()
+            .structured_output::<StructuredAnswer>(policy)
+            .build(),
+    )?;
+
+    let result = runtime.run(agent, "answer").await?;
+
+    assert_eq!(result.text.as_deref(), Some("not-json"));
+    assert!(result.structured_output.is_none());
+    assert_eq!(result.transcript.len(), 2);
+    Ok(())
+}
+
+#[tokio::test]
+async fn structured_output_honors_refs_combinators_and_constraints() -> Result<()> {
+    let schema = serde_json::from_value(serde_json::json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$defs": {
+            "answer": {
+                "type": "string",
+                "minLength": 5,
+                "pattern": "^[a-z]+$"
+            }
+        },
+        "type": "object",
+        "required": ["answer"],
+        "properties": {
+            "answer": {
+                "anyOf": [
+                    {"$ref": "#/$defs/answer"},
+                    {"const": "fallback"}
+                ]
+            }
+        },
+        "additionalProperties": false
+    }))?;
+    let model = MockCompletionModel::new([
+        MockTurn::text(r#"{"answer":"x"}"#),
+        MockTurn::text(r#"{"answer":"valid"}"#),
+    ]);
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(
+        model
+            .clone()
+            .into_ecs_agent_builder()
+            .structured_output_raw(
+                schema,
+                StructuredOutputPolicy {
+                    mode: OutputMode::Native,
+                    max_retries: 1,
+                    best_effort: false,
+                },
+            )
+            .build(),
+    )?;
+
+    let result = runtime.run(agent, "schema").await?;
+
+    assert_eq!(model.request_count(), 2);
+    assert_eq!(
+        result.structured_output,
+        Some(serde_json::json!({"answer":"valid"}))
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn tool_structured_mode_rejects_textual_json() -> Result<()> {
+    let model = MockCompletionModel::new([
+        MockTurn::text(r#"{"answer":"first"}"#),
+        MockTurn::text(r#"{"answer":"second"}"#),
+    ]);
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(
+        model
+            .clone()
+            .into_ecs_agent_builder()
+            .structured_output::<StructuredAnswer>(StructuredOutputPolicy {
+                mode: OutputMode::Tool,
+                max_retries: 1,
+                best_effort: false,
+            })
+            .build(),
+    )?;
+
+    let error = runtime
+        .run(agent, "tool-only")
+        .await
+        .err()
+        .context("tool mode must require the synthetic output tool")?;
+
+    assert!(matches!(error, RuntimeError::StructuredOutput(_)));
+    assert_eq!(model.request_count(), 2);
+    Ok(())
+}
+
+#[tokio::test]
+async fn exact_inflight_tool_version_survives_replacement() -> Result<()> {
+    let model = MockCompletionModel::new([
+        MockTurn::tool_call(
+            "old-call",
+            "counting_portable_tool",
+            serde_json::json!({"value": "old"}),
+        ),
+        MockTurn::text("done"),
+    ]);
+    let old = CountingPortableTool::default();
+    let new = CountingPortableTool::default();
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(model.into_ecs_agent_builder().build())?;
+    let grant = runtime.install_tool(agent, old.clone())?;
+    let handle = runtime.start_run(agent, "go")?;
+
+    // First pass creates the immutable turn snapshot and dispatches the model.
+    let _ = runtime.step(handle).await?;
+    runtime.replace_tool(grant.grant_id, new.clone())?;
+    let result = runtime.drive_to_terminal(handle).await?;
+
+    assert!(matches!(result.terminal_reason, TerminalReason::Completed));
+    assert_eq!(old.calls(), ["old"]);
+    assert!(new.calls().is_empty());
+    Ok(())
+}
+
+#[test]
+fn revoked_grants_cannot_fork_the_immutable_replacement_chain() -> Result<()> {
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(
+        MockCompletionModel::text("unused")
+            .into_ecs_agent_builder()
+            .build(),
+    )?;
+    let original = runtime.install_tool(agent, CountingPortableTool::default())?;
+    let replacement = runtime.replace_tool(original.grant_id, CountingPortableTool::default())?;
+    let topology_after_replacement = runtime.world().entities().len();
+
+    let repeated = runtime
+        .replace_tool(original.grant_id, CountingPortableTool::default())
+        .err()
+        .context("an already-revoked predecessor must not fork the version chain")?;
+    assert!(matches!(
+        repeated,
+        RuntimeError::RevokedGrant(id) if id == original.grant_id
+    ));
+    assert_eq!(replacement.revision, 2);
+    assert_eq!(runtime.world().entities().len(), topology_after_replacement);
+
+    runtime.revoke_grant(replacement.grant_id)?;
+    let revoked = runtime
+        .replace_tool(replacement.grant_id, CountingPortableTool::default())
+        .err()
+        .context("an explicitly revoked grant must not authorize replacement")?;
+    assert!(matches!(
+        revoked,
+        RuntimeError::RevokedGrant(id) if id == replacement.grant_id
+    ));
+    assert_eq!(runtime.world().entities().len(), topology_after_replacement);
+    Ok(())
+}
+
+#[test]
+fn duplicate_active_tool_names_are_rejected_atomically() -> Result<()> {
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(
+        MockCompletionModel::text("unused")
+            .into_ecs_agent_builder()
+            .build(),
+    )?;
+    runtime.install_tool(agent, CountingPortableTool::default())?;
+    let topology_before = runtime.world().entities().len();
+
+    let error = runtime
+        .install_tool(agent, CountingPortableTool::default())
+        .err()
+        .context("one agent's provider-facing tool namespace must be unique")?;
+    assert!(matches!(
+        error,
+        RuntimeError::DuplicateToolName { agent_id, .. } if agent_id == agent
+    ));
+    assert_eq!(runtime.world().entities().len(), topology_before);
+    Ok(())
+}
+
+#[tokio::test]
+async fn memory_bindings_cannot_cross_tenants() -> Result<()> {
+    let owner = TenantId::new();
+    let attacker = TenantId::new();
+    let memory = CountingMemory::default();
+    let mut runtime = runtime()?;
+    let memory_id = runtime.register_memory(owner, memory.clone());
+
+    let definition = MockCompletionModel::text("unused")
+        .into_ecs_agent_builder()
+        .tenant(attacker)
+        .memory(memory_id, "cross-tenant")
+        .build();
+    let rejected_model_id = definition.model_id();
+    let error = runtime
+        .spawn_agent(definition)
+        .err()
+        .context("cross-tenant memory construction must fail")?;
+
+    assert!(matches!(error, RuntimeError::TenantMismatch { .. }));
+    let leaked_model = runtime
+        .spawn_agent_spec(AgentSpec::new(rejected_model_id, attacker))
+        .err()
+        .context("failed agent construction must not leave a registered model")?;
+    assert!(matches!(
+        leaked_model,
+        RuntimeError::UnknownModel(id) if id == rejected_model_id
+    ));
+    assert_eq!(memory.load_count(), 0);
+    assert_eq!(memory.append_count(), 0);
+    Ok(())
+}
+
+#[tokio::test]
+async fn ingress_events_rejections_and_cancellation_are_bounded() -> Result<()> {
+    let model = SlowMock {
+        inner: MockCompletionModel::text("late"),
+        delay: Duration::from_secs(1),
+    };
+    let mut runtime = LocalRuntime::with_config(RuntimeConfig {
+        ingress_capacity: 1,
+        event_capacity: 1,
+        rejection_capacity: 2,
+        effect_timeout: Duration::from_secs(2),
+        ..RuntimeConfig::default()
+    })?;
+    let agent = runtime.spawn_agent(model.into_ecs_agent_builder().build())?;
+    let handle = runtime.start_run(agent, "bounds")?;
+    let mut events = runtime.subscribe(handle)?;
+    let _ = runtime.step(handle).await?;
+    let header = runtime
+        .active_effect_headers(handle)?
+        .into_iter()
+        .next()
+        .context("model operation")?;
+
+    runtime.ingest(EffectIngress::Delta {
+        header,
+        sequence: 0,
+        delta: ProvisionalDelta::Text("first".to_string()),
+    })?;
+    assert!(matches!(
+        runtime.ingest(EffectIngress::Delta {
+            header,
+            sequence: 1,
+            delta: ProvisionalDelta::Text("second".to_string()),
+        }),
+        Err(RuntimeError::IngressFull)
+    ));
+    let _ = runtime.step(handle).await?;
+    assert!(matches!(
+        events.try_recv(),
+        Err(tokio::sync::broadcast::error::TryRecvError::Lagged(_))
+    ));
+
+    for sequence in 1..=3 {
+        let mut hostile = header;
+        hostile.runtime_id = rig_ecs::RuntimeId::new();
+        runtime.ingest(EffectIngress::Delta {
+            header: hostile,
+            sequence,
+            delta: ProvisionalDelta::Text("hostile".to_string()),
+        })?;
+        let _ = runtime.step(handle).await?;
+    }
+    assert_eq!(runtime.effect_rejections().len(), 2);
+
+    runtime.cancel(handle)?;
+    let result = runtime.drive_to_terminal(handle).await?;
+    assert!(matches!(result.terminal_reason, TerminalReason::Cancelled));
+    assert!(runtime.active_effect_headers(handle)?.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn tenant_validation_precedes_run_lifecycle_validation() -> Result<()> {
+    let owner = TenantId::new();
+    let attacker = TenantId::new();
+    let model = SlowMock {
+        inner: MockCompletionModel::text("late"),
+        delay: Duration::from_secs(1),
+    };
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(model.into_ecs_agent_builder().tenant(owner).build())?;
+    let handle = runtime.start_run(agent, "tenant boundary")?;
+    let _ = runtime.step(handle).await?;
+    let header = runtime
+        .active_effect_headers(handle)?
+        .into_iter()
+        .next()
+        .context("model operation")?;
+    let mut hostile_header = header;
+    hostile_header.tenant_id = attacker;
+
+    runtime.ingest(EffectIngress::Delta {
+        header: hostile_header,
+        sequence: 0,
+        delta: ProvisionalDelta::Text("active probe".to_string()),
+    })?;
+    let _ = runtime.step(handle).await?;
+    assert_eq!(
+        runtime.effect_rejections().last().map(|entry| entry.reason),
+        Some(EffectRejectionReason::WrongTenant)
+    );
+
+    let hostile_handle = RunHandle {
+        runtime_id: handle.runtime_id,
+        run_id: handle.run_id,
+        generation: Generation(handle.generation.0.saturating_add(1)),
+        tenant_id: attacker,
+    };
+    assert!(matches!(
+        runtime.cancel(hostile_handle),
+        Err(RuntimeError::TenantMismatch { .. })
+    ));
+
+    runtime.cancel(handle)?;
+    let result = runtime.drive_to_terminal(handle).await?;
+    assert!(matches!(result.terminal_reason, TerminalReason::Cancelled));
+    runtime.ingest(EffectIngress::Delta {
+        header: hostile_header,
+        sequence: 1,
+        delta: ProvisionalDelta::Text("terminal probe".to_string()),
+    })?;
+    assert!(matches!(
+        runtime.step(handle).await?,
+        RunStepStatus::Terminal
+    ));
+    assert_eq!(
+        runtime.effect_rejections().last().map(|entry| entry.reason),
+        Some(EffectRejectionReason::WrongTenant)
+    );
+    assert!(matches!(
+        runtime.finish_run(hostile_handle),
+        Err(RuntimeError::TenantMismatch { .. })
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn hosted_driver_waits_for_slow_effect_without_burning_schedule_passes() -> Result<()> {
+    let model = SlowMock {
+        inner: MockCompletionModel::text("slow success"),
+        delay: Duration::from_millis(75),
+    };
+    let mut local = LocalRuntime::with_config(RuntimeConfig {
+        max_schedule_passes: 8,
+        effect_timeout: Duration::from_secs(1),
+        ..RuntimeConfig::default()
+    })?;
+    let agent = local.spawn_agent(model.into_ecs_agent_builder().build())?;
+    let hosted = HostedRuntime::new(local);
+    let handle = hosted.start_run(agent, "slow").await?;
+
+    let result = hosted.drive_to_terminal(handle).await?;
+
+    assert!(matches!(result.terminal_reason, TerminalReason::Completed));
+    assert_eq!(result.text.as_deref(), Some("slow success"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn effect_queue_backpressure_waits_across_three_runs_without_livelock() -> Result<()> {
+    let mut runtime = LocalRuntime::with_config(RuntimeConfig {
+        effect_queue_capacity: 1,
+        max_effects: 1,
+        max_model_calls: 1,
+        max_schedule_passes: 4,
+        effect_timeout: Duration::from_secs(1),
+        ..RuntimeConfig::default()
+    })?;
+    let slow_agent = runtime.spawn_agent(
+        SlowMock {
+            inner: MockCompletionModel::text("first"),
+            delay: Duration::from_millis(80),
+        }
+        .into_ecs_agent_builder()
+        .build(),
+    )?;
+    let middle_agent = runtime.spawn_agent(
+        MockCompletionModel::text("second")
+            .into_ecs_agent_builder()
+            .build(),
+    )?;
+    let target_agent = runtime.spawn_agent(
+        MockCompletionModel::text("third")
+            .into_ecs_agent_builder()
+            .build(),
+    )?;
+    let slow = runtime.start_run(slow_agent, "slow")?;
+    let _ = runtime.step(slow).await?;
+    let middle = runtime.start_run(middle_agent, "middle")?;
+    let target = runtime.start_run(target_agent, "target")?;
+
+    let target_result = tokio::time::timeout(
+        Duration::from_millis(500),
+        runtime.drive_to_terminal(target),
+    )
+    .await
+    .context("a capacity-waiting run must wake as earlier effects drain")??;
+
+    let slow_result = runtime.drive_to_terminal(slow).await?;
+    let middle_result = runtime.drive_to_terminal(middle).await?;
+    assert_eq!(target_result.text.as_deref(), Some("third"));
+    assert_eq!(slow_result.text.as_deref(), Some("first"));
+    assert_eq!(middle_result.text.as_deref(), Some("second"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn panicking_model_cannot_hang_local_driver() -> Result<()> {
+    let mut runtime = LocalRuntime::with_config(RuntimeConfig {
+        effect_timeout: Duration::from_millis(25),
+        ..RuntimeConfig::default()
+    })?;
+    let agent = runtime.spawn_agent(PanicModel.into_ecs_agent_builder().build())?;
+
+    let outcome = tokio::time::timeout(Duration::from_millis(250), runtime.run(agent, "panic"))
+        .await
+        .context("driver must remain bounded after an effect task panics")?;
+    let error = outcome.err().context("panicking model must fail the run")?;
+
+    assert!(matches!(
+        error,
+        RuntimeError::RunFailed { ref code, .. } if code == "effect_wait"
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn foreign_ingress_cannot_extend_a_missing_target_effect_deadline() -> Result<()> {
+    let foreign_events = (0..20_000)
+        .map(|index| MockStreamEvent::text(index.to_string()))
+        .chain(std::iter::once(
+            MockStreamEvent::final_response_with_total_tokens(20_000),
+        ))
+        .collect::<Vec<_>>();
+    let mut runtime = LocalRuntime::with_config(RuntimeConfig {
+        ingress_capacity: 1,
+        max_effects: 2,
+        max_model_calls: 2,
+        effect_timeout: Duration::from_millis(25),
+        ..RuntimeConfig::default()
+    })?;
+    let foreign_agent = runtime.spawn_agent(
+        MockCompletionModel::from_stream_turns([foreign_events])
+            .into_ecs_agent_builder()
+            .streaming(StreamingMode::Streaming)
+            .build(),
+    )?;
+    let target_agent = runtime.spawn_agent(PanicModel.into_ecs_agent_builder().build())?;
+    let _foreign = runtime.start_run(foreign_agent, "foreign stream")?;
+    let target = runtime.start_run(target_agent, "missing completion")?;
+
+    let outcome = tokio::time::timeout(
+        Duration::from_millis(250),
+        runtime.drive_to_terminal(target),
+    )
+    .await
+    .context("foreign ingress must not postpone the target effect deadline")?;
+    let result = outcome?;
+
+    assert!(matches!(
+        result.terminal_reason,
+        TerminalReason::Failed { .. }
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn dropping_hidden_handle_run_future_cancels_and_cleans_up() -> Result<()> {
+    let config = RuntimeConfig {
+        effect_timeout: Duration::from_secs(1),
+        terminal_retention_ticks: 1,
+        ..RuntimeConfig::default()
+    };
+    let tenant_id = TenantId::new();
+    let slow_inner = MockCompletionModel::text("must not commit");
+    let fast_model = MockCompletionModel::text("fast");
+    let mut runtime = LocalRuntime::with_config(config)?;
+    let slow_model_id = runtime.register_persistable_model(
+        tenant_id,
+        BindingIdentity::new("slow-model", "v1"),
+        SlowMock {
+            inner: slow_inner.clone(),
+            delay: Duration::from_millis(200),
+        },
+    );
+    let fast_model_id = runtime.register_persistable_model(
+        tenant_id,
+        BindingIdentity::new("fast-model", "v1"),
+        fast_model.clone(),
+    );
+    let slow_agent = runtime.spawn_agent_spec(AgentSpec::new(slow_model_id, tenant_id))?;
+    let fast_agent = runtime.spawn_agent_spec(AgentSpec::new(fast_model_id, tenant_id))?;
+
+    assert!(
+        tokio::time::timeout(
+            Duration::from_millis(20),
+            runtime.run(slow_agent, "abandoned prompt")
+        )
+        .await
+        .is_err()
+    );
+    let _ = runtime.run(fast_agent, "retained prompt").await?;
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    assert_eq!(slow_inner.request_count(), 0);
+
+    let protector = XorProtector(0x37);
+    let snapshot = runtime
+        .protected_snapshot_with_policy(&protector, SnapshotContentPolicy::CanonicalRunState)?;
+    let plaintext = protector.unprotect(&snapshot.payload)?;
+    let domain: serde_json::Value = serde_json::from_slice(&plaintext)?;
+    let runs = domain
+        .get("runs")
+        .and_then(serde_json::Value::as_array)
+        .context("snapshot runs")?;
+    assert_eq!(runs.len(), 1);
+    assert!(!String::from_utf8(plaintext)?.contains("abandoned prompt"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn hosted_runs_use_run_scoped_progress_and_wakeups() -> Result<()> {
+    let mut local = LocalRuntime::with_config(RuntimeConfig {
+        max_schedule_passes: 64,
+        effect_timeout: Duration::from_millis(300),
+        ..RuntimeConfig::default()
+    })?;
+    let slow_agent = local.spawn_agent(
+        SlowMock {
+            inner: MockCompletionModel::text("slow"),
+            delay: Duration::from_millis(80),
+        }
+        .into_ecs_agent_builder()
+        .build(),
+    )?;
+    let fast_agent = local.spawn_agent(
+        SlowMock {
+            inner: MockCompletionModel::text("fast"),
+            delay: Duration::from_millis(10),
+        }
+        .into_ecs_agent_builder()
+        .build(),
+    )?;
+    let hosted = HostedRuntime::new(local);
+    let slow = hosted.start_run(slow_agent, "slow").await?;
+    let fast = hosted.start_run(fast_agent, "fast").await?;
+
+    let (slow_result, fast_result) = tokio::time::timeout(Duration::from_millis(200), async {
+        tokio::join!(
+            hosted.drive_to_terminal(slow),
+            hosted.drive_to_terminal(fast)
+        )
+    })
+    .await
+    .context("one run's completion must not strand another run's waiter")?;
+
+    assert_eq!(slow_result?.text.as_deref(), Some("slow"));
+    assert_eq!(fast_result?.text.as_deref(), Some("fast"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn hosted_driver_drains_foreign_ingress_that_blocks_its_own_completion() -> Result<()> {
+    let mut local = LocalRuntime::with_config(RuntimeConfig {
+        ingress_capacity: 1,
+        max_effects: 2,
+        max_model_calls: 2,
+        effect_timeout: Duration::from_millis(500),
+        ..RuntimeConfig::default()
+    })?;
+    let early_agent = local.spawn_agent(
+        SlowMock {
+            inner: MockCompletionModel::text("early"),
+            delay: Duration::from_millis(5),
+        }
+        .into_ecs_agent_builder()
+        .build(),
+    )?;
+    let target_agent = local.spawn_agent(
+        SlowMock {
+            inner: MockCompletionModel::text("target"),
+            delay: Duration::from_millis(40),
+        }
+        .into_ecs_agent_builder()
+        .build(),
+    )?;
+    let hosted = HostedRuntime::new(local);
+    let early = hosted.start_run(early_agent, "early").await?;
+    let target = hosted.start_run(target_agent, "target").await?;
+
+    let target_result =
+        tokio::time::timeout(Duration::from_millis(300), hosted.drive_to_terminal(target))
+            .await
+            .context("foreign ingress must wake the target driver to free the shared channel")??;
+
+    assert_eq!(target_result.text.as_deref(), Some("target"));
+    assert_eq!(
+        hosted.finish_run(early).await?.text.as_deref(),
+        Some("early")
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn hosted_cancellation_wakes_a_run_waiting_for_effect_queue_capacity() -> Result<()> {
+    let mut local = LocalRuntime::with_config(RuntimeConfig {
+        effect_queue_capacity: 1,
+        max_effects: 1,
+        max_model_calls: 1,
+        effect_timeout: Duration::from_secs(1),
+        ..RuntimeConfig::default()
+    })?;
+    let blocking_agent = local.spawn_agent(
+        SlowMock {
+            inner: MockCompletionModel::text("blocking"),
+            delay: Duration::from_millis(500),
+        }
+        .into_ecs_agent_builder()
+        .build(),
+    )?;
+    let waiting_agent = local.spawn_agent(
+        MockCompletionModel::text("must not dispatch")
+            .into_ecs_agent_builder()
+            .build(),
+    )?;
+    let hosted = HostedRuntime::new(local);
+    let blocking = hosted.start_run(blocking_agent, "blocking").await?;
+    let _ = hosted.step(blocking).await?;
+    let waiting = hosted.start_run(waiting_agent, "waiting").await?;
+    let driver = {
+        let hosted = hosted.clone();
+        tokio::spawn(async move { hosted.drive_to_terminal(waiting).await })
+    };
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    hosted.cancel(waiting).await?;
+    let result = tokio::time::timeout(Duration::from_millis(200), driver)
+        .await
+        .context("cancellation must wake the capacity waiter")???;
+
+    assert!(matches!(result.terminal_reason, TerminalReason::Cancelled));
+    hosted.cancel(blocking).await?;
+    let _ = hosted.drive_to_terminal(blocking).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn hosted_deferred_effect_wakes_when_a_semaphore_owner_is_cancelled() -> Result<()> {
+    let mut local = LocalRuntime::with_config(RuntimeConfig {
+        effect_queue_capacity: 8,
+        max_effects: 1,
+        max_model_calls: 1,
+        effect_timeout: Duration::from_secs(1),
+        ..RuntimeConfig::default()
+    })?;
+    let blocking_agent = local.spawn_agent(
+        SlowMock {
+            inner: MockCompletionModel::text("blocking"),
+            delay: Duration::from_millis(500),
+        }
+        .into_ecs_agent_builder()
+        .build(),
+    )?;
+    let target_agent = local.spawn_agent(
+        MockCompletionModel::text("target")
+            .into_ecs_agent_builder()
+            .build(),
+    )?;
+    let hosted = HostedRuntime::new(local);
+    let blocking = hosted.start_run(blocking_agent, "blocking").await?;
+    let _ = hosted.step(blocking).await?;
+    let target = hosted.start_run(target_agent, "deferred").await?;
+    let _ = hosted.step(target).await?;
+    let driver = {
+        let hosted = hosted.clone();
+        tokio::spawn(async move { hosted.drive_to_terminal(target).await })
+    };
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    hosted.cancel(blocking).await?;
+    let blocker_result = hosted.drive_to_terminal(blocking).await?;
+    assert!(matches!(
+        blocker_result.terminal_reason,
+        TerminalReason::Cancelled
+    ));
+    let target_result = tokio::time::timeout(Duration::from_millis(200), driver)
+        .await
+        .context("deferred effect must wake when execution capacity is released")???;
+
+    assert!(matches!(
+        target_result.terminal_reason,
+        TerminalReason::Completed
+    ));
+    assert_eq!(target_result.text.as_deref(), Some("target"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn dropping_hosted_driver_future_leaves_the_run_resumable() -> Result<()> {
+    let mut local = LocalRuntime::with_config(RuntimeConfig {
+        effect_timeout: Duration::from_secs(1),
+        ..RuntimeConfig::default()
+    })?;
+    let agent = local.spawn_agent(
+        SlowMock {
+            inner: MockCompletionModel::text("resumed"),
+            delay: Duration::from_millis(80),
+        }
+        .into_ecs_agent_builder()
+        .build(),
+    )?;
+    let hosted = HostedRuntime::new(local);
+    let handle = hosted.start_run(agent, "resume after drop").await?;
+    let driver = {
+        let hosted = hosted.clone();
+        tokio::spawn(async move { hosted.drive_to_terminal(handle).await })
+    };
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    driver.abort();
+    let _ = driver.await;
+
+    let result = hosted.drive_to_terminal(handle).await?;
+
+    assert!(matches!(result.terminal_reason, TerminalReason::Completed));
+    assert_eq!(result.text.as_deref(), Some("resumed"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn hosted_runtime_rejects_a_second_driver_for_the_same_handle() -> Result<()> {
+    let mut local = runtime()?;
+    let agent = local.spawn_agent(
+        SlowMock {
+            inner: MockCompletionModel::text("single owner"),
+            delay: Duration::from_millis(40),
+        }
+        .into_ecs_agent_builder()
+        .build(),
+    )?;
+    let hosted = HostedRuntime::new(local);
+    let handle = hosted.start_run(agent, "one handle").await?;
+
+    let (left, right) = tokio::join!(
+        hosted.drive_to_terminal(handle),
+        hosted.drive_to_terminal(handle)
+    );
+    let outcomes = [left, right];
+    assert_eq!(
+        outcomes
+            .iter()
+            .filter(|outcome| outcome
+                .as_ref()
+                .is_ok_and(|result| result.text.as_deref() == Some("single owner")))
+            .count(),
+        1
+    );
+    assert_eq!(
+        outcomes
+            .iter()
+            .filter(|outcome| matches!(outcome, Err(RuntimeError::RunAlreadyDriven(id)) if *id == handle.run_id))
+            .count(),
+        1
+    );
+    Ok(())
+}
+
+struct XorProtector(u8);
+
+impl SnapshotProtector for XorProtector {
+    fn protector_id(&self) -> &str {
+        "test-xor-v1"
+    }
+
+    fn protect(&self, plaintext: &[u8]) -> Result<Vec<u8>, SnapshotError> {
+        Ok(plaintext.iter().map(|byte| byte ^ self.0).collect())
+    }
+
+    fn unprotect(&self, protected: &[u8]) -> Result<Vec<u8>, SnapshotError> {
+        Ok(protected.iter().map(|byte| byte ^ self.0).collect())
+    }
+}
+
+fn reprotect_domain(
+    snapshot: &ProtectedSnapshot,
+    protector: &dyn SnapshotProtector,
+    domain: &serde_json::Value,
+) -> Result<ProtectedSnapshot> {
+    let payload = protector.protect(&serde_json::to_vec(domain)?)?;
+    Ok(ProtectedSnapshot {
+        version: snapshot.version,
+        protector_id: snapshot.protector_id.clone(),
+        protected_digest: Sha256::digest(&payload).into(),
+        payload,
+    })
+}
+
+#[tokio::test]
+async fn canonical_snapshot_validation_rejects_impossible_transcript_and_accounting() -> Result<()>
+{
+    let tenant_id = TenantId::new();
+    let identity = BindingIdentity::new("snapshot-validation-model", "v1");
+    let model = MockCompletionModel::new([MockTurn::text("done").with_usage(Usage {
+        total_tokens: 3,
+        ..Usage::new()
+    })]);
+    let mut runtime = runtime()?;
+    let model_id = runtime.register_persistable_model(tenant_id, identity, model.clone());
+    let agent = runtime.spawn_agent_spec(AgentSpec::new(model_id, tenant_id))?;
+    let _ = runtime.run(agent, "snapshot validation").await?;
+    let protector = XorProtector(0x61);
+    let snapshot = runtime
+        .protected_snapshot_with_policy(&protector, SnapshotContentPolicy::CanonicalRunState)?;
+    let base: serde_json::Value = serde_json::from_slice(&protector.unprotect(&snapshot.payload)?)?;
+    let mut invalid_domains = Vec::new();
+
+    let mut boundary = base.clone();
+    let boundary_run = boundary
+        .get_mut("runs")
+        .and_then(serde_json::Value::as_array_mut)
+        .and_then(|runs| runs.first_mut())
+        .context("boundary run")?;
+    let message_count = boundary_run
+        .pointer("/transcript/messages")
+        .and_then(serde_json::Value::as_array)
+        .map(Vec::len)
+        .context("transcript messages")?;
+    boundary_run["transcript"]["new_messages_start"] = serde_json::json!(message_count + 1);
+    invalid_domains.push(boundary);
+
+    let mut duplicate_operation = base.clone();
+    let duplicate_accounting = duplicate_operation
+        .get_mut("runs")
+        .and_then(serde_json::Value::as_array_mut)
+        .and_then(|runs| runs.first_mut())
+        .and_then(|run| run.get_mut("accounting"))
+        .context("duplicate accounting")?;
+    let duplicate_call = duplicate_accounting
+        .get("model_calls")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|calls| calls.first())
+        .cloned()
+        .context("model call")?;
+    duplicate_accounting["model_calls"]
+        .as_array_mut()
+        .context("model calls array")?
+        .push(duplicate_call);
+    duplicate_accounting["model_calls_dispatched"] = serde_json::json!(2);
+    invalid_domains.push(duplicate_operation);
+
+    let mut impossible_dispatch_count = base.clone();
+    impossible_dispatch_count["runs"][0]["accounting"]["model_calls_dispatched"] =
+        serde_json::json!(0);
+    invalid_domains.push(impossible_dispatch_count);
+
+    let mut over_budget_dispatch_count = base.clone();
+    over_budget_dispatch_count["runs"][0]["accounting"]["model_calls_dispatched"] =
+        serde_json::json!(9);
+    invalid_domains.push(over_budget_dispatch_count);
+
+    let mut out_of_order_observation = base.clone();
+    out_of_order_observation["runs"][0]["terminal"]["terminal_tick"] = serde_json::json!(1);
+    out_of_order_observation["runs"][0]["observation"]["observed_tick"] = serde_json::json!(0);
+    invalid_domains.push(out_of_order_observation);
+
+    let tool_call = Message::Assistant {
+        id: None,
+        content: OneOrMany::one(AssistantContent::tool_call(
+            "snapshot-call",
+            "snapshot-tool",
+            serde_json::json!({}),
+        )),
+    };
+    let mut orphan_call = base.clone();
+    orphan_call["runs"][0]["transcript"]["messages"] =
+        serde_json::to_value([Message::user("prompt"), tool_call.clone()])?;
+    invalid_domains.push(orphan_call);
+
+    let mut unmatched_result = base.clone();
+    unmatched_result["runs"][0]["transcript"]["messages"] = serde_json::to_value([
+        Message::user("prompt"),
+        tool_call.clone(),
+        Message::tool_result("different-call", "result"),
+    ])?;
+    invalid_domains.push(unmatched_result);
+
+    let Message::User { content } = Message::tool_result("snapshot-call", "result") else {
+        anyhow::bail!("tool-result constructor returned the wrong role");
+    };
+    let result = content.first();
+    let duplicate_result = Message::User {
+        content: OneOrMany::many([result.clone(), result])?,
+    };
+    let mut duplicate_pairing = base.clone();
+    duplicate_pairing["runs"][0]["transcript"]["messages"] =
+        serde_json::to_value([Message::user("prompt"), tool_call, duplicate_result])?;
+    invalid_domains.push(duplicate_pairing);
+
+    let mut duplicate_assistant_role = base.clone();
+    duplicate_assistant_role["runs"][0]["transcript"]["messages"] = serde_json::to_value([
+        Message::user("prompt"),
+        Message::assistant("first"),
+        Message::assistant("second"),
+    ])?;
+    invalid_domains.push(duplicate_assistant_role);
+
+    let mut usage_mismatch = base;
+    usage_mismatch["runs"][0]["accounting"]["usage"]["total_tokens"] = serde_json::json!(4);
+    invalid_domains.push(usage_mismatch);
+
+    for domain in invalid_domains {
+        let tampered = reprotect_domain(&snapshot, &protector, &domain)?;
+        let mut bindings = RebindRegistry::new();
+        bindings.bind_model(model_id, tenant_id, identity, model.clone());
+        let error =
+            LocalRuntime::restore(RuntimeConfig::default(), &tampered, &protector, bindings)
+                .err()
+                .context("impossible canonical state must be rejected")?;
+        assert!(matches!(
+            error,
+            RuntimeError::Snapshot(SnapshotError::InvalidRelationship(_))
+        ));
+    }
+    Ok(())
+}
+
+#[test]
+fn canonical_snapshot_validation_binds_run_policy_state_to_its_agent() -> Result<()> {
+    let tenant_id = TenantId::new();
+    let identity = BindingIdentity::new("snapshot-policy-model", "v1");
+    let model = MockCompletionModel::text("unused");
+    let policy = StructuredOutputPolicy {
+        mode: OutputMode::Native,
+        max_retries: 1,
+        best_effort: false,
+    };
+    let mut runtime = runtime()?;
+    let model_id = runtime.register_persistable_model(tenant_id, identity, model.clone());
+    let agent = runtime.spawn_agent_spec(
+        AgentSpec::new(model_id, tenant_id)
+            .structured_output::<StructuredAnswer>(policy)
+            .response_retry_policy(ResponseRetryPolicy::RejectEmpty { max_retries: 1 })
+            .invalid_tool_policy(rig_ecs::InvalidToolPolicy::Retry { max_retries: 1 }),
+    )?;
+    let _ = runtime.start_run(agent, "snapshot policy")?;
+    let protector = XorProtector(0x64);
+    let snapshot = runtime
+        .protected_snapshot_with_policy(&protector, SnapshotContentPolicy::CanonicalRunState)?;
+    let base: serde_json::Value = serde_json::from_slice(&protector.unprotect(&snapshot.payload)?)?;
+    let mut invalid_domains = Vec::new();
+
+    let mut missing_structured = base.clone();
+    missing_structured["runs"][0]["structured"] = serde_json::Value::Null;
+    invalid_domains.push(missing_structured);
+
+    let mut added_to_unstructured = base.clone();
+    added_to_unstructured["agents"][0]["spec"]["structured_output"] = serde_json::Value::Null;
+    invalid_domains.push(added_to_unstructured);
+
+    let mut changed_schema = base.clone();
+    changed_schema["runs"][0]["structured"]["schema"] = serde_json::json!({"type":"string"});
+    invalid_domains.push(changed_schema);
+
+    let mut changed_policy = base.clone();
+    changed_policy["runs"][0]["structured"]["policy"]["best_effort"] =
+        serde_json::Value::Bool(true);
+    invalid_domains.push(changed_policy);
+
+    let mut excessive_structured_retries = base.clone();
+    excessive_structured_retries["runs"][0]["structured"]["retries"] = serde_json::json!(2);
+    invalid_domains.push(excessive_structured_retries);
+
+    let mut excessive_response_retries = base.clone();
+    excessive_response_retries["runs"][0]["response_retries"] = serde_json::json!(2);
+    invalid_domains.push(excessive_response_retries);
+
+    let mut excessive_invalid_tool_retries = base.clone();
+    excessive_invalid_tool_retries["runs"][0]["invalid_tool_retries"] = serde_json::json!(2);
+    invalid_domains.push(excessive_invalid_tool_retries);
+
+    let mut inconsistent_resolution = base;
+    inconsistent_resolution["runs"][0]["structured"]["output_tool_name"] =
+        serde_json::json!("forged_output_tool");
+    invalid_domains.push(inconsistent_resolution);
+
+    for domain in invalid_domains {
+        let tampered = reprotect_domain(&snapshot, &protector, &domain)?;
+        let mut bindings = RebindRegistry::new();
+        bindings.bind_model(model_id, tenant_id, identity, model.clone());
+        let error =
+            LocalRuntime::restore(RuntimeConfig::default(), &tampered, &protector, bindings)
+                .err()
+                .context("tampered run policy state must be rejected")?;
+        assert!(matches!(
+            error,
+            RuntimeError::Snapshot(SnapshotError::InvalidRelationship(_))
+        ));
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn canonical_snapshot_validation_rejects_impossible_memory_lifecycle_flags() -> Result<()> {
+    let tenant_id = TenantId::new();
+    let model_identity = BindingIdentity::new("snapshot-memory-model", "v1");
+    let memory_identity = BindingIdentity::new("snapshot-memory", "v1");
+    let model = MockCompletionModel::text("done");
+    let memory = CountingMemory::default();
+    let mut runtime = runtime()?;
+    let model_id = runtime.register_persistable_model(tenant_id, model_identity, model.clone());
+    let memory_id = runtime.register_persistable_memory(tenant_id, memory_identity, memory.clone());
+    let agent = runtime.spawn_agent_spec(
+        AgentSpec::new(model_id, tenant_id).memory(memory_id, "snapshot-memory-thread"),
+    )?;
+    let _ = runtime.run(agent, "persist memory").await?;
+    let protector = XorProtector(0x65);
+    let snapshot = runtime
+        .protected_snapshot_with_policy(&protector, SnapshotContentPolicy::CanonicalRunState)?;
+    let base: serde_json::Value = serde_json::from_slice(&protector.unprotect(&snapshot.payload)?)?;
+
+    let mut loaded_false = base.clone();
+    loaded_false["runs"][0]["memory"]["loaded"] = serde_json::Value::Bool(false);
+
+    let mut ready_but_appended = base;
+    ready_but_appended["runs"][0]["phase"] = serde_json::to_value(RunPhase::ReadyModel)?;
+    ready_but_appended["runs"][0]["terminal"] = serde_json::Value::Null;
+    ready_but_appended["runs"][0]["observation"] = serde_json::Value::Null;
+
+    for domain in [loaded_false, ready_but_appended] {
+        let tampered = reprotect_domain(&snapshot, &protector, &domain)?;
+        let mut bindings = RebindRegistry::new();
+        bindings.bind_model(model_id, tenant_id, model_identity, model.clone());
+        bindings.bind_memory(memory_id, tenant_id, memory_identity, memory.clone());
+        let error =
+            LocalRuntime::restore(RuntimeConfig::default(), &tampered, &protector, bindings)
+                .err()
+                .context("tampered memory lifecycle state must be rejected")?;
+        assert!(matches!(
+            error,
+            RuntimeError::Snapshot(SnapshotError::InvalidRelationship(_))
+        ));
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn canonical_snapshot_validation_rejects_invalid_structured_values() -> Result<()> {
+    let tenant_id = TenantId::new();
+    let identity = BindingIdentity::new("snapshot-structured-value-model", "v1");
+    let model = MockCompletionModel::text(r#"{"answer":"valid"}"#);
+    let mut runtime = runtime()?;
+    let model_id = runtime.register_persistable_model(tenant_id, identity, model.clone());
+    let agent = runtime.spawn_agent_spec(
+        AgentSpec::new(model_id, tenant_id).structured_output::<StructuredAnswer>(
+            StructuredOutputPolicy {
+                mode: OutputMode::Native,
+                max_retries: 0,
+                best_effort: false,
+            },
+        ),
+    )?;
+    let _ = runtime.run(agent, "persist structured value").await?;
+    let protector = XorProtector(0x66);
+    let snapshot = runtime
+        .protected_snapshot_with_policy(&protector, SnapshotContentPolicy::CanonicalRunState)?;
+    let base: serde_json::Value = serde_json::from_slice(&protector.unprotect(&snapshot.payload)?)?;
+
+    let mut schema_invalid = base.clone();
+    schema_invalid["runs"][0]["structured"]["value"] = serde_json::json!({"answer": 7});
+
+    let mut value_before_terminal = base;
+    value_before_terminal["runs"][0]["phase"] = serde_json::to_value(RunPhase::ReadyModel)?;
+    value_before_terminal["runs"][0]["terminal"] = serde_json::Value::Null;
+    value_before_terminal["runs"][0]["observation"] = serde_json::Value::Null;
+
+    for domain in [schema_invalid, value_before_terminal] {
+        let tampered = reprotect_domain(&snapshot, &protector, &domain)?;
+        let mut bindings = RebindRegistry::new();
+        bindings.bind_model(model_id, tenant_id, identity, model.clone());
+        let error =
+            LocalRuntime::restore(RuntimeConfig::default(), &tampered, &protector, bindings)
+                .err()
+                .context("tampered structured-output value must be rejected")?;
+        assert!(matches!(
+            error,
+            RuntimeError::Snapshot(SnapshotError::InvalidRelationship(_))
+        ));
+    }
+    Ok(())
+}
+
+#[test]
+fn snapshot_validation_rejects_duplicate_active_tool_names() -> Result<()> {
+    let tenant_id = TenantId::new();
+    let model_identity = BindingIdentity::new("duplicate-name-model", "v1");
+    let tool_identity = BindingIdentity::new("duplicate-name-tool", "v1");
+    let model = MockCompletionModel::text("unused");
+    let tool = CountingPortableTool::default();
+    let mut runtime = runtime()?;
+    let model_id = runtime.register_persistable_model(tenant_id, model_identity, model.clone());
+    let agent = runtime.spawn_agent_spec(AgentSpec::new(model_id, tenant_id))?;
+    let grant = runtime.install_persistable_tool(agent, tool_identity, tool.clone())?;
+    let protector = XorProtector(0x62);
+    let snapshot = runtime.protected_snapshot(&protector)?;
+    let mut domain: serde_json::Value =
+        serde_json::from_slice(&protector.unprotect(&snapshot.payload)?)?;
+    let grants = domain
+        .get_mut("grants")
+        .and_then(serde_json::Value::as_array_mut)
+        .context("snapshot grants")?;
+    let mut duplicate = grants.first().cloned().context("installed grant")?;
+    duplicate["id"] = serde_json::to_value(rig_ecs::GrantId::new())?;
+    grants.push(duplicate);
+    let tampered = reprotect_domain(&snapshot, &protector, &domain)?;
+    let mut bindings = RebindRegistry::new();
+    bindings.bind_model(model_id, tenant_id, model_identity, model);
+    bindings.bind_tool(grant.capability_id, tool_identity, tool);
+
+    let error = LocalRuntime::restore(RuntimeConfig::default(), &tampered, &protector, bindings)
+        .err()
+        .context("ambiguous active tool names must be rejected during restore")?;
+    assert!(matches!(
+        error,
+        RuntimeError::Snapshot(SnapshotError::InvalidRelationship(_))
+    ));
+    Ok(())
+}
+
+#[test]
+fn unchanged_domain_snapshot_bytes_are_deterministic() -> Result<()> {
+    let tenant_id = TenantId::new();
+    let model_identity = BindingIdentity::new("deterministic-model", "v1");
+    let tool_identity = BindingIdentity::new("deterministic-tool", "v1");
+    let mut runtime = runtime()?;
+    let model_id = runtime.register_persistable_model(
+        tenant_id,
+        model_identity,
+        MockCompletionModel::text("unused"),
+    );
+    let agent = runtime.spawn_agent_spec(AgentSpec::new(model_id, tenant_id))?;
+    runtime.install_persistable_tool(agent, tool_identity, CountingPortableTool::default())?;
+    let protector = XorProtector(0x63);
+
+    let first = runtime.protected_snapshot(&protector)?;
+    let second = runtime.protected_snapshot(&protector)?;
+
+    assert_eq!(
+        protector.unprotect(&first.payload)?,
+        protector.unprotect(&second.payload)?
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn snapshot_policies_control_content_and_restore_requires_exact_rebinding() -> Result<()> {
+    let model = MockCompletionModel::text("secret-answer");
+    let mut runtime = runtime()?;
+    let tenant_id = TenantId::new();
+    let binding_identity = BindingIdentity::new("test-mock-model", "v1/config-a");
+    let model_id = runtime.register_persistable_model(tenant_id, binding_identity, model.clone());
+    let _unused_model = runtime.register_model(
+        tenant_id,
+        DifferentMock(MockCompletionModel::text("unused")),
+    );
+    let agent = runtime.spawn_agent_spec(
+        AgentSpec::new(model_id, tenant_id)
+            .temperature(0.42)
+            .max_tokens(777),
+    )?;
+    let handle = runtime.start_run(agent, "secret-prompt")?;
+    let result = runtime.drive_to_terminal(handle).await?;
+    let protector = XorProtector(0xA5);
+
+    let metadata_snapshot = runtime.protected_snapshot(&protector)?;
+    let metadata_plaintext = protector.unprotect(&metadata_snapshot.payload)?;
+    let metadata_text = String::from_utf8(metadata_plaintext)?;
+    assert!(!metadata_text.contains("secret-prompt"));
+    assert!(!metadata_text.contains("secret-answer"));
+
+    let snapshot = runtime
+        .protected_snapshot_with_policy(&protector, SnapshotContentPolicy::CanonicalRunState)?;
+    let canonical_plaintext = protector.unprotect(&snapshot.payload)?;
+    // The canonical policy persists run content; the protector must still
+    // obscure it in the stored payload bytes.
+    assert_ne!(snapshot.payload, canonical_plaintext);
+    let canonical_text = String::from_utf8(canonical_plaintext)?;
+    assert!(canonical_text.contains("secret-prompt"));
+    assert!(canonical_text.contains("secret-answer"));
+
+    let missing = LocalRuntime::restore(
+        RuntimeConfig::default(),
+        &snapshot,
+        &protector,
+        RebindRegistry::new(),
+    )
+    .err()
+    .context("exact model binding must be mandatory")?;
+    assert!(matches!(
+        missing,
+        RuntimeError::Snapshot(SnapshotError::MissingModel(_))
+    ));
+
+    let mut mismatched_bindings = RebindRegistry::new();
+    mismatched_bindings.bind_model(
+        model_id,
+        tenant_id,
+        BindingIdentity::new("test-mock-model", "v2/incompatible"),
+        DifferentMock(MockCompletionModel::text("wrong implementation")),
+    );
+    let mismatch = LocalRuntime::restore(
+        RuntimeConfig::default(),
+        &snapshot,
+        &protector,
+        mismatched_bindings,
+    )
+    .err()
+    .context("concrete model mismatch must be rejected")?;
+    assert!(matches!(
+        mismatch,
+        RuntimeError::Snapshot(SnapshotError::BindingMismatch { kind: "model", .. })
+    ));
+
+    let mut corrupted = snapshot.clone();
+    if let Some(byte) = corrupted.payload.first_mut() {
+        *byte ^= 0x01;
+    }
+    let corruption = LocalRuntime::restore(
+        RuntimeConfig::default(),
+        &corrupted,
+        &protector,
+        RebindRegistry::new(),
+    )
+    .err()
+    .context("corrupted protected payload must be rejected")?;
+    assert!(matches!(
+        corruption,
+        RuntimeError::Snapshot(SnapshotError::Integrity)
+    ));
+
+    let plaintext = protector.unprotect(&snapshot.payload)?;
+    let mut domain: serde_json::Value = serde_json::from_slice(&plaintext)?;
+    assert!(
+        domain
+            .get("agents")
+            .and_then(serde_json::Value::as_array)
+            .and_then(|agents| agents.first())
+            .and_then(|agent| agent.get("spec"))
+            .and_then(|spec| spec.get("additional_params"))
+            .is_some_and(serde_json::Value::is_null)
+    );
+    let persisted_spec = domain
+        .get("agents")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|agents| agents.first())
+        .and_then(|agent| agent.get("spec"))
+        .context("persisted agent spec")?;
+    assert_eq!(
+        persisted_spec.get("temperature"),
+        Some(&serde_json::json!(0.42))
+    );
+    assert_eq!(
+        persisted_spec.get("max_tokens"),
+        Some(&serde_json::json!(777))
+    );
+    let first_run = domain
+        .get_mut("runs")
+        .and_then(serde_json::Value::as_array_mut)
+        .and_then(|runs| runs.first_mut())
+        .and_then(serde_json::Value::as_object_mut)
+        .context("snapshot should contain one run record")?;
+    first_run.insert(
+        "tenant_id".to_string(),
+        serde_json::to_value(TenantId::new())?,
+    );
+    let tampered_payload = protector.protect(&serde_json::to_vec(&domain)?)?;
+    let tampered = ProtectedSnapshot {
+        version: snapshot.version,
+        protector_id: snapshot.protector_id.clone(),
+        protected_digest: Sha256::digest(&tampered_payload).into(),
+        payload: tampered_payload,
+    };
+    let mut tampered_bindings = RebindRegistry::new();
+    tampered_bindings.bind_model(model_id, tenant_id, binding_identity, model.clone());
+    let relationship_error = LocalRuntime::restore(
+        RuntimeConfig::default(),
+        &tampered,
+        &protector,
+        tampered_bindings,
+    )
+    .err()
+    .context("cross-tenant restored topology must be rejected")?;
+    assert!(matches!(
+        relationship_error,
+        RuntimeError::Snapshot(SnapshotError::InvalidRelationship(_))
+    ));
+
+    let mut bindings = RebindRegistry::new();
+    bindings.bind_model(model_id, tenant_id, binding_identity, model);
+    let mut restored =
+        LocalRuntime::restore(RuntimeConfig::default(), &snapshot, &protector, bindings)?;
+    assert_ne!(restored.id(), runtime.id());
+    let restored_handle = restored.run_handle(result.run_id, tenant_id)?;
+    let restored_result = restored.finish_run(restored_handle)?;
+    assert_eq!(restored_result.text.as_deref(), Some("secret-answer"));
+    let redacted = restored.explain(restored_handle, ContentVisibility::Redacted)?;
+    assert!(redacted.canonical_transcript.is_none());
+    Ok(())
+}
+
+#[test]
+fn snapshots_reject_behavior_bearing_config_the_policy_cannot_preserve() -> Result<()> {
+    let tenant_id = TenantId::new();
+    let model_identity = BindingIdentity::new("test-mock-model", "snapshot-config");
+
+    let mut preamble_runtime = runtime()?;
+    let model_id = preamble_runtime.register_persistable_model(
+        tenant_id,
+        model_identity,
+        MockCompletionModel::text("unused"),
+    );
+    let preamble_agent = preamble_runtime
+        .spawn_agent_spec(AgentSpec::new(model_id, tenant_id).preamble("required safety policy"))?;
+    let preamble_error = preamble_runtime
+        .protected_snapshot(&XorProtector(0x31))
+        .err()
+        .context("metadata-only snapshot must not drop a preamble")?;
+    assert!(matches!(
+        preamble_error,
+        SnapshotError::MetadataOnlyPreamble(id) if id == preamble_agent
+    ));
+
+    let mut params_runtime = runtime()?;
+    let model_id = params_runtime.register_persistable_model(
+        tenant_id,
+        model_identity,
+        MockCompletionModel::text("unused"),
+    );
+    let params_agent = params_runtime.spawn_agent_spec(
+        AgentSpec::new(model_id, tenant_id)
+            .additional_params(serde_json::json!({"api_key":"must-never-persist"})),
+    )?;
+    for policy in [
+        SnapshotContentPolicy::MetadataOnly,
+        SnapshotContentPolicy::CanonicalRunState,
+    ] {
+        let error = params_runtime
+            .protected_snapshot_with_policy(&XorProtector(0x32), policy)
+            .err()
+            .context("provider parameters must make snapshotting explicit")?;
+        assert!(matches!(
+            error,
+            SnapshotError::NonPersistableProviderParameters(id) if id == params_agent
+        ));
+    }
+    Ok(())
+}
+
+#[test]
+fn metadata_snapshot_rejects_memory_topology_instead_of_degrading_it() -> Result<()> {
+    let tenant_id = TenantId::new();
+    let model_identity = BindingIdentity::new("test-mock-model", "memory-snapshot");
+    let memory_identity = BindingIdentity::new("test-memory", "memory-snapshot");
+    let mut runtime = runtime()?;
+    let model_id = runtime.register_persistable_model(
+        tenant_id,
+        model_identity,
+        MockCompletionModel::text("unused"),
+    );
+    let memory_id =
+        runtime.register_persistable_memory(tenant_id, memory_identity, CountingMemory::default());
+    let agent = runtime.spawn_agent_spec(
+        AgentSpec::new(model_id, tenant_id).memory(memory_id, "private-conversation"),
+    )?;
+
+    let error = runtime
+        .protected_snapshot(&XorProtector(0x33))
+        .err()
+        .context("metadata-only snapshot must not drop memory behavior")?;
+
+    assert!(matches!(
+        error,
+        SnapshotError::MetadataOnlyMemory(id) if id == agent
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn persistable_store_replacement_cleanup_roundtrips() -> Result<()> {
+    let tenant_id = TenantId::new();
+    let model_identity = BindingIdentity::new("test-mock-model", "store-snapshot");
+    let old_identity = BindingIdentity::new("fixture-store", "v1");
+    let new_identity = BindingIdentity::new("fixture-store", "v2");
+    let model = MockCompletionModel::text("done");
+    let mut runtime = runtime()?;
+    let model_id = runtime.register_persistable_model(tenant_id, model_identity, model.clone());
+    let agent = runtime.spawn_agent_spec(AgentSpec::new(model_id, tenant_id))?;
+    let old = runtime.install_persistable_vector_store(
+        agent,
+        old_identity,
+        FixtureVectorStore::default(),
+    )?;
+
+    let kind_error = runtime
+        .replace_tool(old.grant_id, CountingPortableTool::default())
+        .err()
+        .context("a generic tool replacement must not preserve a false store kind")?;
+    assert!(matches!(
+        kind_error,
+        RuntimeError::CapabilityKindMismatch {
+            capability_id,
+            expected: CapabilityKind::Tool,
+            actual: CapabilityKind::Store,
+        } if capability_id == old.capability_id
+    ));
+
+    let identity_error = runtime
+        .replace_vector_store(old.grant_id, FixtureVectorStore::default())
+        .err()
+        .context("persistable replacement must require a new identity")?;
+    assert!(matches!(
+        identity_error,
+        RuntimeError::PersistenceIdentityRequired(id) if id == old.capability_id
+    ));
+
+    let replacement_store = FixtureVectorStore::default();
+    let replacement = runtime.replace_persistable_vector_store(
+        old.grant_id,
+        new_identity,
+        replacement_store.clone(),
+    )?;
+    let _ = runtime.run(agent, "cleanup retired store").await?;
+    assert!(matches!(
+        runtime.capability_kind(old.capability_id),
+        Err(RuntimeError::UnknownCapability(id)) if id == old.capability_id
+    ));
+    assert!(matches!(
+        runtime.tool_grant(old.grant_id),
+        Err(RuntimeError::UnknownGrant(id)) if id == old.grant_id
+    ));
+
+    let protector = XorProtector(0x34);
+    let snapshot = runtime.protected_snapshot(&protector)?;
+    let mut wrong_kind_bindings = RebindRegistry::new();
+    wrong_kind_bindings.bind_model(model_id, tenant_id, model_identity, model.clone());
+    wrong_kind_bindings.bind_tool(
+        replacement.capability_id,
+        new_identity,
+        replacement_store.clone(),
+    );
+    let wrong_kind = LocalRuntime::restore(
+        RuntimeConfig::default(),
+        &snapshot,
+        &protector,
+        wrong_kind_bindings,
+    )
+    .err()
+    .context("a store snapshot must reject a generic-tool rebinding")?;
+    assert!(matches!(
+        wrong_kind,
+        RuntimeError::Snapshot(SnapshotError::BindingMismatch {
+            kind: "capability",
+            ..
+        })
+    ));
+
+    let mut bindings = RebindRegistry::new();
+    bindings.bind_model(model_id, tenant_id, model_identity, model);
+    bindings.bind_vector_store(replacement.capability_id, new_identity, replacement_store);
+    let restored =
+        LocalRuntime::restore(RuntimeConfig::default(), &snapshot, &protector, bindings)?;
+    assert_eq!(
+        restored.capability_kind(replacement.capability_id)?,
+        CapabilityKind::Store
+    );
+    Ok(())
+}
+
+#[test]
+fn persistable_dynamic_tool_roundtrips() -> Result<()> {
+    let tenant_id = TenantId::new();
+    let model_identity = BindingIdentity::new("test-mock-model", "dynamic-snapshot");
+    let tool_identity = BindingIdentity::new("dynamic-echo", "v1");
+    let dynamic = PortableDynamicTool::new(
+        "dynamic_echo",
+        "echo dynamic input",
+        serde_json::json!({"type":"object"}),
+        |_arguments| Box::pin(async { Ok(ToolOutput::text("dynamic")) }),
+    );
+    let model = MockCompletionModel::text("unused");
+    let mut runtime = runtime()?;
+    let model_id = runtime.register_persistable_model(tenant_id, model_identity, model.clone());
+    let agent = runtime.spawn_agent_spec(AgentSpec::new(model_id, tenant_id))?;
+    let grant = runtime.install_persistable_dynamic_tool(agent, tool_identity, dynamic.clone())?;
+    let protector = XorProtector(0x36);
+    let snapshot = runtime.protected_snapshot(&protector)?;
+    let mut bindings = RebindRegistry::new();
+    bindings.bind_model(model_id, tenant_id, model_identity, model);
+    bindings.bind_dynamic_tool(grant.capability_id, tool_identity, dynamic);
+
+    let restored =
+        LocalRuntime::restore(RuntimeConfig::default(), &snapshot, &protector, bindings)?;
+
+    assert_eq!(
+        restored.capability_kind(grant.capability_id)?,
+        CapabilityKind::Tool
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn restored_runtime_tick_preserves_terminal_retention_age() -> Result<()> {
+    let config = RuntimeConfig {
+        terminal_retention_ticks: 2,
+        effect_timeout: Duration::from_secs(1),
+        ..RuntimeConfig::default()
+    };
+    let tenant_id = TenantId::new();
+    let model_identity = BindingIdentity::new("test-mock-model", "tick-snapshot");
+    let model = MockCompletionModel::text("done");
+    let mut runtime = LocalRuntime::with_config(config.clone())?;
+    let model_id = runtime.register_persistable_model(tenant_id, model_identity, model.clone());
+    let agent = runtime.spawn_agent_spec(AgentSpec::new(model_id, tenant_id))?;
+    let handle = runtime.start_run(agent, "tick")?;
+
+    loop {
+        match runtime.step(handle).await? {
+            RunStepStatus::Terminal => break,
+            RunStepStatus::Progressed | RunStepStatus::EffectProgressed => {}
+            RunStepStatus::Quiescent => runtime.wait_for_effect().await?,
+        }
+    }
+    // Every Terminal return renews the observed lease, so active polling far
+    // beyond the retention window never loses the run.
+    for _ in 0..12 {
+        assert!(matches!(
+            runtime.step(handle).await?,
+            RunStepStatus::Terminal
+        ));
+    }
+    let result = runtime.finish_run(handle)?;
+    let protector = XorProtector(0x35);
+    let snapshot = runtime
+        .protected_snapshot_with_policy(&protector, SnapshotContentPolicy::CanonicalRunState)?;
+    let mut bindings = RebindRegistry::new();
+    bindings.bind_model(model_id, tenant_id, model_identity, model);
+    let mut restored = LocalRuntime::restore(config, &snapshot, &protector, bindings)?;
+    let restored_handle = restored.run_handle(result.run_id, tenant_id)?;
+    assert!(matches!(
+        restored.step(restored_handle).await?,
+        RunStepStatus::Terminal
+    ));
+
+    // Once its own handle stops being stepped, the observed run ages from its
+    // preserved last observation while another handle pumps the schedule.
+    let pump = restored.start_run(agent, "pump")?;
+    let _ = restored.drive_to_terminal(pump).await?;
+    for _ in 0..4 {
+        let _ = restored.step(pump).await;
+    }
+    assert!(matches!(
+        restored.run_handle(result.run_id, tenant_id),
+        Err(RuntimeError::UnknownRun(id)) if id == result.run_id
+    ));
+    Ok(())
+}
+
+#[test]
+fn snapshots_reject_ephemeral_binding_claims() -> Result<()> {
+    let mut runtime = runtime()?;
+    let _agent = runtime.spawn_agent(
+        MockCompletionModel::text("unused")
+            .into_ecs_agent_builder()
+            .build(),
+    )?;
+
+    let error = runtime
+        .protected_snapshot(&XorProtector(0x5A))
+        .err()
+        .context("ephemeral binding must not claim restart compatibility")?;
+
+    assert!(matches!(
+        error,
+        SnapshotError::MissingBindingIdentity { kind: "model", .. }
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn debug_surfaces_are_redacted_while_typed_provider_details_remain_inspectable() -> Result<()>
+{
+    let secret_prompt = "prompt-secret-4b6579";
+    let secret_output = "output-secret-536563";
+    let secret_provider_body = r#"{"error":"provider-secret-50726f"}"#;
+    let tenant_id = TenantId::new();
+    let spec = AgentSpec::new(rig_ecs::ModelId::new(), tenant_id)
+        .preamble(secret_prompt)
+        .additional_params(serde_json::json!({"api_key": secret_provider_body}));
+    let rendered_spec = format!("{spec:?}");
+    assert!(!rendered_spec.contains(secret_prompt));
+    assert!(!rendered_spec.contains(secret_provider_body));
+    assert!(!rendered_spec.contains(&tenant_id.to_string()));
+
+    let correlation_id = CorrelationId::new();
+    let header = EffectHeader {
+        runtime_id: rig_ecs::RuntimeId::new(),
+        run_id: RunId::new(),
+        operation_id: OperationId::new(),
+        generation: Generation::default(),
+        correlation_id,
+        tenant_id,
+        capability_id: None,
+        grant_id: None,
+        capability_revision: None,
+    };
+    let rendered_header = format!("{header:?}");
+    assert!(!rendered_header.contains(&tenant_id.to_string()));
+    assert!(!rendered_header.contains(&correlation_id.to_string()));
+
+    let capability_id = rig_ecs::CapabilityId::new();
+    let grant_id = rig_ecs::GrantId::new();
+    let agent_id = rig_ecs::AgentId::new();
+    let run_id = RunId::new();
+    let nodes = [
+        format!(
+            "{:?}",
+            CapabilityNode {
+                id: capability_id,
+                tenant_id,
+                kind: CapabilityKind::Tool,
+                definition: None,
+                revision: 1,
+                retired: false,
+            }
+        ),
+        format!(
+            "{:?}",
+            GrantNode {
+                id: grant_id,
+                agent_id,
+                capability_id,
+                tenant_id,
+                revoked: false,
+            }
+        ),
+        format!(
+            "{:?}",
+            RunHandle {
+                runtime_id: rig_ecs::RuntimeId::new(),
+                run_id,
+                generation: Generation::default(),
+                tenant_id,
+            }
+        ),
+    ];
+    assert!(
+        nodes
+            .iter()
+            .all(|debug| !debug.contains(&tenant_id.to_string()))
+    );
+    let tenant_error = RuntimeError::TenantMismatch {
+        expected: tenant_id,
+        actual: TenantId::new(),
+    };
+    assert!(!format!("{tenant_error}").contains(&tenant_id.to_string()));
+    assert!(!format!("{tenant_error:?}").contains(&tenant_id.to_string()));
+
+    let provider =
+        ModelEffectError::Provider(CompletionError::from_provider_body(secret_provider_body));
+    assert_eq!(
+        provider.provider_response_body(),
+        Some(secret_provider_body)
+    );
+    assert!(!format!("{provider}").contains(secret_provider_body));
+    assert!(!format!("{provider:?}").contains(secret_provider_body));
+    let runtime_error = RuntimeError::ModelEffect(Arc::new(provider));
+    assert_eq!(
+        runtime_error.provider_response_json()?,
+        Some(serde_json::json!({"error":"provider-secret-50726f"}))
+    );
+    assert!(!format!("{runtime_error:?}").contains(secret_provider_body));
+
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(
+        MockCompletionModel::text(secret_output)
+            .into_ecs_agent_builder()
+            .preamble(secret_prompt)
+            .build(),
+    )?;
+    let result = runtime.run(agent, secret_prompt).await?;
+    let rendered_result = format!("{result:?}");
+    assert!(!rendered_result.contains(secret_prompt));
+    assert!(!rendered_result.contains(secret_output));
+    Ok(())
+}
+
+#[tokio::test]
+async fn hosted_driver_allows_cancellation_between_schedule_passes() -> Result<()> {
+    let model = MockCompletionModel::text("must not commit");
+    let mut local = runtime()?;
+    let agent = local.spawn_agent(model.into_ecs_agent_builder().build())?;
+    let hosted = HostedRuntime::new(local);
+    let handle = hosted.start_run(agent, "cancel hosted").await?;
+
+    let _ = hosted.step(handle).await?;
+    hosted.cancel(handle).await?;
+    let result = hosted.drive_to_terminal(handle).await?;
+
+    assert!(matches!(result.terminal_reason, TerminalReason::Cancelled));
+    assert_eq!(result.transcript, [Message::user("cancel hosted")]);
+    assert!(result.raw_final::<MockResponse>().is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn hosted_provider_diagnostic_is_typed_only_by_name_and_contains_no_content() -> Result<()> {
+    let model = MockCompletionModel::text("sensitive provider content");
+    let mut local = runtime()?;
+    let agent = local.spawn_agent(model.into_ecs_agent_builder().build())?;
+    let hosted = HostedRuntime::new(local);
+    let handle = hosted.start_run(agent, "sensitive prompt").await?;
+    let result = hosted.drive_to_terminal(handle).await?;
+    let diagnostic = hosted
+        .provider_diagnostic(handle)
+        .await?
+        .context("hosted provider diagnostic")?;
+
+    assert!(diagnostic.provider_type.contains("MockResponse"));
+    let rendered = format!("{diagnostic:?}");
+    assert!(!rendered.contains("sensitive provider content"));
+    assert!(!rendered.contains("sensitive prompt"));
+    assert_eq!(result.text.as_deref(), Some("sensitive provider content"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn tool_mode_best_effort_commits_without_orphan_tool_calls() -> Result<()> {
+    let output_name = synthetic_output_tool_name::<StructuredAnswer>(&[]);
+    let model = MockCompletionModel::new([
+        MockTurn::tool_call(
+            "first",
+            output_name.clone(),
+            serde_json::json!({"wrong": 1}),
+        ),
+        MockTurn::from_contents([
+            AssistantContent::text("nearly"),
+            AssistantContent::ToolCall(ToolCall::new(
+                "peer".to_string(),
+                ToolFunction::new("unrelated_tool".to_string(), serde_json::json!({})),
+            )),
+            AssistantContent::ToolCall(ToolCall::new(
+                "second".to_string(),
+                ToolFunction::new(output_name.clone(), serde_json::json!({"still": 2})),
+            )),
+        ])?,
+    ]);
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(
+        model
+            .clone()
+            .into_ecs_agent_builder()
+            .tool_choice(ToolChoice::Specific {
+                function_names: vec![output_name.clone()],
+            })
+            .structured_output::<StructuredAnswer>(StructuredOutputPolicy {
+                mode: OutputMode::Tool,
+                max_retries: 1,
+                best_effort: true,
+            })
+            .build(),
+    )?;
+
+    let result = runtime.run(agent, "best effort").await?;
+
+    assert_eq!(model.request_count(), 2);
+    assert!(matches!(result.terminal_reason, TerminalReason::Completed));
+    assert!(result.structured_output.is_none());
+    assert_no_orphan_tool_use(&result.transcript);
+    let last_assistant = result
+        .transcript
+        .iter()
+        .rev()
+        .find_map(|message| match message {
+            Message::Assistant { content, .. } => Some(content),
+            _ => None,
+        })
+        .context("best-effort assistant turn")?;
+    assert!(
+        last_assistant
+            .iter()
+            .all(|item| !matches!(item, AssistantContent::ToolCall(_)))
+    );
+    assert_eq!(result.text.as_deref(), Some(r#"nearly{"still":2}"#));
+    Ok(())
+}
+
+#[tokio::test]
+async fn tool_mode_best_effort_snapshot_restores_and_rebinds_handles() -> Result<()> {
+    let output_name = synthetic_output_tool_name::<StructuredAnswer>(&[]);
+    let model = MockCompletionModel::new([MockTurn::tool_call(
+        "only",
+        output_name.clone(),
+        serde_json::json!({"invalid": true}),
+    )]);
+    let tenant_id = TenantId::new();
+    let binding_identity = BindingIdentity::new("test-mock-model", "best-effort/v1");
+    let mut runtime = runtime()?;
+    let model_id = runtime.register_persistable_model(tenant_id, binding_identity, model.clone());
+    let agent = runtime.spawn_agent_spec(
+        AgentSpec::new(model_id, tenant_id)
+            .tool_choice(ToolChoice::Specific {
+                function_names: vec![output_name.clone()],
+            })
+            .structured_output::<StructuredAnswer>(StructuredOutputPolicy {
+                mode: OutputMode::Tool,
+                max_retries: 0,
+                best_effort: true,
+            }),
+    )?;
+    let result = runtime.run(agent, "persist best effort").await?;
+    assert!(matches!(result.terminal_reason, TerminalReason::Completed));
+
+    let protector = XorProtector(0x5A);
+    let snapshot = runtime
+        .protected_snapshot_with_policy(&protector, SnapshotContentPolicy::CanonicalRunState)?;
+    let mut bindings = RebindRegistry::new();
+    bindings.bind_model(
+        model_id,
+        tenant_id,
+        BindingIdentity::new("test-mock-model", "best-effort/v1"),
+        model,
+    );
+    let mut restored =
+        LocalRuntime::restore(RuntimeConfig::default(), &snapshot, &protector, bindings)?;
+
+    let wrong_tenant = restored
+        .run_handle(result.run_id, TenantId::new())
+        .err()
+        .context("foreign tenant must not receive a restored handle")?;
+    assert!(matches!(wrong_tenant, RuntimeError::TenantMismatch { .. }));
+    let unknown = restored
+        .run_handle(RunId::new(), tenant_id)
+        .err()
+        .context("unknown runs must not receive a handle")?;
+    assert!(matches!(unknown, RuntimeError::UnknownRun(_)));
+
+    let restored_handle = restored.run_handle(result.run_id, tenant_id)?;
+    let restored_result = restored.finish_run(restored_handle)?;
+    assert_no_orphan_tool_use(&restored_result.transcript);
+    assert_eq!(restored_result.transcript.len(), result.transcript.len());
+    assert_eq!(restored_result.text, result.text);
+    Ok(())
+}
+
+#[tokio::test]
+async fn memory_after_tool_mode_best_effort_yields_a_valid_next_run() -> Result<()> {
+    let output_name = synthetic_output_tool_name::<StructuredAnswer>(&[]);
+    let model = MockCompletionModel::new([
+        MockTurn::tool_call(
+            "first",
+            output_name.clone(),
+            serde_json::json!({"wrong": 1}),
+        ),
+        MockTurn::text(r#"{"answer":"valid"}"#),
+    ]);
+    let memory = CountingMemory::default();
+    let mut runtime = runtime()?;
+    let tenant_id = TenantId::new();
+    let memory_id = runtime.register_memory(tenant_id, memory.clone());
+    let agent = runtime.spawn_agent(
+        model
+            .clone()
+            .into_ecs_agent_builder()
+            .tenant(tenant_id)
+            .memory(memory_id, "best-effort")
+            .tool_choice(ToolChoice::Specific {
+                function_names: vec![output_name.clone()],
+            })
+            .structured_output::<StructuredAnswer>(StructuredOutputPolicy {
+                mode: OutputMode::Tool,
+                max_retries: 0,
+                best_effort: true,
+            })
+            .build(),
+    )?;
+
+    let first = runtime.run(agent, "first question").await?;
+    assert!(matches!(first.terminal_reason, TerminalReason::Completed));
+    let second = runtime.run(agent, "second question").await?;
+    assert!(matches!(second.terminal_reason, TerminalReason::Completed));
+
+    let second_request = model.requests().pop().context("second model request")?;
+    assert!(second_request.chat_history.len() > 1);
+    assert!(second_request.chat_history.iter().all(|message| {
+        match message {
+            Message::Assistant { content, .. } => content
+                .iter()
+                .all(|item| !matches!(item, AssistantContent::ToolCall(_))),
+            _ => true,
+        }
+    }));
+    Ok(())
+}
+
+#[tokio::test]
+async fn duplicate_tool_call_identities_fail_before_any_tool_executes() -> Result<()> {
+    let model = MockCompletionModel::new([MockTurn::from_contents([
+        AssistantContent::ToolCall(ToolCall::new(
+            "dup".to_string(),
+            ToolFunction::new(
+                "counting_portable_tool".to_string(),
+                serde_json::json!({"value": "a"}),
+            ),
+        )),
+        AssistantContent::ToolCall(ToolCall::new(
+            "dup".to_string(),
+            ToolFunction::new(
+                "counting_portable_tool".to_string(),
+                serde_json::json!({"value": "b"}),
+            ),
+        )),
+    ])?]);
+    let tool = CountingPortableTool::default();
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(model.into_ecs_agent_builder().build())?;
+    runtime.install_tool(agent, tool.clone())?;
+
+    let error = runtime
+        .run(agent, "dup")
+        .await
+        .err()
+        .context("duplicate tool call identities must fail the run")?;
+
+    assert!(matches!(
+        error,
+        RuntimeError::RunFailed { ref code, .. } if code == "duplicate_tool_call"
+    ));
+    assert!(tool.calls().is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn recovery_feedback_clears_after_an_accepted_response() -> Result<()> {
+    let model = MockCompletionModel::new([
+        MockTurn::text(""),
+        MockTurn::tool_call(
+            "call-1",
+            "counting_portable_tool",
+            serde_json::json!({"value": "recovered"}),
+        ),
+        MockTurn::text("final answer"),
+    ]);
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(
+        model
+            .clone()
+            .into_ecs_agent_builder()
+            .response_retry_policy(ResponseRetryPolicy::RejectEmpty { max_retries: 1 })
+            .build(),
+    )?;
+    runtime.install_tool(agent, CountingPortableTool::default())?;
+
+    let result = runtime.run(agent, "question").await?;
+
+    assert_eq!(result.text.as_deref(), Some("final answer"));
+    let requests = model.requests();
+    assert_eq!(requests.len(), 3);
+    let contains_feedback = |request: &CompletionRequest| {
+        request.chat_history.iter().any(|message| match message {
+            Message::User { content } => content.iter().any(|item| {
+                matches!(
+                    item,
+                    UserContent::Text(text) if text.text.contains("previous response was empty")
+                )
+            }),
+            _ => false,
+        })
+    };
+    assert!(contains_feedback(&requests[1]));
+    assert!(!contains_feedback(&requests[2]));
+    Ok(())
+}
+
+#[tokio::test]
+async fn local_deferred_effect_wakes_when_a_semaphore_owner_is_cancelled() -> Result<()> {
+    let mut runtime = LocalRuntime::with_config(RuntimeConfig {
+        max_effects: 1,
+        max_model_calls: 1,
+        effect_timeout: Duration::from_secs(5),
+        ..RuntimeConfig::default()
+    })?;
+    let blocking_agent = runtime.spawn_agent(
+        SlowMock {
+            inner: MockCompletionModel::text("blocking"),
+            delay: Duration::from_secs(30),
+        }
+        .into_ecs_agent_builder()
+        .build(),
+    )?;
+    let target_agent = runtime.spawn_agent(
+        MockCompletionModel::text("target")
+            .into_ecs_agent_builder()
+            .build(),
+    )?;
+    let blocking = runtime.start_run(blocking_agent, "blocking")?;
+    let _ = runtime.step(blocking).await?;
+    let target = runtime.start_run(target_agent, "deferred")?;
+    let _ = runtime.step(target).await?;
+    runtime.cancel(blocking)?;
+
+    let result = tokio::time::timeout(
+        Duration::from_millis(500),
+        runtime.drive_to_terminal(target),
+    )
+    .await
+    .context("deferred local run must wake when execution capacity is released")??;
+
+    assert!(matches!(result.terminal_reason, TerminalReason::Completed));
+    assert_eq!(result.text.as_deref(), Some("target"));
+    let blocker = runtime.finish_run(blocking)?;
+    assert!(matches!(blocker.terminal_reason, TerminalReason::Cancelled));
+    Ok(())
+}
+
+#[tokio::test]
+async fn local_streaming_deferred_effect_wakes_when_a_semaphore_owner_is_cancelled() -> Result<()> {
+    let mut runtime = LocalRuntime::with_config(RuntimeConfig {
+        max_effects: 1,
+        max_model_calls: 1,
+        effect_timeout: Duration::from_secs(5),
+        ..RuntimeConfig::default()
+    })?;
+    let blocking_agent = runtime.spawn_agent(
+        SlowMock {
+            inner: MockCompletionModel::text("blocking"),
+            delay: Duration::from_secs(30),
+        }
+        .into_ecs_agent_builder()
+        .build(),
+    )?;
+    let target_agent = runtime.spawn_agent(
+        MockCompletionModel::from_stream_turns([[
+            MockStreamEvent::text("target"),
+            MockStreamEvent::final_response_with_total_tokens(1),
+        ]])
+        .into_ecs_agent_builder()
+        .streaming(StreamingMode::Streaming)
+        .build(),
+    )?;
+    let blocking = runtime.start_run(blocking_agent, "blocking")?;
+    let _ = runtime.step(blocking).await?;
+    runtime.cancel(blocking)?;
+
+    let mut stream = runtime.start_streaming::<MockResponse>(target_agent, "deferred")?;
+    tokio::time::timeout(Duration::from_millis(500), async {
+        while stream.next_event().await?.is_some() {}
+        Ok::<_, RuntimeError>(())
+    })
+    .await
+    .context("deferred streaming run must wake when execution capacity is released")??;
+    let result = stream.finish()?;
+
+    assert_eq!(result.text.as_deref(), Some("target"));
+    Ok(())
+}
+
+#[tokio::test]
+async fn abandoned_terminal_runs_are_cleaned_after_unobserved_retention() -> Result<()> {
+    let mut runtime = LocalRuntime::with_config(RuntimeConfig {
+        terminal_retention_ticks: 64,
+        unobserved_terminal_retention_ticks: 4,
+        effect_timeout: Duration::from_secs(1),
+        ..RuntimeConfig::default()
+    })?;
+    let abandoned_agent = runtime.spawn_agent(
+        SlowMock {
+            inner: MockCompletionModel::text("abandoned"),
+            delay: Duration::from_secs(30),
+        }
+        .into_ecs_agent_builder()
+        .build(),
+    )?;
+    let pump_agent = runtime.spawn_agent(
+        MockCompletionModel::text("pump")
+            .into_ecs_agent_builder()
+            .build(),
+    )?;
+    // The abandoned run goes terminal through cancellation processed during the
+    // pump run's schedule passes — its own handle is never stepped, so it stays
+    // unobserved and ages on the unobserved clock.
+    let abandoned = runtime.start_run(abandoned_agent, "abandoned")?;
+    runtime.cancel(abandoned)?;
+    let pump = runtime.start_run(pump_agent, "pump")?;
+
+    let mut cleaned = false;
+    for _ in 0..32 {
+        match runtime.step(pump).await {
+            Ok(_) => {}
+            Err(RuntimeError::UnknownRun(_)) => break,
+            Err(error) => return Err(error.into()),
+        }
+        // Existence probe only: `finish_run` would itself observe the run.
+        if matches!(
+            runtime.run_handle(abandoned.run_id, abandoned.tenant_id),
+            Err(RuntimeError::UnknownRun(_))
+        ) {
+            cleaned = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(2)).await;
+    }
+
+    assert!(
+        cleaned,
+        "unobserved terminal run must be cleaned by retention"
+    );
+    Ok(())
+}
+
+#[derive(Clone)]
+struct FixedHistoryMemory(Vec<Message>);
+
+impl ConversationMemory for FixedHistoryMemory {
+    fn load<'a>(
+        &'a self,
+        _conversation_id: &'a str,
+    ) -> WasmBoxedFuture<'a, Result<Vec<Message>, MemoryError>> {
+        let messages = self.0.clone();
+        Box::pin(async move { Ok(messages) })
+    }
+
+    fn append<'a>(
+        &'a self,
+        _conversation_id: &'a str,
+        _messages: Vec<Message>,
+    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn clear<'a>(
+        &'a self,
+        _conversation_id: &'a str,
+    ) -> WasmBoxedFuture<'a, Result<(), MemoryError>> {
+        Box::pin(async move { Ok(()) })
+    }
+}
+
+#[tokio::test]
+async fn non_canonical_memory_history_fails_before_any_model_call() -> Result<()> {
+    let bad_histories = [
+        // A sliding-window cut that orphaned a tool result.
+        vec![
+            Message::user("window start"),
+            Message::tool_result("orphan", "2"),
+        ],
+        // A summarizer that emitted consecutive assistant messages.
+        vec![
+            Message::user("question"),
+            Message::assistant("summary part one"),
+            Message::assistant("summary part two"),
+        ],
+    ];
+    for history in bad_histories {
+        let model = MockCompletionModel::text("never called");
+        let memory = FixedHistoryMemory(history);
+        let mut runtime = runtime()?;
+        let tenant_id = TenantId::new();
+        let memory_id = runtime.register_memory(tenant_id, memory);
+        let agent = runtime.spawn_agent(
+            model
+                .clone()
+                .into_ecs_agent_builder()
+                .tenant(tenant_id)
+                .memory(memory_id, "windowed")
+                .build(),
+        )?;
+
+        let error = runtime
+            .run(agent, "prompt")
+            .await
+            .err()
+            .context("non-canonical loaded history must fail the run")?;
+
+        assert!(matches!(
+            error,
+            RuntimeError::RunFailed { ref code, .. } if code == "memory_history"
+        ));
+        assert_eq!(model.request_count(), 0);
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn assistant_role_prompts_are_rejected_at_start() -> Result<()> {
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(
+        MockCompletionModel::text("unused")
+            .into_ecs_agent_builder()
+            .build(),
+    )?;
+
+    let error = runtime
+        .start_run(agent, Message::assistant("prefill"))
+        .err()
+        .context("assistant prompts must be rejected before run creation")?;
+
+    assert!(matches!(error, RuntimeError::InvalidPrompt { .. }));
+    Ok(())
+}
+
+#[tokio::test]
+async fn memory_history_failure_still_snapshots_and_restores() -> Result<()> {
+    let model = MockCompletionModel::text("never called");
+    let memory = FixedHistoryMemory(vec![Message::tool_result("orphan", "2")]);
+    let tenant_id = TenantId::new();
+    let model_identity = BindingIdentity::new("test-mock-model", "memory-history/v1");
+    let memory_identity = BindingIdentity::new("fixed-history-memory", "memory-history/v1");
+    let mut runtime = runtime()?;
+    let model_id = runtime.register_persistable_model(tenant_id, model_identity, model.clone());
+    let memory_id = runtime.register_persistable_memory(tenant_id, memory_identity, memory.clone());
+    let agent = runtime
+        .spawn_agent_spec(AgentSpec::new(model_id, tenant_id).memory(memory_id, "windowed"))?;
+    let handle = runtime.start_run(agent, "prompt")?;
+    let result = runtime.drive_to_terminal(handle).await?;
+    assert!(matches!(
+        result.terminal_reason,
+        TerminalReason::Failed { ref code } if code == "memory_history"
+    ));
+    assert_eq!(model.request_count(), 0);
+
+    // The rejected history never entered the transcript, so the failed run
+    // must round-trip through snapshot and restore.
+    let protector = XorProtector(0x66);
+    let snapshot = runtime
+        .protected_snapshot_with_policy(&protector, SnapshotContentPolicy::CanonicalRunState)?;
+    let mut bindings = RebindRegistry::new();
+    bindings.bind_model(
+        model_id,
+        tenant_id,
+        BindingIdentity::new("test-mock-model", "memory-history/v1"),
+        model,
+    );
+    bindings.bind_memory(
+        memory_id,
+        tenant_id,
+        BindingIdentity::new("fixed-history-memory", "memory-history/v1"),
+        memory,
+    );
+    let mut restored =
+        LocalRuntime::restore(RuntimeConfig::default(), &snapshot, &protector, bindings)?;
+    let restored_handle = restored.run_handle(handle.run_id, tenant_id)?;
+    let restored_result = restored.finish_run(restored_handle)?;
+    assert!(matches!(
+        restored_result.terminal_reason,
+        TerminalReason::Failed { ref code } if code == "memory_history"
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn multi_turn_tool_runs_commit_under_tail_validation() -> Result<()> {
+    let model = MockCompletionModel::new([
+        MockTurn::tool_call(
+            "a",
+            "counting_portable_tool",
+            serde_json::json!({"value": "1"}),
+        ),
+        MockTurn::tool_call(
+            "b",
+            "counting_portable_tool",
+            serde_json::json!({"value": "2"}),
+        ),
+        MockTurn::text("done"),
+    ]);
+    let tool = CountingPortableTool::default();
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(model.clone().into_ecs_agent_builder().build())?;
+    runtime.install_tool(agent, tool.clone())?;
+
+    let result = runtime.run(agent, "multi turn").await?;
+
+    assert!(matches!(result.terminal_reason, TerminalReason::Completed));
+    assert_eq!(result.text.as_deref(), Some("done"));
+    assert_eq!(model.request_count(), 3);
+    assert_eq!(tool.calls(), ["1", "2"]);
+    assert_eq!(result.transcript.len(), 6);
+    assert_no_orphan_tool_use(&result.transcript);
+    Ok(())
+}
+
+#[tokio::test]
+async fn duplicate_tool_call_identities_recover_under_retry_policy() -> Result<()> {
+    let model = MockCompletionModel::new([
+        MockTurn::from_contents([
+            AssistantContent::ToolCall(ToolCall::new(
+                "dup".to_string(),
+                ToolFunction::new(
+                    "counting_portable_tool".to_string(),
+                    serde_json::json!({"value": "a"}),
+                ),
+            )),
+            AssistantContent::ToolCall(ToolCall::new(
+                "dup".to_string(),
+                ToolFunction::new(
+                    "counting_portable_tool".to_string(),
+                    serde_json::json!({"value": "b"}),
+                ),
+            )),
+        ])?,
+        MockTurn::text("clean answer"),
+    ]);
+    let tool = CountingPortableTool::default();
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(
+        model
+            .clone()
+            .into_ecs_agent_builder()
+            .invalid_tool_policy(InvalidToolPolicy::Retry { max_retries: 1 })
+            .build(),
+    )?;
+    runtime.install_tool(agent, tool.clone())?;
+
+    let result = runtime.run(agent, "dup retry").await?;
+
+    assert!(matches!(result.terminal_reason, TerminalReason::Completed));
+    assert_eq!(result.text.as_deref(), Some("clean answer"));
+    assert_eq!(model.request_count(), 2);
+    assert!(tool.calls().is_empty());
+    assert!(
+        result
+            .events
+            .iter()
+            .any(|event| matches!(event, RunEvent::ResponseRetried))
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn duplicate_tool_call_identities_deduplicate_under_skip_policy() -> Result<()> {
+    let model = MockCompletionModel::new([
+        MockTurn::from_contents([
+            AssistantContent::ToolCall(ToolCall::new(
+                "dup".to_string(),
+                ToolFunction::new(
+                    "counting_portable_tool".to_string(),
+                    serde_json::json!({"value": "first"}),
+                ),
+            )),
+            AssistantContent::ToolCall(ToolCall::new(
+                "dup".to_string(),
+                ToolFunction::new(
+                    "counting_portable_tool".to_string(),
+                    serde_json::json!({"value": "second"}),
+                ),
+            )),
+        ])?,
+        MockTurn::text("after tools"),
+    ]);
+    let tool = CountingPortableTool::default();
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(
+        model
+            .clone()
+            .into_ecs_agent_builder()
+            .invalid_tool_policy(InvalidToolPolicy::Skip)
+            .build(),
+    )?;
+    runtime.install_tool(agent, tool.clone())?;
+
+    let result = runtime.run(agent, "dup skip").await?;
+
+    assert!(matches!(result.terminal_reason, TerminalReason::Completed));
+    assert_eq!(tool.calls(), ["first"]);
+    assert_no_orphan_tool_use(&result.transcript);
+    assert!(
+        result
+            .events
+            .iter()
+            .any(|event| matches!(event, RunEvent::ToolSuppressed { .. }))
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn restored_unobserved_terminal_runs_get_a_fresh_retention_lease() -> Result<()> {
+    let tenant_id = TenantId::new();
+    let abandoned_identity = BindingIdentity::new("slow-model", "lease/v1");
+    let pump_identity = BindingIdentity::new("pump-model", "lease/v1");
+    let abandoned_model = SlowMock {
+        inner: MockCompletionModel::text("abandoned"),
+        delay: Duration::from_secs(30),
+    };
+    let pump_model = MockCompletionModel::text("pump");
+    let mut runtime = LocalRuntime::with_config(RuntimeConfig {
+        terminal_retention_ticks: 1_024,
+        effect_timeout: Duration::from_secs(1),
+        ..RuntimeConfig::default()
+    })?;
+    let abandoned_model_id =
+        runtime.register_persistable_model(tenant_id, abandoned_identity, abandoned_model.clone());
+    let pump_model_id =
+        runtime.register_persistable_model(tenant_id, pump_identity, pump_model.clone());
+    let abandoned_agent =
+        runtime.spawn_agent_spec(AgentSpec::new(abandoned_model_id, tenant_id))?;
+    let pump_agent = runtime.spawn_agent_spec(AgentSpec::new(pump_model_id, tenant_id))?;
+
+    // Cancel the abandoned run and let the pump run's drive process it; the
+    // abandoned handle itself is never stepped, so the run stays unobserved.
+    let abandoned = runtime.start_run(abandoned_agent, "abandoned")?;
+    runtime.cancel(abandoned)?;
+    let pump = runtime.start_run(pump_agent, "pump")?;
+    let _ = runtime.drive_to_terminal(pump).await?;
+    // Age the unobserved run well past the restore-side window below.
+    for _ in 0..30 {
+        assert!(matches!(runtime.step(pump).await?, RunStepStatus::Terminal));
+    }
+
+    let protector = XorProtector(0x21);
+    let snapshot = runtime
+        .protected_snapshot_with_policy(&protector, SnapshotContentPolicy::CanonicalRunState)?;
+    let mut bindings = RebindRegistry::new();
+    bindings.bind_model(
+        abandoned_model_id,
+        tenant_id,
+        BindingIdentity::new("slow-model", "lease/v1"),
+        abandoned_model,
+    );
+    bindings.bind_model(
+        pump_model_id,
+        tenant_id,
+        BindingIdentity::new("pump-model", "lease/v1"),
+        pump_model,
+    );
+    // The restored window (16) is far below the preserved age (~30): without a
+    // fresh retention lease, the first restored schedule pass would clean the
+    // run this snapshot exists to preserve.
+    let mut restored = LocalRuntime::restore(
+        RuntimeConfig {
+            unobserved_terminal_retention_ticks: 16,
+            effect_timeout: Duration::from_secs(1),
+            ..RuntimeConfig::default()
+        },
+        &snapshot,
+        &protector,
+        bindings,
+    )?;
+    let restored_pump = restored.start_run(pump_agent, "restored pump")?;
+    let _ = restored.drive_to_terminal(restored_pump).await?;
+
+    let restored_handle = restored.run_handle(abandoned.run_id, tenant_id)?;
+    let restored_result = restored.finish_run(restored_handle)?;
+    assert!(matches!(
+        restored_result.terminal_reason,
+        TerminalReason::Cancelled
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn retired_tools_stop_advertising_while_references_drain() -> Result<()> {
+    let model = MockCompletionModel::new([MockTurn::text("first"), MockTurn::text("second")]);
+    let tool = CountingPortableTool::default();
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(model.clone().into_ecs_agent_builder().build())?;
+    let grant = runtime.install_tool(agent, tool)?;
+
+    let _ = runtime.run(agent, "before retirement").await?;
+    let first_request = model
+        .requests()
+        .first()
+        .cloned()
+        .context("first model request")?;
+    assert_eq!(first_request.tools.len(), 1);
+
+    runtime.retire_tool(grant.grant_id)?;
+    let _ = runtime.run(agent, "after retirement").await?;
+    let second_request = model.requests().pop().context("second model request")?;
+    assert!(second_request.tools.is_empty());
+    // With no live turn referencing it, cleanup removes the retired
+    // capability entirely.
+    assert!(matches!(
+        runtime.capability_kind(grant.capability_id),
+        Err(RuntimeError::UnknownCapability(_))
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn polling_terminal_steps_renew_the_observed_retention_lease() -> Result<()> {
+    let mut runtime = LocalRuntime::with_config(RuntimeConfig {
+        terminal_retention_ticks: 4,
+        effect_timeout: Duration::from_secs(1),
+        ..RuntimeConfig::default()
+    })?;
+    let polled_agent = runtime.spawn_agent(
+        MockCompletionModel::text("polled")
+            .into_ecs_agent_builder()
+            .build(),
+    )?;
+    let pump_agent = runtime.spawn_agent(
+        MockCompletionModel::text("pump")
+            .into_ecs_agent_builder()
+            .build(),
+    )?;
+    let polled = runtime.start_run(polled_agent, "polled")?;
+    let _ = runtime.drive_to_terminal(polled).await?;
+    let pump = runtime.start_run(pump_agent, "pump")?;
+
+    // Interleaved polling far past the 4-tick window: every Terminal return
+    // renews the lease, so the actively polled run is never cleaned even
+    // while the pump run's passes advance the tick.
+    for _ in 0..12 {
+        assert!(matches!(
+            runtime.step(polled).await?,
+            RunStepStatus::Terminal
+        ));
+        let _ = runtime.step(pump).await;
+    }
+    let result = runtime.finish_run(polled)?;
+    assert!(matches!(result.terminal_reason, TerminalReason::Completed));
+
+    // Once polling stops, the run ages out from its last observation.
+    for _ in 0..8 {
+        let _ = runtime.step(pump).await;
+    }
+    assert!(matches!(
+        runtime.finish_run(polled),
+        Err(RuntimeError::UnknownRun(_))
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn structured_output_turns_pass_through_the_duplicate_identity_ladder() -> Result<()> {
+    let output_name = synthetic_output_tool_name::<StructuredAnswer>(&[]);
+    let duplicate_turn = || {
+        MockTurn::from_contents([
+            AssistantContent::ToolCall(ToolCall::new(
+                "dup".to_string(),
+                ToolFunction::new(output_name.clone(), serde_json::json!({"answer": "first"})),
+            )),
+            AssistantContent::ToolCall(ToolCall::new(
+                "dup".to_string(),
+                ToolFunction::new(output_name.clone(), serde_json::json!({"answer": "second"})),
+            )),
+        ])
+    };
+
+    // Default policy: the duplicated identity fails the run even though the
+    // turn carries the structured-output call.
+    let model = MockCompletionModel::new([duplicate_turn()?]);
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(
+        model
+            .clone()
+            .into_ecs_agent_builder()
+            .tool_choice(ToolChoice::Specific {
+                function_names: vec![output_name.clone()],
+            })
+            .structured_output::<StructuredAnswer>(StructuredOutputPolicy {
+                mode: OutputMode::Tool,
+                max_retries: 0,
+                best_effort: false,
+            })
+            .build(),
+    )?;
+    let error = runtime
+        .run(agent, "dup structured")
+        .await
+        .err()
+        .context("duplicate identities in a structured turn must fail")?;
+    assert!(matches!(
+        error,
+        RuntimeError::RunFailed { ref code, .. } if code == "duplicate_tool_call"
+    ));
+
+    // Retry policy: the same defect recovers on a clean second response.
+    let retry_model = MockCompletionModel::new([
+        duplicate_turn()?,
+        MockTurn::tool_call(
+            "valid",
+            output_name.clone(),
+            serde_json::json!({"answer": "recovered"}),
+        ),
+    ]);
+    let mut retry_runtime = LocalRuntime::new()?;
+    let agent = retry_runtime.spawn_agent(
+        retry_model
+            .clone()
+            .into_ecs_agent_builder()
+            .tool_choice(ToolChoice::Specific {
+                function_names: vec![output_name.clone()],
+            })
+            .invalid_tool_policy(InvalidToolPolicy::Retry { max_retries: 1 })
+            .structured_output::<StructuredAnswer>(StructuredOutputPolicy {
+                mode: OutputMode::Tool,
+                max_retries: 0,
+                best_effort: false,
+            })
+            .build(),
+    )?;
+    let result = retry_runtime.run(agent, "dup structured retry").await?;
+    assert_eq!(
+        result.structured_output,
+        Some(serde_json::json!({"answer": "recovered"}))
+    );
+    assert_eq!(retry_model.request_count(), 2);
+    Ok(())
+}
+
+#[tokio::test]
+async fn mixed_tool_result_and_text_histories_are_accepted() -> Result<()> {
+    let history = vec![
+        Message::user("what is 1+1"),
+        Message::Assistant {
+            id: None,
+            content: OneOrMany::one(AssistantContent::ToolCall(ToolCall::new(
+                "c1".to_string(),
+                ToolFunction::new("calculator".to_string(), serde_json::json!({"sum": "1+1"})),
+            ))),
+        },
+        Message::User {
+            content: OneOrMany::many(vec![
+                UserContent::ToolResult(ToolResult {
+                    id: "c1".to_string(),
+                    call_id: None,
+                    content: OneOrMany::one(ToolResultContent::text("2")),
+                }),
+                UserContent::text("thanks, and please be brief"),
+            ])?,
+        },
+        Message::assistant("It is 2."),
+    ];
+    let model = MockCompletionModel::text("answered");
+    let memory = FixedHistoryMemory(history);
+    let mut runtime = runtime()?;
+    let tenant_id = TenantId::new();
+    let memory_id = runtime.register_memory(tenant_id, memory);
+    let agent = runtime.spawn_agent(
+        model
+            .clone()
+            .into_ecs_agent_builder()
+            .tenant(tenant_id)
+            .memory(memory_id, "classic-history")
+            .build(),
+    )?;
+
+    let result = runtime.run(agent, "next question").await?;
+
+    assert!(matches!(result.terminal_reason, TerminalReason::Completed));
+    assert_eq!(model.request_count(), 1);
+    let request = model.requests().pop().context("model request")?;
+    assert_eq!(request.chat_history.len(), 5);
+    Ok(())
+}
+
+#[tokio::test]
+async fn duplicate_and_invalid_name_retries_share_one_budget() -> Result<()> {
+    let model = MockCompletionModel::new([
+        MockTurn::from_contents([
+            AssistantContent::ToolCall(ToolCall::new(
+                "dup".to_string(),
+                ToolFunction::new(
+                    "counting_portable_tool".to_string(),
+                    serde_json::json!({"value": "a"}),
+                ),
+            )),
+            AssistantContent::ToolCall(ToolCall::new(
+                "dup".to_string(),
+                ToolFunction::new(
+                    "counting_portable_tool".to_string(),
+                    serde_json::json!({"value": "b"}),
+                ),
+            )),
+        ])?,
+        MockTurn::tool_call("solo", "unadvertised_tool", serde_json::json!({})),
+    ]);
+    let tool = CountingPortableTool::default();
+    let mut runtime = runtime()?;
+    let agent = runtime.spawn_agent(
+        model
+            .clone()
+            .into_ecs_agent_builder()
+            .invalid_tool_policy(InvalidToolPolicy::Retry { max_retries: 1 })
+            .build(),
+    )?;
+    runtime.install_tool(agent, tool.clone())?;
+
+    let error = runtime
+        .run(agent, "shared budget")
+        .await
+        .err()
+        .context("second defect must exhaust the shared retry budget")?;
+
+    assert!(matches!(
+        error,
+        RuntimeError::RunFailed { ref code, .. } if code == "invalid_tool_retry_exhausted"
+    ));
+    assert_eq!(model.request_count(), 2);
+    assert!(tool.calls().is_empty());
+    Ok(())
+}

--- a/crates/rig-runtime-conformance/src/lib.rs
+++ b/crates/rig-runtime-conformance/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This unpublished crate supplies scenario definitions and scripted portable
 //! effects. It deliberately contains no production orchestration and no public
-//! cross-runtime trait. `rig-agent` consumes these fixtures only
+//! cross-runtime trait. `rig-agent` and `rig-ecs` consume these fixtures only
 //! from their own tests and adapt them to their native APIs independently.
 
 mod fixtures;

--- a/examples/ecs_agent/Cargo.toml
+++ b/examples/ecs_agent/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "ecs_agent"
+version.workspace = true
+edition.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+rig = { workspace = true, features = ["ecs"] }
+anyhow = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/examples/ecs_agent/src/main.rs
+++ b/examples/ecs_agent/src/main.rs
@@ -1,0 +1,26 @@
+//! Runs an OpenAI model through Rig's experimental native Bevy ECS runtime.
+//! Requires `OPENAI_API_KEY`.
+
+use anyhow::Result;
+use rig::{
+    client::ProviderClient,
+    ecs::{EcsClientExt, LocalRuntime},
+    providers::openai,
+};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let client = openai::Client::from_env()?;
+    let definition = client
+        .ecs_agent(openai::GPT_5_2)
+        .preamble("Answer directly in one short paragraph.")
+        .build();
+    let mut runtime = LocalRuntime::new()?;
+    let agent = runtime.spawn_agent(definition)?;
+
+    let result = runtime
+        .run(agent, "Why can ECS be useful for agent orchestration?")
+        .await?;
+    println!("{}", result.text.as_deref().unwrap_or("<no text>"));
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,13 @@ pub mod agent {
     }
 }
 
+/// Experimental native-only ECS runtime.
+#[cfg(feature = "ecs")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ecs")))]
+pub mod ecs {
+    pub use rig_ecs::*;
+}
+
 /// Provider clients plus classic agent/extractor constructors.
 pub mod client {
     // The classic runtime's `CompletionClient` extension (adding `agent()` /

--- a/tests/fixtures/tool_facade/Cargo.toml
+++ b/tests/fixtures/tool_facade/Cargo.toml
@@ -14,11 +14,13 @@ serde_json = "1.0.150"
 [features]
 default = ["agent", "derive", "reqwest", "rustls"]
 agent = ["rig/agent"]
+ecs = ["rig/ecs"]
 derive = ["rig/derive"]
 reqwest = ["rig/reqwest"]
 rustls = ["rig/rustls"]
 all_root = [
     "rig/agent",
+    "rig/ecs",
     "rig/test-utils",
     "rig/bedrock",
     "rig/candle",

--- a/tests/fixtures/tool_facade/contextual_ecs/.gitignore
+++ b/tests/fixtures/tool_facade/contextual_ecs/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/tests/fixtures/tool_facade/contextual_ecs/Cargo.toml
+++ b/tests/fixtures/tool_facade/contextual_ecs/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rig-contextual-ecs-rejection-fixture"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[workspace]
+
+[dependencies]
+rig = { path = "../../../..", default-features = false, features = ["agent", "ecs"] }
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.150"

--- a/tests/fixtures/tool_facade/contextual_ecs/src/main.rs
+++ b/tests/fixtures/tool_facade/contextual_ecs/src/main.rs
@@ -1,0 +1,41 @@
+use std::convert::Infallible;
+
+use rig::tool::{Tool, ToolContext};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct Arguments;
+
+struct ContextualClassicTool;
+
+impl Tool for ContextualClassicTool {
+    const NAME: &'static str = "contextual_classic_tool";
+    type Args = Arguments;
+    type Output = ();
+    type Error = Infallible;
+
+    fn description(&self) -> String {
+        "classic-only contextual tool".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({"type": "object"})
+    }
+
+    async fn call(
+        &self,
+        _context: &mut ToolContext,
+        _arguments: Self::Args,
+    ) -> Result<Self::Output, Self::Error> {
+        Ok(())
+    }
+}
+
+fn must_not_compile(
+    runtime: &mut rig::ecs::LocalRuntime,
+    agent: rig::ecs::AgentId,
+) {
+    let _ = runtime.install_tool(agent, ContextualClassicTool);
+}
+
+fn main() {}

--- a/tests/providers/anthropic/cassette/ecs_runtime.rs
+++ b/tests/providers/anthropic/cassette/ecs_runtime.rs
@@ -1,0 +1,360 @@
+//! Anthropic Messages acceptance through the experimental ECS runtime.
+
+use rig::{
+    client::CompletionClient,
+    completion::CompletionModel,
+    ecs::{
+        EcsModelExt, HostedRuntime, LocalRuntime, OutputMode, StreamingRunEvent,
+        StructuredOutputPolicy,
+    },
+    providers::anthropic,
+    test_utils::RecordingHttpClient,
+};
+
+use super::super::support::with_anthropic_cassette;
+use crate::support::{
+    BASIC_PREAMBLE, BASIC_PROMPT, PortableAdder, PortableSubtract, STREAMING_PREAMBLE,
+    STREAMING_PROMPT, STREAMING_TOOLS_PREAMBLE, STREAMING_TOOLS_PROMPT, STRUCTURED_OUTPUT_PROMPT,
+    SmokeStructuredOutput, assert_mentions_expected_number, assert_smoke_structured_output,
+    ecs_synthetic_output_tool_name, smoke_structured_output_value,
+};
+
+fn text_response(text: &str) -> String {
+    serde_json::json!({
+        "content": [{"type": "text", "text": text}],
+        "id": "msg_ecs_runtime_acceptance",
+        "model": anthropic::completion::CLAUDE_SONNET_4_6,
+        "role": "assistant",
+        "type": "message",
+        "stop_reason": "end_turn",
+        "stop_sequence": null,
+        "usage": {
+            "input_tokens": 1,
+            "output_tokens": 1,
+            "cache_read_input_tokens": null,
+            "cache_creation_input_tokens": null
+        }
+    })
+    .to_string()
+}
+
+fn output_tool_response(name: &str) -> String {
+    serde_json::json!({
+        "content": [{
+            "type": "tool_use",
+            "id": "toolu_ecs_runtime_acceptance",
+            "name": name,
+            "input": smoke_structured_output_value()
+        }],
+        "id": "msg_ecs_runtime_acceptance",
+        "model": anthropic::completion::CLAUDE_SONNET_4_6,
+        "role": "assistant",
+        "type": "message",
+        "stop_reason": "tool_use",
+        "stop_sequence": null,
+        "usage": {
+            "input_tokens": 1,
+            "output_tokens": 1,
+            "cache_read_input_tokens": null,
+            "cache_creation_input_tokens": null
+        }
+    })
+    .to_string()
+}
+
+fn has_typed_blocking_final<M>(model: &M, result: &rig::ecs::LocalRunResult) -> bool
+where
+    M: CompletionModel,
+    M::Response: std::any::Any + Send + Sync,
+{
+    let _ = model;
+    result.raw_final::<M::Response>().is_some()
+}
+
+async fn run_typed_stream<M>(
+    model: &M,
+    runtime: &mut LocalRuntime,
+    agent: rig::ecs::AgentId,
+    prompt: &str,
+) -> rig::ecs::StreamingRunResult<M::StreamingResponse>
+where
+    M: CompletionModel + Send + Sync + 'static,
+    M::Response: std::any::Any + Send + Sync,
+    M::StreamingResponse: std::any::Any + Send + Sync,
+{
+    let result = runtime
+        .run_streaming::<M::StreamingResponse>(agent, prompt)
+        .await
+        .expect("ECS streaming provider run should succeed");
+    let provisional = result.events.iter().position(|event| {
+        matches!(
+            event,
+            StreamingRunEvent::Runtime(runtime)
+                if matches!(runtime.as_ref(), rig::ecs::RunEvent::Provisional { .. })
+        )
+    });
+    let provider_final = result
+        .events
+        .iter()
+        .position(|event| matches!(event, StreamingRunEvent::ProviderFinal { .. }));
+    assert!(matches!((provisional, provider_final), (Some(delta), Some(final_)) if delta < final_));
+    let _ = model;
+    result
+}
+
+#[tokio::test]
+async fn blocking_exposes_concrete_provider_final() {
+    with_anthropic_cassette("agent/completion_smoke", |client| async move {
+        let model = client.completion_model(anthropic::completion::CLAUDE_SONNET_4_6);
+        let mut runtime = LocalRuntime::new().expect("runtime should build");
+        let agent = runtime
+            .spawn_agent(
+                model
+                    .clone()
+                    .into_ecs_agent_builder()
+                    .preamble(BASIC_PREAMBLE)
+                    .build(),
+            )
+            .expect("agent should spawn");
+
+        let result = runtime
+            .run_blocking(agent, BASIC_PROMPT)
+            .await
+            .expect("ECS blocking provider run should succeed");
+
+        assert!(result.text.as_ref().is_some_and(|text| !text.is_empty()));
+        assert!(has_typed_blocking_final(&model, &result));
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn tool_mode_maps_through_anthropic_messages() {
+    let output_tool = ecs_synthetic_output_tool_name::<SmokeStructuredOutput>();
+    let http = RecordingHttpClient::new(output_tool_response(&output_tool));
+    let client = anthropic::Client::builder()
+        .api_key("test-key")
+        .http_client(http.clone())
+        .build()
+        .expect("Anthropic test client should build");
+    let model = client.completion_model(anthropic::completion::CLAUDE_SONNET_4_6);
+    let mut runtime = LocalRuntime::new().expect("runtime should build");
+    let agent = runtime
+        .spawn_agent(
+            model
+                .clone()
+                .into_ecs_agent_builder()
+                .structured_output::<SmokeStructuredOutput>(StructuredOutputPolicy {
+                    mode: OutputMode::Tool,
+                    max_retries: 0,
+                    best_effort: false,
+                })
+                .build(),
+        )
+        .expect("agent should spawn");
+
+    let result = runtime
+        .run_blocking(agent, STRUCTURED_OUTPUT_PROMPT)
+        .await
+        .expect("ECS Anthropic Tool-mode run should succeed");
+    let structured: SmokeStructuredOutput = serde_json::from_value(
+        result
+            .structured_output
+            .clone()
+            .expect("validated structured output"),
+    )
+    .expect("structured output should deserialize");
+    assert_smoke_structured_output(&structured);
+    assert!(has_typed_blocking_final(&model, &result));
+
+    let requests = http.requests();
+    assert_eq!(requests.len(), 1);
+    let body: serde_json::Value =
+        serde_json::from_slice(&requests[0].body).expect("request should be JSON");
+    assert_eq!(body["tools"][0]["name"], output_tool);
+    assert!(body.get("output_config").is_none());
+}
+
+#[tokio::test]
+async fn prompted_mode_maps_through_anthropic_messages() {
+    let output = smoke_structured_output_value();
+    let http = RecordingHttpClient::new(text_response(&output.to_string()));
+    let client = anthropic::Client::builder()
+        .api_key("test-key")
+        .http_client(http.clone())
+        .build()
+        .expect("Anthropic test client should build");
+    let model = client.completion_model(anthropic::completion::CLAUDE_SONNET_4_6);
+    let mut runtime = LocalRuntime::new().expect("runtime should build");
+    let agent = runtime
+        .spawn_agent(
+            model
+                .clone()
+                .into_ecs_agent_builder()
+                .structured_output::<SmokeStructuredOutput>(StructuredOutputPolicy {
+                    mode: OutputMode::Prompted,
+                    max_retries: 0,
+                    best_effort: false,
+                })
+                .build(),
+        )
+        .expect("agent should spawn");
+
+    let result = runtime
+        .run_blocking(agent, STRUCTURED_OUTPUT_PROMPT)
+        .await
+        .expect("ECS Anthropic Prompted-mode run should succeed");
+    let structured: SmokeStructuredOutput = serde_json::from_value(
+        result
+            .structured_output
+            .clone()
+            .expect("validated structured output"),
+    )
+    .expect("structured output should deserialize");
+    assert_smoke_structured_output(&structured);
+    assert!(has_typed_blocking_final(&model, &result));
+
+    let requests = http.requests();
+    assert_eq!(requests.len(), 1);
+    let body: serde_json::Value =
+        serde_json::from_slice(&requests[0].body).expect("request should be JSON");
+    assert!(body.get("tools").is_none());
+    assert!(body.get("output_config").is_none());
+    assert!(
+        body["system"][0]["text"]
+            .as_str()
+            .is_some_and(|text| text.contains("Respond with only JSON"))
+    );
+}
+
+#[tokio::test]
+async fn hosted_surface_exposes_only_redacted_provider_diagnostics() {
+    with_anthropic_cassette("agent/completion_smoke", |client| async move {
+        let model = client.completion_model(anthropic::completion::CLAUDE_SONNET_4_6);
+        let mut local = LocalRuntime::new().expect("runtime should build");
+        let agent = local
+            .spawn_agent(
+                model
+                    .into_ecs_agent_builder()
+                    .preamble(BASIC_PREAMBLE)
+                    .build(),
+            )
+            .expect("agent should spawn");
+        let hosted = HostedRuntime::new(local);
+        let handle = hosted
+            .start_run(agent, BASIC_PROMPT)
+            .await
+            .expect("hosted run should start");
+        let result = hosted
+            .drive_to_terminal(handle)
+            .await
+            .expect("hosted provider run should finish");
+        let diagnostic = hosted
+            .provider_diagnostic(handle)
+            .await
+            .expect("diagnostic lookup should succeed")
+            .expect("provider diagnostic should exist");
+        let final_text = result.text.as_deref().expect("hosted final text");
+        assert!(!format!("{diagnostic:?}").contains(final_text));
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn streaming_exposes_deltas_and_concrete_provider_final() {
+    with_anthropic_cassette("streaming/streaming_smoke", |client| async move {
+        let model = client.completion_model(anthropic::completion::CLAUDE_SONNET_4_6);
+        let mut runtime = LocalRuntime::new().expect("runtime should build");
+        let agent = runtime
+            .spawn_agent(
+                model
+                    .clone()
+                    .into_ecs_agent_builder()
+                    .preamble(STREAMING_PREAMBLE)
+                    .build(),
+            )
+            .expect("agent should spawn");
+
+        let result = run_typed_stream(&model, &mut runtime, agent, STREAMING_PROMPT).await;
+
+        assert!(
+            result
+                .result
+                .text
+                .as_ref()
+                .is_some_and(|text| !text.is_empty())
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn streaming_tools_roundtrip_through_owned_effects() {
+    with_anthropic_cassette(
+        "streaming_tools/streaming_tools_smoke",
+        |client| async move {
+            let model = client.completion_model(anthropic::completion::CLAUDE_SONNET_4_6);
+            let mut runtime = LocalRuntime::new().expect("runtime should build");
+            let agent = runtime
+                .spawn_agent(
+                    model
+                        .clone()
+                        .into_ecs_agent_builder()
+                        .preamble(STREAMING_TOOLS_PREAMBLE)
+                        .max_model_calls(2)
+                        .build(),
+                )
+                .expect("agent should spawn");
+            runtime
+                .install_tool(agent, PortableAdder)
+                .expect("portable adder should install");
+            runtime
+                .install_tool(agent, PortableSubtract)
+                .expect("portable subtract should install");
+
+            let result =
+                run_typed_stream(&model, &mut runtime, agent, STREAMING_TOOLS_PROMPT).await;
+
+            assert_mentions_expected_number(result.result.text.as_deref().expect("final text"), -3);
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn structured_output_validates_in_the_ecs_runtime() {
+    with_anthropic_cassette(
+        "structured_output/structured_output_smoke",
+        |client| async move {
+            let model = client.completion_model(anthropic::completion::CLAUDE_SONNET_4_6);
+            let mut runtime = LocalRuntime::new().expect("runtime should build");
+            let agent = runtime
+                .spawn_agent(
+                    model
+                        .clone()
+                        .into_ecs_agent_builder()
+                        .structured_output::<SmokeStructuredOutput>(
+                            StructuredOutputPolicy::default(),
+                        )
+                        .build(),
+                )
+                .expect("agent should spawn");
+
+            let result = runtime
+                .run_blocking(agent, STRUCTURED_OUTPUT_PROMPT)
+                .await
+                .expect("ECS structured provider run should succeed");
+            let structured: SmokeStructuredOutput = serde_json::from_value(
+                result
+                    .structured_output
+                    .clone()
+                    .expect("validated structured output"),
+            )
+            .expect("structured output should deserialize");
+
+            assert_smoke_structured_output(&structured);
+            assert!(has_typed_blocking_final(&model, &result));
+        },
+    )
+    .await;
+}

--- a/tests/providers/anthropic/mod.rs
+++ b/tests/providers/anthropic/mod.rs
@@ -4,6 +4,8 @@ mod cassette {
     mod agent;
     mod default_max_turns;
     mod document_file_id;
+    #[cfg(feature = "ecs")]
+    mod ecs_runtime;
     mod empty_end_turn;
     mod image;
     mod messages_behaviors;

--- a/tests/providers/gemini/cassette/ecs_runtime.rs
+++ b/tests/providers/gemini/cassette/ecs_runtime.rs
@@ -1,0 +1,326 @@
+//! Gemini Generate Content acceptance through the experimental ECS runtime.
+
+use rig::providers::gemini::completion::gemini_api_types::{
+    AdditionalParameters, GenerationConfig, ThinkingConfig, ThinkingLevel,
+};
+use rig::{
+    client::CompletionClient,
+    completion::CompletionModel,
+    ecs::{
+        EcsModelExt, HostedRuntime, LocalRuntime, OutputMode, StreamingRunEvent,
+        StructuredOutputPolicy,
+    },
+    providers::gemini,
+    test_utils::{MockHttpResponse, SequencedHttpClient},
+};
+
+use super::super::support::with_gemini_cassette;
+use crate::support::{
+    BASIC_PREAMBLE, BASIC_PROMPT, PortableAdder, PortableSubtract, STREAMING_PREAMBLE,
+    STREAMING_PROMPT, STREAMING_TOOLS_PREAMBLE, STREAMING_TOOLS_PROMPT, STRUCTURED_OUTPUT_PROMPT,
+    SmokeStructuredOutput, assert_mentions_expected_number, assert_smoke_structured_output,
+    smoke_structured_output_value,
+};
+
+fn text_response(text: &str, response_id: &str) -> String {
+    serde_json::json!({
+        "candidates": [{
+            "content": {
+                "parts": [{"text": text}],
+                "role": "model"
+            },
+            "finishReason": "STOP",
+            "index": 0
+        }],
+        "modelVersion": gemini::completion::GEMINI_2_5_FLASH,
+        "responseId": response_id,
+        "usageMetadata": {
+            "promptTokenCount": 1,
+            "candidatesTokenCount": 1,
+            "totalTokenCount": 2
+        }
+    })
+    .to_string()
+}
+
+fn streaming_tool_params() -> serde_json::Value {
+    serde_json::to_value(AdditionalParameters::default().with_config(GenerationConfig::default()))
+        .expect("Gemini additional params should serialize")
+}
+
+fn streaming_params() -> serde_json::Value {
+    let config = GenerationConfig {
+        thinking_config: Some(ThinkingConfig {
+            thinking_budget: None,
+            thinking_level: Some(ThinkingLevel::Medium),
+            include_thoughts: Some(true),
+        }),
+        ..GenerationConfig::default()
+    };
+    serde_json::to_value(AdditionalParameters::default().with_config(config))
+        .expect("Gemini streaming params should serialize")
+}
+
+fn has_typed_blocking_final<M>(model: &M, result: &rig::ecs::LocalRunResult) -> bool
+where
+    M: CompletionModel,
+    M::Response: std::any::Any + Send + Sync,
+{
+    let _ = model;
+    result.raw_final::<M::Response>().is_some()
+}
+
+async fn run_typed_stream<M>(
+    model: &M,
+    runtime: &mut LocalRuntime,
+    agent: rig::ecs::AgentId,
+    prompt: &str,
+) -> rig::ecs::StreamingRunResult<M::StreamingResponse>
+where
+    M: CompletionModel + Send + Sync + 'static,
+    M::Response: std::any::Any + Send + Sync,
+    M::StreamingResponse: std::any::Any + Send + Sync,
+{
+    let result = runtime
+        .run_streaming::<M::StreamingResponse>(agent, prompt)
+        .await
+        .expect("ECS streaming provider run should succeed");
+    let provisional = result.events.iter().position(|event| {
+        matches!(
+            event,
+            StreamingRunEvent::Runtime(runtime)
+                if matches!(runtime.as_ref(), rig::ecs::RunEvent::Provisional { .. })
+        )
+    });
+    let provider_final = result
+        .events
+        .iter()
+        .position(|event| matches!(event, StreamingRunEvent::ProviderFinal { .. }));
+    assert!(matches!((provisional, provider_final), (Some(delta), Some(final_)) if delta < final_));
+    let _ = model;
+    result
+}
+
+#[tokio::test]
+async fn blocking_exposes_concrete_provider_final() {
+    with_gemini_cassette("agent/completion_smoke", |client| async move {
+        let model = client.completion_model(gemini::completion::GEMINI_2_5_FLASH);
+        let mut runtime = LocalRuntime::new().expect("runtime should build");
+        let agent = runtime
+            .spawn_agent(
+                model
+                    .clone()
+                    .into_ecs_agent_builder()
+                    .preamble(BASIC_PREAMBLE)
+                    .build(),
+            )
+            .expect("agent should spawn");
+
+        let result = runtime
+            .run_blocking(agent, BASIC_PROMPT)
+            .await
+            .expect("ECS blocking provider run should succeed");
+
+        assert!(result.text.as_ref().is_some_and(|text| !text.is_empty()));
+        assert!(has_typed_blocking_final(&model, &result));
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn hosted_surface_exposes_only_redacted_provider_diagnostics() {
+    with_gemini_cassette("agent/completion_smoke", |client| async move {
+        let model = client.completion_model(gemini::completion::GEMINI_2_5_FLASH);
+        let mut local = LocalRuntime::new().expect("runtime should build");
+        let agent = local
+            .spawn_agent(
+                model
+                    .into_ecs_agent_builder()
+                    .preamble(BASIC_PREAMBLE)
+                    .build(),
+            )
+            .expect("agent should spawn");
+        let hosted = HostedRuntime::new(local);
+        let handle = hosted
+            .start_run(agent, BASIC_PROMPT)
+            .await
+            .expect("hosted run should start");
+        let result = hosted
+            .drive_to_terminal(handle)
+            .await
+            .expect("hosted provider run should finish");
+        let diagnostic = hosted
+            .provider_diagnostic(handle)
+            .await
+            .expect("diagnostic lookup should succeed")
+            .expect("provider diagnostic should exist");
+        let final_text = result.text.as_deref().expect("hosted final text");
+        assert!(!format!("{diagnostic:?}").contains(final_text));
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn streaming_exposes_deltas_and_concrete_provider_final() {
+    with_gemini_cassette("streaming/streaming_smoke", |client| async move {
+        let model = client.completion_model(gemini::completion::GEMINI_3_FLASH_PREVIEW);
+        let mut runtime = LocalRuntime::new().expect("runtime should build");
+        let agent = runtime
+            .spawn_agent(
+                model
+                    .clone()
+                    .into_ecs_agent_builder()
+                    .preamble(STREAMING_PREAMBLE)
+                    .additional_params(streaming_params())
+                    .build(),
+            )
+            .expect("agent should spawn");
+
+        let result = run_typed_stream(&model, &mut runtime, agent, STREAMING_PROMPT).await;
+
+        assert!(
+            result
+                .result
+                .text
+                .as_ref()
+                .is_some_and(|text| !text.is_empty())
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn streaming_tools_roundtrip_through_owned_effects() {
+    with_gemini_cassette(
+        "streaming_tools/streaming_tools_smoke",
+        |client| async move {
+            let model = client.completion_model(gemini::completion::GEMINI_2_5_FLASH);
+            let mut runtime = LocalRuntime::new().expect("runtime should build");
+            let agent = runtime
+                .spawn_agent(
+                    model
+                        .clone()
+                        .into_ecs_agent_builder()
+                        .preamble(STREAMING_TOOLS_PREAMBLE)
+                        .additional_params(streaming_tool_params())
+                        .max_model_calls(3)
+                        .build(),
+                )
+                .expect("agent should spawn");
+            runtime
+                .install_tool(agent, PortableAdder)
+                .expect("portable adder should install");
+            runtime
+                .install_tool(agent, PortableSubtract)
+                .expect("portable subtract should install");
+
+            let result =
+                run_typed_stream(&model, &mut runtime, agent, STREAMING_TOOLS_PROMPT).await;
+
+            assert_mentions_expected_number(result.result.text.as_deref().expect("final text"), -3);
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn native_structured_output_validates_in_the_ecs_runtime() {
+    with_gemini_cassette(
+        "structured_output/structured_output_smoke",
+        |client| async move {
+            let model = client.completion_model("gemini-3-flash-preview");
+            let mut runtime = LocalRuntime::new().expect("runtime should build");
+            let agent = runtime
+                .spawn_agent(
+                    model
+                        .clone()
+                        .into_ecs_agent_builder()
+                        .structured_output::<SmokeStructuredOutput>(StructuredOutputPolicy {
+                            mode: OutputMode::Native,
+                            ..StructuredOutputPolicy::default()
+                        })
+                        .build(),
+                )
+                .expect("agent should spawn");
+
+            let result = runtime
+                .run_blocking(agent, STRUCTURED_OUTPUT_PROMPT)
+                .await
+                .expect("ECS structured provider run should succeed");
+            let structured: SmokeStructuredOutput = serde_json::from_value(
+                result
+                    .structured_output
+                    .clone()
+                    .expect("validated structured output"),
+            )
+            .expect("structured output should deserialize");
+
+            assert_smoke_structured_output(&structured);
+            assert!(has_typed_blocking_final(&model, &result));
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn invalid_native_output_recovers_through_gemini_generate_content() {
+    let valid = smoke_structured_output_value();
+    let http = SequencedHttpClient::new([
+        MockHttpResponse::success(text_response("not valid JSON", "gemini-ecs-invalid")),
+        MockHttpResponse::success(text_response(&valid.to_string(), "gemini-ecs-valid")),
+    ]);
+    let client = gemini::Client::builder()
+        .api_key("test-key")
+        .http_client(http.clone())
+        .build()
+        .expect("Gemini test client should build");
+    let model = client.completion_model(gemini::completion::GEMINI_2_5_FLASH);
+    let mut runtime = LocalRuntime::new().expect("runtime should build");
+    let agent = runtime
+        .spawn_agent(
+            model
+                .clone()
+                .into_ecs_agent_builder()
+                .max_model_calls(2)
+                .structured_output::<SmokeStructuredOutput>(StructuredOutputPolicy {
+                    mode: OutputMode::Native,
+                    max_retries: 1,
+                    best_effort: false,
+                })
+                .build(),
+        )
+        .expect("agent should spawn");
+
+    let result = runtime
+        .run_blocking(agent, STRUCTURED_OUTPUT_PROMPT)
+        .await
+        .expect("ECS Gemini structured-output recovery should succeed");
+    let structured: SmokeStructuredOutput = serde_json::from_value(
+        result
+            .structured_output
+            .clone()
+            .expect("validated structured output"),
+    )
+    .expect("structured output should deserialize");
+    assert_smoke_structured_output(&structured);
+    assert!(has_typed_blocking_final(&model, &result));
+
+    let requests = http.requests();
+    assert_eq!(requests.len(), 2);
+    assert_eq!(http.remaining_responses(), 0);
+    for request in &requests {
+        let body: serde_json::Value =
+            serde_json::from_slice(&request.body).expect("request should be JSON");
+        assert!(
+            body.pointer("/generationConfig/responseJsonSchema")
+                .is_some()
+        );
+    }
+    let second: serde_json::Value =
+        serde_json::from_slice(&requests[1].body).expect("request should be JSON");
+    assert!(
+        second
+            .to_string()
+            .contains("previous response did not satisfy the required JSON schema")
+    );
+}

--- a/tests/providers/gemini/mod.rs
+++ b/tests/providers/gemini/mod.rs
@@ -13,6 +13,8 @@ mod cassette {
     mod chat_history;
     mod document_ordering;
     mod dynamic_tools;
+    #[cfg(feature = "ecs")]
+    mod ecs_runtime;
     mod embeddings;
     mod extractor;
     mod generate_behaviors;

--- a/tests/providers/openai/cassette/ecs_runtime.rs
+++ b/tests/providers/openai/cassette/ecs_runtime.rs
@@ -1,0 +1,289 @@
+//! OpenAI Responses acceptance through the experimental ECS runtime.
+
+use rig::{
+    client::CompletionClient,
+    completion::CompletionModel,
+    ecs::{
+        EcsModelExt, HostedRuntime, LocalRuntime, OutputMode, StreamingRunEvent,
+        StructuredOutputPolicy,
+    },
+    providers::openai,
+    test_utils::RecordingHttpClient,
+};
+
+use super::super::support::with_openai_cassette;
+use crate::support::{
+    BASIC_PREAMBLE, BASIC_PROMPT, PortableAdder, PortableSubtract, STREAMING_PREAMBLE,
+    STREAMING_PROMPT, STREAMING_TOOLS_PREAMBLE, STREAMING_TOOLS_PROMPT, STRUCTURED_OUTPUT_PROMPT,
+    SmokeStructuredOutput, assert_mentions_expected_number, assert_smoke_structured_output,
+    ecs_synthetic_output_tool_name, smoke_structured_output_value,
+};
+
+fn output_tool_response(name: &str) -> String {
+    serde_json::json!({
+        "id": "resp_ecs_runtime_acceptance",
+        "object": "response",
+        "created_at": 0,
+        "status": "completed",
+        "model": "gpt-4o",
+        "output": [{
+            "type": "function_call",
+            "id": "fc_ecs_runtime_acceptance",
+            "arguments": smoke_structured_output_value().to_string(),
+            "call_id": "call_ecs_runtime_acceptance",
+            "name": name,
+            "status": "completed"
+        }],
+        "tools": []
+    })
+    .to_string()
+}
+
+fn has_typed_blocking_final<M>(model: &M, result: &rig::ecs::LocalRunResult) -> bool
+where
+    M: CompletionModel,
+    M::Response: std::any::Any + Send + Sync,
+{
+    let _ = model;
+    result.raw_final::<M::Response>().is_some()
+}
+
+async fn run_typed_stream<M>(
+    model: &M,
+    runtime: &mut LocalRuntime,
+    agent: rig::ecs::AgentId,
+    prompt: &str,
+) -> rig::ecs::StreamingRunResult<M::StreamingResponse>
+where
+    M: CompletionModel + Send + Sync + 'static,
+    M::Response: std::any::Any + Send + Sync,
+    M::StreamingResponse: std::any::Any + Send + Sync,
+{
+    let result = runtime
+        .run_streaming::<M::StreamingResponse>(agent, prompt)
+        .await
+        .expect("ECS streaming provider run should succeed");
+    let provisional = result.events.iter().position(|event| {
+        matches!(
+            event,
+            StreamingRunEvent::Runtime(runtime)
+                if matches!(runtime.as_ref(), rig::ecs::RunEvent::Provisional { .. })
+        )
+    });
+    let provider_final = result
+        .events
+        .iter()
+        .position(|event| matches!(event, StreamingRunEvent::ProviderFinal { .. }));
+    assert!(matches!((provisional, provider_final), (Some(delta), Some(final_)) if delta < final_));
+    let _ = model;
+    result
+}
+
+#[tokio::test]
+async fn blocking_exposes_concrete_provider_final() {
+    with_openai_cassette("agent/completion_smoke", |client| async move {
+        let model = client.completion_model(openai::GPT_4O);
+        let mut runtime = LocalRuntime::new().expect("runtime should build");
+        let agent = runtime
+            .spawn_agent(
+                model
+                    .clone()
+                    .into_ecs_agent_builder()
+                    .preamble(BASIC_PREAMBLE)
+                    .build(),
+            )
+            .expect("agent should spawn");
+
+        let result = runtime
+            .run_blocking(agent, BASIC_PROMPT)
+            .await
+            .expect("ECS blocking provider run should succeed");
+
+        assert!(result.text.as_ref().is_some_and(|text| !text.is_empty()));
+        assert!(has_typed_blocking_final(&model, &result));
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn hosted_surface_exposes_only_redacted_provider_diagnostics() {
+    with_openai_cassette("agent/completion_smoke", |client| async move {
+        let model = client.completion_model(openai::GPT_4O);
+        let mut local = LocalRuntime::new().expect("runtime should build");
+        let agent = local
+            .spawn_agent(
+                model
+                    .into_ecs_agent_builder()
+                    .preamble(BASIC_PREAMBLE)
+                    .build(),
+            )
+            .expect("agent should spawn");
+        let hosted = HostedRuntime::new(local);
+        let handle = hosted
+            .start_run(agent, BASIC_PROMPT)
+            .await
+            .expect("hosted run should start");
+        let result = hosted
+            .drive_to_terminal(handle)
+            .await
+            .expect("hosted provider run should finish");
+        let diagnostic = hosted
+            .provider_diagnostic(handle)
+            .await
+            .expect("diagnostic lookup should succeed")
+            .expect("provider diagnostic should exist");
+        let final_text = result.text.as_deref().expect("hosted final text");
+        assert!(!format!("{diagnostic:?}").contains(final_text));
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn streaming_exposes_deltas_and_concrete_provider_final() {
+    with_openai_cassette("streaming/streaming_smoke", |client| async move {
+        let model = client.completion_model(openai::GPT_4O);
+        let mut runtime = LocalRuntime::new().expect("runtime should build");
+        let agent = runtime
+            .spawn_agent(
+                model
+                    .clone()
+                    .into_ecs_agent_builder()
+                    .preamble(STREAMING_PREAMBLE)
+                    .build(),
+            )
+            .expect("agent should spawn");
+
+        let result = run_typed_stream(&model, &mut runtime, agent, STREAMING_PROMPT).await;
+
+        assert!(
+            result
+                .result
+                .text
+                .as_ref()
+                .is_some_and(|text| !text.is_empty())
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn streaming_tools_roundtrip_through_owned_effects() {
+    with_openai_cassette(
+        "streaming_tools/streaming_tools_smoke",
+        |client| async move {
+            let model = client.completion_model(openai::GPT_4O);
+            let mut runtime = LocalRuntime::new().expect("runtime should build");
+            let agent = runtime
+                .spawn_agent(
+                    model
+                        .clone()
+                        .into_ecs_agent_builder()
+                        .preamble(STREAMING_TOOLS_PREAMBLE)
+                        .max_model_calls(2)
+                        .build(),
+                )
+                .expect("agent should spawn");
+            runtime
+                .install_tool(agent, PortableAdder)
+                .expect("portable adder should install");
+            runtime
+                .install_tool(agent, PortableSubtract)
+                .expect("portable subtract should install");
+
+            let result =
+                run_typed_stream(&model, &mut runtime, agent, STREAMING_TOOLS_PROMPT).await;
+
+            assert_mentions_expected_number(result.result.text.as_deref().expect("final text"), -3);
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn native_structured_output_validates_in_the_ecs_runtime() {
+    with_openai_cassette(
+        "structured_output/structured_output_smoke",
+        |client| async move {
+            let model = client.completion_model(openai::GPT_4O);
+            let mut runtime = LocalRuntime::new().expect("runtime should build");
+            let agent = runtime
+                .spawn_agent(
+                    model
+                        .clone()
+                        .into_ecs_agent_builder()
+                        .structured_output::<SmokeStructuredOutput>(StructuredOutputPolicy {
+                            mode: OutputMode::Native,
+                            ..StructuredOutputPolicy::default()
+                        })
+                        .build(),
+                )
+                .expect("agent should spawn");
+
+            let result = runtime
+                .run_blocking(agent, STRUCTURED_OUTPUT_PROMPT)
+                .await
+                .expect("ECS structured provider run should succeed");
+            let structured: SmokeStructuredOutput = serde_json::from_value(
+                result
+                    .structured_output
+                    .clone()
+                    .expect("validated structured output"),
+            )
+            .expect("structured output should deserialize");
+
+            assert_smoke_structured_output(&structured);
+            assert!(has_typed_blocking_final(&model, &result));
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn tool_mode_maps_through_openai_responses() {
+    let output_tool = ecs_synthetic_output_tool_name::<SmokeStructuredOutput>();
+    let http = RecordingHttpClient::new(output_tool_response(&output_tool));
+    let client = openai::Client::builder()
+        .api_key("test-key")
+        .http_client(http.clone())
+        .build()
+        .expect("OpenAI test client should build");
+    let model = client.completion_model(openai::GPT_4O);
+    let mut runtime = LocalRuntime::new().expect("runtime should build");
+    let agent = runtime
+        .spawn_agent(
+            model
+                .clone()
+                .into_ecs_agent_builder()
+                .structured_output::<SmokeStructuredOutput>(StructuredOutputPolicy {
+                    mode: OutputMode::Tool,
+                    max_retries: 0,
+                    best_effort: false,
+                })
+                .build(),
+        )
+        .expect("agent should spawn");
+
+    let result = runtime
+        .run_blocking(agent, STRUCTURED_OUTPUT_PROMPT)
+        .await
+        .expect("ECS OpenAI Tool-mode run should succeed");
+    let structured: SmokeStructuredOutput = serde_json::from_value(
+        result
+            .structured_output
+            .clone()
+            .expect("validated structured output"),
+    )
+    .expect("structured output should deserialize");
+    assert_smoke_structured_output(&structured);
+    assert!(has_typed_blocking_final(&model, &result));
+
+    let requests = http.requests();
+    assert_eq!(requests.len(), 1);
+    let body: serde_json::Value =
+        serde_json::from_slice(&requests[0].body).expect("request should be JSON");
+    assert_eq!(body["tools"][0]["name"], output_tool);
+    assert_ne!(
+        body.pointer("/text/format/type").and_then(|v| v.as_str()),
+        Some("json_schema")
+    );
+}

--- a/tests/providers/openai/mod.rs
+++ b/tests/providers/openai/mod.rs
@@ -5,6 +5,8 @@ mod cassette {
     mod chat_history;
     mod completions_api;
     mod document_ordering;
+    #[cfg(feature = "ecs")]
+    mod ecs_runtime;
     mod extractor;
     mod extractor_usage;
     mod gpt_5_6_reasoning;

--- a/tests/tool_facade_features.rs
+++ b/tests/tool_facade_features.rs
@@ -32,6 +32,10 @@ fn portable_tool_facade_is_feature_additive() -> Result<(), Box<dyn std::error::
             "agent",
             &["--no-default-features", "--features", "agent"][..],
         ),
+        (
+            "agent-ecs",
+            &["--no-default-features", "--features", "agent,ecs"][..],
+        ),
         ("default", &[][..]),
         ("all-features", &["--all-features"][..]),
     ] {
@@ -44,6 +48,32 @@ fn portable_tool_facade_is_feature_additive() -> Result<(), Box<dyn std::error::
             )
             .into());
         }
+    }
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(
+    not(feature = "facade-build-tests"),
+    ignore = "slow nested cargo check; run with --features facade-build-tests or --all-features"
+)]
+fn contextual_classic_tool_is_rejected_by_ecs() -> Result<(), Box<dyn std::error::Error>> {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let fixture = root.join("tests/fixtures/tool_facade/contextual_ecs/Cargo.toml");
+    let target_dir = root.join("target/tool-facade-contextual-rejection");
+    let output = cargo_check(&fixture, &target_dir, &[])?;
+
+    if output.status.success() {
+        return Err(
+            "contextual classic tool unexpectedly satisfied the ECS runtime.s portable bound"
+                .into(),
+        );
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if !stderr.contains("PortableTool") || !stderr.contains("ContextualClassicTool") {
+        return Err(format!("unexpected compiler diagnostic:\n{stderr}").into());
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

Adds `rig-ecs`, an **experimental, native-only ECS-based agent runtime** built
on the third-party `bevy_ecs` engine. Opt in with the `ecs` feature and use it
through `rig::ecs`; the classic runtime remains the default.

> **Stacked PR.** This targets `split/core-agent` (#2197), not `main`. Merge
> **after** #2197. The diff shown here is only the ECS layer.

## Design

- The ECS world is authoritative for agent topology and run progression;
  provider/tool/memory work is modeled as owned effects that re-enter through
  validated ingress (generation + correlation + authorization checks).
- Construction uses `EcsClientExt::ecs_agent`, distinct from the classic
  `CompletionClient::agent`, so both runtimes can be used together without
  method collisions.
- `rig-ecs` depends only on `rig-core` (never `rig-agent`); the dependency-graph
  guard enforces it. The shared `rig-runtime-conformance` ledger holds both
  runtimes to the same observable behavior.

## Notes

- Native-only: it `compile_error!`s on wasm and is absent from the facade `wasm`
  feature; it is not in `default` features.
