### PR TITLE
feat(core)!: preserve response headers on non-success HTTP errors

### DIFF
--- a/crates/rig-agent/src/completion.rs
+++ b/crates/rig-agent/src/completion.rs
@@ -83,6 +83,15 @@ impl PromptError {
         }
     }
 
+    /// Returns the HTTP response headers exposed by a wrapped completion error,
+    /// when they were captured (e.g. `Retry-After` on a 429).
+    pub fn provider_response_headers(&self) -> Option<&http::HeaderMap> {
+        match self {
+            Self::CompletionError(error) => error.provider_response_headers(),
+            _ => None,
+        }
+    }
+
     pub(crate) fn prompt_cancelled(
         chat_history: impl IntoIterator<Item = Message>,
         reason: impl Into<String>,
@@ -130,6 +139,15 @@ impl StructuredOutputError {
     pub fn provider_response_status(&self) -> Option<http::StatusCode> {
         match self {
             Self::PromptError(error) => error.provider_response_status(),
+            _ => None,
+        }
+    }
+
+    /// Returns the HTTP response headers exposed through the wrapped prompt
+    /// error, when they were captured (e.g. `Retry-After` on a 429).
+    pub fn provider_response_headers(&self) -> Option<&http::HeaderMap> {
+        match self {
+            Self::PromptError(error) => error.provider_response_headers(),
             _ => None,
         }
     }
@@ -201,6 +219,7 @@ mod provider_response_tests {
             http_client::Error::InvalidStatusCodeWithMessage(
                 http::StatusCode::UNAUTHORIZED,
                 body.to_string(),
+                None,
             ),
         ));
 
@@ -214,6 +233,39 @@ mod provider_response_tests {
             Some(serde_json::json!({
                 "error": { "message": "unauthorized" }
             }))
+        );
+    }
+
+    #[test]
+    fn prompt_error_provider_response_helpers_forward_captured_headers() {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            http::header::RETRY_AFTER,
+            http::HeaderValue::from_static("20"),
+        );
+        let error = PromptError::CompletionError(CompletionError::HttpError(
+            http_client::Error::InvalidStatusCodeWithMessage(
+                http::StatusCode::TOO_MANY_REQUESTS,
+                r#"{"error":{"message":"rate limited"}}"#.to_string(),
+                Some(Box::new(headers)),
+            ),
+        ));
+
+        assert_eq!(
+            error
+                .provider_response_headers()
+                .and_then(|headers| headers.get(http::header::RETRY_AFTER))
+                .and_then(|value| value.to_str().ok()),
+            Some("20"),
+        );
+
+        let error = StructuredOutputError::PromptError(Box::new(error));
+        assert_eq!(
+            error
+                .provider_response_headers()
+                .and_then(|headers| headers.get(http::header::RETRY_AFTER))
+                .and_then(|value| value.to_str().ok()),
+            Some("20"),
         );
     }
 

--- a/crates/rig-core/src/audio_generation.rs
+++ b/crates/rig-core/src/audio_generation.rs
@@ -193,6 +193,7 @@ mod provider_response_tests {
             AudioGenerationError::HttpError(http_client::Error::InvalidStatusCodeWithMessage(
                 StatusCode::BAD_REQUEST,
                 body.to_string(),
+                None,
             ));
 
         assert_eq!(error.provider_response_body(), Some(body));

--- a/crates/rig-core/src/client/mod.rs
+++ b/crates/rig-core/src/client/mod.rs
@@ -530,18 +530,21 @@ where
                 Err(VerifyError::InvalidAuthentication)
             }
             StatusCode::INTERNAL_SERVER_ERROR => {
+                let headers = Box::new(response.headers().clone());
                 let text = http_client::text(response).await?;
                 Err(VerifyError::HttpError(
                     http_client::Error::InvalidStatusCodeWithMessage(
                         StatusCode::INTERNAL_SERVER_ERROR,
                         text,
+                        Some(headers),
                     ),
                 ))
             }
             status if status.as_u16() == 529 => {
+                let headers = Box::new(response.headers().clone());
                 let text = http_client::text(response).await?;
                 Err(VerifyError::HttpError(
-                    http_client::Error::InvalidStatusCodeWithMessage(status, text),
+                    http_client::Error::InvalidStatusCodeWithMessage(status, text, Some(headers)),
                 ))
             }
             _ => {
@@ -550,9 +553,14 @@ where
                 if status.is_success() {
                     Ok(())
                 } else {
+                    let headers = Box::new(response.headers().clone());
                     let text: String = String::from_utf8_lossy(&response.into_body().await?).into();
                     Err(VerifyError::HttpError(
-                        http_client::Error::InvalidStatusCodeWithMessage(status, text),
+                        http_client::Error::InvalidStatusCodeWithMessage(
+                            status,
+                            text,
+                            Some(headers),
+                        ),
                     ))
                 }
             }

--- a/crates/rig-core/src/client/verify.rs
+++ b/crates/rig-core/src/client/verify.rs
@@ -64,6 +64,7 @@ mod provider_response_tests {
         let error = VerifyError::HttpError(http_client::Error::InvalidStatusCodeWithMessage(
             StatusCode::BAD_REQUEST,
             body.to_string(),
+            None,
         ));
 
         assert_eq!(error.provider_response_body(), Some(body));

--- a/crates/rig-core/src/completion/request.rs
+++ b/crates/rig-core/src/completion/request.rs
@@ -1346,6 +1346,7 @@ mod tests {
         let error = CompletionError::HttpError(http_client::Error::InvalidStatusCodeWithMessage(
             http::StatusCode::BAD_REQUEST,
             body.to_string(),
+            None,
         ));
 
         assert_eq!(error.provider_response_body(), Some(body));

--- a/crates/rig-core/src/embeddings/embedding.rs
+++ b/crates/rig-core/src/embeddings/embedding.rs
@@ -264,6 +264,7 @@ mod provider_response_tests {
         let error = EmbeddingError::HttpError(http_client::Error::InvalidStatusCodeWithMessage(
             StatusCode::BAD_REQUEST,
             body.to_string(),
+            None,
         ));
 
         assert_eq!(error.provider_response_body(), Some(body));

--- a/crates/rig-core/src/http_client/mod.rs
+++ b/crates/rig-core/src/http_client/mod.rs
@@ -18,7 +18,7 @@ pub enum Error {
     #[error("Invalid status code: {0}")]
     InvalidStatusCode(StatusCode),
     #[error("Invalid status code {0} with message: {1}")]
-    InvalidStatusCodeWithMessage(StatusCode, String),
+    InvalidStatusCodeWithMessage(StatusCode, String, Option<Box<HeaderMap>>),
     #[error("Header value outside of legal range: {0}")]
     InvalidHeaderValue(#[from] http::header::InvalidHeaderValue),
     #[error("Request in error state, cannot access headers")]
@@ -39,7 +39,7 @@ pub enum Error {
 impl Error {
     pub(crate) fn non_success_status(&self) -> Option<StatusCode> {
         match self {
-            Self::InvalidStatusCode(status) | Self::InvalidStatusCodeWithMessage(status, _) => {
+            Self::InvalidStatusCode(status) | Self::InvalidStatusCodeWithMessage(status, _, _) => {
                 Some(*status)
             }
             _ => None,
@@ -48,7 +48,25 @@ impl Error {
 
     pub(crate) fn non_success_body(&self) -> Option<&str> {
         match self {
-            Self::InvalidStatusCodeWithMessage(_, body) => Some(body.as_str()),
+            Self::InvalidStatusCodeWithMessage(_, body, _) => Some(body.as_str()),
+            _ => None,
+        }
+    }
+
+    /// Returns the response headers of a non-success HTTP response, when they
+    /// were captured at error construction.
+    ///
+    /// Rig's bundled HTTP clients capture the full response [`HeaderMap`]
+    /// whenever a non-success status error is built from a live response, so
+    /// rate-limit metadata such as `Retry-After` or `x-ratelimit-*` stays
+    /// available to callers (for example a [`retry::RetryPolicy`] deciding how
+    /// long to back off after a 429).
+    ///
+    /// Returns `None` when the error was constructed without access to the
+    /// response headers (e.g. errors built from only a status and body).
+    pub fn non_success_headers(&self) -> Option<&HeaderMap> {
+        match self {
+            Self::InvalidStatusCodeWithMessage(_, _, headers) => headers.as_deref(),
             _ => None,
         }
     }
@@ -68,11 +86,12 @@ fn instance_error<E: std::error::Error + 'static>(error: E) -> Error {
 
 async fn non_success_status_error(response: reqwest::Response) -> Error {
     let status = response.status();
+    let headers = Box::new(response.headers().clone());
     let message = response
         .text()
         .await
         .unwrap_or_else(|error| format!("failed to read error response body: {error}"));
-    Error::InvalidStatusCodeWithMessage(status, message)
+    Error::InvalidStatusCodeWithMessage(status, message, Some(headers))
 }
 
 pub type LazyBytes = WasmBoxedFuture<'static, Result<Bytes>>;
@@ -275,6 +294,59 @@ macro_rules! impl_http_client_ext {
 }
 
 impl_http_client_ext!(reqwest::Client);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn non_success_status_error_preserves_response_headers() {
+        let response = http::Response::builder()
+            .status(StatusCode::TOO_MANY_REQUESTS)
+            .header("retry-after", "20")
+            .header("x-ratelimit-remaining", "0")
+            .body(r#"{"error":{"message":"rate limited"}}"#)
+            .expect("valid response");
+        let response = reqwest::Response::from(response);
+
+        let error = non_success_status_error(response).await;
+
+        assert_eq!(
+            error.non_success_status(),
+            Some(StatusCode::TOO_MANY_REQUESTS)
+        );
+        assert_eq!(
+            error.non_success_body(),
+            Some(r#"{"error":{"message":"rate limited"}}"#)
+        );
+        let headers = error
+            .non_success_headers()
+            .expect("headers captured at error construction");
+        assert_eq!(
+            headers.get("retry-after").and_then(|v| v.to_str().ok()),
+            Some("20")
+        );
+        assert_eq!(
+            headers
+                .get("x-ratelimit-remaining")
+                .and_then(|v| v.to_str().ok()),
+            Some("0")
+        );
+    }
+
+    #[test]
+    fn non_success_headers_absent_when_not_captured() {
+        let error = Error::InvalidStatusCodeWithMessage(
+            StatusCode::TOO_MANY_REQUESTS,
+            "rate limited".to_string(),
+            None,
+        );
+        assert!(error.non_success_headers().is_none());
+
+        let error = Error::InvalidStatusCode(StatusCode::TOO_MANY_REQUESTS);
+        assert!(error.non_success_headers().is_none());
+    }
+}
 
 impl_http_client_ext!(
     #[cfg(feature = "reqwest-middleware")]

--- a/crates/rig-core/src/image_generation.rs
+++ b/crates/rig-core/src/image_generation.rs
@@ -185,6 +185,7 @@ mod provider_response_tests {
             ImageGenerationError::HttpError(http_client::Error::InvalidStatusCodeWithMessage(
                 StatusCode::BAD_REQUEST,
                 body.to_string(),
+                None,
             ));
 
         assert_eq!(error.provider_response_body(), Some(body));

--- a/crates/rig-core/src/provider_response.rs
+++ b/crates/rig-core/src/provider_response.rs
@@ -89,6 +89,7 @@ macro_rules! impl_provider_response_helpers {
                     Self::HttpError($crate::http_client::Error::InvalidStatusCodeWithMessage(
                         status,
                         body.into(),
+                        None,
                     ))
                 }
             }
@@ -157,6 +158,25 @@ macro_rules! impl_provider_response_helpers {
                     _ => None,
                 }
             }
+
+            /// Returns the HTTP response headers when this error preserved them.
+            ///
+            /// Rig's bundled HTTP clients capture the response headers whenever a
+            /// non-success status error is built from a live response, so
+            /// rate-limit metadata such as `Retry-After` or `x-ratelimit-*`
+            /// stays available to backoff logic.
+            ///
+            /// Returns `None` when the error carries no captured headers: the
+            /// `ProviderResponse` variant (2xx error envelopes and non-HTTP
+            /// transports), Rig-generated diagnostics, and HTTP errors that were
+            /// constructed from only a status and body (e.g. via
+            /// [`Self::from_http_response`]).
+            pub fn provider_response_headers(&self) -> Option<&http::HeaderMap> {
+                match self {
+                    Self::HttpError(error) => error.non_success_headers(),
+                    _ => None,
+                }
+            }
         }
     };
 }
@@ -219,6 +239,42 @@ mod tests {
             let err = <$err>::from_provider_body("");
             assert_eq!(err.provider_response_body(), Some(""));
             assert!(err.provider_response_json().expect("ok").is_none());
+
+            // Headers are only available when captured at construction: the
+            // status+body funnels never have them...
+            let err = <$err>::from_http_response(StatusCode::SERVICE_UNAVAILABLE, body);
+            assert!(
+                err.provider_response_headers().is_none(),
+                concat!(
+                    stringify!($err),
+                    ": from_http_response cannot invent headers"
+                ),
+            );
+
+            // ...but an HttpError built from a live response preserves them,
+            // keeping `Retry-After` recoverable for backoff logic.
+            let mut headers = http::HeaderMap::new();
+            headers.insert(
+                http::header::RETRY_AFTER,
+                http::HeaderValue::from_static("20"),
+            );
+            let err = <$err>::HttpError($crate::http_client::Error::InvalidStatusCodeWithMessage(
+                StatusCode::TOO_MANY_REQUESTS,
+                body.to_string(),
+                Some(Box::new(headers)),
+            ));
+            assert_eq!(
+                err.provider_response_headers()
+                    .and_then(|headers| headers.get(http::header::RETRY_AFTER))
+                    .and_then(|value| value.to_str().ok()),
+                Some("20"),
+                concat!(stringify!($err), ": captured Retry-After not surfaced"),
+            );
+            assert_eq!(
+                err.provider_response_status(),
+                Some(StatusCode::TOO_MANY_REQUESTS)
+            );
+            assert_eq!(err.provider_response_body(), Some(body));
         }};
     }
 

--- a/crates/rig-core/src/providers/deepseek.rs
+++ b/crates/rig-core/src/providers/deepseek.rs
@@ -451,7 +451,7 @@ where
             .send::<_, Vec<u8>>(req)
             .await
             .map_err(|error| match error {
-                http_client::Error::InvalidStatusCodeWithMessage(status, message) => {
+                http_client::Error::InvalidStatusCodeWithMessage(status, message, _) => {
                     ModelListingError::api_error_with_context(
                         "DeepSeek",
                         path,

--- a/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
+++ b/crates/rig-core/src/providers/internal/openai_chat_completions_compatible.rs
@@ -1109,6 +1109,7 @@ mod tests {
             Err(http_client::Error::InvalidStatusCodeWithMessage(
                 http::StatusCode::BAD_GATEWAY,
                 body.to_string(),
+                None,
             )),
         ];
         let client = SequencedStreamingHttpClient::new(chunks);

--- a/crates/rig-core/src/providers/xiaomimimo.rs
+++ b/crates/rig-core/src/providers/xiaomimimo.rs
@@ -322,7 +322,7 @@ where
             .send::<_, Vec<u8>>(req)
             .await
             .map_err(|error| match error {
-                http_client::Error::InvalidStatusCodeWithMessage(status, message) => {
+                http_client::Error::InvalidStatusCodeWithMessage(status, message, _) => {
                     ModelListingError::api_error_with_context(
                         "Xiaomi MiMo",
                         path,

--- a/crates/rig-core/src/test_utils/http.rs
+++ b/crates/rig-core/src/test_utils/http.rs
@@ -132,7 +132,7 @@ impl RecordingHttpClient {
             MockHttpResponse::Success(response_body) => (http::StatusCode::OK, response_body),
             MockHttpResponse::Error(status, message) => {
                 return Err(http_client::Error::InvalidStatusCodeWithMessage(
-                    status, message,
+                    status, message, None,
                 ));
             }
             MockHttpResponse::ErrorResponse(status, response_body) => (status, response_body),
@@ -417,7 +417,7 @@ impl HttpClientExt for HttpErrorStreamingClient {
         let body = self.body.clone();
         async move {
             Err(http_client::Error::InvalidStatusCodeWithMessage(
-                status, body,
+                status, body, None,
             ))
         }
     }
@@ -482,6 +482,7 @@ impl HttpClientExt for SequencedStreamingHttpClient {
                 return Err(http_client::Error::InvalidStatusCodeWithMessage(
                     http::StatusCode::INTERNAL_SERVER_ERROR,
                     "streaming chunks should only be consumed once".to_string(),
+                    None,
                 ));
             };
 

--- a/crates/rig-core/src/transcription.rs
+++ b/crates/rig-core/src/transcription.rs
@@ -314,6 +314,7 @@ mod provider_response_tests {
             TranscriptionError::HttpError(http_client::Error::InvalidStatusCodeWithMessage(
                 StatusCode::BAD_REQUEST,
                 body.to_string(),
+                None,
             ));
 
         assert_eq!(error.provider_response_body(), Some(body));


### PR DESCRIPTION
## Description

When a provider returns a non-success HTTP status, Rig preserves the status and
the raw body (via #1859's `provider_response_*` helpers), but the response
**headers are discarded at error construction**: `non_success_status_error()`
reads only `.status()` and `.text()`, and
`http_client::Error::InvalidStatusCodeWithMessage` has no slot for them. That
makes rate-limit metadata — most importantly `Retry-After` on a 429, but also
`x-ratelimit-*` — structurally unrecoverable by the caller.

We hit this while wiring provider-aware backoff: a stub server returning
`429` + `Retry-After: 20` + a JSON error body surfaces as
`CompletionError::HttpError(InvalidStatusCodeWithMessage(429, body))` with
`provider_response_status() == Some(429)` and the body intact, but there is no
route to the `Retry-After` value — it is gone before the error reaches caller
code. Notably, Rig's own `http_client::retry::RetryPolicy::retry(&self, error:
&Error, ..)` receives the error and therefore also cannot honor
`Retry-After` today.

This PR captures the response `HeaderMap` wherever a non-success status error
is built from a live response, and exposes it through the same inspection
surface #1859 established:

- `http_client::Error::InvalidStatusCodeWithMessage` gains a third
  `Option<Box<HeaderMap>>` field (boxed to keep the error size unchanged for
  `clippy::result_large_err`) and a public `non_success_headers()` accessor.
- The bundled reqwest-based clients populate it in `non_success_status_error()`
  (both the unary and streaming paths); the generic client `verify()` error
  branches populate it from the response in hand.
- Every capability error (`CompletionError`, `EmbeddingError`,
  `TranscriptionError`, `VerifyError`, `RerankError`, `ImageGenerationError`,
  `AudioGenerationError`) gains `provider_response_headers()` beside the
  existing `provider_response_{status,body,json}` helpers, via
  `impl_provider_response_helpers!`.
- `rig-agent`'s `PromptError` and `StructuredOutputError` forward
  `provider_response_headers()` like the other three helpers.

`from_http_response(status, body)` intentionally keeps its signature: funnels
that only ever had a status and body construct the error with `headers: None`,
and the accessor documents that `None` means "not captured", mirroring
#1859's `Option<StatusCode>` convention. Broadening capture to the 2xx
error-envelope path (`ProviderResponse`) is left as a follow-up in the spirit
of #1931 — the helpers' contract already accommodates it.

Fixes #2210

## Type of change

- [x] New feature
- [x] Breaking change (mechanical: one variant gains a field, see Notes)

## Testing

Original validation (upstream `main` @ `13bfadd`):

- `cargo test -p rig-core --all-features --lib` — **986 passed; 0 failed; 3 ignored**
- `cargo test -p rig-agent --all-features` — **485 passed; 0 failed; 2 ignored** (487 collected)
- `cargo clippy -p rig-core -p rig-agent --all-features --all-targets` — **0 warnings** (identical to a clean `main` baseline; the header field is boxed specifically so `result_large_err` stays quiet)
- `cargo fmt --all --check` — clean
- `cargo doc -p rig-core -p rig-agent --all-features --no-deps` — no new warnings

Re-validated after rebase onto `main` @ `7f1a495`: patch applies cleanly;
`cargo test -p rig-core` — **1000 passed; 0 failed**. (`rig-agent`'s test build
currently fails to compile for us on a *clean* `7f1a495` checkout — E0282/E0432,
identical with and without this patch, so it appears unrelated to this change;
happy to re-run once that builds again in case it's environmental.)

New tests:

- [x] `http_client::tests::non_success_status_error_preserves_response_headers` —
  drives the real construction path with a `reqwest::Response` carrying
  `Retry-After: 20` / `x-ratelimit-remaining: 0` on a 429 and asserts status,
  body, and both headers survive.
- [x] `http_client::tests::non_success_headers_absent_when_not_captured` —
  `None` for errors built without a response.
- [x] `provider_response` `assert_funnel!` extended for **every** capability
  error: `from_http_response` yields `provider_response_headers() == None`
  (funnels cannot invent headers), while an `HttpError` built with captured
  headers surfaces `Retry-After` alongside the preserved 429 status and body.
- [x] `rig-agent`:
  `prompt_error_provider_response_helpers_forward_captured_headers` — forwarding
  through `PromptError` and `StructuredOutputError`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (doc comments on the new accessors; happy to add a MIGRATING.md note if wanted)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Notes

**Breaking surface (mechanical).** `InvalidStatusCodeWithMessage` is a tuple
variant with public fields, so adding the headers slot is source-breaking for
code that constructs or exhaustively matches it:

```rust
// before
Error::InvalidStatusCodeWithMessage(status, message)
// after
Error::InvalidStatusCodeWithMessage(status, message, None)          // construct
Error::InvalidStatusCodeWithMessage(status, message, _) => ...      // match
```

All in-tree sites (2 match arms, ~15 constructions, mostly tests) are updated
in this PR. Users who only consume errors through `Display` or the
`provider_response_*` helpers are unaffected. If you'd rather avoid the break,
the variant could instead become a `#[non_exhaustive]` struct variant with
constructors — larger diff, future-proof against the next field; happy to
rework it that way if that's the preferred direction.

**Why `Option<Box<HeaderMap>>`:** `Option` distinguishes "not captured" (e.g.
built via `from_http_response`, which never sees headers) from "captured and
empty"; the `Box` keeps `http_client::Error` at its previous size so the
crate-wide `clippy::result_large_err` profile stays clean (verified: 0 clippy
warnings, same as `main`).

**Scope notes / possible follow-ups:**

- The 2xx error-envelope path (`ProviderResponse` variant) still reports
  `provider_response_headers() == None`; provider call sites hold the response
  there, so threading headers through is a mechanical broadening in the spirit
  of #1931.
- The SSE `EventSource` connect path still uses `InvalidStatusCode` (status
  only, no body or headers) — untouched here.
- A convenience `retry_after() -> Option<Duration>` parser was deliberately
  left out to keep this minimal; `RetryPolicy` implementors can read the raw
  header value via `non_success_headers()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
