### PR TITLE
fix(openai): omit empty encrypted reasoning in non-streaming responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- *(openai)* Treat empty `encrypted_content` in non-streaming Responses API
+  reasoning items as absent, matching streaming behavior and avoiding empty
+  encrypted reasoning blocks.
+
 - *(aws)* Stop enabling the AWS SDK's legacy Rustls connector in the Bedrock and S3 Vectors integrations, removing vulnerable `rustls-webpki` 0.101 from their active dependency graphs while retaining the modern default HTTPS client.
 
 ### Changed

--- a/crates/rig-core/CHANGELOG.md
+++ b/crates/rig-core/CHANGELOG.md
@@ -183,6 +183,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Streaming execution observation: the atomically surfaced post-batch event is named `ToolExecutionCommitted`, reflecting that it is not a real-time start notification. Applications that need live host lifecycle events should observe `on_tool_call` / `on_tool_result`; typed result metadata remains available through `ToolResultEvent::tool_context` without entering model-facing messages.
 - *(core)* [**breaking**] Mark `PromptError`, `StructuredOutputError`, and `VectorStoreError` as non-exhaustive, requiring downstream match expressions to include a wildcard arm. Conversation memory load failures now surface as the typed `PromptError::MemoryError` variant instead of `CompletionError::RequestError`.
 
+### Fixed
+
+- *(openai)* Treat empty `encrypted_content` in non-streaming Responses API
+  reasoning items as absent, matching streaming behavior and avoiding empty
+  encrypted reasoning blocks.
+
 ## [0.40.0](https://github.com/0xPlaygrounds/rig/compare/rig-core-v0.39.0...rig-core-v0.40.0) - 2026-07-10
 
 ### Added

--- a/crates/rig-core/src/providers/openai/responses_api/mod.rs
+++ b/crates/rig-core/src/providers/openai/responses_api/mod.rs
@@ -2126,7 +2126,9 @@ impl From<Output> for Vec<completion::AssistantContent> {
                         signature: None,
                     }
                 }));
-                if let Some(encrypted_content) = encrypted_content {
+                if let Some(encrypted_content) =
+                    encrypted_content.filter(|content| !content.is_empty())
+                {
                     content.push(message::ReasoningContent::Encrypted(encrypted_content));
                 }
                 vec![completion::AssistantContent::Reasoning(
@@ -4643,6 +4645,55 @@ mod tests {
             serde_json::from_value(value).expect("reasoning should deserialize");
 
         assert_eq!(round_tripped, original);
+    }
+
+    #[test]
+    fn output_reasoning_conversion_omits_empty_encrypted_content() {
+        let output = Output::Reasoning {
+            id: "reasoning_1".to_string(),
+            summary: vec![],
+            content: vec!["visible reasoning".to_string()],
+            encrypted_content: Some(String::new()),
+            status: Some(ToolStatus::Completed),
+        };
+
+        let converted = Vec::<completion::AssistantContent>::from(output);
+
+        assert_eq!(converted.len(), 1);
+        let completion::AssistantContent::Reasoning(reasoning) = &converted[0] else {
+            panic!("expected reasoning output");
+        };
+        assert_eq!(reasoning.id.as_deref(), Some("reasoning_1"));
+        assert_eq!(reasoning.content.len(), 1);
+        assert!(matches!(
+            reasoning.content.first(),
+            Some(message::ReasoningContent::Text { text, .. })
+                if text == "visible reasoning"
+        ));
+    }
+
+    #[test]
+    fn output_reasoning_conversion_preserves_non_empty_encrypted_content() {
+        let output = Output::Reasoning {
+            id: "reasoning_1".to_string(),
+            summary: vec![],
+            content: vec![],
+            encrypted_content: Some("ciphertext".to_string()),
+            status: Some(ToolStatus::Completed),
+        };
+
+        let converted = Vec::<completion::AssistantContent>::from(output);
+
+        assert_eq!(converted.len(), 1);
+        let completion::AssistantContent::Reasoning(reasoning) = &converted[0] else {
+            panic!("expected reasoning output");
+        };
+        assert_eq!(
+            reasoning.content,
+            vec![message::ReasoningContent::Encrypted(
+                "ciphertext".to_string()
+            )]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- treat `encrypted_content: ""` as absent when converting non-streaming OpenAI Responses API reasoning output into Rig content
- preserve non-empty encrypted reasoning payloads unchanged
- add direct regression coverage for both empty omission and non-empty preservation
- document the normalized non-streaming behavior in the root and `rig-core` changelogs

## Why

Follow-up to #2196. That PR fixed the equivalent streaming path, but the non-streaming `Output::Reasoning` conversion still turned an empty provider field into `ReasoningContent::Encrypted("")`.

The normalization belongs at the provider-to-Rig conversion boundary: raw `Output` deserialization and serialization continue to preserve the provider wire value, while canonical Rig reasoning content no longer contains a meaningless empty encrypted block.

## Impact

OpenAI-compatible Responses API providers that return both visible reasoning text and `encrypted_content: ""` now produce only the meaningful visible reasoning content in non-streaming responses. Non-empty encrypted payloads are unaffected.

## Verification

- `cargo fmt --all --check`
- `cargo test -p rig-core --lib output_reasoning_conversion_`
- `cargo test -p rig-core --lib providers::openai::responses_api::tests`
- `cargo test -p rig --all-features --test openai openai::cassette::openai_compatible_reasoning_content -- --nocapture --test-threads=1`
- `cargo check -p rig-core --features wasm --target wasm32-unknown-unknown`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`

Independent full-diff review found no P0–P3 issues.